### PR TITLE
feat(remote-config): clean up unreferenced topic files after refresh

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1289,6 +1289,12 @@
 		3320C44A004844C1977301AB /* RemoteConfigManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6309AD09B1054DC081B6BF7E /* RemoteConfigManager.swift */; };
 		D50B098A156B454292887410 /* TopicFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CDDBB55FE1847498ECBA0A8 /* TopicFetcher.swift */; };
 		853DE70F5F0845C7A614DE45 /* RemoteConfigStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36224D28EF904B44908841D6 /* RemoteConfigStrings.swift */; };
+		EC22142820C24F59BDBE2D93 /* MockTopicFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F26F79D94694476791E8A6AD /* MockTopicFetcher.swift */; };
+		89D9E2DB21A440C78970F299 /* MockTopicFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F26F79D94694476791E8A6AD /* MockTopicFetcher.swift */; };
+		3779447DBC634AA68B7E0683 /* MockRemoteConfigAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2C854303404D8884933ACA /* MockRemoteConfigAPI.swift */; };
+		5481225010164BC5A1579C71 /* MockRemoteConfigAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2C854303404D8884933ACA /* MockRemoteConfigAPI.swift */; };
+		BFDE126A6ADD4D20B6B6B9B2 /* TopicFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2721FAB8C014743B2DC17C7 /* TopicFetcherTests.swift */; };
+		C5EEF4BD66D44A92832DA167 /* RemoteConfigManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A03E9903DDF426A97720D9D /* RemoteConfigManagerTests.swift */; };
 		DB36994E2F435CDC00B1F049 /* PriceFormatterExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB36994D2F435CDC00B1F049 /* PriceFormatterExtensions.swift */; };
 		DB55E6262ECE012600636909 /* FlexSpacer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB55E6252ECE012600636909 /* FlexSpacer.swift */; };
 		DB7EA7762F964CA200BCC082 /* WorkflowResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7EA7742F964CA200BCC082 /* WorkflowResponseTests.swift */; };
@@ -2863,6 +2869,10 @@
 		6309AD09B1054DC081B6BF7E /* RemoteConfigManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigManager.swift; sourceTree = "<group>"; };
 		5CDDBB55FE1847498ECBA0A8 /* TopicFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicFetcher.swift; sourceTree = "<group>"; };
 		36224D28EF904B44908841D6 /* RemoteConfigStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigStrings.swift; sourceTree = "<group>"; };
+		F26F79D94694476791E8A6AD /* MockTopicFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTopicFetcher.swift; sourceTree = "<group>"; };
+		DB2C854303404D8884933ACA /* MockRemoteConfigAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRemoteConfigAPI.swift; sourceTree = "<group>"; };
+		B2721FAB8C014743B2DC17C7 /* TopicFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicFetcherTests.swift; sourceTree = "<group>"; };
+		9A03E9903DDF426A97720D9D /* RemoteConfigManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigManagerTests.swift; sourceTree = "<group>"; };
 		DB36994D2F435CDC00B1F049 /* PriceFormatterExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceFormatterExtensions.swift; sourceTree = "<group>"; };
 		DB55E6252ECE012600636909 /* FlexSpacer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlexSpacer.swift; sourceTree = "<group>"; };
 		DB7EA7732F964CA200BCC082 /* WorkflowDetailProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowDetailProcessorTests.swift; sourceTree = "<group>"; };
@@ -3700,9 +3710,19 @@
 				37E35A5970D1604E8C8011FC /* TestHelpers */,
 				FD8C00452DE79F4000224B78 /* Virtual Currencies */,
 				75A0E78E2E3D1FC300A60BD5 /* SimulatedStore */,
+				E72032998DA642FC86C4364A /* RemoteConfig */,
 				2DC5622524EC63430031F69B /* Info.plist */,
 			);
 			path = UnitTests;
+			sourceTree = "<group>";
+		};
+		E72032998DA642FC86C4364A /* RemoteConfig */ = {
+			isa = PBXGroup;
+			children = (
+				B2721FAB8C014743B2DC17C7 /* TopicFetcherTests.swift */,
+				9A03E9903DDF426A97720D9D /* RemoteConfigManagerTests.swift */,
+			);
+			path = RemoteConfig;
 			sourceTree = "<group>";
 		};
 		2DD02D5924AD128A00419CD9 /* LocalReceiptParsing */ = {
@@ -4178,6 +4198,8 @@
 				FDE57AA62DF892C900101CE2 /* MockVirtualCurrenciesAPI.swift */,
 				75A0E7912E3D205C00A60BD5 /* MockTestStorePurchaseUI.swift */,
 				DBAA1FA72F88EAEB000E8C81 /* MockWorkflowsAPI.swift */,
+				F26F79D94694476791E8A6AD /* MockTopicFetcher.swift */,
+				DB2C854303404D8884933ACA /* MockRemoteConfigAPI.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -6968,6 +6990,8 @@
 				75A3B2B22F16B458001C4CA7 /* MockLargeItemCache.swift in Sources */,
 				3543914526F926D900E669DF /* SKProductSubscriptionDurationExtensions.swift in Sources */,
 				3543913926F90FFB00E669DF /* MockBackend.swift in Sources */,
+				89D9E2DB21A440C78970F299 /* MockTopicFetcher.swift in Sources */,
+				5481225010164BC5A1579C71 /* MockRemoteConfigAPI.swift in Sources */,
 				F5FCD3FC27DA2034003BDC04 /* PriceFormatterProviderTests.swift in Sources */,
 				F5355163286B70E0009CA47A /* OfferingsManagerStoreKitTests.swift in Sources */,
 				35C272A22BC4084C005A0CE8 /* MockDiagnosticsTracker.swift in Sources */,
@@ -7561,6 +7585,10 @@
 				0368727A2D9DCF7100506BBB /* DefaultEnumTests.swift in Sources */,
 				DB3395E32F840ACD0079250C /* BackendGetWorkflowsTests.swift in Sources */,
 				E6A54710537E4AA3810E1CB0 /* BackendGetRemoteConfigTests.swift in Sources */,
+				BFDE126A6ADD4D20B6B6B9B2 /* TopicFetcherTests.swift in Sources */,
+				C5EEF4BD66D44A92832DA167 /* RemoteConfigManagerTests.swift in Sources */,
+				EC22142820C24F59BDBE2D93 /* MockTopicFetcher.swift in Sources */,
+				3779447DBC634AA68B7E0683 /* MockRemoteConfigAPI.swift in Sources */,
 				03C7305B2D35985900297FEC /* TextComponentTests.swift in Sources */,
 				FDE57B0E2DF8BC1100101CE2 /* VirtualCurrenciesDecodingTests.swift in Sources */,
 				75FCD4CE2E37FBE100036C02 /* SimulatedStoreMockData.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1280,6 +1280,12 @@
 		DB3395DD2F840A790079250C /* WorkflowResponseAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3395D92F840A790079250C /* WorkflowResponseAction.swift */; };
 		DB3395E12F840AA60079250C /* WorkflowsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3395E02F840AA60079250C /* WorkflowsAPI.swift */; };
 		DB3395E32F840ACD0079250C /* BackendGetWorkflowsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3395E22F840ACD0079250C /* BackendGetWorkflowsTests.swift */; };
+		3B41364A5DFC4039B3026F40 /* RemoteConfigAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A2DB969D72432B87F48C5F /* RemoteConfigAPI.swift */; };
+		E6B064598F674333A29E0781 /* RemoteConfigCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCF81FAC33B948F0947AE312 /* RemoteConfigCallback.swift */; };
+		A6CC43904EBD4860BFD2BD85 /* GetRemoteConfigOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077FB0E4EC264B2EA08C4521 /* GetRemoteConfigOperation.swift */; };
+		D62A9C83BFD14E5FA0452CC7 /* RemoteConfigResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = E35BAD07C46D469D8CC7C396 /* RemoteConfigResponse.swift */; };
+		E6A54710537E4AA3810E1CB0 /* BackendGetRemoteConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96BC3A5229194DFB9653FC8C /* BackendGetRemoteConfigTests.swift */; };
+		858195FCF0E04E3CAA99F9BB /* RemoteConfigResponseDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E31E8A264E9F4375A3B29D78 /* RemoteConfigResponseDecodingTests.swift */; };
 		DB36994E2F435CDC00B1F049 /* PriceFormatterExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB36994D2F435CDC00B1F049 /* PriceFormatterExtensions.swift */; };
 		DB55E6262ECE012600636909 /* FlexSpacer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB55E6252ECE012600636909 /* FlexSpacer.swift */; };
 		DB7EA7762F964CA200BCC082 /* WorkflowResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7EA7742F964CA200BCC082 /* WorkflowResponseTests.swift */; };
@@ -2845,6 +2851,12 @@
 		DB3395D92F840A790079250C /* WorkflowResponseAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowResponseAction.swift; sourceTree = "<group>"; };
 		DB3395E02F840AA60079250C /* WorkflowsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowsAPI.swift; sourceTree = "<group>"; };
 		DB3395E22F840ACD0079250C /* BackendGetWorkflowsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendGetWorkflowsTests.swift; sourceTree = "<group>"; };
+		F3A2DB969D72432B87F48C5F /* RemoteConfigAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigAPI.swift; sourceTree = "<group>"; };
+		FCF81FAC33B948F0947AE312 /* RemoteConfigCallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigCallback.swift; sourceTree = "<group>"; };
+		077FB0E4EC264B2EA08C4521 /* GetRemoteConfigOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetRemoteConfigOperation.swift; sourceTree = "<group>"; };
+		E35BAD07C46D469D8CC7C396 /* RemoteConfigResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigResponse.swift; sourceTree = "<group>"; };
+		96BC3A5229194DFB9653FC8C /* BackendGetRemoteConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendGetRemoteConfigTests.swift; sourceTree = "<group>"; };
+		E31E8A264E9F4375A3B29D78 /* RemoteConfigResponseDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigResponseDecodingTests.swift; sourceTree = "<group>"; };
 		DB36994D2F435CDC00B1F049 /* PriceFormatterExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceFormatterExtensions.swift; sourceTree = "<group>"; };
 		DB55E6252ECE012600636909 /* FlexSpacer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlexSpacer.swift; sourceTree = "<group>"; };
 		DB7EA7732F964CA200BCC082 /* WorkflowDetailProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowDetailProcessorTests.swift; sourceTree = "<group>"; };
@@ -4534,6 +4546,7 @@
 				1EDB6AA92DC95AB400C771A4 /* WebBillingHTTPRequestPath.swift */,
 				DB3395DA2F840A790079250C /* Workflows */,
 				DB3395E02F840AA60079250C /* WorkflowsAPI.swift */,
+				F3A2DB969D72432B87F48C5F /* RemoteConfigAPI.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -5010,6 +5023,7 @@
 				FDEEEEEE000000000000A001 /* RewardVerificationStatusResponseDecodingTests.swift */,
 				FDE57B0D2DF8BC1100101CE2 /* VirtualCurrenciesDecodingTests.swift */,
 				758593472E37F77700B8E6CE /* WebBillingProductsDecodingTests.swift */,
+				E31E8A264E9F4375A3B29D78 /* RemoteConfigResponseDecodingTests.swift */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -5053,6 +5067,7 @@
 				FD5EB26F2DFB19B800DA1974 /* BackendGetVirtualCurrenciesTests.swift */,
 				FD25F3772F33D502007C1A91 /* BackendIsPurchaseAllowedByRestoreBehaviorTests.swift */,
 				DB3395E22F840ACD0079250C /* BackendGetWorkflowsTests.swift */,
+				96BC3A5229194DFB9653FC8C /* BackendGetRemoteConfigTests.swift */,
 			);
 			path = Backend;
 			sourceTree = "<group>";
@@ -5257,6 +5272,7 @@
 				FDE57A9F2DF8785000101CE2 /* VirtualCurrenciesResponse.swift */,
 				DB3395D42F840A570079250C /* WorkflowsResponse.swift */,
 				755C26A32E310B19006DD0AE /* WebBillingProductsResponse.swift */,
+				E35BAD07C46D469D8CC7C396 /* RemoteConfigResponse.swift */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -6049,6 +6065,7 @@
 				FDE57A9D2DF8783000101CE2 /* VirtualCurrenciesCallback.swift */,
 				DB3395C92F840A2B0079250C /* WorkflowsCallback.swift */,
 				3752A4A3D77644C8B4BDD44D /* WorkflowsListCallback.swift */,
+				FCF81FAC33B948F0947AE312 /* RemoteConfigCallback.swift */,
 			);
 			path = Caching;
 			sourceTree = "<group>";
@@ -6079,6 +6096,7 @@
 				A56DFDEF286643BF00EF2E32 /* PostAttributionDataOperation.swift */,
 				DB3395D02F840A400079250C /* GetWorkflowOperation.swift */,
 				DC140B430FEE4B5897D7DB00 /* GetWorkflowsListOperation.swift */,
+				077FB0E4EC264B2EA08C4521 /* GetRemoteConfigOperation.swift */,
 			);
 			path = Operations;
 			sourceTree = "<group>";
@@ -7158,6 +7176,10 @@
 				2D11F5E1250FF886005A70E8 /* AttributionStrings.swift in Sources */,
 				DB3395DB2F840A790079250C /* WorkflowDetailProcessor.swift in Sources */,
 				DB3395E12F840AA60079250C /* WorkflowsAPI.swift in Sources */,
+				3B41364A5DFC4039B3026F40 /* RemoteConfigAPI.swift in Sources */,
+				E6B064598F674333A29E0781 /* RemoteConfigCallback.swift in Sources */,
+				A6CC43904EBD4860BFD2BD85 /* GetRemoteConfigOperation.swift in Sources */,
+				D62A9C83BFD14E5FA0452CC7 /* RemoteConfigResponse.swift in Sources */,
 				DB3395DD2F840A790079250C /* WorkflowResponseAction.swift in Sources */,
 				2CD72944268A826F00BFC976 /* Date+Extensions.swift in Sources */,
 				57069A5428E3918400B86355 /* AsyncExtensions.swift in Sources */,
@@ -7518,6 +7540,7 @@
 				5766AA5A283D4CAB00FA6091 /* IgnoreHashableTests.swift in Sources */,
 				0368727A2D9DCF7100506BBB /* DefaultEnumTests.swift in Sources */,
 				DB3395E32F840ACD0079250C /* BackendGetWorkflowsTests.swift in Sources */,
+				E6A54710537E4AA3810E1CB0 /* BackendGetRemoteConfigTests.swift in Sources */,
 				03C7305B2D35985900297FEC /* TextComponentTests.swift in Sources */,
 				FDE57B0E2DF8BC1100101CE2 /* VirtualCurrenciesDecodingTests.swift in Sources */,
 				75FCD4CE2E37FBE100036C02 /* SimulatedStoreMockData.swift in Sources */,
@@ -7674,6 +7697,7 @@
 				35E840CE2710E2EB00899AE2 /* MockManageSubscriptionsHelper.swift in Sources */,
 				03A98D322D2441B8009BCA61 /* PaywallDataDecodingTests.swift in Sources */,
 				DB7EA7762F964CA200BCC082 /* WorkflowResponseTests.swift in Sources */,
+				858195FCF0E04E3CAA99F9BB /* RemoteConfigResponseDecodingTests.swift in Sources */,
 				DB7EA7772F964CA200BCC082 /* WorkflowDetailProcessorTests.swift in Sources */,
 				4F8DDB692AAA9189000188F2 /* OperationDispatcherTests.swift in Sources */,
 				57FFD2512922DBED00A9A878 /* MockStoreTransaction.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1286,6 +1286,9 @@
 		D62A9C83BFD14E5FA0452CC7 /* RemoteConfigResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = E35BAD07C46D469D8CC7C396 /* RemoteConfigResponse.swift */; };
 		E6A54710537E4AA3810E1CB0 /* BackendGetRemoteConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96BC3A5229194DFB9653FC8C /* BackendGetRemoteConfigTests.swift */; };
 		858195FCF0E04E3CAA99F9BB /* RemoteConfigResponseDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E31E8A264E9F4375A3B29D78 /* RemoteConfigResponseDecodingTests.swift */; };
+		3320C44A004844C1977301AB /* RemoteConfigManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6309AD09B1054DC081B6BF7E /* RemoteConfigManager.swift */; };
+		D50B098A156B454292887410 /* TopicFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CDDBB55FE1847498ECBA0A8 /* TopicFetcher.swift */; };
+		853DE70F5F0845C7A614DE45 /* RemoteConfigStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36224D28EF904B44908841D6 /* RemoteConfigStrings.swift */; };
 		DB36994E2F435CDC00B1F049 /* PriceFormatterExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB36994D2F435CDC00B1F049 /* PriceFormatterExtensions.swift */; };
 		DB55E6262ECE012600636909 /* FlexSpacer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB55E6252ECE012600636909 /* FlexSpacer.swift */; };
 		DB7EA7762F964CA200BCC082 /* WorkflowResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7EA7742F964CA200BCC082 /* WorkflowResponseTests.swift */; };
@@ -2857,6 +2860,9 @@
 		E35BAD07C46D469D8CC7C396 /* RemoteConfigResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigResponse.swift; sourceTree = "<group>"; };
 		96BC3A5229194DFB9653FC8C /* BackendGetRemoteConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendGetRemoteConfigTests.swift; sourceTree = "<group>"; };
 		E31E8A264E9F4375A3B29D78 /* RemoteConfigResponseDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigResponseDecodingTests.swift; sourceTree = "<group>"; };
+		6309AD09B1054DC081B6BF7E /* RemoteConfigManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigManager.swift; sourceTree = "<group>"; };
+		5CDDBB55FE1847498ECBA0A8 /* TopicFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicFetcher.swift; sourceTree = "<group>"; };
+		36224D28EF904B44908841D6 /* RemoteConfigStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigStrings.swift; sourceTree = "<group>"; };
 		DB36994D2F435CDC00B1F049 /* PriceFormatterExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceFormatterExtensions.swift; sourceTree = "<group>"; };
 		DB55E6252ECE012600636909 /* FlexSpacer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlexSpacer.swift; sourceTree = "<group>"; };
 		DB7EA7732F964CA200BCC082 /* WorkflowDetailProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowDetailProcessorTests.swift; sourceTree = "<group>"; };
@@ -3556,6 +3562,7 @@
 				57488BE729CB7FB60000EE7E /* OfflineEntitlementsStrings.swift */,
 				4F6ABC7D2A81700900250E63 /* PaywallsStrings.swift */,
 				9A65E0A42591A23500DE00B0 /* PurchaseStrings.swift */,
+				36224D28EF904B44908841D6 /* RemoteConfigStrings.swift */,
 				5791FCF22992D3EC00F1FEDA /* SigningStrings.swift */,
 				F5C0196826E880800005D61E /* StoreKitStrings.swift */,
 				757E73D02F0FE26A0066DCDC /* TransactionMetadataStrings.swift */,
@@ -3654,6 +3661,7 @@
 				57488B7D29CB70DA0000EE7E /* OfflineEntitlements */,
 				4F87610D2A5C9E330006FA14 /* Paywalls */,
 				354235D524C11138008C84EE /* Purchasing */,
+				45E2D46098204ACDB35CCD86 /* RemoteConfig */,
 				57F3C0C929B7A04D0004FD7E /* Security */,
 				354895D0267AE32D001DC5B1 /* SubscriberAttributes */,
 				35E840C1270FB45600899AE2 /* Support */,
@@ -4916,6 +4924,15 @@
 				57488C7529CB90F90000EE7E /* PurchasedSK2Product.swift */,
 			);
 			path = OfflineEntitlements;
