### PR TITLE
feat(workflows): add WorkflowManager with list fetch, prefetch and offeringId resolution

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -354,6 +354,7 @@
 		351B51BE26D450E800BD2BD7 /* CustomerInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E359D8F304C83184560135 /* CustomerInfoTests.swift */; };
 		351B51BF26D450E800BD2BD7 /* StoreKitRequestFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BE4244269676E200254A30 /* StoreKitRequestFetcherTests.swift */; };
 		351B51C126D450E800BD2BD7 /* OfferingsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F575859126C08E3F00C12B97 /* OfferingsManagerTests.swift */; };
+		0882A0238A0B15DCAA63DCA5 /* WorkflowManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA47C656406D58B636FD82D /* WorkflowManagerTests.swift */; };
 		351B51C226D450E800BD2BD7 /* ProductRequestDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E350E57B0A393455A72B40 /* ProductRequestDataTests.swift */; };
 		351B51C326D450F200BD2BD7 /* InMemoryCachedObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35E3250FBBB03D92E06EC /* InMemoryCachedObjectTests.swift */; };
 		352137322CDBA2AA00FE961B /* FeatureEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 352137312CDBA2A700FE961B /* FeatureEvent.swift */; };
@@ -908,6 +909,7 @@
 		57E415EF284697A300EA5460 /* PurchasesDeferredPurchasesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E415EE284697A300EA5460 /* PurchasesDeferredPurchasesTests.swift */; };
 		57E415F12846997B00EA5460 /* PurchasesAttributionDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E415F02846997B00EA5460 /* PurchasesAttributionDataTests.swift */; };
 		57E415FF28469EAB00EA5460 /* PurchasesGetProductsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E415FE28469EAB00EA5460 /* PurchasesGetProductsTests.swift */; };
+		94BA76C3AAF699D59AA685FC /* PurchasesWorkflowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78B1498BA2288B4643B248A5 /* PurchasesWorkflowTests.swift */; };
 		57E6195028D291DC0093170C /* StoreKit2CachingProductsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E6194F28D291DC0093170C /* StoreKit2CachingProductsManagerTests.swift */; };
 		57E6C27C29723A94001AFE98 /* Signing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E6C27B29723A94001AFE98 /* Signing.swift */; };
 		57E6C27E29723F9E001AFE98 /* SigningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E6C27D29723F9E001AFE98 /* SigningTests.swift */; };
@@ -1348,6 +1350,7 @@
 		F5714EAC26D7A87B00635477 /* PurchaseOwnershipType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5714EAB26D7A87B00635477 /* PurchaseOwnershipType+Extensions.swift */; };
 		F5714EE526DC2F1D00635477 /* CodableStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5714EE426DC2F1D00635477 /* CodableStrings.swift */; };
 		F575858D26C088FE00C12B97 /* OfferingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F575858C26C088FE00C12B97 /* OfferingsManager.swift */; };
+		678DA8034D806EABC46A0960 /* WorkflowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E52F908EB90930822406495 /* WorkflowManager.swift */; };
 		F575858F26C0893600C12B97 /* MockOfferingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F575858E26C0893600C12B97 /* MockOfferingsManager.swift */; };
 		F5847430278D00C0001B1CE6 /* MockDNSChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F584742F278D00C0001B1CE6 /* MockDNSChecker.swift */; };
 		F5847431278D00C1001B1CE6 /* MockDNSChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F584742F278D00C0001B1CE6 /* MockDNSChecker.swift */; };
@@ -2473,6 +2476,7 @@
 		57E415EE284697A300EA5460 /* PurchasesDeferredPurchasesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesDeferredPurchasesTests.swift; sourceTree = "<group>"; };
 		57E415F02846997B00EA5460 /* PurchasesAttributionDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesAttributionDataTests.swift; sourceTree = "<group>"; };
 		57E415FE28469EAB00EA5460 /* PurchasesGetProductsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesGetProductsTests.swift; sourceTree = "<group>"; };
+		78B1498BA2288B4643B248A5 /* PurchasesWorkflowTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PurchasesWorkflowTests.swift; sourceTree = "<group>"; };
 		57E6194F28D291DC0093170C /* StoreKit2CachingProductsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2CachingProductsManagerTests.swift; sourceTree = "<group>"; };
 		57E6C27B29723A94001AFE98 /* Signing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Signing.swift; sourceTree = "<group>"; };
 		57E6C27D29723F9E001AFE98 /* SigningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SigningTests.swift; sourceTree = "<group>"; };
@@ -2952,8 +2956,10 @@
 		F5714EAB26D7A87B00635477 /* PurchaseOwnershipType+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PurchaseOwnershipType+Extensions.swift"; sourceTree = "<group>"; };
 		F5714EE426DC2F1D00635477 /* CodableStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableStrings.swift; sourceTree = "<group>"; };
 		F575858C26C088FE00C12B97 /* OfferingsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfferingsManager.swift; sourceTree = "<group>"; };
+		6E52F908EB90930822406495 /* WorkflowManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowManager.swift; sourceTree = "<group>"; };
 		F575858E26C0893600C12B97 /* MockOfferingsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOfferingsManager.swift; sourceTree = "<group>"; };
 		F575859126C08E3F00C12B97 /* OfferingsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfferingsManagerTests.swift; sourceTree = "<group>"; };
+		1DA47C656406D58B636FD82D /* WorkflowManagerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowManagerTests.swift; sourceTree = "<group>"; };
 		F584742F278D00C0001B1CE6 /* MockDNSChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDNSChecker.swift; sourceTree = "<group>"; };
 		F591492526B994B400D32E58 /* SKPaymentTransactionExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKPaymentTransactionExtensionsTests.swift; sourceTree = "<group>"; };
 		F591492726B9956C00D32E58 /* MockTransaction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockTransaction.swift; sourceTree = "<group>"; };
@@ -4449,6 +4455,7 @@
 				B3B5FBBB269D121B00104A0C /* Offerings.swift */,
 				35549322269E298B005F9AE9 /* OfferingsFactory.swift */,
 				F575858C26C088FE00C12B97 /* OfferingsManager.swift */,
+				6E52F908EB90930822406495 /* WorkflowManager.swift */,
 				B3D3C4712685784800CB3C21 /* Package.swift */,
 				5766AB4628401B8400FA6091 /* PackageType.swift */,
 				B372EC55268FEF020099171E /* ProductRequestData.swift */,
@@ -4483,6 +4490,7 @@
 				5752E8472892DC500069281E /* ErrorUtilsTests.swift */,
 				37E354B18710B488B8B0D443 /* IntroEligibilityCalculatorTests.swift */,
 				F575859126C08E3F00C12B97 /* OfferingsManagerTests.swift */,
+				1DA47C656406D58B636FD82D /* WorkflowManagerTests.swift */,
 				37E357C2D977BBB081216B5F /* OfferingsTests.swift */,
 				5793396F28E77A5100C1232C /* PaymentQueueWrapperTests.swift */,
 				37E3583675928C01D92E3166 /* ProductRequestDataExtensions.swift */,
@@ -5060,6 +5068,7 @@
 				57E415EE284697A300EA5460 /* PurchasesDeferredPurchasesTests.swift */,
 				57E415F02846997B00EA5460 /* PurchasesAttributionDataTests.swift */,
 				57E415FE28469EAB00EA5460 /* PurchasesGetProductsTests.swift */,
