### PR TITLE
refactor: extract Offering.presentedOfferingContext helper and apply …

### DIFF
--- a/Sources/Paywalls/Events/CustomPaywallImpressionParams.swift
+++ b/Sources/Paywalls/Events/CustomPaywallImpressionParams.swift
@@ -80,7 +80,7 @@ public final class CustomPaywallImpressionParams: NSObject, Sendable {
         self.init(
             paywallId: paywallId,
             offeringId: offering.identifier,
-            presentedOfferingContext: offering.availablePackages.first?.presentedOfferingContext
+            presentedOfferingContext: offering.presentedOfferingContext
         )
     }
 

--- a/Sources/Paywalls/Events/PaywallEvent.swift
+++ b/Sources/Paywalls/Events/PaywallEvent.swift
@@ -176,7 +176,7 @@ extension PaywallEvent {
                 localeIdentifier: locale.identifier,
                 darkMode: darkMode,
                 source: nil,
-                presentedOfferingContext: offering.availablePackages.first?.presentedOfferingContext
+                presentedOfferingContext: offering.presentedOfferingContext
             )
         }
 
@@ -199,7 +199,7 @@ extension PaywallEvent {
                 localeIdentifier: locale.identifier,
                 darkMode: darkMode,
                 source: source,
-                presentedOfferingContext: offering.availablePackages.first?.presentedOfferingContext
+                presentedOfferingContext: offering.presentedOfferingContext
             )
         }
         #endif
@@ -223,7 +223,7 @@ extension PaywallEvent {
                 localeIdentifier: locale.identifier,
                 darkMode: darkMode,
                 source: nil,
-                presentedOfferingContext: offering.availablePackages.first?.presentedOfferingContext
+                presentedOfferingContext: offering.presentedOfferingContext
             )
         }
 
@@ -246,7 +246,7 @@ extension PaywallEvent {
                 localeIdentifier: locale.identifier,
                 darkMode: darkMode,
                 source: source,
-                presentedOfferingContext: offering.availablePackages.first?.presentedOfferingContext
+                presentedOfferingContext: offering.presentedOfferingContext
             )
         }
         // swiftlint:enable missing_docs

--- a/Sources/Purchasing/Offering.swift
+++ b/Sources/Purchasing/Offering.swift
@@ -303,6 +303,11 @@ import Foundation
 @_spi(Internal)
 public extension Offering {
 
+    /// The `PresentedOfferingContext` from the first available package, or `nil` if the offering has no packages.
+    var presentedOfferingContext: PresentedOfferingContext? {
+        return availablePackages.first?.presentedOfferingContext
+    }
+
     /// Copies the Offering and sets the given `presentedOfferingContext` on all `availablePackages`
     func withPresentedOfferingContext(_ presentedOfferingContext: PresentedOfferingContext) -> Self {
         return Self(

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -2298,11 +2298,11 @@ extension Purchases {
         } else if let offeringId = params.offeringId {
             let resolvedOffering = cachedOfferings?[offeringId]
             resolvedOfferingId = offeringId
-            resolvedPresentedOfferingContext = resolvedOffering?.availablePackages.first?.presentedOfferingContext
+            resolvedPresentedOfferingContext = resolvedOffering?.presentedOfferingContext
         } else {
             let resolvedOffering = cachedOfferings?.current
             resolvedOfferingId = resolvedOffering?.identifier
-            resolvedPresentedOfferingContext = resolvedOffering?.availablePackages.first?.presentedOfferingContext
+            resolvedPresentedOfferingContext = resolvedOffering?.presentedOfferingContext
         }
 
         Task {

--- a/Tests/UnitTests/Purchasing/OfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsTests.swift
@@ -555,6 +555,36 @@ class OfferingsTests: TestCase {
 
     }
 
+    // MARK: - presentedOfferingContext helper
+
+    func testPresentedOfferingContextReturnsContextFromFirstPackage() {
+        let context = PresentedOfferingContext(offeringIdentifier: "offering_a")
+        let package = Package(
+            identifier: "$rc_monthly",
+            packageType: .monthly,
+            storeProduct: StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "monthly")),
+            presentedOfferingContext: context,
+            webCheckoutUrl: nil
+        )
+        let offering = Offering(
+            identifier: "offering_a",
+            serverDescription: "",
+            availablePackages: [package],
+            webCheckoutUrl: nil
+        )
+        expect(offering.presentedOfferingContext) == context
+    }
+
+    func testPresentedOfferingContextIsNilForOfferingWithNoPackages() {
+        let offering = Offering(
+            identifier: "empty-offering",
+            serverDescription: "",
+            availablePackages: [],
+            webCheckoutUrl: nil
+        )
+        expect(offering.presentedOfferingContext).to(beNil())
+    }
+
     func testLifetimePackage() throws {
         try testPackageType(packageType: PackageType.lifetime)
     }


### PR DESCRIPTION
Mirrors Android PR https://github.com/RevenueCat/purchases-android/pull/3513

Added a small helper function for getting the `PresentedOfferingContext` from an Offering object as a follow up on https://github.com/RevenueCat/purchases-android/pull/3424#discussion_r3318327894

Replacing all occurrences of 
```
offering.availablePackages.first?.presentedOfferingContext
```

with the use of the new helper
```
offering.presentedOfferingContext
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with unit tests; only affects how placement/targeting context is read for analytics, not purchase logic.
> 
> **Overview**
> Adds an internal `Offering.presentedOfferingContext` helper (same behavior as reading the first package’s context, or `nil` when there are no packages) and switches paywall/custom-paywall code paths to use it instead of repeating `availablePackages.first?.presentedOfferingContext`.
> 
> Call sites updated include `CustomPaywallImpressionParams`, `PaywallEvent` initializers, and `Purchases.trackCustomPaywallImpression` when resolving context from cached offerings. Unit tests cover the helper for offerings with and without packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db14fa7701bfa295025300d70f19effbc5dc3db0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->