+			sourceTree = "<group>";
+		};
+		45E2D46098204ACDB35CCD86 /* RemoteConfig */ = {
+			isa = PBXGroup;
+			children = (
+				6309AD09B1054DC081B6BF7E /* RemoteConfigManager.swift */,
+				5CDDBB55FE1847498ECBA0A8 /* TopicFetcher.swift */,
+			);
+			path = RemoteConfig;
 			sourceTree = "<group>";
 		};
 		57488B8929CB75520000EE7E /* OfflineEntitlements */ = {
@@ -7180,6 +7197,9 @@
 				E6B064598F674333A29E0781 /* RemoteConfigCallback.swift in Sources */,
 				A6CC43904EBD4860BFD2BD85 /* GetRemoteConfigOperation.swift in Sources */,
 				D62A9C83BFD14E5FA0452CC7 /* RemoteConfigResponse.swift in Sources */,
+				3320C44A004844C1977301AB /* RemoteConfigManager.swift in Sources */,
+				D50B098A156B454292887410 /* TopicFetcher.swift in Sources */,
+				853DE70F5F0845C7A614DE45 /* RemoteConfigStrings.swift in Sources */,
 				DB3395DD2F840A790079250C /* WorkflowResponseAction.swift in Sources */,
 				2CD72944268A826F00BFC976 /* Date+Extensions.swift in Sources */,
 				57069A5428E3918400B86355 /* AsyncExtensions.swift in Sources */,

--- a/Sources/Error Handling/BackendError.swift
+++ b/Sources/Error Handling/BackendError.swift
@@ -280,6 +280,9 @@ extension BackendError {
 
         /// A call that is supposed to retrieve a CustomerInfo failed because the json object couldn't be parsed.
         case customerInfoResponseParsing(error: NSError, json: String)
+
+        /// A remote config topic entry contained a malformed blob_ref value.
+        case remoteConfigMalformedBlobRef
     }
 
 }
@@ -302,6 +305,8 @@ extension BackendError.UnexpectedBackendResponseError: DescribableError {
             return "Unable to instantiate a CustomerInfoResponse, CustomerInfo in response was nil."
         case .customerInfoResponseParsing:
             return "Unable to instantiate a CustomerInfoResponse due to malformed json."
+        case .remoteConfigMalformedBlobRef:
+            return "Remote config topic entry contained a malformed blob_ref."
         }
     }
 

--- a/Sources/Logging/Strings/BackendErrorStrings.swift
+++ b/Sources/Logging/Strings/BackendErrorStrings.swift
@@ -30,6 +30,7 @@ enum BackendErrorStrings {
     case unexpected_reward_verification_reward_value
     case unknown_workflow_trigger_type(type: String)
     case unknown_workflow_trigger_action_type(type: String)
+    case unknown_remote_config_topic(key: String)
 
 }
 
@@ -59,6 +60,8 @@ extension BackendErrorStrings: LogMessage {
             return "Received unknown workflow trigger type: \(type)"
         case let .unknown_workflow_trigger_action_type(type):
             return "Received unknown workflow trigger action type: \(type)"
+        case let .unknown_remote_config_topic(key):
+            return "Received unknown remote config topic: \(key)"
         }
     }
 

--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -1,0 +1,58 @@
+//
+//  RemoteConfigStrings.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 27/05/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+
+// swiftlint:disable identifier_name
+
+enum RemoteConfigStrings {
+
+    case remote_config_cache_hit
+    case remote_config_cache_stale_fetching_from_network
+    case remote_config_fetched_from_network
+    case remote_config_fetch_error(BackendError)
+
+    case topic_malformed_blob_ref(topic: RemoteConfigResponse.Topic, entryId: String)
+    case topic_cache_hit(topic: RemoteConfigResponse.Topic, entryId: String)
+    case topic_fetched(topic: RemoteConfigResponse.Topic, entryId: String)
+    case topic_fetch_error(topic: RemoteConfigResponse.Topic, entryId: String, error: BackendError)
+
+}
+
+extension RemoteConfigStrings: LogMessage {
+
+    var description: String {
+        switch self {
+        case .remote_config_cache_hit:
+            return "RemoteConfig: cache is still fresh."
+
+        case .remote_config_cache_stale_fetching_from_network:
+            return "RemoteConfig: cache is stale, fetching from network."
+
+        case .remote_config_fetched_from_network:
+            return "RemoteConfig: fetched from network."
+
+        case let .remote_config_fetch_error(error):
+            return "RemoteConfig: failed to fetch from network: \(error.localizedDescription)"
+
+        case let .topic_malformed_blob_ref(topic, entryId):
+            return "RemoteConfig: topic \(topic) (\(entryId)) has a malformed blob_ref; refusing to fetch."
+
+        case let .topic_cache_hit(topic, entryId):
+            return "RemoteConfig: topic \(topic) (\(entryId)) already cached, skipping download."
+
+        case let .topic_fetched(topic, entryId):
+            return "RemoteConfig: topic \(topic) (\(entryId)) downloaded and cached."
+
+        case let .topic_fetch_error(topic, entryId, error):
+            return "RemoteConfig: failed to fetch topic \(topic) (\(entryId)): \(error.localizedDescription)"
+        }
+    }
+
+    var category: String { return "remote_config" }
+
+}

