### PR TITLE
feat(workflows): add experiment node support

### DIFF
--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowNavigator.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowNavigator.swift
@@ -29,7 +29,7 @@ final class WorkflowNavigator: ObservableObject {
 
     init(workflow: PublishedWorkflow) {
         self.workflow = workflow
-        self.currentStepId = workflow.initialStepId
+        self.currentStepId = Self.resolveExperimentStep(workflow.initialStepId, in: workflow)
     }
 
     var currentStep: WorkflowStep? {
@@ -66,8 +66,8 @@ final class WorkflowNavigator: ObservableObject {
         }
 
         backStack.append(currentStepId)
-        currentStepId = nextStep.id
-        return nextStep
+        currentStepId = Self.resolveExperimentStep(nextStep.id, in: workflow)
+        return workflow.steps[currentStepId]
     }
 
     @discardableResult
@@ -77,6 +77,34 @@ final class WorkflowNavigator: ObservableObject {
         }
         currentStepId = previousStepId
         return workflow.steps[previousStepId]
+    }
+
+    // MARK: - Experiment resolution
+
+    /// If `stepId` points to an experiment step, follows the enrolled variant's trigger action
+    /// to the real content step. Experiment steps are skipped silently (not added to back stack)
+    /// so the user can never navigate back to them. Safe against cycles — stops after visiting
+    /// each step at most once.
+    // Experiment steps are pruned by WorkflowDetailProcessor before the navigator sees the workflow,
+    // so each experiment step has at most one remaining .step action (the enrolled variant's).
+    private static func resolveExperimentStep(_ stepId: String, in workflow: PublishedWorkflow) -> String {
+        var visitedIds = Set<String>()
+        var resolvedId = stepId
+
+        while true {
+            guard !visitedIds.contains(resolvedId),
+                  let step = workflow.steps[resolvedId],
+                  step.isExperimentStep,
+                  let nextAction = step.stepTriggerActions.values
+                      .first(where: { if case .step = $0 { return true }; return false }),
+                  case .step(let nextStepId) = nextAction else {
+                break
+            }
+            visitedIds.insert(resolvedId)
+            resolvedId = nextStepId
+        }
+
+        return resolvedId
     }
 
 }

