### PR TITLE
Make WinbackOfferEligibilityCalculator testable

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1369,6 +1369,8 @@
 		FDAADFD72BE2C67700BD1659 /* StoreKit2ObserverModePurchaseDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDAADFD52BE2C67700BD1659 /* StoreKit2ObserverModePurchaseDetectorTests.swift */; };
 		FDAC7B532CD3D67600DFC0D9 /* WinBackOfferEligibilityCalculatorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDAC7B522CD3D67600DFC0D9 /* WinBackOfferEligibilityCalculatorType.swift */; };
 		FDAC7B552CD3D7A500DFC0D9 /* WinBackOfferEligibilityCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDAC7B542CD3D7A200DFC0D9 /* WinBackOfferEligibilityCalculator.swift */; };
+		FDAC7B592CF000000DFC0D9 /* WinBackEligibilityAdapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDAC7B5A2CF000000DFC0D9 /* WinBackEligibilityAdapters.swift */; };
+		FDAC7B5C2CF100000DFC0D9 /* WinBackOfferEligibilityCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDAC7B5B2CF100000DFC0D9 /* WinBackOfferEligibilityCalculatorTests.swift */; };
 		FDAC7B572CD3FD8500DFC0D9 /* MockWinBackOfferEligibilityCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDAC7B562CD3FD8500DFC0D9 /* MockWinBackOfferEligibilityCalculator.swift */; };
 		FDAC7B582CD3FD8500DFC0D9 /* MockWinBackOfferEligibilityCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDAC7B562CD3FD8500DFC0D9 /* MockWinBackOfferEligibilityCalculator.swift */; };
 		FDAC7B5B2CD4085800DFC0D9 /* PurchasesWinBackOfferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDAC7B5A2CD4085800DFC0D9 /* PurchasesWinBackOfferTests.swift */; };
@@ -2925,7 +2927,9 @@
 		FDAADFD52BE2C67700BD1659 /* StoreKit2ObserverModePurchaseDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2ObserverModePurchaseDetectorTests.swift; sourceTree = "<group>"; };
 		FDAC7B522CD3D67600DFC0D9 /* WinBackOfferEligibilityCalculatorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WinBackOfferEligibilityCalculatorType.swift; sourceTree = "<group>"; };
 		FDAC7B542CD3D7A200DFC0D9 /* WinBackOfferEligibilityCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WinBackOfferEligibilityCalculator.swift; sourceTree = "<group>"; };
+		FDAC7B5A2CF000000DFC0D9 /* WinBackEligibilityAdapters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WinBackEligibilityAdapters.swift; sourceTree = "<group>"; };
 		FDAC7B562CD3FD8500DFC0D9 /* MockWinBackOfferEligibilityCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWinBackOfferEligibilityCalculator.swift; sourceTree = "<group>"; };
+		FDAC7B5B2CF100000DFC0D9 /* WinBackOfferEligibilityCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WinBackOfferEligibilityCalculatorTests.swift; sourceTree = "<group>"; };
 		FDAC7B5A2CD4085800DFC0D9 /* PurchasesWinBackOfferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesWinBackOfferTests.swift; sourceTree = "<group>"; };
 		FDC4BBBC2FB4B904000AC203 /* BillingPlanType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillingPlanType.swift; sourceTree = "<group>"; };
 		FDC4BBC32FB4B914000AC203 /* BillingPlanTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillingPlanTypeTests.swift; sourceTree = "<group>"; };
@@ -4801,6 +4805,7 @@
 				57E6194F28D291DC0093170C /* StoreKit2CachingProductsManagerTests.swift */,
 				4FD291BD2A1E9A2E0098D1B9 /* StoreKit2TransactionFetcherTests.swift */,
 				FDAADFD52BE2C67700BD1659 /* StoreKit2ObserverModePurchaseDetectorTests.swift */,
+				FDAC7B5D2CF100000DFC0D9 /* Win-Back Offers */,
 			);
 			path = StoreKit2;
 			sourceTree = "<group>";
