### PR TITLE
Allow overriding PaywallsTester bundle ID via Tuist env var

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,7 @@ The project uses **Tuist** for managing the Xcode workspace. See **`Contributing
 | `TUIST_RC_API_KEY=appl_xxxxx` | RevenueCat API key written to `Local.xcconfig` at generation time | — |
 | `TUIST_LAUNCH_ARGUMENTS="-Flag1 -Flag2"` | Space-separated launch arguments injected into PaywallsTester scheme run action (enabled by default) | — |
 | `TUIST_SWIFT_CONDITIONS="FLAG1 FLAG2"` | Space-separated Swift compilation conditions injected into all targets | — |
+| `TUIST_PAYWALLS_TESTER_BUNDLE_ID=com.x.PaywallsTester` | Custom bundle identifier for the PaywallsTester target (e.g. testing against another RevenueCat project) | `com.revenuecat.PaywallsTester` |
 
 Example combining multiple variables:
 ```bash

--- a/Projects/PaywallsTester/Project.swift
+++ b/Projects/PaywallsTester/Project.swift
@@ -130,7 +130,7 @@ let project = Project(
             name: "PaywallsTester",
             destinations: allDestinations,
             product: .app,
-            bundleId: "com.revenuecat.PaywallsTester",
+            bundleId: Environment.paywallsTesterBundleId,
             deploymentTargets: allDeploymentTargets,
             infoPlist: "../../Tests/TestingApps/PaywallsTester/PaywallsTester/Info.plist",
             sources: [

--- a/Tuist/ProjectDescriptionHelpers/Environment.swift
+++ b/Tuist/ProjectDescriptionHelpers/Environment.swift
@@ -79,6 +79,21 @@ extension Environment {
         return value.isEmpty ? nil : value
     }
 
+    /// Returns a custom bundle identifier for PaywallsTester.
+    /// Useful when testing against a different RevenueCat project / App Store Connect app
+    /// that requires its own bundle ID (e.g. running on a real device with that project's products).
+    /// Defaults to `com.revenuecat.PaywallsTester` when unset.
+    ///
+    /// Example usage:
+    /// ```bash
+    /// # Generate project with a custom bundle ID
+    /// TUIST_PAYWALLS_TESTER_BUNDLE_ID=com.mycompany.PaywallsTester tuist generate PaywallsTester
+    /// ```
+    public static var paywallsTesterBundleId: String {
+        let value = ProcessInfo.processInfo.environment["TUIST_PAYWALLS_TESTER_BUNDLE_ID"] ?? ""
+        return value.isEmpty ? "com.revenuecat.PaywallsTester" : value
+    }
+
     /// Returns the RevenueCat API key for PaywallsTester, if set.
     /// When set, this will be written to Local.xcconfig during project generation.
     ///


### PR DESCRIPTION
## Motivation

RevenueCat folks often want to run **PaywallsTester** against a *different* RevenueCat project / App Store Connect app, which may require its own bundle identifier (e.g. when running on a real device with that project's products). Today the bundle ID is hardcoded to `com.revenuecat.PaywallsTester` in the Tuist manifest, so testing with another project means hand-editing `Project.swift`.

## Change

Adds a `TUIST_PAYWALLS_TESTER_BUNDLE_ID` environment variable, following the same pattern as the existing `TUIST_RC_API_KEY` / `TUIST_SK_CONFIG_PATH` / `TUIST_LAUNCH_ARGUMENTS` knobs:

```bash
TUIST_PAYWALLS_TESTER_BUNDLE_ID=com.mycompany.PaywallsTester tuist generate PaywallsTester
```

When unset, it defaults to `com.revenuecat.PaywallsTester` (no behavior change).

- `Tuist/ProjectDescriptionHelpers/Environment.swift` — new `paywallsTesterBundleId` accessor (reads the env var via `ProcessInfo`, defaults to the current value)
- `Projects/PaywallsTester/Project.swift` — `bundleId:` now reads `Environment.paywallsTesterBundleId`
- `AGENTS.md` — documented the new variable in the Tuist env-var table

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tuist-only PaywallsTester generation change; default bundle ID is unchanged and the public SDK is unaffected.
> 
> **Overview**
> Adds **`TUIST_PAYWALLS_TESTER_BUNDLE_ID`** so PaywallsTester’s app bundle ID can be set at `tuist generate` time instead of editing the Tuist manifest. **`Environment.paywallsTesterBundleId`** reads the env var (default **`com.revenuecat.PaywallsTester`**), **`Projects/PaywallsTester/Project.swift`** uses it for the target’s `bundleId`, and **`AGENTS.md`** documents the knob alongside the other Tuist variables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 105b654d2c0e4713f2466805711467dedbe543ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->