### PR TITLE
feat(remote-config): add RemoteConfigManager and TopicFetcher

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1326,6 +1326,12 @@
 		3320C44A004844C1977301AB /* RemoteConfigManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6309AD09B1054DC081B6BF7E /* RemoteConfigManager.swift */; };
 		D50B098A156B454292887410 /* TopicFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CDDBB55FE1847498ECBA0A8 /* TopicFetcher.swift */; };
 		853DE70F5F0845C7A614DE45 /* RemoteConfigStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36224D28EF904B44908841D6 /* RemoteConfigStrings.swift */; };
+		EC22142820C24F59BDBE2D93 /* MockTopicFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F26F79D94694476791E8A6AD /* MockTopicFetcher.swift */; };
+		89D9E2DB21A440C78970F299 /* MockTopicFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F26F79D94694476791E8A6AD /* MockTopicFetcher.swift */; };
+		3779447DBC634AA68B7E0683 /* MockRemoteConfigAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2C854303404D8884933ACA /* MockRemoteConfigAPI.swift */; };
+		5481225010164BC5A1579C71 /* MockRemoteConfigAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2C854303404D8884933ACA /* MockRemoteConfigAPI.swift */; };
+		BFDE126A6ADD4D20B6B6B9B2 /* TopicFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2721FAB8C014743B2DC17C7 /* TopicFetcherTests.swift */; };
+		C5EEF4BD66D44A92832DA167 /* RemoteConfigManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A03E9903DDF426A97720D9D /* RemoteConfigManagerTests.swift */; };
 		DB36994E2F435CDC00B1F049 /* PriceFormatterExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB36994D2F435CDC00B1F049 /* PriceFormatterExtensions.swift */; };
 		DB55E6262ECE012600636909 /* FlexSpacer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB55E6252ECE012600636909 /* FlexSpacer.swift */; };
 		DB7EA7762F964CA200BCC082 /* WorkflowResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7EA7742F964CA200BCC082 /* WorkflowResponseTests.swift */; };
@@ -2966,6 +2972,10 @@
 		6309AD09B1054DC081B6BF7E /* RemoteConfigManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigManager.swift; sourceTree = "<group>"; };
 		5CDDBB55FE1847498ECBA0A8 /* TopicFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicFetcher.swift; sourceTree = "<group>"; };
 		36224D28EF904B44908841D6 /* RemoteConfigStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigStrings.swift; sourceTree = "<group>"; };
+		F26F79D94694476791E8A6AD /* MockTopicFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTopicFetcher.swift; sourceTree = "<group>"; };
+		DB2C854303404D8884933ACA /* MockRemoteConfigAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRemoteConfigAPI.swift; sourceTree = "<group>"; };
+		B2721FAB8C014743B2DC17C7 /* TopicFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicFetcherTests.swift; sourceTree = "<group>"; };
+		9A03E9903DDF426A97720D9D /* RemoteConfigManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigManagerTests.swift; sourceTree = "<group>"; };
 		DB36994D2F435CDC00B1F049 /* PriceFormatterExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceFormatterExtensions.swift; sourceTree = "<group>"; };
 		DB55E6252ECE012600636909 /* FlexSpacer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlexSpacer.swift; sourceTree = "<group>"; };
 		DB7EA7732F964CA200BCC082 /* WorkflowDetailProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowDetailProcessorTests.swift; sourceTree = "<group>"; };
@@ -3842,9 +3852,19 @@
 				37E35A5970D1604E8C8011FC /* TestHelpers */,
 				FD8C00452DE79F4000224B78 /* Virtual Currencies */,
 				75A0E78E2E3D1FC300A60BD5 /* SimulatedStore */,
+				E72032998DA642FC86C4364A /* RemoteConfig */,
 				2DC5622524EC63430031F69B /* Info.plist */,
 			);
 			path = UnitTests;
+			sourceTree = "<group>";
+		};
+		E72032998DA642FC86C4364A /* RemoteConfig */ = {
+			isa = PBXGroup;
+			children = (
+				B2721FAB8C014743B2DC17C7 /* TopicFetcherTests.swift */,
+				9A03E9903DDF426A97720D9D /* RemoteConfigManagerTests.swift */,
+			);
+			path = RemoteConfig;
 			sourceTree = "<group>";
 		};
 		2DD02D5924AD128A00419CD9 /* LocalReceiptParsing */ = {
@@ -4322,6 +4342,8 @@
 				75A0E7912E3D205C00A60BD5 /* MockTestStorePurchaseUI.swift */,
 				DBAA1FA72F88EAEB000E8C81 /* MockWorkflowsAPI.swift */,
 				F5B89439B2540823033939B9 /* MockWorkflowManager.swift */,
+				F26F79D94694476791E8A6AD /* MockTopicFetcher.swift */,
+				DB2C854303404D8884933ACA /* MockRemoteConfigAPI.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -7210,6 +7232,8 @@
 				75A3B2B22F16B458001C4CA7 /* MockLargeItemCache.swift in Sources */,
 				3543914526F926D900E669DF /* SKProductSubscriptionDurationExtensions.swift in Sources */,
 				3543913926F90FFB00E669DF /* MockBackend.swift in Sources */,
+				89D9E2DB21A440C78970F299 /* MockTopicFetcher.swift in Sources */,
+				5481225010164BC5A1579C71 /* MockRemoteConfigAPI.swift in Sources */,
 				F5FCD3FC27DA2034003BDC04 /* PriceFormatterProviderTests.swift in Sources */,
 				F5355163286B70E0009CA47A /* OfferingsManagerStoreKitTests.swift in Sources */,
 				35C272A22BC4084C005A0CE8 /* MockDiagnosticsTracker.swift in Sources */,
@@ -7818,6 +7842,10 @@
 				0368727A2D9DCF7100506BBB /* DefaultEnumTests.swift in Sources */,
 				DB3395E32F840ACD0079250C /* BackendGetWorkflowsTests.swift in Sources */,
 				E6A54710537E4AA3810E1CB0 /* BackendGetRemoteConfigTests.swift in Sources */,
+				BFDE126A6ADD4D20B6B6B9B2 /* TopicFetcherTests.swift in Sources */,
+				C5EEF4BD66D44A92832DA167 /* RemoteConfigManagerTests.swift in Sources */,
+				EC22142820C24F59BDBE2D93 /* MockTopicFetcher.swift in Sources */,
+				3779447DBC634AA68B7E0683 /* MockRemoteConfigAPI.swift in Sources */,
 				03C7305B2D35985900297FEC /* TextComponentTests.swift in Sources */,
 				FDE57B0E2DF8BC1100101CE2 /* VirtualCurrenciesDecodingTests.swift in Sources */,
 				75FCD4CE2E37FBE100036C02 /* SimulatedStoreMockData.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1323,6 +1323,9 @@
 		DB3395DD2F840A790079250C /* WorkflowResponseAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3395D92F840A790079250C /* WorkflowResponseAction.swift */; };
 		DB3395E12F840AA60079250C /* WorkflowsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3395E02F840AA60079250C /* WorkflowsAPI.swift */; };
 		DB3395E32F840ACD0079250C /* BackendGetWorkflowsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3395E22F840ACD0079250C /* BackendGetWorkflowsTests.swift */; };
+		3320C44A004844C1977301AB /* RemoteConfigManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6309AD09B1054DC081B6BF7E /* RemoteConfigManager.swift */; };
+		D50B098A156B454292887410 /* TopicFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CDDBB55FE1847498ECBA0A8 /* TopicFetcher.swift */; };
+		853DE70F5F0845C7A614DE45 /* RemoteConfigStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36224D28EF904B44908841D6 /* RemoteConfigStrings.swift */; };
 		DB36994E2F435CDC00B1F049 /* PriceFormatterExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB36994D2F435CDC00B1F049 /* PriceFormatterExtensions.swift */; };
 		DB55E6262ECE012600636909 /* FlexSpacer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB55E6252ECE012600636909 /* FlexSpacer.swift */; };
 		DB7EA7762F964CA200BCC082 /* WorkflowResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7EA7742F964CA200BCC082 /* WorkflowResponseTests.swift */; };
@@ -2960,6 +2963,9 @@
 		DB3395D92F840A790079250C /* WorkflowResponseAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowResponseAction.swift; sourceTree = "<group>"; };
 		DB3395E02F840AA60079250C /* WorkflowsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowsAPI.swift; sourceTree = "<group>"; };
 		DB3395E22F840ACD0079250C /* BackendGetWorkflowsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendGetWorkflowsTests.swift; sourceTree = "<group>"; };
+		6309AD09B1054DC081B6BF7E /* RemoteConfigManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigManager.swift; sourceTree = "<group>"; };
+		5CDDBB55FE1847498ECBA0A8 /* TopicFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicFetcher.swift; sourceTree = "<group>"; };
+		36224D28EF904B44908841D6 /* RemoteConfigStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigStrings.swift; sourceTree = "<group>"; };
 		DB36994D2F435CDC00B1F049 /* PriceFormatterExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceFormatterExtensions.swift; sourceTree = "<group>"; };
 		DB55E6252ECE012600636909 /* FlexSpacer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlexSpacer.swift; sourceTree = "<group>"; };
 		DB7EA7732F964CA200BCC082 /* WorkflowDetailProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowDetailProcessorTests.swift; sourceTree = "<group>"; };
@@ -3697,6 +3703,7 @@
 				57488BE729CB7FB60000EE7E /* OfflineEntitlementsStrings.swift */,
 				4F6ABC7D2A81700900250E63 /* PaywallsStrings.swift */,
 				9A65E0A42591A23500DE00B0 /* PurchaseStrings.swift */,
+				36224D28EF904B44908841D6 /* RemoteConfigStrings.swift */,
 				5791FCF22992D3EC00F1FEDA /* SigningStrings.swift */,
 				F5C0196826E880800005D61E /* StoreKitStrings.swift */,
 				757E73D02F0FE26A0066DCDC /* TransactionMetadataStrings.swift */,