@@ -6250,7 +6255,16 @@
 			isa = PBXGroup;
 			children = (
 				FDAC7B542CD3D7A200DFC0D9 /* WinBackOfferEligibilityCalculator.swift */,
+				FDAC7B5A2CF000000DFC0D9 /* WinBackEligibilityAdapters.swift */,
 				FDAC7B522CD3D67600DFC0D9 /* WinBackOfferEligibilityCalculatorType.swift */,
+			);
+			path = "Win-Back Offers";
+			sourceTree = "<group>";
+		};
+		FDAC7B5D2CF100000DFC0D9 /* Win-Back Offers */ = {
+			isa = PBXGroup;
+			children = (
+				FDAC7B5B2CF100000DFC0D9 /* WinBackOfferEligibilityCalculatorTests.swift */,
 			);
 			path = "Win-Back Offers";
 			sourceTree = "<group>";
@@ -6878,6 +6892,7 @@
 				2D90F8CC26FD2BA1009B9142 /* StoreKitConfigTestCase.swift in Sources */,
 				2D90F8BC26FD20C2009B9142 /* MockReceiptParser.swift in Sources */,
 				57488C8329CB91D20000EE7E /* CustomerInfoOfflineEntitlementsStoreKitTest.swift in Sources */,
+				FDAC7B5C2CF100000DFC0D9 /* WinBackOfferEligibilityCalculatorTests.swift in Sources */,
 				FD2046812CB8333A00166727 /* StoreKit2PurchaseIntentListenerTests.swift in Sources */,
 				57DE80812807529F008D6C6F /* MockStorefront.swift in Sources */,
 				FD6D87582FAE4CD400CAF0F2 /* MockProductsRequestFactory.swift in Sources */,
@@ -7370,6 +7385,7 @@
 				4F6BEDE02A26B65900CD9322 /* DebugViewSheetPresentation.swift in Sources */,
 				4F6BEDD92A26B55C00CD9322 /* DebugViewModel.swift in Sources */,
 				FDAC7B552CD3D7A500DFC0D9 /* WinBackOfferEligibilityCalculator.swift in Sources */,
+				FDAC7B592CF000000DFC0D9 /* WinBackEligibilityAdapters.swift in Sources */,
 				FDE57AA02DF8785000101CE2 /* VirtualCurrenciesResponse.swift in Sources */,
 				16A7F4C32E563B91001F9FC8 /* PaywallAnimation.swift in Sources */,
 				FDA6F96F2E035544008BF232 /* VirtualCurrencyStrings.swift in Sources */,

--- a/Sources/Purchasing/StoreKit2/Win-Back Offers/WinBackEligibilityAdapters.swift
+++ b/Sources/Purchasing/StoreKit2/Win-Back Offers/WinBackEligibilityAdapters.swift
@@ -22,6 +22,7 @@ import StoreKit
 internal enum WinBackEligibilityOwnershipType: Sendable {
     case purchased
     case familyShared
+    case unknown
 }
 
 internal protocol WinBackEligibilityProductType: Sendable {
@@ -142,7 +143,7 @@ private struct StoreKitWinBackStatus: WinBackEligibilityStatusType {
         case .familyShared:
             return .familyShared
         default:
-            return .purchased
+            return .unknown
         }
     }
 
@@ -193,11 +194,15 @@ private struct StoreKitWinBackOffer: WinBackEligibilityOfferType {
 @available(iOS 26.4, tvOS 26.4, macOS 26.4, watchOS 26.4, visionOS 26.4, *)
 private struct StoreKitWinBackPricingTerms: WinBackEligibilityPricingTermsType {
 
+    #if compiler(>=6.3.2)
     private let pricingTerms: Product.SubscriptionInfo.PricingTerms
+    #endif
 
+    #if compiler(>=6.3.2)
     init(_ pricingTerms: Product.SubscriptionInfo.PricingTerms) {
         self.pricingTerms = pricingTerms
     }
+    #endif
 
     var billingPlanType: BillingPlanType? {
         return BillingPlanType.from(storeKitBillingPlanType: self.pricingTerms.billingPlanType)

--- a/Sources/Purchasing/StoreKit2/Win-Back Offers/WinBackEligibilityAdapters.swift
+++ b/Sources/Purchasing/StoreKit2/Win-Back Offers/WinBackEligibilityAdapters.swift
@@ -110,7 +110,11 @@ private struct StoreKitWinBackSubscriptionInfo: WinBackEligibilitySubscriptionIn
     }
 
     var winBackOffers: [any WinBackEligibilityOfferType] {
-        return self.subscriptionInfo.winBackOffers.map(StoreKitWinBackOffer.init)
+        if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+            return self.subscriptionInfo.winBackOffers.map(StoreKitWinBackOffer.init)
+        } else {
+            return []
+        }
     }
 
     var pricingTerms: [any WinBackEligibilityPricingTermsType] {
@@ -163,9 +167,12 @@ private struct StoreKitWinBackRenewalInfo: WinBackEligibilityRenewalInfoType {
     }
 
     var eligibleWinBackOfferIDs: [String] {
-        return self.renewalInfo.eligibleWinBackOfferIDs
+        if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+            return self.renewalInfo.eligibleWinBackOfferIDs
+        } else {
+            return []
+        }
     }
-
 }
 
 @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)

--- a/Sources/Purchasing/StoreKit2/Win-Back Offers/WinBackEligibilityAdapters.swift
+++ b/Sources/Purchasing/StoreKit2/Win-Back Offers/WinBackEligibilityAdapters.swift
@@ -216,7 +216,7 @@ private struct StoreKitWinBackPricingTerms: WinBackEligibilityPricingTermsType {
         #if compiler(>=6.3.2)
         return self.pricingTerms.subscriptionOffers.map(StoreKitWinBackOffer.init)
         #else
-        return self.subscriptionOffers.map(StoreKitWinBackOffer.init)
+        return []
         #endif
     }
 

--- a/Sources/Purchasing/StoreKit2/Win-Back Offers/WinBackEligibilityAdapters.swift
+++ b/Sources/Purchasing/StoreKit2/Win-Back Offers/WinBackEligibilityAdapters.swift
@@ -205,11 +205,19 @@ private struct StoreKitWinBackPricingTerms: WinBackEligibilityPricingTermsType {
     #endif
 
     var billingPlanType: BillingPlanType? {
+        #if compiler(>=6.3.2)
         return BillingPlanType.from(storeKitBillingPlanType: self.pricingTerms.billingPlanType)
+        #else
+        return nil
+        #endif
     }
 
     var subscriptionOffers: [any WinBackEligibilityOfferType] {
+        #if compiler(>=6.3.2)
         return self.pricingTerms.subscriptionOffers.map(StoreKitWinBackOffer.init)
+        #else
+        return self.subscriptionOffers.map(StoreKitWinBackOffer.init)
+        #endif
     }
 
 }

--- a/Sources/Purchasing/StoreKit2/Win-Back Offers/WinBackEligibilityAdapters.swift
+++ b/Sources/Purchasing/StoreKit2/Win-Back Offers/WinBackEligibilityAdapters.swift
@@ -14,11 +14,19 @@
 import StoreKit
 
 // This file isolates StoreKit-backed win-back eligibility adapters behind simple internal protocols.
-// That keeps the calculator's core logic easy to unit test with mocks, without instantiating StoreKit
-// types or relying on StoreKit configuration files.
+// That keeps the WinBackEligibilityCalculator's core logic easy to unit test with mocks,
+// without instantiating StoreKit types or relying on StoreKit configuration files.
+//
+// We need to do this to make WinBackEligibilityCalculator testable since there's a bug that
+// prevents us from loading SKConfig files with SKTestSession in iOS 26.4+, and the APIs
+// for evaluating winback offer eligibility on billing plans are only available on Xcode 26.5+.
+// For more information on this bug, refer to:
+//    - https://developer.apple.com/forums/thread/826971
+//    - FB22500243
+// When this issue is resolved, we may be able to replace this dependency inversion
+// and its associated tests with SKTestSession-based tests.
 
 // MARK: - Testable StoreKit-free types