--- a/Sources/Misc/Codable/AnyDecodable.swift
+++ b/Sources/Misc/Codable/AnyDecodable.swift
@@ -84,6 +84,8 @@ extension AnyDecodable: Encodable {
 
 extension AnyDecodable: Hashable {}
 
+extension AnyDecodable: Sendable {}
+
 // MARK: - Expressible by Literal
 
 extension AnyDecodable: ExpressibleByNilLiteral {

--- a/Sources/Networking/Responses/WorkflowsResponse.swift
+++ b/Sources/Networking/Responses/WorkflowsResponse.swift
@@ -68,6 +68,15 @@ import Foundation
     public var stepScreenType: [String] { screenType }
     let metadata: [String: AnyDecodable]?
 
+    /// Whether this step is an experiment node that should be resolved silently without rendering.
+    public var isExperimentStep: Bool { type == "experiment" }
+
+    /// The experiment ID for this step, if it is an experiment node.
+    public var experimentId: String? {
+        guard case .string(let id) = paramValues["experiment_id"] else { return nil }
+        return id
+    }
+
 }
 
 @_spi(Internal) public struct WorkflowScreen {
@@ -166,7 +175,50 @@ extension WorkflowScreen: Codable, Equatable, Sendable {
 
 }
 
-extension PublishedWorkflow: Codable, Equatable, Sendable {}
+extension PublishedWorkflow: Codable, Equatable, Sendable {
+
+    /// Returns a copy with non-enrolled variant target steps removed from `steps`.
+    /// For each experiment step, the enrolled variant is looked up in `enrolledVariants`
+    /// (keyed by experiment_id → variant_id). Any step that is the direct target of a
+    /// non-enrolled trigger action is dropped, leaving only the enrolled path.
+    ///
+    /// When an experiment_id is absent from `enrolledVariants` (user is below enrollment %),
+    /// we fall back to the "control" variant so unenrolled users always see the control experience.
+    /// If no variant is named "control", we fall back to the lexicographically first key.
+    func pruned(enrolledVariants: [String: String]) -> PublishedWorkflow {
+        var prunedSteps = self.steps
+        for step in self.steps.values where step.isExperimentStep {
+            guard let experimentId = step.experimentId else { continue }
+            let enrolledVariant = enrolledVariants[experimentId]
+                ?? Self.controlVariant(for: step)
+            for (variantId, action) in step.stepTriggerActions {
+                guard variantId != enrolledVariant, case .step(let stepId) = action else { continue }
+                prunedSteps.removeValue(forKey: stepId)
+            }
+        }
+
+        return PublishedWorkflow(
+            id: self.id,
+            displayName: self.displayName,
+            initialStepId: self.initialStepId,
+            singleStepFallbackId: self.singleStepFallbackId,
+            steps: prunedSteps,
+            screens: self.screens,
+            uiConfig: self.uiConfig,
+            contentMaxWidth: self.contentMaxWidth,
+            metadata: self.metadata
+        )
+    }
+
+    /// Returns the control variant key for an experiment step — the variant unenrolled users see.
+    /// Prefers a key literally named "control"; falls back to the lexicographically first key.
+    private static func controlVariant(for step: WorkflowStep) -> String? {
+        let keys = step.stepTriggerActions.keys
+        return keys.contains("control") ? "control" : keys.sorted().first
+    }
+
+}
+
 extension WorkflowDataResult: Equatable, Sendable {}
 
 extension PublishedWorkflow: HTTPResponseBody {}

--- a/Sources/Networking/Workflows/WorkflowDetailProcessor.swift
+++ b/Sources/Networking/Workflows/WorkflowDetailProcessor.swift
@@ -85,7 +85,8 @@ final class WorkflowDetailProcessor: Sendable {
     ) {
         do {
             let envelope = try JSONDecoder.default.decode(InlineEnvelope.self, jsonData: rawData)
-            completion(.success(.init(workflow: envelope.data, enrolledVariants: enrolledVariants)))
+            let workflow = envelope.data.pruned(enrolledVariants: enrolledVariants ?? [:])
+            completion(.success(.init(workflow: workflow, enrolledVariants: enrolledVariants)))
         } catch {
             completion(.failure(error))
         }
@@ -111,6 +112,7 @@ final class WorkflowDetailProcessor: Sendable {
                 }
                 do {
                     let workflow = try PublishedWorkflow.create(with: cdnData)
+                        .pruned(enrolledVariants: enrolledVariants ?? [:])
                     completion(.success(.init(workflow: workflow, enrolledVariants: enrolledVariants)))
                 } catch {
                     completion(.failure(error))

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowNavigatorTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowNavigatorTests.swift
@@ -258,6 +258,83 @@ final class WorkflowNavigatorTests: TestCase {
         expect(destination?.canNavigateBackAfterNavigation) == true
     }
 
+    // MARK: - Experiment step resolution
+    // Variant selection is handled by WorkflowDetailProcessor (pruning non-enrolled steps).
+    // Navigator tests cover structural behaviour: auto-advance, back-stack exclusion, chaining.
+
+    func testExperimentStepIsSkippedAndLandsOnContentStep() throws {
+        // After pruning, experiment step has exactly one action — the enrolled variant's.
+        let workflow = try Self.makeWorkflow(
+            steps: [
+                makeExperimentStep(id: "exp_1", experimentId: "exp_abc", variantActions: [
+                    ("control", "step_control")
+                ]),
+                makeStep(id: "step_control")
+            ],
+            initialStepId: "exp_1"
+        )
+        let navigator = WorkflowNavigator(workflow: workflow)
+
+        expect(navigator.currentStepId) == "step_control"
+    }
+
+    func testExperimentStepNotInBackStackAfterResolution() throws {
+        let workflow = try Self.makeWorkflow(
+            steps: [
+                makeExperimentStep(id: "exp_1", experimentId: "exp_abc", variantActions: [
+                    ("control", "step_control")
+                ]),
+                makeStep(id: "step_control")
+            ],
+            initialStepId: "exp_1"
+        )
+        let navigator = WorkflowNavigator(workflow: workflow)
+
+        expect(navigator.currentStepId) == "step_control"
+        expect(navigator.canNavigateBack) == false
+    }
+
+    func testExperimentStepAfterForwardNavigationIsResolvedSilently() throws {
+        let workflow = try Self.makeWorkflow(
+            steps: [
+                makeStep(id: "step_1", triggers: [("btn", "btn")], triggerActions: [("btn", "exp_1")]),
+                makeExperimentStep(id: "exp_1", experimentId: "exp_abc", variantActions: [
+                    ("variant_b", "step_variant_b")
+                ]),
+                makeStep(id: "step_variant_b")
+            ],
+            initialStepId: "step_1"
+        )
+        let navigator = WorkflowNavigator(workflow: workflow)
+        navigator.triggerAction(componentId: "btn")
+
+        expect(navigator.currentStepId) == "step_variant_b"
+        expect(navigator.canNavigateBack) == true
+        navigator.navigateBack()
+        expect(navigator.currentStepId) == "step_1"
+    }
+
+    func testChainedExperimentStepsAreResolvedToFirstContentStep() throws {
+        // Chained experiment nodes are not a valid workflow configuration in practice,
+        // but the navigator should handle them gracefully rather than getting stuck.
+        let workflow = try Self.makeWorkflow(
+            steps: [
+                makeExperimentStep(id: "exp_1", experimentId: "exp_a", variantActions: [
+                    ("v1", "exp_2")
+                ]),
+                makeExperimentStep(id: "exp_2", experimentId: "exp_b", variantActions: [
+                    ("v2", "step_content")
+                ]),
+                makeStep(id: "step_content")
+            ],
+            initialStepId: "exp_1"
+        )
+        let navigator = WorkflowNavigator(workflow: workflow)
+
+        expect(navigator.currentStepId) == "step_content"
+        expect(navigator.canNavigateBack) == false
+    }
+
     // MARK: - Multiple navigations
 
     func testMultipleForwardAndBackNavigationsWorkCorrectly() throws {
@@ -369,6 +446,28 @@ private extension WorkflowNavigatorTests {
           "type": "screen",
           "triggers": \(triggersJSON),
           "trigger_actions": \(actionsJSON)
+        }
+        """
+        return StepDescriptor(id: id, json: json)
+    }
+
+    /// Creates a `StepDescriptor` for an experiment step with the given variant → target-step-id actions.
+    func makeExperimentStep(
+        id: String,
+        experimentId: String,
+        variantActions: [(variantId: String, targetStepId: String)]
+    ) -> StepDescriptor {
+        let actionsJSON = variantActions
+            .map { #""\#($0.variantId)":{"type":"step","step_id":"\#($0.targetStepId)"}"# }
+            .joined(separator: ",")
+
+        let json = """
+        {
+          "id": "\(id)",
+          "type": "experiment",
+          "param_values": {"experiment_id": "\(experimentId)"},
+          "triggers": [],
+          "trigger_actions": {\(actionsJSON)}
         }
         """
         return StepDescriptor(id: id, json: json)

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
@@ -297,9 +297,11 @@ struct APIKeyDashboardList: View {
                 .sheet(item: self.$presentWorkflowSheetOffering, onDismiss: self.handleWorkflowDismiss) { offering in
                     self.workflowPaywallView(for: offering)
                 }
+#if !os(macOS)
                 .fullScreenCover(item: self.$presentWorkflowFullOffering, onDismiss: self.handleWorkflowDismiss) { offering in
                     self.workflowPaywallView(for: offering)
                 }
+#endif
                 .sheet(item: self.$presentedWorkflowExitOffer) { exitOffering in
                     PaywallView(offering: exitOffering)
                         .customPaywallVariables(self.customVariables)

--- a/Tests/UnitTests/Networking/Workflows/WorkflowDetailProcessorTests.swift
+++ b/Tests/UnitTests/Networking/Workflows/WorkflowDetailProcessorTests.swift
@@ -398,6 +398,47 @@ class WorkflowDetailProcessorTests: TestCase {
         expect(WorkflowDetailProcessor.verifyCdnHash(invalidData, expectedHash: "anything")) == false
     }
 
+    // MARK: - Experiment pruning
+
+    func testNonEnrolledVariantStepsArePrunedFromWorkflow() throws {
+        let inlineData = try Self.inlineEnvelope(workflowDict: Self.workflowWithExperiment())
+        let enrolledVariants = ["exp_abc": "control"]
+
+        let result = try processSync(inlineData, enrolledVariants: enrolledVariants)
+
+        expect(result.workflow.steps["step_control"]).notTo(beNil())
+        expect(result.workflow.steps["step_variant_b"]).to(beNil())
+    }
+
+    func testEnrolledVariantStepIsRetained() throws {
+        let inlineData = try Self.inlineEnvelope(workflowDict: Self.workflowWithExperiment())
+        let enrolledVariants = ["exp_abc": "variant_b"]
+
+        let result = try processSync(inlineData, enrolledVariants: enrolledVariants)
+
+        expect(result.workflow.steps["step_variant_b"]).notTo(beNil())
+        expect(result.workflow.steps["step_control"]).to(beNil())
+    }
+
+    func testNoEnrolledVariantFallsBackToControlVariant() throws {
+        // Users below enrollment % are not in enrolled_variants. They should see control.
+        let inlineData = try Self.inlineEnvelope(workflowDict: Self.workflowWithExperiment())
+
+        let result = try processSync(inlineData, enrolledVariants: nil)
+
+        expect(result.workflow.steps["step_control"]).notTo(beNil())
+        expect(result.workflow.steps["step_variant_b"]).to(beNil())
+    }
+
+    func testExperimentStepItselfIsNotPruned() throws {
+        let inlineData = try Self.inlineEnvelope(workflowDict: Self.workflowWithExperiment())
+        let enrolledVariants = ["exp_abc": "control"]
+
+        let result = try processSync(inlineData, enrolledVariants: enrolledVariants)
+
+        expect(result.workflow.steps["exp_step"]).notTo(beNil())
+    }
+
 }
 
 // MARK: - Fixtures
@@ -434,6 +475,53 @@ private extension WorkflowDetailProcessorTests {
 
     static func minimalWorkflowData(id: String) -> Data {
         return (try? JSONSerialization.data(withJSONObject: minimalWorkflowDict(id: id))) ?? Data()
+    }
+
+    static func workflowWithExperiment() -> [String: Any] {
+        return [
+            "id": "wf_exp",
+            "display_name": "Experiment Workflow",
+            "initial_step_id": "exp_step",
+            "steps": [
+                "exp_step": [
+                    "id": "exp_step",
+                    "type": "experiment",
+                    "param_values": ["experiment_id": "exp_abc"],
+                    "triggers": [] as [Any],
+                    "trigger_actions": [
+                        "control":   ["type": "step", "step_id": "step_control"],
+                        "variant_b": ["type": "step", "step_id": "step_variant_b"]
+                    ] as [String: Any]
+                ] as [String: Any],
+                "step_control":   ["id": "step_control",   "type": "screen"] as [String: Any],
+                "step_variant_b": ["id": "step_variant_b", "type": "screen"] as [String: Any]
+            ] as [String: Any],
+            "screens": [:] as [String: Any],
+            "ui_config": minimalUiConfig
+        ]
+    }
+
+    static func inlineEnvelope(workflowDict: [String: Any]) throws -> Data {
+        let envelope: [String: Any] = ["action": "inline", "data": workflowDict]
+        return try JSONSerialization.data(withJSONObject: envelope)
+    }
+
+    func processSync(
+        _ data: Data,
+        enrolledVariants: [String: String]?
+    ) throws -> WorkflowDetailProcessingResult {
+        var capturedResult: Result<WorkflowDetailProcessingResult, Error>?
+        let processor = WorkflowDetailProcessor(cdnFetch: { _, _, _ in })
+
+        // Inject enrolled_variants into the envelope JSON so the processor reads them
+        var json = (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+        if let ev = enrolledVariants {
+            json["enrolled_variants"] = ev
+        }
+        let patchedData = try JSONSerialization.data(withJSONObject: json)
+
+        processor.process(patchedData) { capturedResult = $0 }
+        return try XCTUnwrap(capturedResult).get()
     }
 
 }


### PR DESCRIPTION
⚠️ **This is exploratory / not production-tested.** This is me trying to make iOS work with experiment nodes in workflows — treat it as a draft for discussion rather than a reviewed feature.

- **`WorkflowsResponse`**: Added `isExperimentStep` / `experimentId` computed properties on `WorkflowStep`, and a `pruned(enrolledVariants:)` method on `PublishedWorkflow` that removes non-enrolled variant target steps before the workflow reaches the navigator. Users below enrollment threshold fall back to the `"control"` variant (or lexicographically first key if none is named `"control"`).
- **`WorkflowDetailProcessor`**: Calls `pruned(enrolledVariants:)` on the decoded workflow so all downstream consumers see a clean step map with only the enrolled path present.
- **`WorkflowNavigator`**: Added `resolveExperimentStep(_:in:)` — when the initial step or a forward-navigation target is an experiment step, the navigator silently advances through it to the first real content step, without adding the experiment step to the back stack (so users can never navigate back to it). Cycle-safe via a visited-IDs set.
- **`AnyDecodable`**: Added `Sendable` conformance (needed to silence a concurrency warning surfaced by the new code).
- **`APIKeyDashboardList`**: Wrapped `fullScreenCover` in `#if !os(macOS)` — `fullScreenCover` is unavailable on macOS and caused a build failure in the tester app.
- **Tests**: Unit tests for processor pruning (`WorkflowDetailProcessorTests`) and navigator resolution / back-stack behaviour (`WorkflowNavigatorTests`).

## What's not tested / open questions

- End-to-end on a real device with a live experiment payload — only unit tests so far.
- The enrolled-variants data path (how `enrolledVariants` gets populated from the backend response) is assumed to already work from the previous networking PR; I haven't verified it flows through correctly in a live session.
- Chained experiment nodes (experiment → experiment → content) are handled defensively but that configuration is not valid in practice — the test just guards against an infinite loop.

## Test plan

- [ ] Unit tests pass (`swift test` / relevant Fastlane lane)
- [ ] PaywallsTester builds on iOS and macOS without errors
- [ ] Manual: load a workflow with an experiment step and confirm the correct variant is rendered

<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
