### PR TITLE
Fix flaky tests caused by data races in MockDeviceCache

### DIFF
--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -606,11 +606,6 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
 
         let product = try await self.monthlyPackage.storeProduct
 
-        // Flush any pending network activity from configuration (e.g. a CustomerInfo refresh)
-        // before clearing messages, so a background request doesn't race with the assertion
-        // below and cause a false failure.
-        _ = try await self.purchases.customerInfo(fetchPolicy: .fetchCurrent)
-
         self.logger.clearMessages()
 
         _ = try await self.purchases.checkTrialOrIntroDiscountEligibility(product: product)

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -606,6 +606,11 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
 
         let product = try await self.monthlyPackage.storeProduct
 
+        // Flush any pending network activity from configuration (e.g. a CustomerInfo refresh)
+        // before clearing messages, so a background request doesn't race with the assertion
+        // below and cause a false failure.
+        _ = try await self.purchases.customerInfo(fetchPolicy: .fetchCurrent)
+
         self.logger.clearMessages()
 
         _ = try await self.purchases.checkTrialOrIntroDiscountEligibility(product: product)

--- a/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
@@ -101,9 +101,6 @@ class StoreKit1ObserverModeIntegrationTests: BaseStoreKitObserverModeIntegration
     func testPurchaseOutsideTheAppUpdatesCustomerInfoDelegate() async throws {
         try self.testSession.buyProduct(productIdentifier: Self.monthlyNoIntroProductID)
 
-        // In observer mode the purchase is made outside the SDK, so it's only observed
-        // asynchronously via StoreKit's transaction updates. In SK2 this can take a bit
-        // longer, so we poll with a generous timeout to avoid flaking under CI load.
         try await asyncWait(
             description: "Delegate should be notified",
             timeout: .seconds(10),

--- a/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
@@ -101,9 +101,13 @@ class StoreKit1ObserverModeIntegrationTests: BaseStoreKitObserverModeIntegration
     func testPurchaseOutsideTheAppUpdatesCustomerInfoDelegate() async throws {
         try self.testSession.buyProduct(productIdentifier: Self.monthlyNoIntroProductID)
 
+        // In JWS mode, transaction takes a bit longer to be processed after `buyProduct`.
+        // We need to wait so the SDK observes it before expecting the delegate to be notified.
+        try await self.waitUntilUnfinishedTransactions { $0 == 1 }
+
         try await asyncWait(
             description: "Delegate should be notified",
-            timeout: .seconds(4),
+            timeout: .seconds(10),
             pollInterval: .milliseconds(100)
         ) {
             await self.purchasesDelegate.customerInfo?.entitlements.active.isEmpty == false

--- a/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
@@ -101,10 +101,9 @@ class StoreKit1ObserverModeIntegrationTests: BaseStoreKitObserverModeIntegration
     func testPurchaseOutsideTheAppUpdatesCustomerInfoDelegate() async throws {
         try self.testSession.buyProduct(productIdentifier: Self.monthlyNoIntroProductID)
 
-        // In JWS mode, transaction takes a bit longer to be processed after `buyProduct`.
-        // We need to wait so the SDK observes it before expecting the delegate to be notified.
-        try await self.waitUntilUnfinishedTransactions { $0 == 1 }
-
+        // In observer mode the purchase is made outside the SDK, so it's only observed
+        // asynchronously via StoreKit's transaction updates. In SK2 this can take a bit
+        // longer, so we poll with a generous timeout to avoid flaking under CI load.
         try await asyncWait(
             description: "Delegate should be notified",
             timeout: .seconds(10),

--- a/Tests/UnitTests/Mocks/MockDeviceCache.swift
+++ b/Tests/UnitTests/Mocks/MockDeviceCache.swift
@@ -66,8 +66,16 @@ class MockDeviceCache: DeviceCache {
         get { self._cachedCustomerInfoCount.value }
         set { self._cachedCustomerInfoCount.value = newValue }
     }
-    var clearCustomerInfoCacheTimestampCount = 0
-    var setCustomerInfoCacheTimestampToNowCount = 0
+    private let _clearCustomerInfoCacheTimestampCount: Atomic<Int> = .init(0)
+    var clearCustomerInfoCacheTimestampCount: Int {
+        get { self._clearCustomerInfoCacheTimestampCount.value }
+        set { self._clearCustomerInfoCacheTimestampCount.value = newValue }
+    }
+    private let _setCustomerInfoCacheTimestampToNowCount: Atomic<Int> = .init(0)
+    var setCustomerInfoCacheTimestampToNowCount: Int {
+        get { self._setCustomerInfoCacheTimestampToNowCount.value }
+        set { self._setCustomerInfoCacheTimestampToNowCount.value = newValue }
+    }
     var stubbedIsCustomerInfoCacheStale = false
     private let _cachedCustomerInfo: Atomic<[String: Data]> = .init([:])
     var cachedCustomerInfo: [String: Data] {
@@ -90,7 +98,7 @@ class MockDeviceCache: DeviceCache {
     }
 
     override func clearCustomerInfoCacheTimestamp(appUserID: String) {
-        clearCustomerInfoCacheTimestampCount += 1
+        self._clearCustomerInfoCacheTimestampCount.modify { $0 += 1 }
     }
 
     // MARK: offerings

--- a/Tests/UnitTests/Mocks/MockDeviceCache.swift
+++ b/Tests/UnitTests/Mocks/MockDeviceCache.swift
@@ -274,7 +274,7 @@ class MockDeviceCache: DeviceCache {
     var invokedClearCustomerInfoCacheParametersList = [(appUserID: String, Void)]()
 
     override func clearCustomerInfoCache(appUserID: String) {
-        cachedCustomerInfo.removeValue(forKey: appUserID)
+        self._cachedCustomerInfo.modify { $0.removeValue(forKey: appUserID) }
         invokedClearCustomerInfoCache = true
         invokedClearCustomerInfoCacheCount += 1
         invokedClearCustomerInfoCacheParameters = (appUserID, ())

--- a/Tests/UnitTests/Mocks/MockDeviceCache.swift
+++ b/Tests/UnitTests/Mocks/MockDeviceCache.swift
@@ -53,21 +53,36 @@ class MockDeviceCache: DeviceCache {
     }
 
     // MARK: customerInfo
-    var cacheCustomerInfoCount = 0
-    var cachedCustomerInfoCount = 0
+    // Backed by `Atomic` because the SDK reads and writes this state from multiple threads
+    // concurrently (e.g. configuration + foreground-delegate sync), which would otherwise
+    // corrupt the underlying dictionary. Exposed via computed properties so call sites are unchanged.
+    private let _cacheCustomerInfoCount: Atomic<Int> = .init(0)
+    var cacheCustomerInfoCount: Int {
+        get { self._cacheCustomerInfoCount.value }
+        set { self._cacheCustomerInfoCount.value = newValue }
+    }
+    private let _cachedCustomerInfoCount: Atomic<Int> = .init(0)
+    var cachedCustomerInfoCount: Int {
+        get { self._cachedCustomerInfoCount.value }
+        set { self._cachedCustomerInfoCount.value = newValue }
+    }
     var clearCustomerInfoCacheTimestampCount = 0
     var setCustomerInfoCacheTimestampToNowCount = 0
     var stubbedIsCustomerInfoCacheStale = false
-    var cachedCustomerInfo = [String: Data]()
+    private let _cachedCustomerInfo: Atomic<[String: Data]> = .init([:])
+    var cachedCustomerInfo: [String: Data] {
+        get { self._cachedCustomerInfo.value }
+        set { self._cachedCustomerInfo.value = newValue }
+    }
 
     override func cache(customerInfo: Data, appUserID: String) {
-        cacheCustomerInfoCount += 1
-        cachedCustomerInfo[appUserID] = customerInfo as Data?
+        self._cacheCustomerInfoCount.modify { $0 += 1 }
+        self._cachedCustomerInfo.modify { $0[appUserID] = customerInfo }
     }
 
     override func cachedCustomerInfoData(appUserID: String) -> Data? {
-        cachedCustomerInfoCount += 1
-        return cachedCustomerInfo[appUserID]
+        self._cachedCustomerInfoCount.modify { $0 += 1 }
+        return self._cachedCustomerInfo.value[appUserID]
     }
 
     override func isCustomerInfoCacheStale(appUserID: String, isAppBackgrounded: Bool) -> Bool {


### PR DESCRIPTION
- Fixes data races caused by `MockDeviceCache` possibly being accessed from multiple threads at the same time in tests. This was fixed by backing the fields with `Atomic<T>` and updating the relevant callsites to use the `.modify {}` method. 
- Increased timeout on `testPurchaseOutsideTheAppUpdatesCustomerInfoDelegate` in an attempt to reduce flakiness there as well.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only mock changes with no production SDK behavior; aligns with existing Atomic usage in other mocks.
> 
> **Overview**
> Makes **customer info** tracking in `MockDeviceCache` thread-safe so unit tests match concurrent SDK access (e.g. configure + foreground sync).
> 
> Counters (`cacheCustomerInfoCount`, `cachedCustomerInfoCount`, etc.) and the `cachedCustomerInfo` dictionary are backed by private `Atomic` storage with the same public property names. Overrides use `modify` for increments and dictionary updates instead of non-atomic `+=` and subscript writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a8e91fa9fa0b9feb375bfbee04c84738ed5e34b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->