-
 internal enum WinBackEligibilityOwnershipType: Sendable {
     case purchased
     case familyShared
@@ -87,7 +95,6 @@ extension WinBackOfferEligibilityCalculator {
         return nil
         #endif
     }
-
 }
 
 private struct StoreKitWinBackProduct: WinBackEligibilityProductType {
@@ -132,7 +139,6 @@ private struct StoreKitWinBackSubscriptionInfo: WinBackEligibilitySubscriptionIn
         return []
         #endif
     }
-
 }
 
 @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
@@ -158,7 +164,6 @@ private struct StoreKitWinBackStatus: WinBackEligibilityStatusType {
     var verifiedRenewalInfo: (any WinBackEligibilityRenewalInfoType)? {
         return self.status.verifiedRenewalInfo.map(StoreKitWinBackRenewalInfo.init)
     }
-
 }
 
 @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
@@ -203,7 +208,6 @@ private struct StoreKitWinBackOffer: WinBackEligibilityOfferType {
     func storeProductDiscount(currencyCode: String?) -> StoreProductDiscount? {
         return StoreProductDiscount(sk2Discount: self.offer, currencyCode: currencyCode)
     }
-
 }
 
 @available(iOS 26.4, tvOS 26.4, macOS 26.4, watchOS 26.4, visionOS 26.4, *)
@@ -234,7 +238,6 @@ private struct StoreKitWinBackPricingTerms: WinBackEligibilityPricingTermsType {
         return []
         #endif
     }
-
 }
 
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)

--- a/Sources/Purchasing/StoreKit2/Win-Back Offers/WinBackEligibilityAdapters.swift
+++ b/Sources/Purchasing/StoreKit2/Win-Back Offers/WinBackEligibilityAdapters.swift
@@ -110,11 +110,15 @@ private struct StoreKitWinBackSubscriptionInfo: WinBackEligibilitySubscriptionIn
     }
 
     var winBackOffers: [any WinBackEligibilityOfferType] {
+        #if compiler(>=6.0)
         if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
             return self.subscriptionInfo.winBackOffers.map(StoreKitWinBackOffer.init)
         } else {
             return []
         }
+        #else
+        return []
+        #endif
     }
 
     var pricingTerms: [any WinBackEligibilityPricingTermsType] {
@@ -167,11 +171,15 @@ private struct StoreKitWinBackRenewalInfo: WinBackEligibilityRenewalInfoType {
     }
 
     var eligibleWinBackOfferIDs: [String] {
+        #if compiler(>=6.0)
         if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
             return self.renewalInfo.eligibleWinBackOfferIDs
         } else {
             return []
         }
+        #else
+        return []
+        #endif
     }
 }
 