@@ -3796,6 +3803,7 @@
 				57488B7D29CB70DA0000EE7E /* OfflineEntitlements */,
 				4F87610D2A5C9E330006FA14 /* Paywalls */,
 				354235D524C11138008C84EE /* Purchasing */,
+				45E2D46098204ACDB35CCD86 /* RemoteConfig */,
 				57F3C0C929B7A04D0004FD7E /* Security */,
 				354895D0267AE32D001DC5B1 /* SubscriberAttributes */,
 				35E840C1270FB45600899AE2 /* Support */,
@@ -5087,6 +5095,15 @@
 				57488C7529CB90F90000EE7E /* PurchasedSK2Product.swift */,
 			);
 			path = OfflineEntitlements;
+			sourceTree = "<group>";
+		};
+		45E2D46098204ACDB35CCD86 /* RemoteConfig */ = {
+			isa = PBXGroup;
+			children = (
+				6309AD09B1054DC081B6BF7E /* RemoteConfigManager.swift */,
+				5CDDBB55FE1847498ECBA0A8 /* TopicFetcher.swift */,
+			);
+			path = RemoteConfig;
 			sourceTree = "<group>";
 		};
 		57488B8929CB75520000EE7E /* OfflineEntitlements */ = {
@@ -7428,6 +7445,9 @@
 				E6B064598F674333A29E0781 /* RemoteConfigCallback.swift in Sources */,
 				A6CC43904EBD4860BFD2BD85 /* GetRemoteConfigOperation.swift in Sources */,
 				D62A9C83BFD14E5FA0452CC7 /* RemoteConfigResponse.swift in Sources */,
+				3320C44A004844C1977301AB /* RemoteConfigManager.swift in Sources */,
+				D50B098A156B454292887410 /* TopicFetcher.swift in Sources */,
+				853DE70F5F0845C7A614DE45 /* RemoteConfigStrings.swift in Sources */,
 				DB3395DD2F840A790079250C /* WorkflowResponseAction.swift in Sources */,
 				2CD72944268A826F00BFC976 /* Date+Extensions.swift in Sources */,
 				57069A5428E3918400B86355 /* AsyncExtensions.swift in Sources */,

--- a/Sources/Error Handling/BackendError.swift
+++ b/Sources/Error Handling/BackendError.swift
@@ -280,6 +280,9 @@ extension BackendError {
 
         /// A call that is supposed to retrieve a CustomerInfo failed because the json object couldn't be parsed.
         case customerInfoResponseParsing(error: NSError, json: String)
+
+        /// A remote config topic entry contained a malformed blob_ref value.
+        case remoteConfigMalformedBlobRef
     }
 
 }
@@ -302,6 +305,8 @@ extension BackendError.UnexpectedBackendResponseError: DescribableError {
             return "Unable to instantiate a CustomerInfoResponse, CustomerInfo in response was nil."
         case .customerInfoResponseParsing:
             return "Unable to instantiate a CustomerInfoResponse due to malformed json."
+        case .remoteConfigMalformedBlobRef:
+            return "Remote config topic entry contained a malformed blob_ref."
         }
     }
 

--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -1,0 +1,58 @@
+//
+//  RemoteConfigStrings.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 27/05/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+
+// swiftlint:disable identifier_name
+
+enum RemoteConfigStrings {
+
+    case remote_config_cache_hit
+    case remote_config_cache_stale_fetching_from_network
+    case remote_config_fetched_from_network
+    case remote_config_fetch_error(BackendError)
+
+    case topic_malformed_blob_ref(topic: RemoteConfigResponse.Topic, entryId: String)
+    case topic_cache_hit(topic: RemoteConfigResponse.Topic, entryId: String)
+    case topic_fetched(topic: RemoteConfigResponse.Topic, entryId: String)
+    case topic_fetch_error(topic: RemoteConfigResponse.Topic, entryId: String, error: BackendError)
+
+}
+
+extension RemoteConfigStrings: LogMessage {
+
+    var description: String {
+        switch self {
+        case .remote_config_cache_hit:
+            return "RemoteConfig: cache is still fresh."
+
+        case .remote_config_cache_stale_fetching_from_network:
+            return "RemoteConfig: cache is stale, fetching from network."
+
+        case .remote_config_fetched_from_network:
+            return "RemoteConfig: fetched from network."
+
+        case let .remote_config_fetch_error(error):
+            return "RemoteConfig: failed to fetch from network: \(error.localizedDescription)"
+
+        case let .topic_malformed_blob_ref(topic, entryId):
+            return "RemoteConfig: topic \(topic) (\(entryId)) has a malformed blob_ref; refusing to fetch."
+
+        case let .topic_cache_hit(topic, entryId):
+            return "RemoteConfig: topic \(topic) (\(entryId)) already cached, skipping download."
+
+        case let .topic_fetched(topic, entryId):
+            return "RemoteConfig: topic \(topic) (\(entryId)) downloaded and cached."
+
+        case let .topic_fetch_error(topic, entryId, error):
+            return "RemoteConfig: failed to fetch topic \(topic) (\(entryId)): \(error.localizedDescription)"
+        }
+    }
+
+    var category: String { return "remote_config" }
+
+}

