### PR TITLE
Add inline presentation mode for SwiftUI paywalls

### DIFF
--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -29,12 +29,35 @@ public enum PaywallPresentationMode {
     @available(macOS, unavailable)
     case fullScreen
 
+    /// Paywall rendered inline in the modified view hierarchy. The exit offer, if any, is still presented modally.
+    case inline(exitOfferPresentationMode: ExitOfferPresentationMode = .sheet)
+
+}
+
+/// Presentation options to use for exit offers shown after an inline paywall is dismissed.
+public enum ExitOfferPresentationMode {
+
+    /// Exit offer presented using SwiftUI's `.sheet`.
+    case sheet
+
+    /// Exit offer presented using SwiftUI's `.fullScreenCover`. `.fullScreenCover` is unavailable on macOS.
+    @available(macOS, unavailable)
+    case fullScreen
+
 }
 
 extension PaywallPresentationMode {
 
     // swiftlint:disable:next missing_docs
     public static let `default`: Self = .sheet
+
+    fileprivate var isInline: Bool {
+        if case .inline = self {
+            return true
+        }
+
+        return false
+    }
 
 }
 
@@ -83,6 +106,8 @@ extension View {
     /// that it will ignore the offering configured in an active experiment.
     /// - Parameter fonts: An optional ``PaywallFontProvider``.
     /// - Parameter presentationMode: The desired presentation mode of the paywall. Defaults to `.sheet`.
+    /// Use `.inline` to render the main paywall directly in the modified view hierarchy. When using `.inline`,
+    /// the caller is responsible for removing or navigating away from the inline paywall after `onDismiss`.
     ///
     /// ### Related Articles
     /// [Documentation](https://rev.cat/paywalls)
@@ -141,6 +166,8 @@ extension View {
     /// that it will ignore the offering configured in an active experiment.
     /// - Parameter fonts: An optional ``PaywallFontProvider``.
     /// - Parameter presentationMode: The desired presentation mode of the paywall. Defaults to `.sheet`.
+    /// Use `.inline` to render the main paywall directly in the modified view hierarchy. When using `.inline`,
+    /// the caller is responsible for removing or navigating away from the inline paywall after `onDismiss`.
     ///
     /// ### Related Articles
     /// [Documentation](https://rev.cat/paywalls)
@@ -217,6 +244,8 @@ extension View {
     /// that it will ignore the offering configured in an active experiment.
     /// - Parameter fonts: An optional ``PaywallFontProvider``.
     /// - Parameter presentationMode: The desired presentation mode of the paywall. Defaults to `.sheet`.
+    /// Use `.inline` to render the main paywall directly in the modified view hierarchy. When using `.inline`,
+    /// the caller is responsible for removing or navigating away from the inline paywall after `onDismiss`.
     ///
     /// ### Related Articles
     /// [Documentation](https://rev.cat/paywalls)
@@ -301,6 +330,8 @@ extension View {
     /// that it will ignore the offering configured in an active experiment.
     /// - Parameter fonts: An optional ``PaywallFontProvider``.
     /// - Parameter presentationMode: The desired presentation mode of the paywall. Defaults to `.sheet`.
+    /// Use `.inline` to render the main paywall directly in the modified view hierarchy. When using `.inline`,
+    /// the caller is responsible for removing or navigating away from the inline paywall after `onDismiss`.
     ///
     /// ### Related Articles
     /// [Documentation](https://rev.cat/paywalls)
@@ -412,6 +443,7 @@ extension View {
     ///     The binding is set to `nil` when the paywall (and any exit offer) is dismissed.
     ///   - fonts: An optional ``PaywallFontProvider``.
     ///   - presentationMode: The desired presentation mode of the paywall. Defaults to `.sheet`.
+    ///     `.inline` is treated as `.sheet` by this binding-based presentation API.
     ///   - purchaseStarted: Called when a purchase is initiated.
     ///   - purchaseCompleted: Called when a purchase completes successfully.
     ///   - purchaseCancelled: Called when a purchase is cancelled.
@@ -539,6 +571,9 @@ private struct PresentingPaywallModifier: ViewModifier {
     @State
     private var data: Data?
 
+    @State
+    private var didHandleMainPaywallDismiss = false
+
     /// The prefetched exit offer, loaded while the main paywall is showing.
     /// This enables immediate presentation when the main paywall dismisses (no loading delay).
     /// Copied to `presentedExitOffer` when ready to show.
@@ -553,6 +588,20 @@ private struct PresentingPaywallModifier: ViewModifier {
     func body(content: Content) -> some View {
         Group {
             switch presentationMode {
+            case .inline(let exitOfferPresentationMode):
+                Group {
+                    if let data = self.data {
+                        self.paywallView(data)
+                    } else {
+                        content
+                    }
+                }
+                .modifier(ExitOfferPresentationModifier(
+                    offering: self.$presentedExitOffer,
+                    presentationMode: exitOfferPresentationMode,
+                    onDismiss: self.handleExitOfferDismiss,
+                    contentBuilder: self.exitOfferPaywallView
+                ))
             case .sheet:
                 content
                     .sheet(item: self.$data, onDismiss: self.handleMainPaywallDismiss) { data in
@@ -567,26 +616,24 @@ private struct PresentingPaywallModifier: ViewModifier {
                             .frame(height: 667)
                         #endif
                     }
-                    .sheet(item: self.$presentedExitOffer, onDismiss: self.handleExitOfferDismiss) { offering in
-                        self.exitOfferPaywallView(for: offering)
-                        #if targetEnvironment(macCatalyst) || os(macOS)
-                        // this should be minHeight, but for consistency with the first paywall it will be
-                        // like this for now
-                            .frame(height: 667)
-                        #endif
-                    }
+                    .modifier(ExitOfferPresentationModifier(
+                        offering: self.$presentedExitOffer,
+                        presentationMode: .sheet,
+                        onDismiss: self.handleExitOfferDismiss,
+                        contentBuilder: self.exitOfferPaywallView
+                    ))
             #if !os(macOS)
             case .fullScreen:
                 content
                     .fullScreenCover(item: self.$data, onDismiss: self.handleMainPaywallDismiss) { data in
                         self.paywallView(data)
                     }
-                    .fullScreenCover(
-                        item: self.$presentedExitOffer,
-                        onDismiss: self.handleExitOfferDismiss
-                    ) { offering in
-                        self.exitOfferPaywallView(for: offering)
-                    }
+                    .modifier(ExitOfferPresentationModifier(
+                        offering: self.$presentedExitOffer,
+                        presentationMode: .fullScreen,
+                        onDismiss: self.handleExitOfferDismiss,
+                        contentBuilder: self.exitOfferPaywallView
+                    ))
             #endif
             }
         }
@@ -621,6 +668,9 @@ private struct PresentingPaywallModifier: ViewModifier {
         if self.shouldDisplay(info) {
             Logger.debug(Strings.displaying_paywall)
 
+            if self.data == nil || self.presentationMode.isInline {
+                self.didHandleMainPaywallDismiss = false
+            }
             self.data = .init(customerInfo: info)
         } else {
             Logger.debug(Strings.not_displaying_paywall)
@@ -673,6 +723,9 @@ private struct PresentingPaywallModifier: ViewModifier {
             self.restoreFailure?($0)
         }
         .interactiveDismissDisabled(self.purchaseHandler.actionInProgress)
+        .onRequestedDismissal {
+            self.close()
+        }
         .onPreferenceChange(WorkflowExitOfferPreferenceKey.self) { context in
             self.handleWorkflowExitOfferPreferenceChange(context)
         }
@@ -688,6 +741,11 @@ private struct PresentingPaywallModifier: ViewModifier {
 
     private func close() {
         Logger.debug(Strings.dismissing_paywall)
+
+        if case .inline = self.presentationMode {
+            self.handleMainPaywallDismiss()
+            return
+        }
 
         self.data = nil
     }
@@ -705,6 +763,9 @@ private struct PresentingPaywallModifier: ViewModifier {
     /// - If a purchase happened in this session, we use `shouldDisplay` with the result's `CustomerInfo`
     /// - This ensures consistent behavior with how the first paywall decides to show/close
     private func handleMainPaywallDismiss() {
+        guard !self.didHandleMainPaywallDismiss else { return }
+        self.didHandleMainPaywallDismiss = true
+
         // Prevent double processing
         guard self.presentedExitOffer == nil else { return }
 
@@ -893,7 +954,7 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
     func body(content: Content) -> some View {
         Group {
             switch presentationMode {
-            case .sheet:
+            case .inline, .sheet:
                 content
                     .sheet(item: self.$offering, onDismiss: self.handleMainPaywallDismiss) { offering in
                         self.paywallView(for: offering)
@@ -1056,6 +1117,38 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
         self.onDismiss?()
     }
 
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(tvOS, unavailable)
+private struct ExitOfferPresentationModifier<PresentedContent: View>: ViewModifier {
+
+    @Binding
+    var offering: Offering?
+
+    let presentationMode: ExitOfferPresentationMode
+    let onDismiss: () -> Void
+    let contentBuilder: (Offering) -> PresentedContent
+
+    func body(content: Content) -> some View {
+        switch presentationMode {
+        case .sheet:
+            content
+                .sheet(item: self.$offering, onDismiss: self.onDismiss) { offering in
+                    self.contentBuilder(offering)
+                    #if targetEnvironment(macCatalyst) || os(macOS)
+                        .frame(height: 667)
+                    #endif
+                }
+        #if !os(macOS)
+        case .fullScreen:
+            content
+                .fullScreenCover(item: self.$offering, onDismiss: self.onDismiss) { offering in
+                    self.contentBuilder(offering)
+                }
+        #endif
+        }
+    }
 }
 
 /// A stateful wrapper around the offer cache that has no published properties

--- a/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/PaywallViewAPI.swift
+++ b/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/PaywallViewAPI.swift
@@ -94,6 +94,11 @@ struct App: View {
             .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", fonts: self.fonts)
             .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", presentationMode: .sheet)
             .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", presentationMode: .fullScreen)
+            .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", presentationMode: .inline())
+            .presentPaywallIfNeeded(
+                requiredEntitlementIdentifier: "",
+                presentationMode: .inline(exitOfferPresentationMode: .fullScreen)
+            )
             .presentPaywallIfNeeded(requiredEntitlementIdentifier: "",
                                     purchaseCompleted: self.purchaseOrRestoreCompleted)
             .presentPaywallIfNeeded(requiredEntitlementIdentifier: "",
@@ -259,6 +264,14 @@ struct App: View {
                 self.purchaseOrRestoreCompleted($0)
             }
             .presentPaywallIfNeeded(presentationMode: .sheet) { (_: CustomerInfo) in
+                false
+            }
+            .presentPaywallIfNeeded(presentationMode: .inline()) { (_: CustomerInfo) in
+                false
+            }
+            .presentPaywallIfNeeded(
+                presentationMode: .inline(exitOfferPresentationMode: .fullScreen)
+            ) { (_: CustomerInfo) in
                 false
             }
             .presentPaywallIfNeeded(offering: self.offering, fonts: self.fonts) { (_: CustomerInfo) in

--- a/Tests/RevenueCatUITests/PresentIfNeededTests.swift
+++ b/Tests/RevenueCatUITests/PresentIfNeededTests.swift
@@ -81,6 +81,70 @@ class PresentIfNeededTests: TestCase {
         expect(customerInfo).toEventually(be(TestData.customerInfo))
     }
 
+    func testInlinePresentWithPurchaseHandlerDismissesOnce() throws {
+        let handler: PurchaseHandler = .mock()
+        var customerInfo: CustomerInfo?
+        var dismissCount = 0
+
+        let dispose = try Text("")
+            .presentPaywallIfNeeded(offering: Self.offering,
+                                    introEligibility: .producing(eligibility: .eligible),
+                                    purchaseHandler: handler,
+                                    presentationMode: .inline()) { _ in
+                return true
+            } purchaseCompleted: {
+                customerInfo = $0
+            } onDismiss: {
+                dismissCount += 1
+            } customerInfoFetcher: {
+                return TestData.customerInfo
+            }
+            .addToHierarchy()
+
+        defer { dispose() }
+
+        Task {
+            _ = try await handler.purchase(package: Self.package)
+        }
+
+        expect(customerInfo).toEventually(be(TestData.customerInfo))
+        expect(dismissCount).toEventually(equal(1))
+    }
+
+    func testInlinePresentWithPurchaseHandlerDismissesAfterCustomerInfoRefresh() throws {
+        let handler: PurchaseHandler = .mock()
+        let scenePhaseController = ScenePhaseController()
+        var dismissCount = 0
+
+        let dispose = try InlinePaywall(
+            scenePhaseController: scenePhaseController,
+            purchaseHandler: handler,
+            onDismiss: {
+                dismissCount += 1
+            }
+        )
+        .addToHierarchy()
+
+        defer { dispose() }
+
+        Task {
+            _ = try await handler.purchase(package: Self.package)
+        }
+
+        expect(dismissCount).toEventually(equal(1))
+
+        scenePhaseController.scenePhase = .inactive
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+        scenePhaseController.scenePhase = .active
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+
+        Task {
+            _ = try await handler.purchase(package: Self.package)
+        }
+
+        expect(dismissCount).toEventually(equal(2))
+    }
+
     func testPresentWithPurchaseFailureHandler() throws {
         var error: NSError?
 
@@ -286,6 +350,40 @@ class PresentIfNeededTests: TestCase {
         .mock(purchasesAreCompletedBy: .myApp,
               performPurchase: performPurchase,
               performRestore: performRestore)
+    }
+
+}
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+private final class ScenePhaseController: ObservableObject {
+
+    @Published
+    var scenePhase: ScenePhase = .active
+
+}
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+private struct InlinePaywall: View {
+
+    @ObservedObject
+    var scenePhaseController: ScenePhaseController
+
+    let purchaseHandler: PurchaseHandler
+    let onDismiss: () -> Void
+
+    var body: some View {
+        Text("")
+            .presentPaywallIfNeeded(offering: TestData.offeringWithNoIntroOffer,
+                                    introEligibility: .producing(eligibility: .eligible),
+                                    purchaseHandler: self.purchaseHandler,
+                                    presentationMode: .inline()) { _ in
+                return true
+            } onDismiss: {
+                self.onDismiss()
+            } customerInfoFetcher: {
+                return TestData.customerInfo
+            }
+            .environment(\.scenePhase, self.scenePhaseController.scenePhase)
     }
 
 }


### PR DESCRIPTION
Adds an `.inline` `PaywallPresentationMode` for `presentPaywallIfNeeded`, allowing the main paywall to render directly in the caller's view hierarchy while keeping exit offers presented modally.

Also adds an `ExitOfferPresentationMode` for inline paywalls, documents the inline dismissal responsibility, and covers the new API plus inline dismissal behavior in tests.

<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

Not applicable for `purchases-android` and hybrids: this change adds a SwiftUI-specific `RevenueCatUI` presentation mode.

### Motivation
`presentPaywallIfNeeded` currently requires the main paywall to be presented modally as a sheet or full-screen cover. Some SwiftUI flows already own their screen transition, such as onboarding navigation stacks, and need the paywall rendered inline while still using `presentPaywallIfNeeded` so RevenueCat managed behavior like exit offers continues to work.

### Description
Adds an `.inline` case to `PaywallPresentationMode` for `presentPaywallIfNeeded`. Inline mode renders the main paywall directly in the modified view hierarchy instead of presenting it with `.sheet` or `.fullScreenCover`.

Exit offers remain modal. Inline mode accepts an `ExitOfferPresentationMode`, allowing the caller to choose whether exit offers are shown as a sheet or full-screen cover.

This also documents the caller responsibility for inline dismissal: when using `.inline`, the caller should remove or navigate away from the inline paywall after `onDismiss`.

Added API tester coverage for the new `.inline()` and `.inline(exitOfferPresentationMode:)` call sites, plus a `PresentIfNeededTests` regression test covering inline dismissal behavior.

Tested with:

```sh
xcodebuild test -project RevenueCat.xcodeproj -scheme RevenueCatUITests -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:RevenueCatUITests/PresentIfNeededTests
```

Passed: 10 tests, 0 failures.

```
xcodebuild build -project RevenueCat.xcodeproj -scheme RevenueCat -destination 'generic/platform=iOS Simulator'
```
Passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches paywall presentation and purchase/dismiss flows in RevenueCatUI; behavior is covered by new tests but affects monetization UX paths.
> 
> **Overview**
> Adds **`.inline`** to `PaywallPresentationMode` so `presentPaywallIfNeeded` can embed the main paywall in the caller’s view hierarchy instead of only sheet/full-screen. Exit offers stay modal via new **`ExitOfferPresentationMode`** (sheet or full screen). Docs note that with inline, the app should remove or navigate away after `onDismiss`.
> 
> `PresentingPaywallModifier` switches on `.inline` to swap in `PaywallView` when needed, routes close/dismiss through **`onRequestedDismissal`** and **`handleMainPaywallDismiss`**, and guards duplicate dismiss with **`didHandleMainPaywallDismiss`**. Exit-offer presentation is centralized in **`ExitOfferPresentationModifier`**. The binding-based `presentPaywall` API still presents modally (inline maps to sheet).
> 
> API tester and **`PresentIfNeededTests`** cover inline call sites and dismissal (including scene-phase refresh).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 718a8bd6d574b78876e41f30f313d04aad55b6b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->