--- a/Sources/Purchasing/StoreKit2/Win-Back Offers/WinBackEligibilityAdapters.swift
+++ b/Sources/Purchasing/StoreKit2/Win-Back Offers/WinBackEligibilityAdapters.swift
@@ -1,0 +1,227 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WinBackEligibilityAdapters.swift
+//
+//  Created by Will Taylor on 5/28/26.
+
+import StoreKit
+
+// This file isolates StoreKit-backed win-back eligibility adapters behind simple internal protocols.
+// That keeps the calculator's core logic easy to unit test with mocks, without instantiating StoreKit
+// types or relying on StoreKit configuration files.
+
+// MARK: - Testable StoreKit-free types
+
+internal enum WinBackEligibilityOwnershipType: Sendable {
+    case purchased
+    case familyShared
+}
+
+internal protocol WinBackEligibilityProductType: Sendable {
+    var currencyCode: String? { get }
+    var billingPlanType: BillingPlanType? { get }
+    var subscriptionInfo: (any WinBackEligibilitySubscriptionInfoType)? { get }
+}
+
+internal protocol WinBackEligibilitySubscriptionInfoType: Sendable {
+    func statuses() async throws -> [any WinBackEligibilityStatusType]
+
+    var winBackOffers: [any WinBackEligibilityOfferType] { get }
+    var pricingTerms: [any WinBackEligibilityPricingTermsType] { get }
+}
+
+internal protocol WinBackEligibilityStatusType: Sendable {
+    var ownershipType: WinBackEligibilityOwnershipType { get }
+    var verifiedRenewalInfo: (any WinBackEligibilityRenewalInfoType)? { get }
+}
+
+internal protocol WinBackEligibilityRenewalInfoType: Sendable {
+    var eligibleWinBackOfferIDs: [String] { get }
+}
+
+internal protocol WinBackEligibilityOfferType: Sendable {
+    var id: String? { get }
+    var type: StoreProductDiscount.DiscountType { get }
+
+    func storeProductDiscount(currencyCode: String?) -> StoreProductDiscount?
+}
+
+internal protocol WinBackEligibilityPricingTermsType: Sendable {
+    var billingPlanType: BillingPlanType? { get }
+    var subscriptionOffers: [any WinBackEligibilityOfferType] { get }
+}
+
+// MARK: - StoreKit adapters
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+extension WinBackOfferEligibilityCalculator {
+
+    func storeKitWinBackEligibilityProduct(from product: StoreProduct) -> (any WinBackEligibilityProductType)? {
+        guard let subscriptionInfo = product.sk2Product?.subscription else {
+            return nil
+        }
+
+        return StoreKitWinBackProduct(
+            currencyCode: product.currencyCode,
+            billingPlanType: self.storeKitWinBackBillingPlanType(from: product),
+            subscriptionInfo: StoreKitWinBackSubscriptionInfo(subscriptionInfo)
+        )
+    }
+
+    private func storeKitWinBackBillingPlanType(from product: StoreProduct) -> BillingPlanType? {
+        #if compiler(>=6.3.2)
+        if #available(iOS 26.4, tvOS 26.4, macOS 26.4, watchOS 26.4, visionOS 26.4, *) {
+            return product.installmentsInfo?.billingPlanType
+        } else {
+            return nil
+        }
+        #else
+        return nil
+        #endif
+    }
+
+}
+
+private struct StoreKitWinBackProduct: WinBackEligibilityProductType {
+    let currencyCode: String?
+    let billingPlanType: BillingPlanType?
+    let subscriptionInfo: (any WinBackEligibilitySubscriptionInfoType)?
+}
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+private struct StoreKitWinBackSubscriptionInfo: WinBackEligibilitySubscriptionInfoType {
+
+    private let subscriptionInfo: Product.SubscriptionInfo
+
+    init(_ subscriptionInfo: Product.SubscriptionInfo) {
+        self.subscriptionInfo = subscriptionInfo
+    }
+
+    func statuses() async throws -> [any WinBackEligibilityStatusType] {
+        return try await self.subscriptionInfo.status.map(StoreKitWinBackStatus.init)
+    }
+
+    var winBackOffers: [any WinBackEligibilityOfferType] {
+        return self.subscriptionInfo.winBackOffers.map(StoreKitWinBackOffer.init)
+    }
+
+    var pricingTerms: [any WinBackEligibilityPricingTermsType] {
+        #if compiler(>=6.3.2)
+        if #available(iOS 26.4, tvOS 26.4, macOS 26.4, watchOS 26.4, visionOS 26.4, *) {
+            return self.subscriptionInfo.pricingTerms.map(StoreKitWinBackPricingTerms.init)
+        } else {
+            return []
+        }
+        #else
+        return []
+        #endif
+    }
+
+}
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+private struct StoreKitWinBackStatus: WinBackEligibilityStatusType {
+
+    private let status: Product.SubscriptionInfo.Status
+
+    init(_ status: Product.SubscriptionInfo.Status) {
+        self.status = status
+    }
+
+    var ownershipType: WinBackEligibilityOwnershipType {
+        switch self.status.transaction.unsafePayloadValue.ownershipType {
+        case .purchased:
+            return .purchased
+        case .familyShared:
+            return .familyShared
+        default:
+            return .purchased
+        }
+    }
+
+    var verifiedRenewalInfo: (any WinBackEligibilityRenewalInfoType)? {
+        return self.status.verifiedRenewalInfo.map(StoreKitWinBackRenewalInfo.init)
+    }
+
+}
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+private struct StoreKitWinBackRenewalInfo: WinBackEligibilityRenewalInfoType {
+
+    private let renewalInfo: Product.SubscriptionInfo.RenewalInfo
+
+    init(_ renewalInfo: Product.SubscriptionInfo.RenewalInfo) {
+        self.renewalInfo = renewalInfo
+    }
+
+    var eligibleWinBackOfferIDs: [String] {
+        return self.renewalInfo.eligibleWinBackOfferIDs
+    }
+
+}
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+private struct StoreKitWinBackOffer: WinBackEligibilityOfferType {
+
+    private let offer: Product.SubscriptionOffer
+
+    init(_ offer: Product.SubscriptionOffer) {
+        self.offer = offer
+    }
+
+    var id: String? {
+        return self.offer.id
+    }
+
+    var type: StoreProductDiscount.DiscountType {
+        return StoreProductDiscount.DiscountType.from(sk2Discount: self.offer) ?? .promotional
+    }
+
+    func storeProductDiscount(currencyCode: String?) -> StoreProductDiscount? {
+        return StoreProductDiscount(sk2Discount: self.offer, currencyCode: currencyCode)
+    }
+
+}
+
+@available(iOS 26.4, tvOS 26.4, macOS 26.4, watchOS 26.4, visionOS 26.4, *)
+private struct StoreKitWinBackPricingTerms: WinBackEligibilityPricingTermsType {
+
+    private let pricingTerms: Product.SubscriptionInfo.PricingTerms
+
+    init(_ pricingTerms: Product.SubscriptionInfo.PricingTerms) {
+        self.pricingTerms = pricingTerms
+    }
+
+    var billingPlanType: BillingPlanType? {
+        return BillingPlanType.from(storeKitBillingPlanType: self.pricingTerms.billingPlanType)
+    }
+
+    var subscriptionOffers: [any WinBackEligibilityOfferType] {
+        return self.pricingTerms.subscriptionOffers.map(StoreKitWinBackOffer.init)
+    }
+
+}
+
+@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+extension StoreKit.Product.SubscriptionInfo.Status {
+    var verifiedRenewalInfo: StoreKit.Product.SubscriptionInfo.RenewalInfo? {
+        switch self.renewalInfo {
+        case .unverified:
+            Logger.warn(
+                Strings.storeKit.sk2_unverified_renewal_info(
+                    productIdentifier: String(self.transaction.underlyingTransaction.productID)
+                )
+            )
+            return nil
+        case .verified(let status):
+            return status
+        }
+    }
+}

--- a/Sources/Purchasing/StoreKit2/Win-Back Offers/WinBackOfferEligibilityCalculator.swift
+++ b/Sources/Purchasing/StoreKit2/Win-Back Offers/WinBackOfferEligibilityCalculator.swift
@@ -11,8 +11,6 @@
 //
 //  Created by Will Taylor on 10/31/24.
 
