### PR TITLE
Add SPI to render a workflow from already-resolved data (preview/tooling)

### DIFF
--- a/RevenueCatUI/Data/PaywallViewConfiguration.swift
+++ b/RevenueCatUI/Data/PaywallViewConfiguration.swift
@@ -27,6 +27,12 @@ struct PaywallViewConfiguration {
     var purchaseHandler: PurchaseHandler
     var promoOfferCache: PaywallPromoOfferCache?
 
+    #if !os(tvOS)
+    /// A pre-resolved workflow context. When set, the paywall renders this workflow directly instead of
+    /// fetching one from the network. Used by previewing/tooling (e.g. the RevenueCat dashboard app).
+    var workflowContext: WorkflowContext?
+    #endif
+
     init(
         content: Content,
         customerInfo: CustomerInfo? = nil,

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -145,6 +145,37 @@ public struct PaywallView: View {
         )
     }
 
+    /// Create a view that renders a pre-resolved workflow without performing a network fetch.
+    ///
+    /// Intended for previewing/tooling (e.g. the RevenueCat dashboard app). Build the
+    /// ``WorkflowContext`` with its `preview` factory.
+    // swiftlint:disable:next missing_docs
+    @_spi(Internal) public init(
+        workflowContext: WorkflowContext,
+        fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
+        displayCloseButton: Bool = false,
+        introEligibility: TrialOrIntroEligibilityChecker? = nil,
+        performPurchase: PerformPurchase? = nil,
+        performRestore: PerformRestore? = nil
+    ) {
+        let purchaseHandler = PurchaseHandler.default(
+            performPurchase: performPurchase,
+            performRestore: performRestore
+        )
+
+        var configuration = PaywallViewConfiguration(
+            offering: workflowContext.initialOffering,
+            fonts: fonts,
+            displayCloseButton: displayCloseButton,
+            useDraftPaywall: false,
+            introEligibility: introEligibility,
+            purchaseHandler: purchaseHandler
+        )
+        configuration.workflowContext = workflowContext
+
+        self.init(configuration: configuration)
+    }
+
     init(configuration: PaywallViewConfiguration, paywallViewOwnsPurchaseHandler: Bool = true) {
         self.paywallViewOwnsPurchaseHandler = paywallViewOwnsPurchaseHandler
         if paywallViewOwnsPurchaseHandler {
@@ -164,6 +195,7 @@ public struct PaywallView: View {
                 for: configuration.content
             )
         )
+        self._workflowContext = .init(initialValue: configuration.workflowContext)
         self._customerInfo = .init(
             initialValue: configuration.customerInfo ?? Self.loadCachedCustomerInfoIfPossible()
         )

--- a/RevenueCatUI/Purchasing/WorkflowContext.swift
+++ b/RevenueCatUI/Purchasing/WorkflowContext.swift
@@ -14,8 +14,11 @@ import Foundation
 
 #if !os(tvOS)
 
+/// Resolved data needed to render a workflow: the workflow definition plus the offerings its screens
+/// reference. Built internally from a network fetch, or via the `preview` factory for tooling that
+/// already holds the data.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-struct WorkflowContext {
+@_spi(Internal) public struct WorkflowContext {
     let workflow: PublishedWorkflow
     let allOfferings: Offerings
     let initialOffering: Offering
@@ -246,6 +249,37 @@ struct WorkflowContext {
 struct WorkflowPackageContext {
     let selectedPackage: Package
     let packages: [Package]
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@_spi(Internal) public extension WorkflowContext {
+
+    /// Builds a ``WorkflowContext`` from already-resolved workflow data so a workflow can be rendered
+    /// by `PaywallView`'s workflow initializer without performing a network fetch.
+    ///
+    /// Intended for previewing/tooling such as the RevenueCat dashboard app, which already holds the
+    /// workflow definition and builds mock offerings locally (mirroring how it previews paywalls).
+    ///
+    /// - Parameters:
+    ///   - workflow: The decoded workflow definition.
+    ///   - initialOffering: The offering for the workflow's initial screen. Must carry the screen's
+    ///     `paywallComponents` (build it with the SPI `Offering` initializer, as paywall previews do).
+    ///   - additionalOfferings: Any other offerings referenced by the workflow's screens/exit offers.
+    ///   - presentedOfferingContext: Optional placement/targeting context propagated across steps.
+    static func preview(
+        workflow: PublishedWorkflow,
+        initialOffering: Offering,
+        additionalOfferings: [Offering] = [],
+        presentedOfferingContext: PresentedOfferingContext? = nil
+    ) -> WorkflowContext {
+        return WorkflowContext(
+            workflow: workflow,
+            allOfferings: .preview(offerings: [initialOffering] + additionalOfferings),
+            initialOffering: initialOffering,
+            presentedOfferingContext: presentedOfferingContext
+        )
+    }
+
 }
 
 // Temporary launch-argument gate — remove once workflows are fully released.

--- a/Sources/Purchasing/Offerings.swift
+++ b/Sources/Purchasing/Offerings.swift
@@ -121,6 +121,32 @@ public extension Offerings {
         return description
     }
 
+    /// Creates an ``Offerings`` instance containing the provided offerings, without performing a network
+    /// fetch. Intended for previewing/tooling (e.g. the RevenueCat dashboard app rendering a paywall or
+    /// workflow from data it already holds).
+    @_spi(Internal) public static func preview(
+        offerings: [Offering],
+        currentOfferingID: String? = nil
+    ) -> Offerings {
+        return Offerings(
+            offerings: Dictionary(offerings.map { ($0.identifier, $0) }, uniquingKeysWith: { first, _ in first }),
+            currentOfferingID: currentOfferingID,
+            placements: nil,
+            targeting: nil,
+            contents: .init(
+                response: .init(
+                    currentOfferingId: currentOfferingID,
+                    offerings: [],
+                    placements: nil,
+                    targeting: nil,
+                    uiConfig: nil
+                ),
+                httpResponseOriginalSource: .mainServer
+            ),
+            loadedFromDiskCache: false
+        )
+    }
+
     /**
      Retrieves a current offering for a placement identifier, use this to access offerings defined by targeting
      placements configured in the RevenueCat dashboard, 


### PR DESCRIPTION
## Summary

Adds a small `@_spi(Internal)` surface so tooling that already holds a workflow definition and offerings (e.g. the RevenueCat dashboard app) can render a workflow with `PaywallView` directly, without a network fetch. This mirrors the existing paywall-preview SPI (`PaywallView.init(offering:useDraftPaywall:…)`).

## Changes

- **`Offerings.preview(offerings:currentOfferingID:)`** — builds an `Offerings` collection from `[Offering]` without a network fetch.
- **`WorkflowContext`** is now `@_spi(Internal) public`, with a **`preview(workflow:initialOffering:additionalOfferings:presentedOfferingContext:)`** factory that assembles it from a `PublishedWorkflow` plus locally-built offerings.
- **`PaywallView.init(workflowContext:fonts:displayCloseButton:introEligibility:performPurchase:performRestore:)`** — seeds the pre-resolved context (new `PaywallViewConfiguration.workflowContext` field, `#if !os(tvOS)`) so rendering bypasses the network resolve path.

The internal renderers stay internal; `PaywallView` reaches them once the context is injected.

## Usage

```swift
@_spi(Internal) import RevenueCat
@_spi(Internal) import RevenueCatUI

let context = WorkflowContext.preview(
    workflow: publishedWorkflow,
    initialOffering: mockInitialOffering
)
PaywallView(workflowContext: context, displayCloseButton: true,
            performPurchase: { _ in (true, nil) },
            performRestore: { (false, nil) })
```

## Verification

- ✅ `RevenueCatUI` builds for iOS Simulator.
- ✅ SwiftLint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
