### PR TITLE
Bump Max Log Count in Tests

### DIFF
--- a/Tests/RevenueCatUITests/Helpers/TestCase.swift
+++ b/Tests/RevenueCatUITests/Helpers/TestCase.swift
@@ -27,7 +27,7 @@ class TestCase: XCTestCase {
     final func initializeLogger() {
         guard self.logger == nil else { return }
 
-        self.logger = TestLogHandler(capacity: 1000, testIdentifier: self.name)
+        self.logger = TestLogHandler(capacity: 10000, testIdentifier: self.name)
     }
 
     @MainActor


### PR DESCRIPTION
### Description
The `record-and-push-paywall-template-screenshots` job is failing in main because we've exceeded the max log count:

```
testPaywallValidationScreenshots, 1018 messages have been stored. This is likely a programming error and PaywallScreenshotTests.TestLogHandler (created by -[TakeScreenshotTests testPaywallValidationScreenshots] in PaywallScreenshotTests/TestCase.swift:30 has leaked.
```

This PR bumps the max log count from 1k to 10k to attempt to alleviate this issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only logging limit change with no impact on app runtime, security, or data handling.
> 
> **Overview**
> Raises the per-test log buffer on the shared UI test base class from **1,000** to **10,000** messages so verbose flows (e.g. paywall validation screenshot tests) no longer trip the “max messages stored / likely leak” guard in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81bf1ac32cc413b0af2cbf9f7d28d3d6fe7bb79c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->