-import StoreKit
-
 @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 final class WinBackOfferEligibilityCalculator: Sendable {
 
@@ -55,10 +53,26 @@ extension WinBackOfferEligibilityCalculator {
             throw ErrorUtils.featureNotSupportedWithStoreKit1Error()
         }
 
+        guard let product = self.storeKitWinBackEligibilityProduct(from: product) else {
+            return []
+        }
+
+        return await self.calculateEligibleWinBackOffers(forProduct: product)
+        #else
+        return []
+        #endif
+    }
+
+    @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+    func calculateEligibleWinBackOffers(
+        forProduct product: any WinBackEligibilityProductType
+    ) async -> [WinBackOffer] {
+
+        #if compiler(>=6.0)
         let eligibleWinBackOfferIDs: [String] = await self.calculateEligibleWinBackOfferIDs(forProduct: product)
         guard !eligibleWinBackOfferIDs.isEmpty else { return [] }
 
-        let winbackOffersByID: [String: Product.SubscriptionOffer] = self.winbackOffersByID(for: product)
+        let winbackOffersByID: [String: any WinBackEligibilityOfferType] = self.winbackOffersByID(for: product)
         guard !winbackOffersByID.isEmpty else { return [] }
 
         let eligibleWinBackOffers: [WinBackOffer] = eligibleWinBackOfferIDs
@@ -67,7 +81,7 @@ extension WinBackOfferEligibilityCalculator {
                 guard let winbackOffer = winbackOffersByID[winbackOfferID] else {
                     return nil
                 }
-                return StoreProductDiscount(sk2Discount: winbackOffer, currencyCode: product.currencyCode)
+                return winbackOffer.storeProductDiscount(currencyCode: product.currencyCode)
             }
             // Convert the StoreProductDiscounts to WinBackOffer objects
             .map { WinBackOffer(discount: $0) }
@@ -79,14 +93,16 @@ extension WinBackOfferEligibilityCalculator {
     }
 
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
-    private func calculateEligibleWinBackOfferIDs(forProduct product: StoreProduct) async -> [String] {
+    private func calculateEligibleWinBackOfferIDs(
+        forProduct product: any WinBackEligibilityProductType
+    ) async -> [String] {
         #if compiler(>=6.0)
-        guard let subscriptionInfo = product.sk2Product?.subscription else {
+        guard let subscriptionInfo = product.subscriptionInfo else {
             // If StoreKit.Product.subscription is nil, then the product isn't a subscription
             return []
         }
 
-        guard let statuses = try? await subscriptionInfo.status, !statuses.isEmpty else {
+        guard let statuses = try? await subscriptionInfo.statuses(), !statuses.isEmpty else {
             // If statuses is empty, the subscriber was never subscribed to a product in the subscription group.
             return []
         }
@@ -95,7 +111,7 @@ extension WinBackOfferEligibilityCalculator {
         // Thus, there can be at most 1 renewalInfo that is not a family shared one.
         // See https://developer.apple.com/videos/play/wwdc2024/10110/ for an example.
         guard let purchaseSubscriptionStatus = statuses.first(where: {
-            $0.transaction.unsafePayloadValue.ownershipType == .purchased
+            $0.ownershipType == .purchased
         }) else {
             return []
         }
@@ -111,7 +127,7 @@ extension WinBackOfferEligibilityCalculator {
         #if compiler(>=6.3.2)
         if #available(iOS 26.4, tvOS 26.4, macOS 26.4, watchOS 26.4, visionOS 26.4, *) {
             let availableOfferIDs: Set<String>
-            if let billingPlan = product.installmentsInfo?.billingPlanType {
+            if let billingPlan = product.billingPlanType {
                 availableOfferIDs = availableWinBackOfferIDs(
                     forBillingPlan: billingPlan,
                     subscriptionInfo: subscriptionInfo
@@ -137,12 +153,12 @@ extension WinBackOfferEligibilityCalculator {
 
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     private func winbackOffersByID(
-        for product: StoreProduct
-    ) -> [String: Product.SubscriptionOffer] {
+        for product: any WinBackEligibilityProductType
+    ) -> [String: any WinBackEligibilityOfferType] {
         #if compiler(>=6.0)
-        var winbackOffersByID: [String: Product.SubscriptionOffer] = [:]
+        var winbackOffersByID: [String: any WinBackEligibilityOfferType] = [:]
 
-        guard let subscriptionInfo = product.sk2Product?.subscription else {
+        guard let subscriptionInfo = product.subscriptionInfo else {
             return winbackOffersByID
         }
 
@@ -176,33 +192,15 @@ extension WinBackOfferEligibilityCalculator {
     }
 }
 
-@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
-extension StoreKit.Product.SubscriptionInfo.Status {
-    var verifiedRenewalInfo: StoreKit.Product.SubscriptionInfo.RenewalInfo? {
-        switch self.renewalInfo {
-        case .unverified:
-            Logger.warn(
-                Strings.storeKit.sk2_unverified_renewal_info(
-                    productIdentifier: String(self.transaction.underlyingTransaction.productID)
-                )
-            )
-            return nil
-        case .verified(let status):
-            return status
-        }
-    }
-}
-
 @available(iOS 26.4, tvOS 26.4, macOS 26.4, watchOS 26.4, *)
 private extension WinBackOfferEligibilityCalculator {
     private func availableWinBackOfferIDs(
         forBillingPlan billingPlanType: BillingPlanType,
-        subscriptionInfo: Product.SubscriptionInfo
+        subscriptionInfo: any WinBackEligibilitySubscriptionInfoType
     ) -> Set<String> {
         #if compiler(>=6.3.2)
-        let skBillingPlanType = billingPlanType.skBillingPlanType
         guard let applicablePricingTerms = subscriptionInfo.pricingTerms.first(where: {
-            $0.billingPlanType == skBillingPlanType
+            $0.billingPlanType == billingPlanType
         }) else {
             // The user is not eligible for pricing terms with the requested billing plan. Therefore, they are
             // not eligible for winback offers on that given billing plan type.

--- a/Tests/StoreKitUnitTests/StoreKit2/Win-Back Offers/WinBackOfferEligibilityCalculatorTests.swift
+++ b/Tests/StoreKitUnitTests/StoreKit2/Win-Back Offers/WinBackOfferEligibilityCalculatorTests.swift
@@ -1,0 +1,355 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WinBackOfferEligibilityCalculatorTests.swift
+//
+//  Created by Will Taylor on 5/27/26.
+
+import Nimble
+@testable @_spi(Internal) import RevenueCat
+import XCTest
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+final class WinBackOfferEligibilityCalculatorTests: TestCase {
+
+    private var calculator: WinBackOfferEligibilityCalculator!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try AvailabilityChecks.iOS18APIAvailableOrSkipTest()
+
+        self.calculator = WinBackOfferEligibilityCalculator(
+            systemInfo: MockSystemInfo(finishTransactions: true, storeKitVersion: .storeKit2)
+        )
+    }
+
+    func testReturnsEmptyForProductWithoutSubscriptionInfo() async {
+        let product = MockWinBackEligibilityProduct(subscriptionInfo: nil)
+
+        let offers = await self.calculator.calculateEligibleWinBackOffers(forProduct: product)
+
+        expect(offers).to(beEmpty())
+    }
+
+    func testReturnsEmptyWhenStatusLookupFails() async {
+        let product = MockWinBackEligibilityProduct(
+            subscriptionInfo: MockWinBackEligibilitySubscriptionInfo(statusesResult: .failure(MockError.mockError))
+        )
+
+        let offers = await self.calculator.calculateEligibleWinBackOffers(forProduct: product)
+
+        expect(offers).to(beEmpty())
+    }
+
+    func testReturnsEmptyWhenThereAreNoStatuses() async {
+        let product = MockWinBackEligibilityProduct(
+            subscriptionInfo: MockWinBackEligibilitySubscriptionInfo(statuses: [])
+        )
+
+        let offers = await self.calculator.calculateEligibleWinBackOffers(forProduct: product)
+
+        expect(offers).to(beEmpty())
+    }
+
+    func testReturnsEmptyWhenPurchasedStatusHasNoVerifiedRenewalInfo() async {
+        let product = MockWinBackEligibilityProduct(
+            subscriptionInfo: MockWinBackEligibilitySubscriptionInfo(
+                statuses: [
+                    MockWinBackEligibilityStatus(
+                        ownershipType: .purchased,
+                        verifiedRenewalInfo: nil
+                    )
+                ],
+                winBackOffers: [MockWinBackEligibilityOffer.winBack(identifier: "winback_offer")]
+            )
+        )
+
+        let offers = await self.calculator.calculateEligibleWinBackOffers(forProduct: product)
+
+        expect(offers).to(beEmpty())
+    }
+
+    func testReturnsEligibleWinBackOffersInOrder() async {
+        let product = MockWinBackEligibilityProduct(
+            subscriptionInfo: MockWinBackEligibilitySubscriptionInfo(
+                statuses: [
+                    MockWinBackEligibilityStatus(
+                        ownershipType: .purchased,
+                        eligibleWinBackOfferIDs: ["first_offer", "second_offer"]
+                    )
+                ],
+                winBackOffers: [
+                    MockWinBackEligibilityOffer.winBack(identifier: "first_offer"),
+                    MockWinBackEligibilityOffer.winBack(identifier: "second_offer"),
+                    MockWinBackEligibilityOffer.winBack(identifier: "ineligible_offer")
+                ]
+            )
+        )
+
+        let offers = await self.calculator.calculateEligibleWinBackOffers(forProduct: product)
+
+        expect(offers.map(\.discount.offerIdentifier)) == ["first_offer", "second_offer"]
+    }
+
+    func testFiltersOutEligibleIDsThatDoNotHaveAvailableWinBackOffers() async {
+        let product = MockWinBackEligibilityProduct(
+            subscriptionInfo: MockWinBackEligibilitySubscriptionInfo(
+                statuses: [
+                    MockWinBackEligibilityStatus(
+                        ownershipType: .purchased,
+                        eligibleWinBackOfferIDs: ["available_offer", "missing_offer"]
+                    )
+                ],
+                winBackOffers: [MockWinBackEligibilityOffer.winBack(identifier: "available_offer")]
+            )
+        )
+
+        let offers = await self.calculator.calculateEligibleWinBackOffers(forProduct: product)
+
+        expect(offers.map(\.discount.offerIdentifier)) == ["available_offer"]
+    }
+
+    func testIgnoresNonWinBackOffersFromPricingTerms() async throws {
+        try AvailabilityChecks.iOS264APIAvailableOrSkipTest()
+
+        let product = MockWinBackEligibilityProduct(
+            billingPlanType: .monthly,
+            subscriptionInfo: MockWinBackEligibilitySubscriptionInfo(
+                statuses: [
+                    MockWinBackEligibilityStatus(
+                        ownershipType: .purchased,
+                        eligibleWinBackOfferIDs: ["promo_offer", "winback_offer"]
+                    )
+                ],
+                pricingTerms: [
+                    MockWinBackEligibilityPricingTerms(
+                        billingPlanType: .monthly,
+                        subscriptionOffers: [
+                            MockWinBackEligibilityOffer.promotional(identifier: "promo_offer"),
+                            MockWinBackEligibilityOffer.winBack(identifier: "winback_offer")
+                        ]
+                    )
+                ]
+            )
+        )
+
+        let offers = await self.calculator.calculateEligibleWinBackOffers(forProduct: product)
+
+        expect(offers.map(\.discount.offerIdentifier)) == ["winback_offer"]
+    }
+
+    func testFiltersWinBackOffersToProductBillingPlan() async throws {
+        try AvailabilityChecks.iOS264APIAvailableOrSkipTest()
+
+        let product = MockWinBackEligibilityProduct(
+            billingPlanType: .monthly,
+            subscriptionInfo: MockWinBackEligibilitySubscriptionInfo(
+                statuses: [
+                    MockWinBackEligibilityStatus(
+                        ownershipType: .purchased,
+                        eligibleWinBackOfferIDs: ["upfront_offer", "monthly_offer"]
+                    )
+                ],
+                pricingTerms: [
+                    MockWinBackEligibilityPricingTerms(
+                        billingPlanType: .upFront,
+                        subscriptionOffers: [MockWinBackEligibilityOffer.winBack(identifier: "upfront_offer")]
+                    ),
+                    MockWinBackEligibilityPricingTerms(
+                        billingPlanType: .monthly,
+                        subscriptionOffers: [MockWinBackEligibilityOffer.winBack(identifier: "monthly_offer")]
+                    )
+                ]
+            )
+        )
+
+        let offers = await self.calculator.calculateEligibleWinBackOffers(forProduct: product)
+
+        expect(offers.map(\.discount.offerIdentifier)) == ["monthly_offer"]
+    }
+
+}
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+private struct MockWinBackEligibilityProduct: WinBackEligibilityProductType {
+
+    let product: TestStoreProduct
+    let subscriptionInfo: (any WinBackEligibilitySubscriptionInfoType)?
+
+    var currencyCode: String? {
+        return self.product.currencyCode
+    }
+
+    var billingPlanType: BillingPlanType? {
+        return self.product.installmentsInfo?.billingPlanType
+    }
+
+    init(
+        currencyCode: String = "USD",
+        billingPlanType: BillingPlanType? = nil,
+        subscriptionInfo: (any WinBackEligibilitySubscriptionInfoType)? = MockWinBackEligibilitySubscriptionInfo()
+    ) {
+        self.product = Self.product(
+            currencyCode: currencyCode,
+            billingPlanType: billingPlanType
+        )
+        self.subscriptionInfo = subscriptionInfo
+    }
+
+    init(
+        product: TestStoreProduct,
+        subscriptionInfo: (any WinBackEligibilitySubscriptionInfoType)? = MockWinBackEligibilitySubscriptionInfo()
+    ) {
+        self.product = product
+        self.subscriptionInfo = subscriptionInfo
+    }
+
+    private static func product(
+        currencyCode: String,
+        billingPlanType: BillingPlanType?
+    ) -> TestStoreProduct {
+        return TestStoreProduct(
+            localizedTitle: "product",
+            price: 3.99,
+            currencyCode: currencyCode,
+            localizedPriceString: "$3.99",
+            productIdentifier: "product",
+            productType: .autoRenewableSubscription,
+            localizedDescription: "",
+            subscriptionPeriod: SubscriptionPeriod(value: 1, unit: .month),
+            locale: Locale(identifier: "en_US"),
+            installmentsInfo: billingPlanType.map(Self.installmentsInfo)
+        )
+    }
+
+    private static func installmentsInfo(billingPlanType: BillingPlanType) -> InstallmentsInfo {
+        return InstallmentsInfo(
+            commitmentInstallmentsCount: 3,
+            commitmentInstallmentPeriod: SubscriptionPeriod(value: 1, unit: .month),
+            installmentBillingPrice: 3.99,
+            installmentBillingDisplayPrice: "$3.99",
+            commitmentTotalPeriod: SubscriptionPeriod(value: 3, unit: .month),
+            commitmentTotalPrice: 11.97,
+            commitmentTotalDisplayPrice: "$11.97",
+            billingPlanType: billingPlanType
+        )
+    }
+
+}
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+private struct MockWinBackEligibilitySubscriptionInfo: WinBackEligibilitySubscriptionInfoType {
+
+    let statusesResult: Result<[any WinBackEligibilityStatusType], Error>
+    let winBackOffers: [any WinBackEligibilityOfferType]
+    let pricingTerms: [any WinBackEligibilityPricingTermsType]
+
+    init(
+        statuses: [any WinBackEligibilityStatusType] = [],
+        winBackOffers: [any WinBackEligibilityOfferType] = [],
+        pricingTerms: [any WinBackEligibilityPricingTermsType] = []
+    ) {
+        self.statusesResult = .success(statuses)
+        self.winBackOffers = winBackOffers
+        self.pricingTerms = pricingTerms
+    }
+
+    init(
+        statusesResult: Result<[any WinBackEligibilityStatusType], Error>,
+        winBackOffers: [any WinBackEligibilityOfferType] = [],
+        pricingTerms: [any WinBackEligibilityPricingTermsType] = []
+    ) {
+        self.statusesResult = statusesResult
+        self.winBackOffers = winBackOffers
+        self.pricingTerms = pricingTerms
+    }
+
+    func statuses() async throws -> [any WinBackEligibilityStatusType] {
+        return try self.statusesResult.get()
+    }
+
+}
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+private struct MockWinBackEligibilityStatus: WinBackEligibilityStatusType {
+
+    let ownershipType: WinBackEligibilityOwnershipType
+    let verifiedRenewalInfo: (any WinBackEligibilityRenewalInfoType)?
+
+    init(
+        ownershipType: WinBackEligibilityOwnershipType,
+        eligibleWinBackOfferIDs: [String]
+    ) {
+        self.ownershipType = ownershipType
+        self.verifiedRenewalInfo = MockWinBackEligibilityRenewalInfo(
+            eligibleWinBackOfferIDs: eligibleWinBackOfferIDs
+        )
+    }
+
+    init(
+        ownershipType: WinBackEligibilityOwnershipType,
+        verifiedRenewalInfo: (any WinBackEligibilityRenewalInfoType)?
+    ) {
+        self.ownershipType = ownershipType
+        self.verifiedRenewalInfo = verifiedRenewalInfo
+    }
+
+}
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+private struct MockWinBackEligibilityRenewalInfo: WinBackEligibilityRenewalInfoType {
+
+    let eligibleWinBackOfferIDs: [String]
+
+}
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+private struct MockWinBackEligibilityOffer: WinBackEligibilityOfferType {
+
+    let id: String?
+    let type: StoreProductDiscount.DiscountType
+
+    func storeProductDiscount(currencyCode: String?) -> StoreProductDiscount? {
+        return TestStoreProductDiscount(
+            identifier: self.id ?? "",
+            price: 0,
+            localizedPriceString: "$0.00",
+            paymentMode: .freeTrial,
+            subscriptionPeriod: .init(value: 1, unit: .month),
+            numberOfPeriods: 1,
+            type: self.type
+        ).toStoreProductDiscount()
+    }
+
+}
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+private extension WinBackEligibilityOfferType where Self == MockWinBackEligibilityOffer {
+
+    static func winBack(identifier: String) -> Self {
+        return .init(id: identifier, type: .winBack)
+    }
+
+    static func promotional(identifier: String) -> Self {
+        return .init(id: identifier, type: .promotional)
+    }
+
+}
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+private struct MockWinBackEligibilityPricingTerms: WinBackEligibilityPricingTermsType {
+
+    let billingPlanType: BillingPlanType?
+    let subscriptionOffers: [any WinBackEligibilityOfferType]
+
+}
+
+private enum MockError: Error {
+    case mockError
+}

--- a/Tests/StoreKitUnitTests/StoreKit2/Win-Back Offers/WinBackOfferEligibilityCalculatorTests.swift
+++ b/Tests/StoreKitUnitTests/StoreKit2/Win-Back Offers/WinBackOfferEligibilityCalculatorTests.swift
@@ -133,6 +133,25 @@ final class WinBackOfferEligibilityCalculatorTests: TestCase {
         expect(offers.map(\.discount.offerIdentifier)) == ["available_offer"]
     }
 
+    func testReturnsSubscriptionInfoWinBackOfferForNonMonthlyProduct() async {
+        let product = MockWinBackEligibilityProduct(
+            subscriptionPeriod: SubscriptionPeriod(value: 1, unit: .year),
+            subscriptionInfo: MockWinBackEligibilitySubscriptionInfo(
+                statuses: [
+                    MockWinBackEligibilityStatus(
+                        ownershipType: .purchased,
+                        eligibleWinBackOfferIDs: ["annual_offer"]
+                    )
+                ],
+                winBackOffers: [MockWinBackEligibilityOffer.winBack(identifier: "annual_offer")]
+            )
+        )
+
+        let offers = await self.calculator.calculateEligibleWinBackOffers(forProduct: product)
+
+        expect(offers.map(\.discount.offerIdentifier)) == ["annual_offer"]
+    }
+
     func testIgnoresNonWinBackOffersFromPricingTerms() async throws {
         try AvailabilityChecks.iOS264APIAvailableOrSkipTest()
 
@@ -211,11 +230,13 @@ private struct MockWinBackEligibilityProduct: WinBackEligibilityProductType {
     init(
         currencyCode: String = "USD",
         billingPlanType: BillingPlanType? = nil,
+        subscriptionPeriod: SubscriptionPeriod = SubscriptionPeriod(value: 1, unit: .month),
         subscriptionInfo: (any WinBackEligibilitySubscriptionInfoType)? = MockWinBackEligibilitySubscriptionInfo()
     ) {
         self.product = Self.product(
             currencyCode: currencyCode,
-            billingPlanType: billingPlanType
+            billingPlanType: billingPlanType,
+            subscriptionPeriod: subscriptionPeriod
         )
         self.subscriptionInfo = subscriptionInfo
     }
@@ -230,7 +251,8 @@ private struct MockWinBackEligibilityProduct: WinBackEligibilityProductType {
 
     private static func product(
         currencyCode: String,
-        billingPlanType: BillingPlanType?
+        billingPlanType: BillingPlanType?,
+        subscriptionPeriod: SubscriptionPeriod
     ) -> TestStoreProduct {
         return TestStoreProduct(
             localizedTitle: "product",
@@ -240,7 +262,7 @@ private struct MockWinBackEligibilityProduct: WinBackEligibilityProductType {
             productIdentifier: "product",
             productType: .autoRenewableSubscription,
             localizedDescription: "",
-            subscriptionPeriod: SubscriptionPeriod(value: 1, unit: .month),
+            subscriptionPeriod: subscriptionPeriod,
             locale: Locale(identifier: "en_US"),
             installmentsInfo: billingPlanType.map(Self.installmentsInfo)
         )

--- a/Tests/StoreKitUnitTests/StoreKit2/Win-Back Offers/WinBackOfferEligibilityCalculatorTests.swift
+++ b/Tests/StoreKitUnitTests/StoreKit2/Win-Back Offers/WinBackOfferEligibilityCalculatorTests.swift
@@ -75,6 +75,24 @@ final class WinBackOfferEligibilityCalculatorTests: TestCase {
         expect(offers).to(beEmpty())
     }
 
+    func testReturnsEmptyForUnknownOwnershipType() async {
+        let product = MockWinBackEligibilityProduct(
+            subscriptionInfo: MockWinBackEligibilitySubscriptionInfo(
+                statuses: [
+                    MockWinBackEligibilityStatus(
+                        ownershipType: .unknown,
+                        eligibleWinBackOfferIDs: ["winback_offer"]
+                    )
+                ],
+                winBackOffers: [MockWinBackEligibilityOffer.winBack(identifier: "winback_offer")]
+            )
+        )
+
+        let offers = await self.calculator.calculateEligibleWinBackOffers(forProduct: product)
+
+        expect(offers).to(beEmpty())
+    }
+
     func testReturnsEligibleWinBackOffersInOrder() async {
         let product = MockWinBackEligibilityProduct(
             subscriptionInfo: MockWinBackEligibilitySubscriptionInfo(


### PR DESCRIPTION
### Description
Make the `WinbackOfferEligibilityCalculator` testable by removing its direct dependencies on StoreKit classes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how win-back offers are resolved for subscriptions (purchase-relevant), but it is largely a structural refactor with new coverage; incorrect adapter mapping could change which offers are returned.
> 
> **Overview**
> Refactors **win-back offer eligibility** so `WinBackOfferEligibilityCalculator` runs on internal, StoreKit-free protocols instead of `Product` / `StoreProduct` types directly. A new `WinBackEligibilityAdapters.swift` maps real StoreKit subscription data into those protocols at the public entry point; eligibility rules (purchased ownership, renewal IDs, billing-plan filtering on iOS 26.4+) stay the same but are easier to unit test.
> 
> Adds **`WinBackOfferEligibilityCalculatorTests`** with mocks covering empty/error paths, offer ordering, missing offers, and billing-plan / pricing-term filtering when the newer APIs are available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c2c53af625035e22fab07b2f43fdfdea5193231. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->