### PR TITLE
Fix flaky metadata-sync & consent-status unit tests

### DIFF
--- a/Sources/Purchasing/Purchases/TransactionMetadataSyncHelper.swift
+++ b/Sources/Purchasing/Purchases/TransactionMetadataSyncHelper.swift
@@ -25,7 +25,7 @@ final class TransactionMetadataSyncHelper {
     private let operationDispatcher: OperationDispatcher
     private let transactionPoster: TransactionPosterType
 
-    private let isSyncing: Atomic<Bool> = .init(false)
+    let isSyncing: Atomic<Bool> = .init(false)
 
     private var appUserID: String { self.currentUserProvider.currentAppUserID }
 

--- a/Tests/UnitTests/Mocks/MockDateProvider.swift
+++ b/Tests/UnitTests/Mocks/MockDateProvider.swift
@@ -8,11 +8,13 @@ import Foundation
 
 class MockDateProvider: DateProvider {
 
-    private var dates: [Date]
-    private var currentIndex = 0
+    private let dates: [Date]
+    // `now()` can be called concurrently (e.g. parallel `post(receipt:)` calls), so the
+    // index must be mutated atomically to avoid a data race that drops increments.
+    private let currentIndex: Atomic<Int> = .init(0)
 
     var invokedNowCount: Int {
-        return currentIndex
+        return self.currentIndex.value
     }
     var invokedNow: Bool {
         return invokedNowCount > 0
@@ -31,8 +33,11 @@ class MockDateProvider: DateProvider {
     }
 
     override func now() -> Date {
-        defer { currentIndex += 1 }
-        return dates[min(currentIndex, dates.count - 1)]
+        return self.currentIndex.modify { index in
+            let date = self.dates[min(index, self.dates.count - 1)]
+            index += 1
+            return date
+        }
     }
 }
 

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -201,6 +201,7 @@ class BasePurchasesTests: TestCase {
     var diagnosticsTracker: DiagnosticsTrackerType?
     var mockVirtualCurrencyManager: MockVirtualCurrencyManager!
     var mockLocalTransactionMetadataStore: MockLocalTransactionMetadataStore!
+    var transactionMetadataSyncHelper: TransactionMetadataSyncHelper!
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     var mockDiagnosticsTracker: MockDiagnosticsTracker {
@@ -319,6 +320,7 @@ class BasePurchasesTests: TestCase {
             operationDispatcher: self.mockOperationDispatcher,
             transactionPoster: self.transactionPoster
         )
+        self.transactionMetadataSyncHelper = transactionMetadataSyncHelper
 
         self.purchases = Purchases(appUserID: appUserId,
                                    requestFetcher: self.requestFetcher,
@@ -696,6 +698,8 @@ private extension BasePurchasesTests {
         self.paywallCache = nil
         self.eventsManager = nil
         self.webPurchaseRedemptionHelper = nil
+        self.transactionMetadataSyncHelper = nil
+        self.mockLocalTransactionMetadataStore = nil
         self.purchases = nil
     }
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesDelegateTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesDelegateTests.swift
@@ -85,7 +85,20 @@ class PurchasesDelegateTests: BasePurchasesTests {
 
     // MARK: - Cached Transaction Metadata Sync
 
+    /// `Purchases` starts a cached-metadata sync at configure time. It holds an in-progress guard,
+    /// so a foreground sync triggered while that initial sync is still running is silently skipped.
+    /// Wait for the initial sync to read the store and finish before triggering our own, so these
+    /// tests are deterministic regardless of how the two syncs interleave.
+    private func waitForInitialMetadataSyncToComplete() async {
+        await expect {
+            self.mockLocalTransactionMetadataStore.invokedGetAllStoredMetadataCount.value > 0
+                && !self.transactionMetadataSyncHelper.isSyncing.value
+        }.toEventually(beTrue())
+    }
+
     func testApplicationDidBecomeActiveSyncsCachedTransactionMetadata() async throws {
+        await self.waitForInitialMetadataSyncToComplete()
+
         let transactionId = "cached_transaction_1"
         let metadata = createCachedMetadata(transactionId: transactionId, productIdentifier: "product_1")
 
@@ -103,6 +116,8 @@ class PurchasesDelegateTests: BasePurchasesTests {
     }
 
     func testApplicationDidBecomeActiveSyncsMultipleCachedTransactions() async throws {
+        await self.waitForInitialMetadataSyncToComplete()
+
         let transactionId1 = "cached_transaction_1"
         let transactionId2 = "cached_transaction_2"
         let metadata1 = createCachedMetadata(transactionId: transactionId1, productIdentifier: "product_1")
@@ -127,12 +142,16 @@ class PurchasesDelegateTests: BasePurchasesTests {
 
     func testApplicationDidBecomeActiveDoesNotPostWhenNoCachedMetadata() async {
         // No metadata stored
+        await self.waitForInitialMetadataSyncToComplete()
 
         // Fire the applicationDidBecomeActive notification
         self.notificationCenter.fireNotifications()
 
-        // Give some time for any async operations to complete
-        try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
+        // Wait for the foreground sync to read the (empty) store rather than sleeping a fixed
+        // interval: the initial sync already read it once, so a second read means ours ran too.
+        await expect(
+            self.mockLocalTransactionMetadataStore.invokedGetAllStoredMetadataCount.value
+        ).toEventually(beGreaterThanOrEqualTo(2))
 
         // Backend should not have been called for receipt posting with an associated transaction ID
         let postedWithTransactionId = self.backend.postedAssociatedTransactionIds.compactMap { $0 }


### PR DESCRIPTION
## Summary

Fixes a few cases of flaky unit tests:

- `PurchasesDelegateTests.testApplicationDidBecomeActiveSyncsCachedTransactionMetadata` / `…SyncsMultipleCachedTransactions` / `…DoesNotPostWhenNoCachedMetadata`
- `BackendSubscriberAttributesTests.testPostReceiptCachesRequestsWhenOnlyConsentStatus…Timestamps`

## Fixes

1. `.configure` metadata sync data race; on SDK configuration any locally stored transaction metadata (on disk) is synced (using a fire-and-forget Task{}). In the tests we instantly trigger the `didBecomeActive` notification, which also triggers a sync. At that point `isSyncing` is still true (sometimes), since the background Task hasn’t finished yet, causing the sync triggered by the foreground notification to get skipped. We’re now observing the `isSyncing` in the test in order to wait for the initial sync before testing our triggered sync.

2. Some tests (e.g. `testPostReceiptCachesRequestsWhenOnlyConsentStatusTimestampDiffers`) concurrently call `POST /receipt` that use the `MockDateProvider` to increment the `currentIndex`. However this was done in a non-atomic` way, causing data races. Fixed by making the index use `Atomic` 

## Validation

Failing run (17/20 failed) [link](https://app.circleci.com/pipelines/gh/RevenueCat/purchases-ios/38577/workflows/a05dc09e-1dcd-4717-9c45-2b3a67831274)

Successful run after fix (20/20 succeeded) [link](https://app.circleci.com/pipelines/gh/RevenueCat/purchases-ios/38577/workflows/f4f4b39b-0979-4abf-b2c6-f95224d0e4cf)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test harness timing, mock thread-safety, and internal visibility of a sync flag; no purchase or networking logic changes.
> 
> **Overview**
> Stabilizes flaky unit tests around **cached transaction metadata sync** and **concurrent receipt posting** without changing product behavior.
> 
> **Metadata sync tests** now wait for the configure-time metadata sync to finish (`isSyncing` cleared and the local store read at least once) before firing `applicationDidBecomeActive`, so foreground-triggered sync is not skipped by the in-progress guard. The empty-cache case waits for a second store read instead of a fixed sleep.
> 
> **`MockDateProvider`** advances its stubbed date index with **`Atomic`** so parallel `post(receipt:)` tests do not race on `now()`.
> 
> **`TransactionMetadataSyncHelper.isSyncing`** is exposed (no longer `private`) so tests can observe sync completion; the test base holds a reference to the same helper instance used by `Purchases`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef10830516825e59394ddd65da1966c7309c18c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->