--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -11,12 +11,11 @@ import Foundation
 
 enum RemoteConfigStrings {
 
-    case remote_config_cache_hit
-    case remote_config_cache_stale_fetching_from_network
-    case remote_config_fetched_from_network
     case remote_config_fetch_error(BackendError)
 
     case topic_malformed_blob_ref(topic: RemoteConfigResponse.Topic, entryId: String)
+    case topic_caches_dir_unavailable(topic: RemoteConfigResponse.Topic, entryId: String)
+    case topic_invalid_blob_url(topic: RemoteConfigResponse.Topic, entryId: String, urlString: String)
     case topic_cache_hit(topic: RemoteConfigResponse.Topic, entryId: String)
     case topic_fetched(topic: RemoteConfigResponse.Topic, entryId: String)
     case topic_fetch_error(topic: RemoteConfigResponse.Topic, entryId: String, error: BackendError)
@@ -27,20 +26,17 @@ extension RemoteConfigStrings: LogMessage {
 
     var description: String {
         switch self {
-        case .remote_config_cache_hit:
-            return "RemoteConfig: cache is still fresh."
-
-        case .remote_config_cache_stale_fetching_from_network:
-            return "RemoteConfig: cache is stale, fetching from network."
-
-        case .remote_config_fetched_from_network:
-            return "RemoteConfig: fetched from network."
-
         case let .remote_config_fetch_error(error):
             return "RemoteConfig: failed to fetch from network: \(error.localizedDescription)"
 
         case let .topic_malformed_blob_ref(topic, entryId):
             return "RemoteConfig: topic \(topic) (\(entryId)) has a malformed blob_ref; refusing to fetch."
+
+        case let .topic_caches_dir_unavailable(topic, entryId):
+            return "RemoteConfig: topic \(topic) (\(entryId)) could not resolve caches directory; skipping."
+
+        case let .topic_invalid_blob_url(topic, entryId, urlString):
+            return "RemoteConfig: topic \(topic) (\(entryId)) produced an invalid URL '\(urlString)'; skipping."
 
         case let .topic_cache_hit(topic, entryId):
             return "RemoteConfig: topic \(topic) (\(entryId)) already cached, skipping download."

--- a/Sources/Logging/Strings/Strings.swift
+++ b/Sources/Logging/Strings/Strings.swift
@@ -31,6 +31,7 @@ enum Strings {
     static let offlineEntitlements = OfflineEntitlementsStrings.self
     static let paywalls = PaywallsStrings.self
     static let purchase = PurchaseStrings.self
+    static let remoteConfig = RemoteConfigStrings.self
     static let webRedemption = WebRedemptionStrings.self
     static let receipt = ReceiptStrings.self
     static let signing = SigningStrings.self

--- a/Sources/Networking/Operations/GetRemoteConfigOperation.swift
+++ b/Sources/Networking/Operations/GetRemoteConfigOperation.swift
@@ -15,14 +15,16 @@ final class GetRemoteConfigOperation: CacheableNetworkOperation {
         configuration: NetworkConfiguration,
         callbackCache: CallbackCache<RemoteConfigCallback>
     ) -> CacheableNetworkOperationFactory<GetRemoteConfigOperation> {
-        return .init({ cacheKey in
+        return .init(
+            { cacheKey in
                 .init(
                     configuration: configuration,
                     callbackCache: callbackCache,
                     cacheKey: cacheKey
                 )
-        },
-                     individualizedCacheKeyPart: "")
+            },
+            individualizedCacheKeyPart: ""
+        )
     }
 
     private init(

--- a/Sources/RemoteConfig/RemoteConfigManager.swift
+++ b/Sources/RemoteConfig/RemoteConfigManager.swift
@@ -66,14 +66,18 @@ private extension RemoteConfigManager {
         guard !tasks.isEmpty else { return nil }
 
         return await withTaskGroup(of: BackendError?.self) { group in
-            for task in tasks {
-                group.addTask {
-                    await self.topicFetcher.fetchTopicIfNeeded(
-                        topic: task.topic,
-                        entryId: task.entryId,
-                        topicEntry: task.entry,
-                        source: source
-                    )
+            var iterator = tasks.makeIterator()
+
+            for _ in 0..<min(Self.maxParallelTopicDownloads, tasks.count) {
+                if let task = iterator.next() {
+                    group.addTask {
+                        await self.topicFetcher.fetchTopicIfNeeded(
+                            topic: task.topic,
+                            entryId: task.entryId,
+                            topicEntry: task.entry,
+                            source: source
+                        )
+                    }
                 }
             }
 
@@ -81,6 +85,16 @@ private extension RemoteConfigManager {
             for await error in group {
                 if let error, firstError == nil {
                     firstError = error
+                }
+                if let task = iterator.next() {
+                    group.addTask {
+                        await self.topicFetcher.fetchTopicIfNeeded(
+                            topic: task.topic,
+                            entryId: task.entryId,
+                            topicEntry: task.entry,
+                            source: source
+                        )
+                    }
                 }
             }
             return firstError
@@ -94,5 +108,6 @@ private extension RemoteConfigManager {
     }
 
     static let defaultEntryID = "default"
+    static let maxParallelTopicDownloads = 4
 
 }

--- a/Sources/RemoteConfig/RemoteConfigManager.swift
+++ b/Sources/RemoteConfig/RemoteConfigManager.swift
@@ -1,0 +1,98 @@
+//
+//  RemoteConfigManager.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 27/05/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+
+class RemoteConfigManager {
+
+    private let remoteConfigAPI: RemoteConfigAPI
+    private let topicFetcher: TopicFetcher
+
+    init(
+        remoteConfigAPI: RemoteConfigAPI,
+        topicFetcher: TopicFetcher
+    ) {
+        self.remoteConfigAPI = remoteConfigAPI
+        self.topicFetcher = topicFetcher
+    }
+
+    func updateRemoteConfigIfNeeded(
+        isAppBackgrounded: Bool,
+        completion: (@MainActor @Sendable (BackendError?) -> Void)?
+    ) {
+        Task {
+            let result: Result<RemoteConfigResponse, BackendError> = await withCheckedContinuation { continuation in
+                self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: isAppBackgrounded) { result in
+                    continuation.resume(returning: result)
+                }
+            }
+
+            let error: BackendError?
+            switch result {
+            case let .success(response):
+                error = await self.handleResponse(response)
+            case let .failure(backendError):
+                Logger.error(Strings.remoteConfig.remote_config_fetch_error(backendError))
+                error = backendError
+            }
+
+            if let completion {
+                await MainActor.run { completion(error) }
+            }
+        }
+    }
+
+}
+
+// @unchecked because:
+// - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.
+extension RemoteConfigManager: @unchecked Sendable {}
+
+private extension RemoteConfigManager {
+
+    func handleResponse(_ response: RemoteConfigResponse) async -> BackendError? {
+        // WIP: pick source by weighted priority once WeightedSource is wired up (#3458 equivalent).
+        guard let source = response.blobSources.first else { return nil }
+
+        let tasks: [TopicTask] = response.manifest.topics.compactMap { topic, entries in
+            guard let entry = entries[Self.defaultEntryID] else { return nil }
+            return TopicTask(topic: topic, entryId: Self.defaultEntryID, entry: entry)
+        }
+
+        guard !tasks.isEmpty else { return nil }
+
+        return await withTaskGroup(of: BackendError?.self) { group in
+            for task in tasks {
+                group.addTask {
+                    await self.topicFetcher.fetchTopicIfNeeded(
+                        topic: task.topic,
+                        entryId: task.entryId,
+                        topicEntry: task.entry,
+                        source: source
+                    )
+                }
+            }
+
+            var firstError: BackendError?
+            for await error in group {
+                if let error, firstError == nil {
+                    firstError = error
+                }
+            }
+            return firstError
+        }
+    }
+
+    struct TopicTask {
+        let topic: RemoteConfigResponse.Topic
+        let entryId: String
+        let entry: RemoteConfigResponse.TopicEntry
+    }
+
+    static let defaultEntryID = "default"
+
+}

--- a/Sources/RemoteConfig/TopicFetcher.swift
+++ b/Sources/RemoteConfig/TopicFetcher.swift
@@ -156,7 +156,7 @@ private extension TopicFetcher {
         guard let cachesDir = self.baseCacheURL ?? DirectoryHelper.baseUrl(for: .cache) else { return nil }
         let topicDir = cachesDir
             .appendingPathComponent(Self.topicsRoot)
-            .appendingPathComponent(topic.wireKey)
+            .appendingPathComponent(topic.rawValue)
 
         if !self.fileManager.fileExists(atPath: topicDir.path) {
             try? self.fileManager.createDirectory(at: topicDir, withIntermediateDirectories: true, attributes: nil)

--- a/Sources/RemoteConfig/TopicFetcher.swift
+++ b/Sources/RemoteConfig/TopicFetcher.swift
@@ -8,17 +8,41 @@
 import CryptoKit
 import Foundation
 
+protocol FileManaging: AnyObject {
+    func fileExists(atPath path: String) -> Bool
+    func createDirectory(
+        at url: URL,
+        withIntermediateDirectories createIntermediates: Bool,
+        attributes attr: [FileAttributeKey: Any]?
+    ) throws
+    func replaceItemAt(
+        _ originalItemURL: URL,
+        withItemAt newItemURL: URL,
+        backupItemName: String?,
+        options mask: FileManager.ItemReplacementOptions
+    ) throws -> URL?
+    func removeItem(at url: URL) throws
+}
+
+extension FileManager: FileManaging {}
+
 class TopicFetcher {
 
     private static let topicsRoot = "RevenueCat/topics"
     private static let blobRefPlaceholder = "{blob_ref}"
 
-    private let fileManager: FileManager
+    private let fileManager: any FileManaging
     private let urlSession: URLSession
+    private let baseCacheURL: URL?
 
-    init(fileManager: FileManager = .default, urlSession: URLSession = .shared) {
+    init(
+        fileManager: any FileManaging = FileManager.default,
+        urlSession: URLSession = .shared,
+        baseCacheURL: URL? = nil
+    ) {
         self.fileManager = fileManager
         self.urlSession = urlSession
+        self.baseCacheURL = baseCacheURL
     }
 
     func fetchTopicIfNeeded(
@@ -29,23 +53,11 @@ class TopicFetcher {
     ) async -> BackendError? {
         guard self.isValidBlobRef(topicEntry.blobRef) else {
             Logger.error(Strings.remoteConfig.topic_malformed_blob_ref(topic: topic, entryId: entryId))
-            return .networkError(.networkError(
-                NSError(
-                    domain: "com.revenuecat.remoteconfig",
-                    code: -1,
-                    userInfo: [NSLocalizedDescriptionKey: "Malformed blob_ref for topic \(topic) (\(entryId))"]
-                )
-            ))
+            return TopicFetchError.malformedBlobRef.backendError
         }
 
         guard let targetFile = self.topicFile(topic: topic, blobRef: topicEntry.blobRef) else {
-            return .networkError(.networkError(
-                NSError(
-                    domain: "com.revenuecat.remoteconfig",
-                    code: -4,
-                    userInfo: [NSLocalizedDescriptionKey: "Could not resolve caches directory"]
-                )
-            ))
+            return TopicFetchError.cachesDirectoryUnavailable.backendError
         }
 
         if self.fileManager.fileExists(atPath: targetFile.path) {
@@ -58,13 +70,7 @@ class TopicFetcher {
             with: topicEntry.blobRef
         )
         guard let url = URL(string: urlString) else {
-            return .networkError(.networkError(
-                NSError(
-                    domain: "com.revenuecat.remoteconfig",
-                    code: -3,
-                    userInfo: [NSLocalizedDescriptionKey: "Invalid blob URL: \(urlString)"]
-                )
-            ))
+            return TopicFetchError.invalidBlobURL(urlString: urlString).backendError
         }
 
         let error = await self.download(url: url, expectedSHA256: topicEntry.blobRef, targetFile: targetFile)
@@ -82,16 +88,54 @@ class TopicFetcher {
 // - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.
 extension TopicFetcher: @unchecked Sendable {}
 
+private enum TopicFetchError {
+
+    case malformedBlobRef
+    case cachesDirectoryUnavailable
+    case invalidBlobURL(urlString: String)
+    case unexpectedHTTPStatus(statusCode: Int)
+    case sha256Mismatch(expected: String, actual: String)
+    case writeFailure(error: Error)
+
+    var backendError: BackendError {
+        switch self {
+        case .malformedBlobRef:
+            return .unexpectedBackendResponse(.remoteConfigMalformedBlobRef)
+        case .cachesDirectoryUnavailable:
+            return Self.make(code: -4, "Could not resolve caches directory")
+        case .invalidBlobURL(let urlString):
+            return Self.make(code: -3, "Invalid blob URL: \(urlString)")
+        case .unexpectedHTTPStatus(let statusCode):
+            return Self.make(code: -5, "Unexpected HTTP status: \(statusCode)")
+        case .sha256Mismatch(let expected, let actual):
+            return Self.make(code: -2, "SHA-256 mismatch: expected \(expected), got \(actual)")
+        case .writeFailure(let error):
+            return .networkError(.networkError(error))
+        }
+    }
+
+    private static func make(code: Int, _ message: String) -> BackendError {
+        .networkError(.networkError(
+            NSError(
+                domain: "com.revenuecat.remoteconfig",
+                code: code,
+                userInfo: [NSLocalizedDescriptionKey: message]
+            )
+        ))
+    }
+
+}
+
 private extension TopicFetcher {
 
     func topicFile(topic: RemoteConfigResponse.Topic, blobRef: String) -> URL? {
-        guard let cachesDir = DirectoryHelper.baseUrl(for: .cache) else { return nil }
+        guard let cachesDir = self.baseCacheURL ?? DirectoryHelper.baseUrl(for: .cache) else { return nil }
         let topicDir = cachesDir
             .appendingPathComponent(Self.topicsRoot)
             .appendingPathComponent(topic.wireKey)
 
         if !self.fileManager.fileExists(atPath: topicDir.path) {
-            try? self.fileManager.createDirectory(at: topicDir, withIntermediateDirectories: true)
+            try? self.fileManager.createDirectory(at: topicDir, withIntermediateDirectories: true, attributes: nil)
         }
 
         return topicDir.appendingPathComponent(blobRef)
@@ -99,9 +143,16 @@ private extension TopicFetcher {
 
     func download(url: URL, expectedSHA256: String, targetFile: URL) async -> BackendError? {
         return await withCheckedContinuation { continuation in
-            self.urlSession.dataTask(with: url) { [self] data, _, error in
+            self.urlSession.dataTask(with: url) { [self] data, response, error in
                 if let error {
                     continuation.resume(returning: .networkError(.networkError(error)))
+                    return
+                }
+
+                let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+                guard statusCode == 200 else {
+                    let error = TopicFetchError.unexpectedHTTPStatus(statusCode: statusCode).backendError
+                    continuation.resume(returning: error)
                     return
                 }
 
@@ -115,14 +166,10 @@ private extension TopicFetcher {
                     .joined()
 
                 guard actualSHA256 == expectedSHA256 else {
-                    continuation.resume(returning: .networkError(.networkError(
-                        NSError(
-                            domain: "com.revenuecat.remoteconfig",
-                            code: -2,
-                            userInfo: [NSLocalizedDescriptionKey:
-                                "SHA-256 mismatch: expected \(expectedSHA256), got \(actualSHA256)"]
-                        )
-                    )))
+                    continuation.resume(returning: TopicFetchError.sha256Mismatch(
+                        expected: expectedSHA256,
+                        actual: actualSHA256
+                    ).backendError)
                     return
                 }
 
@@ -131,11 +178,13 @@ private extension TopicFetcher {
 
                 do {
                     try data.write(to: tempFile, options: .atomic)
-                    _ = try? self.fileManager.replaceItemAt(targetFile, withItemAt: tempFile)
+                    _ = try self.fileManager.replaceItemAt(
+                        targetFile, withItemAt: tempFile, backupItemName: nil, options: []
+                    )
                     continuation.resume(returning: nil)
                 } catch {
                     try? self.fileManager.removeItem(at: tempFile)
-                    continuation.resume(returning: .networkError(.networkError(error)))
+                    continuation.resume(returning: TopicFetchError.writeFailure(error: error).backendError)
                 }
             }.resume()
         }

--- a/Sources/RemoteConfig/TopicFetcher.swift
+++ b/Sources/RemoteConfig/TopicFetcher.swift
@@ -33,7 +33,7 @@ protocol BlobDownloader: AnyObject {
 
 extension HTTPClient: BlobDownloader {}
 
-private final class URLSessionBlobDownloader: BlobDownloader {
+final class URLSessionBlobDownloader: BlobDownloader {
 
     private let session: URLSession
 
@@ -69,7 +69,7 @@ class TopicFetcher {
 
     init(
         fileManager: any FileManaging = FileManager.default,
-        downloader: any BlobDownloader = URLSessionBlobDownloader(),
+        downloader: any BlobDownloader,
         baseCacheURL: URL? = nil
     ) {
         self.fileManager = fileManager

--- a/Sources/RemoteConfig/TopicFetcher.swift
+++ b/Sources/RemoteConfig/TopicFetcher.swift
@@ -21,6 +21,7 @@ protocol FileManaging: AnyObject {
         backupItemName: String?,
         options mask: FileManager.ItemReplacementOptions
     ) throws -> URL?
+    func copyItem(at srcURL: URL, to dstURL: URL) throws
     func removeItem(at url: URL) throws
 }
 
@@ -45,7 +46,7 @@ private final class URLSessionBlobDownloader: BlobDownloader {
             if let error {
                 completion(.failure(error))
             } else if let httpResponse = response as? HTTPURLResponse,
-                      !(200..<300).contains(httpResponse.statusCode) {
+                      httpResponse.statusCode != 200 {
                 completion(.failure(URLError(.badServerResponse)))
             } else if let data {
                 completion(.success(data))
@@ -189,13 +190,18 @@ private extension TopicFetcher {
                     let tempFile = parent.appendingPathComponent("rc_topic_\(UUID().uuidString).tmp")
 
                     do {
+                        defer { try? self.fileManager.removeItem(at: tempFile) }
                         try data.write(to: tempFile, options: .atomic)
-                        _ = try self.fileManager.replaceItemAt(
-                            targetFile, withItemAt: tempFile, backupItemName: nil, options: []
-                        )
+                        do {
+                            _ = try self.fileManager.replaceItemAt(
+                                targetFile, withItemAt: tempFile, backupItemName: nil, options: []
+                            )
+                        } catch {
+                            try? self.fileManager.removeItem(at: targetFile)
+                            try self.fileManager.copyItem(at: tempFile, to: targetFile)
+                        }
                         continuation.resume(returning: nil)
                     } catch {
-                        try? self.fileManager.removeItem(at: tempFile)
                         continuation.resume(returning: TopicFetchError.writeFailure(error: error).backendError)
                     }
                 }
@@ -204,7 +210,7 @@ private extension TopicFetcher {
     }
 
     func isValidBlobRef(_ blobRef: String) -> Bool {
-        !blobRef.isEmpty && blobRef.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber) }
+        blobRef.range(of: "^[a-fA-F0-9]{64}$", options: .regularExpression) != nil
     }
 
 }

--- a/Sources/RemoteConfig/TopicFetcher.swift
+++ b/Sources/RemoteConfig/TopicFetcher.swift
@@ -1,0 +1,148 @@
+//
+//  TopicFetcher.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 27/05/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import CryptoKit
+import Foundation
+
+class TopicFetcher {
+
+    private static let topicsRoot = "RevenueCat/topics"
+    private static let blobRefPlaceholder = "{blob_ref}"
+
+    private let fileManager: FileManager
+    private let urlSession: URLSession
+
+    init(fileManager: FileManager = .default, urlSession: URLSession = .shared) {
+        self.fileManager = fileManager
+        self.urlSession = urlSession
+    }
+
+    func fetchTopicIfNeeded(
+        topic: RemoteConfigResponse.Topic,
+        entryId: String,
+        topicEntry: RemoteConfigResponse.TopicEntry,
+        source: RemoteConfigResponse.BlobSource
+    ) async -> BackendError? {
+        guard self.isValidBlobRef(topicEntry.blobRef) else {
+            Logger.error(Strings.remoteConfig.topic_malformed_blob_ref(topic: topic, entryId: entryId))
+            return .networkError(.networkError(
+                NSError(
+                    domain: "com.revenuecat.remoteconfig",
+                    code: -1,
+                    userInfo: [NSLocalizedDescriptionKey: "Malformed blob_ref for topic \(topic) (\(entryId))"]
+                )
+            ))
+        }
+
+        guard let targetFile = self.topicFile(topic: topic, blobRef: topicEntry.blobRef) else {
+            return .networkError(.networkError(
+                NSError(
+                    domain: "com.revenuecat.remoteconfig",
+                    code: -4,
+                    userInfo: [NSLocalizedDescriptionKey: "Could not resolve caches directory"]
+                )
+            ))
+        }
+
+        if self.fileManager.fileExists(atPath: targetFile.path) {
+            Logger.verbose(Strings.remoteConfig.topic_cache_hit(topic: topic, entryId: entryId))
+            return nil
+        }
+
+        let urlString = source.urlFormat.replacingOccurrences(
+            of: Self.blobRefPlaceholder,
+            with: topicEntry.blobRef
+        )
+        guard let url = URL(string: urlString) else {
+            return .networkError(.networkError(
+                NSError(
+                    domain: "com.revenuecat.remoteconfig",
+                    code: -3,
+                    userInfo: [NSLocalizedDescriptionKey: "Invalid blob URL: \(urlString)"]
+                )
+            ))
+        }
+
+        let error = await self.download(url: url, expectedSHA256: topicEntry.blobRef, targetFile: targetFile)
+        if let error {
+            Logger.error(Strings.remoteConfig.topic_fetch_error(topic: topic, entryId: entryId, error: error))
+        } else {
+            Logger.debug(Strings.remoteConfig.topic_fetched(topic: topic, entryId: entryId))
+        }
+        return error
+    }
+
+}
+
+// @unchecked because:
+// - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.
+extension TopicFetcher: @unchecked Sendable {}
+
+private extension TopicFetcher {
+
+    func topicFile(topic: RemoteConfigResponse.Topic, blobRef: String) -> URL? {
+        guard let cachesDir = DirectoryHelper.baseUrl(for: .cache) else { return nil }
+        let topicDir = cachesDir
+            .appendingPathComponent(Self.topicsRoot)
+            .appendingPathComponent(topic.wireKey)
+
+        if !self.fileManager.fileExists(atPath: topicDir.path) {
+            try? self.fileManager.createDirectory(at: topicDir, withIntermediateDirectories: true)
+        }
+
+        return topicDir.appendingPathComponent(blobRef)
+    }
+
+    func download(url: URL, expectedSHA256: String, targetFile: URL) async -> BackendError? {
+        return await withCheckedContinuation { continuation in
+            self.urlSession.dataTask(with: url) { [self] data, _, error in
+                if let error {
+                    continuation.resume(returning: .networkError(.networkError(error)))
+                    return
+                }
+
+                guard let data else {
+                    continuation.resume(returning: .networkError(.unexpectedResponse(nil)))
+                    return
+                }
+
+                let actualSHA256 = SHA256.hash(data: data)
+                    .map { String(format: "%02x", $0) }
+                    .joined()
+
+                guard actualSHA256 == expectedSHA256 else {
+                    continuation.resume(returning: .networkError(.networkError(
+                        NSError(
+                            domain: "com.revenuecat.remoteconfig",
+                            code: -2,
+                            userInfo: [NSLocalizedDescriptionKey:
+                                "SHA-256 mismatch: expected \(expectedSHA256), got \(actualSHA256)"]
+                        )
+                    )))
+                    return
+                }
+
+                let parent = targetFile.deletingLastPathComponent()
+                let tempFile = parent.appendingPathComponent("rc_topic_\(UUID().uuidString).tmp")
+
+                do {
+                    try data.write(to: tempFile, options: .atomic)
+                    _ = try? self.fileManager.replaceItemAt(targetFile, withItemAt: tempFile)
+                    continuation.resume(returning: nil)
+                } catch {
+                    try? self.fileManager.removeItem(at: tempFile)
+                    continuation.resume(returning: .networkError(.networkError(error)))
+                }
+            }.resume()
+        }
+    }
+
+    func isValidBlobRef(_ blobRef: String) -> Bool {
+        !blobRef.isEmpty && blobRef.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber) }
+    }
+
+}

--- a/Sources/RemoteConfig/TopicFetcher.swift
+++ b/Sources/RemoteConfig/TopicFetcher.swift
@@ -26,22 +26,53 @@ protocol FileManaging: AnyObject {
 
 extension FileManager: FileManaging {}
 
+protocol BlobDownloader: AnyObject {
+    func fetchRawData(from url: URL, completion: @escaping (Result<Data, Error>) -> Void)
+}
+
+extension HTTPClient: BlobDownloader {}
+
+private final class URLSessionBlobDownloader: BlobDownloader {
+
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    func fetchRawData(from url: URL, completion: @escaping (Result<Data, Error>) -> Void) {
+        self.session.dataTask(with: url) { data, response, error in
+            if let error {
+                completion(.failure(error))
+            } else if let httpResponse = response as? HTTPURLResponse,
+                      !(200..<300).contains(httpResponse.statusCode) {
+                completion(.failure(URLError(.badServerResponse)))
+            } else if let data {
+                completion(.success(data))
+            } else {
+                completion(.failure(URLError(.unknown)))
+            }
+        }.resume()
+    }
+
+}
+
 class TopicFetcher {
 
     private static let topicsRoot = "RevenueCat/topics"
     private static let blobRefPlaceholder = "{blob_ref}"
 
     private let fileManager: any FileManaging
-    private let urlSession: URLSession
+    private let downloader: any BlobDownloader
     private let baseCacheURL: URL?
 
     init(
         fileManager: any FileManaging = FileManager.default,
-        urlSession: URLSession = .shared,
+        downloader: any BlobDownloader = URLSessionBlobDownloader(),
         baseCacheURL: URL? = nil
     ) {
         self.fileManager = fileManager
-        self.urlSession = urlSession
+        self.downloader = downloader
         self.baseCacheURL = baseCacheURL
     }
 
@@ -56,7 +87,13 @@ class TopicFetcher {
             return TopicFetchError.malformedBlobRef.backendError
         }
 
-        guard let targetFile = self.topicFile(topic: topic, blobRef: topicEntry.blobRef) else {
+        // Normalize to lowercase so the cache path and SHA-256 comparison are
+        // always consistent regardless of whether the backend sends upper- or
+        // lower-case hex (SHA256.hash produces lowercase via %02x).
+        let blobRef = topicEntry.blobRef.lowercased()
+
+        guard let targetFile = self.topicFile(topic: topic, blobRef: blobRef) else {
+            Logger.error(Strings.remoteConfig.topic_caches_dir_unavailable(topic: topic, entryId: entryId))
             return TopicFetchError.cachesDirectoryUnavailable.backendError
         }
 
@@ -65,15 +102,15 @@ class TopicFetcher {
             return nil
         }
 
-        let urlString = source.urlFormat.replacingOccurrences(
-            of: Self.blobRefPlaceholder,
-            with: topicEntry.blobRef
-        )
+        let urlString = source.urlFormat.replacingOccurrences(of: Self.blobRefPlaceholder, with: blobRef)
         guard let url = URL(string: urlString) else {
-            return TopicFetchError.invalidBlobURL(urlString: urlString).backendError
+            Logger.error(Strings.remoteConfig.topic_invalid_blob_url(
+                topic: topic, entryId: entryId, urlString: urlString
+            ))
+            return TopicFetchError.invalidBlobURL.backendError
         }
 
-        let error = await self.download(url: url, expectedSHA256: topicEntry.blobRef, targetFile: targetFile)
+        let error = await self.download(url: url, expectedSHA256: blobRef, targetFile: targetFile)
         if let error {
             Logger.error(Strings.remoteConfig.topic_fetch_error(topic: topic, entryId: entryId, error: error))
         } else {
@@ -92,8 +129,7 @@ private enum TopicFetchError {
 
     case malformedBlobRef
     case cachesDirectoryUnavailable
-    case invalidBlobURL(urlString: String)
-    case unexpectedHTTPStatus(statusCode: Int)
+    case invalidBlobURL
     case sha256Mismatch(expected: String, actual: String)
     case writeFailure(error: Error)
 
@@ -102,26 +138,14 @@ private enum TopicFetchError {
         case .malformedBlobRef:
             return .unexpectedBackendResponse(.remoteConfigMalformedBlobRef)
         case .cachesDirectoryUnavailable:
-            return Self.make(code: -4, "Could not resolve caches directory")
-        case .invalidBlobURL(let urlString):
-            return Self.make(code: -3, "Invalid blob URL: \(urlString)")
-        case .unexpectedHTTPStatus(let statusCode):
-            return Self.make(code: -5, "Unexpected HTTP status: \(statusCode)")
-        case .sha256Mismatch(let expected, let actual):
-            return Self.make(code: -2, "SHA-256 mismatch: expected \(expected), got \(actual)")
+            return .networkError(.networkError(URLError(.cannotCreateFile)))
+        case .invalidBlobURL:
+            return .networkError(.networkError(URLError(.badURL)))
+        case .sha256Mismatch:
+            return .networkError(.networkError(URLError(.cannotDecodeRawData)))
         case .writeFailure(let error):
             return .networkError(.networkError(error))
         }
-    }
-
-    private static func make(code: Int, _ message: String) -> BackendError {
-        .networkError(.networkError(
-            NSError(
-                domain: "com.revenuecat.remoteconfig",
-                code: code,
-                userInfo: [NSLocalizedDescriptionKey: message]
-            )
-        ))
     }
 
 }
@@ -143,50 +167,39 @@ private extension TopicFetcher {
 
     func download(url: URL, expectedSHA256: String, targetFile: URL) async -> BackendError? {
         return await withCheckedContinuation { continuation in
-            self.urlSession.dataTask(with: url) { [self] data, response, error in
-                if let error {
+            self.downloader.fetchRawData(from: url) { [self] result in
+                switch result {
+                case .failure(let error):
                     continuation.resume(returning: .networkError(.networkError(error)))
-                    return
+
+                case .success(let data):
+                    let actualSHA256 = SHA256.hash(data: data)
+                        .map { String(format: "%02x", $0) }
+                        .joined()
+
+                    guard actualSHA256 == expectedSHA256 else {
+                        continuation.resume(returning: TopicFetchError.sha256Mismatch(
+                            expected: expectedSHA256,
+                            actual: actualSHA256
+                        ).backendError)
+                        return
+                    }
+
+                    let parent = targetFile.deletingLastPathComponent()
+                    let tempFile = parent.appendingPathComponent("rc_topic_\(UUID().uuidString).tmp")
+
+                    do {
+                        try data.write(to: tempFile, options: .atomic)
+                        _ = try self.fileManager.replaceItemAt(
+                            targetFile, withItemAt: tempFile, backupItemName: nil, options: []
+                        )
+                        continuation.resume(returning: nil)
+                    } catch {
+                        try? self.fileManager.removeItem(at: tempFile)
+                        continuation.resume(returning: TopicFetchError.writeFailure(error: error).backendError)
+                    }
                 }
-
-                let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
-                guard statusCode == 200 else {
-                    let error = TopicFetchError.unexpectedHTTPStatus(statusCode: statusCode).backendError
-                    continuation.resume(returning: error)
-                    return
-                }
-
-                guard let data else {
-                    continuation.resume(returning: .networkError(.unexpectedResponse(nil)))
-                    return
-                }
-
-                let actualSHA256 = SHA256.hash(data: data)
-                    .map { String(format: "%02x", $0) }
-                    .joined()
-
-                guard actualSHA256 == expectedSHA256 else {
-                    continuation.resume(returning: TopicFetchError.sha256Mismatch(
-                        expected: expectedSHA256,
-                        actual: actualSHA256
-                    ).backendError)
-                    return
-                }
-
-                let parent = targetFile.deletingLastPathComponent()
-                let tempFile = parent.appendingPathComponent("rc_topic_\(UUID().uuidString).tmp")
-
-                do {
-                    try data.write(to: tempFile, options: .atomic)
-                    _ = try self.fileManager.replaceItemAt(
-                        targetFile, withItemAt: tempFile, backupItemName: nil, options: []
-                    )
-                    continuation.resume(returning: nil)
-                } catch {
-                    try? self.fileManager.removeItem(at: tempFile)
-                    continuation.resume(returning: TopicFetchError.writeFailure(error: error).backendError)
-                }
-            }.resume()
+            }
         }
     }
 

--- a/Tests/UnitTests/Mocks/MockRemoteConfigAPI.swift
+++ b/Tests/UnitTests/Mocks/MockRemoteConfigAPI.swift
@@ -1,0 +1,31 @@
+//
+//  MockRemoteConfigAPI.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 28/05/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+@testable import RevenueCat
+
+class MockRemoteConfigAPI: RemoteConfigAPI {
+
+    var stubbedResult: Result<RemoteConfigResponse, BackendError>?
+    var invokedGetRemoteConfigCount = 0
+    var invokedIsAppBackgrounded: Bool?
+
+    convenience init() {
+        self.init(backendConfig: MockBackendConfiguration())
+    }
+
+    override func getRemoteConfig(
+        isAppBackgrounded: Bool,
+        completion: @escaping RemoteConfigResponseHandler
+    ) {
+        self.invokedGetRemoteConfigCount += 1
+        self.invokedIsAppBackgrounded = isAppBackgrounded
+        if let result = self.stubbedResult {
+            completion(result)
+        }
+    }
+
+}

--- a/Tests/UnitTests/Mocks/MockTopicFetcher.swift
+++ b/Tests/UnitTests/Mocks/MockTopicFetcher.swift
@@ -1,0 +1,36 @@
+//
+//  MockTopicFetcher.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 28/05/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+@testable import RevenueCat
+
+class MockTopicFetcher: TopicFetcher {
+
+    struct FetchCall {
+        let topic: RemoteConfigResponse.Topic
+        let entryId: String
+        let topicEntry: RemoteConfigResponse.TopicEntry
+        let source: RemoteConfigResponse.BlobSource
+    }
+
+    var stubbedFetchResult: BackendError?
+    var fetchCalls: [FetchCall] = []
+
+    convenience init() {
+        self.init(fileManager: FileManager.default, urlSession: .shared)
+    }
+
+    override func fetchTopicIfNeeded(
+        topic: RemoteConfigResponse.Topic,
+        entryId: String,
+        topicEntry: RemoteConfigResponse.TopicEntry,
+        source: RemoteConfigResponse.BlobSource
+    ) async -> BackendError? {
+        self.fetchCalls.append(FetchCall(topic: topic, entryId: entryId, topicEntry: topicEntry, source: source))
+        return self.stubbedFetchResult
+    }
+
+}

--- a/Tests/UnitTests/Mocks/MockTopicFetcher.swift
+++ b/Tests/UnitTests/Mocks/MockTopicFetcher.swift
@@ -20,7 +20,7 @@ class MockTopicFetcher: TopicFetcher {
     var fetchCalls: [FetchCall] = []
 
     convenience init() {
-        self.init(fileManager: FileManager.default, urlSession: .shared)
+        self.init(fileManager: FileManager.default)
     }
 
     override func fetchTopicIfNeeded(

--- a/Tests/UnitTests/Mocks/MockTopicFetcher.swift
+++ b/Tests/UnitTests/Mocks/MockTopicFetcher.swift
@@ -20,7 +20,8 @@ class MockTopicFetcher: TopicFetcher {
     var fetchCalls: [FetchCall] = []
 
     convenience init() {
-        self.init(fileManager: FileManager.default)
+        // Downloader is never exercised: `fetchTopicIfNeeded` is overridden below.
+        self.init(fileManager: FileManager.default, downloader: URLSessionBlobDownloader())
     }
 
     override func fetchTopicIfNeeded(

--- a/Tests/UnitTests/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/RemoteConfig/RemoteConfigManagerTests.swift
@@ -1,0 +1,239 @@
+//
+//  RemoteConfigManagerTests.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 28/05/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+final class RemoteConfigManagerTests: TestCase {
+
+    private var remoteConfigAPI: MockRemoteConfigAPI!
+    private var topicFetcher: MockTopicFetcher!
+    private var manager: RemoteConfigManager!
+
+    override func setUp() {
+        super.setUp()
+        self.remoteConfigAPI = MockRemoteConfigAPI()
+        self.topicFetcher = MockTopicFetcher()
+        self.manager = RemoteConfigManager(
+            remoteConfigAPI: self.remoteConfigAPI,
+            topicFetcher: self.topicFetcher
+        )
+    }
+
+    // MARK: - Happy path
+
+    func testSingleTopicDelegatesToFetcherAndCompletesWithNil() {
+        let src = makeSource(id: "primary")
+        let entry = makeEntry(blobRef: "abc123def456")
+        self.remoteConfigAPI.stubbedResult = .success(makeResponse(
+            sources: [src],
+            topics: [.productEntitlementMapping: ["default": entry]]
+        ))
+
+        var receivedError: BackendError?
+        waitUntil { done in
+            self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false) { error in
+                receivedError = error
+                done()
+            }
+        }
+
+        expect(receivedError).to(beNil())
+        expect(self.topicFetcher.fetchCalls).to(haveCount(1))
+        let call = self.topicFetcher.fetchCalls.first
+        expect(call?.topic).to(equal(.productEntitlementMapping))
+        expect(call?.entryId).to(equal("default"))
+        expect(call?.topicEntry).to(equal(entry))
+        expect(call?.source).to(equal(src))
+    }
+
+    // MARK: - Empty / missing data
+
+    func testEmptySourcesSkipsTopicFetcherAndCompletesWithNil() {
+        self.remoteConfigAPI.stubbedResult = .success(makeResponse(
+            sources: [],
+            topics: [.productEntitlementMapping: ["default": makeEntry(blobRef: "abc")]]
+        ))
+
+        var receivedError: BackendError?
+        waitUntil { done in
+            self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false) { error in
+                receivedError = error
+                done()
+            }
+        }
+
+        expect(receivedError).to(beNil())
+        expect(self.topicFetcher.fetchCalls).to(beEmpty())
+    }
+
+    func testEmptyTopicsSkipsTopicFetcherAndCompletesWithNil() {
+        self.remoteConfigAPI.stubbedResult = .success(makeResponse(
+            sources: [makeSource(id: "primary")],
+            topics: [:]
+        ))
+
+        var receivedError: BackendError?
+        waitUntil { done in
+            self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false) { error in
+                receivedError = error
+                done()
+            }
+        }
+
+        expect(receivedError).to(beNil())
+        expect(self.topicFetcher.fetchCalls).to(beEmpty())
+    }
+
+    func testTopicWithoutDefaultEntryIdIsSkipped() {
+        self.remoteConfigAPI.stubbedResult = .success(makeResponse(
+            sources: [makeSource(id: "primary")],
+            topics: [.productEntitlementMapping: ["EXPERIMENT_A": makeEntry(blobRef: "abc")]]
+        ))
+
+        var receivedError: BackendError?
+        waitUntil { done in
+            self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false) { error in
+                receivedError = error
+                done()
+            }
+        }
+
+        expect(receivedError).to(beNil())
+        expect(self.topicFetcher.fetchCalls).to(beEmpty())
+    }
+
+    // MARK: - Source selection
+
+    func testSelectsFirstSourceWhenMultipleAvailable() {
+        let first = makeSource(id: "first")
+        let second = makeSource(id: "second")
+        self.remoteConfigAPI.stubbedResult = .success(makeResponse(
+            sources: [first, second],
+            topics: [.productEntitlementMapping: ["default": makeEntry(blobRef: "abc")]]
+        ))
+
+        waitUntil { done in
+            self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false) { _ in done() }
+        }
+
+        expect(self.topicFetcher.fetchCalls.first?.source).to(equal(first))
+    }
+
+    // MARK: - Error propagation
+
+    func testFetcherErrorIsForwardedToCompletion() {
+        let fetcherError = BackendError.networkError(.networkError(
+            NSError(domain: "test", code: -1, userInfo: nil)
+        ))
+        self.remoteConfigAPI.stubbedResult = .success(makeResponse(
+            sources: [makeSource(id: "primary")],
+            topics: [.productEntitlementMapping: ["default": makeEntry(blobRef: "abc")]]
+        ))
+        self.topicFetcher.stubbedFetchResult = fetcherError
+
+        var receivedError: BackendError?
+        waitUntil { done in
+            self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false) { error in
+                receivedError = error
+                done()
+            }
+        }
+
+        expect(receivedError).toNot(beNil())
+    }
+
+    func testBackendErrorShortCircuitsBeforeFetcher() {
+        let backendError = BackendError.networkError(.networkError(
+            NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet, userInfo: nil)
+        ))
+        self.remoteConfigAPI.stubbedResult = .failure(backendError)
+
+        var receivedError: BackendError?
+        waitUntil { done in
+            self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false) { error in
+                receivedError = error
+                done()
+            }
+        }
+
+        expect(receivedError).toNot(beNil())
+        expect(self.topicFetcher.fetchCalls).to(beEmpty())
+    }
+
+    // MARK: - isAppBackgrounded forwarding
+
+    func testIsAppBackgroundedIsForwardedToAPI() {
+        self.remoteConfigAPI.stubbedResult = .success(makeResponse(sources: [], topics: [:]))
+
+        waitUntil { done in
+            self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: true) { _ in done() }
+        }
+
+        expect(self.remoteConfigAPI.invokedIsAppBackgrounded).to(beTrue())
+    }
+
+    // MARK: - Nil completion
+
+    func testNilCompletionDoesNotCrash() {
+        self.remoteConfigAPI.stubbedResult = .success(makeResponse(
+            sources: [makeSource(id: "primary")],
+            topics: [.productEntitlementMapping: ["default": makeEntry(blobRef: "abc")]]
+        ))
+
+        self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false, completion: nil)
+
+        expect(self.topicFetcher.fetchCalls).toEventually(haveCount(1))
+    }
+
+    func testFetchRunsEvenWithNilCompletion() {
+        let src = makeSource(id: "primary")
+        let entry = makeEntry(blobRef: "abc")
+        self.remoteConfigAPI.stubbedResult = .success(makeResponse(
+            sources: [src],
+            topics: [.productEntitlementMapping: ["default": entry]]
+        ))
+
+        self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false, completion: nil)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount).toEventually(equal(1))
+        expect(self.topicFetcher.fetchCalls).toEventually(haveCount(1))
+    }
+
+}
+
+// MARK: - Helpers
+
+private extension RemoteConfigManagerTests {
+
+    func makeSource(id: String) -> RemoteConfigResponse.BlobSource {
+        RemoteConfigResponse.BlobSource(
+            id: id,
+            urlFormat: "https://assets.example.com/{blob_ref}",
+            priority: 0,
+            weight: 100
+        )
+    }
+
+    func makeEntry(blobRef: String) -> RemoteConfigResponse.TopicEntry {
+        RemoteConfigResponse.TopicEntry(blobRef: blobRef)
+    }
+
+    func makeResponse(
+        sources: [RemoteConfigResponse.BlobSource],
+        topics: [RemoteConfigResponse.Topic: [String: RemoteConfigResponse.TopicEntry]]
+    ) -> RemoteConfigResponse {
+        RemoteConfigResponse(
+            blobSources: sources,
+            manifest: RemoteConfigResponse.Manifest(topics: topics)
+        )
+    }
+
+}

--- a/Tests/UnitTests/RemoteConfig/TopicFetcherTests.swift
+++ b/Tests/UnitTests/RemoteConfig/TopicFetcherTests.swift
@@ -1,0 +1,373 @@
+//
+//  TopicFetcherTests.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 28/05/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import CryptoKit
+import Foundation
+import Nimble
+import OHHTTPStubs
+import OHHTTPStubsSwift
+import XCTest
+
+@testable import RevenueCat
+
+final class TopicFetcherTests: TestCase {
+
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        self.tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: self.tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        HTTPStubs.removeAllStubs()
+        try? FileManager.default.removeItem(at: self.tempDir)
+        super.tearDown()
+    }
+
+    // MARK: - Cache hit
+
+    func testCacheHitReturnsNilWithoutDownloading() async throws {
+        let payload = Data("{\"cached\":true}".utf8)
+        let blobRef = sha256Hex(payload)
+        let target = topicFile(topic: .productEntitlementMapping, blobRef: blobRef)
+        try FileManager.default.createDirectory(
+            at: target.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try payload.write(to: target)
+
+        var downloadAttempted = false
+        stub(condition: isHost("assets.example.com")) { _ in
+            downloadAttempted = true
+            return HTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
+        }
+
+        let error = await makeFetcher().fetchTopicIfNeeded(
+            topic: .productEntitlementMapping,
+            entryId: "default",
+            topicEntry: .init(blobRef: blobRef),
+            source: makeSource()
+        )
+
+        expect(error).to(beNil())
+        expect(downloadAttempted).to(beFalse())
+    }
+
+    // MARK: - Download + verify
+
+    func testDownloadVerifiesSHA256AndStoresAtExpectedPath() async {
+        let payload = Data("{\"hello\":\"world\"}".utf8)
+        let blobRef = sha256Hex(payload)
+        stubDownload(url: "https://assets.example.com/\(blobRef)", data: payload)
+
+        let error = await makeFetcher().fetchTopicIfNeeded(
+            topic: .productEntitlementMapping,
+            entryId: "default",
+            topicEntry: .init(blobRef: blobRef),
+            source: makeSource(urlFormat: "https://assets.example.com/{blob_ref}")
+        )
+
+        let target = topicFile(topic: .productEntitlementMapping, blobRef: blobRef)
+        expect(error).to(beNil())
+        expect(FileManager.default.fileExists(atPath: target.path)).to(beTrue())
+        expect(try? Data(contentsOf: target)).to(equal(payload))
+        expect(self.leftoverTempFiles(in: target.deletingLastPathComponent())).to(beEmpty())
+    }
+
+    func testDownloadSubstitutesBlobRefPlaceholderInURL() async {
+        let payload = Data("{}".utf8)
+        let blobRef = sha256Hex(payload)
+        let expectedURL = "https://cdn.example.com/topics/\(blobRef)"
+
+        var requestedURL: String?
+        stub(condition: isAbsoluteURLString(expectedURL)) { request in
+            requestedURL = request.url?.absoluteString
+            return HTTPStubsResponse(data: payload, statusCode: 200, headers: nil)
+        }
+
+        let error = await makeFetcher().fetchTopicIfNeeded(
+            topic: .productEntitlementMapping,
+            entryId: "default",
+            topicEntry: .init(blobRef: blobRef),
+            source: makeSource(urlFormat: "https://cdn.example.com/topics/{blob_ref}")
+        )
+
+        expect(error).to(beNil())
+        expect(requestedURL).to(equal(expectedURL))
+    }
+
+    // MARK: - Error cases
+
+    func testDownloadSurfacesErrorWhenHTTPNon200() async {
+        let payload = Data("{}".utf8)
+        let blobRef = sha256Hex(payload)
+        stubDownload(url: "https://assets.example.com/\(blobRef)", data: Data(), statusCode: 404)
+
+        let error = await makeFetcher().fetchTopicIfNeeded(
+            topic: .productEntitlementMapping,
+            entryId: "default",
+            topicEntry: .init(blobRef: blobRef),
+            source: makeSource(urlFormat: "https://assets.example.com/{blob_ref}")
+        )
+
+        expect(error).toNot(beNil())
+        let target = topicFile(topic: .productEntitlementMapping, blobRef: blobRef)
+        expect(FileManager.default.fileExists(atPath: target.path)).to(beFalse())
+    }
+
+    func testDownloadSurfacesErrorOnNetworkFailure() async {
+        let blobRef = String(repeating: "a", count: 64)
+        let networkError = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
+        stub(condition: isHost("assets.example.com")) { _ in
+            HTTPStubsResponse(error: networkError)
+        }
+
+        let error = await makeFetcher().fetchTopicIfNeeded(
+            topic: .productEntitlementMapping,
+            entryId: "default",
+            topicEntry: .init(blobRef: blobRef),
+            source: makeSource(urlFormat: "https://assets.example.com/{blob_ref}")
+        )
+
+        expect(error).toNot(beNil())
+        let target = topicFile(topic: .productEntitlementMapping, blobRef: blobRef)
+        expect(FileManager.default.fileExists(atPath: target.path)).to(beFalse())
+        expect(self.leftoverTempFiles(in: target.deletingLastPathComponent())).to(beEmpty())
+    }
+
+    func testDownloadSurfacesErrorWhenSHA256Mismatch() async {
+        let payload = Data("{\"actual\":\"contents\"}".utf8)
+        let wrongBlobRef = String(repeating: "0", count: 64)
+        stubDownload(url: "https://assets.example.com/\(wrongBlobRef)", data: payload)
+
+        let error = await makeFetcher().fetchTopicIfNeeded(
+            topic: .productEntitlementMapping,
+            entryId: "default",
+            topicEntry: .init(blobRef: wrongBlobRef),
+            source: makeSource(urlFormat: "https://assets.example.com/{blob_ref}")
+        )
+
+        expect(error).toNot(beNil())
+        let target = topicFile(topic: .productEntitlementMapping, blobRef: wrongBlobRef)
+        expect(FileManager.default.fileExists(atPath: target.path)).to(beFalse())
+        expect(self.leftoverTempFiles(in: target.deletingLastPathComponent())).to(beEmpty())
+    }
+
+    // MARK: - Write failure
+
+    func testDownloadSurfacesErrorWhenRenameFails() async {
+        let payload = Data("{\"hello\":\"world\"}".utf8)
+        let blobRef = sha256Hex(payload)
+        stubDownload(url: "https://assets.example.com/\(blobRef)", data: payload)
+
+        let renameError = NSError(domain: NSCocoaErrorDomain, code: NSFileWriteUnknownError)
+        let fetcher = TopicFetcher(
+            fileManager: FailingReplaceFileManager(replaceItemAtError: renameError),
+            baseCacheURL: self.tempDir
+        )
+
+        let error = await fetcher.fetchTopicIfNeeded(
+            topic: .productEntitlementMapping,
+            entryId: "default",
+            topicEntry: .init(blobRef: blobRef),
+            source: makeSource(urlFormat: "https://assets.example.com/{blob_ref}")
+        )
+
+        expect(error).toNot(beNil())
+        let target = topicFile(topic: .productEntitlementMapping, blobRef: blobRef)
+        expect(FileManager.default.fileExists(atPath: target.path)).to(beFalse())
+        expect(self.leftoverTempFiles(in: target.deletingLastPathComponent())).to(beEmpty())
+    }
+
+    // MARK: - Multiple entries
+
+    func testDownloadMultipleEntryIdsWriteToDistinctPaths() async {
+        let payloadA = Data("{\"entryId\":\"A\"}".utf8)
+        let payloadB = Data("{\"entryId\":\"B\"}".utf8)
+        let blobRefA = sha256Hex(payloadA)
+        let blobRefB = sha256Hex(payloadB)
+        stubDownload(url: "https://assets.example.com/\(blobRefA)", data: payloadA)
+        stubDownload(url: "https://assets.example.com/\(blobRefB)", data: payloadB)
+
+        let fetcher = makeFetcher()
+        let source = makeSource(urlFormat: "https://assets.example.com/{blob_ref}")
+
+        let errorA = await fetcher.fetchTopicIfNeeded(
+            topic: .productEntitlementMapping,
+            entryId: "default",
+            topicEntry: .init(blobRef: blobRefA),
+            source: source
+        )
+        let errorB = await fetcher.fetchTopicIfNeeded(
+            topic: .productEntitlementMapping,
+            entryId: "EXPERIMENT_A",
+            topicEntry: .init(blobRef: blobRefB),
+            source: source
+        )
+
+        expect(errorA).to(beNil())
+        expect(errorB).to(beNil())
+
+        let targetA = topicFile(topic: .productEntitlementMapping, blobRef: blobRefA)
+        let targetB = topicFile(topic: .productEntitlementMapping, blobRef: blobRefB)
+        expect(FileManager.default.fileExists(atPath: targetA.path)).to(beTrue())
+        expect(FileManager.default.fileExists(atPath: targetB.path)).to(beTrue())
+        expect(targetA).toNot(equal(targetB))
+        expect(try? Data(contentsOf: targetA)).to(equal(payloadA))
+        expect(try? Data(contentsOf: targetB)).to(equal(payloadB))
+    }
+
+    // MARK: - Blob ref validation
+
+    func testFetchTopicIfNeededRejectsMalformedBlobRef() async {
+        var downloadAttempted = false
+        stub(condition: isHost("assets.example.com")) { _ in
+            downloadAttempted = true
+            return HTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
+        }
+
+        let error = await makeFetcher().fetchTopicIfNeeded(
+            topic: .productEntitlementMapping,
+            entryId: "default",
+            topicEntry: .init(blobRef: "not-valid!"),
+            source: makeSource()
+        )
+
+        if case .unexpectedBackendResponse(.remoteConfigMalformedBlobRef, _, _) = error {
+            // expected
+        } else {
+            fail("Expected .unexpectedBackendResponse(.remoteConfigMalformedBlobRef), got \(String(describing: error))")
+        }
+        expect(downloadAttempted).to(beFalse())
+        let topicDir = tempDir
+            .appendingPathComponent("RevenueCat/topics")
+            .appendingPathComponent(RemoteConfigResponse.Topic.productEntitlementMapping.wireKey)
+        expect(FileManager.default.fileExists(atPath: topicDir.path) &&
+               (try? FileManager.default.contentsOfDirectory(atPath: topicDir.path))?.isEmpty == false
+        ).to(beFalse())
+    }
+
+    func testFetchTopicIfNeededRejectsPathTraversalBlobRef() async {
+        var downloadAttempted = false
+        stub(condition: isHost("assets.example.com")) { _ in
+            downloadAttempted = true
+            return HTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
+        }
+
+        let error = await makeFetcher().fetchTopicIfNeeded(
+            topic: .productEntitlementMapping,
+            entryId: "default",
+            topicEntry: .init(blobRef: "../../escape"),
+            source: makeSource()
+        )
+
+        if case .unexpectedBackendResponse(.remoteConfigMalformedBlobRef, _, _) = error {
+            // expected
+        } else {
+            fail("Expected .unexpectedBackendResponse(.remoteConfigMalformedBlobRef), got \(String(describing: error))")
+        }
+        expect(downloadAttempted).to(beFalse())
+        let escapedTarget = tempDir.deletingLastPathComponent().appendingPathComponent("escape")
+        expect(FileManager.default.fileExists(atPath: escapedTarget.path)).to(beFalse())
+    }
+
+    func testFetchTopicIfNeededAcceptsMixedCaseHexBlobRef() async {
+        let mixedCaseHex = "ABCDEFabcdef" + String(repeating: "0", count: 52)
+        stubDownload(url: "https://assets.example.com/\(mixedCaseHex)", data: Data("ignored".utf8))
+
+        let error = await makeFetcher().fetchTopicIfNeeded(
+            topic: .productEntitlementMapping,
+            entryId: "default",
+            topicEntry: .init(blobRef: mixedCaseHex),
+            source: makeSource(urlFormat: "https://assets.example.com/{blob_ref}")
+        )
+
+        // Validation passes; download was attempted (SHA-256 will mismatch since "ignored" != mixedCaseHex)
+        expect(error).toNot(beNil())
+        // Error is SHA-256 mismatch, not validation rejection — meaning the request was made
+        let target = topicFile(topic: .productEntitlementMapping, blobRef: mixedCaseHex)
+        expect(FileManager.default.fileExists(atPath: target.path)).to(beFalse())
+    }
+
+}
+
+// MARK: - Helpers
+
+private extension TopicFetcherTests {
+
+    func makeFetcher() -> TopicFetcher {
+        TopicFetcher(baseCacheURL: self.tempDir)
+    }
+
+    func makeSource(urlFormat: String = "https://assets.example.com/{blob_ref}") -> RemoteConfigResponse.BlobSource {
+        RemoteConfigResponse.BlobSource(id: "primary", urlFormat: urlFormat, priority: 0, weight: 100)
+    }
+
+    func topicFile(topic: RemoteConfigResponse.Topic, blobRef: String) -> URL {
+        self.tempDir
+            .appendingPathComponent("RevenueCat/topics")
+            .appendingPathComponent(topic.wireKey)
+            .appendingPathComponent(blobRef)
+    }
+
+    func leftoverTempFiles(in dir: URL) -> [URL] {
+        let contents = (try? FileManager.default.contentsOfDirectory(
+            at: dir,
+            includingPropertiesForKeys: nil
+        )) ?? []
+        return contents.filter { $0.lastPathComponent.hasPrefix("rc_topic_") }
+    }
+
+    func stubDownload(url: String, data: Data, statusCode: Int32 = 200) {
+        stub(condition: isAbsoluteURLString(url)) { _ in
+            HTTPStubsResponse(data: data, statusCode: statusCode, headers: nil)
+        }
+    }
+
+    func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+}
+
+private final class FailingReplaceFileManager: FileManaging {
+
+    private let replaceItemAtError: Error
+    private let base = FileManager.default
+
+    init(replaceItemAtError: Error) {
+        self.replaceItemAtError = replaceItemAtError
+    }
+
+    func fileExists(atPath path: String) -> Bool {
+        base.fileExists(atPath: path)
+    }
+
+    func createDirectory(
+        at url: URL,
+        withIntermediateDirectories createIntermediates: Bool,
+        attributes attr: [FileAttributeKey: Any]?
+    ) throws {
+        try base.createDirectory(at: url, withIntermediateDirectories: createIntermediates, attributes: attr)
+    }
+
+    func replaceItemAt(
+        _ originalItemURL: URL,
+        withItemAt newItemURL: URL,
+        backupItemName: String?,
+        options mask: FileManager.ItemReplacementOptions
+    ) throws -> URL? {
+        throw self.replaceItemAtError
+    }
+
+    func removeItem(at url: URL) throws {
+        try base.removeItem(at: url)
+    }
+
+}

--- a/Tests/UnitTests/RemoteConfig/TopicFetcherTests.swift
+++ b/Tests/UnitTests/RemoteConfig/TopicFetcherTests.swift
@@ -247,7 +247,7 @@ final class TopicFetcherTests: TestCase {
         expect(downloadAttempted).to(beFalse())
         let topicDir = tempDir
             .appendingPathComponent("RevenueCat/topics")
-            .appendingPathComponent(RemoteConfigResponse.Topic.productEntitlementMapping.wireKey)
+            .appendingPathComponent(RemoteConfigResponse.Topic.productEntitlementMapping.rawValue)
         expect(FileManager.default.fileExists(atPath: topicDir.path) &&
                (try? FileManager.default.contentsOfDirectory(atPath: topicDir.path))?.isEmpty == false
         ).to(beFalse())
@@ -313,7 +313,7 @@ private extension TopicFetcherTests {
     func topicFile(topic: RemoteConfigResponse.Topic, blobRef: String) -> URL {
         self.tempDir
             .appendingPathComponent("RevenueCat/topics")
-            .appendingPathComponent(topic.wireKey)
+            .appendingPathComponent(topic.rawValue)
             .appendingPathComponent(blobRef)
     }
 

--- a/Tests/UnitTests/RemoteConfig/TopicFetcherTests.swift
+++ b/Tests/UnitTests/RemoteConfig/TopicFetcherTests.swift
@@ -279,7 +279,9 @@ final class TopicFetcherTests: TestCase {
 
     func testFetchTopicIfNeededAcceptsMixedCaseHexBlobRef() async {
         let mixedCaseHex = "ABCDEFabcdef" + String(repeating: "0", count: 52)
-        stubDownload(url: "https://assets.example.com/\(mixedCaseHex)", data: Data("ignored".utf8))
+        let normalizedHex = mixedCaseHex.lowercased()
+        // The blob ref is normalized to lowercase before use, so the URL and cache path use normalizedHex.
+        stubDownload(url: "https://assets.example.com/\(normalizedHex)", data: Data("ignored".utf8))
 
         let error = await makeFetcher().fetchTopicIfNeeded(
             topic: .productEntitlementMapping,
@@ -288,10 +290,9 @@ final class TopicFetcherTests: TestCase {
             source: makeSource(urlFormat: "https://assets.example.com/{blob_ref}")
         )
 
-        // Validation passes; download was attempted (SHA-256 will mismatch since "ignored" != mixedCaseHex)
+        // Validation passes; download was attempted (SHA-256 will mismatch since "ignored" != normalizedHex)
         expect(error).toNot(beNil())
-        // Error is SHA-256 mismatch, not validation rejection — meaning the request was made
-        let target = topicFile(topic: .productEntitlementMapping, blobRef: mixedCaseHex)
+        let target = topicFile(topic: .productEntitlementMapping, blobRef: normalizedHex)
         expect(FileManager.default.fileExists(atPath: target.path)).to(beFalse())
     }
 

--- a/Tests/UnitTests/RemoteConfig/TopicFetcherTests.swift
+++ b/Tests/UnitTests/RemoteConfig/TopicFetcherTests.swift
@@ -169,6 +169,7 @@ final class TopicFetcherTests: TestCase {
         let renameError = NSError(domain: NSCocoaErrorDomain, code: NSFileWriteUnknownError)
         let fetcher = TopicFetcher(
             fileManager: FailingReplaceFileManager(replaceItemAtError: renameError),
+            downloader: URLSessionBlobDownloader(),
             baseCacheURL: self.tempDir
         )
 
@@ -303,7 +304,7 @@ final class TopicFetcherTests: TestCase {
 private extension TopicFetcherTests {
 
     func makeFetcher() -> TopicFetcher {
-        TopicFetcher(baseCacheURL: self.tempDir)
+        TopicFetcher(downloader: URLSessionBlobDownloader(), baseCacheURL: self.tempDir)
     }
 
     func makeSource(urlFormat: String = "https://assets.example.com/{blob_ref}") -> RemoteConfigResponse.BlobSource {

--- a/Tests/UnitTests/RemoteConfig/TopicFetcherTests.swift
+++ b/Tests/UnitTests/RemoteConfig/TopicFetcherTests.swift
@@ -367,6 +367,10 @@ private final class FailingReplaceFileManager: FileManaging {
         throw self.replaceItemAtError
     }
 
+    func copyItem(at srcURL: URL, to dstURL: URL) throws {
+        throw self.replaceItemAtError
+    }
+
     func removeItem(at url: URL) throws {
         try base.removeItem(at: url)
     }


### PR DESCRIPTION
This PR builds on #6854 and mirrors Android PR [#3437](https://github.com/RevenueCat/purchases-android/pull/3437)

Implements the `RemoteConfigManager`, responsible for fetching the config from the API using the `RemoteConfigAPI`, and subsequently calling the new `TopicFetcher` in order to fetch the topics found in the config (limit to 4 concurrently).

The `TopicManager` downloads the topic data to disk and verifies it's hash matches with the known hash (the blob_ref from the API). We currently only download the `default` topic entry. 

In this PR we currently pick the first api/blob source, this will be changed to use a decisive algorithm based on weights and priority in a follow up PR.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New network and on-disk caching path for remote config blobs with integrity checks; limited to default topic entries and first blob source until follow-up work lands.
> 
> **Overview**
> Adds **`RemoteConfigManager`** and **`TopicFetcher`** to drive the remote-config blob pipeline after the API returns a manifest.
> 
> **`updateRemoteConfigIfNeeded`** loads config via **`RemoteConfigAPI`**, uses the **first** blob source (weighted/priority selection deferred), and fetches manifest topics that have a **`default`** entry with up to **four** concurrent **`TopicFetcher`** calls. Errors from the API or any topic fetch are surfaced on an optional **MainActor** completion.
> 
> **`TopicFetcher`** skips work when a file already exists under **`RevenueCat/topics/{topic}/{blob_ref}`**, otherwise downloads from the source URL ( **`{blob_ref}`** substitution), **SHA-256**-checks the payload, and writes atomically. Invalid **`blob_ref`** values map to **`remoteConfigMalformedBlobRef`**; dedicated **`RemoteConfigStrings`** logging was added.
> 
> Unit tests and mocks cover manager orchestration, cache hits, hash mismatch, and blob validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a6fd80db86a7663b23899df41d3f75857dae7e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->