### PR TITLE
feat(workflows): add WorkflowsCache and disk persistence for workflows list

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -424,6 +424,8 @@
 		3DD6C3CC5EC6B69E9DA9571D /* Evaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B78483ACCDD62ABD40AF8827 /* Evaluator.swift */; };
 		424117A427E05CDDE5CAB803 /* LogicOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EF5BB0DF2CED359AB0089B4 /* LogicOperators.swift */; };
 		42F1DF385E3C1F9903A07FBF /* ProductsFetcherSK1.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB3CBAA73855779FE828CE2 /* ProductsFetcherSK1.swift */; };
+		461DF6CBD6A73F7081683DC4 /* WorkflowsCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = C41FD75CE31F51BBE614F9B0 /* WorkflowsCache.swift */; };
+		6305B8C113CE294A18FD62BD /* WorkflowsCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D8A2C402AB81F3C35672B14 /* WorkflowsCacheTests.swift */; };
 		49554883F2D5ED48F0907FB9 /* ExitOfferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D26169F24D341F77345716D /* ExitOfferTests.swift */; };
 		4D21041E2CF548790095D254 /* GradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D21041D2CF548790095D254 /* GradientView.swift */; };
 		4D2A00682CD1EED3008318CA /* PurchaseParamsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D2A00672CD1EED2008318CA /* PurchaseParamsTests.swift */; };
@@ -2875,6 +2877,8 @@
 		B7BA50D5AA17E5D4A5D3E99D /* Operators.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Operators.swift; sourceTree = "<group>"; };
 		B807748D6D88B7836EC273ED /* EqualityOperators.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EqualityOperators.swift; sourceTree = "<group>"; };
 		B8BCBA1A622A35B377B35254 /* ValueTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ValueTests.swift; sourceTree = "<group>"; };
+		9D8A2C402AB81F3C35672B14 /* WorkflowsCacheTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowsCacheTests.swift; sourceTree = "<group>"; };
+		C41FD75CE31F51BBE614F9B0 /* WorkflowsCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowsCache.swift; sourceTree = "<group>"; };
 		CC1A2B3C2E1234AB00AABBCC /* CustomVariablesEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomVariablesEditorView.swift; sourceTree = "<group>"; };
 		CDD7D260191B3B9A1FA0C277 /* LogicOperatorsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LogicOperatorsTests.swift; sourceTree = "<group>"; };
 		CF01A0F868569B5E2D5CA465 /* PaywallsV2LayoutFixtures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaywallsV2LayoutFixtures.swift; path = Tests/RevenueCatUITests/PaywallsV2/PaywallsV2LayoutFixtures.swift; sourceTree = SOURCE_ROOT; };
@@ -4723,6 +4727,7 @@
 				37E35D87B7E6F91E27E98F42 /* DeviceCacheTests.swift */,
 				37E35E3250FBBB03D92E06EC /* InMemoryCachedObjectTests.swift */,
 				1622D3FA2E900DE000C20E3C /* ChecksumTests.swift */,
+				9D8A2C402AB81F3C35672B14 /* WorkflowsCacheTests.swift */,
 			);
 			path = Caching;
 			sourceTree = "<group>";
@@ -6272,6 +6277,7 @@
 				16BCA3672E4D9B0C00B39E7F /* FileRepository.swift */,
 				B3B5FBBE269E081E00104A0C /* InMemoryCachedObject.swift */,
 				16BCA3692E4D9B2C00B39E7F /* KeyedDeferredValueStore.swift */,
+				C41FD75CE31F51BBE614F9B0 /* WorkflowsCache.swift */,
 			);
 			path = Caching;
 			sourceTree = "<group>";
@@ -7599,6 +7605,7 @@
 				DDD45A15A641C0FF0BEF6178 /* PaywallCountdownComponent.swift in Sources */,
 				51978277F6FF8880DDF3028D /* ExitOffer.swift in Sources */,
 				909114C714204DFB8C4F3F72 /* TransactionReason.swift in Sources */,
+				461DF6CBD6A73F7081683DC4 /* WorkflowsCache.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7959,6 +7966,7 @@
 				5796A38A27D6B96300653165 /* BackendGetCustomerInfoTests.swift in Sources */,
 				49554883F2D5ED48F0907FB9 /* ExitOfferTests.swift in Sources */,
 				2B699E6661ECFB93B146A2D9 /* SynchronizedUserDefaultsTests.swift in Sources */,
