### PR TITLE
feat(PaywallsTester): runtime API key swap via Settings tab

### DIFF
--- a/Contributing/DEVELOPMENT.md
+++ b/Contributing/DEVELOPMENT.md
@@ -47,6 +47,18 @@ tuist generate Maestro  # Generates the Maestro example app
 
 When you generate a specific target (for example, `tuist generate RevenueCat`), Tuist only includes the files necessary to work on that target locally. This keeps the workspace lightweight and focused on what you need.
 
+### Working on Workflows in PaywallsTester
+
+The workflows endpoint is still gated behind the `-EnableWorkflowsEndpoint` launch argument. To work on
+workflows locally, generate PaywallsTester with the launch argument injected into its run action:
+
+```bash
+TUIST_LAUNCH_ARGUMENTS="-EnableWorkflowsEndpoint" tuist generate PaywallsTester
+```
+
+Then run the PaywallsTester scheme from Xcode. The launch argument is only applied when running from
+Xcode, it does not reach archived/TestFlight builds.
+
 ## Using Remote RevenueCat / RevenueCatUI Checkouts
 
 Set the `TUIST_RC_LOCAL` environment variable to `false` to resolve `RevenueCat` and `RevenueCatUI` from their remote sources instead of the local checkout.

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/Configuration.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/Configuration.swift
@@ -37,9 +37,6 @@ enum Configuration {
 /// Runtime debug settings for PaywallsTester, persisted in `UserDefaults` so they survive a
 /// kill/relaunch. Lets anyone running the app point it at their own RevenueCat project without
 /// rebuilding or editing `local.xcconfig`.
-///
-/// Note: PaywallsTester has no unit-test target (its test target is snapshot-only), so this type
-/// and the settings screen are verified manually. See the design doc for the manual checklist.
 final class DebugSettingsStore: ObservableObject {
 
     enum Keys {

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/Configuration.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/Configuration.swift
@@ -5,6 +5,7 @@
 //  Created by Nacho Soto on 7/13/23.
 //
 
+import Combine
 import Foundation
 import RevenueCat
 
@@ -24,11 +25,72 @@ enum Configuration {
         Purchases.proxyURL = Constants.proxyURL.flatMap { URL(string: $0) }
 
         Purchases.configure(
-            with: .init(withAPIKey: Constants.apiKey)
+            with: .init(withAPIKey: DebugSettingsStore.effectiveAPIKey)
                 .with(entitlementVerificationMode: .informational)
                 .with(diagnosticsEnabled: true)
                 .with(purchasesAreCompletedBy: .revenueCat, storeKitVersion: .storeKit2)
         )
+    }
+
+}
+
+/// Runtime debug settings for PaywallsTester, persisted in `UserDefaults` so they survive a
+/// kill/relaunch. Lets anyone running the app point it at their own RevenueCat project without
+/// rebuilding or editing `local.xcconfig`.
+///
+/// Note: PaywallsTester has no unit-test target (its test target is snapshot-only), so this type
+/// and the settings screen are verified manually. See the design doc for the manual checklist.
+final class DebugSettingsStore: ObservableObject {
+
+    enum Keys {
+        static let apiKeyOverride = "debug.apiKeyOverride"
+    }
+
+    static let shared = DebugSettingsStore()
+
+    /// The API key to configure `Purchases` with: a non-empty override, otherwise the build-time
+    /// default from `Constants.apiKey`. Reads `UserDefaults` directly so it is safe to call at
+    /// launch from `Configuration.configure()` without touching the observable instance.
+    static var effectiveAPIKey: String {
+        let override = UserDefaults.standard.string(forKey: Keys.apiKeyOverride)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return override.isEmpty ? Constants.apiKey : override
+    }
+
+    private let defaults: UserDefaults
+
+    /// Empty string means "no override" (falls back to `Constants.apiKey`).
+    @Published var apiKeyOverride: String {
+        didSet {
+            let trimmed = apiKeyOverride.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty {
+                defaults.removeObject(forKey: Keys.apiKeyOverride)
+            } else {
+                defaults.set(trimmed, forKey: Keys.apiKeyOverride)
+            }
+        }
+    }
+
+    /// Bumped on every reconfigure so views can rebuild against the freshly configured instance.
+    @Published private(set) var configurationGeneration: Int = 0
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.apiKeyOverride = defaults.string(forKey: Keys.apiKeyOverride) ?? ""
+    }
+
+    /// Persists the current values and re-configures `Purchases` with the new key so the change
+    /// takes effect without relaunching. A cold relaunch reaches the same state because the
+    /// persisted override is read again in `Configuration.configure()`.
+    func apply() {
+        Configuration.configure()
+        configurationGeneration += 1
+    }
+
+    /// Clears the API key override (reverting to the build default) and re-configures.
+    func resetToDefault() {
+        apiKeyOverride = ""
+        apply()
     }
 
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/AppContentView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/AppContentView.swift
@@ -14,16 +14,22 @@ struct AppContentView: View {
     private enum Tab {
         case examples
         case livePaywalls
+        case settings
     }
 
     @State
     private var selectedTab: Tab = Purchases.isConfigured ? .livePaywalls : .examples
+
+    @ObservedObject
+    private var settings = DebugSettingsStore.shared
 
     var body: some View {
         TabView(selection: $selectedTab) {
 
             if Purchases.isConfigured {
                 APIKeyDashboardList()
+                    // Rebuild against the freshly configured instance after an API key swap.
+                    .id(settings.configurationGeneration)
                     .tabItem {
                         Label("Live Paywalls", systemImage: "testtube.2")
                     }
@@ -40,9 +46,61 @@ struct AppContentView: View {
                 .tag(Tab.examples)
             #endif
 
-            if !Purchases.isConfigured {
-                Text("Purchases is not configured")
+            // Always available so the API key can be set even from a "not configured" state.
+            DebugSettingsView(settings: settings)
+                .tabItem {
+                    Label("Settings", systemImage: "gearshape")
+                }
+                .tag(Tab.settings)
+        }
+    }
+
+}
+
+/// Lets anyone running PaywallsTester point the app at their own RevenueCat project at runtime.
+/// The entered key is persisted (see `DebugSettingsStore`) so it survives a kill/relaunch.
+private struct DebugSettingsView: View {
+
+    @ObservedObject var settings: DebugSettingsStore
+
+    @State private var apiKeyDraft: String = ""
+    @State private var showAppliedConfirmation: Bool = false
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section {
+                    TextField("API Key", text: $apiKeyDraft)
+                        .autocorrectionDisabled()
+                        #if os(iOS)
+                        .textInputAutocapitalization(.never)
+                        #endif
+                } header: {
+                    Text("RevenueCat API Key")
+                } footer: {
+                    Text("Leave empty to use the build default. Applied now and on next launch.")
+                }
+
+                Section {
+                    Button("Apply") {
+                        settings.apiKeyOverride = apiKeyDraft
+                        settings.apply()
+                        showAppliedConfirmation = true
+                    }
+
+                    Button("Reset to default", role: .destructive) {
+                        settings.resetToDefault()
+                        apiKeyDraft = settings.apiKeyOverride
+                    }
+                }
             }
+            .navigationTitle("Settings")
+        }
+        .onAppear { apiKeyDraft = settings.apiKeyOverride }
+        .alert("Configuration applied", isPresented: $showAppliedConfirmation) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text("Purchases was reconfigured with the entered API key.")
         }
     }
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/AppContentView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/AppContentView.swift
@@ -57,8 +57,6 @@ struct AppContentView: View {
 
 }
 
-/// Lets anyone running PaywallsTester point the app at their own RevenueCat project at runtime.
-/// The entered key is persisted (see `DebugSettingsStore`) so it survives a kill/relaunch.
 private struct DebugSettingsView: View {
 
     @ObservedObject var settings: DebugSettingsStore


### PR DESCRIPTION
## Description

Adds a **Settings** tab to PaywallsTester that lets anyone running the app point it at their own RevenueCat project at runtime, without rebuilding or editing `local.xcconfig`.

| Header |
|--------|
|<img width="546" height="1040" alt="Screenshot 2026-05-29 at 10 40 56" src="https://github.com/user-attachments/assets/6110a9d5-3b5b-44bc-a7e5-b2a95ce0e2fe" /> | 

### What this does
- New **Settings** tab (always visible, including from a "not configured" state) with an **API Key** field, **Apply**, and **Reset to default**.
- The entered key is persisted in `UserDefaults` (`debug.apiKeyOverride`) and read at launch in `Configuration.configure()` via `DebugSettingsStore.effectiveAPIKey`, so it **survives a kill/relaunch**. Empty = "no override" (falls back to the build-time `Constants.apiKey`).
- **Apply** reconfigures `Purchases` live and bumps a generation counter so the Live Paywalls tab rebuilds against the new key, no relaunch needed.

## Notes
- Scope: PaywallsTester (sample app) only. No changes to the shipped SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
