### PR TITLE
fix workflow header transitions

### DIFF
--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -123,6 +123,16 @@ enum Strings {
     case paywall_close_workflow_action_not_handled(componentName: String?)
     case paywall_workflow_trigger_not_handled(componentName: String?)
     case workflow_package_context_unresolvable(stepId: String)
+    case workflow_header_transition(
+        stage: String,
+        transitionId: String,
+        mode: String,
+        currentHeader: String,
+        outgoingHeader: String,
+        progress: String,
+        currentOpacity: String,
+        outgoingOpacity: String
+    )
 
 }
 
@@ -399,6 +409,20 @@ extension Strings: CustomStringConvertible {
         case let .workflow_package_context_unresolvable(stepId):
             return "Could not resolve package context for singleStepFallbackId '\(stepId)'. " +
             "Price/period variables may not resolve on packageless screens."
+        case let .workflow_header_transition(
+            stage,
+            transitionId,
+            mode,
+            currentHeader,
+            outgoingHeader,
+            progress,
+            currentOpacity,
+            outgoingOpacity
+        ):
+            return "[RC_WORKFLOW_HEADER_DEBUG] Workflow header transition \(stage): " +
+            "transitionId=\(transitionId), mode=\(mode), currentHeader=\(currentHeader), " +
+            "outgoingHeader=\(outgoingHeader), progress=\(progress), " +
+            "currentOpacity=\(currentOpacity), outgoingOpacity=\(outgoingOpacity)"
         }
     }
 

--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -123,16 +123,6 @@ enum Strings {
     case paywall_close_workflow_action_not_handled(componentName: String?)
     case paywall_workflow_trigger_not_handled(componentName: String?)
     case workflow_package_context_unresolvable(stepId: String)
-    case workflow_header_transition(
-        stage: String,
-        transitionId: String,
-        mode: String,
-        currentHeader: String,
-        outgoingHeader: String,
-        progress: String,
-        currentOpacity: String,
-        outgoingOpacity: String
-    )
 
 }
 
@@ -409,20 +399,6 @@ extension Strings: CustomStringConvertible {
         case let .workflow_package_context_unresolvable(stepId):
             return "Could not resolve package context for singleStepFallbackId '\(stepId)'. " +
             "Price/period variables may not resolve on packageless screens."
-        case let .workflow_header_transition(
-            stage,
-            transitionId,
-            mode,
-            currentHeader,
-            outgoingHeader,
-            progress,
-            currentOpacity,
-            outgoingOpacity
-        ):
-            return "[RC_WORKFLOW_HEADER_DEBUG] Workflow header transition \(stage): " +
-            "transitionId=\(transitionId), mode=\(mode), currentHeader=\(currentHeader), " +
-            "outgoingHeader=\(outgoingHeader), progress=\(progress), " +
-            "currentOpacity=\(currentOpacity), outgoingOpacity=\(outgoingOpacity)"
         }
     }
 