+				6305B8C113CE294A18FD62BD /* WorkflowsCacheTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Caching/DeviceCache.swift
+++ b/Sources/Caching/DeviceCache.swift
@@ -276,26 +276,19 @@ class DeviceCache {
     }
 
     // MARK: - Workflows list response
-    // The workflows list is persisted under a single, non-user-scoped key
-    // Cross-user safety is handled by clearing it on identity transitions, just like the offerings cache.
+    // The workflows list is persisted under a single, non-user-scoped key.
+    // Cross-user safety is handled by clearing it on identity transitions.
 
     func cachedWorkflowsListResponse() -> WorkflowsListResponse? {
         return self.value(for: CacheKey.workflowsListResponse)
     }
 
     func cache(workflowsListResponse: WorkflowsListResponse) {
-        let key = CacheKey.workflowsListResponse.rawValue
-        if self.largeItemCache.set(codable: workflowsListResponse, forKey: key) {
-            // Delete old file from documents directory if it exists
-            self.deleteOldFileIfNeeded(for: key)
-        }
+        self.largeItemCache.set(codable: workflowsListResponse, forKey: CacheKey.workflowsListResponse.rawValue)
     }
 
     func clearWorkflowsListResponseCache() {
         self.largeItemCache.removeObject(forKey: CacheKey.workflowsListResponse.rawValue)
-
-        // Delete old workflows list file from documents directory if it exists
-        self.deleteOldFileIfNeeded(for: CacheKey.workflowsListResponse.rawValue)
     }
 
     // MARK: - subscriber attributes
@@ -427,8 +420,6 @@ class DeviceCache {
                                       environment: .init(sandbox: isSandbox))
     }
 
-    /// The same foreground/background cache TTL used by offerings, resolved for the current
-    /// environment. Exposed so other caches (e.g. `WorkflowsCache`) reuse the identical policy.
     func cacheDurationInSeconds(isAppBackgrounded: Bool) -> TimeInterval {
         return self.cacheDurationInSeconds(isAppBackgrounded: isAppBackgrounded,
                                            isSandbox: self.systemInfo.isSandbox)

--- a/Sources/Caching/DeviceCache.swift
+++ b/Sources/Caching/DeviceCache.swift
@@ -275,6 +275,29 @@ class DeviceCache {
         }
     }
 
+    // MARK: - Workflows list response
+    // The workflows list is persisted under a single, non-user-scoped key (mirroring the Android SDK).
+    // Cross-user safety is handled by clearing it on identity transitions, just like the offerings cache.
+
+    func cachedWorkflowsListResponse() -> WorkflowsListResponse? {
+        return self.value(for: CacheKey.workflowsListResponse)
+    }
+
+    func cache(workflowsListResponse: WorkflowsListResponse) {
+        let key = CacheKey.workflowsListResponse.rawValue
+        if self.largeItemCache.set(codable: workflowsListResponse, forKey: key) {
+            // Delete old file from documents directory if it exists
+            self.deleteOldFileIfNeeded(for: key)
+        }
+    }
+
+    func clearWorkflowsListResponseCache() {
+        self.largeItemCache.removeObject(forKey: CacheKey.workflowsListResponse.rawValue)
+
+        // Delete old workflows list file from documents directory if it exists
+        self.deleteOldFileIfNeeded(for: CacheKey.workflowsListResponse.rawValue)
+    }
+
     // MARK: - subscriber attributes
     // Write operations use `lockingUserDefaults` to ensure atomic read-modify-write.
     // Read operations use the lock-free `userDefaults` since they don't modify data.
@@ -402,6 +425,13 @@ class DeviceCache {
     private func cacheDurationInSeconds(isAppBackgrounded: Bool, isSandbox: Bool) -> TimeInterval {
         return CacheDuration.duration(status: .init(backgrounded: isAppBackgrounded),
                                       environment: .init(sandbox: isSandbox))
+    }
+
+    /// The same foreground/background cache TTL used by offerings, resolved for the current
+    /// environment. Exposed so other caches (e.g. `WorkflowsCache`) reuse the identical policy.
+    func cacheDurationInSeconds(isAppBackgrounded: Bool) -> TimeInterval {
+        return self.cacheDurationInSeconds(isAppBackgrounded: isAppBackgrounded,
+                                           isSandbox: self.systemInfo.isSandbox)
     }
 
     // MARK: - Products Entitlements
@@ -541,6 +571,7 @@ class DeviceCache {
         case customerInfo(String)
         case customerInfoLastUpdated(String)
         case offerings(String)
+        case workflowsListResponse
         case legacySubscriberAttributes(String)
         case attributionDataDefaults(String)
         case syncedSK2ObserverModeTransactionIDs
@@ -552,6 +583,7 @@ class DeviceCache {
             case let .customerInfo(userID): return "\(Self.base)purchaserInfo.\(userID)"
             case let .customerInfoLastUpdated(userID): return "\(Self.base)purchaserInfoLastUpdated.\(userID)"
             case let .offerings(userID): return "\(Self.base)offerings.\(userID)"
+            case .workflowsListResponse: return "\(Self.base)workflowsListResponse"
             case let .legacySubscriberAttributes(userID): return "\(Self.legacySubscriberAttributesBase)\(userID)"
             case let .attributionDataDefaults(userID): return "\(Self.base)attribution.\(userID)"
             case .syncedSK2ObserverModeTransactionIDs:

--- a/Sources/Caching/DeviceCache.swift
+++ b/Sources/Caching/DeviceCache.swift
@@ -184,10 +184,7 @@ class DeviceCache {
             }
 
             let timeSinceLastCheck = cachesLastUpdated.timeIntervalSinceNow * -1
-            let cacheDurationInSeconds = self.cacheDurationInSeconds(
-                isAppBackgrounded: isAppBackgrounded,
-                isSandbox: self.systemInfo.isSandbox
-            )
+            let cacheDurationInSeconds = self.cacheDurationInSeconds(isAppBackgrounded: isAppBackgrounded)
 
             return timeSinceLastCheck >= cacheDurationInSeconds
         }
@@ -253,8 +250,7 @@ class DeviceCache {
     func isOfferingsCacheStale(isAppBackgrounded: Bool) -> Bool {
         // Time-based staleness, or
         return self.offeringsCachedObject.isCacheStale(
-            durationInSeconds: self.cacheDurationInSeconds(isAppBackgrounded: isAppBackgrounded,
-                                                           isSandbox: self.systemInfo.isSandbox)
+            durationInSeconds: self.cacheDurationInSeconds(isAppBackgrounded: isAppBackgrounded)
         ) ||
         // Locale-based staleness
         self.offeringsCachePreferredLocales.value != self.systemInfo.preferredLocales
@@ -415,14 +411,9 @@ class DeviceCache {
         }
     }
 
-    private func cacheDurationInSeconds(isAppBackgrounded: Bool, isSandbox: Bool) -> TimeInterval {
-        return CacheDuration.duration(status: .init(backgrounded: isAppBackgrounded),
-                                      environment: .init(sandbox: isSandbox))
-    }
-
     func cacheDurationInSeconds(isAppBackgrounded: Bool) -> TimeInterval {
-        return self.cacheDurationInSeconds(isAppBackgrounded: isAppBackgrounded,
-                                           isSandbox: self.systemInfo.isSandbox)
+        return CacheDuration.duration(status: .init(backgrounded: isAppBackgrounded),
+                                      environment: .init(sandbox: self.systemInfo.isSandbox))
     }
 
     // MARK: - Products Entitlements
@@ -512,10 +503,7 @@ class DeviceCache {
             }
 
             let timeSinceLastCheck = cachesLastUpdated.timeIntervalSinceNow * -1
-            let cacheDurationInSeconds = self.cacheDurationInSeconds(
-                isAppBackgrounded: isAppBackgrounded,
-                isSandbox: self.systemInfo.isSandbox
-            )
+            let cacheDurationInSeconds = self.cacheDurationInSeconds(isAppBackgrounded: isAppBackgrounded)
 
             return timeSinceLastCheck >= cacheDurationInSeconds
         }

--- a/Sources/Caching/DeviceCache.swift
+++ b/Sources/Caching/DeviceCache.swift
@@ -276,7 +276,7 @@ class DeviceCache {
     }
 
     // MARK: - Workflows list response
-    // The workflows list is persisted under a single, non-user-scoped key (mirroring the Android SDK).
+    // The workflows list is persisted under a single, non-user-scoped key
     // Cross-user safety is handled by clearing it on identity transitions, just like the offerings cache.
 
     func cachedWorkflowsListResponse() -> WorkflowsListResponse? {

--- a/Sources/Caching/WorkflowsCache.swift
+++ b/Sources/Caching/WorkflowsCache.swift
@@ -32,7 +32,7 @@ import Foundation
 /// Timestamps are stamped via an injected ``DateProvider`` (rather than reusing `InMemoryCachedObject`,
 /// whose staleness is tied to the real wall clock) so cache-expiry behavior is deterministically
 /// testable, mirroring the Android SDK's `WorkflowsCache`.
-class WorkflowsCache {
+final class WorkflowsCache {
 
     private struct CachedWorkflow {
         let result: WorkflowDataResult

--- a/Sources/Caching/WorkflowsCache.swift
+++ b/Sources/Caching/WorkflowsCache.swift
@@ -31,7 +31,6 @@ final class WorkflowsCache {
 
     private struct CachedList {
         let response: WorkflowsListResponse
-        let workflowIdByOfferingId: [String: String]
         let lastUpdated: Date
     }
 
@@ -80,10 +79,8 @@ final class WorkflowsCache {
     /// A fetch in flight during an identity transition can complete *after* ``clearCache()`` and
     /// repopulate the cache with the previous user's list (last-write-wins). This is not guarded
     /// here; it self-heals on the next fetch, as the offerings cache does.
-    func cache(workflowsList response: WorkflowsListResponse, workflowIdByOfferingId: [String: String]) {
-        self.cachedList.value = CachedList(response: response,
-                                           workflowIdByOfferingId: workflowIdByOfferingId,
-                                           lastUpdated: self.dateProvider.now())
+    func cache(workflowsList response: WorkflowsListResponse) {
+        self.cachedList.value = CachedList(response: response, lastUpdated: self.dateProvider.now())
         self.deviceCache.cache(workflowsListResponse: response)
     }
 
@@ -93,8 +90,13 @@ final class WorkflowsCache {
         return self.deviceCache.cachedWorkflowsListResponse()
     }
 
+    /// Resolves the workflow id for an offering, derived from ``WorkflowSummary/offeringId`` in the
+    /// cached list. Falls back to the disk copy so it still resolves after a restore, before the
+    /// next fetch repopulates the in-memory cache. If more than one workflow maps to the same
+    /// offering, the last one in the list wins.
     func workflowId(forOfferingId offeringId: String) -> String? {
-        return self.cachedList.value?.workflowIdByOfferingId[offeringId]
+        let response = self.cachedList.value?.response ?? self.deviceCache.cachedWorkflowsListResponse()
+        return response?.workflows.last { $0.offeringId == offeringId }?.id
     }
 
     // MARK: -

--- a/Sources/Caching/WorkflowsCache.swift
+++ b/Sources/Caching/WorkflowsCache.swift
@@ -76,10 +76,6 @@ final class WorkflowsCache {
     }
 
     /// Caches the workflows list in memory and persists it to disk.
-    ///
-    /// A fetch in flight during an identity transition can complete *after* ``clearCache()`` and
-    /// repopulate the cache with the previous user's list (last-write-wins). This is not guarded
-    /// here; it self-heals on the next fetch, as the offerings cache does.
     func cache(workflowsList response: WorkflowsListResponse) {
         self.cachedList.value = CachedList(response: response,
                                            offeringIdToWorkflowId: Self.offeringIdToWorkflowId(from: response),
@@ -94,9 +90,7 @@ final class WorkflowsCache {
     }
 
     /// Resolves the workflow id for an offering from the in-memory list, or `nil` when the list
-    /// hasn't been cached this session. Restoring the persisted list after a backend failure is the
-    /// caller's responsibility (via ``cachedWorkflowsListResponseFromDisk()`` + ``cache(workflowsList:)``),
-    /// the same way the offerings cache is hydrated from disk, so this lookup never touches disk.
+    /// hasn't been cached this session.
     func workflowId(forOfferingId offeringId: String) -> String? {
         return self.cachedList.value?.offeringIdToWorkflowId[offeringId]
     }

--- a/Sources/Caching/WorkflowsCache.swift
+++ b/Sources/Caching/WorkflowsCache.swift
@@ -31,6 +31,7 @@ final class WorkflowsCache {
 
     private struct CachedList {
         let response: WorkflowsListResponse
+        let offeringIdToWorkflowId: [String: String]
         let lastUpdated: Date
     }
 
@@ -80,7 +81,9 @@ final class WorkflowsCache {
     /// repopulate the cache with the previous user's list (last-write-wins). This is not guarded
     /// here; it self-heals on the next fetch, as the offerings cache does.
     func cache(workflowsList response: WorkflowsListResponse) {
-        self.cachedList.value = CachedList(response: response, lastUpdated: self.dateProvider.now())
+        self.cachedList.value = CachedList(response: response,
+                                           offeringIdToWorkflowId: Self.offeringIdToWorkflowId(from: response),
+                                           lastUpdated: self.dateProvider.now())
         self.deviceCache.cache(workflowsListResponse: response)
     }
 
@@ -90,13 +93,12 @@ final class WorkflowsCache {
         return self.deviceCache.cachedWorkflowsListResponse()
     }
 
-    /// Resolves the workflow id for an offering, derived from ``WorkflowSummary/offeringId`` in the
-    /// cached list. Falls back to the disk copy so it still resolves after a restore, before the
-    /// next fetch repopulates the in-memory cache. If more than one workflow maps to the same
-    /// offering, the last one in the list wins.
+    /// Resolves the workflow id for an offering from the in-memory list, or `nil` when the list
+    /// hasn't been cached this session. Restoring the persisted list after a backend failure is the
+    /// caller's responsibility (via ``cachedWorkflowsListResponseFromDisk()`` + ``cache(workflowsList:)``),
+    /// the same way the offerings cache is hydrated from disk, so this lookup never touches disk.
     func workflowId(forOfferingId offeringId: String) -> String? {
-        let response = self.cachedList.value?.response ?? self.deviceCache.cachedWorkflowsListResponse()
-        return response?.workflows.last { $0.offeringId == offeringId }?.id
+        return self.cachedList.value?.offeringIdToWorkflowId[offeringId]
     }
 
     // MARK: -
@@ -110,6 +112,21 @@ final class WorkflowsCache {
     private func isStale(lastUpdated: Date, isAppBackgrounded: Bool) -> Bool {
         let duration = self.deviceCache.cacheDurationInSeconds(isAppBackgrounded: isAppBackgrounded)
         return self.dateProvider.now().timeIntervalSince(lastUpdated) >= duration
+    }
+
+    /// Builds the `offeringId → workflowId` lookup from the list. Workflows without an `offeringId`
+    /// are skipped, and when more than one workflow maps to the same offering the last one in the
+    /// list wins.
+    private static func offeringIdToWorkflowId(from response: WorkflowsListResponse) -> [String: String] {
+        var map: [String: String] = [:]
+        for workflow in response.workflows {
+            guard let offeringId = workflow.offeringId else { continue }
+            if map[offeringId] != nil {
+                Logger.warn(Strings.backendError.duplicate_offering_id_in_workflows(offeringId: offeringId))
+            }
+            map[offeringId] = workflow.id
+        }
+        return map
     }
 
 }

--- a/Sources/Caching/WorkflowsCache.swift
+++ b/Sources/Caching/WorkflowsCache.swift
@@ -1,0 +1,131 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WorkflowsCache.swift
+//
+//  Created by RevenueCat.
+
+import Foundation
+
+/// In-memory cache for all workflow data: the resolved per-workflow ``WorkflowDataResult``s and the
+/// workflows list (plus its derived offeringId → workflowId map). It is the single owner of this
+/// state so that clearing it on identity transitions wipes everything at once, mirroring how
+/// `DeviceCache` owns the in-memory offerings cache.
+///
+/// Why in-memory, like offerings: this layer sits on top of the durable copy that lives on disk in
+/// `DeviceCache`, for the same reason the offerings cache does, to serve already-fetched and
+/// prefetched data synchronously within a session, so opening a paywall reuses a resolved workflow
+/// instead of paying another backend/CDN round-trip. Time-based staleness
+/// (``isWorkflowsListCacheStale(isAppBackgrounded:)`` / ``isWorkflowCacheStale(workflowId:isAppBackgrounded:)``)
+/// then decides when a refetch is due, using the same 5 min / 25 hr foreground/background TTL as offerings.
+///
+/// It also owns the disk copy of the workflows list: ``cache(workflowsList:offeringIdMap:)`` persists
+/// it, ``cachedWorkflowsListResponseFromDisk()`` restores it on backend failure, and ``clearCache()``
+/// wipes it.
+///
+/// Timestamps are stamped via an injected ``DateProvider`` (rather than reusing `InMemoryCachedObject`,
+/// whose staleness is tied to the real wall clock) so cache-expiry behavior is deterministically
+/// testable, mirroring the Android SDK's `WorkflowsCache`.
+class WorkflowsCache {
+
+    private struct CachedWorkflow {
+        let result: WorkflowDataResult
+        let lastUpdated: Date
+    }
+
+    private struct CachedList {
+        let response: WorkflowsListResponse
+        let offeringIdToWorkflowId: [String: String]
+        let lastUpdated: Date
+    }
+
+    private let deviceCache: DeviceCache
+    private let dateProvider: DateProvider
+
+    private let cachedWorkflows: Atomic<[String: CachedWorkflow]> = .init([:])
+    private let cachedList: Atomic<CachedList?> = .init(nil)
+
+    init(deviceCache: DeviceCache,
+         dateProvider: DateProvider = DateProvider()) {
+        self.deviceCache = deviceCache
+        self.dateProvider = dateProvider
+    }
+
+    // MARK: - Workflow detail cache
+
+    func cachedWorkflow(workflowId: String) -> WorkflowDataResult? {
+        return self.cachedWorkflows.value[workflowId]?.result
+    }
+
+    func isWorkflowCacheStale(workflowId: String, isAppBackgrounded: Bool) -> Bool {
+        guard let cached = self.cachedWorkflows.value[workflowId] else {
+            return true
+        }
+        return self.isStale(lastUpdated: cached.lastUpdated, isAppBackgrounded: isAppBackgrounded)
+    }
+
+    func cache(workflow: WorkflowDataResult, workflowId: String) {
+        self.cachedWorkflows.modify {
+            $0[workflowId] = CachedWorkflow(result: workflow, lastUpdated: self.dateProvider.now())
+        }
+    }
+
+    // MARK: - Workflows list cache
+
+    func isWorkflowsListCacheStale(isAppBackgrounded: Bool) -> Bool {
+        guard let cached = self.cachedList.value else {
+            return true
+        }
+        return self.isStale(lastUpdated: cached.lastUpdated, isAppBackgrounded: isAppBackgrounded)
+    }
+
+    /// Caches the workflows list in memory and persists it to disk, the same way
+    /// `DeviceCache.cache(offerings:...)` caches offerings.
+    ///
+    /// This means workflows share the same accepted appUserID limitation as offerings: a fetch that
+    /// is in flight during an identity transition can complete *after* ``clearCache()`` and repopulate
+    /// the cleared cache with the previous user's list (last-write-wins). It is not guarded here, so
+    /// it self-heals on the next fetch, exactly as the offerings cache does. If we ever decide to
+    /// close that window, it should be done consistently for both caches rather than only here.
+    func cache(workflowsList response: WorkflowsListResponse, offeringIdMap: [String: String]) {
+        self.cachedList.value = CachedList(response: response,
+                                           offeringIdToWorkflowId: offeringIdMap,
+                                           lastUpdated: self.dateProvider.now())
+        self.deviceCache.cache(workflowsListResponse: response)
+    }
+
+    /// Reads the last workflows list persisted by ``cache(workflowsList:offeringIdMap:)``, or `nil`
+    /// when nothing is cached or the payload can't be parsed. Used to recover the list after a
+    /// backend failure, mirroring how the offerings response is restored from disk.
+    func cachedWorkflowsListResponseFromDisk() -> WorkflowsListResponse? {
+        return self.deviceCache.cachedWorkflowsListResponse()
+    }
+
+    func workflowId(forOfferingId offeringId: String) -> String? {
+        return self.cachedList.value?.offeringIdToWorkflowId[offeringId]
+    }
+
+    // MARK: -
+
+    func clearCache() {
+        self.cachedWorkflows.value = [:]
+        self.cachedList.value = nil
+        self.deviceCache.clearWorkflowsListResponseCache()
+    }
+
+    private func isStale(lastUpdated: Date, isAppBackgrounded: Bool) -> Bool {
+        let duration = self.deviceCache.cacheDurationInSeconds(isAppBackgrounded: isAppBackgrounded)
+        return self.dateProvider.now().timeIntervalSince(lastUpdated) >= duration
+    }
+
+}
+
+// @unchecked because:
+// - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.
+extension WorkflowsCache: @unchecked Sendable {}

--- a/Sources/Caching/WorkflowsCache.swift
+++ b/Sources/Caching/WorkflowsCache.swift
@@ -13,25 +13,15 @@
 
 import Foundation
 
-/// In-memory cache for all workflow data: the resolved per-workflow ``WorkflowDataResult``s and the
-/// workflows list (plus its derived offeringId → workflowId map). It is the single owner of this
-/// state so that clearing it on identity transitions wipes everything at once, mirroring how
-/// `DeviceCache` owns the in-memory offerings cache.
+/// In-memory cache for workflow data: the resolved per-workflow ``WorkflowDataResult``s and the
+/// workflows list (plus its `offeringId → workflowId` map). It is the single owner of this state,
+/// so ``clearCache()`` wipes everything at once on identity transitions.
 ///
-/// Why in-memory, like offerings: this layer sits on top of the durable copy that lives on disk in
-/// `DeviceCache`, for the same reason the offerings cache does, to serve already-fetched and
-/// prefetched data synchronously within a session, so opening a paywall reuses a resolved workflow
-/// instead of paying another backend/CDN round-trip. Time-based staleness
-/// (``isWorkflowsListCacheStale(isAppBackgrounded:)`` / ``isWorkflowCacheStale(workflowId:isAppBackgrounded:)``)
-/// then decides when a refetch is due, using the same 5 min / 25 hr foreground/background TTL as offerings.
-///
-/// It also owns the disk copy of the workflows list: ``cache(workflowsList:offeringIdMap:)`` persists
-/// it, ``cachedWorkflowsListResponseFromDisk()`` restores it on backend failure, and ``clearCache()``
-/// wipes it.
-///
-/// Timestamps are stamped via an injected ``DateProvider`` (rather than reusing `InMemoryCachedObject`,
-/// whose staleness is tied to the real wall clock) so cache-expiry behavior is deterministically
-/// testable.
+/// Like the offerings cache, it sits on top of the durable copy in `DeviceCache` and serves
+/// already-fetched data synchronously within a session. Time-based staleness uses the same
+/// foreground/background TTL as offerings, stamped via an injected ``DateProvider`` (rather than
+/// `InMemoryCachedObject`, whose staleness is tied to the real wall clock) so expiry is
+/// deterministically testable.
 final class WorkflowsCache {
 
     private struct CachedWorkflow {
@@ -41,7 +31,7 @@ final class WorkflowsCache {
 
     private struct CachedList {
         let response: WorkflowsListResponse
-        let offeringIdToWorkflowId: [String: String]
+        let workflowIdByOfferingId: [String: String]
         let lastUpdated: Date
     }
 
@@ -85,30 +75,26 @@ final class WorkflowsCache {
         return self.isStale(lastUpdated: cached.lastUpdated, isAppBackgrounded: isAppBackgrounded)
     }
 
-    /// Caches the workflows list in memory and persists it to disk, the same way
-    /// `DeviceCache.cache(offerings:...)` caches offerings.
+    /// Caches the workflows list in memory and persists it to disk.
     ///
-    /// This means workflows share the same accepted appUserID limitation as offerings: a fetch that
-    /// is in flight during an identity transition can complete *after* ``clearCache()`` and repopulate
-    /// the cleared cache with the previous user's list (last-write-wins). It is not guarded here, so
-    /// it self-heals on the next fetch, exactly as the offerings cache does. If we ever decide to
-    /// close that window, it should be done consistently for both caches rather than only here.
-    func cache(workflowsList response: WorkflowsListResponse, offeringIdMap: [String: String]) {
+    /// A fetch in flight during an identity transition can complete *after* ``clearCache()`` and
+    /// repopulate the cache with the previous user's list (last-write-wins). This is not guarded
+    /// here; it self-heals on the next fetch, as the offerings cache does.
+    func cache(workflowsList response: WorkflowsListResponse, workflowIdByOfferingId: [String: String]) {
         self.cachedList.value = CachedList(response: response,
-                                           offeringIdToWorkflowId: offeringIdMap,
+                                           workflowIdByOfferingId: workflowIdByOfferingId,
                                            lastUpdated: self.dateProvider.now())
         self.deviceCache.cache(workflowsListResponse: response)
     }
 
-    /// Reads the last workflows list persisted by ``cache(workflowsList:offeringIdMap:)``, or `nil`
-    /// when nothing is cached or the payload can't be parsed. Used to recover the list after a
-    /// backend failure, mirroring how the offerings response is restored from disk.
+    /// Reads the last persisted workflows list, or `nil` when nothing is cached or the payload
+    /// can't be parsed. Used to recover the list after a backend failure.
     func cachedWorkflowsListResponseFromDisk() -> WorkflowsListResponse? {
         return self.deviceCache.cachedWorkflowsListResponse()
     }
 
     func workflowId(forOfferingId offeringId: String) -> String? {
-        return self.cachedList.value?.offeringIdToWorkflowId[offeringId]
+        return self.cachedList.value?.workflowIdByOfferingId[offeringId]
     }
 
     // MARK: -

--- a/Sources/Caching/WorkflowsCache.swift
+++ b/Sources/Caching/WorkflowsCache.swift
@@ -31,7 +31,7 @@ import Foundation
 ///
 /// Timestamps are stamped via an injected ``DateProvider`` (rather than reusing `InMemoryCachedObject`,
 /// whose staleness is tied to the real wall clock) so cache-expiry behavior is deterministically
-/// testable, mirroring the Android SDK's `WorkflowsCache`.
+/// testable.
 final class WorkflowsCache {
 
     private struct CachedWorkflow {
@@ -126,6 +126,5 @@ final class WorkflowsCache {
 
 }
 
-// @unchecked because:
-// - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.
+// @unchecked because its mutable state is held in thread-safe `Atomic` containers.
 extension WorkflowsCache: @unchecked Sendable {}

--- a/Sources/Logging/Strings/BackendErrorStrings.swift
+++ b/Sources/Logging/Strings/BackendErrorStrings.swift
@@ -30,6 +30,7 @@ enum BackendErrorStrings {
     case unexpected_reward_verification_reward_value
     case unknown_workflow_trigger_type(type: String)
     case unknown_workflow_trigger_action_type(type: String)
+    case duplicate_offering_id_in_workflows(offeringId: String)
 
 }
 
@@ -59,6 +60,8 @@ extension BackendErrorStrings: LogMessage {
             return "Received unknown workflow trigger type: \(type)"
         case let .unknown_workflow_trigger_action_type(type):
             return "Received unknown workflow trigger action type: \(type)"
+        case let .duplicate_offering_id_in_workflows(offeringId):
+            return "Duplicate offeringId in workflows response: \(offeringId)"
         }
     }
 

--- a/Tests/UnitTests/Caching/DeviceCacheTests.swift
+++ b/Tests/UnitTests/Caching/DeviceCacheTests.swift
@@ -497,6 +497,50 @@ class DeviceCacheTests: TestCase {
         expect(self.mockFileCache.saveDataInvocations.count) == 1
     }
 
+    // MARK: - Workflows list response
+
+    func testWorkflowsListResponseIsProperlyCachedToDisk() {
+        self.mockFileCache.stubSaveData(with: .success(.init(data: .init(), url: .mockFileLocation)))
+
+        expect(self.mockFileCache.saveDataInvocations.count) == 0
+
+        self.deviceCache.cache(workflowsListResponse: .init(workflows: [
+            .init(id: "wf_1", displayName: "Flow", offeringId: "default", prefetch: true)
+        ]))
+
+        expect(self.mockFileCache.saveDataInvocations.count) == 1
+    }
+
+    func testCachedWorkflowsListResponseRoundTripsThroughDisk() throws {
+        let response = WorkflowsListResponse(workflows: [
+            .init(id: "wf_1", displayName: "Flow A", offeringId: "default", prefetch: true),
+            .init(id: "wf_2", displayName: "Flow B", offeringId: nil, prefetch: false)
+        ])
+
+        self.mockFileCache.stubSaveData(with: .success(.init(data: .init(), url: .mockFileLocation)))
+        self.mockFileCache.stubCachedContentExists(with: true)
+        self.mockFileCache.stubLoadFile(with: .success(try response.jsonEncodedData))
+
+        self.deviceCache.cache(workflowsListResponse: response)
+
+        let cached = self.deviceCache.cachedWorkflowsListResponse()
+        expect(cached) == response
+    }
+
+    func testCachedWorkflowsListResponseReturnsNilWhenNothingCached() {
+        expect(self.deviceCache.cachedWorkflowsListResponse()).to(beNil())
+    }
+
+    func testWorkflowsListResponseIsNeverSavedToUserDefaults() {
+        let workflowsKey = "com.revenuecat.userdefaults.workflowsListResponse"
+        self.mockFileCache.stubSaveData(with: .success(.init(data: .init(), url: .mockFileLocation)))
+
+        self.deviceCache.cache(workflowsListResponse: .init(workflows: []))
+
+        expect(self.mockUserDefaults.mockValues[workflowsKey]).to(beNil())
+        expect(self.mockFileCache.saveDataInvocations.count) == 1
+    }
+
     func testSetLatestAdvertisingIdsByNetworkSentMapsAttributionNetworksToStringKeys() {
         let userId = "asdf"
         let token = "token"

--- a/Tests/UnitTests/Caching/WorkflowsCacheTests.swift
+++ b/Tests/UnitTests/Caching/WorkflowsCacheTests.swift
@@ -118,6 +118,18 @@ class WorkflowsCacheTests: TestCase {
         expect(self.cache.isWorkflowsListCacheStale(isAppBackgrounded: false)) == true
     }
 
+    func testIsWorkflowsListCacheStaleIsFalseAfterForegroundTTLWhenBackgrounded() {
+        self.cache.cache(workflowsList: .init(workflows: []))
+        self.dateProvider.advance(by: 6 * 60)
+        expect(self.cache.isWorkflowsListCacheStale(isAppBackgrounded: true)) == false
+    }
+
+    func testIsWorkflowsListCacheStaleIsTrueAfterBackgroundTTLExpires() {
+        self.cache.cache(workflowsList: .init(workflows: []))
+        self.dateProvider.advance(by: 26 * 60 * 60)
+        expect(self.cache.isWorkflowsListCacheStale(isAppBackgrounded: true)) == true
+    }
+
     func testWorkflowIdForOfferingIdIsDerivedFromTheCachedList() {
         self.cache.cache(workflowsList: .init(workflows: [
             .init(id: "wf_1", displayName: "Flow", offeringId: "default", prefetch: false)
@@ -157,7 +169,7 @@ class WorkflowsCacheTests: TestCase {
 
     // MARK: - Disk persistence
 
-    func testCacheWorkflowsListPersistsResponseToDisk() {
+    func testCacheWorkflowsListForwardsResponseToDeviceCache() {
         self.cache.cache(workflowsList: .init(workflows: [
             .init(id: "wf_1", displayName: "Flow", offeringId: "default", prefetch: false)
         ]))

--- a/Tests/UnitTests/Caching/WorkflowsCacheTests.swift
+++ b/Tests/UnitTests/Caching/WorkflowsCacheTests.swift
@@ -1,0 +1,214 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WorkflowsCacheTests.swift
+//
+//  Created by RevenueCat.
+
+import Foundation
+import Nimble
+import XCTest
+
+@_spi(Internal) @testable import RevenueCat
+
+class WorkflowsCacheTests: TestCase {
+
+    private var dateProvider: MockCurrentDateProvider!
+    private var deviceCache: MockDeviceCache!
+    private var systemInfo: MockSystemInfo!
+    private var cache: WorkflowsCache!
+
+    override func setUp() {
+        super.setUp()
+
+        self.dateProvider = MockCurrentDateProvider()
+        self.systemInfo = MockSystemInfo(finishTransactions: false)
+        // Production environment so foreground (5 min) and background (25 hr) TTLs differ.
+        self.systemInfo.stubbedIsSandbox = false
+        self.deviceCache = MockDeviceCache(systemInfo: self.systemInfo)
+        self.cache = WorkflowsCache(deviceCache: self.deviceCache,
+                                    dateProvider: self.dateProvider)
+    }
+
+    // MARK: - Workflow detail cache
+
+    func testCachedWorkflowReturnsNilWhenNothingCached() {
+        expect(self.cache.cachedWorkflow(workflowId: "wf_1")).to(beNil())
+    }
+
+    func testCachedWorkflowReturnsCachedValueAfterCaching() throws {
+        let result = try Self.workflowDataResult(id: "wf_1")
+        self.cache.cache(workflow: result, workflowId: "wf_1")
+        expect(self.cache.cachedWorkflow(workflowId: "wf_1")) == result
+    }
+
+    func testIsWorkflowCacheStaleIsTrueWhenNothingCached() {
+        expect(self.cache.isWorkflowCacheStale(workflowId: "wf_1", isAppBackgrounded: false)) == true
+        expect(self.cache.isWorkflowCacheStale(workflowId: "wf_1", isAppBackgrounded: true)) == true
+    }
+
+    func testIsWorkflowCacheStaleIsFalseRightAfterCachingInForeground() throws {
+        self.cache.cache(workflow: try Self.workflowDataResult(id: "wf_1"), workflowId: "wf_1")
+        expect(self.cache.isWorkflowCacheStale(workflowId: "wf_1", isAppBackgrounded: false)) == false
+    }
+
+    func testIsWorkflowCacheStaleIsTrueAfterForegroundTTLExpires() throws {
+        self.cache.cache(workflow: try Self.workflowDataResult(id: "wf_1"), workflowId: "wf_1")
+        self.dateProvider.advance(by: 6 * 60)
+        expect(self.cache.isWorkflowCacheStale(workflowId: "wf_1", isAppBackgrounded: false)) == true
+    }
+
+    func testIsWorkflowCacheStaleIsFalseAfterForegroundTTLWhenBackgrounded() throws {
+        self.cache.cache(workflow: try Self.workflowDataResult(id: "wf_1"), workflowId: "wf_1")
+        self.dateProvider.advance(by: 6 * 60)
+        expect(self.cache.isWorkflowCacheStale(workflowId: "wf_1", isAppBackgrounded: true)) == false
+    }
+
+    func testIsWorkflowCacheStaleIsTrueAfterBackgroundTTLExpires() throws {
+        self.cache.cache(workflow: try Self.workflowDataResult(id: "wf_1"), workflowId: "wf_1")
+        self.dateProvider.advance(by: 26 * 60 * 60)
+        expect(self.cache.isWorkflowCacheStale(workflowId: "wf_1", isAppBackgrounded: true)) == true
+    }
+
+    func testClearCacheRemovesAllCachedWorkflows() throws {
+        self.cache.cache(workflow: try Self.workflowDataResult(id: "wf_1"), workflowId: "wf_1")
+        self.cache.cache(workflow: try Self.workflowDataResult(id: "wf_2"), workflowId: "wf_2")
+
+        self.cache.clearCache()
+
+        expect(self.cache.cachedWorkflow(workflowId: "wf_1")).to(beNil())
+        expect(self.cache.cachedWorkflow(workflowId: "wf_2")).to(beNil())
+        expect(self.cache.isWorkflowCacheStale(workflowId: "wf_1", isAppBackgrounded: false)) == true
+        expect(self.cache.isWorkflowCacheStale(workflowId: "wf_2", isAppBackgrounded: false)) == true
+    }
+
+    func testDifferentWorkflowIdsAreCachedIndependently() throws {
+        let first = try Self.workflowDataResult(id: "wf_1")
+        self.cache.cache(workflow: first, workflowId: "wf_1")
+        self.dateProvider.advance(by: 6 * 60)
+        let second = try Self.workflowDataResult(id: "wf_2")
+        self.cache.cache(workflow: second, workflowId: "wf_2")
+
+        // Both values remain retrievable.
+        expect(self.cache.cachedWorkflow(workflowId: "wf_1")) == first
+        expect(self.cache.cachedWorkflow(workflowId: "wf_2")) == second
+
+        // wf_1 was cached 6 minutes ago so it is stale in foreground; wf_2 is fresh.
+        expect(self.cache.isWorkflowCacheStale(workflowId: "wf_1", isAppBackgrounded: false)) == true
+        expect(self.cache.isWorkflowCacheStale(workflowId: "wf_2", isAppBackgrounded: false)) == false
+    }
+
+    // MARK: - Workflows list cache
+
+    func testIsWorkflowsListCacheStaleIsTrueInitiallyAndFalseAfterCaching() {
+        expect(self.cache.isWorkflowsListCacheStale(isAppBackgrounded: false)) == true
+        self.cache.cache(workflowsList: .init(workflows: []), offeringIdMap: [:])
+        expect(self.cache.isWorkflowsListCacheStale(isAppBackgrounded: false)) == false
+    }
+
+    func testIsWorkflowsListCacheStaleIsTrueAfterForegroundTTLExpires() {
+        self.cache.cache(workflowsList: .init(workflows: []), offeringIdMap: [:])
+        self.dateProvider.advance(by: 6 * 60)
+        expect(self.cache.isWorkflowsListCacheStale(isAppBackgrounded: false)) == true
+    }
+
+    func testWorkflowIdForOfferingIdReturnsMappedIdOrNil() {
+        self.cache.cache(workflowsList: .init(workflows: []), offeringIdMap: ["default": "wf_1"])
+        expect(self.cache.workflowId(forOfferingId: "default")) == "wf_1"
+        expect(self.cache.workflowId(forOfferingId: "premium")).to(beNil())
+    }
+
+    func testClearCacheResetsWorkflowsListStalenessAndOfferingIdMap() {
+        self.cache.cache(workflowsList: .init(workflows: []), offeringIdMap: ["default": "wf_1"])
+        self.cache.clearCache()
+        expect(self.cache.isWorkflowsListCacheStale(isAppBackgrounded: false)) == true
+        expect(self.cache.workflowId(forOfferingId: "default")).to(beNil())
+    }
+
+    // MARK: - Disk persistence
+
+    func testCacheWorkflowsListPersistsResponseToDisk() {
+        self.cache.cache(
+            workflowsList: .init(workflows: [
+                .init(id: "wf_1", displayName: "Flow", offeringId: "default", prefetch: false)
+            ]),
+            offeringIdMap: ["default": "wf_1"]
+        )
+        expect(self.deviceCache.cacheWorkflowsListResponseCount) == 1
+    }
+
+    func testClearCacheClearsDiskCache() {
+        self.cache.clearCache()
+        expect(self.deviceCache.clearWorkflowsListResponseCacheCount) == 1
+    }
+
+    func testCachedWorkflowsListResponseFromDiskReturnsPersistedResponse() {
+        self.deviceCache.stubbedCachedWorkflowsListResponse = .init(workflows: [
+            .init(id: "wf_1", displayName: "Flow", offeringId: "default", prefetch: false)
+        ])
+        let response = self.cache.cachedWorkflowsListResponseFromDisk()
+        expect(response?.workflows.first?.id) == "wf_1"
+    }
+
+    func testCachedWorkflowsListResponseFromDiskReturnsNilWhenNothingCached() {
+        self.deviceCache.stubbedCachedWorkflowsListResponse = nil
+        expect(self.cache.cachedWorkflowsListResponseFromDisk()).to(beNil())
+    }
+
+    // MARK: - Helpers
+
+    private static func workflowDataResult(id: String) throws -> WorkflowDataResult {
+        return .init(workflow: try self.publishedWorkflow(id: id), enrolledVariants: nil)
+    }
+
+    private static func publishedWorkflow(id: String) throws -> PublishedWorkflow {
+        let json = """
+        {
+          "id": "\(id)",
+          "display_name": "Test",
+          "initial_step_id": "step_1",
+          "steps": {
+            "step_1": { "id": "step_1", "type": "screen", "screen_id": "screen_1" }
+          },
+          "screens": {
+            "screen_1": {
+              "template_name": "tmpl",
+              "asset_base_url": "https://assets.revenuecat.com",
+              "default_locale": "en_US",
+              "components_localizations": {},
+              "components_config": {
+                "base": {
+                  "stack": {
+                    "type": "stack",
+                    "components": [],
+                    "dimension": { "type": "vertical", "alignment": "center", "distribution": "center" },
+                    "size": { "width": { "type": "fill" }, "height": { "type": "fill" } },
+                    "padding": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 },
+                    "margin": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 }
+                  },
+                  "background": {
+                    "type": "color",
+                    "value": { "light": { "type": "hex", "value": "#FFFFFF" } }
+                  }
+                }
+              },
+              "offering_identifier": "default"
+            }
+          },
+          "ui_config": {
+            "app": { "colors": {}, "fonts": {} },
+            "localizations": {}
+          }
+        }
+        """
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        return try JSONDecoder.default.decode(PublishedWorkflow.self, from: data)
+    }
+
+}

--- a/Tests/UnitTests/Caching/WorkflowsCacheTests.swift
+++ b/Tests/UnitTests/Caching/WorkflowsCacheTests.swift
@@ -108,24 +108,24 @@ class WorkflowsCacheTests: TestCase {
 
     func testIsWorkflowsListCacheStaleIsTrueInitiallyAndFalseAfterCaching() {
         expect(self.cache.isWorkflowsListCacheStale(isAppBackgrounded: false)) == true
-        self.cache.cache(workflowsList: .init(workflows: []), offeringIdMap: [:])
+        self.cache.cache(workflowsList: .init(workflows: []), workflowIdByOfferingId: [:])
         expect(self.cache.isWorkflowsListCacheStale(isAppBackgrounded: false)) == false
     }
 
     func testIsWorkflowsListCacheStaleIsTrueAfterForegroundTTLExpires() {
-        self.cache.cache(workflowsList: .init(workflows: []), offeringIdMap: [:])
+        self.cache.cache(workflowsList: .init(workflows: []), workflowIdByOfferingId: [:])
         self.dateProvider.advance(by: 6 * 60)
         expect(self.cache.isWorkflowsListCacheStale(isAppBackgrounded: false)) == true
     }
 
     func testWorkflowIdForOfferingIdReturnsMappedIdOrNil() {
-        self.cache.cache(workflowsList: .init(workflows: []), offeringIdMap: ["default": "wf_1"])
+        self.cache.cache(workflowsList: .init(workflows: []), workflowIdByOfferingId: ["default": "wf_1"])
         expect(self.cache.workflowId(forOfferingId: "default")) == "wf_1"
         expect(self.cache.workflowId(forOfferingId: "premium")).to(beNil())
     }
 
     func testClearCacheResetsWorkflowsListStalenessAndOfferingIdMap() {
-        self.cache.cache(workflowsList: .init(workflows: []), offeringIdMap: ["default": "wf_1"])
+        self.cache.cache(workflowsList: .init(workflows: []), workflowIdByOfferingId: ["default": "wf_1"])
         self.cache.clearCache()
         expect(self.cache.isWorkflowsListCacheStale(isAppBackgrounded: false)) == true
         expect(self.cache.workflowId(forOfferingId: "default")).to(beNil())
@@ -138,7 +138,7 @@ class WorkflowsCacheTests: TestCase {
             workflowsList: .init(workflows: [
                 .init(id: "wf_1", displayName: "Flow", offeringId: "default", prefetch: false)
             ]),
-            offeringIdMap: ["default": "wf_1"]
+            workflowIdByOfferingId: ["default": "wf_1"]
         )
         expect(self.deviceCache.cacheWorkflowsListResponseCount) == 1
     }

--- a/Tests/UnitTests/Caching/WorkflowsCacheTests.swift
+++ b/Tests/UnitTests/Caching/WorkflowsCacheTests.swift
@@ -134,11 +134,16 @@ class WorkflowsCacheTests: TestCase {
         expect(self.cache.workflowId(forOfferingId: "default")) == "wf_2"
     }
 
-    func testWorkflowIdForOfferingIdFallsBackToDiskWhenNotInMemory() {
+    func testWorkflowIdForOfferingIdDoesNotFallBackToDiskWhenNotInMemory() {
+        // The lookup is in-memory only. Restoring the disk copy is the caller's job (via
+        // `cachedWorkflowsListResponseFromDisk()` + `cache(workflowsList:)`), so an uncached list
+        // resolves to nil without touching disk.
         self.deviceCache.stubbedCachedWorkflowsListResponse = .init(workflows: [
             .init(id: "wf_1", displayName: "Flow", offeringId: "default", prefetch: false)
         ])
-        expect(self.cache.workflowId(forOfferingId: "default")) == "wf_1"
+
+        expect(self.cache.workflowId(forOfferingId: "default")).to(beNil())
+        expect(self.deviceCache.invokedCachedWorkflowsListResponse) == false
     }
 
     func testClearCacheResetsWorkflowsListStalenessAndWorkflowIdLookup() {

--- a/Tests/UnitTests/Caching/WorkflowsCacheTests.swift
+++ b/Tests/UnitTests/Caching/WorkflowsCacheTests.swift
@@ -108,24 +108,43 @@ class WorkflowsCacheTests: TestCase {
 
     func testIsWorkflowsListCacheStaleIsTrueInitiallyAndFalseAfterCaching() {
         expect(self.cache.isWorkflowsListCacheStale(isAppBackgrounded: false)) == true
-        self.cache.cache(workflowsList: .init(workflows: []), workflowIdByOfferingId: [:])
+        self.cache.cache(workflowsList: .init(workflows: []))
         expect(self.cache.isWorkflowsListCacheStale(isAppBackgrounded: false)) == false
     }
 
     func testIsWorkflowsListCacheStaleIsTrueAfterForegroundTTLExpires() {
-        self.cache.cache(workflowsList: .init(workflows: []), workflowIdByOfferingId: [:])
+        self.cache.cache(workflowsList: .init(workflows: []))
         self.dateProvider.advance(by: 6 * 60)
         expect(self.cache.isWorkflowsListCacheStale(isAppBackgrounded: false)) == true
     }
 
-    func testWorkflowIdForOfferingIdReturnsMappedIdOrNil() {
-        self.cache.cache(workflowsList: .init(workflows: []), workflowIdByOfferingId: ["default": "wf_1"])
+    func testWorkflowIdForOfferingIdIsDerivedFromTheCachedList() {
+        self.cache.cache(workflowsList: .init(workflows: [
+            .init(id: "wf_1", displayName: "Flow", offeringId: "default", prefetch: false)
+        ]))
         expect(self.cache.workflowId(forOfferingId: "default")) == "wf_1"
         expect(self.cache.workflowId(forOfferingId: "premium")).to(beNil())
     }
 
-    func testClearCacheResetsWorkflowsListStalenessAndOfferingIdMap() {
-        self.cache.cache(workflowsList: .init(workflows: []), workflowIdByOfferingId: ["default": "wf_1"])
+    func testWorkflowIdForOfferingIdReturnsLastMatchWhenOfferingIsDuplicated() {
+        self.cache.cache(workflowsList: .init(workflows: [
+            .init(id: "wf_1", displayName: "Flow", offeringId: "default", prefetch: false),
+            .init(id: "wf_2", displayName: "Flow", offeringId: "default", prefetch: false)
+        ]))
+        expect(self.cache.workflowId(forOfferingId: "default")) == "wf_2"
+    }
+
+    func testWorkflowIdForOfferingIdFallsBackToDiskWhenNotInMemory() {
+        self.deviceCache.stubbedCachedWorkflowsListResponse = .init(workflows: [
+            .init(id: "wf_1", displayName: "Flow", offeringId: "default", prefetch: false)
+        ])
+        expect(self.cache.workflowId(forOfferingId: "default")) == "wf_1"
+    }
+
+    func testClearCacheResetsWorkflowsListStalenessAndWorkflowIdLookup() {
+        self.cache.cache(workflowsList: .init(workflows: [
+            .init(id: "wf_1", displayName: "Flow", offeringId: "default", prefetch: false)
+        ]))
         self.cache.clearCache()
         expect(self.cache.isWorkflowsListCacheStale(isAppBackgrounded: false)) == true
         expect(self.cache.workflowId(forOfferingId: "default")).to(beNil())
@@ -134,12 +153,9 @@ class WorkflowsCacheTests: TestCase {
     // MARK: - Disk persistence
 
     func testCacheWorkflowsListPersistsResponseToDisk() {
-        self.cache.cache(
-            workflowsList: .init(workflows: [
-                .init(id: "wf_1", displayName: "Flow", offeringId: "default", prefetch: false)
-            ]),
-            workflowIdByOfferingId: ["default": "wf_1"]
-        )
+        self.cache.cache(workflowsList: .init(workflows: [
+            .init(id: "wf_1", displayName: "Flow", offeringId: "default", prefetch: false)
+        ]))
         expect(self.deviceCache.cacheWorkflowsListResponseCount) == 1
     }
 

--- a/Tests/UnitTests/Mocks/MockDeviceCache.swift
+++ b/Tests/UnitTests/Mocks/MockDeviceCache.swift
@@ -4,7 +4,7 @@
 //
 
 import Foundation
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 
 class MockDeviceCache: DeviceCache {
 
@@ -124,6 +124,26 @@ class MockDeviceCache: DeviceCache {
 
     override func offeringsCacheStatus(isAppBackgrounded: Bool) -> CacheStatus {
         return self.stubbedOfferingCacheStatus ?? super.offeringsCacheStatus(isAppBackgrounded: isAppBackgrounded)
+    }
+
+    // MARK: Workflows list response
+
+    var cacheWorkflowsListResponseCount = 0
+    var clearWorkflowsListResponseCacheCount = 0
+    var stubbedCachedWorkflowsListResponse: WorkflowsListResponse?
+    var invokedCachedWorkflowsListResponse = false
+
+    override func cache(workflowsListResponse: WorkflowsListResponse) {
+        self.cacheWorkflowsListResponseCount += 1
+    }
+
+    override func cachedWorkflowsListResponse() -> WorkflowsListResponse? {
+        self.invokedCachedWorkflowsListResponse = true
+        return self.stubbedCachedWorkflowsListResponse
+    }
+
+    override func clearWorkflowsListResponseCache() {
+        self.clearWorkflowsListResponseCacheCount += 1
     }
 
     // MARK: SubscriberAttributes


### PR DESCRIPTION
Port of https://github.com/RevenueCat/purchases-android/pull/3508 (1 of 3 stacked PRs).

Android #3508 wires up workflows fetching end-to-end and adds in-memory + disk caching. We already have the workflow networking layer on iOS (`WorkflowsAPI`, the `getWorkflow`/`getWorkflows` endpoints, response models), so this port is really about the orchestration + caching + lifecycle we're missing. Splitting it into three stacked PRs:

1. **This one — caching foundation**
2. `WorkflowManager` + list fetch + offeringId→workflowId resolution
3. Lifecycle wiring (OfferingsManager timing, IdentityManager cache clearing) + gating

## What Changed

- New **`WorkflowsCache`**, owner of in-memory workflow state: resolved per-workflow `WorkflowDataResult`s plus the workflows list and its `offeringId → workflowId` map. Same 5 min / 25 hr foreground/background TTL as offerings. It also owns the disk copy of the list (persist on cache, restore on backend failure, wipe on clear), same as `DeviceCache` does for offerings.
- `DeviceCache` gets disk persistence for the workflows-list response (`cachedWorkflowsListResponse` / `cache(workflowsListResponse:)` / `clearWorkflowsListResponseCache`)

Nothing calls this yet, it's just the foundation the next two PRs build on.

## Notes

- `WorkflowsCache` keeps its own timestamps via an injected `DateProvider` instead of reusing `InMemoryCachedObject` (whose staleness is tied to the real wall clock) so the TTL is actually testable. Same as Android.
- Didn't port Android's network-level request dedup (`pendingCompletionCallbacks`/`FetchDecision`), our `CallbackCache` already dedups in-flight requests. PR 2 only needs the higher-level "fire once the list + prefetches are done" piece.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained caching with broad unit tests and no production wiring yet; the non-user-scoped workflows list key relies on future identity-transition clearing.
> 
> **Overview**
> Adds a **workflows caching foundation** that is not wired into fetch/orchestration yet.
> 
> **`WorkflowsCache`** holds in-memory per-workflow `WorkflowDataResult` entries and the workflows list, including an `offeringId → workflowId` map built when the list is cached. Staleness uses the same foreground/background TTL as offerings, driven by an injectable `DateProvider` (not `InMemoryCachedObject`) so TTL behavior is testable. `clearCache()` clears memory and the on-disk list.
> 
> **`DeviceCache`** gains disk persistence for `WorkflowsListResponse` under a single non-user-scoped key (`workflowsListResponse`), stored via large-item/file cache (not UserDefaults). `cacheDurationInSeconds` no longer takes `isSandbox`; callers pass only background state and sandbox is read from `systemInfo`.
> 
> Duplicate `offeringId` entries in a workflows list log a backend warning; the **last** workflow wins for lookup.
> 
> Unit tests cover `WorkflowsCache` TTL/staleness, list↔offering mapping, disk round-trip, and `DeviceCache` workflows-list caching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b528ba6e207a1e02c0785692a80288acd49c1776. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->