+				78B1498BA2288B4643B248A5 /* PurchasesWorkflowTests.swift */,
 				57FDAA952846BDE2009A48F1 /* PurchasesTransactionHandlingTests.swift */,
 				57FDAA992846C2BD009A48F1 /* PurchasesDelegateTests.swift */,
 				57DBFA5C28AADA43002D18CA /* PurchasesLogInTests.swift */,
@@ -7491,6 +7500,7 @@
 				2DDF41BC24F6F392005BC22D /* ArraySlice_UInt8+Extensions.swift in Sources */,
 				574A2F4B282D7AEA00150D40 /* PostOfferResponse.swift in Sources */,
 				F575858D26C088FE00C12B97 /* OfferingsManager.swift in Sources */,
+				678DA8034D806EABC46A0960 /* WorkflowManager.swift in Sources */,
 				B34605CB279A6E380031CA74 /* PostReceiptDataOperation.swift in Sources */,
 				4FFCED882AA941D200118EF4 /* FeatureEventsRequest.swift in Sources */,
 				DB001004AAAA0001AAAA0001 /* FeatureEventsRequest+WorkflowEvent.swift in Sources */,
@@ -7707,6 +7717,7 @@
 				F2138021CD5445218F7CE984 /* DangerousSettingsTests.swift in Sources */,
 				16E4A3C89791426AAD027A49 /* PlatformInfoTests.swift in Sources */,
 				57E415FF28469EAB00EA5460 /* PurchasesGetProductsTests.swift in Sources */,
+				94BA76C3AAF699D59AA685FC /* PurchasesWorkflowTests.swift in Sources */,
 				900D270E2F96A00000D32EDF /* PurchasesRewardVerificationTests.swift in Sources */,
 				57045B3829C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift in Sources */,
 				351B514726D44A0D00BD2BD7 /* MockSystemInfo.swift in Sources */,
@@ -7880,6 +7891,7 @@
 				351B516126D44BEB00BD2BD7 /* IdentityManagerTests.swift in Sources */,
 				579D2E3A28F0BF5A0094B36F /* BackendInternalTests.swift in Sources */,
 				351B51C126D450E800BD2BD7 /* OfferingsManagerTests.swift in Sources */,
+				0882A0238A0B15DCAA63DCA5 /* WorkflowManagerTests.swift in Sources */,
 				5796A39927D6C1E000653165 /* BackendPostSubscriberAttributesTests.swift in Sources */,
 				35D8330A262FBA9A00E60AC5 /* MockUserDefaults.swift in Sources */,
 				E1C0A004BEEF0001CCDD0001 /* HeaderComponentTests.swift in Sources */,

--- a/Sources/Caching/WorkflowsCache.swift
+++ b/Sources/Caching/WorkflowsCache.swift
@@ -84,9 +84,21 @@ final class WorkflowsCache {
     }
 
     /// Reads the last persisted workflows list, or `nil` when nothing is cached or the payload
-    /// can't be parsed. Used to recover the list after a backend failure.
+    /// can't be parsed.
     func cachedWorkflowsListResponseFromDisk() -> WorkflowsListResponse? {
         return self.deviceCache.cachedWorkflowsListResponse()
+    }
+
+    /// Restores the in-memory `offeringId → workflowId` map from the last list persisted on disk,
+    /// keeping the entry stale so the next fetch still hits the backend. Used to recover after a
+    /// backend failure: it keeps ``workflowId(forOfferingId:)`` resolving previously-fetched data
+    /// without suppressing the next refresh, mirroring how the offerings cache serves its disk copy
+    /// while staying stale. No-op when nothing is persisted, and the on-disk copy is left untouched.
+    func restoreWorkflowsListFromDisk() {
+        guard let response = self.cachedWorkflowsListResponseFromDisk() else { return }
+        self.cachedList.value = CachedList(response: response,
+                                           offeringIdToWorkflowId: Self.offeringIdToWorkflowId(from: response),
+                                           lastUpdated: .distantPast)
     }
 
     /// Resolves the workflow id for an offering from the in-memory list, or `nil` when the list