--- a/RevenueCatUI/Modifiers/EnvironmentValues+Workflow.swift
+++ b/RevenueCatUI/Modifiers/EnvironmentValues+Workflow.swift
@@ -32,6 +32,39 @@ struct WorkflowPageTransitionContext {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct WorkflowRenderingContext {
+
+    /// Transition state consumed by workflow page bodies and header controls.
+    let pageTransition: WorkflowPageTransitionContext
+    /// Whether page-owned headers should be hidden while a workflow-level header overlay is visible.
+    /// The header layout is preserved so body content does not jump when the overlay appears.
+    let pageHeaderSuppressed: Bool
+    /// Marks the header subtree so only header buttons consume workflow page transition context.
+    let isHeader: Bool
+
+    static let identity = Self()
+
+    init(
+        pageTransition: WorkflowPageTransitionContext = .identity,
+        pageHeaderSuppressed: Bool = false,
+        isHeader: Bool = false
+    ) {
+        self.pageTransition = pageTransition
+        self.pageHeaderSuppressed = pageHeaderSuppressed
+        self.isHeader = isHeader
+    }
+
+    func markingHeader() -> Self {
+        return .init(
+            pageTransition: self.pageTransition,
+            pageHeaderSuppressed: self.pageHeaderSuppressed,
+            isHeader: true
+        )
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private struct WorkflowTriggerActionKey: EnvironmentKey {
     static let defaultValue: ((String) -> Bool)? = nil
 }
@@ -42,21 +75,8 @@ private struct CloseWorkflowActionKey: EnvironmentKey {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-private struct WorkflowPageTransitionContextKey: EnvironmentKey {
-    static let defaultValue = WorkflowPageTransitionContext.identity
-}
-
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-private struct WorkflowPageHeaderSuppressedKey: EnvironmentKey {
-    /// Hides headers rendered inside page snapshots while the workflow-level header overlay owns the transition.
-    /// The header layout is preserved so body content does not jump when the overlay appears.
-    static let defaultValue = false
-}
-
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-private struct IsWorkflowHeaderKey: EnvironmentKey {
-    /// Marks the header subtree so only header buttons consume workflow page transition context.
-    static let defaultValue = false
+private struct WorkflowRenderingContextKey: EnvironmentKey {
+    static let defaultValue = WorkflowRenderingContext.identity
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
@@ -81,19 +101,9 @@ extension EnvironmentValues {
         set { self[WorkflowTriggerActionKey.self] = newValue }
     }
 
-    var workflowPageTransitionContext: WorkflowPageTransitionContext {
-        get { self[WorkflowPageTransitionContextKey.self] }
-        set { self[WorkflowPageTransitionContextKey.self] = newValue }
-    }
-
-    var workflowPageHeaderSuppressed: Bool {
-        get { self[WorkflowPageHeaderSuppressedKey.self] }
-        set { self[WorkflowPageHeaderSuppressedKey.self] = newValue }
-    }
-
-    var isWorkflowHeader: Bool {
-        get { self[IsWorkflowHeaderKey.self] }
-        set { self[IsWorkflowHeaderKey.self] = newValue }
+    var workflowRenderingContext: WorkflowRenderingContext {
+        get { self[WorkflowRenderingContextKey.self] }
+        set { self[WorkflowRenderingContextKey.self] = newValue }
     }
 
     var workflowPackageContext: WorkflowPackageContext? {

--- a/RevenueCatUI/Modifiers/EnvironmentValues+Workflow.swift
+++ b/RevenueCatUI/Modifiers/EnvironmentValues+Workflow.swift
@@ -21,7 +21,7 @@ struct WorkflowPageTransitionContext {
     /// Header buttons use the inverse value so they stay visually fixed while page content slides.
     let pageOffset: CGFloat
     /// Opacity for buttons rendered inside workflow headers.
-    /// This crossfades outgoing and incoming header buttons during page transitions.
+    /// Header buttons fade when a header enters or leaves, but stay stable when both pages share the same header.
     let headerButtonOpacity: CGFloat
     /// Whether the page is currently participating in a workflow-level transition.
     /// Child component entrance transitions and horizontal safe-area bleed should be suppressed while this is true.
@@ -44,6 +44,13 @@ private struct CloseWorkflowActionKey: EnvironmentKey {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private struct WorkflowPageTransitionContextKey: EnvironmentKey {
     static let defaultValue = WorkflowPageTransitionContext.identity
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private struct WorkflowPageHeaderSuppressedKey: EnvironmentKey {
+    /// Hides headers rendered inside page snapshots while the workflow-level header overlay owns the transition.
+    /// The header layout is preserved so body content does not jump when the overlay appears.
+    static let defaultValue = false
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
@@ -77,6 +84,11 @@ extension EnvironmentValues {
     var workflowPageTransitionContext: WorkflowPageTransitionContext {
         get { self[WorkflowPageTransitionContextKey.self] }
         set { self[WorkflowPageTransitionContextKey.self] = newValue }
+    }
+
+    var workflowPageHeaderSuppressed: Bool {
+        get { self[WorkflowPageHeaderSuppressedKey.self] }
+        set { self[WorkflowPageHeaderSuppressedKey.self] = newValue }
     }
 
     var isWorkflowHeader: Bool {

--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
@@ -57,8 +57,7 @@ struct ButtonComponentView: View {
     @Environment(\.componentInteractionLogger) var componentInteractionLogger
     @Environment(\.workflowTriggerAction) private var workflowTriggerAction
     @Environment(\.closeWorkflowAction) private var closeWorkflowAction
-    @Environment(\.workflowPageTransitionContext) private var workflowPageTransitionContext
-    @Environment(\.isWorkflowHeader) private var isWorkflowHeader
+    @Environment(\.workflowRenderingContext) private var workflowRenderingContext
 
     private let viewModel: ButtonComponentViewModel
     private let onDismiss: () -> Void
@@ -115,8 +114,8 @@ struct ButtonComponentView: View {
             .withTransition(viewModel.component.transition)
             .disabled(self.shouldBeDisabled)
             .opacity(self.shouldBeDisabled ? 0.35 : 1.0)
-            .offset(x: self.isWorkflowHeader ? -self.workflowPageTransitionContext.pageOffset : 0)
-            .opacity(self.isWorkflowHeader ? self.workflowPageTransitionContext.headerButtonOpacity : 1)
+            .offset(x: self.workflowRenderingContext.isHeader ? -self.headerPageOffset : 0)
+            .opacity(self.workflowRenderingContext.isHeader ? self.headerButtonOpacity : 1)
             #if canImport(SafariServices) && canImport(UIKit)
             .sheet(isPresented: .isNotNil(self.$inAppBrowserURL)) {
                 SafariView(url: self.inAppBrowserURL!)
@@ -128,6 +127,14 @@ struct ButtonComponentView: View {
             #endif
             #endif
         }
+    }
+
+    private var headerPageOffset: CGFloat {
+        return self.workflowRenderingContext.pageTransition.pageOffset
+    }
+
+    private var headerButtonOpacity: CGFloat {
+        return self.workflowRenderingContext.pageTransition.headerButtonOpacity
     }
 
     private func performAction() async throws {

--- a/RevenueCatUI/Templates/V2/Components/Header/HeaderComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Header/HeaderComponentView.swift
@@ -21,6 +21,9 @@ struct HeaderComponentView: View {
     @Environment(\.safeAreaInsets)
     private var safeAreaInsets
 
+    @Environment(\.workflowRenderingContext)
+    private var workflowRenderingContext
+
     private let viewModel: HeaderComponentViewModel
     private let onDismiss: () -> Void
 
@@ -43,7 +46,7 @@ struct HeaderComponentView: View {
                 trailing: 0
             )
         )
-        .environment(\.isWorkflowHeader, true)
+        .environment(\.workflowRenderingContext, self.workflowRenderingContext.markingHeader())
     }
 
 }

--- a/RevenueCatUI/Templates/V2/Components/Root/RootView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Root/RootView.swift
@@ -32,8 +32,8 @@ struct RootView: View {
     @Environment(\.workflowPackageContext)
     private var workflowPackageContext
 
-    @Environment(\.workflowPageHeaderSuppressed)
-    private var workflowPageHeaderSuppressed
+    @Environment(\.workflowRenderingContext)
+    private var workflowRenderingContext
 
     private let viewModel: RootViewModel
     private let onDismiss: () -> Void
@@ -76,7 +76,7 @@ struct RootView: View {
                     onDismiss: onDismiss
                 )
                 .fixedSize(horizontal: false, vertical: true)
-                .opacity(self.workflowPageHeaderSuppressed ? 0 : 1)
+                .opacity(self.workflowRenderingContext.pageHeaderSuppressed ? 0 : 1)
             }
 
             ZStack(alignment: .top) {
@@ -96,7 +96,7 @@ struct RootView: View {
                         onDismiss: onDismiss
                     )
                     .fixedSize(horizontal: false, vertical: true)
-                    .opacity(self.workflowPageHeaderSuppressed ? 0 : 1)
+                    .opacity(self.workflowRenderingContext.pageHeaderSuppressed ? 0 : 1)
                     .overlay(GeometryReader { proxy in
                         Color.clear.preference(
                             key: OverlaidHeaderHeightKey.self,

--- a/RevenueCatUI/Templates/V2/Components/Root/RootView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Root/RootView.swift
@@ -32,6 +32,9 @@ struct RootView: View {
     @Environment(\.workflowPackageContext)
     private var workflowPackageContext
 
+    @Environment(\.workflowPageHeaderSuppressed)
+    private var workflowPageHeaderSuppressed
+
     private let viewModel: RootViewModel
     private let onDismiss: () -> Void
     private let defaultPackage: Package?
@@ -73,6 +76,7 @@ struct RootView: View {
                     onDismiss: onDismiss
                 )
                 .fixedSize(horizontal: false, vertical: true)
+                .opacity(self.workflowPageHeaderSuppressed ? 0 : 1)
             }
 
             ZStack(alignment: .top) {
@@ -92,6 +96,7 @@ struct RootView: View {
                         onDismiss: onDismiss
                     )
                     .fixedSize(horizontal: false, vertical: true)
+                    .opacity(self.workflowPageHeaderSuppressed ? 0 : 1)
                     .overlay(GeometryReader { proxy in
                         Color.clear.preference(
                             key: OverlaidHeaderHeightKey.self,

--- a/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
@@ -31,8 +31,8 @@ struct BackgroundStyleModifier: ViewModifier {
     @Environment(\.colorScheme)
     var colorScheme
 
-    @Environment(\.workflowPageTransitionContext)
-    var workflowPageTransitionContext
+    @Environment(\.workflowRenderingContext)
+    var workflowRenderingContext
 
     @State var size: CGSize?
 
@@ -58,7 +58,7 @@ struct BackgroundStyleModifier: ViewModifier {
     private var ignoresSafeAreaEdges: Edge.Set {
         // Keep workflow page backgrounds stable under the top/bottom safe areas while sliding,
         // but avoid horizontal safe-area expansion from escaping the page's clipped bounds.
-        return self.workflowPageTransitionContext.isTransitioning ? .vertical : .all
+        return self.workflowRenderingContext.pageTransition.isTransitioning ? .vertical : .all
     }
 
 }

--- a/RevenueCatUI/Templates/V2/ViewHelpers/TransitionModifier.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/TransitionModifier.swift
@@ -19,8 +19,8 @@ struct TransitionModifier: ViewModifier {
     let transition: PaywallComponent.Transition
 
     #if !os(tvOS)
-    @Environment(\.workflowPageTransitionContext)
-    private var workflowPageTransitionContext
+    @Environment(\.workflowRenderingContext)
+    private var workflowRenderingContext
     #endif
 
     @State var isPresented: Bool = false
@@ -72,7 +72,7 @@ struct TransitionModifier: ViewModifier {
         // also run their configured delayed transitions while the page is sliding, they
         // can flash or appear late inside the preserved outgoing/incoming page trees.
         // Render them immediately and let WorkflowPaywallView own the page-level motion.
-        return self.workflowPageTransitionContext.isTransitioning
+        return self.workflowRenderingContext.pageTransition.isTransitioning
         #else
         return false
         #endif

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -214,7 +214,10 @@ struct WorkflowPaywallView: View {
     private let onDismiss: () -> Void
 
     @StateObject private var navigator: WorkflowNavigator
-    @StateObject private var paywallPromoOfferCache: PaywallPromoOfferCache
+    // Held via PromoOfferCacheOwner so this view owns one cache shared across all workflow pages
+    // without subscribing to its @Published changes: body only forwards the cache to children.
+    // Observing it directly would re-render the whole page ForEach + header overlay on each update.
+    @StateObject private var promoOfferCacheOwner: PromoOfferCacheOwner
     @State private var hasLoggedInvalidState = false
     @State private var transitionState: WorkflowPageTransitionState<RenderedPage>
     @State private var activeTransitionID: UUID?
@@ -238,8 +241,10 @@ struct WorkflowPaywallView: View {
         self.displayCloseButton = displayCloseButton
         self.onDismiss = onDismiss
         self._navigator = .init(wrappedValue: WorkflowNavigator(workflow: context.workflow))
-        self._paywallPromoOfferCache = .init(wrappedValue: promoOfferCache ?? PaywallPromoOfferCache(
-            subscriptionHistoryTracker: purchaseHandler.subscriptionHistoryTracker
+        self._promoOfferCacheOwner = .init(wrappedValue: PromoOfferCacheOwner(
+            cache: promoOfferCache ?? PaywallPromoOfferCache(
+                subscriptionHistoryTracker: purchaseHandler.subscriptionHistoryTracker
+            )
         ))
         let initialStepId = context.workflow.initialStepId
         let initialPackageInput = Self.buildPackageInput(
@@ -379,7 +384,7 @@ struct WorkflowPaywallView: View {
             closeWorkflowAction: self.onDismiss,
             failedToLoadFont: self.failedToLoadFont,
             colorScheme: self.colorScheme,
-            promoOfferCache: self.paywallPromoOfferCache,
+            promoOfferCache: self.promoOfferCacheOwner.cache,
             introEligibilityContext: page.introOfferEligibilityContext,
             selectedPackageContextOverride: page.packageContext
         )
@@ -400,7 +405,7 @@ struct WorkflowPaywallView: View {
                             purchaseHandler: self.purchaseHandler,
                             introEligibilityChecker: self.introEligibilityChecker,
                             introOfferEligibilityContext: displayedPage.page.introOfferEligibilityContext,
-                            paywallPromoOfferCache: self.paywallPromoOfferCache,
+                            paywallPromoOfferCache: self.promoOfferCacheOwner.cache,
                             showZeroDecimalPlacePrices: self.showZeroDecimalPlacePrices,
                             onDismiss: self.handleDismiss,
                             closeWorkflowAction: self.onDismiss,

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -142,21 +142,6 @@ struct WorkflowHeaderTransition {
         return self.mode != .none
     }
 
-    fileprivate var debugName: String {
-        switch self.mode {
-        case .none:
-            return "none"
-        case .entering:
-            return "entering"
-        case .leaving:
-            return "leaving"
-        case .replacing:
-            return "replacing"
-        case .stable:
-            return "stable"
-        }
-    }
-
     init<Header: Equatable>(
         currentHeader: Header?,
         outgoingHeader: Header?
@@ -831,6 +816,7 @@ private struct WorkflowHeaderOverlayPageView: View {
                 onDismiss: self.onDismiss
             )
             .fixedSize(horizontal: false, vertical: true)
+            .fixMacButtons()
             .frame(maxWidth: .infinity, alignment: .top)
             .opacity(self.headerOpacity)
             .environment(\.locale, contentLocale)

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -295,14 +295,17 @@ struct WorkflowPaywallView: View {
 
                     self.pageView(for: displayedPage.page)
                         .environment(
-                            \.workflowPageTransitionContext,
-                            .init(
-                                pageOffset: pageOffset,
-                                headerButtonOpacity: self.transitionState.headerButtonOpacity(
-                                    for: displayedPage.role,
-                                    headerTransition: self.headerTransition
+                            \.workflowRenderingContext,
+                            WorkflowRenderingContext(
+                                pageTransition: .init(
+                                    pageOffset: pageOffset,
+                                    headerButtonOpacity: self.transitionState.headerButtonOpacity(
+                                        for: displayedPage.role,
+                                        headerTransition: self.headerTransition
+                                    ),
+                                    isTransitioning: self.transitionState.isTransitioning
                                 ),
-                                isTransitioning: self.transitionState.isTransitioning
+                                pageHeaderSuppressed: self.shouldRenderWorkflowHeaderOverlay
                             )
                         )
                         .frame(width: proxy.size.width, height: proxy.size.height)
@@ -403,7 +406,6 @@ struct WorkflowPaywallView: View {
         .environment(\.workflowTriggerAction, { componentId in
             return self.handleTriggeredNavigation(componentId: componentId)
         })
-        .environment(\.workflowPageHeaderSuppressed, self.shouldRenderWorkflowHeaderOverlay)
     }
 
     @ViewBuilder
@@ -481,29 +483,6 @@ struct WorkflowPaywallView: View {
         )?.exitOfferOffering
     }
 
-    private func logHeaderTransition(stage: String, transitionID: UUID) {
-        let headerTransition = self.headerTransition
-
-        Logger.debug(
-            Strings.workflow_header_transition(
-                stage: stage,
-                transitionId: transitionID.uuidString,
-                mode: headerTransition.debugName,
-                currentHeader: self.transitionState.currentPage?.headerDebugDescription ?? "none",
-                outgoingHeader: self.transitionState.outgoingPage?.headerDebugDescription ?? "none",
-                progress: self.transitionState.progress.workflowDebugDescription,
-                currentOpacity: self.transitionState.headerButtonOpacity(
-                    for: .current,
-                    headerTransition: headerTransition
-                ).workflowDebugDescription,
-                outgoingOpacity: self.transitionState.headerButtonOpacity(
-                    for: .outgoing,
-                    headerTransition: headerTransition
-                ).workflowDebugDescription
-            )
-        )
-    }
-
     static func exitOfferContext(
         for context: WorkflowContext,
         currentStepId: String
@@ -556,7 +535,6 @@ struct WorkflowPaywallView: View {
 
         let transitionID = UUID()
         self.activeTransitionID = transitionID
-        self.logHeaderTransition(stage: "start", transitionID: transitionID)
     }
 
     @MainActor
@@ -595,7 +573,6 @@ struct WorkflowPaywallView: View {
             return
         }
 
-        self.logHeaderTransition(stage: "finish", transitionID: id)
         self.transitionState.completeTransition()
         self.activeTransitionID = nil
     }
@@ -747,29 +724,6 @@ private struct RenderedPage: Identifiable {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-private extension RenderedPage {
-
-    var headerDebugDescription: String {
-        guard let headerComponent else {
-            return "none"
-        }
-
-        let name = headerComponent.stack.name ?? "nil"
-        return "stackName=\(name), components=\(headerComponent.stack.components.count), " +
-            "hash=\(headerComponent.hashValue)"
-    }
-
-}
-
-private extension CGFloat {
-
-    var workflowDebugDescription: String {
-        return "\(self)"
-    }
-
-}
-
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private struct DisplayedPage: Identifiable {
     let role: WorkflowPageTransitionState<RenderedPage>.PageRole
     let page: RenderedPage
@@ -887,8 +841,10 @@ private struct WorkflowHeaderOverlayPageView: View {
             .environment(\.workflowPackageContext, self.page.effectiveWorkflowPackageContext)
             .environment(\.closeWorkflowAction, self.closeWorkflowAction)
             .environment(
-                \.workflowPageTransitionContext,
-                .init(pageOffset: 0, headerButtonOpacity: 1, isTransitioning: true)
+                \.workflowRenderingContext,
+                WorkflowRenderingContext(
+                    pageTransition: .init(pageOffset: 0, headerButtonOpacity: 1, isTransitioning: true)
+                )
             )
             .environmentObject(self.purchaseHandler)
             .environmentObject(self.introOfferEligibilityContext)

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -419,7 +419,7 @@ struct WorkflowPaywallView: View {
             .frame(width: proxy.size.width, height: proxy.size.height, alignment: .top)
             .transitionClipMask(proxy: proxy)
             .environment(\.safeAreaInsets, proxy.safeAreaInsets)
-            .edgesIgnoringSafeArea(.top)
+            .ignoresSafeArea(edges: .top)
             .allowsHitTesting(false)
         }
     }
@@ -730,6 +730,9 @@ private final class WorkflowHeaderOverlayStateManager: ObservableObject {
     }
 }
 
+/// Rebuilds a full `PaywallState` purely to render the page's header in the transition overlay.
+/// This is heavier than reusing the page's own state, but it only lives for the duration of a
+/// page transition, so the cost is bounded and not on the steady-state render path.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private struct WorkflowHeaderOverlayPageView: View {
 

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -214,7 +214,6 @@ struct WorkflowPaywallView: View {
     private let onDismiss: () -> Void
 
     @StateObject private var navigator: WorkflowNavigator
-    @StateObject private var introOfferEligibilityContext: IntroOfferEligibilityContext
     @StateObject private var paywallPromoOfferCache: PaywallPromoOfferCache
     @State private var hasLoggedInvalidState = false
     @State private var transitionState: WorkflowPageTransitionState<RenderedPage>
@@ -239,9 +238,6 @@ struct WorkflowPaywallView: View {
         self.displayCloseButton = displayCloseButton
         self.onDismiss = onDismiss
         self._navigator = .init(wrappedValue: WorkflowNavigator(workflow: context.workflow))
-        self._introOfferEligibilityContext = .init(
-            wrappedValue: .init(introEligibilityChecker: introEligibilityChecker)
-        )
         self._paywallPromoOfferCache = .init(wrappedValue: promoOfferCache ?? PaywallPromoOfferCache(
             subscriptionHistoryTracker: purchaseHandler.subscriptionHistoryTracker
         ))
@@ -258,8 +254,8 @@ struct WorkflowPaywallView: View {
                 currentPage: Self.renderedPage(
                     from: context,
                     stepId: initialStepId,
-                    canNavigateBack: false,
-                    displayCloseButton: displayCloseButton,
+                    showCloseButton: displayCloseButton,
+                    introEligibilityChecker: introEligibilityChecker,
                     packageInput: initialPackageInput
                 )
             )
@@ -384,7 +380,7 @@ struct WorkflowPaywallView: View {
             failedToLoadFont: self.failedToLoadFont,
             colorScheme: self.colorScheme,
             promoOfferCache: self.paywallPromoOfferCache,
-            introEligibilityContext: self.introOfferEligibilityContext,
+            introEligibilityContext: page.introOfferEligibilityContext,
             selectedPackageContextOverride: page.packageContext
         )
         .environment(\.workflowPackageContext, page.effectiveWorkflowPackageContext)
@@ -403,7 +399,7 @@ struct WorkflowPaywallView: View {
                             page: displayedPage.page,
                             purchaseHandler: self.purchaseHandler,
                             introEligibilityChecker: self.introEligibilityChecker,
-                            introOfferEligibilityContext: self.introOfferEligibilityContext,
+                            introOfferEligibilityContext: displayedPage.page.introOfferEligibilityContext,
                             paywallPromoOfferCache: self.paywallPromoOfferCache,
                             showZeroDecimalPlacePrices: self.showZeroDecimalPlacePrices,
                             onDismiss: self.handleDismiss,
@@ -565,8 +561,8 @@ struct WorkflowPaywallView: View {
     private static func renderedPage(
         from context: WorkflowContext,
         stepId: String,
-        canNavigateBack: Bool,
-        displayCloseButton: Bool,
+        showCloseButton: Bool,
+        introEligibilityChecker: TrialOrIntroEligibilityChecker,
         packageInput: RenderedPagePackageInput
     ) -> RenderedPage? {
         guard let step = context.workflow.steps[stepId],
@@ -584,7 +580,8 @@ struct WorkflowPaywallView: View {
         return .init(
             content: .init(paywallComponents: paywallComponents, offering: offering),
             headerComponent: screen.componentsConfig.base.header,
-            showCloseButton: !canNavigateBack && displayCloseButton,
+            showCloseButton: showCloseButton,
+            introOfferEligibilityContext: .init(introEligibilityChecker: introEligibilityChecker),
             packageContext: packageInput.packageContext,
             effectiveWorkflowPackageContext: packageInput.effectiveWorkflowPackageContext
         )
@@ -637,8 +634,8 @@ struct WorkflowPaywallView: View {
         return Self.renderedPage(
             from: self.context,
             stepId: stepId,
-            canNavigateBack: canNavigateBack,
-            displayCloseButton: self.displayCloseButton,
+            showCloseButton: !canNavigateBack && self.displayCloseButton,
+            introEligibilityChecker: self.introEligibilityChecker,
             packageInput: .init(
                 packageContext: packageContext,
                 effectiveWorkflowPackageContext: self.context.effectivePackageContext(
@@ -676,8 +673,8 @@ struct WorkflowPaywallView: View {
         return Self.renderedPage(
             from: self.context,
             stepId: stepId,
-            canNavigateBack: canNavigateBack,
-            displayCloseButton: self.displayCloseButton,
+            showCloseButton: !canNavigateBack && self.displayCloseButton,
+            introEligibilityChecker: self.introEligibilityChecker,
             packageInput: packageInput
         )
     }
@@ -704,6 +701,8 @@ private struct RenderedPage: Identifiable {
     let content: CurrentStepContent
     let headerComponent: PaywallComponent.HeaderComponent?
     let showCloseButton: Bool
+    /// Page-scoped so late async eligibility checks cannot overwrite another workflow step.
+    let introOfferEligibilityContext: IntroOfferEligibilityContext
     let packageContext: PackageContext
     let effectiveWorkflowPackageContext: WorkflowPackageContext?
 }

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -95,16 +95,88 @@ struct WorkflowPageTransitionState<Page> {
     }
 
     func headerButtonOpacity(for role: PageRole) -> CGFloat {
+        return self.headerButtonOpacity(for: role, headerTransition: .replacing)
+    }
+
+    func headerButtonOpacity(for role: PageRole, headerTransition: WorkflowHeaderTransition) -> CGFloat {
         guard self.isTransitioning else {
             return role == .current ? 1 : 0
         }
 
-        switch role {
-        case .current:
-            return self.progress
-        case .outgoing:
-            return 1 - self.progress
+        switch headerTransition.mode {
+        case .none:
+            return role == .current ? 1 : 0
+        case .stable:
+            return role == .current ? 1 : 0
+        case .entering:
+            return role == .current ? self.progress : 0
+        case .leaving:
+            return role == .outgoing ? 1 - self.progress : 0
+        case .replacing:
+            switch role {
+            case .current:
+                return self.progress
+            case .outgoing:
+                return 1 - self.progress
+            }
         }
+    }
+
+}
+
+struct WorkflowHeaderTransition {
+
+    fileprivate enum Mode {
+        case none
+        case entering
+        case leaving
+        case replacing
+        case stable
+    }
+
+    fileprivate static let replacing = Self(mode: .replacing)
+
+    fileprivate let mode: Mode
+
+    var shouldRenderOverlay: Bool {
+        return self.mode != .none
+    }
+
+    fileprivate var debugName: String {
+        switch self.mode {
+        case .none:
+            return "none"
+        case .entering:
+            return "entering"
+        case .leaving:
+            return "leaving"
+        case .replacing:
+            return "replacing"
+        case .stable:
+            return "stable"
+        }
+    }
+
+    init<Header: Equatable>(
+        currentHeader: Header?,
+        outgoingHeader: Header?
+    ) {
+        switch (currentHeader, outgoingHeader) {
+        case (.none, .none):
+            self.mode = .none
+        case (.some, .none):
+            self.mode = .entering
+        case (.none, .some):
+            self.mode = .leaving
+        case let (.some(current), .some(outgoing)) where current == outgoing:
+            self.mode = .stable
+        case (.some, .some):
+            self.mode = .replacing
+        }
+    }
+
+    private init(mode: Mode) {
+        self.mode = mode
     }
 
 }
@@ -136,6 +208,7 @@ struct WorkflowPaywallView: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.workflowExitOfferOfferingBinding) private var exitOfferOfferingBinding
 
     enum DismissalAction: Equatable {
@@ -153,10 +226,11 @@ struct WorkflowPaywallView: View {
     private let introEligibilityChecker: TrialOrIntroEligibilityChecker
     private let showZeroDecimalPlacePrices: Bool
     private let displayCloseButton: Bool
-    private let promoOfferCache: PaywallPromoOfferCache?
     private let onDismiss: () -> Void
 
     @StateObject private var navigator: WorkflowNavigator
+    @StateObject private var introOfferEligibilityContext: IntroOfferEligibilityContext
+    @StateObject private var paywallPromoOfferCache: PaywallPromoOfferCache
     @State private var hasLoggedInvalidState = false
     @State private var transitionState: WorkflowPageTransitionState<RenderedPage>
     @State private var activeTransitionID: UUID?
@@ -178,9 +252,14 @@ struct WorkflowPaywallView: View {
         self.introEligibilityChecker = introEligibilityChecker
         self.showZeroDecimalPlacePrices = showZeroDecimalPlacePrices
         self.displayCloseButton = displayCloseButton
-        self.promoOfferCache = promoOfferCache
         self.onDismiss = onDismiss
         self._navigator = .init(wrappedValue: WorkflowNavigator(workflow: context.workflow))
+        self._introOfferEligibilityContext = .init(
+            wrappedValue: .init(introEligibilityChecker: introEligibilityChecker)
+        )
+        self._paywallPromoOfferCache = .init(wrappedValue: promoOfferCache ?? PaywallPromoOfferCache(
+            subscriptionHistoryTracker: purchaseHandler.subscriptionHistoryTracker
+        ))
         let initialStepId = context.workflow.initialStepId
         let initialPackageInput = Self.buildPackageInput(
             stepId: initialStepId,
@@ -219,7 +298,10 @@ struct WorkflowPaywallView: View {
                             \.workflowPageTransitionContext,
                             .init(
                                 pageOffset: pageOffset,
-                                headerButtonOpacity: self.transitionState.headerButtonOpacity(for: displayedPage.role),
+                                headerButtonOpacity: self.transitionState.headerButtonOpacity(
+                                    for: displayedPage.role,
+                                    headerTransition: self.headerTransition
+                                ),
                                 isTransitioning: self.transitionState.isTransitioning
                             )
                         )
@@ -228,6 +310,9 @@ struct WorkflowPaywallView: View {
                         .offset(x: pageOffset)
                         .zIndex(self.transitionState.zIndex(for: displayedPage.role))
                 }
+
+                self.workflowHeaderOverlay(proxy: proxy)
+                    .zIndex(2)
 
                 if self.transitionState.currentPage == nil {
                     Color.clear
@@ -285,6 +370,17 @@ struct WorkflowPaywallView: View {
         .compactMap { $0 }
     }
 
+    private var headerTransition: WorkflowHeaderTransition {
+        return .init(
+            currentHeader: self.transitionState.currentPage?.headerComponent,
+            outgoingHeader: self.transitionState.outgoingPage?.headerComponent
+        )
+    }
+
+    private var shouldRenderWorkflowHeaderOverlay: Bool {
+        return self.transitionState.isTransitioning && self.headerTransition.shouldRenderOverlay
+    }
+
     private func pageView(for page: RenderedPage) -> some View {
         PaywallsV2View(
             paywallComponents: page.content.paywallComponents,
@@ -299,13 +395,50 @@ struct WorkflowPaywallView: View {
             closeWorkflowAction: self.onDismiss,
             failedToLoadFont: self.failedToLoadFont,
             colorScheme: self.colorScheme,
-            promoOfferCache: self.promoOfferCache,
+            promoOfferCache: self.paywallPromoOfferCache,
+            introEligibilityContext: self.introOfferEligibilityContext,
             selectedPackageContextOverride: page.packageContext
         )
         .environment(\.workflowPackageContext, page.effectiveWorkflowPackageContext)
         .environment(\.workflowTriggerAction, { componentId in
             return self.handleTriggeredNavigation(componentId: componentId)
         })
+        .environment(\.workflowPageHeaderSuppressed, self.shouldRenderWorkflowHeaderOverlay)
+    }
+
+    @ViewBuilder
+    private func workflowHeaderOverlay(proxy: GeometryProxy) -> some View {
+        if self.shouldRenderWorkflowHeaderOverlay {
+            ZStack(alignment: .top) {
+                ForEach(self.displayedPages) { displayedPage in
+                    if displayedPage.page.headerComponent != nil {
+                        WorkflowHeaderOverlayPageView(
+                            page: displayedPage.page,
+                            purchaseHandler: self.purchaseHandler,
+                            introEligibilityChecker: self.introEligibilityChecker,
+                            introOfferEligibilityContext: self.introOfferEligibilityContext,
+                            paywallPromoOfferCache: self.paywallPromoOfferCache,
+                            showZeroDecimalPlacePrices: self.showZeroDecimalPlacePrices,
+                            onDismiss: self.handleDismiss,
+                            closeWorkflowAction: self.onDismiss,
+                            failedToLoadFont: self.failedToLoadFont,
+                            colorScheme: self.colorScheme,
+                            horizontalSizeClass: self.horizontalSizeClass,
+                            headerOpacity: self.transitionState.headerButtonOpacity(
+                                for: displayedPage.role,
+                                headerTransition: self.headerTransition
+                            )
+                        )
+                        .zIndex(displayedPage.role == .current ? 1 : 0)
+                    }
+                }
+            }
+            .frame(width: proxy.size.width, height: proxy.size.height, alignment: .top)
+            .transitionClipMask(proxy: proxy)
+            .environment(\.safeAreaInsets, proxy.safeAreaInsets)
+            .edgesIgnoringSafeArea(.top)
+            .allowsHitTesting(false)
+        }
     }
 
     private func failedToLoadFont(_ fontConfig: UIConfig.FontsConfig) {
@@ -346,6 +479,29 @@ struct WorkflowPaywallView: View {
         self.exitOfferOfferingBinding.wrappedValue = Self.exitOfferContext(
             for: self.context, currentStepId: self.navigator.currentStepId
         )?.exitOfferOffering
+    }
+
+    private func logHeaderTransition(stage: String, transitionID: UUID) {
+        let headerTransition = self.headerTransition
+
+        Logger.debug(
+            Strings.workflow_header_transition(
+                stage: stage,
+                transitionId: transitionID.uuidString,
+                mode: headerTransition.debugName,
+                currentHeader: self.transitionState.currentPage?.headerDebugDescription ?? "none",
+                outgoingHeader: self.transitionState.outgoingPage?.headerDebugDescription ?? "none",
+                progress: self.transitionState.progress.workflowDebugDescription,
+                currentOpacity: self.transitionState.headerButtonOpacity(
+                    for: .current,
+                    headerTransition: headerTransition
+                ).workflowDebugDescription,
+                outgoingOpacity: self.transitionState.headerButtonOpacity(
+                    for: .outgoing,
+                    headerTransition: headerTransition
+                ).workflowDebugDescription
+            )
+        )
     }
 
     static func exitOfferContext(
@@ -400,6 +556,7 @@ struct WorkflowPaywallView: View {
 
         let transitionID = UUID()
         self.activeTransitionID = transitionID
+        self.logHeaderTransition(stage: "start", transitionID: transitionID)
     }
 
     @MainActor
@@ -438,6 +595,7 @@ struct WorkflowPaywallView: View {
             return
         }
 
+        self.logHeaderTransition(stage: "finish", transitionID: id)
         self.transitionState.completeTransition()
         self.activeTransitionID = nil
     }
@@ -463,6 +621,7 @@ struct WorkflowPaywallView: View {
 
         return .init(
             content: .init(paywallComponents: paywallComponents, offering: offering),
+            headerComponent: screen.componentsConfig.base.header,
             showCloseButton: !canNavigateBack && displayCloseButton,
             packageContext: packageInput.packageContext,
             effectiveWorkflowPackageContext: packageInput.effectiveWorkflowPackageContext
@@ -581,9 +740,33 @@ struct WorkflowPaywallView: View {
 private struct RenderedPage: Identifiable {
     let id = UUID()
     let content: CurrentStepContent
+    let headerComponent: PaywallComponent.HeaderComponent?
     let showCloseButton: Bool
     let packageContext: PackageContext
     let effectiveWorkflowPackageContext: WorkflowPackageContext?
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension RenderedPage {
+
+    var headerDebugDescription: String {
+        guard let headerComponent else {
+            return "none"
+        }
+
+        let name = headerComponent.stack.name ?? "nil"
+        return "stackName=\(name), components=\(headerComponent.stack.components.count), " +
+            "hash=\(headerComponent.hashValue)"
+    }
+
+}
+
+private extension CGFloat {
+
+    var workflowDebugDescription: String {
+        return "\(self)"
+    }
+
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
@@ -598,6 +781,122 @@ private struct DisplayedPage: Identifiable {
 private struct CurrentStepContent {
     let paywallComponents: Offering.PaywallComponents
     let offering: Offering
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private final class WorkflowHeaderOverlayStateManager: ObservableObject {
+    let state: Result<PaywallState, Error>
+
+    init(state: Result<PaywallState, Error>) {
+        self.state = state
+    }
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private struct WorkflowHeaderOverlayPageView: View {
+
+    @StateObject private var stateManager: WorkflowHeaderOverlayStateManager
+
+    private let page: RenderedPage
+    private let purchaseHandler: PurchaseHandler
+    private let introOfferEligibilityContext: IntroOfferEligibilityContext
+    private let paywallPromoOfferCache: PaywallPromoOfferCache
+    private let uiConfigProvider: UIConfigProvider
+    private let onDismiss: () -> Void
+    private let closeWorkflowAction: () -> Void
+    private let horizontalSizeClass: UserInterfaceSizeClass?
+    private let headerOpacity: CGFloat
+
+    init(
+        page: RenderedPage,
+        purchaseHandler: PurchaseHandler,
+        introEligibilityChecker: TrialOrIntroEligibilityChecker,
+        introOfferEligibilityContext: IntroOfferEligibilityContext,
+        paywallPromoOfferCache: PaywallPromoOfferCache,
+        showZeroDecimalPlacePrices: Bool,
+        onDismiss: @escaping () -> Void,
+        closeWorkflowAction: @escaping () -> Void,
+        failedToLoadFont: @escaping UIConfigProvider.FailedToLoadFont,
+        colorScheme: ColorScheme,
+        horizontalSizeClass: UserInterfaceSizeClass?,
+        headerOpacity: CGFloat
+    ) {
+        let paywallComponents = page.content.paywallComponents
+        let uiConfigProvider = UIConfigProvider(
+            uiConfig: paywallComponents.uiConfig,
+            failedToLoadFont: failedToLoadFont,
+            automaticallyScaleFontSize: paywallComponents.data.automaticallyScaleFontSize
+        )
+
+        self.page = page
+        self.purchaseHandler = purchaseHandler
+        self.introOfferEligibilityContext = introOfferEligibilityContext
+        self.paywallPromoOfferCache = paywallPromoOfferCache
+        self.uiConfigProvider = uiConfigProvider
+        self.onDismiss = onDismiss
+        self.closeWorkflowAction = closeWorkflowAction
+        self.horizontalSizeClass = horizontalSizeClass
+        self.headerOpacity = headerOpacity
+        self._stateManager = .init(
+            wrappedValue: .init(
+                state: PaywallsV2View.createPaywallState(
+                    componentsConfig: paywallComponents.data.componentsConfig.base,
+                    componentsLocalizations: paywallComponents.data.componentsLocalizations,
+                    preferredLocales: purchaseHandler.preferredLocales,
+                    defaultLocale: paywallComponents.data.defaultLocale,
+                    uiConfigProvider: uiConfigProvider,
+                    offering: page.content.offering,
+                    introEligibilityChecker: introEligibilityChecker,
+                    showZeroDecimalPlacePrices: showZeroDecimalPlacePrices,
+                    colorScheme: colorScheme
+                )
+            )
+        )
+    }
+
+    var body: some View {
+        switch self.stateManager.state {
+        case .success(let paywallState):
+            self.headerView(paywallState: paywallState)
+        case .failure:
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private func headerView(paywallState: PaywallState) -> some View {
+        if let headerViewModel = paywallState.rootViewModel.headerViewModel {
+            let contentLocale = paywallState.rootViewModel.localizationProvider.locale
+            let defaultPackage = PaywallsV2View.effectiveDefaultPackage(
+                pageDefaultPackage: paywallState.viewModelFactory.packageValidator.defaultSelectedPackage,
+                workflowDefaultPackage: self.page.effectiveWorkflowPackageContext?.selectedPackage
+            )
+
+            HeaderComponentView(
+                viewModel: headerViewModel,
+                onDismiss: self.onDismiss
+            )
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .top)
+            .opacity(self.headerOpacity)
+            .environment(\.locale, contentLocale)
+            .environment(\.layoutDirection, contentLocale.swiftUILayoutDirection)
+            .environment(\.screenCondition, ScreenCondition.from(self.horizontalSizeClass))
+            .environment(\.selectedPackageId, self.page.packageContext.package?.identifier)
+            .environment(\.planSelectionDefaultPackage, defaultPackage)
+            .environment(\.workflowPackageContext, self.page.effectiveWorkflowPackageContext)
+            .environment(\.closeWorkflowAction, self.closeWorkflowAction)
+            .environment(
+                \.workflowPageTransitionContext,
+                .init(pageOffset: 0, headerButtonOpacity: 1, isTransitioning: true)
+            )
+            .environmentObject(self.purchaseHandler)
+            .environmentObject(self.introOfferEligibilityContext)
+            .environmentObject(self.paywallPromoOfferCache)
+            .environmentObject(self.page.packageContext)
+        }
+    }
+
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -1063,7 +1063,11 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
 /// without notifying the PresentPaywallViewModifier — therefore preventing an entire paywall redraw.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @MainActor
-private final class PromoOfferCacheOwner: ObservableObject {
+/// Holds a `PaywallPromoOfferCache` with a stable, create-once lifetime when stored as a
+/// `@StateObject`, while exposing it as a plain `let` and publishing nothing of its own.
+/// This lets an owning view keep a single shared cache alive without re-rendering on the
+/// cache's `@Published` changes (the view only forwards the cache to its children).
+internal final class PromoOfferCacheOwner: ObservableObject {
     let cache: PaywallPromoOfferCache
     init(cache: PaywallPromoOfferCache) {
         self.cache = cache

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
@@ -110,6 +110,84 @@ final class WorkflowPaywallViewTests: TestCase {
         expect(state.headerButtonOpacity(for: .outgoing)) == 0
     }
 
+    func testMatchingHeadersStayPinnedWithoutCrossfading() {
+        var state = WorkflowPageTransitionState(currentPage: "step_1")
+        let headerTransition = WorkflowHeaderTransition(
+            currentHeader: "shared_header",
+            outgoingHeader: "shared_header"
+        )
+
+        state.beginTransition(to: "step_2", direction: .forward)
+
+        expect(state.headerButtonOpacity(for: .current, headerTransition: headerTransition)) == 1
+        expect(state.headerButtonOpacity(for: .outgoing, headerTransition: headerTransition)) == 0
+
+        state.advanceAnimation()
+
+        expect(state.headerButtonOpacity(for: .current, headerTransition: headerTransition)) == 1
+        expect(state.headerButtonOpacity(for: .outgoing, headerTransition: headerTransition)) == 0
+    }
+
+    func testHeaderFadesInWhenOnlyIncomingPageHasHeader() {
+        var state = WorkflowPageTransitionState(currentPage: "step_1")
+        let headerTransition = WorkflowHeaderTransition(
+            currentHeader: "incoming_header",
+            outgoingHeader: nil as String?
+        )
+
+        state.beginTransition(to: "step_2", direction: .forward)
+
+        expect(state.headerButtonOpacity(for: .current, headerTransition: headerTransition)) == 0
+        expect(state.headerButtonOpacity(for: .outgoing, headerTransition: headerTransition)) == 0
+
+        state.advanceAnimation()
+
+        expect(state.headerButtonOpacity(for: .current, headerTransition: headerTransition)) == 1
+        expect(state.headerButtonOpacity(for: .outgoing, headerTransition: headerTransition)) == 0
+    }
+
+    func testHeaderFadesOutWhenOnlyOutgoingPageHasHeader() {
+        var state = WorkflowPageTransitionState(currentPage: "step_1")
+        let headerTransition = WorkflowHeaderTransition(
+            currentHeader: nil as String?,
+            outgoingHeader: "outgoing_header"
+        )
+
+        state.beginTransition(to: "step_2", direction: .forward)
+
+        expect(state.headerButtonOpacity(for: .current, headerTransition: headerTransition)) == 0
+        expect(state.headerButtonOpacity(for: .outgoing, headerTransition: headerTransition)) == 1
+
+        state.advanceAnimation()
+
+        expect(state.headerButtonOpacity(for: .current, headerTransition: headerTransition)) == 0
+        expect(state.headerButtonOpacity(for: .outgoing, headerTransition: headerTransition)) == 0
+    }
+
+    func testHeaderOverlayOnlyRendersWhenAtLeastOnePageHasAHeader() {
+        let noHeader = WorkflowHeaderTransition(
+            currentHeader: nil as String?,
+            outgoingHeader: nil as String?
+        )
+        let entering = WorkflowHeaderTransition(
+            currentHeader: "incoming_header",
+            outgoingHeader: nil as String?
+        )
+        let leaving = WorkflowHeaderTransition(
+            currentHeader: nil as String?,
+            outgoingHeader: "outgoing_header"
+        )
+        let stable = WorkflowHeaderTransition(
+            currentHeader: "shared_header",
+            outgoingHeader: "shared_header"
+        )
+
+        expect(noHeader.shouldRenderOverlay) == false
+        expect(entering.shouldRenderOverlay) == true
+        expect(leaving.shouldRenderOverlay) == true
+        expect(stable.shouldRenderOverlay) == true
+    }
+
     func testCompletingTransitionDropsOutgoingPage() {
         var state = WorkflowPageTransitionState(currentPage: "step_1")
 

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
@@ -188,6 +188,16 @@ final class WorkflowPaywallViewTests: TestCase {
         expect(stable.shouldRenderOverlay) == true
     }
 
+    func testWorkflowRenderingContextDefaultsToNonTransitioningPageContent() {
+        let context = WorkflowRenderingContext.identity
+
+        expect(context.pageTransition.pageOffset) == 0
+        expect(context.pageTransition.headerButtonOpacity) == 1
+        expect(context.pageTransition.isTransitioning) == false
+        expect(context.pageHeaderSuppressed) == false
+        expect(context.isHeader) == false
+    }
+
     func testCompletingTransitionDropsOutgoingPage() {
         var state = WorkflowPageTransitionState(currentPage: "step_1")
 


### PR DESCRIPTION
Stacked on #6877.

Linear: https://linear.app/revenuecat/issue/WEB-4339/page-transition-glitches-on-second-screen

## What Changed

- Moves workflow headers into a workflow-level overlay during page transitions.
- Suppresses page-owned headers while the overlay owns the transition, preserving layout so body content does not jump.
- Keeps shared headers pinned, fades headers only when entering/leaving, and retains crossfade behavior for true replacement.

## Media


https://github.com/user-attachments/assets/b82fa21a-f358-4c30-9572-a85ca5caa15a



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes are confined to Paywalls V2 workflow UI and SwiftUI transition state, but they touch navigation, header layering, and eligibility/cache lifetime across steps—regressions would show as visual glitches or wrong intro/promo state, not purchase logic.
> 
> **Overview**
> Fixes workflow paywall **page-transition glitches** by moving header rendering out of the sliding page snapshots and into a workflow-level overlay for the duration of each transition.
> 
> **`WorkflowRenderingContext`** replaces separate environment keys (`workflowPageTransitionContext`, `isWorkflowHeader`) and adds **`pageHeaderSuppressed`**: in-page headers stay in the layout but are hidden (`opacity` 0) while the overlay is active, so body content does not jump. **`WorkflowHeaderTransition`** classifies incoming/outgoing headers (none, entering, leaving, stable, replacing) and drives **header button opacity** so shared headers stay pinned without crossfade, while true header swaps still crossfade.
> 
> During transitions, **`WorkflowHeaderOverlayPageView`** rebuilds header UI above the clipped pages (non-interactive overlay); **`PromoOfferCacheOwner`** is shared via `@StateObject` so promo-cache `@Published` updates do not re-render the whole page stack. Each workflow step gets a **page-scoped `IntroOfferEligibilityContext`** passed into `PaywallsV2View`. Unit tests cover the new header transition modes and rendering context defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 153509a5f42c2d33feca8641bd81bb85e0123e08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->