### PR TITLE
[Billing Plans]: Only return intro offers on billing plan when fetching for a billing plan product

### DIFF
--- a/Sources/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
@@ -110,7 +110,7 @@ internal struct SK2StoreProduct: StoreProductType {
         }
 
         #if compiler(>=6.3.2)
-        if self.compoundProductIdentifier.productPlanIdentifier != nil,
+        if self.representsBillingPlan,
            #available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *) {
 
             return self.pricingTerms?.subscriptionOffers
@@ -127,7 +127,7 @@ internal struct SK2StoreProduct: StoreProductType {
 
     var discounts: [StoreProductDiscount] {
         #if compiler(>=6.3.2)
-        if self.compoundProductIdentifier.productPlanIdentifier != nil,
+        if self.representsBillingPlan,
            #available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *) {
             let promotionalOffersOnApplicablePricingTerms = self.pricingTerms
                 .map({
@@ -145,6 +145,11 @@ internal struct SK2StoreProduct: StoreProductType {
     }
 
     var id: String { return self.compoundProductIdentifier.compoundProductIdentifier }
+
+    /// Whether this product represents a specific billing plan rather than the base product.
+    var representsBillingPlan: Bool {
+        self.compoundProductIdentifier.productPlanIdentifier != nil
+    }
 }
 
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)

--- a/Sources/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
@@ -20,6 +20,9 @@ internal struct SK2StoreProduct: StoreProductType {
         self._underlyingSK2Product = .init(sk2Product)
         self.compoundProductIdentifier = CompoundProductIdentifier(for: sk2Product)
         self.installmentsInfo = nil
+        #if compiler(>=6.3.2)
+        self._pricingTerms = nil
+        #endif
     }
 
     @available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *)
@@ -31,6 +34,9 @@ internal struct SK2StoreProduct: StoreProductType {
         self._underlyingSK2Product = .init(sk2Product)
         self.compoundProductIdentifier = compoundProductIdentifier
         self.installmentsInfo = installmentsInfo
+        #if compiler(>=6.3.2)
+        self._pricingTerms = Self.pricingTerms(for: sk2Product, installmentsInfo: installmentsInfo)
+        #endif
     }
 
     // We can't directly store instances of StoreKit.Product, since that causes
@@ -45,6 +51,10 @@ internal struct SK2StoreProduct: StoreProductType {
     private let priceFormatterProvider: PriceFormatterProvider = .init()
 
     let installmentsInfo: InstallmentsInfo?
+
+    #if compiler(>=6.3.2)
+    private let _pricingTerms: (any Sendable)?
+    #endif
 
     var productCategory: StoreProduct.ProductCategory {
         return self.productType.productCategory
@@ -94,19 +104,32 @@ internal struct SK2StoreProduct: StoreProductType {
     }
 
     var introductoryDiscount: StoreProductDiscount? {
-        self.underlyingSK2Product.subscription?.introductoryOffer
-            .flatMap { StoreProductDiscount(sk2Discount: $0, currencyCode: self.currencyCode) }
+        func introductoryDiscountOnProduct() -> StoreProductDiscount? {
+            return self.underlyingSK2Product.subscription?.introductoryOffer
+                .flatMap { StoreProductDiscount(sk2Discount: $0, currencyCode: self.currencyCode) }
+        }
+
+        #if compiler(>=6.3.2)
+        if self.compoundProductIdentifier.productPlanIdentifier != nil,
+           #available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *) {
+
+            return self.pricingTerms?.subscriptionOffers
+                .filter({ $0.type == .introductory })
+                .first
+                .flatMap { StoreProductDiscount(sk2Discount: $0, currencyCode: self.currencyCode) }
+        } else {
+            return introductoryDiscountOnProduct()
+        }
+        #else
+        return introductoryDiscountOnProduct()
+        #endif
     }
 
     var discounts: [StoreProductDiscount] {
         #if compiler(>=6.3.2)
-        if #available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *),
-           let billingPlan = self.installmentsInfo?.billingPlanType {
-            let promotionalOffersOnApplicablePricingTerms = self
-                .underlyingSK2Product
-                .subscription?
-                .pricingTerms
-                .first(where: { $0.billingPlanType == billingPlan.skBillingPlanType })
+        if self.compoundProductIdentifier.productPlanIdentifier != nil,
+           #available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *) {
+            let promotionalOffersOnApplicablePricingTerms = self.pricingTerms
                 .map({
                     $0.subscriptionOffers.filter({ $0.type == .promotional })
                         .compactMap { StoreProductDiscount(sk2Discount: $0, currencyCode: self.currencyCode) }
@@ -168,20 +191,13 @@ private extension SK2StoreProduct {
 #if compiler(>=6.3.2)
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 extension SK2StoreProduct {
-    func contains(
-        subscriptionOfferType: StoreKit.Product.SubscriptionOffer.OfferType,
-        on billingPlanType: BillingPlanType
+    func containsSubscriptionOfferTypeOnBillingPlan(
+        subscriptionOfferType: StoreKit.Product.SubscriptionOffer.OfferType
     ) -> Bool {
-        if let subscription = self.underlyingSK2Product.subscription,
-            #available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *) {
-            // Check to make sure that an intro offer is available on the billing plan
-            guard let applicablePricingTerms = subscription.pricingTerms.first(where: {
-                $0.billingPlanType == billingPlanType.skBillingPlanType
-            }) else {
-                return false
-            }
+        if #available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *) {
+            guard let pricingTerms = self.pricingTerms else { return false }
 
-            return applicablePricingTerms.subscriptionOffers.contains(where: {
+            return pricingTerms.subscriptionOffers.contains(where: {
                 $0.type == subscriptionOfferType
             })
         } else {
@@ -190,6 +206,29 @@ extension SK2StoreProduct {
         }
     }
 }
+
+@available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *)
+private extension SK2StoreProduct {
+
+    var pricingTerms: StoreKit.Product.SubscriptionInfo.PricingTerms? {
+        return self._pricingTerms as? StoreKit.Product.SubscriptionInfo.PricingTerms
+    }
+
+    static func pricingTerms(
+        for sk2Product: SK2Product,
+        installmentsInfo: InstallmentsInfo?
+    ) -> StoreKit.Product.SubscriptionInfo.PricingTerms? {
+        guard let billingPlan = installmentsInfo?.billingPlanType else {
+            return nil
+        }
+
+        return sk2Product
+            .subscription?
+            .pricingTerms
+            .first(where: { $0.billingPlanType == billingPlan.skBillingPlanType })
+    }
+}
+
 #endif
 
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)

--- a/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -171,7 +171,7 @@ class TrialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityCheckerTy
         let sk2Product = sk2StoreProduct.underlyingSK2Product
 
         #if compiler(>=6.3.2)
-        if sk2StoreProduct.installmentsInfo != nil,
+        if sk2StoreProduct.representsBillingPlan,
            let subscription = sk2Product.subscription {
             let billingPlanContainsIntroOffer = sk2StoreProduct.containsSubscriptionOfferTypeOnBillingPlan(
                 subscriptionOfferType: .introductory

--- a/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -171,11 +171,10 @@ class TrialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityCheckerTy
         let sk2Product = sk2StoreProduct.underlyingSK2Product
 
         #if compiler(>=6.3.2)
-        if let installmentsInfo = sk2StoreProduct.installmentsInfo,
+        if sk2StoreProduct.installmentsInfo != nil,
            let subscription = sk2Product.subscription {
-            let billingPlanContainsIntroOffer = sk2StoreProduct.contains(
-                subscriptionOfferType: .introductory,
-                on: installmentsInfo.billingPlanType
+            let billingPlanContainsIntroOffer = sk2StoreProduct.containsSubscriptionOfferTypeOnBillingPlan(
+                subscriptionOfferType: .introductory
             )
 
             guard billingPlanContainsIntroOffer else {

--- a/Tests/StoreKitUnitTests/StoreProductTests.swift
+++ b/Tests/StoreKitUnitTests/StoreProductTests.swift
@@ -558,6 +558,30 @@ extension StoreProductTests {
         expect(storeProduct.id) == Self.productID
     }
 
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    func testRepresentsBillingPlanReturnsFalseForSK2ProductWithoutProductPlanIdentifier() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        let storeProduct = try await self.fetchSk2StoreProduct(Self.productID)
+        expect(storeProduct.representsBillingPlan) == false
+    }
+
+    @available(iOS 26.4, tvOS 26.4, macOS 26.4, watchOS 26.4, visionOS 26.4, *)
+    func testRepresentsBillingPlanReturnsTrueForSK2ProductWithProductPlanIdentifier() async throws {
+        try AvailabilityChecks.iOS264APIAvailableOrSkipTest()
+
+        let productIdentifier = "com.revenuecat.annual_with_commitment"
+        let compoundProductIdentifier = try XCTUnwrap(CompoundProductIdentifier(
+            compoundProductIdentifier: "\(productIdentifier):monthly"
+        ))
+        let storeProduct = SK2StoreProduct(
+            sk2Product: try await self.fetchSk2Product(productIdentifier),
+            compoundProductIdentifier: compoundProductIdentifier
+        )
+
+        expect(storeProduct.representsBillingPlan) == true
+    }
+
     func testIdAddsMonthlyProductPlanIdentifierForMonthlyInstallmentsInfo() throws {
         let productIdentifier = "com.revenuecat.product"
         let storeProduct = Self.testProduct(


### PR DESCRIPTION
### Description
This PR fixes a bug where we would return intro offers on the main StoreKit product for products represented by a billing plan. This meant that if an upFront variation of a product had an intro offer, but the `monthly` billing plan did not, `StoreProduct.introductoryDiscount` would return the intro offer, even though it isn't present on the monthly billing plan.

### Testing
- Manually verified the changes
- Unable to write effective tests due to the SKTestSession bug with SKConfig files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes purchase-facing offer and intro-eligibility behavior for billing-plan SK2 products on iOS 26.4+; wrong pricing-term selection would mislead paywalls but scope is narrow and guarded by compiler/OS availability.
> 
> **Overview**
> Fixes **billing-plan** `StoreProduct` instances incorrectly surfacing **introductory** and **promotional** offers from the base StoreKit subscription when those offers exist only on other pricing terms (e.g. up-front vs monthly).
> 
> `SK2StoreProduct` now treats a product as a billing plan when `compoundProductIdentifier` includes a **product plan id**, caches the matching **`pricingTerms`** at init, and uses that slice for `introductoryDiscount`, `discounts`, and intro-eligibility checks instead of the subscription-level offers. Eligibility uses the renamed **`containsSubscriptionOfferTypeOnBillingPlan`** helper. Unit tests cover **`representsBillingPlan`** for with/without plan id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 094317baa8c95cdcd521b1216a8ff81986db35db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->