--- a/Sources/Logging/Strings/PaywallsStrings.swift
+++ b/Sources/Logging/Strings/PaywallsStrings.swift
@@ -22,6 +22,7 @@ enum PaywallsStrings {
     case warming_up_fonts(fontsURLS: Set<URL>)
     case warming_up_videos(videoURLs: Set<URLWithValidation>)
     case warming_up_workflow(screenCount: Int)
+    case error_fetching_workflows_list(BackendError)
     case error_prefetching_image(URL, Error)
     case font_download_already_in_progress(name: String, fontURL: URL)
     case font_downloaded_sucessfully(name: String, fontURL: URL)
@@ -168,6 +169,9 @@ extension PaywallsStrings: LogMessage {
 
         case let .warming_up_workflow(screenCount):
             return "Warming up workflow caches for \(screenCount) screen(s)"
+
+        case let .error_fetching_workflows_list(error):
+            return "Error fetching workflows list: \(error.localizedDescription)"
 
         case let .background_task_started(taskName):
             return "Background task started: \(taskName)"

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -990,7 +990,7 @@ public extension Purchases {
         // back to the offering identifier itself, which the backend also accepts as a workflow key.
         // The map is empty until the workflows list has been fetched, so the fallback preserves the
         // original behavior. `WorkflowManager` handles caching and asset warm-up.
-        let workflowId = self.workflowManager.workflowId(forOfferingId: offeringID) ?? offeringID
+        let workflowId = self.workflowManager.cachedWorkflowId(forOfferingId: offeringID) ?? offeringID
         return try await Async.call { completion in
             self.workflowManager.getWorkflow(
                 appUserID: self.appUserID,

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -281,6 +281,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
     private let notificationCenter: NotificationCenter
     private let offeringsFactory: OfferingsFactory
     private let offeringsManager: OfferingsManager
+    private let workflowManager: WorkflowManager
     private let offlineEntitlementsManager: OfflineEntitlementsManager
     private let productsManager: ProductsManagerType
     private let customerInfoManager: CustomerInfoManager
@@ -376,6 +377,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         let attributionFetcher = AttributionFetcher(attributionFactory: attributionTypeFactory, systemInfo: systemInfo)
         let userDefaults = userDefaults ?? UserDefaults.computeDefault()
         let deviceCache = DeviceCache(systemInfo: systemInfo, userDefaults: userDefaults)
+        let workflowsCache = WorkflowsCache(deviceCache: deviceCache)
 
         let diagnosticsFileHandler: DiagnosticsFileHandlerType? = {
             guard diagnosticsEnabled,
@@ -674,6 +676,11 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             paywallCache = nil
         }
 
+        let workflowManager = WorkflowManager(backend: backend,
+                                              workflowsCache: workflowsCache,
+                                              paywallCache: paywallCache,
+                                              operationDispatcher: operationDispatcher)
+
         let virtualCurrencyManager = VirtualCurrencyManager(
             identityManager: identityManager,
             deviceCache: deviceCache,
@@ -710,6 +717,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                   eventsManager: eventsManager,
                   productsManager: productsManager,
                   offeringsManager: offeringsManager,
+                  workflowManager: workflowManager,
                   offlineEntitlementsManager: offlineEntitlementsManager,
                   purchasesOrchestrator: purchasesOrchestrator,
                   purchasedProductsFetcher: purchasedProductsFetcher,
@@ -744,6 +752,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
          eventsManager: EventsManagerType?,
          productsManager: ProductsManagerType,
          offeringsManager: OfferingsManager,
+         workflowManager: WorkflowManager,
          offlineEntitlementsManager: OfflineEntitlementsManager,
          purchasesOrchestrator: PurchasesOrchestrator,
          purchasedProductsFetcher: PurchasedProductsFetcherType?,
@@ -796,6 +805,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.eventsManager = eventsManager
         self.productsManager = productsManager
         self.offeringsManager = offeringsManager
+        self.workflowManager = workflowManager
         self.offlineEntitlementsManager = offlineEntitlementsManager
         self.purchasesOrchestrator = purchasesOrchestrator
         self.purchasedProductsFetcher = purchasedProductsFetcher
@@ -975,23 +985,20 @@ public extension Purchases {
     }
 
     @_spi(Internal)
-    // The backend uses the offering identifier as the workflow lookup key.
     func workflow(forOfferingIdentifier offeringID: String) async throws -> WorkflowDataResult {
-        let result = try await Async.call { completion in
-            self.backend.workflowsAPI.getWorkflow(
+        // Prefer the workflowId resolved from the workflows list (offeringId → workflowId), falling
+        // back to the offering identifier itself, which the backend also accepts as a workflow key.
+        // The map is empty until the workflows list has been fetched, so the fallback preserves the
+        // original behavior. `WorkflowManager` handles caching and asset warm-up.
+        let workflowId = self.workflowManager.workflowId(forOfferingId: offeringID) ?? offeringID
+        return try await Async.call { completion in
+            self.workflowManager.getWorkflow(
                 appUserID: self.appUserID,
-                workflowId: offeringID,
+                workflowId: workflowId,
                 isAppBackgrounded: false,
                 completion: completion
             )
         }
-        if #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *),
-           let cache = self.paywallCache {
-            self.operationDispatcher.dispatchOnWorkerThread {
-                await cache.warmUpWorkflowCaches(workflow: result.workflow)
-            }
-        }
-        return result
     }
 
     internal func offerings(fetchPolicy: OfferingsManager.FetchPolicy) async throws -> Offerings {

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -64,11 +64,11 @@ class WorkflowManager {
 
     /// Fetches the workflows list, persists it, then prefetches every entry flagged `prefetch == true`.
     /// `onComplete` fires only after the list fetch **and** all prefetch fetches finish (success or
-    /// failure), making it safe to call ``workflowId(forOfferingId:)`` from `onComplete`.
+    /// failure), making it safe to call ``cachedWorkflowId(forOfferingId:)`` from `onComplete`.
     ///
     /// When the in-memory list cache is still fresh, no network request is made and `onComplete` fires
     /// immediately. On a backend failure `onComplete` still fires (so callers waiting on it, e.g.
-    /// offerings delivery, are never blocked); ``workflowId(forOfferingId:)`` keeps resolving from the
+    /// offerings delivery, are never blocked); ``cachedWorkflowId(forOfferingId:)`` keeps resolving from the
     /// last list persisted on disk until the next fetch succeeds.
     func getWorkflowsList(appUserID: String,
                           isAppBackgrounded: Bool,
@@ -95,7 +95,7 @@ class WorkflowManager {
             case let .failure(error):
                 Logger.error(Strings.paywalls.error_fetching_workflows_list(error))
                 // Restore the in-memory offeringId -> workflowId map from the last list persisted on
-                // disk, so `workflowId(forOfferingId:)` keeps resolving previously-fetched data after
+                // disk, so `cachedWorkflowId(forOfferingId:)` keeps resolving previously-fetched data after
                 // a backend failure instead of returning nil. The entry stays stale so the next
                 // fetch still retries the backend.
                 self.workflowsCache.restoreWorkflowsListFromDisk()
@@ -104,7 +104,7 @@ class WorkflowManager {
         }
     }
 
-    func workflowId(forOfferingId offeringId: String) -> String? {
+    func cachedWorkflowId(forOfferingId offeringId: String) -> String? {
         return self.workflowsCache.workflowId(forOfferingId: offeringId)
     }
 
@@ -116,13 +116,15 @@ private extension WorkflowManager {
 
     static let paywallWorkflowType = "paywall"
 
-    /// Prefetches the workflows flagged `prefetch == true`, calling `onComplete` once every prefetch
-    /// finishes (success or failure). When there is nothing to prefetch, `onComplete` fires right away.
+    /// Prefetches the workflows flagged `prefetch == true` that are tied to an offering, calling
+    /// `onComplete` once every prefetch finishes (success or failure). Workflows without an
+    /// `offeringId` can't be resolved via ``cachedWorkflowId(forOfferingId:)``, so they're skipped.
+    /// When there is nothing to prefetch, `onComplete` fires right away.
     func prefetchWorkflows(_ workflows: [WorkflowSummary],
                            appUserID: String,
                            isAppBackgrounded: Bool,
                            onComplete: @escaping () -> Void) {
-        let prefetchWorkflows = workflows.filter { $0.prefetch }
+        let prefetchWorkflows = workflows.filter { $0.prefetch && $0.offeringId != nil }
         guard !prefetchWorkflows.isEmpty else {
             onComplete()
             return

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -1,0 +1,157 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WorkflowManager.swift
+//
+//  Created by RevenueCat.
+
+import Foundation
+
+/// Orchestrates fetching paywall workflows on top of the `WorkflowsAPI` networking layer, mirroring
+/// the role `OfferingsManager` plays for offerings. It serves a fresh cached workflow without a
+/// backend round-trip via ``WorkflowsCache``, and prefetches workflows flagged `prefetch == true`
+/// so they are warm by the time their paywall opens.
+class WorkflowManager {
+
+    private let backend: Backend
+    private let workflowsCache: WorkflowsCache
+    private let paywallCache: PaywallCacheWarmingType?
+    private let operationDispatcher: OperationDispatcher
+
+    init(backend: Backend,
+         workflowsCache: WorkflowsCache,
+         paywallCache: PaywallCacheWarmingType?,
+         operationDispatcher: OperationDispatcher) {
+        self.backend = backend
+        self.workflowsCache = workflowsCache
+        self.paywallCache = paywallCache
+        self.operationDispatcher = operationDispatcher
+    }
+
+    /// Resolves a workflow, serving a fresh cached result without a backend round-trip when possible.
+    /// On a cache miss (or stale entry) it fetches from the backend, caches the result, and warms up
+    /// its assets before delivering it.
+    func getWorkflow(appUserID: String,
+                     workflowId: String,
+                     isAppBackgrounded: Bool,
+                     completion: @escaping (Result<WorkflowDataResult, BackendError>) -> Void) {
+        if let cached = self.workflowsCache.cachedWorkflow(workflowId: workflowId),
+           !self.workflowsCache.isWorkflowCacheStale(workflowId: workflowId, isAppBackgrounded: isAppBackgrounded) {
+            completion(.success(cached))
+            return
+        }
+
+        self.backend.workflowsAPI.getWorkflow(appUserID: appUserID,
+                                              workflowId: workflowId,
+                                              isAppBackgrounded: isAppBackgrounded) { [weak self] result in
+            guard let self else {
+                completion(result)
+                return
+            }
+            if case let .success(dataResult) = result {
+                self.workflowsCache.cache(workflow: dataResult, workflowId: workflowId)
+                self.warmUpAssets(for: dataResult)
+            }
+            completion(result)
+        }
+    }
+
+    /// Fetches the workflows list, persists it, then prefetches every entry flagged `prefetch == true`.
+    /// `onComplete` fires only after the list fetch **and** all prefetch fetches finish (success or
+    /// failure), making it safe to call ``workflowId(forOfferingId:)`` from `onComplete`.
+    ///
+    /// When the in-memory list cache is still fresh, no network request is made and `onComplete` fires
+    /// immediately. On a backend failure `onComplete` still fires (so callers waiting on it, e.g.
+    /// offerings delivery, are never blocked); ``workflowId(forOfferingId:)`` keeps resolving from the
+    /// last list persisted on disk until the next fetch succeeds.
+    func getWorkflowsList(appUserID: String,
+                          isAppBackgrounded: Bool,
+                          onComplete: @escaping () -> Void = {}) {
+        guard self.workflowsCache.isWorkflowsListCacheStale(isAppBackgrounded: isAppBackgrounded) else {
+            onComplete()
+            return
+        }
+
+        self.backend.workflowsAPI.getWorkflows(appUserID: appUserID,
+                                               isAppBackgrounded: isAppBackgrounded,
+                                               type: Self.paywallWorkflowType) { [weak self] result in
+            guard let self else {
+                onComplete()
+                return
+            }
+            switch result {
+            case let .success(response):
+                self.workflowsCache.cache(workflowsList: response)
+                self.prefetchWorkflows(response.workflows,
+                                       appUserID: appUserID,
+                                       isAppBackgrounded: isAppBackgrounded,
+                                       onComplete: onComplete)
+            case let .failure(error):
+                Logger.error(Strings.paywalls.error_fetching_workflows_list(error))
+                onComplete()
+            }
+        }
+    }
+
+    func workflowId(forOfferingId offeringId: String) -> String? {
+        return self.workflowsCache.workflowId(forOfferingId: offeringId)
+    }
+
+}
+
+// MARK: - Private
+
+private extension WorkflowManager {
+
+    static let paywallWorkflowType = "paywall"
+
+    /// Prefetches the workflows flagged `prefetch == true`, calling `onComplete` once every prefetch
+    /// finishes (success or failure). When there is nothing to prefetch, `onComplete` fires right away.
+    func prefetchWorkflows(_ workflows: [WorkflowSummary],
+                           appUserID: String,
+                           isAppBackgrounded: Bool,
+                           onComplete: @escaping () -> Void) {
+        let prefetchWorkflows = workflows.filter { $0.prefetch }
+        guard !prefetchWorkflows.isEmpty else {
+            onComplete()
+            return
+        }
+
+        // Lock-guarded counter so `onComplete` fires exactly once, after the last prefetch lands,
+        // regardless of which thread each completion arrives on.
+        let remaining: Atomic<Int> = .init(prefetchWorkflows.count)
+        for summary in prefetchWorkflows {
+            self.getWorkflow(appUserID: appUserID,
+                             workflowId: summary.id,
+                             isAppBackgrounded: isAppBackgrounded) { _ in
+                let left = remaining.modify { value -> Int in
+                    value -= 1
+                    return value
+                }
+                if left == 0 {
+                    onComplete()
+                }
+            }
+        }
+    }
+
+    func warmUpAssets(for result: WorkflowDataResult) {
+        if #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *),
+           let paywallCache = self.paywallCache {
+            self.operationDispatcher.dispatchOnWorkerThread {
+                await paywallCache.warmUpWorkflowCaches(workflow: result.workflow)
+            }
+        }
+    }
+
+}
+
+// @unchecked because:
+// - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.
+extension WorkflowManager: @unchecked Sendable {}

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -94,6 +94,12 @@ class WorkflowManager {
                                        onComplete: onComplete)
             case let .failure(error):
                 Logger.error(Strings.paywalls.error_fetching_workflows_list(error))
+                // Restore the in-memory offeringId -> workflowId map from the last list persisted on
+                // disk, so `workflowId(forOfferingId:)` keeps resolving previously-fetched data after
+                // a backend failure instead of returning nil.
+                if let cachedResponse = self.workflowsCache.cachedWorkflowsListResponseFromDisk() {
+                    self.workflowsCache.cache(workflowsList: cachedResponse)
+                }
                 onComplete()
             }
         }

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -96,10 +96,9 @@ class WorkflowManager {
                 Logger.error(Strings.paywalls.error_fetching_workflows_list(error))
                 // Restore the in-memory offeringId -> workflowId map from the last list persisted on
                 // disk, so `workflowId(forOfferingId:)` keeps resolving previously-fetched data after
-                // a backend failure instead of returning nil.
-                if let cachedResponse = self.workflowsCache.cachedWorkflowsListResponseFromDisk() {
-                    self.workflowsCache.cache(workflowsList: cachedResponse)
-                }
+                // a backend failure instead of returning nil. The entry stays stale so the next
+                // fetch still retries the backend.
+                self.workflowsCache.restoreWorkflowsListFromDisk()
                 onComplete()
             }
         }

--- a/Tests/UnitTests/Mocks/MockWorkflowsAPI.swift
+++ b/Tests/UnitTests/Mocks/MockWorkflowsAPI.swift
@@ -23,7 +23,14 @@ class MockWorkflowsAPI: WorkflowsAPI, @unchecked Sendable {
     var invokedGetWorkflow = false
     var invokedGetWorkflowCount = 0
     var invokedGetWorkflowParameters: (appUserID: String, workflowId: String, isAppBackgrounded: Bool)?
+    var invokedGetWorkflowParametersList: [(appUserID: String, workflowId: String, isAppBackgrounded: Bool)] = []
     var stubbedGetWorkflowResult: Result<WorkflowDataResult, BackendError>?
+    /// Per-workflowId result, used when set; otherwise falls back to `stubbedGetWorkflowResult`.
+    var stubbedGetWorkflowResults: [String: Result<WorkflowDataResult, BackendError>] = [:]
+    /// When `true`, completions are captured instead of fired so tests can control ordering.
+    var shouldStoreGetWorkflowCompletions = false
+    private(set) var capturedGetWorkflowCompletions:
+        [(workflowId: String, completion: WorkflowDetailResponseHandler)] = []
 
     override func getWorkflow(appUserID: String,
                               workflowId: String,
@@ -32,8 +39,26 @@ class MockWorkflowsAPI: WorkflowsAPI, @unchecked Sendable {
         self.invokedGetWorkflow = true
         self.invokedGetWorkflowCount += 1
         self.invokedGetWorkflowParameters = (appUserID, workflowId, isAppBackgrounded)
+        self.invokedGetWorkflowParametersList.append((appUserID, workflowId, isAppBackgrounded))
 
-        completion(self.stubbedGetWorkflowResult ?? .failure(.missingAppUserID()))
+        if self.shouldStoreGetWorkflowCompletions {
+            self.capturedGetWorkflowCompletions.append((workflowId, completion))
+            return
+        }
+
+        completion(self.stubbedGetWorkflowResults[workflowId]
+                   ?? self.stubbedGetWorkflowResult
+                   ?? .failure(.missingAppUserID()))
+    }
+
+    /// Fires (and removes) the captured completion for `workflowId`. Requires
+    /// `shouldStoreGetWorkflowCompletions == true`.
+    func completeStoredGetWorkflow(workflowId: String,
+                                   with result: Result<WorkflowDataResult, BackendError>) {
+        guard let index = self.capturedGetWorkflowCompletions.firstIndex(where: { $0.workflowId == workflowId })
+        else { return }
+        let entry = self.capturedGetWorkflowCompletions.remove(at: index)
+        entry.completion(result)
     }
 
     var invokedGetWorkflows = false

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -342,6 +342,12 @@ class BasePurchasesTests: TestCase {
                                    eventsManager: self.eventsManager,
                                    productsManager: self.mockProductsManager,
                                    offeringsManager: self.mockOfferingsManager,
+                                   workflowManager: WorkflowManager(
+                                    backend: self.backend,
+                                    workflowsCache: WorkflowsCache(deviceCache: self.deviceCache),
+                                    paywallCache: self.paywallCache,
+                                    operationDispatcher: self.mockOperationDispatcher
+                                   ),
                                    offlineEntitlementsManager: self.mockOfflineEntitlementsManager,
                                    purchasesOrchestrator: self.purchasesOrchestrator,
                                    purchasedProductsFetcher: self.mockPurchasedProductsFetcher,
@@ -490,7 +496,7 @@ extension BasePurchasesTests {
             let customerCenterConfig = CustomerCenterConfigAPI(backendConfig: backendConfig)
             let redeemWebPurchaseAPI = RedeemWebPurchaseAPI(backendConfig: backendConfig)
             let virtualCurrenciesAPI = VirtualCurrenciesAPI(backendConfig: backendConfig)
-            let workflowsAPI = WorkflowsAPI(backendConfig: backendConfig)
+            let workflowsAPI = MockWorkflowsAPI()
             let remoteConfigAPI = RemoteConfigAPI(backendConfig: backendConfig)
 
             self.init(backendConfig: backendConfig,

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesWorkflowTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesWorkflowTests.swift
@@ -1,0 +1,89 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PurchasesWorkflowTests.swift
+//
+//  Created by RevenueCat.
+
+import Nimble
+import XCTest
+
+@testable @_spi(Internal) import RevenueCat
+
+class PurchasesWorkflowTests: BasePurchasesTests {
+
+    private var mockWorkflowsAPI: MockWorkflowsAPI!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        self.setupPurchases()
+        self.mockWorkflowsAPI = try XCTUnwrap(self.backend.workflowsAPI as? MockWorkflowsAPI)
+    }
+
+    func testWorkflowForOfferingIdentifierFallsBackToOfferingIdAsWorkflowId() async throws {
+        let expected = try Self.workflowDataResult(id: "default")
+        self.mockWorkflowsAPI.stubbedGetWorkflowResult = .success(expected)
+
+        // No workflows list has been fetched yet, so the offeringId → workflowId map is empty and the
+        // offering identifier itself is used as the workflow lookup key, preserving the prior behavior.
+        let result = try await self.purchases.workflow(forOfferingIdentifier: "default")
+
+        expect(self.mockWorkflowsAPI.invokedGetWorkflowParameters?.workflowId) == "default"
+        expect(result) == expected
+    }
+
+    // MARK: - Helpers
+
+    private static func workflowDataResult(id: String) throws -> WorkflowDataResult {
+        let json = """
+        {
+          "id": "\(id)",
+          "display_name": "Test",
+          "initial_step_id": "step_1",
+          "steps": {
+            "step_1": { "id": "step_1", "type": "screen", "screen_id": "screen_1" }
+          },
+          "screens": {
+            "screen_1": {
+              "template_name": "tmpl",
+              "asset_base_url": "https://assets.revenuecat.com",
+              "default_locale": "en_US",
+              "components_localizations": {},
+              "components_config": {
+                "base": {
+                  "stack": {
+                    "type": "stack",
+                    "components": [],
+                    "dimension": { "type": "vertical", "alignment": "center", "distribution": "center" },
+                    "size": { "width": { "type": "fill" }, "height": { "type": "fill" } },
+                    "padding": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 },
+                    "margin": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 }
+                  },
+                  "background": {
+                    "type": "color",
+                    "value": { "light": { "type": "hex", "value": "#FFFFFF" } }
+                  }
+                }
+              },
+              "offering_identifier": "default"
+            }
+          },
+          "ui_config": {
+            "app": { "colors": {}, "fonts": {} },
+            "localizations": {}
+          }
+        }
+        """
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let workflow = try JSONDecoder.default.decode(PublishedWorkflow.self, from: data)
+        return .init(workflow: workflow, enrolledVariants: nil)
+    }
+
+}

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -160,6 +160,36 @@ class WorkflowManagerTests: TestCase {
         expect(self.manager.workflowId(forOfferingId: "default")) == "wf_1"
     }
 
+    func testGetWorkflowsListKeepsCacheStaleAfterBackendFailureSoNextCallRetries() {
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .failure(.missingAppUserID())
+        self.mockDeviceCache.stubbedCachedWorkflowsListResponse = .init(workflows: [
+            .init(id: "wf_1", displayName: "Flow", offeringId: "default", prefetch: false)
+        ])
+
+        // First fetch fails and restores the list from disk, but leaves it stale.
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        expect(self.workflowsCache.isWorkflowsListCacheStale(isAppBackgrounded: false)) == true
+
+        // A second call therefore still hits the backend rather than short-circuiting on the
+        // restored entry.
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        expect(self.mockWorkflowsAPI.invokedGetWorkflowsCount) == 2
+    }
+
+    func testGetWorkflowsListDoesNotRewriteDiskWhenRestoringAfterBackendFailure() {
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .failure(.missingAppUserID())
+        self.mockDeviceCache.stubbedCachedWorkflowsListResponse = .init(workflows: [
+            .init(id: "wf_1", displayName: "Flow", offeringId: "default", prefetch: false)
+        ])
+
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        // The list was read from disk to restore the in-memory map; it must not be written back.
+        expect(self.mockDeviceCache.cacheWorkflowsListResponseCount) == 0
+    }
+
     func testGetWorkflowsListWithDuplicateOfferingIdKeepsLastEntry() {
         self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: [
             .init(id: "wf_first", displayName: "First", offeringId: "shared", prefetch: false),

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -127,9 +127,9 @@ class WorkflowManagerTests: TestCase {
 
     func testGetWorkflowsListTriggersGetWorkflowForEachPrefetchEntryOnly() throws {
         self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: [
-            .init(id: "wf_prefetch", displayName: "A", offeringId: nil, prefetch: true),
-            .init(id: "wf_skip", displayName: "B", offeringId: nil, prefetch: false),
-            .init(id: "wf_also_prefetch", displayName: "C", offeringId: nil, prefetch: true)
+            .init(id: "wf_prefetch", displayName: "A", offeringId: "off_a", prefetch: true),
+            .init(id: "wf_skip", displayName: "B", offeringId: "off_b", prefetch: false),
+            .init(id: "wf_also_prefetch", displayName: "C", offeringId: "off_c", prefetch: true)
         ]))
         self.mockWorkflowsAPI.stubbedGetWorkflowResult = .success(try Self.workflowDataResult(id: "wf"))
 
@@ -139,6 +139,21 @@ class WorkflowManagerTests: TestCase {
         expect(prefetchedIds).to(contain("wf_prefetch", "wf_also_prefetch"))
         expect(prefetchedIds).toNot(contain("wf_skip"))
         expect(self.mockWorkflowsAPI.invokedGetWorkflowCount) == 2
+    }
+
+    func testGetWorkflowsListSkipsPrefetchForWorkflowsWithoutOfferingId() throws {
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: [
+            .init(id: "wf_with_offering", displayName: "A", offeringId: "off_a", prefetch: true),
+            .init(id: "wf_without_offering", displayName: "B", offeringId: nil, prefetch: true)
+        ]))
+        self.mockWorkflowsAPI.stubbedGetWorkflowResult = .success(try Self.workflowDataResult(id: "wf"))
+
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        let prefetchedIds = self.mockWorkflowsAPI.invokedGetWorkflowParametersList.map { $0.workflowId }
+        expect(prefetchedIds).to(contain("wf_with_offering"))
+        expect(prefetchedIds).toNot(contain("wf_without_offering"))
+        expect(self.mockWorkflowsAPI.invokedGetWorkflowCount) == 1
     }
 
     func testGetWorkflowsListDoesNotCacheOnBackendFailure() {
@@ -157,7 +172,7 @@ class WorkflowManagerTests: TestCase {
 
         self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
 
-        expect(self.manager.workflowId(forOfferingId: "default")) == "wf_1"
+        expect(self.manager.cachedWorkflowId(forOfferingId: "default")) == "wf_1"
     }
 
     func testGetWorkflowsListKeepsCacheStaleAfterBackendFailureSoNextCallRetries() {
@@ -198,13 +213,13 @@ class WorkflowManagerTests: TestCase {
 
         self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
 
-        expect(self.manager.workflowId(forOfferingId: "shared")) == "wf_last"
+        expect(self.manager.cachedWorkflowId(forOfferingId: "shared")) == "wf_last"
     }
 
-    // MARK: - workflowId(forOfferingId:)
+    // MARK: - cachedWorkflowId(forOfferingId:)
 
     func testWorkflowIdForOfferingIdReturnsNilBeforeListIsFetched() {
-        expect(self.manager.workflowId(forOfferingId: "default")).to(beNil())
+        expect(self.manager.cachedWorkflowId(forOfferingId: "default")).to(beNil())
     }
 
     func testWorkflowIdForOfferingIdReturnsWorkflowIdAfterListIsFetched() {
@@ -214,8 +229,8 @@ class WorkflowManagerTests: TestCase {
 
         self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
 
-        expect(self.manager.workflowId(forOfferingId: "default")) == "wf_abc"
-        expect(self.manager.workflowId(forOfferingId: "premium")).to(beNil())
+        expect(self.manager.cachedWorkflowId(forOfferingId: "default")) == "wf_abc"
+        expect(self.manager.cachedWorkflowId(forOfferingId: "premium")).to(beNil())
     }
 
     func testWorkflowIdForOfferingIdReturnsNilForWorkflowWithNilOfferingId() {
@@ -225,7 +240,7 @@ class WorkflowManagerTests: TestCase {
 
         self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
 
-        expect(self.manager.workflowId(forOfferingId: "default")).to(beNil())
+        expect(self.manager.cachedWorkflowId(forOfferingId: "default")).to(beNil())
     }
 
     // MARK: - onComplete
@@ -255,8 +270,8 @@ class WorkflowManagerTests: TestCase {
 
     func testGetWorkflowsListCallsOnCompleteOnlyAfterAllPrefetchWorkflowsComplete() throws {
         self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: [
-            .init(id: "wf_a", displayName: "A", offeringId: nil, prefetch: true),
-            .init(id: "wf_b", displayName: "B", offeringId: nil, prefetch: true)
+            .init(id: "wf_a", displayName: "A", offeringId: "off_a", prefetch: true),
+            .init(id: "wf_b", displayName: "B", offeringId: "off_b", prefetch: true)
         ]))
         self.mockWorkflowsAPI.shouldStoreGetWorkflowCompletions = true
         let result = try Self.workflowDataResult(id: "wf")
@@ -273,8 +288,8 @@ class WorkflowManagerTests: TestCase {
 
     func testGetWorkflowsListCallsOnCompleteEvenIfAPrefetchWorkflowFails() throws {
         self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: [
-            .init(id: "wf_a", displayName: "A", offeringId: nil, prefetch: true),
-            .init(id: "wf_b", displayName: "B", offeringId: nil, prefetch: true)
+            .init(id: "wf_a", displayName: "A", offeringId: "off_a", prefetch: true),
+            .init(id: "wf_b", displayName: "B", offeringId: "off_b", prefetch: true)
         ]))
         self.mockWorkflowsAPI.shouldStoreGetWorkflowCompletions = true
 

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -1,0 +1,320 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WorkflowManagerTests.swift
+//
+//  Created by RevenueCat.
+
+import Foundation
+import Nimble
+import XCTest
+
+@_spi(Internal) @testable import RevenueCat
+
+class WorkflowManagerTests: TestCase {
+
+    private let appUserID = "user_1"
+
+    private var dateProvider: MockCurrentDateProvider!
+    private var mockBackend: MockBackend!
+    private var mockWorkflowsAPI: MockWorkflowsAPI!
+    private var mockDeviceCache: MockDeviceCache!
+    private var mockOperationDispatcher: MockOperationDispatcher!
+    private var systemInfo: MockSystemInfo!
+    private var workflowsCache: WorkflowsCache!
+    private var manager: WorkflowManager!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        self.dateProvider = MockCurrentDateProvider()
+        self.systemInfo = MockSystemInfo(finishTransactions: false)
+        self.systemInfo.stubbedIsSandbox = false
+        self.mockBackend = MockBackend()
+        self.mockWorkflowsAPI = try XCTUnwrap(self.mockBackend.workflowsAPI as? MockWorkflowsAPI)
+        self.mockDeviceCache = MockDeviceCache(systemInfo: self.systemInfo)
+        self.mockOperationDispatcher = MockOperationDispatcher()
+        self.workflowsCache = WorkflowsCache(deviceCache: self.mockDeviceCache, dateProvider: self.dateProvider)
+        self.manager = WorkflowManager(backend: self.mockBackend,
+                                       workflowsCache: self.workflowsCache,
+                                       paywallCache: nil,
+                                       operationDispatcher: self.mockOperationDispatcher)
+    }
+
+    // MARK: - getWorkflow cache
+
+    func testGetWorkflowCachesResultOnSuccess() throws {
+        let expected = try Self.workflowDataResult(id: "wf_1")
+        self.mockWorkflowsAPI.stubbedGetWorkflowResult = .success(expected)
+
+        self.manager.getWorkflow(appUserID: self.appUserID, workflowId: "wf_1", isAppBackgrounded: false) { _ in }
+
+        expect(self.workflowsCache.cachedWorkflow(workflowId: "wf_1")) == expected
+    }
+
+    func testGetWorkflowReturnsCachedResultWithoutCallingBackendWhenFresh() throws {
+        let expected = try Self.workflowDataResult(id: "wf_1")
+        self.mockWorkflowsAPI.stubbedGetWorkflowResult = .success(expected)
+
+        // First call populates the cache.
+        self.manager.getWorkflow(appUserID: self.appUserID, workflowId: "wf_1", isAppBackgrounded: false) { _ in }
+
+        // Second call within TTL should hit the cache.
+        var secondResult: WorkflowDataResult?
+        self.manager.getWorkflow(appUserID: self.appUserID, workflowId: "wf_1", isAppBackgrounded: false) {
+            secondResult = try? $0.get()
+        }
+
+        expect(secondResult) == expected
+        expect(self.mockWorkflowsAPI.invokedGetWorkflowCount) == 1
+    }
+
+    func testGetWorkflowRefetchesWhenCacheIsStale() throws {
+        let expected = try Self.workflowDataResult(id: "wf_1")
+        self.mockWorkflowsAPI.stubbedGetWorkflowResult = .success(expected)
+
+        self.manager.getWorkflow(appUserID: self.appUserID, workflowId: "wf_1", isAppBackgrounded: false) { _ in }
+
+        // Past the 5-minute foreground TTL.
+        self.dateProvider.advance(by: 6 * 60)
+        self.manager.getWorkflow(appUserID: self.appUserID, workflowId: "wf_1", isAppBackgrounded: false) { _ in }
+
+        expect(self.mockWorkflowsAPI.invokedGetWorkflowCount) == 2
+    }
+
+    func testGetWorkflowForwardsBackendError() {
+        self.mockWorkflowsAPI.stubbedGetWorkflowResult = .failure(.missingAppUserID())
+
+        var error: BackendError?
+        self.manager.getWorkflow(appUserID: self.appUserID, workflowId: "wf_1", isAppBackgrounded: false) {
+            if case let .failure(failure) = $0 { error = failure }
+        }
+
+        expect(error).toNot(beNil())
+        expect(self.workflowsCache.cachedWorkflow(workflowId: "wf_1")).to(beNil())
+    }
+
+    // MARK: - getWorkflowsList
+
+    func testGetWorkflowsListCallsBackendAndCachesPayload() {
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: [
+            .init(id: "wf_1", displayName: "Flow A", offeringId: "default", prefetch: false)
+        ]))
+
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        expect(self.mockWorkflowsAPI.invokedGetWorkflowsCount) == 1
+        expect(self.mockWorkflowsAPI.invokedGetWorkflowsParameters?.type) == "paywall"
+        expect(self.mockDeviceCache.cacheWorkflowsListResponseCount) == 1
+        expect(self.mockWorkflowsAPI.invokedGetWorkflowCount) == 0
+    }
+
+    func testGetWorkflowsListSkipsNetworkWhenCacheIsFresh() {
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: []))
+
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+        self.dateProvider.advance(by: 1) // still within TTL
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        expect(self.mockWorkflowsAPI.invokedGetWorkflowsCount) == 1
+    }
+
+    func testGetWorkflowsListTriggersGetWorkflowForEachPrefetchEntryOnly() throws {
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: [
+            .init(id: "wf_prefetch", displayName: "A", offeringId: nil, prefetch: true),
+            .init(id: "wf_skip", displayName: "B", offeringId: nil, prefetch: false),
+            .init(id: "wf_also_prefetch", displayName: "C", offeringId: nil, prefetch: true)
+        ]))
+        self.mockWorkflowsAPI.stubbedGetWorkflowResult = .success(try Self.workflowDataResult(id: "wf"))
+
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        let prefetchedIds = self.mockWorkflowsAPI.invokedGetWorkflowParametersList.map { $0.workflowId }
+        expect(prefetchedIds).to(contain("wf_prefetch", "wf_also_prefetch"))
+        expect(prefetchedIds).toNot(contain("wf_skip"))
+        expect(self.mockWorkflowsAPI.invokedGetWorkflowCount) == 2
+    }
+
+    func testGetWorkflowsListDoesNotCacheOnBackendFailure() {
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .failure(.missingAppUserID())
+
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        expect(self.mockDeviceCache.cacheWorkflowsListResponseCount) == 0
+    }
+
+    func testGetWorkflowsListRestoresOfferingIdMapFromDiskOnBackendFailure() {
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .failure(.missingAppUserID())
+        self.mockDeviceCache.stubbedCachedWorkflowsListResponse = .init(workflows: [
+            .init(id: "wf_1", displayName: "Flow", offeringId: "default", prefetch: false)
+        ])
+
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        expect(self.manager.workflowId(forOfferingId: "default")) == "wf_1"
+    }
+
+    func testGetWorkflowsListWithDuplicateOfferingIdKeepsLastEntry() {
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: [
+            .init(id: "wf_first", displayName: "First", offeringId: "shared", prefetch: false),
+            .init(id: "wf_last", displayName: "Last", offeringId: "shared", prefetch: false)
+        ]))
+
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        expect(self.manager.workflowId(forOfferingId: "shared")) == "wf_last"
+    }
+
+    // MARK: - workflowId(forOfferingId:)
+
+    func testWorkflowIdForOfferingIdReturnsNilBeforeListIsFetched() {
+        expect(self.manager.workflowId(forOfferingId: "default")).to(beNil())
+    }
+
+    func testWorkflowIdForOfferingIdReturnsWorkflowIdAfterListIsFetched() {
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: [
+            .init(id: "wf_abc", displayName: "Flow", offeringId: "default", prefetch: false)
+        ]))
+
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        expect(self.manager.workflowId(forOfferingId: "default")) == "wf_abc"
+        expect(self.manager.workflowId(forOfferingId: "premium")).to(beNil())
+    }
+
+    func testWorkflowIdForOfferingIdReturnsNilForWorkflowWithNilOfferingId() {
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: [
+            .init(id: "wf_no_offering", displayName: "Flow", offeringId: nil, prefetch: false)
+        ]))
+
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        expect(self.manager.workflowId(forOfferingId: "default")).to(beNil())
+    }
+
+    // MARK: - onComplete
+
+    func testGetWorkflowsListCallsOnCompleteAfterSuccessWithNoPrefetch() {
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: [
+            .init(id: "wf_1", displayName: "Flow", offeringId: "default", prefetch: false)
+        ]))
+
+        var completed = false
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false) { completed = true }
+
+        expect(completed) == true
+    }
+
+    func testGetWorkflowsListCallsOnCompleteImmediatelyWhenCacheIsFresh() {
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: []))
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        self.dateProvider.advance(by: 1)
+        var completed = false
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false) { completed = true }
+
+        expect(completed) == true
+        expect(self.mockWorkflowsAPI.invokedGetWorkflowsCount) == 1
+    }
+
+    func testGetWorkflowsListCallsOnCompleteOnlyAfterAllPrefetchWorkflowsComplete() throws {
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: [
+            .init(id: "wf_a", displayName: "A", offeringId: nil, prefetch: true),
+            .init(id: "wf_b", displayName: "B", offeringId: nil, prefetch: true)
+        ]))
+        self.mockWorkflowsAPI.shouldStoreGetWorkflowCompletions = true
+        let result = try Self.workflowDataResult(id: "wf")
+
+        var completed = false
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false) { completed = true }
+
+        expect(completed) == false
+        self.mockWorkflowsAPI.completeStoredGetWorkflow(workflowId: "wf_a", with: .success(result))
+        expect(completed) == false
+        self.mockWorkflowsAPI.completeStoredGetWorkflow(workflowId: "wf_b", with: .success(result))
+        expect(completed) == true
+    }
+
+    func testGetWorkflowsListCallsOnCompleteEvenIfAPrefetchWorkflowFails() throws {
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: [
+            .init(id: "wf_a", displayName: "A", offeringId: nil, prefetch: true),
+            .init(id: "wf_b", displayName: "B", offeringId: nil, prefetch: true)
+        ]))
+        self.mockWorkflowsAPI.shouldStoreGetWorkflowCompletions = true
+
+        var completed = false
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false) { completed = true }
+
+        self.mockWorkflowsAPI.completeStoredGetWorkflow(workflowId: "wf_a",
+                                                        with: .success(try Self.workflowDataResult(id: "wf_a")))
+        expect(completed) == false
+        self.mockWorkflowsAPI.completeStoredGetWorkflow(workflowId: "wf_b", with: .failure(.missingAppUserID()))
+        expect(completed) == true
+    }
+
+    func testGetWorkflowsListCallsOnCompleteAfterNetworkError() {
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .failure(.missingAppUserID())
+
+        var completed = false
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false) { completed = true }
+
+        expect(completed) == true
+    }
+
+    // MARK: - Helpers
+
+    private static func workflowDataResult(id: String) throws -> WorkflowDataResult {
+        return .init(workflow: try self.publishedWorkflow(id: id), enrolledVariants: nil)
+    }
+
+    private static func publishedWorkflow(id: String) throws -> PublishedWorkflow {
+        let json = """
+        {
+          "id": "\(id)",
+          "display_name": "Test",
+          "initial_step_id": "step_1",
+          "steps": {
+            "step_1": { "id": "step_1", "type": "screen", "screen_id": "screen_1" }
+          },
+          "screens": {
+            "screen_1": {
+              "template_name": "tmpl",
+              "asset_base_url": "https://assets.revenuecat.com",
+              "default_locale": "en_US",
+              "components_localizations": {},
+              "components_config": {
+                "base": {
+                  "stack": {
+                    "type": "stack",
+                    "components": [],
+                    "dimension": { "type": "vertical", "alignment": "center", "distribution": "center" },
+                    "size": { "width": { "type": "fill" }, "height": { "type": "fill" } },
+                    "padding": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 },
+                    "margin": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 }
+                  },
+                  "background": {
+                    "type": "color",
+                    "value": { "light": { "type": "hex", "value": "#FFFFFF" } }
+                  }
+                }
+              },
+              "offering_identifier": "default"
+            }
+          },
+          "ui_config": {
+            "app": { "colors": {}, "fonts": {} },
+            "localizations": {}
+          }
+        }
+        """
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        return try JSONDecoder.default.decode(PublishedWorkflow.self, from: data)
+    }
+
+}

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -252,6 +252,12 @@ class PurchasesSubscriberAttributesTests: TestCase {
                               eventsManager: nil,
                               productsManager: mockProductsManager,
                               offeringsManager: mockOfferingsManager,
+                              workflowManager: WorkflowManager(
+                                backend: mockBackend,
+                                workflowsCache: WorkflowsCache(deviceCache: mockDeviceCache),
+                                paywallCache: MockPaywallCacheWarming(),
+                                operationDispatcher: mockOperationDispatcher
+                              ),
                               offlineEntitlementsManager: mockOfflineEntitlementsManager,
                               purchasesOrchestrator: purchasesOrchestrator,
                               purchasedProductsFetcher: mockPurchasedProductsFetcher,


### PR DESCRIPTION
Port of https://github.com/RevenueCat/purchases-android/pull/3508 (2 of 3). The cache foundation (#6881) is already merged, so this now sits directly on `main`.

This is the orchestration layer on top of the `WorkflowsCache`.

## What Changed

- New `WorkflowManager` (parallels `OfferingsManager`):
  - `getWorkflow` serves a fresh cached workflow straight from `WorkflowsCache` (no backend round-trip); on a miss it fetches, caches, and warms up the assets.
  - `getWorkflowsList` fetches the paywall workflows list, persists it, builds the `offeringId → workflowId` map, and prefetches every entry flagged `prefetch == true`. `onComplete` fires only after the list fetch **and** all prefetches finish (lock-guarded counter). On a backend failure it still fires, after restoring the map from disk (kept stale so the next call retries), so whoever's waiting on it is never left hanging.
  - `workflowId(forOfferingId:)` exposes the map.
- `Purchases.workflow(forOfferingIdentifier:)` now goes through `WorkflowManager`: it resolves the offeringId via the map and falls back to the offering identifier itself as the workflow key. The map is empty until the list is fetched (that wiring is PR 3), so behavior is unchanged for now.
- Wired `WorkflowsCache` + `WorkflowManager` into `PurchasesFactory`.

## Notes

- Android dedups in-flight requests itself; we don't need that since `CallbackCache` already does. I only ported the higher-level "fire once the list + prefetches are done" aggregation.
- Asset warm-up now happens on a cache **miss** instead of on every `workflow(forOfferingIdentifier:)` call. Same net effect (assets get warmed when the cache is populated), just not redundantly re-warmed on cache hits. Flagging it so it doesn't read as an oversight.
- Failure recovery restores the list from disk as **stale** (via `WorkflowsCache.restoreWorkflowsListFromDisk()`) rather than re-caching it as fresh, so the map keeps resolving but the next fetch still retries the backend, mirroring how the offerings cache serves its disk copy. Android currently marks it fresh, so this intentionally diverges; worth aligning Android later.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches paywall workflow loading and caching in Purchases; behavior is mostly gated until list fetch is wired, but cache/TTL and failure-recovery paths affect which workflow id and assets load.
> 
> **Overview**
> Introduces **`WorkflowManager`** as the orchestration layer over `WorkflowsCache` and `WorkflowsAPI`, parallel to how offerings use `OfferingsManager`.
> 
> **`getWorkflow`** returns fresh in-memory workflow data without a network call; on miss/stale it fetches, caches, and **warms paywall assets only on that path** (no longer on every `Purchases.workflow` call). **`getWorkflowsList`** loads the paywall workflows list, persists it, builds **`offeringId → workflowId`**, and prefetches entries with `prefetch == true`, with **`onComplete` after list + all prefetches** (or immediately if list cache is fresh). On list fetch failure it logs a new paywall string, **restores the map from disk as stale** via `WorkflowsCache.restoreWorkflowsListFromDisk()`, and still calls `onComplete`.
> 
> **`Purchases`** now owns shared `WorkflowsCache` + `WorkflowManager`; **`workflow(forOfferingIdentifier:)`** resolves workflow id from the map when present, else uses the offering id, and delegates to `WorkflowManager`. List fetch wiring to offerings is left for a follow-up PR, so runtime behavior is unchanged until then.
> 
> Tests: **`WorkflowManagerTests`**, **`PurchasesWorkflowTests`**, and richer **`MockWorkflowsAPI`**; Xcode project entries for new sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23ed6c561bc78baaa1370b7a20011b4c890c9cf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

