### PR TITLE
Log reward verification failure reason

### DIFF
--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/Logging/Strings/RewardVerificationStrings.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/Logging/Strings/RewardVerificationStrings.swift
@@ -15,7 +15,6 @@ enum RewardVerificationStrings {
     case setup_purchases_not_configured
     case setup_install(adType: String, transactionID: String)
 
-    case outcome_cancelled(transactionID: String)
     case outcome_suppressed(transactionID: String)
 
     case result_callback_requires_enable
@@ -31,9 +30,6 @@ extension RewardVerificationStrings: LogMessage {
         case let .setup_install(adType, transactionID):
             return "Reward verification install on ad type=\(adType) transactionID=\(transactionID)"
 
-        case let .outcome_cancelled(transactionID):
-            return "Reward verification outcome cancelled (task cancelled before delivery) " +
-                "transactionID=\(transactionID)"
         case let .outcome_suppressed(transactionID):
             return "Reward verification outcome suppressed (token already consumed) transactionID=\(transactionID)"
 

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/Dispatcher.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/Dispatcher.swift
@@ -16,9 +16,7 @@ internal extension RewardVerification {
     enum Dispatcher {
 
         /// Awaits the verification result, then hops to the main actor to deliver it under the
-        /// one-shot guard. Always delivers exactly one result (including on cancellation, where the
-        /// poll resolves to `.failed`) so the result callback's always-fires contract holds and no
-        /// continuation is ever stranded.
+        /// one-shot guard.
         static func run(
             clientTransactionID: String,
             state: State,

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/Dispatcher.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/Dispatcher.swift
@@ -16,8 +16,9 @@ internal extension RewardVerification {
     enum Dispatcher {
 
         /// Awaits the verification result, then hops to the main actor to deliver it under the
-        /// one-shot guard. If the surrounding `Task` was cancelled, returns without firing so
-        /// `state.consumeFireToken()` stays available for a later dispatch.
+        /// one-shot guard. Always delivers exactly one result (including on cancellation, where the
+        /// poll resolves to `.failed`) so the result callback's always-fires contract holds and no
+        /// continuation is ever stranded.
         static func run(
             clientTransactionID: String,
             state: State,
@@ -26,13 +27,7 @@ internal extension RewardVerification {
         ) async {
             let result = await pollRewardVerification(clientTransactionID)
 
-            // Production never cancels this task, but if a future caller (or a test) does,
-            // skip the delivery and preserve the token instead of burning it.
             await MainActor.run {
-                if Task.isCancelled {
-                    Logger.debug(RewardVerificationStrings.outcome_cancelled(transactionID: clientTransactionID))
-                    return
-                }
                 guard state.consumeFireToken() else {
                     Logger.debug(RewardVerificationStrings.outcome_suppressed(transactionID: clientTransactionID))
                     return

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/DispatcherTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/DispatcherTests.swift
@@ -115,29 +115,40 @@ final class DispatcherTests: AdapterTestCase {
         XCTAssertEqual(recorder.snapshot().first?.verifiedReward, .unsupportedReward)
     }
 
-    func testDispatchCancellationDoesNotFireHandlerAndPreservesGuard() async {
+    func testDispatchCancellationStillDeliversFailedAndConsumesGuard() async {
+        // The result callback's contract is that it always fires exactly once. On cancellation the
+        // poll resolves to `.failed` and the dispatcher still delivers it (rather than silently
+        // dropping the callback and stranding the caller).
         let state = RewardVerification.State(clientTransactionID: "tx-dispatch-cancel")
         let recorder = ResultRecorder()
+        let pollStarted = MainActorAssertionRecorder()
 
         let task = RewardVerification.Dispatcher.dispatch(
             clientTransactionID: state.clientTransactionID,
             state: state,
             pollRewardVerification: { _ in
-                try? await Task.sleep(nanoseconds: UInt64.max)
+                pollStarted.markFired()
+                // Hang cooperatively until cancelled, then resolve to `.failed` (mirrors the core
+                // poller mapping cancellation → `.failed`).
+                while !Task.isCancelled {
+                    try? await Task.sleep(nanoseconds: 1_000_000)
+                }
                 return .failed
             },
             resultHandler: { recorder.append($0) }
         )
 
-        // Yield once so the dispatched Task starts and is parked inside the hanging poll before cancel.
-        await Task.yield()
+        // Wait until the poll is in-flight before cancelling so cancellation interrupts it.
+        while !pollStarted.didFire {
+            await Task.yield()
+        }
         task.cancel()
         await task.value
 
-        XCTAssertTrue(recorder.snapshot().isEmpty,
-                      "Cancelling the dispatched task must not deliver a result")
-        XCTAssertTrue(state.consumeFireToken(),
-                      "Cancellation must leave the one-shot guard intact for a later attempt")
+        XCTAssertEqual(recorder.snapshot(), [.failed],
+                       "Cancellation must still deliver exactly one .failed result")
+        XCTAssertFalse(state.consumeFireToken(),
+                       "Delivering the cancellation result must consume the one-shot guard")
     }
 
     // MARK: - Threading

--- a/Sources/Ads/RewardVerification/Networking/RewardVerificationStatusResponse.swift
+++ b/Sources/Ads/RewardVerification/Networking/RewardVerificationStatusResponse.swift
@@ -21,8 +21,22 @@ struct RewardVerificationStatusResponse: Equatable {
 
         case verified(AdReward)
         case pending
-        case failed
+        case failed(Failure)
         case unknown
+
+    }
+
+    /// Backend-provided detail accompanying a `failed` status.
+    ///
+    /// Both fields are optional: older backends (and the no-record/feature-off paths) may omit them.
+    struct Failure: Equatable {
+
+        /// Raw `failure_reason` wire value (e.g. `no_access`). Stored as-is for forward
+        /// compatibility — unrecognized values are kept rather than dropped. `nil` when absent.
+        let reason: String?
+
+        /// Human-readable cause, logged verbatim. `nil` when absent.
+        let message: String?
 
     }
 }
@@ -32,6 +46,10 @@ extension RewardVerificationStatusResponse: Decodable {
     private enum CodingKeys: String, CodingKey {
         case status
         case reward
+        // `JSONDecoder.default` uses `.convertFromSnakeCase`, so the wire key `failure_reason`
+        // is converted to `failureReason` before matching — use the camelCase name here.
+        case failureReason
+        case message
     }
 
     private enum RewardCodingKeys: String, CodingKey {
@@ -60,11 +78,21 @@ extension RewardVerificationStatusResponse: Decodable {
         case "pending":
             return .pending
         case "failed":
-            return .failed
+            return .failed(Self.decodeFailure(from: container))
         default:
             Logger.warn(Strings.backendError.unknown_reward_verification_status(status: rawStatus))
             return .unknown
         }
+    }
+
+    private static func decodeFailure(
+        from container: KeyedDecodingContainer<CodingKeys>
+    ) -> Failure {
+        // Both fields are best-effort: a malformed/absent value degrades to `nil` rather than
+        // failing the decode, so a `failed` status is never lost over a missing reason/message.
+        let reason = (try? container.decodeIfPresent(String.self, forKey: .failureReason)) ?? nil
+        let message = (try? container.decodeIfPresent(String.self, forKey: .message)) ?? nil
+        return Failure(reason: reason, message: message)
     }
 
     private static func decodeVerifiedReward(

--- a/Sources/Ads/RewardVerification/Networking/RewardVerificationStatusResponse.swift
+++ b/Sources/Ads/RewardVerification/Networking/RewardVerificationStatusResponse.swift
@@ -46,8 +46,6 @@ extension RewardVerificationStatusResponse: Decodable {
     private enum CodingKeys: String, CodingKey {
         case status
         case reward
-        // `JSONDecoder.default` uses `.convertFromSnakeCase`, so the wire key `failure_reason`
-        // is converted to `failureReason` before matching — use the camelCase name here.
         case failureReason
         case message
     }
@@ -88,10 +86,8 @@ extension RewardVerificationStatusResponse: Decodable {
     private static func decodeFailure(
         from container: KeyedDecodingContainer<CodingKeys>
     ) -> Failure {
-        // Both fields are best-effort: a malformed/absent value degrades to `nil` rather than
-        // failing the decode, so a `failed` status is never lost over a missing reason/message.
-        let reason = (try? container.decodeIfPresent(String.self, forKey: .failureReason)) ?? nil
-        let message = (try? container.decodeIfPresent(String.self, forKey: .message)) ?? nil
+        let reason = try? container.decodeIfPresent(String.self, forKey: .failureReason)
+        let message = try? container.decodeIfPresent(String.self, forKey: .message)
         return Failure(reason: reason, message: message)
     }
 

--- a/Sources/Ads/RewardVerification/Outcome.swift
+++ b/Sources/Ads/RewardVerification/Outcome.swift
@@ -14,7 +14,7 @@ import Foundation
 
 internal extension RewardVerification {
 
-    /// Terminal SSV verdict delivered by `Dispatcher`.
+    /// Terminal SSV verdict from the polling loop.
     enum Outcome: Sendable {
         case verified(AdReward)
         case failed(FailureReason)

--- a/Sources/Ads/RewardVerification/Outcome.swift
+++ b/Sources/Ads/RewardVerification/Outcome.swift
@@ -27,10 +27,33 @@ internal extension RewardVerification {
         }
     }
 
-    /// Internal classification of why verification failed.
+    /// Internal classification of *why* verification failed. Not exposed publicly — every case
+    /// maps to the binary public `RewardVerificationResult.failed`; it only drives the diagnostic
+    /// logged by ``Poller`` so the cause is visible without leaking new public surface.
     enum FailureReason: Sendable, Equatable {
-        case timeout
-        case backendError
-        case unknown
+
+        /// The backend definitively rejected the reward. `message` is the backend-provided,
+        /// human-readable cause (logged verbatim) and `reason` the raw `failure_reason` code
+        /// (e.g. `no_access`); either may be `nil`, but both are carried so the cause survives
+        /// when the backend supplies only one of them.
+        case backendRejected(reason: String?, message: String?)
+
+        /// Attempt budget exhausted while the status was still `pending` — the SSV callback
+        /// was never received in time.
+        case exhaustedPending
+
+        /// Attempt budget exhausted while repeatedly hitting transient errors (network / brief
+        /// backend unavailability).
+        case exhaustedTransient
+
+        /// Attempt budget exhausted after the backend returned a status this SDK doesn't recognize.
+        case unexpectedResponse
+
+        /// Polling stopped on an unrecoverable, non-retryable error (terminal transport/HTTP
+        /// failure or a decoding error). `error` is that error's description.
+        case terminalError(error: String)
+
+        /// The polling task was cancelled before completion.
+        case cancelled
     }
 }

--- a/Sources/Ads/RewardVerification/Poller.swift
+++ b/Sources/Ads/RewardVerification/Poller.swift
@@ -41,9 +41,10 @@ internal extension RewardVerification {
 
     /// Bounded polling loop. Retries `pending`/`unknown` statuses and transient `BackendError`
     /// throws within an attempt budget; everything else (terminal `BackendError`, sleeper failure,
-    /// any unrecognised throw) collapses to `.failed`. Honors `Task.isCancelled` between attempts
-    /// and after each attempt completes, mapping cancellation to `.failed(.cancelled)` and exiting
-    /// early without further polling.
+    /// any unrecognised throw) ends in `.failed` carrying a specific `FailureReason` (the binary
+    /// collapse to a public result happens upstream). Honors `Task.isCancelled` between attempts and
+    /// after each attempt completes, mapping cancellation to `.failed(.cancelled)` and exiting early
+    /// without further polling.
     struct Poller: Sendable {
 
         static let defaultMaxAttempts = 10

--- a/Sources/Ads/RewardVerification/Poller.swift
+++ b/Sources/Ads/RewardVerification/Poller.swift
@@ -41,8 +41,9 @@ internal extension RewardVerification {
 
     /// Bounded polling loop. Retries `pending`/`unknown` statuses and transient `BackendError`
     /// throws within an attempt budget; everything else (terminal `BackendError`, sleeper failure,
-    /// any unrecognised throw) collapses to `.failed`. Honors `Task.isCancelled` between
-    /// attempts and exits early without further polling.
+    /// any unrecognised throw) collapses to `.failed`. Honors `Task.isCancelled` between attempts
+    /// and after each attempt completes, mapping cancellation to `.failed(.cancelled)` and exiting
+    /// early without further polling.
     struct Poller: Sendable {
 
         static let defaultMaxAttempts = 10
@@ -79,6 +80,8 @@ internal extension RewardVerification {
                 maxAttempts: self.maxAttempts
             ))
 
+            var lastDisposition: PollDisposition = .pending
+
             for attempt in 0..<self.maxAttempts {
                 Logger.verbose(AdsStrings.poll_attempt(
                     attempt: attempt + 1,
@@ -87,47 +90,112 @@ internal extension RewardVerification {
                 ))
 
                 if Task.isCancelled {
-                    Logger.debug(AdsStrings.poll_cancelled(transactionID: clientTransactionID))
-                    return .failed(.unknown)
+                    Logger.warn(AdsStrings.poll_cancelled(transactionID: clientTransactionID))
+                    return .failed(.cancelled)
                 }
                 if attempt > 0 {
                     try? await self.sleeper.sleep(seconds: self.jitter.sample())
                 }
 
-                do {
-                    let status = try await self.statusPoller.pollStatus(
-                        clientTransactionID: clientTransactionID
-                    )
-                    Logger.debug(AdsStrings.poll_status(
-                        status: status.logDescription,
-                        transactionID: clientTransactionID
-                    ))
-                    switch status {
-                    case .verified(let reward): return .verified(reward)
-                    case .failed: return .failed(.backendError)
-                    case .pending, .unknown: continue
-                    }
-                } catch let error as BackendError where error.isTransient {
-                    Logger.debug(AdsStrings.poll_transient_error(
-                        error: error,
-                        transactionID: clientTransactionID
-                    ))
-                    continue
-                } catch {
-                    Logger.error(AdsStrings.poll_terminal_error(
-                        error: error,
-                        transactionID: clientTransactionID
-                    ))
-                    return .failed(error is BackendError ? .backendError : .unknown)
+                switch await self.pollOnce(clientTransactionID: clientTransactionID) {
+                case .finished(let outcome):
+                    return outcome
+                case .retry(let disposition):
+                    lastDisposition = disposition
                 }
             }
 
-            Logger.warn(AdsStrings.poll_exhausted(
-                maxAttempts: self.maxAttempts,
-                transactionID: clientTransactionID
+            return .failed(self.exhaustionReason(
+                for: lastDisposition,
+                clientTransactionID: clientTransactionID
             ))
-            return .failed(.timeout)
         }
+
+        /// Runs a single poll attempt: either a terminal `Outcome` or a `retry` carrying the
+        /// disposition to remember for exhaustion classification.
+        private func pollOnce(clientTransactionID: String) async -> PollAttemptResult {
+            do {
+                let status = try await self.statusPoller.pollStatus(
+                    clientTransactionID: clientTransactionID
+                )
+                // A cancellation that lands while the status request is in flight won't surface as a
+                // `CancellationError` if the request resolves successfully. Re-check before logging or
+                // acting on the status, so a late cancellation maps to `.failed(.cancelled)` instead of
+                // emitting a stale outcome (e.g. a backend-rejection warning the caller never receives).
+                if Task.isCancelled {
+                    Logger.warn(AdsStrings.poll_cancelled(transactionID: clientTransactionID))
+                    return .finished(.failed(.cancelled))
+                }
+                Logger.debug(AdsStrings.poll_status(
+                    status: status.logDescription,
+                    transactionID: clientTransactionID
+                ))
+                switch status {
+                case .verified(let reward):
+                    return .finished(.verified(reward))
+                case let .failed(reason, message):
+                    Logger.warn(AdsStrings.poll_backend_rejected(
+                        reason: reason,
+                        message: message,
+                        transactionID: clientTransactionID
+                    ))
+                    return .finished(.failed(.backendRejected(reason: reason, message: message)))
+                case .pending:
+                    return .retry(.pending)
+                case .unknown:
+                    return .retry(.unknownStatus)
+                }
+            } catch let error as BackendError where error.isTransient {
+                Logger.debug(AdsStrings.poll_transient_error(
+                    error: error,
+                    transactionID: clientTransactionID
+                ))
+                return .retry(.transient)
+            } catch is CancellationError {
+                Logger.warn(AdsStrings.poll_cancelled(transactionID: clientTransactionID))
+                return .finished(.failed(.cancelled))
+            } catch {
+                // A non-retryable transport/HTTP failure or a decoding error stopped the poll.
+                Logger.error(AdsStrings.poll_terminal_error(
+                    error: error,
+                    transactionID: clientTransactionID
+                ))
+                return .finished(.failed(.terminalError(error: "\(error)")))
+            }
+        }
+
+        /// Logs the diagnostic for an exhausted poll and returns the matching ``FailureReason``.
+        private func exhaustionReason(
+            for disposition: PollDisposition,
+            clientTransactionID: String
+        ) -> FailureReason {
+            switch disposition {
+            case .pending:
+                Logger.warn(AdsStrings.poll_exhausted_pending(transactionID: clientTransactionID))
+                return .exhaustedPending
+            case .transient:
+                Logger.warn(AdsStrings.poll_exhausted_transient(transactionID: clientTransactionID))
+                return .exhaustedTransient
+            case .unknownStatus:
+                Logger.warn(AdsStrings.poll_unexpected_response(transactionID: clientTransactionID))
+                return .unexpectedResponse
+            }
+        }
+    }
+
+    /// The most recent non-terminal result of a poll attempt, used to classify *why* the attempt
+    /// budget was exhausted (last-observed disposition wins).
+    enum PollDisposition {
+        case pending
+        case transient
+        case unknownStatus
+    }
+
+    /// Outcome of a single ``Poller`` attempt: a terminal result, or a retry carrying the
+    /// disposition to remember.
+    enum PollAttemptResult {
+        case finished(Outcome)
+        case retry(PollDisposition)
     }
 
     // MARK: - Production seam impls

--- a/Sources/Ads/RewardVerification/RewardVerificationPollStatus.swift
+++ b/Sources/Ads/RewardVerification/RewardVerificationPollStatus.swift
@@ -23,7 +23,12 @@ import Foundation
     case pending
 
     /// The reward postback was rejected by the backend.
-    case failed
+    ///
+    /// - Parameters:
+    ///   - reason: Raw `failure_reason` wire value (e.g. `no_access`), or `nil` when the backend
+    ///     didn't provide one. Kept as a string for forward compatibility.
+    ///   - message: Human-readable cause provided by the backend, logged verbatim, or `nil`.
+    case failed(reason: String?, message: String?)
 
     /// The backend returned an unrecognized status value.
     case unknown

--- a/Sources/Ads/RewardVerification/RewardVerificationPollStatus.swift
+++ b/Sources/Ads/RewardVerification/RewardVerificationPollStatus.swift
@@ -14,7 +14,7 @@
 import Foundation
 
 /// Result of a single ad reward verification status poll.
-@_spi(Internal) public enum RewardVerificationPollStatus: Sendable, Equatable {
+enum RewardVerificationPollStatus: Sendable, Equatable {
 
     /// Verified by the backend, with the granted reward payload.
     case verified(AdReward)

--- a/Sources/Logging/Strings/AdsStrings.swift
+++ b/Sources/Logging/Strings/AdsStrings.swift
@@ -67,11 +67,11 @@ extension AdsStrings: LogMessage {
                 ?? "the server rejected it."
             return "Reward verification failed: \(detail) transactionID=\(transactionID)"
         case let .poll_exhausted_pending(transactionID):
-            return "Reward verification timed out: the AdMob server-side verification (SSV) callback " +
+            return "Reward verification timed out: the server-side verification (SSV) callback " +
                 "was not received in time. Possible causes: SSV is not enabled/configured for this ad " +
-                "unit in the AdMob Dashboard, the SSV callback URL is misconfigured in the AdMob " +
-                "Dashboard, AdMob delayed delivering the callback, or RevenueCat failed to process the " +
-                "SSV webhook. transactionID=\(transactionID)"
+                "unit in your ad network's dashboard, the SSV callback URL is misconfigured, the ad " +
+                "network delayed delivering the callback, or RevenueCat failed to process the SSV " +
+                "webhook. transactionID=\(transactionID)"
         case let .poll_exhausted_transient(transactionID):
             return "Reward verification timed out after repeated transient errors while polling — " +
                 "typically unstable device network connectivity. The reward couldn't be verified. " +

--- a/Sources/Logging/Strings/AdsStrings.swift
+++ b/Sources/Logging/Strings/AdsStrings.swift
@@ -25,9 +25,14 @@ enum AdsStrings {
     case poll_attempt(attempt: Int, maxAttempts: Int, transactionID: String)
     case poll_status(status: String, transactionID: String)
     case poll_transient_error(error: Error, transactionID: String)
+
+    // Terminal failure diagnostics (one is logged when polling ends in `failed`).
+    case poll_backend_rejected(reason: String?, message: String?, transactionID: String)
+    case poll_exhausted_pending(transactionID: String)
+    case poll_exhausted_transient(transactionID: String)
+    case poll_unexpected_response(transactionID: String)
     case poll_terminal_error(error: Error, transactionID: String)
     case poll_cancelled(transactionID: String)
-    case poll_exhausted(maxAttempts: Int, transactionID: String)
     case reward_verification_completed(outcome: String, transactionID: String)
 
 }
@@ -53,12 +58,34 @@ extension AdsStrings: LogMessage {
             return "Reward verification poll status=\(status) transactionID=\(transactionID)"
         case let .poll_transient_error(error, transactionID):
             return "Reward verification poll transient error, retrying: \(error) transactionID=\(transactionID)"
+
+        case let .poll_backend_rejected(reason, message, transactionID):
+            // Prefer the human-readable message; fall back to the raw failure_reason code so the
+            // cause still surfaces when the backend sends a reason without a message.
+            let detail = message
+                ?? reason.map { "the server rejected it (reason: \($0))" }
+                ?? "the server rejected it."
+            return "Reward verification failed: \(detail) transactionID=\(transactionID)"
+        case let .poll_exhausted_pending(transactionID):
+            return "Reward verification timed out: the AdMob server-side verification (SSV) callback " +
+                "was not received in time. Possible causes: SSV is not enabled/configured for this ad " +
+                "unit in the AdMob Dashboard, the SSV callback URL is misconfigured in the AdMob " +
+                "Dashboard, AdMob delayed delivering the callback, or RevenueCat failed to process the " +
+                "SSV webhook. transactionID=\(transactionID)"
+        case let .poll_exhausted_transient(transactionID):
+            return "Reward verification timed out after repeated transient errors while polling — " +
+                "typically unstable device network connectivity. The reward couldn't be verified. " +
+                "transactionID=\(transactionID)"
+        case let .poll_unexpected_response(transactionID):
+            return "Reward verification stopped after the server returned a status this SDK version " +
+                "doesn't recognize. Update to the latest SDK version; if you're already on the latest, " +
+                "contact RevenueCat support. transactionID=\(transactionID)"
         case let .poll_terminal_error(error, transactionID):
-            return "Reward verification poll terminal error: \(error) transactionID=\(transactionID)"
+            return "Reward verification stopped after an unrecoverable error: \(error). This is " +
+                "unexpected; if it persists, contact RevenueCat support with the error above. " +
+                "transactionID=\(transactionID)"
         case let .poll_cancelled(transactionID):
-            return "Reward verification poll cancelled transactionID=\(transactionID)"
-        case let .poll_exhausted(maxAttempts, transactionID):
-            return "Reward verification poll exhausted \(maxAttempts) attempts transactionID=\(transactionID)"
+            return "Reward verification was cancelled before completion. transactionID=\(transactionID)"
         case let .reward_verification_completed(outcome, transactionID):
             return "Reward verification completed outcome=\(outcome) transactionID=\(transactionID)"
         }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1728,10 +1728,8 @@ extension Purchases {
 
     /// Polls the backend once for reward verification status using `client_transaction_id`.
     ///
-    /// Internal API for RC ad adapters.
-    ///
     /// Cancelling the calling `Task` does not cancel the in-flight HTTP request.
-    @_spi(Internal) public func pollRewardVerificationStatus(
+    func pollRewardVerificationStatus(
         clientTransactionID: String
     ) async throws -> RewardVerificationPollStatus {
         do {

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1762,8 +1762,8 @@ extension Purchases {
             return .verified(reward)
         case .pending:
             return .pending
-        case .failed:
-            return .failed
+        case let .failed(failure):
+            return .failed(reason: failure.reason, message: failure.message)
         case .unknown:
             return .unknown
         }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1722,7 +1722,7 @@ extension Purchases {
 
 }
 
-// MARK: - Reward Verification (Internal SPI)
+// MARK: - Reward Verification
 
 extension Purchases {
 

--- a/Tests/UnitTests/Ads/RewardVerification/RewardVerificationOutcomeTests.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/RewardVerificationOutcomeTests.swift
@@ -44,23 +44,17 @@ final class RewardVerificationOutcomeTests: TestCase {
         }
     }
 
-    func testAllCasesAreConstructibleAndExhaustiveInSwitch() throws {
-        let payload = try XCTUnwrap(VirtualCurrencyReward(code: "coins", amount: 1))
-        let cases: [RewardVerification.Outcome] = [
-            .verified(.virtualCurrency(payload)),
-            .verified(.noReward),
-            .verified(.unsupportedReward),
-            .failed(.timeout),
-            .failed(.backendError),
-            .failed(.unknown)
-        ]
-
-        for outcome in cases {
-            switch outcome {
-            case .verified: continue
-            case .failed: continue
-            }
+    func testFailedReasonsCarryTheirPayloads() {
+        let backendRejected = RewardVerification.Outcome.failed(
+            .backendRejected(reason: "no_access", message: "nope")
+        )
+        guard case .failed(.backendRejected("no_access", "nope")) = backendRejected else {
+            return XCTFail("Expected .failed(.backendRejected(\"no_access\", \"nope\")), got \(backendRejected)")
         }
-        XCTAssertEqual(cases.count, 6)
+
+        let terminal = RewardVerification.Outcome.failed(.terminalError(error: "boom"))
+        guard case .failed(.terminalError("boom")) = terminal else {
+            return XCTFail("Expected .failed(.terminalError(\"boom\")), got \(terminal)")
+        }
     }
 }

--- a/Tests/UnitTests/Ads/RewardVerification/RewardVerificationPollerTestDoubles.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/RewardVerificationPollerTestDoubles.swift
@@ -62,6 +62,34 @@ final class HangingStatusPoller: RewardVerificationStatusPolling, @unchecked Sen
     }
 }
 
+/// Signals that the in-flight `pollStatus` call has started, observes cancellation cooperatively
+/// (without throwing), then resolves to a successful status. Models the race where a status request
+/// completes successfully at the same moment the surrounding task is cancelled — the poller must
+/// still collapse that to `.failed(.cancelled)`.
+final class CancelThenSucceedStatusPoller: RewardVerificationStatusPolling, @unchecked Sendable {
+
+    private let started: Atomic<Bool>
+    private let successStatus: RewardVerificationPollStatus
+    private(set) var callCount = 0
+
+    var didStart: Bool { self.started.value }
+
+    init(started: Atomic<Bool>, successStatus: RewardVerificationPollStatus) {
+        self.started = started
+        self.successStatus = successStatus
+    }
+
+    func pollStatus(clientTransactionID: String) async throws -> RewardVerificationPollStatus {
+        self.callCount += 1
+        self.started.value = true
+        // Wait for cancellation cooperatively *without* throwing, then resolve successfully.
+        while !Task.isCancelled {
+            await Task.yield()
+        }
+        return self.successStatus
+    }
+}
+
 final class ScriptedStatusPoller: RewardVerificationStatusPolling, @unchecked Sendable {
 
     enum Step {

--- a/Tests/UnitTests/Ads/RewardVerification/RewardVerificationPollerTests.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/RewardVerificationPollerTests.swift
@@ -43,11 +43,44 @@ final class RewardVerificationPollerTests: TestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .failed(.backendError) = outcome else {
-            return XCTFail("Expected .failed(.backendError), got \(outcome)")
+        guard case .failed(.backendRejected(nil, nil)) = outcome else {
+            return XCTFail("Expected .failed(.backendRejected(nil, nil)), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.receivedIDs, ["tx-1"])
         XCTAssertTrue(sleeper.delays.isEmpty)
+    }
+
+    func testFailedForwardsBackendReasonAndMessage() async {
+        let statusPoller = StubStatusPoller(statuses: [.failed(
+            reason: "no_access",
+            message: "AdMob server-side reward verification is not enabled for this app."
+        )])
+        let sleeper = RecordingSleeper()
+        let sut = makePoller(statusPoller: statusPoller, sleeper: sleeper)
+
+        let outcome = await sut.run(clientTransactionID: "tx-1")
+
+        guard case let .failed(.backendRejected(reason, message)) = outcome else {
+            return XCTFail("Expected .failed(.backendRejected), got \(outcome)")
+        }
+        XCTAssertEqual(reason, "no_access")
+        XCTAssertEqual(message, "AdMob server-side reward verification is not enabled for this app.")
+        XCTAssertEqual(statusPoller.receivedIDs, ["tx-1"])
+        XCTAssertTrue(sleeper.delays.isEmpty)
+    }
+
+    func testFailedWithReasonButNoMessageForwardsReason() async {
+        // Forward-compat: backend may send a failure_reason without a human message; the reason
+        // must still survive so the diagnostic isn't a generic fallback.
+        let statusPoller = StubStatusPoller(statuses: [.failed(reason: "no_access", message: nil)])
+        let sleeper = RecordingSleeper()
+        let sut = makePoller(statusPoller: statusPoller, sleeper: sleeper)
+
+        let outcome = await sut.run(clientTransactionID: "tx-1")
+
+        guard case .failed(.backendRejected("no_access", nil)) = outcome else {
+            return XCTFail("Expected .failed(.backendRejected(\"no_access\", nil)), got \(outcome)")
+        }
     }
 
     func testPendingThenVerifiedSleepsBetweenAttempts() async {
@@ -71,8 +104,8 @@ final class RewardVerificationPollerTests: TestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .failed(.timeout) = outcome else {
-            return XCTFail("Expected .failed(.timeout), got \(outcome)")
+        guard case .failed(.exhaustedPending) = outcome else {
+            return XCTFail("Expected .failed(.exhaustedPending), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.receivedIDs.count, 10)
         XCTAssertEqual(sleeper.delays.count, 9)
@@ -95,14 +128,16 @@ final class RewardVerificationPollerTests: TestCase {
     }
 
     func testFailedOnLaterAttemptReturnsFailedWithoutAdditionalPolls() async {
-        let statusPoller = StubStatusPoller(statuses: [.pending, .pending, .failed(reason: nil, message: nil)])
+        let statusPoller = StubStatusPoller(
+            statuses: [.pending, .pending, .failed(reason: nil, message: nil)]
+        )
         let sleeper = RecordingSleeper()
         let sut = makePoller(statusPoller: statusPoller, sleeper: sleeper, maxAttempts: 10)
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .failed(.backendError) = outcome else {
-            return XCTFail("Expected .failed(.backendError), got \(outcome)")
+        guard case .failed(.backendRejected) = outcome else {
+            return XCTFail("Expected .failed(.backendRejected), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.receivedIDs.count, 3)
         XCTAssertEqual(sleeper.delays.count, 2)
@@ -120,6 +155,35 @@ final class RewardVerificationPollerTests: TestCase {
         }
         XCTAssertEqual(statusPoller.receivedIDs.count, 3)
         XCTAssertEqual(sleeper.delays.count, 2)
+    }
+
+    func testAllUnknownStatusesExhaustToUnexpectedResponse() async {
+        // Unknown statuses keep polling (version-skew tolerance), but an exhaustion ending on
+        // `unknown` is bucketed as unexpected_response rather than a plain timeout.
+        let statusPoller = StubStatusPoller(statuses: Array(repeating: .unknown, count: 5))
+        let sleeper = RecordingSleeper()
+        let sut = makePoller(statusPoller: statusPoller, sleeper: sleeper, maxAttempts: 5)
+
+        let outcome = await sut.run(clientTransactionID: "tx-1")
+
+        guard case .failed(.unexpectedResponse) = outcome else {
+            return XCTFail("Expected .failed(.unexpectedResponse), got \(outcome)")
+        }
+        XCTAssertEqual(statusPoller.receivedIDs.count, 5)
+    }
+
+    func testPendingAfterUnknownExhaustsAsPendingLastDispositionWins() async {
+        // Last-observed disposition wins: an `unknown` earlier in the run does not stick once a
+        // later `pending` is seen.
+        let statusPoller = StubStatusPoller(statuses: [.unknown, .pending, .pending])
+        let sleeper = RecordingSleeper()
+        let sut = makePoller(statusPoller: statusPoller, sleeper: sleeper, maxAttempts: 3)
+
+        let outcome = await sut.run(clientTransactionID: "tx-1")
+
+        guard case .failed(.exhaustedPending) = outcome else {
+            return XCTFail("Expected .failed(.exhaustedPending), got \(outcome)")
+        }
     }
 
     // MARK: - Transient connection-level retry path
@@ -168,9 +232,9 @@ final class RewardVerificationPollerTests: TestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .failed(.timeout) = outcome else {
+        guard case .failed(.exhaustedTransient) = outcome else {
             return XCTFail(
-                "Expected .failed(.timeout) after exhausting the budget on transient throws, got \(outcome)"
+                "Expected .failed(.exhaustedTransient) after exhausting the budget on transient throws, got \(outcome)"
             )
         }
         XCTAssertEqual(statusPoller.callCount, 5,
@@ -179,6 +243,8 @@ final class RewardVerificationPollerTests: TestCase {
     }
 
     func testMixedPendingAndTransientThrowsExhaustsBudgetAndReturnsFailed() async {
+        // Ends on `pending`, so last-observed disposition wins: exhausted-pending even though
+        // transient throws happened earlier in the run.
         let statusPoller = ScriptedStatusPoller(steps: [
             .status(.pending),
             .throwError(makeConnectivityError()),
@@ -191,8 +257,8 @@ final class RewardVerificationPollerTests: TestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .failed(.timeout) = outcome else {
-            return XCTFail("Expected .failed(.timeout), got \(outcome)")
+        guard case .failed(.exhaustedPending) = outcome else {
+            return XCTFail("Expected .failed(.exhaustedPending), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.callCount, 5)
         XCTAssertEqual(sleeper.delays.count, 4)
@@ -265,11 +331,37 @@ final class RewardVerificationPollerTests: TestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .failed(.backendError) = outcome else {
-            return XCTFail("Expected .failed(.backendError), got \(outcome)")
+        guard case .failed(.terminalError) = outcome else {
+            return XCTFail("Expected .failed(.terminalError), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.callCount, 1, "A 4xx must not be retried")
         XCTAssertTrue(sleeper.delays.isEmpty)
+    }
+
+    func testUnexpectedBackendResponseErrorReturnsFailedWithoutRetrying() async {
+        let statusPoller = ThrowingStatusPoller(error: ErrorCode.unexpectedBackendResponseError)
+        let sleeper = RecordingSleeper()
+        let sut = makePoller(statusPoller: statusPoller, sleeper: sleeper)
+
+        let outcome = await sut.run(clientTransactionID: "tx-1")
+
+        guard case .failed(.terminalError) = outcome else {
+            return XCTFail("Expected .failed(.terminalError), got \(outcome)")
+        }
+        XCTAssertEqual(statusPoller.callCount, 1)
+    }
+
+    func testApiEndpointBlockedErrorReturnsFailedWithoutRetrying() async {
+        let statusPoller = ThrowingStatusPoller(error: ErrorCode.apiEndpointBlockedError)
+        let sleeper = RecordingSleeper()
+        let sut = makePoller(statusPoller: statusPoller, sleeper: sleeper)
+
+        let outcome = await sut.run(clientTransactionID: "tx-1")
+
+        guard case .failed(.terminalError) = outcome else {
+            return XCTFail("Expected .failed(.terminalError), got \(outcome)")
+        }
+        XCTAssertEqual(statusPoller.callCount, 1)
     }
 
     func testServerErrorAfterPendingIsRetried() async {
@@ -298,8 +390,8 @@ final class RewardVerificationPollerTests: TestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .failed(.backendError) = outcome else {
-            return XCTFail("Expected .failed(.backendError), got \(outcome)")
+        guard case .failed(.terminalError) = outcome else {
+            return XCTFail("Expected .failed(.terminalError), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.callCount, 1, "A terminal BackendError must not be retried")
         XCTAssertTrue(sleeper.delays.isEmpty)
@@ -313,8 +405,8 @@ final class RewardVerificationPollerTests: TestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .failed(.backendError) = outcome else {
-            return XCTFail("Expected .failed(.backendError), got \(outcome)")
+        guard case .failed(.terminalError) = outcome else {
+            return XCTFail("Expected .failed(.terminalError), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.callCount, 1)
     }
@@ -329,8 +421,8 @@ final class RewardVerificationPollerTests: TestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .failed(.backendError) = outcome else {
-            return XCTFail("Expected .failed(.backendError), got \(outcome)")
+        guard case .failed(.terminalError) = outcome else {
+            return XCTFail("Expected .failed(.terminalError), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.callCount, 2)
     }
@@ -338,28 +430,31 @@ final class RewardVerificationPollerTests: TestCase {
     // MARK: - Catch-all behaviour
 
     func testCancellationErrorFromPollStatusReturnsFailedWithoutRetrying() async {
+        // A thrown `CancellationError` is treated as cancellation (not a terminal error):
+        // surfaces `.cancelled` and is not retried.
         let statusPoller = ThrowingStatusPoller(error: CancellationError())
         let sleeper = RecordingSleeper()
         let sut = makePoller(statusPoller: statusPoller, sleeper: sleeper)
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .failed(.unknown) = outcome else {
-            return XCTFail("Expected .failed(.unknown), got \(outcome)")
+        guard case .failed(.cancelled) = outcome else {
+            return XCTFail("Expected .failed(.cancelled), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.callCount, 1, "Cancellation throws are not retried")
         XCTAssertTrue(sleeper.delays.isEmpty)
     }
 
     func testUnrecognisedErrorTypeFromPollStatusReturnsFailedWithoutRetrying() async {
+        // A non-transient, non-cancellation throw is an unrecoverable terminal error.
         let statusPoller = ThrowingStatusPoller(error: PollerSentinelError())
         let sleeper = RecordingSleeper()
         let sut = makePoller(statusPoller: statusPoller, sleeper: sleeper)
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .failed(.unknown) = outcome else {
-            return XCTFail("Expected .failed(.unknown), got \(outcome)")
+        guard case .failed(.terminalError) = outcome else {
+            return XCTFail("Expected .failed(.terminalError), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.callCount, 1, "Unrecognised throws are not retried")
     }
@@ -375,12 +470,37 @@ final class RewardVerificationPollerTests: TestCase {
         task.cancel()
         let outcome = await task.value
 
-        guard case .failed(.unknown) = outcome else {
-            return XCTFail("Expected .failed(.unknown) after cancellation, got \(outcome)")
+        guard case .failed(.cancelled) = outcome else {
+            return XCTFail("Expected .failed(.cancelled) after cancellation, got \(outcome)")
         }
         XCTAssertEqual(statusPoller.callCount, 0,
                        "Cancellation must short-circuit before any pollStatus call")
         XCTAssertTrue(sleeper.delays.isEmpty)
+    }
+
+    func testCancellationWhileStatusRequestSucceedsCollapsesToCancelled() async {
+        // The status request resolves to `.verified` *after* the task is cancelled (no
+        // `CancellationError` thrown). The poller must re-observe cancellation and surface
+        // `.failed(.cancelled)` instead of delivering the stale success.
+        let started = Atomic<Bool>(false)
+        let statusPoller = CancelThenSucceedStatusPoller(started: started, successStatus: .verified(.noReward))
+        let sleeper = RecordingSleeper()
+        let sut = makePoller(statusPoller: statusPoller, sleeper: sleeper)
+
+        let task = Task<RewardVerification.Outcome, Never> {
+            await sut.run(clientTransactionID: "tx-1")
+        }
+        // Cancel only once the poll is in flight, so cancellation interrupts a started request.
+        while !started.value {
+            await Task.yield()
+        }
+        task.cancel()
+        let outcome = await task.value
+
+        guard case .failed(.cancelled) = outcome else {
+            return XCTFail("Expected .failed(.cancelled) for success-after-cancel, got \(outcome)")
+        }
+        XCTAssertEqual(statusPoller.callCount, 1, "The in-flight attempt must not be retried")
     }
 
     func testSleeperFailureIsSwallowedAndLoopContinuesToNextAttempt() async {
@@ -406,8 +526,8 @@ final class RewardVerificationPollerTests: TestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .failed(.timeout) = outcome else {
-            return XCTFail("Expected .failed(.timeout), got \(outcome)")
+        guard case .failed(.exhaustedPending) = outcome else {
+            return XCTFail("Expected .failed(.exhaustedPending), got \(outcome)")
         }
         XCTAssertTrue(statusPoller.receivedIDs.isEmpty)
         XCTAssertTrue(sleeper.delays.isEmpty)
@@ -420,8 +540,8 @@ final class RewardVerificationPollerTests: TestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .failed(.timeout) = outcome else {
-            return XCTFail("Expected .failed(.timeout), got \(outcome)")
+        guard case .failed(.exhaustedPending) = outcome else {
+            return XCTFail("Expected .failed(.exhaustedPending), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.receivedIDs, ["tx-1"])
         XCTAssertTrue(sleeper.delays.isEmpty)

--- a/Tests/UnitTests/Ads/RewardVerification/RewardVerificationPollerTests.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/RewardVerificationPollerTests.swift
@@ -37,7 +37,7 @@ final class RewardVerificationPollerTests: TestCase {
     }
 
     func testFailedReturnsAfterFirstAttempt() async {
-        let statusPoller = StubStatusPoller(statuses: [.failed])
+        let statusPoller = StubStatusPoller(statuses: [.failed(reason: nil, message: nil)])
         let sleeper = RecordingSleeper()
         let sut = makePoller(statusPoller: statusPoller, sleeper: sleeper)
 
@@ -95,7 +95,7 @@ final class RewardVerificationPollerTests: TestCase {
     }
 
     func testFailedOnLaterAttemptReturnsFailedWithoutAdditionalPolls() async {
-        let statusPoller = StubStatusPoller(statuses: [.pending, .pending, .failed])
+        let statusPoller = StubStatusPoller(statuses: [.pending, .pending, .failed(reason: nil, message: nil)])
         let sleeper = RecordingSleeper()
         let sut = makePoller(statusPoller: statusPoller, sleeper: sleeper, maxAttempts: 10)
 

--- a/Tests/UnitTests/Networking/Backend/BackendGetRewardVerificationStatusTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRewardVerificationStatusTests.swift
@@ -114,6 +114,30 @@ final class BackendGetRewardVerificationStatusTests: BaseBackendTests {
         expect(response.status) == .failed(.init(reason: nil, message: nil))
     }
 
+    func testGetRewardVerificationStatusFailedForwardsReasonAndMessage() throws {
+        self.httpClient.mock(
+            requestPath: .rewardVerificationStatus(
+                appUserID: Self.userID,
+                clientTransactionID: Self.clientTransactionID
+            ),
+            response: .init(statusCode: .success, response: Self.failedWithReasonResponse)
+        )
+
+        let result = waitUntilValue { completed in
+            self.adsAPI.getRewardVerificationStatus(
+                appUserID: Self.userID,
+                clientTransactionID: Self.clientTransactionID,
+                completion: completed
+            )
+        }
+
+        let response = try XCTUnwrap(result?.value)
+        expect(response.status) == .failed(.init(
+            reason: "no_access",
+            message: "AdMob server-side reward verification is not enabled for this app."
+        ))
+    }
+
     func testGetRewardVerificationStatusUnknownStatusDecodesAsUnknown() throws {
         // Defence-in-depth: future backend additions must not break decode.
         self.httpClient.mock(
@@ -344,5 +368,11 @@ private extension BackendGetRewardVerificationStatusTests {
     ]
     static let pendingResponse: [String: Any] = ["status": "pending"]
     static let failedResponse: [String: Any] = ["status": "failed"]
+    static let failedWithReasonResponse: [String: Any] = [
+        "status": "failed",
+        "reward": NSNull(),
+        "failure_reason": "no_access",
+        "message": "AdMob server-side reward verification is not enabled for this app."
+    ]
 
 }

--- a/Tests/UnitTests/Networking/Backend/BackendGetRewardVerificationStatusTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRewardVerificationStatusTests.swift
@@ -111,7 +111,7 @@ final class BackendGetRewardVerificationStatusTests: BaseBackendTests {
         }
 
         let response = try XCTUnwrap(result?.value)
-        expect(response.status) == .failed
+        expect(response.status) == .failed(.init(reason: nil, message: nil))
     }
 
     func testGetRewardVerificationStatusUnknownStatusDecodesAsUnknown() throws {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRewardVerificationStatusTests/iOS14-testGetRewardVerificationStatusFailedForwardsReasonAndMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRewardVerificationStatusTests/iOS14-testGetRewardVerificationStatusFailedForwardsReasonAndMessage.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/ads/reward_verifications/AABBCCDD-1111-2222-3333-444455556666"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRewardVerificationStatusTests/iOS15-testGetRewardVerificationStatusFailedForwardsReasonAndMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRewardVerificationStatusTests/iOS15-testGetRewardVerificationStatusFailedForwardsReasonAndMessage.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/ads/reward_verifications/AABBCCDD-1111-2222-3333-444455556666"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRewardVerificationStatusTests/iOS16-testGetRewardVerificationStatusFailedForwardsReasonAndMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRewardVerificationStatusTests/iOS16-testGetRewardVerificationStatusFailedForwardsReasonAndMessage.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/ads/reward_verifications/AABBCCDD-1111-2222-3333-444455556666"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRewardVerificationStatusTests/iOS17-testGetRewardVerificationStatusFailedForwardsReasonAndMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRewardVerificationStatusTests/iOS17-testGetRewardVerificationStatusFailedForwardsReasonAndMessage.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "content-type" : "application/json",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-Storefront" : "USA",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Version" : "4.0.0"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/ads/reward_verifications/AABBCCDD-1111-2222-3333-444455556666"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRewardVerificationStatusTests/iOS18-testGetRewardVerificationStatusFailedForwardsReasonAndMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRewardVerificationStatusTests/iOS18-testGetRewardVerificationStatusFailedForwardsReasonAndMessage.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/ads/reward_verifications/AABBCCDD-1111-2222-3333-444455556666"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRewardVerificationStatusTests/iOS26-testGetRewardVerificationStatusFailedForwardsReasonAndMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRewardVerificationStatusTests/iOS26-testGetRewardVerificationStatusFailedForwardsReasonAndMessage.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/ads/reward_verifications/AABBCCDD-1111-2222-3333-444455556666"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRewardVerificationStatusTests/macOS-testGetRewardVerificationStatusFailedForwardsReasonAndMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRewardVerificationStatusTests/macOS-testGetRewardVerificationStatusFailedForwardsReasonAndMessage.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "false",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/ads/reward_verifications/AABBCCDD-1111-2222-3333-444455556666"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRewardVerificationStatusTests/tvOS18-testGetRewardVerificationStatusFailedForwardsReasonAndMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRewardVerificationStatusTests/tvOS18-testGetRewardVerificationStatusFailedForwardsReasonAndMessage.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "2",
+    "X-StoreKit2-Enabled" : "true",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/ads/reward_verifications/AABBCCDD-1111-2222-3333-444455556666"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRewardVerificationStatusTests/watchOS-testGetRewardVerificationStatusFailedForwardsReasonAndMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetRewardVerificationStatusTests/watchOS-testGetRewardVerificationStatusFailedForwardsReasonAndMessage.1.json
@@ -1,0 +1,30 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Apple-Device-Identifier" : "5D7C0074-07E4-4564-AAA4-4008D0640881",
+    "X-Client-Build-Version" : "12345",
+    "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
+    "X-Client-Version" : "17.0.0",
+    "X-Installation-Method" : "unknown",
+    "X-Is-Backgrounded" : "false",
+    "X-Is-Debug-Build" : "true",
+    "X-Is-Sandbox" : "true",
+    "X-Observer-Mode-Enabled" : "false",
+    "X-Platform" : "iOS",
+    "X-Platform-Device" : "arm64",
+    "X-Platform-Flavor" : "native",
+    "X-Platform-Version" : "Version 17.0.0 (Build 21A342)",
+    "X-Preferred-Locales" : "en_EN",
+    "X-Retry-Count" : "0",
+    "X-StoreKit-Version" : "1",
+    "X-StoreKit2-Enabled" : "false",
+    "X-Storefront" : "USA",
+    "X-Version" : "4.0.0",
+    "content-type" : "application/json"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/ads/reward_verifications/AABBCCDD-1111-2222-3333-444455556666"
+  }
+}

--- a/Tests/UnitTests/Networking/Responses/RewardVerificationStatusResponseDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/RewardVerificationStatusResponseDecodingTests.swift
@@ -34,7 +34,39 @@ final class RewardVerificationStatusResponseDecodingTests: TestCase {
 
     func testDecodesFailedStatus() throws {
         let response = try Self.decode(["status": "failed"])
-        expect(response.status) == .failed
+        expect(response.status) == .failed(.init(reason: nil, message: nil))
+    }
+
+    func testDecodesFailedStatusWithReasonAndMessage() throws {
+        let response = try Self.decode([
+            "status": "failed",
+            "failure_reason": "no_access",
+            "message": "AdMob server-side reward verification is not enabled for this app."
+        ])
+        expect(response.status) == .failed(.init(
+            reason: "no_access",
+            message: "AdMob server-side reward verification is not enabled for this app."
+        ))
+    }
+
+    func testDecodesFailedStatusWithNullReasonAndMessage() throws {
+        let json = #"{"status":"failed","reward":null,"failure_reason":null,"message":null}"#
+        let response = try RewardVerificationStatusResponse.create(with: Data(json.utf8))
+        expect(response.status) == .failed(.init(reason: nil, message: nil))
+    }
+
+    func testDecodesFailedStatusWithUnrecognizedReasonKeepsRawValue() throws {
+        // Forward compatibility: a `failure_reason` this SDK version doesn't know about must
+        // still decode (kept as the raw string) so the `failed` status and message survive.
+        let response = try Self.decode([
+            "status": "failed",
+            "failure_reason": "some_future_reason",
+            "message": "A brand new failure cause."
+        ])
+        expect(response.status) == .failed(.init(
+            reason: "some_future_reason",
+            message: "A brand new failure cause."
+        ))
     }
 
     func testDecodesUnrecognizedStatusAsUnknown() throws {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesRewardVerificationTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesRewardVerificationTests.swift
@@ -84,11 +84,29 @@ final class PurchasesRewardVerificationTests: BasePurchasesTests {
     }
 
     func testPollRewardVerificationStatusMapsFailedStatus() async throws {
-        try self.mockAdsAPI.stubbedGetRewardVerificationStatusResult = .success(.init(status: .failed))
+        try self.mockAdsAPI.stubbedGetRewardVerificationStatusResult = .success(
+            .init(status: .failed(.init(reason: nil, message: nil)))
+        )
 
         let status = try await self.purchases.pollRewardVerificationStatus(clientTransactionID: "tx-id")
 
-        expect(status) == .failed
+        expect(status) == .failed(reason: nil, message: nil)
+    }
+
+    func testPollRewardVerificationStatusForwardsFailureReasonAndMessage() async throws {
+        try self.mockAdsAPI.stubbedGetRewardVerificationStatusResult = .success(
+            .init(status: .failed(.init(
+                reason: "no_access",
+                message: "AdMob server-side reward verification is not enabled for this app."
+            )))
+        )
+
+        let status = try await self.purchases.pollRewardVerificationStatus(clientTransactionID: "tx-id")
+
+        expect(status) == .failed(
+            reason: "no_access",
+            message: "AdMob server-side reward verification is not enabled for this app."
+        )
     }
 
     func testPollRewardVerificationStatusForwardsBackendError() async throws {
@@ -139,7 +157,7 @@ extension PurchasesRewardVerificationTests {
     }
 
     func testPollRewardVerificationReturnsFailed() async {
-        let poller = self.makeStubPoller(statuses: [.failed])
+        let poller = self.makeStubPoller(statuses: [.failed(reason: nil, message: nil)])
 
         let result = await self.purchases.pollRewardVerification(clientTransactionID: "tx-1", poller: poller)
 
@@ -172,7 +190,7 @@ extension PurchasesRewardVerificationTests {
     }
 
     func testPollRewardVerificationDoesNotInvalidateCacheOnFailed() async {
-        let poller = self.makeStubPoller(statuses: [.failed])
+        let poller = self.makeStubPoller(statuses: [.failed(reason: nil, message: nil)])
 
         _ = await self.purchases.pollRewardVerification(clientTransactionID: "tx-1", poller: poller)
 


### PR DESCRIPTION
## Motivation

AdMob reward verification was binary verified/failed with no diagnostic, so the backend's new `failure_reason`/`message` fields had nothing surfacing them. This threads the cause through to a clear, per-failure log.

## Changes

The poller now distinguishes *why* verification failed — backend-rejected, timed out, transient-erroring, unrecognized status, terminal error, or cancelled — and logs a specific diagnostic for each (backend rejections log the server's message verbatim). The public `RewardVerificationResult` stays binary (`verified`/`failed`); the detail lives only in logs, so there's no API-surface change.

Also: on cancellation the result callback now always fires `.failed` rather than being silently dropped, keeping the always-fires-once contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reward-verification polling, cancellation, and AdMob callback delivery semantics in ads flows; public result shape is unchanged but integrators may see `.failed` where callbacks were previously silent on cancel.
> 
> **Overview**
> Threads backend **`failure_reason`** and **`message`** through reward-verification decoding into internal failure classification, so polling logs a **specific diagnostic** per outcome (server rejection with verbatim message, SSV timeout, transient exhaustion, unrecognized status, terminal errors, cancellation) while **`RewardVerificationResult` stays binary** (`verified` / `failed`).
> 
> The poller is refactored around single-attempt handling and **last-observed disposition** when the attempt budget runs out, with stricter **cancellation** handling (including after an in-flight status succeeds) mapping to internal `.cancelled` and public `.failed`. **AdMob `Dispatcher`** no longer drops the result callback when the dispatch task is cancelled—it still delivers **exactly one** `.failed` and consumes the one-shot guard.
> 
> `pollRewardVerificationStatus` / `RewardVerificationPollStatus` visibility is tightened (no longer public SPI); tests cover decoding, polling paths, and dispatcher cancellation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fdc3722f429c6413ca44b43fa0435030018ee0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