--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -11,12 +11,11 @@ import Foundation
 
 enum RemoteConfigStrings {
 
-    case remote_config_cache_hit
-    case remote_config_cache_stale_fetching_from_network
-    case remote_config_fetched_from_network
     case remote_config_fetch_error(BackendError)
 
     case topic_malformed_blob_ref(topic: RemoteConfigResponse.Topic, entryId: String)
+    case topic_caches_dir_unavailable(topic: RemoteConfigResponse.Topic, entryId: String)
+    case topic_invalid_blob_url(topic: RemoteConfigResponse.Topic, entryId: String, urlString: String)
     case topic_cache_hit(topic: RemoteConfigResponse.Topic, entryId: String)
     case topic_fetched(topic: RemoteConfigResponse.Topic, entryId: String)
     case topic_fetch_error(topic: RemoteConfigResponse.Topic, entryId: String, error: BackendError)
@@ -27,20 +26,17 @@ extension RemoteConfigStrings: LogMessage {
 
     var description: String {
         switch self {
-        case .remote_config_cache_hit:
-            return "RemoteConfig: cache is still fresh."
-
-        case .remote_config_cache_stale_fetching_from_network:
-            return "RemoteConfig: cache is stale, fetching from network."
-
-        case .remote_config_fetched_from_network:
-            return "RemoteConfig: fetched from network."
-
         case let .remote_config_fetch_error(error):
             return "RemoteConfig: failed to fetch from network: \(error.localizedDescription)"
 
         case let .topic_malformed_blob_ref(topic, entryId):
             return "RemoteConfig: topic \(topic) (\(entryId)) has a malformed blob_ref; refusing to fetch."
+
+        case let .topic_caches_dir_unavailable(topic, entryId):
+            return "RemoteConfig: topic \(topic) (\(entryId)) could not resolve caches directory; skipping."
+
+        case let .topic_invalid_blob_url(topic, entryId, urlString):
+            return "RemoteConfig: topic \(topic) (\(entryId)) produced an invalid URL '\(urlString)'; skipping."
 
         case let .topic_cache_hit(topic, entryId):
             return "RemoteConfig: topic \(topic) (\(entryId)) already cached, skipping download."

--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -20,6 +20,10 @@ enum RemoteConfigStrings {
     case topic_fetched(topic: RemoteConfigResponse.Topic, entryId: String)
     case topic_fetch_error(topic: RemoteConfigResponse.Topic, entryId: String, error: BackendError)
 
+    case topic_cleanup_deleted(path: String)
+    case topic_cleanup_delete_failed(path: String, error: Error)
+    case topic_cleanup_list_failed(path: String, error: Error)
+
 }
 
 extension RemoteConfigStrings: LogMessage {
@@ -46,6 +50,17 @@ extension RemoteConfigStrings: LogMessage {
 
         case let .topic_fetch_error(topic, entryId, error):
             return "RemoteConfig: failed to fetch topic \(topic) (\(entryId)): \(error.localizedDescription)"
+
+        case let .topic_cleanup_deleted(path):
+            return "RemoteConfig: deleted unreferenced topic file at \(path)."
+
+        case let .topic_cleanup_delete_failed(path, error):
+            return "RemoteConfig: failed to delete unreferenced topic file at \(path): " +
+                "\(error.localizedDescription)"
+
+        case let .topic_cleanup_list_failed(path, error):
+            return "RemoteConfig: failed to list topic files at \(path); skipping cleanup for that " +
+                "topic: \(error.localizedDescription)"
         }
     }
 

--- a/Sources/Logging/Strings/Strings.swift
+++ b/Sources/Logging/Strings/Strings.swift
@@ -31,6 +31,7 @@ enum Strings {
     static let offlineEntitlements = OfflineEntitlementsStrings.self
     static let paywalls = PaywallsStrings.self
     static let purchase = PurchaseStrings.self
+    static let remoteConfig = RemoteConfigStrings.self
     static let webRedemption = WebRedemptionStrings.self
     static let receipt = ReceiptStrings.self
     static let signing = SigningStrings.self

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -26,6 +26,7 @@ class Backend {
     let virtualCurrenciesAPI: VirtualCurrenciesAPI
     let workflowsAPI: WorkflowsAPI
     let adsAPI: AdsAPI
+    let remoteConfigAPI: RemoteConfigAPI
 
     private let config: BackendConfiguration
 
@@ -67,6 +68,7 @@ class Backend {
         let virtualCurrenciesAPI = VirtualCurrenciesAPI(backendConfig: backendConfig)
         let workflowsAPI = WorkflowsAPI(backendConfig: backendConfig)
         let adsAPI = AdsAPI(backendConfig: backendConfig)
+        let remoteConfigAPI = RemoteConfigAPI(backendConfig: backendConfig)
 
         self.init(backendConfig: backendConfig,
                   customerAPI: customer,
@@ -79,7 +81,8 @@ class Backend {
                   redeemWebPurchaseAPI: redeemWebPurchaseAPI,
                   virtualCurrenciesAPI: virtualCurrenciesAPI,
                   workflowsAPI: workflowsAPI,
-                  adsAPI: adsAPI)
+                  adsAPI: adsAPI,
+                  remoteConfigAPI: remoteConfigAPI)
     }
 
     required init(backendConfig: BackendConfiguration,
@@ -93,7 +96,8 @@ class Backend {
                   redeemWebPurchaseAPI: RedeemWebPurchaseAPI,
                   virtualCurrenciesAPI: VirtualCurrenciesAPI,
                   workflowsAPI: WorkflowsAPI,
-                  adsAPI: AdsAPI) {
+                  adsAPI: AdsAPI,
+                  remoteConfigAPI: RemoteConfigAPI) {
         self.config = backendConfig
 
         self.customer = customerAPI
@@ -107,6 +111,7 @@ class Backend {
         self.virtualCurrenciesAPI = virtualCurrenciesAPI
         self.workflowsAPI = workflowsAPI
         self.adsAPI = adsAPI
+        self.remoteConfigAPI = remoteConfigAPI
     }
 
     func clearHTTPClientCaches() {

--- a/Sources/Networking/Caching/RemoteConfigCallback.swift
+++ b/Sources/Networking/Caching/RemoteConfigCallback.swift
@@ -1,0 +1,15 @@
+//
+//  RemoteConfigCallback.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 27/05/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+
+struct RemoteConfigCallback: CacheKeyProviding {
+
+    let cacheKey: String
+    let completion: (Result<RemoteConfigResponse, BackendError>) -> Void
+
+}

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -263,6 +263,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .postRedeemWebPurchase,
                 .getCustomerCenterConfig,
                 .postCreateTicket,
+                // WIP: Move to true when we have the final endpoint for remote config, and we can remove the fallback
                 .getRemoteConfig:
             return false
         case .rewardVerificationStatus:

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -109,6 +109,8 @@ extension HTTPRequest {
         case postCreateTicket
         case isPurchaseAllowedByRestoreBehavior(appUserID: String)
         case rewardVerificationStatus(appUserID: String, clientTransactionID: String)
+        // WIP: endpoint path and signing requirements subject to change
+        case getRemoteConfig
 
     }
 
@@ -203,6 +205,9 @@ extension HTTPRequest.Path: HTTPRequestPath {
         case .health,
              .appHealthReportAvailability:
             return false
+
+        case .getRemoteConfig:
+            return true
         }
     }
 
@@ -229,7 +234,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .rewardVerificationStatus:
             return true
         case .health,
-             .appHealthReportAvailability:
+             .appHealthReportAvailability,
+             .getRemoteConfig:
             return false
         }
     }
@@ -256,7 +262,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .postOfferForSigning,
                 .postRedeemWebPurchase,
                 .getCustomerCenterConfig,
-                .postCreateTicket:
+                .postCreateTicket,
+                .getRemoteConfig:
             return false
         case .rewardVerificationStatus:
             return true
@@ -286,13 +293,19 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .getProductEntitlementMapping,
                 .getCustomerCenterConfig,
                 .appHealthReport,
-                .postCreateTicket:
+                .postCreateTicket,
+                .getRemoteConfig:
             return false
         }
     }
 
     var relativePath: String {
-        return "/v1/\(self.pathComponent)"
+        switch self {
+        case .getRemoteConfig:
+            return "/v2/config"
+        default:
+            return "/v1/\(self.pathComponent)"
+        }
     }
 
     var pathComponent: String {
@@ -362,6 +375,9 @@ extension HTTPRequest.Path: HTTPRequestPath {
 
         case let .rewardVerificationStatus(appUserID, clientTransactionID):
             return "subscribers/\(Self.escape(appUserID))/ads/reward_verifications/\(Self.escape(clientTransactionID))"
+
+        case .getRemoteConfig:
+            return "config"
         }
     }
 
@@ -428,6 +444,9 @@ extension HTTPRequest.Path: HTTPRequestPath {
 
         case .rewardVerificationStatus:
             return "get_reward_verification_status"
+
+        case .getRemoteConfig:
+            return "get_remote_config"
         }
     }
 

--- a/Sources/Networking/Operations/GetRemoteConfigOperation.swift
+++ b/Sources/Networking/Operations/GetRemoteConfigOperation.swift
@@ -1,0 +1,66 @@
+//
+//  GetRemoteConfigOperation.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 27/05/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+
+final class GetRemoteConfigOperation: CacheableNetworkOperation {
+
+    private let callbackCache: CallbackCache<RemoteConfigCallback>
+
+    static func createFactory(
+        configuration: NetworkConfiguration,
+        callbackCache: CallbackCache<RemoteConfigCallback>
+    ) -> CacheableNetworkOperationFactory<GetRemoteConfigOperation> {
+        return .init({ cacheKey in
+                .init(
+                    configuration: configuration,
+                    callbackCache: callbackCache,
+                    cacheKey: cacheKey
+                )
+        },
+                     individualizedCacheKeyPart: "")
+    }
+
+    private init(
+        configuration: NetworkConfiguration,
+        callbackCache: CallbackCache<RemoteConfigCallback>,
+        cacheKey: String
+    ) {
+        self.callbackCache = callbackCache
+        super.init(configuration: configuration, cacheKey: cacheKey)
+    }
+
+    override func begin(completion: @escaping () -> Void) {
+        self.getRemoteConfig(completion: completion)
+    }
+
+}
+
+// Restating inherited @unchecked Sendable from Foundation's Operation
+extension GetRemoteConfigOperation: @unchecked Sendable {}
+
+private extension GetRemoteConfigOperation {
+
+    func getRemoteConfig(completion: @escaping () -> Void) {
+        let request = HTTPRequest(method: .get, path: .getRemoteConfig)
+
+        self.httpClient.perform(request) { (response: VerifiedHTTPResponse<RemoteConfigResponse>.Result) in
+            defer {
+                completion()
+            }
+
+            self.callbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
+                callback.completion(
+                    response
+                        .map { $0.body }
+                        .mapError(BackendError.networkError)
+                )
+            }
+        }
+    }
+
+}

--- a/Sources/Networking/Operations/GetRemoteConfigOperation.swift
+++ b/Sources/Networking/Operations/GetRemoteConfigOperation.swift
@@ -15,14 +15,16 @@ final class GetRemoteConfigOperation: CacheableNetworkOperation {
         configuration: NetworkConfiguration,
         callbackCache: CallbackCache<RemoteConfigCallback>
     ) -> CacheableNetworkOperationFactory<GetRemoteConfigOperation> {
-        return .init({ cacheKey in
+        return .init(
+            { cacheKey in
                 .init(
                     configuration: configuration,
                     callbackCache: callbackCache,
                     cacheKey: cacheKey
                 )
-        },
-                     individualizedCacheKeyPart: "")
+            },
+            individualizedCacheKeyPart: ""
+        )
     }
 
     private init(

--- a/Sources/Networking/RemoteConfigAPI.swift
+++ b/Sources/Networking/RemoteConfigAPI.swift
@@ -1,0 +1,41 @@
+//
+//  RemoteConfigAPI.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 27/05/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+
+class RemoteConfigAPI {
+
+    typealias RemoteConfigResponseHandler = Backend.ResponseHandler<RemoteConfigResponse>
+
+    private let callbackCache: CallbackCache<RemoteConfigCallback>
+    private let backendConfig: BackendConfiguration
+
+    init(backendConfig: BackendConfiguration) {
+        self.backendConfig = backendConfig
+        self.callbackCache = .init()
+    }
+
+    func getRemoteConfig(
+        isAppBackgrounded: Bool,
+        completion: @escaping RemoteConfigResponseHandler
+    ) {
+        let factory = GetRemoteConfigOperation.createFactory(
+            configuration: self.backendConfig,
+            callbackCache: self.callbackCache
+        )
+
+        let callback = RemoteConfigCallback(cacheKey: factory.cacheKey, completion: completion)
+        let cacheStatus = self.callbackCache.add(callback)
+
+        self.backendConfig.addCacheableOperation(
+            with: factory,
+            delay: .default(forBackgroundedApp: isAppBackgrounded),
+            cacheStatus: cacheStatus
+        )
+    }
+
+}

--- a/Sources/Networking/Responses/RemoteConfigResponse.swift
+++ b/Sources/Networking/Responses/RemoteConfigResponse.swift
@@ -55,14 +55,14 @@ extension RemoteConfigResponse {
 
         case productEntitlementMapping
 
-        var wireKey: String {
+        var rawValue: String {
             switch self {
             case .productEntitlementMapping: return "product_entitlement_mapping"
             }
         }
 
-        init?(wireKey: String) {
-            switch wireKey {
+        init?(rawValue: String) {
+            switch rawValue {
             case "product_entitlement_mapping": self = .productEntitlementMapping
             default: return nil
             }
@@ -106,7 +106,7 @@ extension RemoteConfigResponse.Manifest: Codable {
             forKey: .topics
         ) ?? [:]
         self.topics = rawTopics.reduce(into: [:]) { result, pair in
-            if let topic = RemoteConfigResponse.Topic(wireKey: pair.key) {
+            if let topic = RemoteConfigResponse.Topic(rawValue: pair.key) {
                 result[topic] = pair.value
             } else {
                 Logger.warn(Strings.backendError.unknown_remote_config_topic(key: pair.key))
@@ -116,7 +116,7 @@ extension RemoteConfigResponse.Manifest: Codable {
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        let rawTopics = Dictionary(uniqueKeysWithValues: topics.map { ($0.key.wireKey, $0.value) })
+        let rawTopics = Dictionary(uniqueKeysWithValues: topics.map { ($0.key.rawValue, $0.value) })
         try container.encode(rawTopics, forKey: .topics)
     }
 

--- a/Sources/Networking/Responses/RemoteConfigResponse.swift
+++ b/Sources/Networking/Responses/RemoteConfigResponse.swift
@@ -1,0 +1,125 @@
+//
+//  RemoteConfigResponse.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 27/05/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+
+struct RemoteConfigResponse: Equatable {
+
+    let apiSources: [ApiSource]
+    let blobSources: [BlobSource]
+    let manifest: Manifest
+
+    init(
+        apiSources: [ApiSource] = [],
+        blobSources: [BlobSource] = [],
+        manifest: Manifest = Manifest()
+    ) {
+        self.apiSources = apiSources
+        self.blobSources = blobSources
+        self.manifest = manifest
+    }
+
+}
+
+extension RemoteConfigResponse {
+
+    struct ApiSource: Codable, Equatable {
+        let id: String
+        let url: String
+        let priority: Int
+        let weight: Int
+    }
+
+    struct BlobSource: Codable, Equatable {
+        let id: String
+        let urlFormat: String
+        let priority: Int
+        let weight: Int
+    }
+
+    struct Manifest: Equatable {
+
+        let topics: [Topic: [String: TopicEntry]]
+
+        init(topics: [Topic: [String: TopicEntry]] = [:]) {
+            self.topics = topics
+        }
+
+    }
+
+    enum Topic: Hashable {
+
+        case productEntitlementMapping
+
+        var wireKey: String {
+            switch self {
+            case .productEntitlementMapping: return "product_entitlement_mapping"
+            }
+        }
+
+        init?(wireKey: String) {
+            switch wireKey {
+            case "product_entitlement_mapping": self = .productEntitlementMapping
+            default: return nil
+            }
+        }
+
+    }
+
+    struct TopicEntry: Codable, Equatable {
+        let blobRef: String
+    }
+
+}
+
+// MARK: - Codable
+
+extension RemoteConfigResponse: Codable {
+
+    private enum CodingKeys: CodingKey {
+        case apiSources, blobSources, manifest
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.apiSources = try container.decodeIfPresent([ApiSource].self, forKey: .apiSources) ?? []
+        self.blobSources = try container.decodeIfPresent([BlobSource].self, forKey: .blobSources) ?? []
+        self.manifest = try container.decodeIfPresent(Manifest.self, forKey: .manifest) ?? Manifest()
+    }
+
+}
+
+extension RemoteConfigResponse.Manifest: Codable {
+
+    private enum CodingKeys: CodingKey {
+        case topics
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let rawTopics = try container.decodeIfPresent(
+            [String: [String: RemoteConfigResponse.TopicEntry]].self,
+            forKey: .topics
+        ) ?? [:]
+        self.topics = rawTopics.reduce(into: [:]) { result, pair in
+            if let topic = RemoteConfigResponse.Topic(wireKey: pair.key) {
+                result[topic] = pair.value
+            }
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        let rawTopics = Dictionary(uniqueKeysWithValues: topics.map { ($0.key.wireKey, $0.value) })
+        try container.encode(rawTopics, forKey: .topics)
+    }
+
+}
+
+// MARK: - HTTPResponseBody
+
+extension RemoteConfigResponse: HTTPResponseBody {}

--- a/Sources/Networking/Responses/RemoteConfigResponse.swift
+++ b/Sources/Networking/Responses/RemoteConfigResponse.swift
@@ -108,6 +108,8 @@ extension RemoteConfigResponse.Manifest: Codable {
         self.topics = rawTopics.reduce(into: [:]) { result, pair in
             if let topic = RemoteConfigResponse.Topic(wireKey: pair.key) {
                 result[topic] = pair.value
+            } else {
+                Logger.warn(Strings.backendError.unknown_remote_config_topic(key: pair.key))
             }
         }
     }

--- a/Sources/Networking/Responses/RemoteConfigResponse.swift
+++ b/Sources/Networking/Responses/RemoteConfigResponse.swift
@@ -51,7 +51,7 @@ extension RemoteConfigResponse {
 
     }
 
-    enum Topic: Hashable {
+    enum Topic: Hashable, CaseIterable {
 
         case productEntitlementMapping
 

--- a/Sources/RemoteConfig/RemoteConfigManager.swift
+++ b/Sources/RemoteConfig/RemoteConfigManager.swift
@@ -66,14 +66,18 @@ private extension RemoteConfigManager {
         guard !tasks.isEmpty else { return nil }
 
         return await withTaskGroup(of: BackendError?.self) { group in
-            for task in tasks {
-                group.addTask {
-                    await self.topicFetcher.fetchTopicIfNeeded(
-                        topic: task.topic,
-                        entryId: task.entryId,
-                        topicEntry: task.entry,
-                        source: source
-                    )
+            var iterator = tasks.makeIterator()
+
+            for _ in 0..<min(Self.maxParallelTopicDownloads, tasks.count) {
+                if let task = iterator.next() {
+                    group.addTask {
+                        await self.topicFetcher.fetchTopicIfNeeded(
+                            topic: task.topic,
+                            entryId: task.entryId,
+                            topicEntry: task.entry,
+                            source: source
+                        )
+                    }
                 }
             }
 
@@ -81,6 +85,16 @@ private extension RemoteConfigManager {
             for await error in group {
                 if let error, firstError == nil {
                     firstError = error
+                }
+                if let task = iterator.next() {
+                    group.addTask {
+                        await self.topicFetcher.fetchTopicIfNeeded(
+                            topic: task.topic,
+                            entryId: task.entryId,
+                            topicEntry: task.entry,
+                            source: source
+                        )
+                    }
                 }
             }
             return firstError
@@ -94,5 +108,6 @@ private extension RemoteConfigManager {
     }
 
     static let defaultEntryID = "default"
+    static let maxParallelTopicDownloads = 4
 
 }

--- a/Sources/RemoteConfig/RemoteConfigManager.swift
+++ b/Sources/RemoteConfig/RemoteConfigManager.swift
@@ -121,8 +121,10 @@ private extension RemoteConfigManager {
     func buildReferenceSet(
         manifest: RemoteConfigResponse.Manifest
     ) -> [RemoteConfigResponse.Topic: Set<String>] {
+        // Normalize to lowercase so the keep-set matches the on-disk filenames produced by
+        // `TopicFetcher.fetchTopicIfNeeded`, which lowercases blob refs before writing.
         manifest.topics.mapValues { entries in
-            Set(entries.values.map { $0.blobRef })
+            Set(entries.values.map { $0.blobRef.lowercased() })
         }
     }
 

--- a/Sources/RemoteConfig/RemoteConfigManager.swift
+++ b/Sources/RemoteConfig/RemoteConfigManager.swift
@@ -56,16 +56,33 @@ private extension RemoteConfigManager {
 
     func handleResponse(_ response: RemoteConfigResponse) async -> BackendError? {
         // WIP: pick source by weighted priority once WeightedSource is wired up (#3458 equivalent).
-        guard let source = response.blobSources.first else { return nil }
+        let source = response.blobSources.first
 
         let tasks: [TopicTask] = response.manifest.topics.compactMap { topic, entries in
             guard let entry = entries[Self.defaultEntryID] else { return nil }
             return TopicTask(topic: topic, entryId: Self.defaultEntryID, entry: entry)
         }
 
-        guard !tasks.isEmpty else { return nil }
+        let referenced = self.buildReferenceSet(manifest: response.manifest)
 
-        return await withTaskGroup(of: BackendError?.self) { group in
+        let firstError: BackendError?
+        if let source, !tasks.isEmpty {
+            firstError = await self.downloadTopics(tasks: tasks, source: source)
+        } else {
+            firstError = nil
+        }
+
+        if firstError == nil, source != nil, !tasks.isEmpty {
+            await self.topicFetcher.cleanupUnreferencedTopics(referenced: referenced)
+        }
+        return firstError
+    }
+
+    func downloadTopics(
+        tasks: [TopicTask],
+        source: RemoteConfigResponse.BlobSource
+    ) async -> BackendError? {
+        await withTaskGroup(of: BackendError?.self) { group -> BackendError? in
             var iterator = tasks.makeIterator()
 
             for _ in 0..<min(Self.maxParallelTopicDownloads, tasks.count) {
@@ -98,6 +115,14 @@ private extension RemoteConfigManager {
                 }
             }
             return firstError
+        }
+    }
+
+    func buildReferenceSet(
+        manifest: RemoteConfigResponse.Manifest
+    ) -> [RemoteConfigResponse.Topic: Set<String>] {
+        manifest.topics.mapValues { entries in
+            Set(entries.values.map { $0.blobRef })
         }
     }
 

--- a/Sources/RemoteConfig/RemoteConfigManager.swift
+++ b/Sources/RemoteConfig/RemoteConfigManager.swift
@@ -1,0 +1,98 @@
+//
+//  RemoteConfigManager.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 27/05/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+
+class RemoteConfigManager {
+
+    private let remoteConfigAPI: RemoteConfigAPI
+    private let topicFetcher: TopicFetcher
+
+    init(
+        remoteConfigAPI: RemoteConfigAPI,
+        topicFetcher: TopicFetcher
+    ) {
+        self.remoteConfigAPI = remoteConfigAPI
+        self.topicFetcher = topicFetcher
+    }
+
+    func updateRemoteConfigIfNeeded(
+        isAppBackgrounded: Bool,
+        completion: (@MainActor @Sendable (BackendError?) -> Void)?
+    ) {
+        Task {
+            let result: Result<RemoteConfigResponse, BackendError> = await withCheckedContinuation { continuation in
+                self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: isAppBackgrounded) { result in
+                    continuation.resume(returning: result)
+                }
+            }
+
+            let error: BackendError?
+            switch result {
+            case let .success(response):
+                error = await self.handleResponse(response)
+            case let .failure(backendError):
+                Logger.error(Strings.remoteConfig.remote_config_fetch_error(backendError))
+                error = backendError
+            }
+
+            if let completion {
+                await MainActor.run { completion(error) }
+            }
+        }
+    }
+
+}
+
+// @unchecked because:
+// - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.
+extension RemoteConfigManager: @unchecked Sendable {}
+
+private extension RemoteConfigManager {
+
+    func handleResponse(_ response: RemoteConfigResponse) async -> BackendError? {
+        // WIP: pick source by weighted priority once WeightedSource is wired up (#3458 equivalent).
+        guard let source = response.blobSources.first else { return nil }
+
+        let tasks: [TopicTask] = response.manifest.topics.compactMap { topic, entries in
+            guard let entry = entries[Self.defaultEntryID] else { return nil }
+            return TopicTask(topic: topic, entryId: Self.defaultEntryID, entry: entry)
+        }
+
+        guard !tasks.isEmpty else { return nil }
+
+        return await withTaskGroup(of: BackendError?.self) { group in
+            for task in tasks {
+                group.addTask {
+                    await self.topicFetcher.fetchTopicIfNeeded(
+                        topic: task.topic,
+                        entryId: task.entryId,
+                        topicEntry: task.entry,
+                        source: source
+                    )
+                }
+            }
+
+            var firstError: BackendError?
+            for await error in group {
+                if let error, firstError == nil {
+                    firstError = error
+                }
+            }
+            return firstError
+        }
+    }
+
+    struct TopicTask {
+        let topic: RemoteConfigResponse.Topic
+        let entryId: String
+        let entry: RemoteConfigResponse.TopicEntry
+    }
+
+    static let defaultEntryID = "default"
+
+}

--- a/Sources/RemoteConfig/TopicFetcher.swift
+++ b/Sources/RemoteConfig/TopicFetcher.swift
@@ -156,7 +156,7 @@ private extension TopicFetcher {
         guard let cachesDir = self.baseCacheURL ?? DirectoryHelper.baseUrl(for: .cache) else { return nil }
         let topicDir = cachesDir
             .appendingPathComponent(Self.topicsRoot)
-            .appendingPathComponent(topic.wireKey)
+            .appendingPathComponent(topic.rawValue)
 
         if !self.fileManager.fileExists(atPath: topicDir.path) {
             try? self.fileManager.createDirectory(at: topicDir, withIntermediateDirectories: true, attributes: nil)

--- a/Sources/RemoteConfig/TopicFetcher.swift
+++ b/Sources/RemoteConfig/TopicFetcher.swift
@@ -8,17 +8,41 @@
 import CryptoKit
 import Foundation
 
+protocol FileManaging: AnyObject {
+    func fileExists(atPath path: String) -> Bool
+    func createDirectory(
+        at url: URL,
+        withIntermediateDirectories createIntermediates: Bool,
+        attributes attr: [FileAttributeKey: Any]?
+    ) throws
+    func replaceItemAt(
+        _ originalItemURL: URL,
+        withItemAt newItemURL: URL,
+        backupItemName: String?,
+        options mask: FileManager.ItemReplacementOptions
+    ) throws -> URL?
+    func removeItem(at url: URL) throws
+}
+
+extension FileManager: FileManaging {}
+
 class TopicFetcher {
 
     private static let topicsRoot = "RevenueCat/topics"
     private static let blobRefPlaceholder = "{blob_ref}"
 
-    private let fileManager: FileManager
+    private let fileManager: any FileManaging
     private let urlSession: URLSession
+    private let baseCacheURL: URL?
 
-    init(fileManager: FileManager = .default, urlSession: URLSession = .shared) {
+    init(
+        fileManager: any FileManaging = FileManager.default,
+        urlSession: URLSession = .shared,
+        baseCacheURL: URL? = nil
+    ) {
         self.fileManager = fileManager
         self.urlSession = urlSession
+        self.baseCacheURL = baseCacheURL
     }
 
     func fetchTopicIfNeeded(
@@ -29,23 +53,11 @@ class TopicFetcher {
     ) async -> BackendError? {
         guard self.isValidBlobRef(topicEntry.blobRef) else {
             Logger.error(Strings.remoteConfig.topic_malformed_blob_ref(topic: topic, entryId: entryId))
-            return .networkError(.networkError(
-                NSError(
-                    domain: "com.revenuecat.remoteconfig",
-                    code: -1,
-                    userInfo: [NSLocalizedDescriptionKey: "Malformed blob_ref for topic \(topic) (\(entryId))"]
-                )
-            ))
+            return TopicFetchError.malformedBlobRef.backendError
         }
 
         guard let targetFile = self.topicFile(topic: topic, blobRef: topicEntry.blobRef) else {
-            return .networkError(.networkError(
-                NSError(
-                    domain: "com.revenuecat.remoteconfig",
-                    code: -4,
-                    userInfo: [NSLocalizedDescriptionKey: "Could not resolve caches directory"]
-                )
-            ))
+            return TopicFetchError.cachesDirectoryUnavailable.backendError
         }
 
         if self.fileManager.fileExists(atPath: targetFile.path) {
@@ -58,13 +70,7 @@ class TopicFetcher {
             with: topicEntry.blobRef
         )
         guard let url = URL(string: urlString) else {
-            return .networkError(.networkError(
-                NSError(
-                    domain: "com.revenuecat.remoteconfig",
-                    code: -3,
-                    userInfo: [NSLocalizedDescriptionKey: "Invalid blob URL: \(urlString)"]
-                )
-            ))
+            return TopicFetchError.invalidBlobURL(urlString: urlString).backendError
         }
 
         let error = await self.download(url: url, expectedSHA256: topicEntry.blobRef, targetFile: targetFile)
@@ -82,16 +88,54 @@ class TopicFetcher {
 // - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.
 extension TopicFetcher: @unchecked Sendable {}
 
+private enum TopicFetchError {
+
+    case malformedBlobRef
+    case cachesDirectoryUnavailable
+    case invalidBlobURL(urlString: String)
+    case unexpectedHTTPStatus(statusCode: Int)
+    case sha256Mismatch(expected: String, actual: String)
+    case writeFailure(error: Error)
+
+    var backendError: BackendError {
+        switch self {
+        case .malformedBlobRef:
+            return .unexpectedBackendResponse(.remoteConfigMalformedBlobRef)
+        case .cachesDirectoryUnavailable:
+            return Self.make(code: -4, "Could not resolve caches directory")
+        case .invalidBlobURL(let urlString):
+            return Self.make(code: -3, "Invalid blob URL: \(urlString)")
+        case .unexpectedHTTPStatus(let statusCode):
+            return Self.make(code: -5, "Unexpected HTTP status: \(statusCode)")
+        case .sha256Mismatch(let expected, let actual):
+            return Self.make(code: -2, "SHA-256 mismatch: expected \(expected), got \(actual)")
+        case .writeFailure(let error):
+            return .networkError(.networkError(error))
+        }
+    }
+
+    private static func make(code: Int, _ message: String) -> BackendError {
+        .networkError(.networkError(
+            NSError(
+                domain: "com.revenuecat.remoteconfig",
+                code: code,
+                userInfo: [NSLocalizedDescriptionKey: message]
+            )
+        ))
+    }
+
+}
+
 private extension TopicFetcher {
 
     func topicFile(topic: RemoteConfigResponse.Topic, blobRef: String) -> URL? {
-        guard let cachesDir = DirectoryHelper.baseUrl(for: .cache) else { return nil }
+        guard let cachesDir = self.baseCacheURL ?? DirectoryHelper.baseUrl(for: .cache) else { return nil }
         let topicDir = cachesDir
             .appendingPathComponent(Self.topicsRoot)
             .appendingPathComponent(topic.wireKey)
 
         if !self.fileManager.fileExists(atPath: topicDir.path) {
-            try? self.fileManager.createDirectory(at: topicDir, withIntermediateDirectories: true)
+            try? self.fileManager.createDirectory(at: topicDir, withIntermediateDirectories: true, attributes: nil)
         }
 
         return topicDir.appendingPathComponent(blobRef)
@@ -99,9 +143,16 @@ private extension TopicFetcher {
 
     func download(url: URL, expectedSHA256: String, targetFile: URL) async -> BackendError? {
         return await withCheckedContinuation { continuation in
-            self.urlSession.dataTask(with: url) { [self] data, _, error in
+            self.urlSession.dataTask(with: url) { [self] data, response, error in
                 if let error {
                     continuation.resume(returning: .networkError(.networkError(error)))
+                    return
+                }
+
+                let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+                guard statusCode == 200 else {
+                    let error = TopicFetchError.unexpectedHTTPStatus(statusCode: statusCode).backendError
+                    continuation.resume(returning: error)
                     return
                 }
 
@@ -115,14 +166,10 @@ private extension TopicFetcher {
                     .joined()
 
                 guard actualSHA256 == expectedSHA256 else {
-                    continuation.resume(returning: .networkError(.networkError(
-                        NSError(
-                            domain: "com.revenuecat.remoteconfig",
-                            code: -2,
-                            userInfo: [NSLocalizedDescriptionKey:
-                                "SHA-256 mismatch: expected \(expectedSHA256), got \(actualSHA256)"]
-                        )
-                    )))
+                    continuation.resume(returning: TopicFetchError.sha256Mismatch(
+                        expected: expectedSHA256,
+                        actual: actualSHA256
+                    ).backendError)
                     return
                 }
 
@@ -131,11 +178,13 @@ private extension TopicFetcher {
 
                 do {
                     try data.write(to: tempFile, options: .atomic)
-                    _ = try? self.fileManager.replaceItemAt(targetFile, withItemAt: tempFile)
+                    _ = try self.fileManager.replaceItemAt(
+                        targetFile, withItemAt: tempFile, backupItemName: nil, options: []
+                    )
                     continuation.resume(returning: nil)
                 } catch {
                     try? self.fileManager.removeItem(at: tempFile)
-                    continuation.resume(returning: .networkError(.networkError(error)))
+                    continuation.resume(returning: TopicFetchError.writeFailure(error: error).backendError)
                 }
             }.resume()
         }

--- a/Sources/RemoteConfig/TopicFetcher.swift
+++ b/Sources/RemoteConfig/TopicFetcher.swift
@@ -21,6 +21,7 @@ protocol FileManaging: AnyObject {
         backupItemName: String?,
         options mask: FileManager.ItemReplacementOptions
     ) throws -> URL?
+    func copyItem(at srcURL: URL, to dstURL: URL) throws
     func removeItem(at url: URL) throws
 }
 
@@ -45,7 +46,7 @@ private final class URLSessionBlobDownloader: BlobDownloader {
             if let error {
                 completion(.failure(error))
             } else if let httpResponse = response as? HTTPURLResponse,
-                      !(200..<300).contains(httpResponse.statusCode) {
+                      httpResponse.statusCode != 200 {
                 completion(.failure(URLError(.badServerResponse)))
             } else if let data {
                 completion(.success(data))
@@ -189,13 +190,18 @@ private extension TopicFetcher {
                     let tempFile = parent.appendingPathComponent("rc_topic_\(UUID().uuidString).tmp")
 
                     do {
+                        defer { try? self.fileManager.removeItem(at: tempFile) }
                         try data.write(to: tempFile, options: .atomic)
-                        _ = try self.fileManager.replaceItemAt(
-                            targetFile, withItemAt: tempFile, backupItemName: nil, options: []
-                        )
+                        do {
+                            _ = try self.fileManager.replaceItemAt(
+                                targetFile, withItemAt: tempFile, backupItemName: nil, options: []
+                            )
+                        } catch {
+                            try? self.fileManager.removeItem(at: targetFile)
+                            try self.fileManager.copyItem(at: tempFile, to: targetFile)
+                        }
                         continuation.resume(returning: nil)
                     } catch {
-                        try? self.fileManager.removeItem(at: tempFile)
                         continuation.resume(returning: TopicFetchError.writeFailure(error: error).backendError)
                     }
                 }
@@ -204,7 +210,7 @@ private extension TopicFetcher {
     }
 
     func isValidBlobRef(_ blobRef: String) -> Bool {
-        !blobRef.isEmpty && blobRef.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber) }
+        blobRef.range(of: "^[a-fA-F0-9]{64}$", options: .regularExpression) != nil
     }
 
 }

--- a/Sources/RemoteConfig/TopicFetcher.swift
+++ b/Sources/RemoteConfig/TopicFetcher.swift
@@ -1,0 +1,148 @@
+//
+//  TopicFetcher.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 27/05/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import CryptoKit
+import Foundation
+
+class TopicFetcher {
+
+    private static let topicsRoot = "RevenueCat/topics"
+    private static let blobRefPlaceholder = "{blob_ref}"
+
+    private let fileManager: FileManager
+    private let urlSession: URLSession
+
+    init(fileManager: FileManager = .default, urlSession: URLSession = .shared) {
+        self.fileManager = fileManager
+        self.urlSession = urlSession
+    }
+
+    func fetchTopicIfNeeded(
+        topic: RemoteConfigResponse.Topic,
+        entryId: String,
+        topicEntry: RemoteConfigResponse.TopicEntry,
+        source: RemoteConfigResponse.BlobSource
+    ) async -> BackendError? {
+        guard self.isValidBlobRef(topicEntry.blobRef) else {
+            Logger.error(Strings.remoteConfig.topic_malformed_blob_ref(topic: topic, entryId: entryId))
+            return .networkError(.networkError(
+                NSError(
+                    domain: "com.revenuecat.remoteconfig",
+                    code: -1,
+                    userInfo: [NSLocalizedDescriptionKey: "Malformed blob_ref for topic \(topic) (\(entryId))"]
+                )
+            ))
+        }
+
+        guard let targetFile = self.topicFile(topic: topic, blobRef: topicEntry.blobRef) else {
+            return .networkError(.networkError(
+                NSError(
+                    domain: "com.revenuecat.remoteconfig",
+                    code: -4,
+                    userInfo: [NSLocalizedDescriptionKey: "Could not resolve caches directory"]
+                )
+            ))
+        }
+
+        if self.fileManager.fileExists(atPath: targetFile.path) {
+            Logger.verbose(Strings.remoteConfig.topic_cache_hit(topic: topic, entryId: entryId))
+            return nil
+        }
+
+        let urlString = source.urlFormat.replacingOccurrences(
+            of: Self.blobRefPlaceholder,
+            with: topicEntry.blobRef
+        )
+        guard let url = URL(string: urlString) else {
+            return .networkError(.networkError(
+                NSError(
+                    domain: "com.revenuecat.remoteconfig",
+                    code: -3,
+                    userInfo: [NSLocalizedDescriptionKey: "Invalid blob URL: \(urlString)"]
+                )
+            ))
+        }
+
+        let error = await self.download(url: url, expectedSHA256: topicEntry.blobRef, targetFile: targetFile)
+        if let error {
+            Logger.error(Strings.remoteConfig.topic_fetch_error(topic: topic, entryId: entryId, error: error))
+        } else {
+            Logger.debug(Strings.remoteConfig.topic_fetched(topic: topic, entryId: entryId))
+        }
+        return error
+    }
+
+}
+
+// @unchecked because:
+// - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.
+extension TopicFetcher: @unchecked Sendable {}
+
+private extension TopicFetcher {
+
+    func topicFile(topic: RemoteConfigResponse.Topic, blobRef: String) -> URL? {
+        guard let cachesDir = DirectoryHelper.baseUrl(for: .cache) else { return nil }
+        let topicDir = cachesDir
+            .appendingPathComponent(Self.topicsRoot)
+            .appendingPathComponent(topic.wireKey)
+
+        if !self.fileManager.fileExists(atPath: topicDir.path) {
+            try? self.fileManager.createDirectory(at: topicDir, withIntermediateDirectories: true)
+        }
+
+        return topicDir.appendingPathComponent(blobRef)
+    }
+
+    func download(url: URL, expectedSHA256: String, targetFile: URL) async -> BackendError? {
+        return await withCheckedContinuation { continuation in
+            self.urlSession.dataTask(with: url) { [self] data, _, error in
+                if let error {
+                    continuation.resume(returning: .networkError(.networkError(error)))
+                    return
+                }
+
+                guard let data else {
+                    continuation.resume(returning: .networkError(.unexpectedResponse(nil)))
+                    return
+                }
+
+                let actualSHA256 = SHA256.hash(data: data)
+                    .map { String(format: "%02x", $0) }
+                    .joined()
+
+                guard actualSHA256 == expectedSHA256 else {
+                    continuation.resume(returning: .networkError(.networkError(
+                        NSError(
+                            domain: "com.revenuecat.remoteconfig",
+                            code: -2,
+                            userInfo: [NSLocalizedDescriptionKey:
+                                "SHA-256 mismatch: expected \(expectedSHA256), got \(actualSHA256)"]
+                        )
+                    )))
+                    return
+                }
+
+                let parent = targetFile.deletingLastPathComponent()
+                let tempFile = parent.appendingPathComponent("rc_topic_\(UUID().uuidString).tmp")
+
+                do {
+                    try data.write(to: tempFile, options: .atomic)
+                    _ = try? self.fileManager.replaceItemAt(targetFile, withItemAt: tempFile)
+                    continuation.resume(returning: nil)
+                } catch {
+                    try? self.fileManager.removeItem(at: tempFile)
+                    continuation.resume(returning: .networkError(.networkError(error)))
+                }
+            }.resume()
+        }
+    }
+
+    func isValidBlobRef(_ blobRef: String) -> Bool {
+        !blobRef.isEmpty && blobRef.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber) }
+    }
+
+}

--- a/Sources/RemoteConfig/TopicFetcher.swift
+++ b/Sources/RemoteConfig/TopicFetcher.swift
@@ -26,22 +26,53 @@ protocol FileManaging: AnyObject {
 
 extension FileManager: FileManaging {}
 
+protocol BlobDownloader: AnyObject {
+    func fetchRawData(from url: URL, completion: @escaping (Result<Data, Error>) -> Void)
+}
+
+extension HTTPClient: BlobDownloader {}
+
+private final class URLSessionBlobDownloader: BlobDownloader {
+
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    func fetchRawData(from url: URL, completion: @escaping (Result<Data, Error>) -> Void) {
+        self.session.dataTask(with: url) { data, response, error in
+            if let error {
+                completion(.failure(error))
+            } else if let httpResponse = response as? HTTPURLResponse,
+                      !(200..<300).contains(httpResponse.statusCode) {
+                completion(.failure(URLError(.badServerResponse)))
+            } else if let data {
+                completion(.success(data))
+            } else {
+                completion(.failure(URLError(.unknown)))
+            }
+        }.resume()
+    }
+
+}
+
 class TopicFetcher {
 
     private static let topicsRoot = "RevenueCat/topics"
     private static let blobRefPlaceholder = "{blob_ref}"
 
     private let fileManager: any FileManaging
-    private let urlSession: URLSession
+    private let downloader: any BlobDownloader
     private let baseCacheURL: URL?
 
     init(
         fileManager: any FileManaging = FileManager.default,
-        urlSession: URLSession = .shared,
+        downloader: any BlobDownloader = URLSessionBlobDownloader(),
         baseCacheURL: URL? = nil
     ) {
         self.fileManager = fileManager
-        self.urlSession = urlSession
+        self.downloader = downloader
         self.baseCacheURL = baseCacheURL
     }
 
@@ -56,7 +87,13 @@ class TopicFetcher {
             return TopicFetchError.malformedBlobRef.backendError
         }
 
-        guard let targetFile = self.topicFile(topic: topic, blobRef: topicEntry.blobRef) else {
+        // Normalize to lowercase so the cache path and SHA-256 comparison are
+        // always consistent regardless of whether the backend sends upper- or
+        // lower-case hex (SHA256.hash produces lowercase via %02x).
+        let blobRef = topicEntry.blobRef.lowercased()
+
+        guard let targetFile = self.topicFile(topic: topic, blobRef: blobRef) else {
+            Logger.error(Strings.remoteConfig.topic_caches_dir_unavailable(topic: topic, entryId: entryId))
             return TopicFetchError.cachesDirectoryUnavailable.backendError
         }
 
@@ -65,15 +102,15 @@ class TopicFetcher {
             return nil
         }
 
-        let urlString = source.urlFormat.replacingOccurrences(
-            of: Self.blobRefPlaceholder,
-            with: topicEntry.blobRef
-        )
+        let urlString = source.urlFormat.replacingOccurrences(of: Self.blobRefPlaceholder, with: blobRef)
         guard let url = URL(string: urlString) else {
-            return TopicFetchError.invalidBlobURL(urlString: urlString).backendError
+            Logger.error(Strings.remoteConfig.topic_invalid_blob_url(
+                topic: topic, entryId: entryId, urlString: urlString
+            ))
+            return TopicFetchError.invalidBlobURL.backendError
         }
 
-        let error = await self.download(url: url, expectedSHA256: topicEntry.blobRef, targetFile: targetFile)
+        let error = await self.download(url: url, expectedSHA256: blobRef, targetFile: targetFile)
         if let error {
             Logger.error(Strings.remoteConfig.topic_fetch_error(topic: topic, entryId: entryId, error: error))
         } else {
@@ -92,8 +129,7 @@ private enum TopicFetchError {
 
     case malformedBlobRef
     case cachesDirectoryUnavailable
-    case invalidBlobURL(urlString: String)
-    case unexpectedHTTPStatus(statusCode: Int)
+    case invalidBlobURL
     case sha256Mismatch(expected: String, actual: String)
     case writeFailure(error: Error)
 
@@ -102,26 +138,14 @@ private enum TopicFetchError {
         case .malformedBlobRef:
             return .unexpectedBackendResponse(.remoteConfigMalformedBlobRef)
         case .cachesDirectoryUnavailable:
-            return Self.make(code: -4, "Could not resolve caches directory")
-        case .invalidBlobURL(let urlString):
-            return Self.make(code: -3, "Invalid blob URL: \(urlString)")
-        case .unexpectedHTTPStatus(let statusCode):
-            return Self.make(code: -5, "Unexpected HTTP status: \(statusCode)")
-        case .sha256Mismatch(let expected, let actual):
-            return Self.make(code: -2, "SHA-256 mismatch: expected \(expected), got \(actual)")
+            return .networkError(.networkError(URLError(.cannotCreateFile)))
+        case .invalidBlobURL:
+            return .networkError(.networkError(URLError(.badURL)))
+        case .sha256Mismatch:
+            return .networkError(.networkError(URLError(.cannotDecodeRawData)))
         case .writeFailure(let error):
             return .networkError(.networkError(error))
         }
-    }
-
-    private static func make(code: Int, _ message: String) -> BackendError {
-        .networkError(.networkError(
-            NSError(
-                domain: "com.revenuecat.remoteconfig",
-                code: code,
-                userInfo: [NSLocalizedDescriptionKey: message]
-            )
-        ))
     }
 
 }
@@ -143,50 +167,39 @@ private extension TopicFetcher {
 
     func download(url: URL, expectedSHA256: String, targetFile: URL) async -> BackendError? {
         return await withCheckedContinuation { continuation in
-            self.urlSession.dataTask(with: url) { [self] data, response, error in
-                if let error {
+            self.downloader.fetchRawData(from: url) { [self] result in
+                switch result {
+                case .failure(let error):
                     continuation.resume(returning: .networkError(.networkError(error)))
-                    return
+
+                case .success(let data):
+                    let actualSHA256 = SHA256.hash(data: data)
+                        .map { String(format: "%02x", $0) }
+                        .joined()
+
+                    guard actualSHA256 == expectedSHA256 else {
+                        continuation.resume(returning: TopicFetchError.sha256Mismatch(
+                            expected: expectedSHA256,
+                            actual: actualSHA256
+                        ).backendError)
+                        return
+                    }
+
+                    let parent = targetFile.deletingLastPathComponent()
+                    let tempFile = parent.appendingPathComponent("rc_topic_\(UUID().uuidString).tmp")
+
+                    do {
+                        try data.write(to: tempFile, options: .atomic)
+                        _ = try self.fileManager.replaceItemAt(
+                            targetFile, withItemAt: tempFile, backupItemName: nil, options: []
+                        )
+                        continuation.resume(returning: nil)
+                    } catch {
+                        try? self.fileManager.removeItem(at: tempFile)
+                        continuation.resume(returning: TopicFetchError.writeFailure(error: error).backendError)
+                    }
                 }
-
-                let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
-                guard statusCode == 200 else {
-                    let error = TopicFetchError.unexpectedHTTPStatus(statusCode: statusCode).backendError
-                    continuation.resume(returning: error)
-                    return
-                }
-
-                guard let data else {
-                    continuation.resume(returning: .networkError(.unexpectedResponse(nil)))
-                    return
-                }
-
-                let actualSHA256 = SHA256.hash(data: data)
-                    .map { String(format: "%02x", $0) }
-                    .joined()
-
-                guard actualSHA256 == expectedSHA256 else {
-                    continuation.resume(returning: TopicFetchError.sha256Mismatch(
-                        expected: expectedSHA256,
-                        actual: actualSHA256
-                    ).backendError)
-                    return
-                }
-
-                let parent = targetFile.deletingLastPathComponent()
-                let tempFile = parent.appendingPathComponent("rc_topic_\(UUID().uuidString).tmp")
-
-                do {
-                    try data.write(to: tempFile, options: .atomic)
-                    _ = try self.fileManager.replaceItemAt(
-                        targetFile, withItemAt: tempFile, backupItemName: nil, options: []
-                    )
-                    continuation.resume(returning: nil)
-                } catch {
-                    try? self.fileManager.removeItem(at: tempFile)
-                    continuation.resume(returning: TopicFetchError.writeFailure(error: error).backendError)
-                }
-            }.resume()
+            }
         }
     }
 

--- a/Sources/RemoteConfig/TopicFetcher.swift
+++ b/Sources/RemoteConfig/TopicFetcher.swift
@@ -23,6 +23,7 @@ protocol FileManaging: AnyObject {
     ) throws -> URL?
     func copyItem(at srcURL: URL, to dstURL: URL) throws
     func removeItem(at url: URL) throws
+    func contentsOfDirectory(at url: URL) throws -> [URL]
 }
 
 extension FileManager: FileManaging {}
@@ -62,6 +63,7 @@ class TopicFetcher {
 
     private static let topicsRoot = "RevenueCat/topics"
     private static let blobRefPlaceholder = "{blob_ref}"
+    private static let tempPrefix = "rc_topic_"
 
     private let fileManager: any FileManaging
     private let downloader: any BlobDownloader
@@ -120,6 +122,15 @@ class TopicFetcher {
         return error
     }
 
+    // todo: currently must be called after all `fetchTopicIfNeeded` are completed.
+    // Otherwise we could potentially remove new data we don't know about yet. We could
+    // improve this in the future with a guard of some sort.
+    func cleanupUnreferencedTopics(referenced: [RemoteConfigResponse.Topic: Set<String>]) async {
+        Task.detached(priority: .utility) { [self] in
+            self.deleteUnreferencedTopicFiles(referenced: referenced)
+        }
+    }
+
 }
 
 // @unchecked because:
@@ -153,11 +164,52 @@ private enum TopicFetchError {
 
 private extension TopicFetcher {
 
-    func topicFile(topic: RemoteConfigResponse.Topic, blobRef: String) -> URL? {
+    func topicsRootURL() -> URL? {
         guard let cachesDir = self.baseCacheURL ?? DirectoryHelper.baseUrl(for: .cache) else { return nil }
-        let topicDir = cachesDir
-            .appendingPathComponent(Self.topicsRoot)
-            .appendingPathComponent(topic.rawValue)
+        return cachesDir.appendingPathComponent(Self.topicsRoot)
+    }
+
+    func deleteUnreferencedTopicFiles(referenced: [RemoteConfigResponse.Topic: Set<String>]) {
+        guard let topicsRoot = self.topicsRootURL() else { return }
+        guard self.fileManager.fileExists(atPath: topicsRoot.path) else { return }
+
+        // todo: iterating `Topic.allCases` could leave orphaned files for topics that are
+        // removed from the SDK enum. We could improve this by removing everything not
+        // returned by the api.
+        // Layout assumption: each `topics/<topic>/` dir contains only 64-hex blob files and
+        // `rc_topic_*.tmp` in-flight downloads. Anything else gets wiped.
+        for topic in RemoteConfigResponse.Topic.allCases {
+            let topicDir = topicsRoot.appendingPathComponent(topic.rawValue)
+            guard self.fileManager.fileExists(atPath: topicDir.path) else { continue }
+
+            let files: [URL]
+            do {
+                files = try self.fileManager.contentsOfDirectory(at: topicDir)
+            } catch {
+                Logger.error(Strings.remoteConfig.topic_cleanup_list_failed(path: topicDir.path, error: error))
+                continue
+            }
+
+            let keep = referenced[topic] ?? []
+            for file in files {
+                let name = file.lastPathComponent
+                if name.hasPrefix(Self.tempPrefix) { continue }
+                if keep.contains(name) { continue }
+                do {
+                    try self.fileManager.removeItem(at: file)
+                    Logger.verbose(Strings.remoteConfig.topic_cleanup_deleted(path: file.path))
+                } catch {
+                    Logger.error(
+                        Strings.remoteConfig.topic_cleanup_delete_failed(path: file.path, error: error)
+                    )
+                }
+            }
+        }
+    }
+
+    func topicFile(topic: RemoteConfigResponse.Topic, blobRef: String) -> URL? {
+        guard let topicsRoot = self.topicsRootURL() else { return nil }
+        let topicDir = topicsRoot.appendingPathComponent(topic.rawValue)
 
         if !self.fileManager.fileExists(atPath: topicDir.path) {
             try? self.fileManager.createDirectory(at: topicDir, withIntermediateDirectories: true, attributes: nil)
@@ -187,7 +239,7 @@ private extension TopicFetcher {
                     }
 
                     let parent = targetFile.deletingLastPathComponent()
-                    let tempFile = parent.appendingPathComponent("rc_topic_\(UUID().uuidString).tmp")
+                    let tempFile = parent.appendingPathComponent("\(Self.tempPrefix)\(UUID().uuidString).tmp")
 
                     do {
                         defer { try? self.fileManager.removeItem(at: tempFile) }

--- a/Tests/UnitTests/Mocks/MockBackend.swift
+++ b/Tests/UnitTests/Mocks/MockBackend.swift
@@ -48,6 +48,7 @@ class MockBackend: Backend {
         let virtualCurrenciesAPI = MockVirtualCurrenciesAPI()
         let workflowsAPI = MockWorkflowsAPI()
         let adsAPI = MockAdsAPI()
+        let remoteConfigAPI = RemoteConfigAPI(backendConfig: backendConfig)
 
         self.init(backendConfig: backendConfig,
                   customerAPI: customer,
@@ -60,7 +61,8 @@ class MockBackend: Backend {
                   redeemWebPurchaseAPI: redeemWebPurchaseAPI,
                   virtualCurrenciesAPI: virtualCurrenciesAPI,
                   workflowsAPI: workflowsAPI,
-                  adsAPI: adsAPI)
+                  adsAPI: adsAPI,
+                  remoteConfigAPI: remoteConfigAPI)
     }
 
     override func post(receipt: EncodedAppleReceipt,

--- a/Tests/UnitTests/Mocks/MockRemoteConfigAPI.swift
+++ b/Tests/UnitTests/Mocks/MockRemoteConfigAPI.swift
@@ -1,0 +1,31 @@
+//
+//  MockRemoteConfigAPI.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 28/05/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+@testable import RevenueCat
+
+class MockRemoteConfigAPI: RemoteConfigAPI {
+
+    var stubbedResult: Result<RemoteConfigResponse, BackendError>?
+    var invokedGetRemoteConfigCount = 0
+    var invokedIsAppBackgrounded: Bool?
+
+    convenience init() {
+        self.init(backendConfig: MockBackendConfiguration())
+    }
+
+    override func getRemoteConfig(
+        isAppBackgrounded: Bool,
+        completion: @escaping RemoteConfigResponseHandler
+    ) {
+        self.invokedGetRemoteConfigCount += 1
+        self.invokedIsAppBackgrounded = isAppBackgrounded
+        if let result = self.stubbedResult {
+            completion(result)
+        }
+    }
+
+}

--- a/Tests/UnitTests/Mocks/MockTopicFetcher.swift
+++ b/Tests/UnitTests/Mocks/MockTopicFetcher.swift
@@ -1,0 +1,36 @@
+//
+//  MockTopicFetcher.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 28/05/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+@testable import RevenueCat
+
+class MockTopicFetcher: TopicFetcher {
+
+    struct FetchCall {
+        let topic: RemoteConfigResponse.Topic
+        let entryId: String
+        let topicEntry: RemoteConfigResponse.TopicEntry
+        let source: RemoteConfigResponse.BlobSource
+    }
+
+    var stubbedFetchResult: BackendError?
+    var fetchCalls: [FetchCall] = []
+
+    convenience init() {
+        self.init(fileManager: FileManager.default, urlSession: .shared)
+    }
+
+    override func fetchTopicIfNeeded(
+        topic: RemoteConfigResponse.Topic,
+        entryId: String,
+        topicEntry: RemoteConfigResponse.TopicEntry,
+        source: RemoteConfigResponse.BlobSource
+    ) async -> BackendError? {
+        self.fetchCalls.append(FetchCall(topic: topic, entryId: entryId, topicEntry: topicEntry, source: source))
+        return self.stubbedFetchResult
+    }
+
+}

--- a/Tests/UnitTests/Mocks/MockTopicFetcher.swift
+++ b/Tests/UnitTests/Mocks/MockTopicFetcher.swift
@@ -16,8 +16,15 @@ class MockTopicFetcher: TopicFetcher {
         let source: RemoteConfigResponse.BlobSource
     }
 
-    var stubbedFetchResult: BackendError?
-    var fetchCalls: [FetchCall] = []
+    enum Call: Equatable {
+        case fetch
+        case cleanup
+    }
+
+    let stubbedFetchResult: Atomic<BackendError?> = .init(nil)
+    let fetchCalls: Atomic<[FetchCall]> = .init([])
+    let cleanupCalls: Atomic<[[RemoteConfigResponse.Topic: Set<String>]]> = .init([])
+    let callOrder: Atomic<[Call]> = .init([])
 
     convenience init() {
         self.init(fileManager: FileManager.default)
@@ -29,8 +36,16 @@ class MockTopicFetcher: TopicFetcher {
         topicEntry: RemoteConfigResponse.TopicEntry,
         source: RemoteConfigResponse.BlobSource
     ) async -> BackendError? {
-        self.fetchCalls.append(FetchCall(topic: topic, entryId: entryId, topicEntry: topicEntry, source: source))
-        return self.stubbedFetchResult
+        self.fetchCalls.modify {
+            $0.append(FetchCall(topic: topic, entryId: entryId, topicEntry: topicEntry, source: source))
+        }
+        self.callOrder.modify { $0.append(.fetch) }
+        return self.stubbedFetchResult.value
+    }
+
+    override func cleanupUnreferencedTopics(referenced: [RemoteConfigResponse.Topic: Set<String>]) async {
+        self.cleanupCalls.modify { $0.append(referenced) }
+        self.callOrder.modify { $0.append(.cleanup) }
     }
 
 }

--- a/Tests/UnitTests/Mocks/MockTopicFetcher.swift
+++ b/Tests/UnitTests/Mocks/MockTopicFetcher.swift
@@ -20,7 +20,7 @@ class MockTopicFetcher: TopicFetcher {
     var fetchCalls: [FetchCall] = []
 
     convenience init() {
-        self.init(fileManager: FileManager.default, urlSession: .shared)
+        self.init(fileManager: FileManager.default)
     }
 
     override func fetchTopicIfNeeded(

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -1,0 +1,219 @@
+//
+//  BackendGetRemoteConfigTests.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 27/05/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+final class BackendGetRemoteConfigTests: BaseBackendTests {
+
+    override func createClient() -> MockHTTPClient {
+        super.createClient(#file)
+    }
+
+    // MARK: - Basic request
+
+    func testGetRemoteConfigCallsHTTPMethod() {
+        self.httpClient.mock(
+            requestPath: .getRemoteConfig,
+            response: .init(statusCode: .success, response: Self.fullResponse)
+        )
+
+        let result = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+        }
+
+        expect(result).to(beSuccess())
+        expect(self.httpClient.calls).to(haveCount(1))
+    }
+
+    func testGetRemoteConfigUsesCorrectPath() {
+        self.httpClient.mock(
+            requestPath: .getRemoteConfig,
+            response: .init(statusCode: .success, response: Self.fullResponse)
+        )
+
+        waitUntil { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false) { _ in completed() }
+        }
+
+        expect(self.httpClient.calls.map { $0.request.path as? HTTPRequest.Path }) == [.getRemoteConfig]
+    }
+
+    // MARK: - Jitterable delay
+
+    func testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded() {
+        self.httpClient.mock(
+            requestPath: .getRemoteConfig,
+            response: .init(statusCode: .success, response: Self.fullResponse)
+        )
+
+        let result = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: true, completion: completed)
+        }
+
+        expect(result).to(beSuccess())
+        expect(self.operationDispatcher.invokedDispatchOnWorkerThreadDelayParam) == JitterableDelay.default
+    }
+
+    func testGetRemoteConfigUsesNoDelayWhenNotBackgrounded() {
+        self.httpClient.mock(
+            requestPath: .getRemoteConfig,
+            response: .init(statusCode: .success, response: Self.fullResponse)
+        )
+
+        let result = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+        }
+
+        expect(result).to(beSuccess())
+        expect(self.operationDispatcher.invokedDispatchOnWorkerThreadDelayParam) == JitterableDelay.none
+    }
+
+    // MARK: - Request coalescing
+
+    func testGetRemoteConfigCoalescesSimultaneousRequests() {
+        self.httpClient.mock(
+            requestPath: .getRemoteConfig,
+            response: .init(statusCode: .success,
+                            response: Self.fullResponse,
+                            delay: .milliseconds(10))
+        )
+
+        let responses: Atomic<Int> = .init(0)
+
+        self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false) { _ in responses.value += 1 }
+        self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false) { _ in responses.value += 1 }
+
+        expect(responses.value).toEventually(equal(2))
+        expect(self.httpClient.calls).to(haveCount(1))
+    }
+
+    func testCoalescedRequestsLogDebugMessage() {
+        self.httpClient.mock(
+            requestPath: .getRemoteConfig,
+            response: .init(statusCode: .success,
+                            response: Self.fullResponse,
+                            delay: .milliseconds(10))
+        )
+
+        self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false) { _ in }
+        self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false) { _ in }
+
+        expect(self.httpClient.calls).toEventually(haveCount(1))
+        expect(self.httpClient.calls).toNever(haveCount(2))
+
+        self.logger.verifyMessageWasLogged(
+            "Network operation '\(GetRemoteConfigOperation.self)' found with the same cache key",
+            level: .debug
+        )
+    }
+
+    // MARK: - Response parsing
+
+    func testGetRemoteConfigParsesFullResponse() throws {
+        self.httpClient.mock(
+            requestPath: .getRemoteConfig,
+            response: .init(statusCode: .success, response: Self.fullResponse)
+        )
+
+        let result: Result<RemoteConfigResponse, BackendError>? = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+        }
+
+        let response = try XCTUnwrap(result?.value)
+        expect(response.apiSources).to(haveCount(1))
+        expect(response.apiSources[0].id) == "primary"
+        expect(response.blobSources).to(haveCount(1))
+        expect(response.blobSources[0].id) == "cloudfront-primary"
+
+        let pem = response.manifest.topics[.productEntitlementMapping]
+        expect(pem?["DEFAULT"]?.blobRef) == "6a4d0f53d9f6b8e2f4dca0fd1c7c4f5e3e1b1ef0"
+    }
+
+    func testGetRemoteConfigParsesEmptyResponse() throws {
+        self.httpClient.mock(
+            requestPath: .getRemoteConfig,
+            response: .init(statusCode: .success, response: [:] as [String: Any])
+        )
+
+        let result: Result<RemoteConfigResponse, BackendError>? = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+        }
+
+        let response = try XCTUnwrap(result?.value)
+        expect(response.apiSources).to(beEmpty())
+        expect(response.blobSources).to(beEmpty())
+        expect(response.manifest.topics).to(beEmpty())
+    }
+
+    // MARK: - Error handling
+
+    func testGetRemoteConfigFailSendsError() {
+        self.httpClient.mock(
+            requestPath: .getRemoteConfig,
+            response: .init(error: .unexpectedResponse(nil))
+        )
+
+        let result = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+        }
+
+        expect(result).to(beFailure())
+    }
+
+    func testGetRemoteConfigNetworkErrorSendsError() {
+        let mockedError: NetworkError = .unexpectedResponse(nil)
+
+        self.httpClient.mock(
+            requestPath: .getRemoteConfig,
+            response: .init(error: mockedError)
+        )
+
+        let result = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+        }
+
+        expect(result).to(beFailure())
+        expect(result?.error) == .networkError(mockedError)
+    }
+
+}
+
+private extension BackendGetRemoteConfigTests {
+
+    static let fullResponse: [String: Any] = [
+        "api_sources": [
+            [
+                "id": "primary",
+                "url": "https://api.revenuecat.com/",
+                "priority": 0,
+                "weight": 100
+            ] as [String: Any]
+        ],
+        "blob_sources": [
+            [
+                "id": "cloudfront-primary",
+                "url_format": "https://assets.revenuecat.com/rc_app_1234/{blob_ref}",
+                "priority": 0,
+                "weight": 100
+            ] as [String: Any]
+        ],
+        "manifest": [
+            "topics": [
+                "product_entitlement_mapping": [
+                    "DEFAULT": [
+                        "blob_ref": "6a4d0f53d9f6b8e2f4dca0fd1c7c4f5e3e1b1ef0"
+                    ]
+                ]
+            ]
+        ] as [String: Any]
+    ]
+
+}

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -134,7 +134,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(response.blobSources[0].id) == "cloudfront-primary"
 
         let pem = response.manifest.topics[.productEntitlementMapping]
-        expect(pem?["DEFAULT"]?.blobRef) == "6a4d0f53d9f6b8e2f4dca0fd1c7c4f5e3e1b1ef0"
+        expect(pem?["default"]?.blobRef) == "6a4d0f53d9f6b8e2f4dca0fd1c7c4f5e3e1b1ef0"
     }
 
     func testGetRemoteConfigParsesEmptyResponse() throws {
@@ -208,7 +208,7 @@ private extension BackendGetRemoteConfigTests {
         "manifest": [
             "topics": [
                 "product_entitlement_mapping": [
-                    "DEFAULT": [
+                    "default": [
                         "blob_ref": "6a4d0f53d9f6b8e2f4dca0fd1c7c4f5e3e1b1ef0"
                     ]
                 ]

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -38,6 +38,7 @@ class BaseBackendTests: TestCase {
     private(set) var virtualCurrenciesAPI: VirtualCurrenciesAPI!
     private(set) var workflowsAPI: WorkflowsAPI!
     private(set) var adsAPI: AdsAPI!
+    private(set) var remoteConfigAPI: RemoteConfigAPI!
     /// Controls what the CDN fetch returns. Tests can reassign this before triggering a `use_cdn` response
     /// because the closure registered with `WorkflowsAPI` captures `self` and reads this property at call time.
     var stubbedCdnFetch: WorkflowCdnFetch = { _, _, completion in completion(.success(Data())) }
@@ -103,6 +104,7 @@ class BaseBackendTests: TestCase {
             self?.stubbedCdnFetch(cdnUrl, hash, completion) ?? completion(.success(Data()))
         })
         self.adsAPI = AdsAPI(backendConfig: backendConfig)
+        self.remoteConfigAPI = RemoteConfigAPI(backendConfig: backendConfig)
 
         self.backend = Backend(backendConfig: backendConfig,
                                customerAPI: customer,
@@ -115,7 +117,8 @@ class BaseBackendTests: TestCase {
                                redeemWebPurchaseAPI: self.redeemWebPurchaseAPI,
                                virtualCurrenciesAPI: self.virtualCurrenciesAPI,
                                workflowsAPI: self.workflowsAPI,
-                               adsAPI: self.adsAPI)
+                               adsAPI: self.adsAPI,
+                               remoteConfigAPI: self.remoteConfigAPI)
     }
 
     var verificationMode: Configuration.EntitlementVerificationMode {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testCoalescedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testCoalescedRequestsLogDebugMessage.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigCallsHTTPMethod.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigFailSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigFailSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigNetworkErrorSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigParsesEmptyResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigParsesEmptyResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigParsesFullResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigParsesFullResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigUsesCorrectPath.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigUsesCorrectPath.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS14-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testCoalescedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testCoalescedRequestsLogDebugMessage.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigCallsHTTPMethod.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigFailSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigFailSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigNetworkErrorSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigParsesEmptyResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigParsesEmptyResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigParsesFullResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigParsesFullResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigUsesCorrectPath.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigUsesCorrectPath.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS15-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testCoalescedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testCoalescedRequestsLogDebugMessage.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigCallsHTTPMethod.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigFailSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigFailSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigNetworkErrorSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigParsesEmptyResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigParsesEmptyResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigParsesFullResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigParsesFullResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigUsesCorrectPath.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigUsesCorrectPath.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS16-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testCoalescedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testCoalescedRequestsLogDebugMessage.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigCallsHTTPMethod.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigFailSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigFailSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigNetworkErrorSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigParsesEmptyResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigParsesEmptyResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigParsesFullResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigParsesFullResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigUsesCorrectPath.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigUsesCorrectPath.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS17-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testCoalescedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testCoalescedRequestsLogDebugMessage.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigCallsHTTPMethod.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigFailSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigFailSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigNetworkErrorSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigParsesEmptyResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigParsesEmptyResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigParsesFullResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigParsesFullResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigUsesCorrectPath.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigUsesCorrectPath.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS18-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testCoalescedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testCoalescedRequestsLogDebugMessage.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigCallsHTTPMethod.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigFailSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigFailSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigNetworkErrorSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigParsesEmptyResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigParsesEmptyResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigParsesFullResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigParsesFullResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigUsesCorrectPath.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigUsesCorrectPath.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/iOS26-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testCoalescedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testCoalescedRequestsLogDebugMessage.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigCallsHTTPMethod.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigFailSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigFailSendsError.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigNetworkErrorSendsError.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigParsesEmptyResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigParsesEmptyResponse.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigParsesFullResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigParsesFullResponse.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigUsesCorrectPath.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigUsesCorrectPath.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/macOS-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testCoalescedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testCoalescedRequestsLogDebugMessage.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigCallsHTTPMethod.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigFailSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigFailSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigNetworkErrorSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigParsesEmptyResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigParsesEmptyResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigParsesFullResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigParsesFullResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigUsesCorrectPath.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigUsesCorrectPath.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/tvOS18-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testCoalescedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testCoalescedRequestsLogDebugMessage.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigCallsHTTPMethod.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigCoalescesSimultaneousRequests.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigFailSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigFailSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigNetworkErrorSendsError.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigParsesEmptyResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigParsesEmptyResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigParsesFullResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigParsesFullResponse.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigUsesCorrectPath.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigUsesCorrectPath.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRemoteConfigTests/watchOS-testGetRemoteConfigUsesNoDelayWhenNotBackgrounded.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v2/config"
+  }
+}

--- a/Tests/UnitTests/Networking/Responses/RemoteConfigResponseDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/RemoteConfigResponseDecodingTests.swift
@@ -1,0 +1,253 @@
+//
+//  RemoteConfigResponseDecodingTests.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 27/05/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+import Nimble
+@testable import RevenueCat
+import XCTest
+
+final class RemoteConfigResponseDecodingTests: TestCase {
+
+    // MARK: - Full payload
+
+    func testDeserializesFullPayload() throws {
+        let payload = """
+        {
+          "api_sources": [
+            {
+              "id": "primary",
+              "url": "https://api.revenuecat.com/",
+              "priority": 0,
+              "weight": 100
+            }
+          ],
+          "blob_sources": [
+            {
+              "id": "cloudfront-primary",
+              "url_format": "https://assets.revenuecat.com/rc_app_1234/{blob_ref}",
+              "priority": 0,
+              "weight": 100
+            }
+          ],
+          "manifest": {
+            "topics": {
+              "product_entitlement_mapping": {
+                "DEFAULT": {
+                  "blob_ref": "abc123"
+                }
+              }
+            }
+          }
+        }
+        """.asData
+
+        let response = try JSONDecoder.default.decode(RemoteConfigResponse.self, from: payload)
+
+        expect(response.apiSources).to(haveCount(1))
+        expect(response.apiSources[0].id) == "primary"
+        expect(response.apiSources[0].url) == "https://api.revenuecat.com/"
+        expect(response.apiSources[0].priority) == 0
+        expect(response.apiSources[0].weight) == 100
+
+        expect(response.blobSources).to(haveCount(1))
+        expect(response.blobSources[0].id) == "cloudfront-primary"
+        expect(response.blobSources[0].urlFormat) == "https://assets.revenuecat.com/rc_app_1234/{blob_ref}"
+        expect(response.blobSources[0].priority) == 0
+        expect(response.blobSources[0].weight) == 100
+
+        let pem = try XCTUnwrap(response.manifest.topics[.productEntitlementMapping])
+        expect(pem["DEFAULT"]?.blobRef) == "abc123"
+    }
+
+    // MARK: - Default values
+
+    func testMissingSourcesAndManifestFallBackToDefaults() throws {
+        let response = try JSONDecoder.default.decode(RemoteConfigResponse.self, from: "{}".asData)
+
+        expect(response.apiSources).to(beEmpty())
+        expect(response.blobSources).to(beEmpty())
+        expect(response.manifest.topics).to(beEmpty())
+    }
+
+    func testMissingManifestTopicsFallsBackToEmpty() throws {
+        let response = try JSONDecoder.default.decode(
+            RemoteConfigResponse.self,
+            from: #"{"manifest": {}}"#.asData
+        )
+
+        expect(response.manifest.topics).to(beEmpty())
+    }
+
+    // MARK: - Unknown fields are ignored
+
+    func testUnknownTopLevelFieldsAreIgnored() throws {
+        let payload = """
+        {
+          "future_top_level": true,
+          "api_sources": [
+            {
+              "id": "primary",
+              "url": "https://api.revenuecat.com/",
+              "priority": 0,
+              "weight": 100,
+              "future_field": "ignored"
+            }
+          ],
+          "blob_sources": [
+            {
+              "id": "primary",
+              "url_format": "https://assets.example/{blob_ref}",
+              "priority": 0,
+              "weight": 100,
+              "future_field": "ignored"
+            }
+          ],
+          "manifest": {
+            "future_manifest_field": [],
+            "topics": {
+              "product_entitlement_mapping": {
+                "DEFAULT": {
+                  "blob_ref": "abc",
+                  "future_per_entry": 7
+                }
+              }
+            }
+          }
+        }
+        """.asData
+
+        let response = try JSONDecoder.default.decode(RemoteConfigResponse.self, from: payload)
+
+        expect(response.apiSources).to(haveCount(1))
+        expect(response.apiSources[0].id) == "primary"
+        expect(response.blobSources).to(haveCount(1))
+        expect(response.blobSources[0].id) == "primary"
+        expect(response.manifest.topics[.productEntitlementMapping]?["DEFAULT"]?.blobRef) == "abc"
+    }
+
+    // MARK: - Unknown topic keys dropped
+
+    func testUnknownTopicNamesAreDropped() throws {
+        let payload = """
+        {
+          "manifest": {
+            "topics": {
+              "product_entitlement_mapping": {"DEFAULT": {"blob_ref": "abc"}},
+              "future_topic": {"DEFAULT": {"blob_ref": "def"}},
+              "another_unknown": {"DEFAULT": {"blob_ref": "ghi"}}
+            }
+          }
+        }
+        """.asData
+
+        let response = try JSONDecoder.default.decode(RemoteConfigResponse.self, from: payload)
+
+        expect(response.manifest.topics).to(haveCount(1))
+        expect(response.manifest.topics.keys).to(contain(.productEntitlementMapping))
+    }
+
+    func testAllUnknownTopicsProducesEmptyMap() throws {
+        let payload = """
+        {"manifest": {"topics": {"future_topic": {"DEFAULT": {"blob_ref": "abc"}}}}}
+        """.asData
+
+        let response = try JSONDecoder.default.decode(RemoteConfigResponse.self, from: payload)
+
+        expect(response.manifest.topics).to(beEmpty())
+    }
+
+    func testEmptyTopicsObjectProducesEmptyMap() throws {
+        let response = try JSONDecoder.default.decode(
+            RemoteConfigResponse.self,
+            from: #"{"manifest": {"topics": {}}}"#.asData
+        )
+
+        expect(response.manifest.topics).to(beEmpty())
+    }
+
+    func testMultipleVariantKeysForKnownTopicArePreserved() throws {
+        let payload = """
+        {
+          "manifest": {
+            "topics": {
+              "product_entitlement_mapping": {
+                "DEFAULT": {"blob_ref": "default-blob"},
+                "EXPERIMENT_A": {"blob_ref": "experiment-blob"}
+              }
+            }
+          }
+        }
+        """.asData
+
+        let response = try JSONDecoder.default.decode(RemoteConfigResponse.self, from: payload)
+
+        let variants = try XCTUnwrap(response.manifest.topics[.productEntitlementMapping])
+        expect(variants).to(haveCount(2))
+        expect(variants["DEFAULT"]?.blobRef) == "default-blob"
+        expect(variants["EXPERIMENT_A"]?.blobRef) == "experiment-blob"
+    }
+
+    // MARK: - Encoding round-trip
+
+    func testTopicsEncodeBackToWireKey() throws {
+        let manifest = RemoteConfigResponse.Manifest(
+            topics: [.productEntitlementMapping: ["DEFAULT": .init(blobRef: "abc")]]
+        )
+
+        let encoded = try JSONEncoder().encode(manifest)
+        let json = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+
+        expect(json).to(contain("\"product_entitlement_mapping\""))
+        expect(json).toNot(contain("productEntitlementMapping"))
+    }
+
+    func testRoundTripPreservesKnownTopics() throws {
+        let original = RemoteConfigResponse(
+            apiSources: [.init(id: "primary", url: "https://api.revenuecat.com/", priority: 0, weight: 100)],
+            blobSources: [.init(id: "cdn", urlFormat: "https://assets.example/{blob_ref}", priority: 0, weight: 100)],
+            manifest: .init(topics: [.productEntitlementMapping: ["DEFAULT": .init(blobRef: "abc")]])
+        )
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder.default.decode(RemoteConfigResponse.self, from: encoded)
+
+        expect(decoded) == original
+    }
+
+    // MARK: - Topic init
+
+    func testTopicInitFromKnownWireKey() {
+        expect(RemoteConfigResponse.Topic(wireKey: "product_entitlement_mapping")) == .productEntitlementMapping
+    }
+
+    func testTopicInitReturnsNilForUnknownWireKey() {
+        expect(RemoteConfigResponse.Topic(wireKey: "future_topic")).to(beNil())
+        expect(RemoteConfigResponse.Topic(wireKey: "PRODUCT_ENTITLEMENT_MAPPING")).to(beNil())
+        expect(RemoteConfigResponse.Topic(wireKey: "")).to(beNil())
+    }
+
+    // MARK: - Type errors are rejected
+
+    func testWrongTypeForBlobSourcesIsRejected() {
+        expect {
+            try JSONDecoder.default.decode(
+                RemoteConfigResponse.self,
+                from: #"{"blob_sources": "not-an-array"}"#.asData
+            )
+        }.to(throwError())
+    }
+
+    func testWrongTypeForApiSourcesIsRejected() {
+        expect {
+            try JSONDecoder.default.decode(
+                RemoteConfigResponse.self,
+                from: #"{"api_sources": "not-an-array"}"#.asData
+            )
+        }.to(throwError())
+    }
+
+}

--- a/Tests/UnitTests/Networking/Responses/RemoteConfigResponseDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/RemoteConfigResponseDecodingTests.swift
@@ -36,7 +36,7 @@ final class RemoteConfigResponseDecodingTests: TestCase {
           "manifest": {
             "topics": {
               "product_entitlement_mapping": {
-                "DEFAULT": {
+                "default": {
                   "blob_ref": "abc123"
                 }
               }
@@ -60,7 +60,7 @@ final class RemoteConfigResponseDecodingTests: TestCase {
         expect(response.blobSources[0].weight) == 100
 
         let pem = try XCTUnwrap(response.manifest.topics[.productEntitlementMapping])
-        expect(pem["DEFAULT"]?.blobRef) == "abc123"
+        expect(pem["default"]?.blobRef) == "abc123"
     }
 
     // MARK: - Default values
@@ -110,7 +110,7 @@ final class RemoteConfigResponseDecodingTests: TestCase {
             "future_manifest_field": [],
             "topics": {
               "product_entitlement_mapping": {
-                "DEFAULT": {
+                "default": {
                   "blob_ref": "abc",
                   "future_per_entry": 7
                 }
@@ -126,7 +126,7 @@ final class RemoteConfigResponseDecodingTests: TestCase {
         expect(response.apiSources[0].id) == "primary"
         expect(response.blobSources).to(haveCount(1))
         expect(response.blobSources[0].id) == "primary"
-        expect(response.manifest.topics[.productEntitlementMapping]?["DEFAULT"]?.blobRef) == "abc"
+        expect(response.manifest.topics[.productEntitlementMapping]?["default"]?.blobRef) == "abc"
     }
 
     // MARK: - Unknown topic keys dropped
@@ -136,9 +136,9 @@ final class RemoteConfigResponseDecodingTests: TestCase {
         {
           "manifest": {
             "topics": {
-              "product_entitlement_mapping": {"DEFAULT": {"blob_ref": "abc"}},
-              "future_topic": {"DEFAULT": {"blob_ref": "def"}},
-              "another_unknown": {"DEFAULT": {"blob_ref": "ghi"}}
+              "product_entitlement_mapping": {"default": {"blob_ref": "abc"}},
+              "future_topic": {"default": {"blob_ref": "def"}},
+              "another_unknown": {"default": {"blob_ref": "ghi"}}
             }
           }
         }
@@ -152,7 +152,7 @@ final class RemoteConfigResponseDecodingTests: TestCase {
 
     func testAllUnknownTopicsProducesEmptyMap() throws {
         let payload = """
-        {"manifest": {"topics": {"future_topic": {"DEFAULT": {"blob_ref": "abc"}}}}}
+        {"manifest": {"topics": {"future_topic": {"default": {"blob_ref": "abc"}}}}}
         """.asData
 
         let response = try JSONDecoder.default.decode(RemoteConfigResponse.self, from: payload)
@@ -175,7 +175,7 @@ final class RemoteConfigResponseDecodingTests: TestCase {
           "manifest": {
             "topics": {
               "product_entitlement_mapping": {
-                "DEFAULT": {"blob_ref": "default-blob"},
+                "default": {"blob_ref": "default-blob"},
                 "EXPERIMENT_A": {"blob_ref": "experiment-blob"}
               }
             }
@@ -187,7 +187,7 @@ final class RemoteConfigResponseDecodingTests: TestCase {
 
         let variants = try XCTUnwrap(response.manifest.topics[.productEntitlementMapping])
         expect(variants).to(haveCount(2))
-        expect(variants["DEFAULT"]?.blobRef) == "default-blob"
+        expect(variants["default"]?.blobRef) == "default-blob"
         expect(variants["EXPERIMENT_A"]?.blobRef) == "experiment-blob"
     }
 
@@ -195,7 +195,7 @@ final class RemoteConfigResponseDecodingTests: TestCase {
 
     func testTopicsEncodeBackToWireKey() throws {
         let manifest = RemoteConfigResponse.Manifest(
-            topics: [.productEntitlementMapping: ["DEFAULT": .init(blobRef: "abc")]]
+            topics: [.productEntitlementMapping: ["default": .init(blobRef: "abc")]]
         )
 
         let encoded = try JSONEncoder().encode(manifest)
@@ -209,7 +209,7 @@ final class RemoteConfigResponseDecodingTests: TestCase {
         let original = RemoteConfigResponse(
             apiSources: [.init(id: "primary", url: "https://api.revenuecat.com/", priority: 0, weight: 100)],
             blobSources: [.init(id: "cdn", urlFormat: "https://assets.example/{blob_ref}", priority: 0, weight: 100)],
-            manifest: .init(topics: [.productEntitlementMapping: ["DEFAULT": .init(blobRef: "abc")]])
+            manifest: .init(topics: [.productEntitlementMapping: ["default": .init(blobRef: "abc")]])
         )
 
         let encoded = try JSONEncoder().encode(original)

--- a/Tests/UnitTests/Networking/Responses/RemoteConfigResponseDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/RemoteConfigResponseDecodingTests.swift
@@ -193,7 +193,7 @@ final class RemoteConfigResponseDecodingTests: TestCase {
 
     // MARK: - Encoding round-trip
 
-    func testTopicsEncodeBackToWireKey() throws {
+    func testTopicsEncodeBackToRawValue() throws {
         let manifest = RemoteConfigResponse.Manifest(
             topics: [.productEntitlementMapping: ["default": .init(blobRef: "abc")]]
         )
@@ -220,14 +220,14 @@ final class RemoteConfigResponseDecodingTests: TestCase {
 
     // MARK: - Topic init
 
-    func testTopicInitFromKnownWireKey() {
-        expect(RemoteConfigResponse.Topic(wireKey: "product_entitlement_mapping")) == .productEntitlementMapping
+    func testTopicInitFromKnownRawValue() {
+        expect(RemoteConfigResponse.Topic(rawValue: "product_entitlement_mapping")) == .productEntitlementMapping
     }
 
-    func testTopicInitReturnsNilForUnknownWireKey() {
-        expect(RemoteConfigResponse.Topic(wireKey: "future_topic")).to(beNil())
-        expect(RemoteConfigResponse.Topic(wireKey: "PRODUCT_ENTITLEMENT_MAPPING")).to(beNil())
-        expect(RemoteConfigResponse.Topic(wireKey: "")).to(beNil())
+    func testTopicInitReturnsNilForUnknownRawValue() {
+        expect(RemoteConfigResponse.Topic(rawValue: "future_topic")).to(beNil())
+        expect(RemoteConfigResponse.Topic(rawValue: "PRODUCT_ENTITLEMENT_MAPPING")).to(beNil())
+        expect(RemoteConfigResponse.Topic(rawValue: "")).to(beNil())
     }
 
     // MARK: - Type errors are rejected

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -489,6 +489,7 @@ extension BasePurchasesTests {
             let redeemWebPurchaseAPI = RedeemWebPurchaseAPI(backendConfig: backendConfig)
             let virtualCurrenciesAPI = VirtualCurrenciesAPI(backendConfig: backendConfig)
             let workflowsAPI = WorkflowsAPI(backendConfig: backendConfig)
+            let remoteConfigAPI = RemoteConfigAPI(backendConfig: backendConfig)
 
             self.init(backendConfig: backendConfig,
                       customerAPI: customer,
@@ -501,7 +502,8 @@ extension BasePurchasesTests {
                       redeemWebPurchaseAPI: redeemWebPurchaseAPI,
                       virtualCurrenciesAPI: virtualCurrenciesAPI,
                       workflowsAPI: workflowsAPI,
-                      adsAPI: mockAdsAPI)
+                      adsAPI: mockAdsAPI,
+                      remoteConfigAPI: remoteConfigAPI)
         }
 
         var userID: String?

--- a/Tests/UnitTests/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/RemoteConfig/RemoteConfigManagerTests.swift
@@ -46,8 +46,8 @@ final class RemoteConfigManagerTests: TestCase {
         }
 
         expect(receivedError).to(beNil())
-        expect(self.topicFetcher.fetchCalls).to(haveCount(1))
-        let call = self.topicFetcher.fetchCalls.first
+        expect(self.topicFetcher.fetchCalls.value).to(haveCount(1))
+        let call = self.topicFetcher.fetchCalls.value.first
         expect(call?.topic).to(equal(.productEntitlementMapping))
         expect(call?.entryId).to(equal("default"))
         expect(call?.topicEntry).to(equal(entry))
@@ -71,7 +71,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
 
         expect(receivedError).to(beNil())
-        expect(self.topicFetcher.fetchCalls).to(beEmpty())
+        expect(self.topicFetcher.fetchCalls.value).to(beEmpty())
     }
 
     func testEmptyTopicsSkipsTopicFetcherAndCompletesWithNil() {
@@ -89,7 +89,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
 
         expect(receivedError).to(beNil())
-        expect(self.topicFetcher.fetchCalls).to(beEmpty())
+        expect(self.topicFetcher.fetchCalls.value).to(beEmpty())
     }
 
     func testTopicWithoutDefaultEntryIdIsSkipped() {
@@ -107,7 +107,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
 
         expect(receivedError).to(beNil())
-        expect(self.topicFetcher.fetchCalls).to(beEmpty())
+        expect(self.topicFetcher.fetchCalls.value).to(beEmpty())
     }
 
     // MARK: - Source selection
@@ -124,7 +124,7 @@ final class RemoteConfigManagerTests: TestCase {
             self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false) { _ in done() }
         }
 
-        expect(self.topicFetcher.fetchCalls.first?.source).to(equal(first))
+        expect(self.topicFetcher.fetchCalls.value.first?.source).to(equal(first))
     }
 
     // MARK: - Error propagation
@@ -137,7 +137,7 @@ final class RemoteConfigManagerTests: TestCase {
             sources: [makeSource(id: "primary")],
             topics: [.productEntitlementMapping: ["default": makeEntry(blobRef: "abc")]]
         ))
-        self.topicFetcher.stubbedFetchResult = fetcherError
+        self.topicFetcher.stubbedFetchResult.value = fetcherError
 
         var receivedError: BackendError?
         waitUntil { done in
@@ -165,7 +165,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
 
         expect(receivedError).toNot(beNil())
-        expect(self.topicFetcher.fetchCalls).to(beEmpty())
+        expect(self.topicFetcher.fetchCalls.value).to(beEmpty())
     }
 
     // MARK: - isAppBackgrounded forwarding
@@ -190,7 +190,118 @@ final class RemoteConfigManagerTests: TestCase {
 
         self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false, completion: nil)
 
-        expect(self.topicFetcher.fetchCalls).toEventually(haveCount(1))
+        expect(self.topicFetcher.fetchCalls.value).toEventually(haveCount(1))
+    }
+
+    // MARK: - Cleanup
+
+    func testTriggersCleanupWithAllEntryIdBlobRefsAfterSuccessfulDownload() {
+        let defaultEntry = makeEntry(blobRef: "blob-default")
+        let experimentEntry = makeEntry(blobRef: "blob-experiment")
+        self.remoteConfigAPI.stubbedResult = .success(makeResponse(
+            sources: [makeSource(id: "primary")],
+            topics: [.productEntitlementMapping: [
+                "default": defaultEntry,
+                "EXPERIMENT_A": experimentEntry
+            ]]
+        ))
+
+        waitUntil { done in
+            self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false) { _ in done() }
+        }
+
+        expect(self.topicFetcher.cleanupCalls.value).to(haveCount(1))
+        expect(self.topicFetcher.cleanupCalls.value.first).to(equal(
+            [.productEntitlementMapping: ["blob-default", "blob-experiment"]]
+        ))
+        // Cleanup must run after all downloads complete.
+        expect(self.topicFetcher.callOrder.value).to(equal([.fetch, .cleanup]))
+    }
+
+    func testDoesNotTriggerCleanupWhenTasksFilteredEmpty() {
+        // Manifest has a topic, but no `default` entryId — so tasks is empty.
+        self.remoteConfigAPI.stubbedResult = .success(makeResponse(
+            sources: [makeSource(id: "primary")],
+            topics: [.productEntitlementMapping: ["EXPERIMENT_A": makeEntry(blobRef: "abc")]]
+        ))
+
+        waitUntil { done in
+            self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false) { _ in done() }
+        }
+
+        expect(self.topicFetcher.cleanupCalls.value).to(beEmpty())
+    }
+
+    func testBackToBackRefreshesEachTriggerCleanup() {
+        self.remoteConfigAPI.stubbedResult = .success(makeResponse(
+            sources: [makeSource(id: "primary")],
+            topics: [.productEntitlementMapping: ["default": makeEntry(blobRef: "abc")]]
+        ))
+
+        waitUntil { done in
+            self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false) { _ in done() }
+        }
+        waitUntil { done in
+            self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false) { _ in done() }
+        }
+
+        expect(self.topicFetcher.cleanupCalls.value).to(haveCount(2))
+    }
+
+    func testDoesNotTriggerCleanupWhenFetcherDownloadFails() {
+        let fetcherError = BackendError.networkError(.networkError(
+            NSError(domain: "test", code: -1, userInfo: nil)
+        ))
+        self.remoteConfigAPI.stubbedResult = .success(makeResponse(
+            sources: [makeSource(id: "primary")],
+            topics: [.productEntitlementMapping: ["default": makeEntry(blobRef: "abc")]]
+        ))
+        self.topicFetcher.stubbedFetchResult.value = fetcherError
+
+        waitUntil { done in
+            self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false) { _ in done() }
+        }
+
+        expect(self.topicFetcher.cleanupCalls.value).to(beEmpty())
+    }
+
+    func testDoesNotTriggerCleanupWhenBackendErrors() {
+        let backendError = BackendError.networkError(.networkError(
+            NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet, userInfo: nil)
+        ))
+        self.remoteConfigAPI.stubbedResult = .failure(backendError)
+
+        waitUntil { done in
+            self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false) { _ in done() }
+        }
+
+        expect(self.topicFetcher.cleanupCalls.value).to(beEmpty())
+    }
+
+    func testDoesNotTriggerCleanupWhenManifestHasNoTopics() {
+        self.remoteConfigAPI.stubbedResult = .success(makeResponse(
+            sources: [makeSource(id: "primary")],
+            topics: [:]
+        ))
+
+        waitUntil { done in
+            self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false) { _ in done() }
+        }
+
+        expect(self.topicFetcher.cleanupCalls.value).to(beEmpty())
+    }
+
+    func testDoesNotTriggerCleanupWhenSourcesAreEmpty() {
+        self.remoteConfigAPI.stubbedResult = .success(makeResponse(
+            sources: [],
+            topics: [.productEntitlementMapping: ["default": makeEntry(blobRef: "abc")]]
+        ))
+
+        waitUntil { done in
+            self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false) { _ in done() }
+        }
+
+        expect(self.topicFetcher.cleanupCalls.value).to(beEmpty())
     }
 
     func testFetchRunsEvenWithNilCompletion() {
@@ -204,7 +315,7 @@ final class RemoteConfigManagerTests: TestCase {
         self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false, completion: nil)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount).toEventually(equal(1))
-        expect(self.topicFetcher.fetchCalls).toEventually(haveCount(1))
+        expect(self.topicFetcher.fetchCalls.value).toEventually(haveCount(1))
     }
 
 }

--- a/Tests/UnitTests/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/RemoteConfig/RemoteConfigManagerTests.swift
@@ -218,6 +218,24 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.topicFetcher.callOrder.value).to(equal([.fetch, .cleanup]))
     }
 
+    func testCleanupReferenceSetIsLowercased() {
+        // Backend may return mixed-case hex; on-disk filenames are lowercase. Cleanup must
+        // match against lowercased blob refs or it would delete freshly-downloaded files.
+        let mixedCase = "ABCDEFabcdef" + String(repeating: "0", count: 52)
+        self.remoteConfigAPI.stubbedResult = .success(makeResponse(
+            sources: [makeSource(id: "primary")],
+            topics: [.productEntitlementMapping: ["default": makeEntry(blobRef: mixedCase)]]
+        ))
+
+        waitUntil { done in
+            self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false) { _ in done() }
+        }
+
+        expect(self.topicFetcher.cleanupCalls.value.first).to(equal(
+            [.productEntitlementMapping: [mixedCase.lowercased()]]
+        ))
+    }
+
     func testDoesNotTriggerCleanupWhenTasksFilteredEmpty() {
         // Manifest has a topic, but no `default` entryId — so tasks is empty.
         self.remoteConfigAPI.stubbedResult = .success(makeResponse(

--- a/Tests/UnitTests/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/RemoteConfig/RemoteConfigManagerTests.swift
@@ -1,0 +1,239 @@
+//
+//  RemoteConfigManagerTests.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 28/05/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+final class RemoteConfigManagerTests: TestCase {
+
+    private var remoteConfigAPI: MockRemoteConfigAPI!
+    private var topicFetcher: MockTopicFetcher!
+    private var manager: RemoteConfigManager!
+
+    override func setUp() {
+        super.setUp()
+        self.remoteConfigAPI = MockRemoteConfigAPI()
+        self.topicFetcher = MockTopicFetcher()
+        self.manager = RemoteConfigManager(
+            remoteConfigAPI: self.remoteConfigAPI,
+            topicFetcher: self.topicFetcher
+        )
+    }
+
+    // MARK: - Happy path
+
+    func testSingleTopicDelegatesToFetcherAndCompletesWithNil() {
+        let src = makeSource(id: "primary")
+        let entry = makeEntry(blobRef: "abc123def456")
+        self.remoteConfigAPI.stubbedResult = .success(makeResponse(
+            sources: [src],
+            topics: [.productEntitlementMapping: ["default": entry]]
+        ))
+
+        var receivedError: BackendError?
+        waitUntil { done in
+            self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false) { error in
+                receivedError = error
+                done()
+            }
+        }
+
+        expect(receivedError).to(beNil())
+        expect(self.topicFetcher.fetchCalls).to(haveCount(1))
+        let call = self.topicFetcher.fetchCalls.first
+        expect(call?.topic).to(equal(.productEntitlementMapping))
+        expect(call?.entryId).to(equal("default"))
+        expect(call?.topicEntry).to(equal(entry))
+        expect(call?.source).to(equal(src))
+    }
+
+    // MARK: - Empty / missing data
+
+    func testEmptySourcesSkipsTopicFetcherAndCompletesWithNil() {
+        self.remoteConfigAPI.stubbedResult = .success(makeResponse(
+            sources: [],
+            topics: [.productEntitlementMapping: ["default": makeEntry(blobRef: "abc")]]
+        ))
+
+        var receivedError: BackendError?
+        waitUntil { done in
+            self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false) { error in
+                receivedError = error
+                done()
+            }
+        }
+
+        expect(receivedError).to(beNil())
+        expect(self.topicFetcher.fetchCalls).to(beEmpty())
+    }
+
+    func testEmptyTopicsSkipsTopicFetcherAndCompletesWithNil() {
+        self.remoteConfigAPI.stubbedResult = .success(makeResponse(
+            sources: [makeSource(id: "primary")],
+            topics: [:]
+        ))
+
+        var receivedError: BackendError?
+        waitUntil { done in
+            self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false) { error in
+                receivedError = error
+                done()
+            }
+        }
+
+        expect(receivedError).to(beNil())
+        expect(self.topicFetcher.fetchCalls).to(beEmpty())
+    }
+
+    func testTopicWithoutDefaultEntryIdIsSkipped() {
+        self.remoteConfigAPI.stubbedResult = .success(makeResponse(
+            sources: [makeSource(id: "primary")],
+            topics: [.productEntitlementMapping: ["EXPERIMENT_A": makeEntry(blobRef: "abc")]]
+        ))
+
+        var receivedError: BackendError?
+        waitUntil { done in
+            self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false) { error in
+                receivedError = error
+                done()
+            }
+        }
+
+        expect(receivedError).to(beNil())
+        expect(self.topicFetcher.fetchCalls).to(beEmpty())
+    }
+
+    // MARK: - Source selection
+
+    func testSelectsFirstSourceWhenMultipleAvailable() {
+        let first = makeSource(id: "first")
+        let second = makeSource(id: "second")
+        self.remoteConfigAPI.stubbedResult = .success(makeResponse(
+            sources: [first, second],
+            topics: [.productEntitlementMapping: ["default": makeEntry(blobRef: "abc")]]
+        ))
+
+        waitUntil { done in
+            self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false) { _ in done() }
+        }
+
+        expect(self.topicFetcher.fetchCalls.first?.source).to(equal(first))
+    }
+
+    // MARK: - Error propagation
+
+    func testFetcherErrorIsForwardedToCompletion() {
+        let fetcherError = BackendError.networkError(.networkError(
+            NSError(domain: "test", code: -1, userInfo: nil)
+        ))
+        self.remoteConfigAPI.stubbedResult = .success(makeResponse(
+            sources: [makeSource(id: "primary")],
+            topics: [.productEntitlementMapping: ["default": makeEntry(blobRef: "abc")]]
+        ))
+        self.topicFetcher.stubbedFetchResult = fetcherError
+
+        var receivedError: BackendError?
+        waitUntil { done in
+            self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false) { error in
+                receivedError = error
+                done()
+            }
+        }
+
+        expect(receivedError).toNot(beNil())
+    }
+
+    func testBackendErrorShortCircuitsBeforeFetcher() {
+        let backendError = BackendError.networkError(.networkError(
+            NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet, userInfo: nil)
+        ))
+        self.remoteConfigAPI.stubbedResult = .failure(backendError)
+
+        var receivedError: BackendError?
+        waitUntil { done in
+            self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false) { error in
+                receivedError = error
+                done()
+            }
+        }
+
+        expect(receivedError).toNot(beNil())
+        expect(self.topicFetcher.fetchCalls).to(beEmpty())
+    }
+
+    // MARK: - isAppBackgrounded forwarding
+
+    func testIsAppBackgroundedIsForwardedToAPI() {
+        self.remoteConfigAPI.stubbedResult = .success(makeResponse(sources: [], topics: [:]))
+
+        waitUntil { done in
+            self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: true) { _ in done() }
+        }
+
+        expect(self.remoteConfigAPI.invokedIsAppBackgrounded).to(beTrue())
+    }
+
+    // MARK: - Nil completion
+
+    func testNilCompletionDoesNotCrash() {
+        self.remoteConfigAPI.stubbedResult = .success(makeResponse(
+            sources: [makeSource(id: "primary")],
+            topics: [.productEntitlementMapping: ["default": makeEntry(blobRef: "abc")]]
+        ))
+
+        self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false, completion: nil)
+
+        expect(self.topicFetcher.fetchCalls).toEventually(haveCount(1))
+    }
+
+    func testFetchRunsEvenWithNilCompletion() {
+        let src = makeSource(id: "primary")
+        let entry = makeEntry(blobRef: "abc")
+        self.remoteConfigAPI.stubbedResult = .success(makeResponse(
+            sources: [src],
+            topics: [.productEntitlementMapping: ["default": entry]]
+        ))
+
+        self.manager.updateRemoteConfigIfNeeded(isAppBackgrounded: false, completion: nil)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount).toEventually(equal(1))
+        expect(self.topicFetcher.fetchCalls).toEventually(haveCount(1))
+    }
+
+}
+
+// MARK: - Helpers
+
+private extension RemoteConfigManagerTests {
+
+    func makeSource(id: String) -> RemoteConfigResponse.BlobSource {
+        RemoteConfigResponse.BlobSource(
+            id: id,
+            urlFormat: "https://assets.example.com/{blob_ref}",
+            priority: 0,
+            weight: 100
+        )
+    }
+
+    func makeEntry(blobRef: String) -> RemoteConfigResponse.TopicEntry {
+        RemoteConfigResponse.TopicEntry(blobRef: blobRef)
+    }
+
+    func makeResponse(
+        sources: [RemoteConfigResponse.BlobSource],
+        topics: [RemoteConfigResponse.Topic: [String: RemoteConfigResponse.TopicEntry]]
+    ) -> RemoteConfigResponse {
+        RemoteConfigResponse(
+            blobSources: sources,
+            manifest: RemoteConfigResponse.Manifest(topics: topics)
+        )
+    }
+
+}

--- a/Tests/UnitTests/RemoteConfig/TopicFetcherTests.swift
+++ b/Tests/UnitTests/RemoteConfig/TopicFetcherTests.swift
@@ -277,6 +277,89 @@ final class TopicFetcherTests: TestCase {
         expect(FileManager.default.fileExists(atPath: escapedTarget.path)).to(beFalse())
     }
 
+    // MARK: - Cleanup
+
+    func testCleanupDeletesFilesWhoseBlobRefIsNotInReferenceSet() async throws {
+        let keptBlob = String(repeating: "a", count: 64)
+        let staleBlob = String(repeating: "b", count: 64)
+        let keptFile = try writeTopicFile(topic: .productEntitlementMapping, blobRef: keptBlob, byte: 1)
+        let staleFile = try writeTopicFile(topic: .productEntitlementMapping, blobRef: staleBlob, byte: 2)
+
+        await makeFetcher().cleanupUnreferencedTopics(
+            referenced: [.productEntitlementMapping: [keptBlob]]
+        )
+
+        // Cleanup is dispatched on a detached task; assertions wait for it to complete.
+        await expect(FileManager.default.fileExists(atPath: staleFile.path)).toEventually(beFalse())
+        expect(FileManager.default.fileExists(atPath: keptFile.path)).to(beTrue())
+    }
+
+    func testCleanupDeletesEveryFileForTopicAbsentFromReferenceSet() async throws {
+        let blobA = String(repeating: "a", count: 64)
+        let blobB = String(repeating: "b", count: 64)
+        let fileA = try writeTopicFile(topic: .productEntitlementMapping, blobRef: blobA, byte: 1)
+        let fileB = try writeTopicFile(topic: .productEntitlementMapping, blobRef: blobB, byte: 2)
+
+        await makeFetcher().cleanupUnreferencedTopics(referenced: [:])
+
+        await expect(FileManager.default.fileExists(atPath: fileA.path)).toEventually(beFalse())
+        await expect(FileManager.default.fileExists(atPath: fileB.path)).toEventually(beFalse())
+    }
+
+    func testCleanupIsNoOpWhenTopicsRootDoesNotExist() async {
+        let topicsRoot = self.tempDir.appendingPathComponent("RevenueCat/topics")
+
+        await makeFetcher().cleanupUnreferencedTopics(
+            referenced: [.productEntitlementMapping: [String(repeating: "a", count: 64)]]
+        )
+
+        // Cleanup must not create the topics root itself.
+        expect(FileManager.default.fileExists(atPath: topicsRoot.path)).to(beFalse())
+    }
+
+    func testCleanupSilentlySkipsTopicWhenContentsOfDirectoryFails() async throws {
+        let blob = String(repeating: "a", count: 64)
+        let file = try writeTopicFile(topic: .productEntitlementMapping, blobRef: blob, byte: 1)
+
+        let fetcher = TopicFetcher(
+            fileManager: ListingFailureFileManager(),
+            baseCacheURL: self.tempDir
+        )
+        await fetcher.cleanupUnreferencedTopics(referenced: [:])
+
+        // Listing failed silently — file is preserved, nothing crashes.
+        expect(FileManager.default.fileExists(atPath: file.path)).to(beTrue())
+    }
+
+    func testCleanupKeepsTempFilesWithRcTopicPrefixUntouched() async throws {
+        let staleBlob = String(repeating: "a", count: 64)
+        let staleFile = try writeTopicFile(topic: .productEntitlementMapping, blobRef: staleBlob, byte: 1)
+        let tempFile = staleFile.deletingLastPathComponent().appendingPathComponent("rc_topic_inflight.tmp")
+        try Data([2]).write(to: tempFile)
+
+        await makeFetcher().cleanupUnreferencedTopics(referenced: [:])
+
+        await expect(FileManager.default.fileExists(atPath: staleFile.path)).toEventually(beFalse())
+        expect(FileManager.default.fileExists(atPath: tempFile.path)).to(beTrue())
+    }
+
+    func testCleanupKeepsReferencedFileWhenOtherFilesInSameDirAreDeleted() async throws {
+        let keptBlob = String(repeating: "c", count: 64)
+        let staleBlob1 = String(repeating: "d", count: 64)
+        let staleBlob2 = String(repeating: "e", count: 64)
+        let kept = try writeTopicFile(topic: .productEntitlementMapping, blobRef: keptBlob, byte: 0)
+        let stale1 = try writeTopicFile(topic: .productEntitlementMapping, blobRef: staleBlob1, byte: 1)
+        let stale2 = try writeTopicFile(topic: .productEntitlementMapping, blobRef: staleBlob2, byte: 2)
+
+        await makeFetcher().cleanupUnreferencedTopics(
+            referenced: [.productEntitlementMapping: [keptBlob]]
+        )
+
+        await expect(FileManager.default.fileExists(atPath: stale1.path)).toEventually(beFalse())
+        await expect(FileManager.default.fileExists(atPath: stale2.path)).toEventually(beFalse())
+        expect(FileManager.default.fileExists(atPath: kept.path)).to(beTrue())
+    }
+
     func testFetchTopicIfNeededAcceptsMixedCaseHexBlobRef() async {
         let mixedCaseHex = "ABCDEFabcdef" + String(repeating: "0", count: 52)
         let normalizedHex = mixedCaseHex.lowercased()
@@ -315,6 +398,20 @@ private extension TopicFetcherTests {
             .appendingPathComponent("RevenueCat/topics")
             .appendingPathComponent(topic.rawValue)
             .appendingPathComponent(blobRef)
+    }
+
+    func writeTopicFile(
+        topic: RemoteConfigResponse.Topic,
+        blobRef: String,
+        byte: UInt8
+    ) throws -> URL {
+        let file = topicFile(topic: topic, blobRef: blobRef)
+        try FileManager.default.createDirectory(
+            at: file.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data([byte]).write(to: file)
+        return file
     }
 
     func leftoverTempFiles(in dir: URL) -> [URL] {
@@ -373,6 +470,54 @@ private final class FailingReplaceFileManager: FileManaging {
 
     func removeItem(at url: URL) throws {
         try base.removeItem(at: url)
+    }
+
+    func contentsOfDirectory(at url: URL) throws -> [URL] {
+        try base.contentsOfDirectory(at: url)
+    }
+
+}
+
+private final class ListingFailureFileManager: FileManaging {
+
+    private let base = FileManager.default
+
+    func fileExists(atPath path: String) -> Bool {
+        base.fileExists(atPath: path)
+    }
+
+    func createDirectory(
+        at url: URL,
+        withIntermediateDirectories createIntermediates: Bool,
+        attributes attr: [FileAttributeKey: Any]?
+    ) throws {
+        try base.createDirectory(at: url, withIntermediateDirectories: createIntermediates, attributes: attr)
+    }
+
+    func replaceItemAt(
+        _ originalItemURL: URL,
+        withItemAt newItemURL: URL,
+        backupItemName: String?,
+        options mask: FileManager.ItemReplacementOptions
+    ) throws -> URL? {
+        try base.replaceItemAt(
+            originalItemURL,
+            withItemAt: newItemURL,
+            backupItemName: backupItemName,
+            options: mask
+        )
+    }
+
+    func copyItem(at srcURL: URL, to dstURL: URL) throws {
+        try base.copyItem(at: srcURL, to: dstURL)
+    }
+
+    func removeItem(at url: URL) throws {
+        try base.removeItem(at: url)
+    }
+
+    func contentsOfDirectory(at url: URL) throws -> [URL] {
+        throw NSError(domain: NSCocoaErrorDomain, code: NSFileReadUnknownError)
     }
 
 }

--- a/Tests/UnitTests/RemoteConfig/TopicFetcherTests.swift
+++ b/Tests/UnitTests/RemoteConfig/TopicFetcherTests.swift
@@ -1,0 +1,373 @@
+//
+//  TopicFetcherTests.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 28/05/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import CryptoKit
+import Foundation
+import Nimble
+import OHHTTPStubs
+import OHHTTPStubsSwift
+import XCTest
+
+@testable import RevenueCat
+
+final class TopicFetcherTests: TestCase {
+
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        self.tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: self.tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        HTTPStubs.removeAllStubs()
+        try? FileManager.default.removeItem(at: self.tempDir)
+        super.tearDown()
+    }
+
+    // MARK: - Cache hit
+
+    func testCacheHitReturnsNilWithoutDownloading() async throws {
+        let payload = Data("{\"cached\":true}".utf8)
+        let blobRef = sha256Hex(payload)
+        let target = topicFile(topic: .productEntitlementMapping, blobRef: blobRef)
+        try FileManager.default.createDirectory(
+            at: target.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try payload.write(to: target)
+
+        var downloadAttempted = false
+        stub(condition: isHost("assets.example.com")) { _ in
+            downloadAttempted = true
+            return HTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
+        }
+
+        let error = await makeFetcher().fetchTopicIfNeeded(
+            topic: .productEntitlementMapping,
+            entryId: "default",
+            topicEntry: .init(blobRef: blobRef),
+            source: makeSource()
+        )
+
+        expect(error).to(beNil())
+        expect(downloadAttempted).to(beFalse())
+    }
+
+    // MARK: - Download + verify
+
+    func testDownloadVerifiesSHA256AndStoresAtExpectedPath() async {
+        let payload = Data("{\"hello\":\"world\"}".utf8)
+        let blobRef = sha256Hex(payload)
+        stubDownload(url: "https://assets.example.com/\(blobRef)", data: payload)
+
+        let error = await makeFetcher().fetchTopicIfNeeded(
+            topic: .productEntitlementMapping,
+            entryId: "default",
+            topicEntry: .init(blobRef: blobRef),
+            source: makeSource(urlFormat: "https://assets.example.com/{blob_ref}")
+        )
+
+        let target = topicFile(topic: .productEntitlementMapping, blobRef: blobRef)
+        expect(error).to(beNil())
+        expect(FileManager.default.fileExists(atPath: target.path)).to(beTrue())
+        expect(try? Data(contentsOf: target)).to(equal(payload))
+        expect(self.leftoverTempFiles(in: target.deletingLastPathComponent())).to(beEmpty())
+    }
+
+    func testDownloadSubstitutesBlobRefPlaceholderInURL() async {
+        let payload = Data("{}".utf8)
+        let blobRef = sha256Hex(payload)
+        let expectedURL = "https://cdn.example.com/topics/\(blobRef)"
+
+        var requestedURL: String?
+        stub(condition: isAbsoluteURLString(expectedURL)) { request in
+            requestedURL = request.url?.absoluteString
+            return HTTPStubsResponse(data: payload, statusCode: 200, headers: nil)
+        }
+
+        let error = await makeFetcher().fetchTopicIfNeeded(
+            topic: .productEntitlementMapping,
+            entryId: "default",
+            topicEntry: .init(blobRef: blobRef),
+            source: makeSource(urlFormat: "https://cdn.example.com/topics/{blob_ref}")
+        )
+
+        expect(error).to(beNil())
+        expect(requestedURL).to(equal(expectedURL))
+    }
+
+    // MARK: - Error cases
+
+    func testDownloadSurfacesErrorWhenHTTPNon200() async {
+        let payload = Data("{}".utf8)
+        let blobRef = sha256Hex(payload)
+        stubDownload(url: "https://assets.example.com/\(blobRef)", data: Data(), statusCode: 404)
+
+        let error = await makeFetcher().fetchTopicIfNeeded(
+            topic: .productEntitlementMapping,
+            entryId: "default",
+            topicEntry: .init(blobRef: blobRef),
+            source: makeSource(urlFormat: "https://assets.example.com/{blob_ref}")
+        )
+
+        expect(error).toNot(beNil())
+        let target = topicFile(topic: .productEntitlementMapping, blobRef: blobRef)
+        expect(FileManager.default.fileExists(atPath: target.path)).to(beFalse())
+    }
+
+    func testDownloadSurfacesErrorOnNetworkFailure() async {
+        let blobRef = String(repeating: "a", count: 64)
+        let networkError = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
+        stub(condition: isHost("assets.example.com")) { _ in
+            HTTPStubsResponse(error: networkError)
+        }
+
+        let error = await makeFetcher().fetchTopicIfNeeded(
+            topic: .productEntitlementMapping,
+            entryId: "default",
+            topicEntry: .init(blobRef: blobRef),
+            source: makeSource(urlFormat: "https://assets.example.com/{blob_ref}")
+        )
+
+        expect(error).toNot(beNil())
+        let target = topicFile(topic: .productEntitlementMapping, blobRef: blobRef)
+        expect(FileManager.default.fileExists(atPath: target.path)).to(beFalse())
+        expect(self.leftoverTempFiles(in: target.deletingLastPathComponent())).to(beEmpty())
+    }
+
+    func testDownloadSurfacesErrorWhenSHA256Mismatch() async {
+        let payload = Data("{\"actual\":\"contents\"}".utf8)
+        let wrongBlobRef = String(repeating: "0", count: 64)
+        stubDownload(url: "https://assets.example.com/\(wrongBlobRef)", data: payload)
+
+        let error = await makeFetcher().fetchTopicIfNeeded(
+            topic: .productEntitlementMapping,
+            entryId: "default",
+            topicEntry: .init(blobRef: wrongBlobRef),
+            source: makeSource(urlFormat: "https://assets.example.com/{blob_ref}")
+        )
+
+        expect(error).toNot(beNil())
+        let target = topicFile(topic: .productEntitlementMapping, blobRef: wrongBlobRef)
+        expect(FileManager.default.fileExists(atPath: target.path)).to(beFalse())
+        expect(self.leftoverTempFiles(in: target.deletingLastPathComponent())).to(beEmpty())
+    }
+
+    // MARK: - Write failure
+
+    func testDownloadSurfacesErrorWhenRenameFails() async {
+        let payload = Data("{\"hello\":\"world\"}".utf8)
+        let blobRef = sha256Hex(payload)
+        stubDownload(url: "https://assets.example.com/\(blobRef)", data: payload)
+
+        let renameError = NSError(domain: NSCocoaErrorDomain, code: NSFileWriteUnknownError)
+        let fetcher = TopicFetcher(
+            fileManager: FailingReplaceFileManager(replaceItemAtError: renameError),
+            baseCacheURL: self.tempDir
+        )
+
+        let error = await fetcher.fetchTopicIfNeeded(
+            topic: .productEntitlementMapping,
+            entryId: "default",
+            topicEntry: .init(blobRef: blobRef),
+            source: makeSource(urlFormat: "https://assets.example.com/{blob_ref}")
+        )
+
+        expect(error).toNot(beNil())
+        let target = topicFile(topic: .productEntitlementMapping, blobRef: blobRef)
+        expect(FileManager.default.fileExists(atPath: target.path)).to(beFalse())
+        expect(self.leftoverTempFiles(in: target.deletingLastPathComponent())).to(beEmpty())
+    }
+
+    // MARK: - Multiple entries
+
+    func testDownloadMultipleEntryIdsWriteToDistinctPaths() async {
+        let payloadA = Data("{\"entryId\":\"A\"}".utf8)
+        let payloadB = Data("{\"entryId\":\"B\"}".utf8)
+        let blobRefA = sha256Hex(payloadA)
+        let blobRefB = sha256Hex(payloadB)
+        stubDownload(url: "https://assets.example.com/\(blobRefA)", data: payloadA)
+        stubDownload(url: "https://assets.example.com/\(blobRefB)", data: payloadB)
+
+        let fetcher = makeFetcher()
+        let source = makeSource(urlFormat: "https://assets.example.com/{blob_ref}")
+
+        let errorA = await fetcher.fetchTopicIfNeeded(
+            topic: .productEntitlementMapping,
+            entryId: "default",
+            topicEntry: .init(blobRef: blobRefA),
+            source: source
+        )
+        let errorB = await fetcher.fetchTopicIfNeeded(
+            topic: .productEntitlementMapping,
+            entryId: "EXPERIMENT_A",
+            topicEntry: .init(blobRef: blobRefB),
+            source: source
+        )
+
+        expect(errorA).to(beNil())
+        expect(errorB).to(beNil())
+
+        let targetA = topicFile(topic: .productEntitlementMapping, blobRef: blobRefA)
+        let targetB = topicFile(topic: .productEntitlementMapping, blobRef: blobRefB)
+        expect(FileManager.default.fileExists(atPath: targetA.path)).to(beTrue())
+        expect(FileManager.default.fileExists(atPath: targetB.path)).to(beTrue())
+        expect(targetA).toNot(equal(targetB))
+        expect(try? Data(contentsOf: targetA)).to(equal(payloadA))
+        expect(try? Data(contentsOf: targetB)).to(equal(payloadB))
+    }
+
+    // MARK: - Blob ref validation
+
+    func testFetchTopicIfNeededRejectsMalformedBlobRef() async {
+        var downloadAttempted = false
+        stub(condition: isHost("assets.example.com")) { _ in
+            downloadAttempted = true
+            return HTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
+        }
+
+        let error = await makeFetcher().fetchTopicIfNeeded(
+            topic: .productEntitlementMapping,
+            entryId: "default",
+            topicEntry: .init(blobRef: "not-valid!"),
+            source: makeSource()
+        )
+
+        if case .unexpectedBackendResponse(.remoteConfigMalformedBlobRef, _, _) = error {
+            // expected
+        } else {
+            fail("Expected .unexpectedBackendResponse(.remoteConfigMalformedBlobRef), got \(String(describing: error))")
+        }
+        expect(downloadAttempted).to(beFalse())
+        let topicDir = tempDir
+            .appendingPathComponent("RevenueCat/topics")
+            .appendingPathComponent(RemoteConfigResponse.Topic.productEntitlementMapping.wireKey)
+        expect(FileManager.default.fileExists(atPath: topicDir.path) &&
+               (try? FileManager.default.contentsOfDirectory(atPath: topicDir.path))?.isEmpty == false
+        ).to(beFalse())
+    }
+
+    func testFetchTopicIfNeededRejectsPathTraversalBlobRef() async {
+        var downloadAttempted = false
+        stub(condition: isHost("assets.example.com")) { _ in
+            downloadAttempted = true
+            return HTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
+        }
+
+        let error = await makeFetcher().fetchTopicIfNeeded(
+            topic: .productEntitlementMapping,
+            entryId: "default",
+            topicEntry: .init(blobRef: "../../escape"),
+            source: makeSource()
+        )
+
+        if case .unexpectedBackendResponse(.remoteConfigMalformedBlobRef, _, _) = error {
+            // expected
+        } else {
+            fail("Expected .unexpectedBackendResponse(.remoteConfigMalformedBlobRef), got \(String(describing: error))")
+        }
+        expect(downloadAttempted).to(beFalse())
+        let escapedTarget = tempDir.deletingLastPathComponent().appendingPathComponent("escape")
+        expect(FileManager.default.fileExists(atPath: escapedTarget.path)).to(beFalse())
+    }
+
+    func testFetchTopicIfNeededAcceptsMixedCaseHexBlobRef() async {
+        let mixedCaseHex = "ABCDEFabcdef" + String(repeating: "0", count: 52)
+        stubDownload(url: "https://assets.example.com/\(mixedCaseHex)", data: Data("ignored".utf8))
+
+        let error = await makeFetcher().fetchTopicIfNeeded(
+            topic: .productEntitlementMapping,
+            entryId: "default",
+            topicEntry: .init(blobRef: mixedCaseHex),
+            source: makeSource(urlFormat: "https://assets.example.com/{blob_ref}")
+        )
+
+        // Validation passes; download was attempted (SHA-256 will mismatch since "ignored" != mixedCaseHex)
+        expect(error).toNot(beNil())
+        // Error is SHA-256 mismatch, not validation rejection — meaning the request was made
+        let target = topicFile(topic: .productEntitlementMapping, blobRef: mixedCaseHex)
+        expect(FileManager.default.fileExists(atPath: target.path)).to(beFalse())
+    }
+
+}
+
+// MARK: - Helpers
+
+private extension TopicFetcherTests {
+
+    func makeFetcher() -> TopicFetcher {
+        TopicFetcher(baseCacheURL: self.tempDir)
+    }
+
+    func makeSource(urlFormat: String = "https://assets.example.com/{blob_ref}") -> RemoteConfigResponse.BlobSource {
+        RemoteConfigResponse.BlobSource(id: "primary", urlFormat: urlFormat, priority: 0, weight: 100)
+    }
+
+    func topicFile(topic: RemoteConfigResponse.Topic, blobRef: String) -> URL {
+        self.tempDir
+            .appendingPathComponent("RevenueCat/topics")
+            .appendingPathComponent(topic.wireKey)
+            .appendingPathComponent(blobRef)
+    }
+
+    func leftoverTempFiles(in dir: URL) -> [URL] {
+        let contents = (try? FileManager.default.contentsOfDirectory(
+            at: dir,
+            includingPropertiesForKeys: nil
+        )) ?? []
+        return contents.filter { $0.lastPathComponent.hasPrefix("rc_topic_") }
+    }
+
+    func stubDownload(url: String, data: Data, statusCode: Int32 = 200) {
+        stub(condition: isAbsoluteURLString(url)) { _ in
+            HTTPStubsResponse(data: data, statusCode: statusCode, headers: nil)
+        }
+    }
+
+    func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+}
+
+private final class FailingReplaceFileManager: FileManaging {
+
+    private let replaceItemAtError: Error
+    private let base = FileManager.default
+
+    init(replaceItemAtError: Error) {
+        self.replaceItemAtError = replaceItemAtError
+    }
+
+    func fileExists(atPath path: String) -> Bool {
+        base.fileExists(atPath: path)
+    }
+
+    func createDirectory(
+        at url: URL,
+        withIntermediateDirectories createIntermediates: Bool,
+        attributes attr: [FileAttributeKey: Any]?
+    ) throws {
+        try base.createDirectory(at: url, withIntermediateDirectories: createIntermediates, attributes: attr)
+    }
+
+    func replaceItemAt(
+        _ originalItemURL: URL,
+        withItemAt newItemURL: URL,
+        backupItemName: String?,
+        options mask: FileManager.ItemReplacementOptions
+    ) throws -> URL? {
+        throw self.replaceItemAtError
+    }
+
+    func removeItem(at url: URL) throws {
+        try base.removeItem(at: url)
+    }
+
+}

--- a/Tests/UnitTests/RemoteConfig/TopicFetcherTests.swift
+++ b/Tests/UnitTests/RemoteConfig/TopicFetcherTests.swift
@@ -247,7 +247,7 @@ final class TopicFetcherTests: TestCase {
         expect(downloadAttempted).to(beFalse())
         let topicDir = tempDir
             .appendingPathComponent("RevenueCat/topics")
-            .appendingPathComponent(RemoteConfigResponse.Topic.productEntitlementMapping.wireKey)
+            .appendingPathComponent(RemoteConfigResponse.Topic.productEntitlementMapping.rawValue)
         expect(FileManager.default.fileExists(atPath: topicDir.path) &&
                (try? FileManager.default.contentsOfDirectory(atPath: topicDir.path))?.isEmpty == false
         ).to(beFalse())
@@ -313,7 +313,7 @@ private extension TopicFetcherTests {
     func topicFile(topic: RemoteConfigResponse.Topic, blobRef: String) -> URL {
         self.tempDir
             .appendingPathComponent("RevenueCat/topics")
-            .appendingPathComponent(topic.wireKey)
+            .appendingPathComponent(topic.rawValue)
             .appendingPathComponent(blobRef)
     }
 

--- a/Tests/UnitTests/RemoteConfig/TopicFetcherTests.swift
+++ b/Tests/UnitTests/RemoteConfig/TopicFetcherTests.swift
@@ -279,7 +279,9 @@ final class TopicFetcherTests: TestCase {
 
     func testFetchTopicIfNeededAcceptsMixedCaseHexBlobRef() async {
         let mixedCaseHex = "ABCDEFabcdef" + String(repeating: "0", count: 52)
-        stubDownload(url: "https://assets.example.com/\(mixedCaseHex)", data: Data("ignored".utf8))
+        let normalizedHex = mixedCaseHex.lowercased()
+        // The blob ref is normalized to lowercase before use, so the URL and cache path use normalizedHex.
+        stubDownload(url: "https://assets.example.com/\(normalizedHex)", data: Data("ignored".utf8))
 
         let error = await makeFetcher().fetchTopicIfNeeded(
             topic: .productEntitlementMapping,
@@ -288,10 +290,9 @@ final class TopicFetcherTests: TestCase {
             source: makeSource(urlFormat: "https://assets.example.com/{blob_ref}")
         )
 
-        // Validation passes; download was attempted (SHA-256 will mismatch since "ignored" != mixedCaseHex)
+        // Validation passes; download was attempted (SHA-256 will mismatch since "ignored" != normalizedHex)
         expect(error).toNot(beNil())
-        // Error is SHA-256 mismatch, not validation rejection — meaning the request was made
-        let target = topicFile(topic: .productEntitlementMapping, blobRef: mixedCaseHex)
+        let target = topicFile(topic: .productEntitlementMapping, blobRef: normalizedHex)
         expect(FileManager.default.fileExists(atPath: target.path)).to(beFalse())
     }
 

--- a/Tests/UnitTests/RemoteConfig/TopicFetcherTests.swift
+++ b/Tests/UnitTests/RemoteConfig/TopicFetcherTests.swift
@@ -367,6 +367,10 @@ private final class FailingReplaceFileManager: FileManaging {
         throw self.replaceItemAtError
     }
 
+    func copyItem(at srcURL: URL, to dstURL: URL) throws {
+        throw self.replaceItemAtError
+    }
+
     func removeItem(at url: URL) throws {
         try base.removeItem(at: url)
     }


### PR DESCRIPTION
This PR builds on #6863 and mirrors Android PR https://github.com/RevenueCat/purchases-android/pull/3439.

Implemented cleaning up unreferenced topic files after fetching a new version of the remote config. This cleans up any topic files that are no longer actively used by the remote-config API.

This triggers only after a successful fetch of the remote-config topics list and is non-blocking. Any errors encountered are being logged but fail silently by design.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cleanup deletes cache files on disk and must stay aligned with lowercase blob refs and download ordering; mistakes could remove still-needed topic data, though guards and tests limit exposure.
> 
> **Overview**
> After a **successful** remote config topic refresh, the SDK now **prunes stale cached topic blobs** under `RevenueCat/topics` so disk use tracks the current manifest.
> 
> `RemoteConfigManager` builds a **keep-set** from **all manifest entry IDs** (not only `default`), **lowercases** blob refs to match on-disk names, runs parallel downloads via a refactored `downloadTopics`, then calls cleanup only when there is a blob source, non-empty download tasks, and **no fetch error**. `Topic` gains **`CaseIterable`** for per-topic directory scans.
> 
> `TopicFetcher` lists each topic directory, **deletes files** whose basename is not in the keep-set, **skips** `rc_topic_*.tmp` in-flight downloads, and runs deletion on a **detached utility task** with new cleanup log strings; delete/list failures are logged and ignored.
> 
> Unit tests cover manager gating (including mixed-case refs and fetch/backend failures) and fetcher file deletion behavior; mocks record cleanup order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8daff28c6e6cc0bce566868d2a20fb7a94b26012. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->