### PR TITLE
Don't log App Store / StoreKit messages when using a Test Store API key

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -979,6 +979,7 @@
 		75A4EBF12EAB9A27007C71C1 /* PurchasesFallbackURLBackendIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75A4EBF02EAB9A27007C71C1 /* PurchasesFallbackURLBackendIntegrationTests.swift */; };
 		75A9F25C2E38DE57005D1AB1 /* GetWebBillingProductsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75A9F25B2E38DE57005D1AB1 /* GetWebBillingProductsOperation.swift */; };
 		75ABFDB52D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75ABFDB42D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift */; };
+		FE5151005A0000000000A001 /* CustomerInfoManagerSimulatedStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5151005A0000000000A002 /* CustomerInfoManagerSimulatedStoreTests.swift */; };
 		75ADC06C2E437D4900210ECA /* SimulatedStoreProductsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75ADC0682E437D4900210ECA /* SimulatedStoreProductsManager.swift */; };
 		75ADC06D2E437D4900210ECA /* SimulatedStoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75ADC06B2E437D4900210ECA /* SimulatedStoreTransaction.swift */; };
 		75ADC06E2E437D4900210ECA /* SimulatedStorePurchaseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75ADC0692E437D4900210ECA /* SimulatedStorePurchaseHandler.swift */; };
@@ -2553,6 +2554,7 @@
 		75A4EBF02EAB9A27007C71C1 /* PurchasesFallbackURLBackendIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesFallbackURLBackendIntegrationTests.swift; sourceTree = "<group>"; };
 		75A9F25B2E38DE57005D1AB1 /* GetWebBillingProductsOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetWebBillingProductsOperation.swift; sourceTree = "<group>"; };
 		75ABFDB42D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoManagerUIPreviewModeTests.swift; sourceTree = "<group>"; };
+		FE5151005A0000000000A002 /* CustomerInfoManagerSimulatedStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoManagerSimulatedStoreTests.swift; sourceTree = "<group>"; };
 		75ADC0682E437D4900210ECA /* SimulatedStoreProductsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatedStoreProductsManager.swift; sourceTree = "<group>"; };
 		75ADC0692E437D4900210ECA /* SimulatedStorePurchaseHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatedStorePurchaseHandler.swift; sourceTree = "<group>"; };
 		75ADC06A2E437D4900210ECA /* SimulatedStorePurchaseUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatedStorePurchaseUI.swift; sourceTree = "<group>"; };
@@ -4810,6 +4812,7 @@
 				37E35E992F1916C7F3911E7B /* CustomerInfoManagerTests.swift */,
 				4F3D56622A1E66A10070105A /* CustomerInfoManagerPostReceiptTests.swift */,
 				75ABFDB42D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift */,
+				FE5151005A0000000000A002 /* CustomerInfoManagerSimulatedStoreTests.swift */,
 				37E35294EBC1E5A879C95540 /* IdentityManagerTests.swift */,
 			);
 			path = Identity;
@@ -7802,6 +7805,7 @@
 				FD43A7982E01F77300CBA838 /* PurchasesVirtualCurrenciesTests.swift in Sources */,
 				2DDF41E124F6F527005BC22D /* MockReceiptParser.swift in Sources */,
 				75ABFDB52D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift in Sources */,
+				FE5151005A0000000000A001 /* CustomerInfoManagerSimulatedStoreTests.swift in Sources */,
 				57E415EB2846962500EA5460 /* PurchasesSyncPurchasesTests.swift in Sources */,
 				900D27072F96943200D32EDF /* BackendGetRewardVerificationStatusTests.swift in Sources */,
 				5766AAC5283E843300FA6091 /* PurchasesConfiguringTests.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -981,6 +981,7 @@
 		75ABFDB52D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75ABFDB42D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift */; };
 		FE5151005A0000000000A001 /* CustomerInfoManagerSimulatedStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5151005A0000000000A002 /* CustomerInfoManagerSimulatedStoreTests.swift */; };
 		FE5151005B0000000000A001 /* OfferingStringsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5151005B0000000000A002 /* OfferingStringsTests.swift */; };
+		FE5151005B0000000000B001 /* ConfigureStringsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5151005B0000000000B002 /* ConfigureStringsTests.swift */; };
 		75ADC06C2E437D4900210ECA /* SimulatedStoreProductsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75ADC0682E437D4900210ECA /* SimulatedStoreProductsManager.swift */; };
 		75ADC06D2E437D4900210ECA /* SimulatedStoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75ADC06B2E437D4900210ECA /* SimulatedStoreTransaction.swift */; };
 		75ADC06E2E437D4900210ECA /* SimulatedStorePurchaseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75ADC0692E437D4900210ECA /* SimulatedStorePurchaseHandler.swift */; };
@@ -2557,6 +2558,7 @@
 		75ABFDB42D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoManagerUIPreviewModeTests.swift; sourceTree = "<group>"; };
 		FE5151005A0000000000A002 /* CustomerInfoManagerSimulatedStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoManagerSimulatedStoreTests.swift; sourceTree = "<group>"; };
 		FE5151005B0000000000A002 /* OfferingStringsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfferingStringsTests.swift; sourceTree = "<group>"; };
+		FE5151005B0000000000B002 /* ConfigureStringsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigureStringsTests.swift; sourceTree = "<group>"; };
 		75ADC0682E437D4900210ECA /* SimulatedStoreProductsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatedStoreProductsManager.swift; sourceTree = "<group>"; };
 		75ADC0692E437D4900210ECA /* SimulatedStorePurchaseHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatedStorePurchaseHandler.swift; sourceTree = "<group>"; };
 		75ADC06A2E437D4900210ECA /* SimulatedStorePurchaseUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatedStorePurchaseUI.swift; sourceTree = "<group>"; };
@@ -4538,6 +4540,7 @@
 				1DA47C656406D58B636FD82D /* WorkflowManagerTests.swift */,
 				37E357C2D977BBB081216B5F /* OfferingsTests.swift */,
 				FE5151005B0000000000A002 /* OfferingStringsTests.swift */,
+				FE5151005B0000000000B002 /* ConfigureStringsTests.swift */,
 				5793396F28E77A5100C1232C /* PaymentQueueWrapperTests.swift */,
 				37E3583675928C01D92E3166 /* ProductRequestDataExtensions.swift */,
 				37E3548189DA008320B3FC98 /* ProductRequestDataInitializationTests.swift */,
@@ -7763,6 +7766,7 @@
 				B36824BF268FBC8700957E4C /* SubscriberAttributeTests.swift in Sources */,
 				351B51BC26D450E800BD2BD7 /* OfferingsTests.swift in Sources */,
 				FE5151005B0000000000A001 /* OfferingStringsTests.swift in Sources */,
+				FE5151005B0000000000B001 /* ConfigureStringsTests.swift in Sources */,
 				5796A38827D6B85900653165 /* BackendPostReceiptDataTests.swift in Sources */,
 				5752E8482892DC500069281E /* ErrorUtilsTests.swift in Sources */,
 				16BCA36E2E4D9B9300B39E7F /* DeferredValueStoresTests.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -980,6 +980,8 @@
 		75A9F25C2E38DE57005D1AB1 /* GetWebBillingProductsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75A9F25B2E38DE57005D1AB1 /* GetWebBillingProductsOperation.swift */; };
 		75ABFDB52D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75ABFDB42D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift */; };
 		FE5151005A0000000000A001 /* CustomerInfoManagerSimulatedStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5151005A0000000000A002 /* CustomerInfoManagerSimulatedStoreTests.swift */; };
+		FE5151005C0000000000A001 /* SimulatedStoreTransactionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5151005C0000000000A002 /* SimulatedStoreTransactionFetcher.swift */; };
+		FE5151005C0000000000B001 /* SimulatedStoreTransactionFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5151005C0000000000B002 /* SimulatedStoreTransactionFetcherTests.swift */; };
 		FE5151005B0000000000A001 /* OfferingStringsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5151005B0000000000A002 /* OfferingStringsTests.swift */; };
 		FE5151005B0000000000B001 /* ConfigureStringsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5151005B0000000000B002 /* ConfigureStringsTests.swift */; };
 		75ADC06C2E437D4900210ECA /* SimulatedStoreProductsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75ADC0682E437D4900210ECA /* SimulatedStoreProductsManager.swift */; };
@@ -2557,6 +2559,8 @@
 		75A9F25B2E38DE57005D1AB1 /* GetWebBillingProductsOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetWebBillingProductsOperation.swift; sourceTree = "<group>"; };
 		75ABFDB42D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoManagerUIPreviewModeTests.swift; sourceTree = "<group>"; };
 		FE5151005A0000000000A002 /* CustomerInfoManagerSimulatedStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoManagerSimulatedStoreTests.swift; sourceTree = "<group>"; };
+		FE5151005C0000000000A002 /* SimulatedStoreTransactionFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatedStoreTransactionFetcher.swift; sourceTree = "<group>"; };
+		FE5151005C0000000000B002 /* SimulatedStoreTransactionFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatedStoreTransactionFetcherTests.swift; sourceTree = "<group>"; };
 		FE5151005B0000000000A002 /* OfferingStringsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfferingStringsTests.swift; sourceTree = "<group>"; };
 		FE5151005B0000000000B002 /* ConfigureStringsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigureStringsTests.swift; sourceTree = "<group>"; };
 		75ADC0682E437D4900210ECA /* SimulatedStoreProductsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatedStoreProductsManager.swift; sourceTree = "<group>"; };
@@ -5503,6 +5507,7 @@
 			children = (
 				75A0E78F2E3D1FCF00A60BD5 /* SimulatedStorePurchaseHandlerTests.swift */,
 				750B39FD2E40940F005E141D /* PurchasesOrchestratorSimulatedStoreTests.swift */,
+				FE5151005C0000000000B002 /* SimulatedStoreTransactionFetcherTests.swift */,
 			);
 			path = SimulatedStore;
 			sourceTree = "<group>";
@@ -5511,6 +5516,7 @@
 			isa = PBXGroup;
 			children = (
 				75ADC0682E437D4900210ECA /* SimulatedStoreProductsManager.swift */,
+				FE5151005C0000000000A002 /* SimulatedStoreTransactionFetcher.swift */,
 				75ADC0692E437D4900210ECA /* SimulatedStorePurchaseHandler.swift */,
 				75ADC06A2E437D4900210ECA /* SimulatedStorePurchaseUI.swift */,
 				75ADC06B2E437D4900210ECA /* SimulatedStoreTransaction.swift */,
@@ -7515,6 +7521,7 @@
 				B35F9E0926B4BEED00095C3F /* String+Extensions.swift in Sources */,
 				574A2EE7282C3F0800150D40 /* AnyDecodable.swift in Sources */,
 				75ADC06C2E437D4900210ECA /* SimulatedStoreProductsManager.swift in Sources */,
+				FE5151005C0000000000A001 /* SimulatedStoreTransactionFetcher.swift in Sources */,
 				75ADC06D2E437D4900210ECA /* SimulatedStoreTransaction.swift in Sources */,
 				9094B41C2E96A9A70094AD5F /* AdEvent.swift in Sources */,
 				AD5000000000000000ADAD04 /* AdRewardEvents.swift in Sources */,
@@ -7814,6 +7821,7 @@
 				2DDF41E124F6F527005BC22D /* MockReceiptParser.swift in Sources */,
 				75ABFDB52D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift in Sources */,
 				FE5151005A0000000000A001 /* CustomerInfoManagerSimulatedStoreTests.swift in Sources */,
+				FE5151005C0000000000B001 /* SimulatedStoreTransactionFetcherTests.swift in Sources */,
 				57E415EB2846962500EA5460 /* PurchasesSyncPurchasesTests.swift in Sources */,
 				900D27072F96943200D32EDF /* BackendGetRewardVerificationStatusTests.swift in Sources */,
 				5766AAC5283E843300FA6091 /* PurchasesConfiguringTests.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -980,6 +980,7 @@
 		75A9F25C2E38DE57005D1AB1 /* GetWebBillingProductsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75A9F25B2E38DE57005D1AB1 /* GetWebBillingProductsOperation.swift */; };
 		75ABFDB52D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75ABFDB42D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift */; };
 		FE5151005A0000000000A001 /* CustomerInfoManagerSimulatedStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5151005A0000000000A002 /* CustomerInfoManagerSimulatedStoreTests.swift */; };
+		FE5151005B0000000000A001 /* OfferingStringsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5151005B0000000000A002 /* OfferingStringsTests.swift */; };
 		75ADC06C2E437D4900210ECA /* SimulatedStoreProductsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75ADC0682E437D4900210ECA /* SimulatedStoreProductsManager.swift */; };
 		75ADC06D2E437D4900210ECA /* SimulatedStoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75ADC06B2E437D4900210ECA /* SimulatedStoreTransaction.swift */; };
 		75ADC06E2E437D4900210ECA /* SimulatedStorePurchaseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75ADC0692E437D4900210ECA /* SimulatedStorePurchaseHandler.swift */; };
@@ -2555,6 +2556,7 @@
 		75A9F25B2E38DE57005D1AB1 /* GetWebBillingProductsOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetWebBillingProductsOperation.swift; sourceTree = "<group>"; };
 		75ABFDB42D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoManagerUIPreviewModeTests.swift; sourceTree = "<group>"; };
 		FE5151005A0000000000A002 /* CustomerInfoManagerSimulatedStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoManagerSimulatedStoreTests.swift; sourceTree = "<group>"; };
+		FE5151005B0000000000A002 /* OfferingStringsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfferingStringsTests.swift; sourceTree = "<group>"; };
 		75ADC0682E437D4900210ECA /* SimulatedStoreProductsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatedStoreProductsManager.swift; sourceTree = "<group>"; };
 		75ADC0692E437D4900210ECA /* SimulatedStorePurchaseHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatedStorePurchaseHandler.swift; sourceTree = "<group>"; };
 		75ADC06A2E437D4900210ECA /* SimulatedStorePurchaseUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatedStorePurchaseUI.swift; sourceTree = "<group>"; };
@@ -4535,6 +4537,7 @@
 				F575859126C08E3F00C12B97 /* OfferingsManagerTests.swift */,
 				1DA47C656406D58B636FD82D /* WorkflowManagerTests.swift */,
 				37E357C2D977BBB081216B5F /* OfferingsTests.swift */,
+				FE5151005B0000000000A002 /* OfferingStringsTests.swift */,
 				5793396F28E77A5100C1232C /* PaymentQueueWrapperTests.swift */,
 				37E3583675928C01D92E3166 /* ProductRequestDataExtensions.swift */,
 				37E3548189DA008320B3FC98 /* ProductRequestDataInitializationTests.swift */,
@@ -7759,6 +7762,7 @@
 				1DE37A192F61AF94009CA3AC /* PurchasesCustomPaywallEventsTests.swift in Sources */,
 				B36824BF268FBC8700957E4C /* SubscriberAttributeTests.swift in Sources */,
 				351B51BC26D450E800BD2BD7 /* OfferingsTests.swift in Sources */,
+				FE5151005B0000000000A001 /* OfferingStringsTests.swift in Sources */,
 				5796A38827D6B85900653165 /* BackendPostReceiptDataTests.swift in Sources */,
 				5752E8482892DC500069281E /* ErrorUtilsTests.swift in Sources */,
 				16BCA36E2E4D9B9300B39E7F /* DeferredValueStoresTests.swift in Sources */,

--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -425,16 +425,6 @@ private extension CustomerInfoManager {
             return
         }
 
-        // The Simulated Store ("Test Store") never touches StoreKit, so skip reading
-        // StoreKit transactions and the storefront and fetch CustomerInfo from the backend directly.
-        if self.systemInfo.isSimulatedStoreAPIKey {
-            self.requestCustomerInfo(appUserID: appUserID,
-                                     isAppBackgrounded: isAppBackgrounded) { result in
-                completion(CustomerInfoDataResult(result: result))
-            }
-            return
-        }
-
         if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
             _ = Task<Void, Never> {
                 let transactions = await self.transactionFetcher.unfinishedVerifiedTransactions

--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -424,6 +424,17 @@ private extension CustomerInfoManager {
             completion(CustomerInfoDataResult(result: .success(previewCustomerInfo)))
             return
         }
+
+        // The Simulated Store ("Test Store") never touches StoreKit, so skip reading
+        // StoreKit transactions and the storefront and fetch CustomerInfo from the backend directly.
+        guard !self.systemInfo.isSimulatedStoreAPIKey else {
+            self.requestCustomerInfo(appUserID: appUserID,
+                                     isAppBackgrounded: isAppBackgrounded) { result in
+                completion(CustomerInfoDataResult(result: result))
+            }
+            return
+        }
+
         if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
             _ = Task<Void, Never> {
                 let transactions = await self.transactionFetcher.unfinishedVerifiedTransactions

--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -427,7 +427,7 @@ private extension CustomerInfoManager {
 
         // The Simulated Store ("Test Store") never touches StoreKit, so skip reading
         // StoreKit transactions and the storefront and fetch CustomerInfo from the backend directly.
-        guard !self.systemInfo.isSimulatedStoreAPIKey else {
+        if self.systemInfo.isSimulatedStoreAPIKey {
             self.requestCustomerInfo(appUserID: appUserID,
                                      isAppBackgrounded: isAppBackgrounded) { result in
                 completion(CustomerInfoDataResult(result: result))

--- a/Sources/Logging/Strings/ConfigureStrings.swift
+++ b/Sources/Logging/Strings/ConfigureStrings.swift
@@ -51,7 +51,7 @@ enum ConfigureStrings {
 
     case system_version(String)
 
-    case is_simulator(Bool)
+    case is_simulator(Bool, apiKeyValidationResult: Configuration.APIKeyValidationResult)
 
     case simulatedStoreAPIKey
 
@@ -135,12 +135,20 @@ extension ConfigureStrings: LogMessage {
             return "Bundle ID - \(bundleID)"
         case let .system_version(osVersion):
             return "System Version - \(osVersion)"
-        case let .is_simulator(isSimulator):
-            return isSimulator
-                ? "Using a simulator. Ensure you have a StoreKit Config " +
-                "file set up before trying to fetch products or make purchases.\n" +
-                "See https://errors.rev.cat/testing-in-simulator for more details."
-                : "Not using a simulator."
+        case let .is_simulator(isSimulator, apiKeyValidationResult):
+            guard isSimulator else {
+                return "Not using a simulator."
+            }
+
+            if case .simulatedStore = apiKeyValidationResult {
+                return "Using a simulator with a Test Store API key. Test Store products are fetched from " +
+                "RevenueCat's backend, so purchases are simulated and don't rely on StoreKit. " +
+                "No additional simulator configuration is required to fetch products or make purchases."
+            }
+
+            return "Using a simulator. Ensure you have a StoreKit Config " +
+            "file set up before trying to fetch products or make purchases.\n" +
+            "See https://errors.rev.cat/testing-in-simulator for more details."
         case .simulatedStoreAPIKey:
             return "Using a Test Store API key.\n" +
             "The Test Store is for development only. Never use a Test Store API key in production. " +

--- a/Sources/Logging/Strings/ConfigureStrings.swift
+++ b/Sources/Logging/Strings/ConfigureStrings.swift
@@ -142,8 +142,7 @@ extension ConfigureStrings: LogMessage {
 
             if case .simulatedStore = apiKeyValidationResult {
                 return "Using a simulator with a Test Store API key. Test Store products are fetched from " +
-                "RevenueCat's backend, so purchases are simulated and don't rely on StoreKit. " +
-                "No additional simulator configuration is required to fetch products or make purchases."
+                "RevenueCat's backend, so purchases are simulated and don't rely on StoreKit."
             }
 
             return "Using a simulator. Ensure you have a StoreKit Config " +

--- a/Sources/Logging/Strings/OfferingStrings.swift
+++ b/Sources/Logging/Strings/OfferingStrings.swift
@@ -225,15 +225,9 @@ extension OfferingStrings: LogMessage {
                 "with your simulator." +
                 "\nMore information: https://rev.cat/ios-18-4-simulator-issue"
             case .simulatedStore:
-                return "None of the Test Store products registered in the RevenueCat dashboard could be fetched." +
-                "\nThis issue is widely reported by iOS 18.4 simulator users. Try using a different iOS version " +
-                "with your simulator." +
-                "\nMore information: https://rev.cat/ios-18-4-simulator-issue"
+                return "None of the Test Store products registered in the RevenueCat dashboard could be fetched."
             case .otherPlatforms:
-                return "None of the products registered in the RevenueCat dashboard could be fetched." +
-                "\nThis issue is widely reported by iOS 18.4 simulator users. Try using a different iOS version " +
-                "with your simulator." +
-                "\nMore information: https://rev.cat/ios-18-4-simulator-issue"
+                return "None of the products registered in the RevenueCat dashboard could be fetched."
             }
 
         case let .simulated_store_invalid_trial_period(productId, periodDuration):

--- a/Sources/Logging/Strings/OfferingStrings.swift
+++ b/Sources/Logging/Strings/OfferingStrings.swift
@@ -38,7 +38,7 @@ enum OfferingStrings {
     case completion_handlers_waiting_on_products(handlersCount: Int)
     case configuration_error_products_not_found
     case configuration_error_no_products_for_offering(apiKeyValidationResult: Configuration.APIKeyValidationResult)
-    case offering_empty(offeringIdentifier: String)
+    case offering_empty(offeringIdentifier: String, apiKeyValidationResult: Configuration.APIKeyValidationResult)
     case product_details_empty_title(productIdentifier: String)
     case unknown_package_type(Package)
     case custom_package_type(Package)
@@ -152,12 +152,28 @@ extension OfferingStrings: LogMessage {
             "https://rev.cat/how-to-configure-offerings.\nMore information: https://rev.cat/why-are-offerings-empty"
             return description
 
-        case .offering_empty(let offeringIdentifier):
-            return "There's a problem with your configuration. No packages could be found for offering with  " +
-            "identifier \(offeringIdentifier). This could be due to Products not being configured correctly in the " +
-            "RevenueCat dashboard, App Store Connect (or the StoreKit Configuration file " +
-            "if one is being used). \nTo configure products, follow the instructions in " +
-            "https://rev.cat/how-to-configure-offerings. \nMore information: https://rev.cat/why-are-offerings-empty"
+        case let .offering_empty(offeringIdentifier, apiKeyValidationResult):
+            switch apiKeyValidationResult.storeNameForLogging {
+            case "App Store":
+                return "There's a problem with your configuration. No packages could be found for offering with  " +
+                "identifier \(offeringIdentifier). This could be due to Products not being configured correctly in " +
+                "the RevenueCat dashboard, App Store Connect (or the StoreKit Configuration file " +
+                "if one is being used). \nTo configure products, follow the instructions in " +
+                "https://rev.cat/how-to-configure-offerings. " +
+                "\nMore information: https://rev.cat/why-are-offerings-empty"
+            case "Test Store":
+                return "There's a problem with your configuration. No packages could be found for offering with " +
+                "identifier \(offeringIdentifier). This could be due to Test Store products not being configured " +
+                "correctly in the RevenueCat dashboard. \nTo configure products, follow the instructions in " +
+                "https://rev.cat/how-to-configure-offerings. " +
+                "\nMore information: https://rev.cat/why-are-offerings-empty"
+            default:
+                return "There's a problem with your configuration. No packages could be found for offering with " +
+                "identifier \(offeringIdentifier). This could be due to products not being configured correctly in " +
+                "the RevenueCat dashboard. \nTo configure products, follow the instructions in " +
+                "https://rev.cat/how-to-configure-offerings. " +
+                "\nMore information: https://rev.cat/why-are-offerings-empty"
+            }
 
         case let .product_details_empty_title(identifier):
             return "Empty Product titles are not supported. Found in product with identifier: \(identifier)"

--- a/Sources/Logging/Strings/OfferingStrings.swift
+++ b/Sources/Logging/Strings/OfferingStrings.swift
@@ -64,16 +64,16 @@ extension OfferingStrings: LogMessage {
     var description: String {
         switch self {
         case let .cannot_find_product_configuration_error(identifiers, apiKeyValidationResult):
-            switch apiKeyValidationResult.storeNameForLogging {
-            case "App Store":
+            switch apiKeyValidationResult {
+            case .validApplePlatform, .legacy:
                 return "Could not find products with identifiers: \(identifiers)." +
                     "\nThere is a problem with your configuration in App Store Connect. " +
                     "\nMore info here: https://errors.rev.cat/configuring-products"
-            case "Test Store":
+            case .simulatedStore:
                 return "Could not find products with identifiers: \(identifiers)." +
                     "\nThere is a problem with your Test Store configuration in the RevenueCat dashboard. " +
                     "\nMore info here: https://errors.rev.cat/configuring-products"
-            default:
+            case .otherPlatforms:
                 return "Could not find products with identifiers: \(identifiers)." +
                     "\nThere is a problem with your product configuration in the RevenueCat dashboard. " +
                     "\nMore info here: https://errors.rev.cat/configuring-products"
@@ -145,16 +145,16 @@ extension OfferingStrings: LogMessage {
             return "\(handlersCount) completion handlers waiting on products"
 
         case let .configuration_error_products_not_found(apiKeyValidationResult):
-            switch apiKeyValidationResult.storeNameForLogging {
-            case "App Store":
+            switch apiKeyValidationResult {
+            case .validApplePlatform, .legacy:
                 return "There's a problem with your configuration. None of the products registered in the " +
                 "RevenueCat dashboard could be fetched from App Store Connect (or the StoreKit Configuration " +
                 "file if one is being used). \nMore information: https://rev.cat/why-are-offerings-empty"
-            case "Test Store":
+            case .simulatedStore:
                 return "There's a problem with your configuration. None of the Test Store products registered in " +
                 "the RevenueCat dashboard could be fetched. " +
                 "\nMore information: https://rev.cat/why-are-offerings-empty"
-            default:
+            case .otherPlatforms:
                 return "There's a problem with your configuration. None of the products registered in the " +
                 "RevenueCat dashboard could be fetched. " +
                 "\nMore information: https://rev.cat/why-are-offerings-empty"
@@ -176,21 +176,21 @@ extension OfferingStrings: LogMessage {
             return description
 
         case let .offering_empty(offeringIdentifier, apiKeyValidationResult):
-            switch apiKeyValidationResult.storeNameForLogging {
-            case "App Store":
+            switch apiKeyValidationResult {
+            case .validApplePlatform, .legacy:
                 return "There's a problem with your configuration. No packages could be found for offering with  " +
                 "identifier \(offeringIdentifier). This could be due to Products not being configured correctly in " +
                 "the RevenueCat dashboard, App Store Connect (or the StoreKit Configuration file " +
                 "if one is being used). \nTo configure products, follow the instructions in " +
                 "https://rev.cat/how-to-configure-offerings. " +
                 "\nMore information: https://rev.cat/why-are-offerings-empty"
-            case "Test Store":
+            case .simulatedStore:
                 return "There's a problem with your configuration. No packages could be found for offering with " +
                 "identifier \(offeringIdentifier). This could be due to Test Store products not being configured " +
                 "correctly in the RevenueCat dashboard. \nTo configure products, follow the instructions in " +
                 "https://rev.cat/how-to-configure-offerings. " +
                 "\nMore information: https://rev.cat/why-are-offerings-empty"
-            default:
+            case .otherPlatforms:
                 return "There's a problem with your configuration. No packages could be found for offering with " +
                 "identifier \(offeringIdentifier). This could be due to products not being configured correctly in " +
                 "the RevenueCat dashboard. \nTo configure products, follow the instructions in " +
@@ -217,19 +217,19 @@ extension OfferingStrings: LogMessage {
             return "Package: \(old) already exists, overwriting with: \(new)"
 
         case let .known_issue_ios_18_4_simulator_products_not_found(apiKeyValidationResult):
-            switch apiKeyValidationResult.storeNameForLogging {
-            case "App Store":
+            switch apiKeyValidationResult {
+            case .validApplePlatform, .legacy:
                 return "None of the products registered in the RevenueCat dashboard could be fetched from App " +
                 "Store Connect (or the StoreKit Configuration file if one is being used)." +
                 "\nThis issue is widely reported by iOS 18.4 simulator users. Try using a different iOS version " +
                 "with your simulator." +
                 "\nMore information: https://rev.cat/ios-18-4-simulator-issue"
-            case "Test Store":
+            case .simulatedStore:
                 return "None of the Test Store products registered in the RevenueCat dashboard could be fetched." +
                 "\nThis issue is widely reported by iOS 18.4 simulator users. Try using a different iOS version " +
                 "with your simulator." +
                 "\nMore information: https://rev.cat/ios-18-4-simulator-issue"
-            default:
+            case .otherPlatforms:
                 return "None of the products registered in the RevenueCat dashboard could be fetched." +
                 "\nThis issue is widely reported by iOS 18.4 simulator users. Try using a different iOS version " +
                 "with your simulator." +

--- a/Sources/Logging/Strings/OfferingStrings.swift
+++ b/Sources/Logging/Strings/OfferingStrings.swift
@@ -18,7 +18,8 @@ import StoreKit
 // swiftlint:disable identifier_name
 enum OfferingStrings {
 
-    case cannot_find_product_configuration_error(identifiers: Set<String>)
+    case cannot_find_product_configuration_error(identifiers: Set<String>,
+                                                 apiKeyValidationResult: Configuration.APIKeyValidationResult)
     case fetching_offerings_error(error: OfferingsManager.Error, underlyingError: Error?)
     case error_fetching_offerings_using_disk_cache
     case found_existing_product_request(identifiers: Set<String>)
@@ -36,14 +37,14 @@ enum OfferingStrings {
     case fetching_products_finished
     case fetching_products(identifiers: Set<String>)
     case completion_handlers_waiting_on_products(handlersCount: Int)
-    case configuration_error_products_not_found
+    case configuration_error_products_not_found(apiKeyValidationResult: Configuration.APIKeyValidationResult)
     case configuration_error_no_products_for_offering(apiKeyValidationResult: Configuration.APIKeyValidationResult)
     case offering_empty(offeringIdentifier: String, apiKeyValidationResult: Configuration.APIKeyValidationResult)
     case product_details_empty_title(productIdentifier: String)
     case unknown_package_type(Package)
     case custom_package_type(Package)
     case overriding_package(old: String, new: String)
-    case known_issue_ios_18_4_simulator_products_not_found
+    case known_issue_ios_18_4_simulator_products_not_found(apiKeyValidationResult: Configuration.APIKeyValidationResult)
 
     case simulated_store_invalid_trial_period(productId: String, periodDuration: String)
     case simulated_store_invalid_intro_price_period(productId: String, periodDuration: String)
@@ -62,10 +63,21 @@ extension OfferingStrings: LogMessage {
 
     var description: String {
         switch self {
-        case .cannot_find_product_configuration_error(let identifiers):
-            return "Could not find products with identifiers: \(identifiers)." +
-                "\nThere is a problem with your configuration in App Store Connect. " +
-                "\nMore info here: https://errors.rev.cat/configuring-products"
+        case let .cannot_find_product_configuration_error(identifiers, apiKeyValidationResult):
+            switch apiKeyValidationResult.storeNameForLogging {
+            case "App Store":
+                return "Could not find products with identifiers: \(identifiers)." +
+                    "\nThere is a problem with your configuration in App Store Connect. " +
+                    "\nMore info here: https://errors.rev.cat/configuring-products"
+            case "Test Store":
+                return "Could not find products with identifiers: \(identifiers)." +
+                    "\nThere is a problem with your Test Store configuration in the RevenueCat dashboard. " +
+                    "\nMore info here: https://errors.rev.cat/configuring-products"
+            default:
+                return "Could not find products with identifiers: \(identifiers)." +
+                    "\nThere is a problem with your product configuration in the RevenueCat dashboard. " +
+                    "\nMore info here: https://errors.rev.cat/configuring-products"
+            }
 
         case let .fetching_offerings_error(error, underlyingError):
             var result = "Error fetching offerings - \(error.localizedDescription)"
@@ -132,10 +144,21 @@ extension OfferingStrings: LogMessage {
         case .completion_handlers_waiting_on_products(let handlersCount):
             return "\(handlersCount) completion handlers waiting on products"
 
-        case .configuration_error_products_not_found:
-            return "There's a problem with your configuration. None of the products registered in the RevenueCat " +
-            "dashboard could be fetched from App Store Connect (or the StoreKit Configuration file " +
-            "if one is being used). \nMore information: https://rev.cat/why-are-offerings-empty"
+        case let .configuration_error_products_not_found(apiKeyValidationResult):
+            switch apiKeyValidationResult.storeNameForLogging {
+            case "App Store":
+                return "There's a problem with your configuration. None of the products registered in the " +
+                "RevenueCat dashboard could be fetched from App Store Connect (or the StoreKit Configuration " +
+                "file if one is being used). \nMore information: https://rev.cat/why-are-offerings-empty"
+            case "Test Store":
+                return "There's a problem with your configuration. None of the Test Store products registered in " +
+                "the RevenueCat dashboard could be fetched. " +
+                "\nMore information: https://rev.cat/why-are-offerings-empty"
+            default:
+                return "There's a problem with your configuration. None of the products registered in the " +
+                "RevenueCat dashboard could be fetched. " +
+                "\nMore information: https://rev.cat/why-are-offerings-empty"
+            }
 
         case .configuration_error_no_products_for_offering(let apiKeyValidationResult):
             var description: String
@@ -193,12 +216,25 @@ extension OfferingStrings: LogMessage {
         case let .overriding_package(old, new):
             return "Package: \(old) already exists, overwriting with: \(new)"
 
-        case .known_issue_ios_18_4_simulator_products_not_found:
-            return "None of the products registered in the RevenueCat dashboard could be fetched from App Store " +
-            "Connect (or the StoreKit Configuration file if one is being used)." +
-            "\nThis issue is widely reported by iOS 18.4 simulator users. Try using a different iOS version with " +
-            "your simulator." +
-            "\nMore information: https://rev.cat/ios-18-4-simulator-issue"
+        case let .known_issue_ios_18_4_simulator_products_not_found(apiKeyValidationResult):
+            switch apiKeyValidationResult.storeNameForLogging {
+            case "App Store":
+                return "None of the products registered in the RevenueCat dashboard could be fetched from App " +
+                "Store Connect (or the StoreKit Configuration file if one is being used)." +
+                "\nThis issue is widely reported by iOS 18.4 simulator users. Try using a different iOS version " +
+                "with your simulator." +
+                "\nMore information: https://rev.cat/ios-18-4-simulator-issue"
+            case "Test Store":
+                return "None of the Test Store products registered in the RevenueCat dashboard could be fetched." +
+                "\nThis issue is widely reported by iOS 18.4 simulator users. Try using a different iOS version " +
+                "with your simulator." +
+                "\nMore information: https://rev.cat/ios-18-4-simulator-issue"
+            default:
+                return "None of the products registered in the RevenueCat dashboard could be fetched." +
+                "\nThis issue is widely reported by iOS 18.4 simulator users. Try using a different iOS version " +
+                "with your simulator." +
+                "\nMore information: https://rev.cat/ios-18-4-simulator-issue"
+            }
 
         case let .simulated_store_invalid_trial_period(productId, periodDuration):
             return "Skipping free trial for simulated store product '\(productId)': " +

--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -16,6 +16,7 @@ import Foundation
 import StoreKit
 
 // swiftlint:disable identifier_name
+// swiftlint:disable file_length
 
 enum PurchaseStrings {
 

--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -94,6 +94,7 @@ enum PurchaseStrings {
     case sync_purchases_simulated_store
     case restore_purchases_simulated_store
     case simulating_purchase_success
+    case simulated_store_unexpected_receipt_fetch
 
     // Cached metadata
     case posting_remaining_cached_metadata(count: Int)
@@ -369,6 +370,9 @@ extension PurchaseStrings: LogMessage {
 
         case .simulating_purchase_success:
             return "[Test Store] Performing test purchase. This purchase won't appear in production."
+
+        case .simulated_store_unexpected_receipt_fetch:
+            return "[Test Store] Unexpectedly fetching a receipt. Returning an empty receipt."
 
         case let .posting_remaining_cached_metadata(count):
             return "Posting \(count) remaining cached transaction metadata entries"

--- a/Sources/Purchasing/OfferingsFactory.swift
+++ b/Sources/Purchasing/OfferingsFactory.swift
@@ -17,16 +17,20 @@ import StoreKit
 
 class OfferingsFactory {
 
-    func createOfferings(from storeProductsByID: [String: StoreProduct],
-                         contents: Offerings.Contents,
-                         loadedFromDiskCache: Bool) -> Offerings? {
+    func createOfferings(
+        from storeProductsByID: [String: StoreProduct],
+        contents: Offerings.Contents,
+        loadedFromDiskCache: Bool,
+        apiKeyValidationResult: Configuration.APIKeyValidationResult = .validApplePlatform
+    ) -> Offerings? {
         let data = contents.response
         let offerings: [String: Offering] = data
             .offerings
             .compactMap { offeringData in
                 createOffering(from: storeProductsByID,
                                offering: offeringData,
-                               uiConfig: data.uiConfig)
+                               uiConfig: data.uiConfig,
+                               apiKeyValidationResult: apiKeyValidationResult)
             }
             .dictionaryAllowingDuplicateKeys { $0.identifier }
 
@@ -45,7 +49,8 @@ class OfferingsFactory {
     func createOffering(
         from storeProductsByID: [String: StoreProduct],
         offering: OfferingsResponse.Offering,
-        uiConfig: UIConfig?
+        uiConfig: UIConfig?,
+        apiKeyValidationResult: Configuration.APIKeyValidationResult = .validApplePlatform
     ) -> Offering? {
         let availablePackages: [Package] = offering.packages.compactMap { package in
             createPackage(with: package, productsByID: storeProductsByID, offeringIdentifier: offering.identifier)
@@ -53,9 +58,11 @@ class OfferingsFactory {
 
         guard !availablePackages.isEmpty else {
             #if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION && !DEBUG
-            Logger.debug(Strings.offering.offering_empty(offeringIdentifier: offering.identifier))
+            Logger.debug(Strings.offering.offering_empty(offeringIdentifier: offering.identifier,
+                                                         apiKeyValidationResult: apiKeyValidationResult))
             #else
-            Logger.warn(Strings.offering.offering_empty(offeringIdentifier: offering.identifier))
+            Logger.warn(Strings.offering.offering_empty(offeringIdentifier: offering.identifier,
+                                                        apiKeyValidationResult: apiKeyValidationResult))
             #endif
             return nil
         }

--- a/Sources/Purchasing/OfferingsFactory.swift
+++ b/Sources/Purchasing/OfferingsFactory.swift
@@ -17,11 +17,16 @@ import StoreKit
 
 class OfferingsFactory {
 
+    private let systemInfo: SystemInfo
+
+    init(systemInfo: SystemInfo) {
+        self.systemInfo = systemInfo
+    }
+
     func createOfferings(
         from storeProductsByID: [String: StoreProduct],
         contents: Offerings.Contents,
-        loadedFromDiskCache: Bool,
-        apiKeyValidationResult: Configuration.APIKeyValidationResult = .validApplePlatform
+        loadedFromDiskCache: Bool
     ) -> Offerings? {
         let data = contents.response
         let offerings: [String: Offering] = data
@@ -29,8 +34,7 @@ class OfferingsFactory {
             .compactMap { offeringData in
                 createOffering(from: storeProductsByID,
                                offering: offeringData,
-                               uiConfig: data.uiConfig,
-                               apiKeyValidationResult: apiKeyValidationResult)
+                               uiConfig: data.uiConfig)
             }
             .dictionaryAllowingDuplicateKeys { $0.identifier }
 
@@ -49,14 +53,14 @@ class OfferingsFactory {
     func createOffering(
         from storeProductsByID: [String: StoreProduct],
         offering: OfferingsResponse.Offering,
-        uiConfig: UIConfig?,
-        apiKeyValidationResult: Configuration.APIKeyValidationResult = .validApplePlatform
+        uiConfig: UIConfig?
     ) -> Offering? {
         let availablePackages: [Package] = offering.packages.compactMap { package in
             createPackage(with: package, productsByID: storeProductsByID, offeringIdentifier: offering.identifier)
         }
 
         guard !availablePackages.isEmpty else {
+            let apiKeyValidationResult = self.systemInfo.apiKeyValidationResult
             #if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION && !DEBUG
             Logger.debug(Strings.offering.offering_empty(offeringIdentifier: offering.identifier,
                                                          apiKeyValidationResult: apiKeyValidationResult))

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -300,8 +300,7 @@ private extension OfferingsManager {
             if let createdOfferings = self.offeringsFactory.createOfferings(
                 from: productsByID,
                 contents: contents,
-                loadedFromDiskCache: loadedFromDiskCache,
-                apiKeyValidationResult: self.systemInfo.apiKeyValidationResult
+                loadedFromDiskCache: loadedFromDiskCache
             ) {
                 completion(.success(OfferingsResultData(offerings: createdOfferings,
                                                         requestedProductIds: productIdentifiers,

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -265,13 +265,15 @@ private extension OfferingsManager {
 
         self.fetchProducts(withIdentifiers: productIdentifiers, fromResponse: contents.response) { result in
             let products = result.value ?? []
+            let apiKeyValidationResult = self.systemInfo.apiKeyValidationResult
 
             guard products.isEmpty == false else {
                 // Check if empty products is likely caused by https://github.com/RevenueCat/purchases-ios/issues/4954
                 // There is a widely reported bug in the iOS 18.4 Simulator affecting some HTTP requests
                 let showSimulatorWarning = self.systemInfo.isSubjectToKnownIssue_18_4_sim()
                 completion(.failure(Self.createErrorForEmptyResult(result.error,
-                                                                   showSimulatorWarning: showSimulatorWarning)))
+                                                                   showSimulatorWarning: showSimulatorWarning,
+                                                                   apiKeyValidationResult: apiKeyValidationResult)))
                 return
             }
 
@@ -283,11 +285,14 @@ private extension OfferingsManager {
                 switch fetchPolicy {
                 case .ignoreNotFoundProducts:
                     Logger.appleWarning(
-                        Strings.offering.cannot_find_product_configuration_error(identifiers: missingProductIDs)
+                        Strings.offering.cannot_find_product_configuration_error(
+                            identifiers: missingProductIDs,
+                            apiKeyValidationResult: apiKeyValidationResult)
                     )
 
                 case .failIfProductsAreMissing:
-                    completion(.failure(.missingProducts(identifiers: missingProductIDs)))
+                    completion(.failure(.missingProducts(identifiers: missingProductIDs,
+                                                         apiKeyValidationResult: apiKeyValidationResult)))
                     return
                 }
             }
@@ -338,17 +343,28 @@ private extension OfferingsManager {
         }
     }
 
-    private static func createErrorForEmptyResult(_ error: PurchasesError?,
-                                                  showSimulatorWarning: Bool = false) -> OfferingsManager.Error {
+    private static func createErrorForEmptyResult(
+        _ error: PurchasesError?,
+        showSimulatorWarning: Bool = false,
+        apiKeyValidationResult: Configuration.APIKeyValidationResult
+    ) -> OfferingsManager.Error {
         if let purchasesError = error,
            case ErrorCode.productRequestTimedOut = purchasesError.error {
             return .timeout(purchasesError)
         } else if showSimulatorWarning {
-            return .configurationError(Strings.offering.known_issue_ios_18_4_simulator_products_not_found.description,
-                                       underlyingError: error?.asPublicError)
+            return .configurationError(
+                Strings.offering.known_issue_ios_18_4_simulator_products_not_found(
+                    apiKeyValidationResult: apiKeyValidationResult
+                ).description,
+                underlyingError: error?.asPublicError
+            )
         } else {
-            return .configurationError(Strings.offering.configuration_error_products_not_found.description,
-                                       underlyingError: error?.asPublicError)
+            return .configurationError(
+                Strings.offering.configuration_error_products_not_found(
+                    apiKeyValidationResult: apiKeyValidationResult
+                ).description,
+                underlyingError: error?.asPublicError
+            )
         }
     }
 
@@ -544,7 +560,9 @@ extension OfferingsManager {
         case configurationError(String, PublicError?, ErrorSource)
         case timeout(PurchasesError)
         case noOfferingsFound(ErrorSource)
-        case missingProducts(identifiers: Set<String>, ErrorSource)
+        case missingProducts(identifiers: Set<String>,
+                             apiKeyValidationResult: Configuration.APIKeyValidationResult,
+                             ErrorSource)
 
     }
 
@@ -572,9 +590,12 @@ extension OfferingsManager.Error: PurchasesErrorConvertible {
                                                              functionName: source.function,
                                                              line: source.line)
 
-        case let .missingProducts(identifiers, source):
+        case let .missingProducts(identifiers, apiKeyValidationResult, source):
             return ErrorUtils.configurationError(
-                message: Strings.offering.cannot_find_product_configuration_error(identifiers: identifiers).description,
+                message: Strings.offering.cannot_find_product_configuration_error(
+                    identifiers: identifiers,
+                    apiKeyValidationResult: apiKeyValidationResult
+                ).description,
                 fileName: source.file,
                 functionName: source.function,
                 line: source.line
@@ -602,11 +623,14 @@ extension OfferingsManager.Error: PurchasesErrorConvertible {
 
     static func missingProducts(
         identifiers: Set<String>,
+        apiKeyValidationResult: Configuration.APIKeyValidationResult,
         file: String = #fileID,
         function: String = #function,
         line: UInt = #line
     ) -> Self {
-        return .missingProducts(identifiers: identifiers, .init(file: file, function: function, line: line))
+        return .missingProducts(identifiers: identifiers,
+                                apiKeyValidationResult: apiKeyValidationResult,
+                                .init(file: file, function: function, line: line))
     }
 
 }

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -292,9 +292,12 @@ private extension OfferingsManager {
                 }
             }
 
-            if let createdOfferings = self.offeringsFactory.createOfferings(from: productsByID,
-                                                                            contents: contents,
-                                                                            loadedFromDiskCache: loadedFromDiskCache) {
+            if let createdOfferings = self.offeringsFactory.createOfferings(
+                from: productsByID,
+                contents: contents,
+                loadedFromDiskCache: loadedFromDiskCache,
+                apiKeyValidationResult: self.systemInfo.apiKeyValidationResult
+            ) {
                 completion(.success(OfferingsResultData(offerings: createdOfferings,
                                                         requestedProductIds: productIdentifiers,
                                                         notFoundProductIds: missingProductIDs)))

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -400,7 +400,9 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         let purchasedProductsFetcher = OfflineCustomerInfoCreator.createPurchasedProductsFetcherIfAvailable(
             diagnosticsTracker: diagnosticsTracker
         )
-        let transactionFetcher = StoreKit2TransactionFetcher(diagnosticsTracker: diagnosticsTracker)
+        let transactionFetcher: StoreKit2TransactionFetcherType = systemInfo.isSimulatedStoreAPIKey
+            ? SimulatedStoreTransactionFetcher()
+            : StoreKit2TransactionFetcher(diagnosticsTracker: diagnosticsTracker)
 
         let backend = Backend(
             systemInfo: systemInfo,

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -786,7 +786,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         Logger.debug(Strings.configure.sdk_version(Self.frameworkVersion))
         Logger.debug(Strings.configure.bundle_id(SystemInfo.bundleIdentifier))
         Logger.debug(Strings.configure.system_version(SystemInfo.systemVersion))
-        Logger.debug(Strings.configure.is_simulator(SystemInfo.isRunningInSimulator))
+        Logger.debug(Strings.configure.is_simulator(SystemInfo.isRunningInSimulator,
+                                                    apiKeyValidationResult: systemInfo.apiKeyValidationResult))
         Logger.user(Strings.configure.initial_app_user_id(isSet: appUserID != nil))
         Logger.debug(Strings.configure.response_verification_mode(systemInfo.responseVerificationMode))
         Logger.debug(Strings.configure.storekit_version(systemInfo.storeKitVersion))

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -429,7 +429,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
         let simulatedStorePurchaseHandler = SimulatedStorePurchaseHandler(systemInfo: systemInfo)
 
-        let offeringsFactory = OfferingsFactory()
+        let offeringsFactory = OfferingsFactory(systemInfo: systemInfo)
         let receiptParser = PurchasesReceiptParser.default
         let transactionsManager = TransactionsManager(receiptParser: receiptParser)
 

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -2337,11 +2337,11 @@ extension PurchasesOrchestrator {
     }
 
     private func setSK2DelegateAndStartListening() async {
-        await storeKit2TransactionListener.set(delegate: self)
-
-        // The Simulated Store ("Test Store") never produces StoreKit transactions,
-        // so there's no point in observing `StoreKit.Transaction.updates`.
+        // The Simulated Store ("Test Store") never produces StoreKit transactions, so there's no
+        // delegate to notify and no point observing `StoreKit.Transaction.updates`.
         guard !self.systemInfo.isSimulatedStoreAPIKey else { return }
+
+        await storeKit2TransactionListener.set(delegate: self)
 
         if systemInfo.storeKitVersion == .storeKit2 {
             await storeKit2TransactionListener.listenForTransactions()

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -1077,6 +1077,7 @@ final class PurchasesOrchestrator {
     ) {
         // We can't inject StoreKit2PurchaseIntentListener in the constructor since
         // it has different availability requirements than the constructor.
+        guard !self.systemInfo.isSimulatedStoreAPIKey else { return }
 
         if systemInfo.storeKitVersion == .storeKit2 {
             self._storeKit2PurchaseIntentListener = storeKit2PurchaseIntentListener

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -2338,6 +2338,11 @@ extension PurchasesOrchestrator {
 
     private func setSK2DelegateAndStartListening() async {
         await storeKit2TransactionListener.set(delegate: self)
+
+        // The Simulated Store ("Test Store") never produces StoreKit transactions,
+        // so there's no point in observing `StoreKit.Transaction.updates`.
+        guard !self.systemInfo.isSimulatedStoreAPIKey else { return }
+
         if systemInfo.storeKitVersion == .storeKit2 {
             await storeKit2TransactionListener.listenForTransactions()
         }

--- a/Sources/Purchasing/SimulatedStore/SimulatedStoreTransactionFetcher.swift
+++ b/Sources/Purchasing/SimulatedStore/SimulatedStoreTransactionFetcher.swift
@@ -17,7 +17,7 @@ import StoreKit
 /// Implementation of `StoreKit2TransactionFetcherType` for the Simulated Store ("Test Store").
 ///
 /// The Simulated Store never uses StoreKit, so there are never any transactions to fetch. Every
-/// member returns an empty/`nil` result and nothing is logged.
+/// member returns an empty/`nil` result.
 final class SimulatedStoreTransactionFetcher: StoreKit2TransactionFetcherType {
 
     init() {}
@@ -59,6 +59,8 @@ final class SimulatedStoreTransactionFetcher: StoreKit2TransactionFetcherType {
     /// Returns an empty receipt to satisfy the protocol.
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func fetchReceipt(containing transaction: StoreTransactionType) async -> StoreKit2Receipt {
+        Logger.warn(Strings.purchase.simulated_store_unexpected_receipt_fetch)
+
         return .init(
             environment: .xcode,
             subscriptionStatusBySubscriptionGroupId: [:],

--- a/Sources/Purchasing/SimulatedStore/SimulatedStoreTransactionFetcher.swift
+++ b/Sources/Purchasing/SimulatedStore/SimulatedStoreTransactionFetcher.swift
@@ -1,0 +1,72 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SimulatedStoreTransactionFetcher.swift
+//
+//  Created by Rick van der Linden on 6/4/26.
+
+import Foundation
+import StoreKit
+
+/// Implementation of `StoreKit2TransactionFetcherType` for the Simulated Store ("Test Store").
+///
+/// The Simulated Store never uses StoreKit, so there are never any transactions to fetch. Every
+/// member returns an empty/`nil` result and nothing is logged.
+final class SimulatedStoreTransactionFetcher: StoreKit2TransactionFetcherType {
+
+    init() {}
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    var unfinishedVerifiedTransactions: [StoreTransaction] {
+        get async { [] }
+    }
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    var hasPendingConsumablePurchase: Bool {
+        get async { false }
+    }
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    var firstVerifiedAutoRenewableTransaction: StoreTransaction? {
+        get async { nil }
+    }
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    var firstVerifiedTransaction: StoreTransaction? {
+        get async { nil }
+    }
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    var oldestVerifiedTransaction: StoreTransaction? {
+        get async { nil }
+    }
+
+    var appTransactionJWS: String? {
+        get async { nil }
+    }
+
+    func appTransactionJWS(_ completionHandler: @escaping (String?) -> Void) {
+        completionHandler(nil)
+    }
+
+    /// Unused in Simulated Store mode: no transactions are ever posted, so no receipt is fetched.
+    /// Returns an empty receipt to satisfy the protocol.
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    func fetchReceipt(containing transaction: StoreTransactionType) async -> StoreKit2Receipt {
+        return .init(
+            environment: .xcode,
+            subscriptionStatusBySubscriptionGroupId: [:],
+            transactions: [],
+            bundleId: "",
+            originalApplicationVersion: nil,
+            originalPurchaseDate: nil
+        )
+    }
+
+}

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallPreviewResourcesLoader.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallPreviewResourcesLoader.swift
@@ -127,7 +127,13 @@ class PaywallPreviewResourcesLoader {
                 uiConfig: offeringsResponse.uiConfig
             )
 
-            let offerings = OfferingsFactory().createOfferings(from: [
+            let systemInfo = SystemInfo(
+                platformInfo: nil,
+                finishTransactions: true,
+                apiKey: "preview_api_key",
+                preferredLocalesProvider: .init(preferredLocaleOverride: nil)
+            )
+            let offerings = OfferingsFactory(systemInfo: systemInfo).createOfferings(from: [
                 "com.revenuecat.lifetime_product": .init(sk1Product: PreviewMock.Product(
                     price: 1.99,
                     unit: .week,

--- a/Tests/StoreKitUnitTests/BasePurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/BasePurchasesOrchestratorTests.swift
@@ -96,7 +96,9 @@ class BasePurchasesOrchestratorTests: StoreKitConfigTestCase {
                                                          operationDispatcher: self.operationDispatcher,
                                                          systemInfo: self.systemInfo,
                                                          backend: self.backend,
-                                                         offeringsFactory: OfferingsFactory(),
+                                                         offeringsFactory: OfferingsFactory(
+                                                            systemInfo: self.systemInfo
+                                                         ),
                                                          productsManager: self.productsManager,
                                                          diagnosticsTracker: self.mockDiagnosticsTracker)
         self.setUpStoreKit1Wrapper()

--- a/Tests/StoreKitUnitTests/OfferingsManagerStoreKitTests.swift
+++ b/Tests/StoreKitUnitTests/OfferingsManagerStoreKitTests.swift
@@ -26,7 +26,7 @@ class OfferingsManagerStoreKitTests: StoreKitConfigTestCase {
                                         storeKitVersion: .storeKit2)
     let mockBackend = MockBackend()
     var mockOfferings: MockOfferingsAPI!
-    let mockOfferingsFactory = OfferingsFactory()
+    lazy var mockOfferingsFactory = OfferingsFactory(systemInfo: self.mockSystemInfo)
     var mockProductsManager: MockProductsManager!
     var mockDiagnosticsTracker: DiagnosticsTrackerType!
     var offeringsManager: OfferingsManager!

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
@@ -1980,8 +1980,9 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
             storeKit2ObserverModePurchaseDetector: storeKit2ObserverModePurchasesDetector
         )
 
-        // The delegate is still set, but the listener must never start observing StoreKit transactions.
-        expect(transactionListener.invokedDelegateSetter).toEventually(beTrue())
+        // In Simulated Store mode the delegate is never set and the listener never starts
+        // observing StoreKit transactions.
+        expect(transactionListener.invokedDelegateSetter) == false
         expect(transactionListener.invokedListenForTransactions) == false
         expect(transactionListener.invokedListenForTransactionsCount) == 0
     }

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
@@ -1968,6 +1968,24 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
         expect(transactionListener.invokedListenForTransactionsCount) == 1
     }
 
+    func testSK2DoesNotListenForSK2TransactionsInSimulatedStore() throws {
+        self.systemInfo.stubbedApiKeyValidationResult = .simulatedStore
+
+        let transactionListener = MockStoreKit2TransactionListener()
+        let storeKit2ObserverModePurchasesDetector = MockStoreKit2ObserverModePurchaseDetector()
+
+        self.setUpOrchestrator(
+            storeKit2TransactionListener: transactionListener,
+            storeKit2StorefrontListener: StoreKit2StorefrontListener(delegate: nil, userDefaults: nil),
+            storeKit2ObserverModePurchaseDetector: storeKit2ObserverModePurchasesDetector
+        )
+
+        // The delegate is still set, but the listener must never start observing StoreKit transactions.
+        expect(transactionListener.invokedDelegateSetter).toEventually(beTrue())
+        expect(transactionListener.invokedListenForTransactions) == false
+        expect(transactionListener.invokedListenForTransactionsCount) == 0
+    }
+
     // MARK: - Sync Purchases
 
     func verifySyncPurchases(transaction: StoreTransaction) async throws {

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
@@ -2586,6 +2586,30 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
     }
 
     @available(iOS 16.4, macOS 14.4, *)
+    func testSetSK2PurchaseIntentListenerDoesNothingInSimulatedStore() {
+        let transactionListener = MockStoreKit2TransactionListener()
+        let storeKit2ObserverModePurchaseDetector = MockStoreKit2ObserverModePurchaseDetector()
+        let diagnosticsSynchronizer = MockDiagnosticsSynchronizer()
+        let diagnosticsTracker = MockDiagnosticsTracker()
+
+        self.systemInfo.stubbedApiKeyValidationResult = .simulatedStore
+        self.setUpOrchestrator(
+            storeKit2TransactionListener: transactionListener,
+            storeKit2StorefrontListener: StoreKit2StorefrontListener(delegate: nil, userDefaults: nil),
+            storeKit2ObserverModePurchaseDetector: storeKit2ObserverModePurchaseDetector,
+            diagnosticsSynchronizer: diagnosticsSynchronizer,
+            diagnosticsTracker: diagnosticsTracker
+        )
+
+        let purchaseIntentListener = MockStoreKit2PurchaseIntentListener()
+
+        self.orchestrator.setSK2PurchaseIntentListener(purchaseIntentListener)
+        expect(purchaseIntentListener.listenForPurchaseIntentsCalled).to(beFalse())
+        expect(purchaseIntentListener.lastProvidedDelegate).to(beNil())
+        expect(purchaseIntentListener.setDelegateCalled).to(beFalse())
+    }
+
+    @available(iOS 16.4, macOS 14.4, *)
     func testSetSK2PurchaseIntentListenerStartsListeningAndSetsDelegateInSK2Mode() {
         let transactionListener = MockStoreKit2TransactionListener()
         let storeKit2ObserverModePurchaseDetector = MockStoreKit2ObserverModePurchaseDetector()

--- a/Tests/UnitTests/Caching/DeviceCacheTests.swift
+++ b/Tests/UnitTests/Caching/DeviceCacheTests.swift
@@ -1299,9 +1299,10 @@ private extension DeviceCacheTests {
         )
 
         let offering = try XCTUnwrap(
-            OfferingsFactory().createOffering(from: products,
-                                              offering: offeringsData,
-                                              uiConfig: nil)
+            OfferingsFactory(systemInfo: MockSystemInfo(finishTransactions: true))
+                .createOffering(from: products,
+                                offering: offeringsData,
+                                uiConfig: nil)
         )
         return Offerings(
             offerings: [offeringIdentifier: offering],

--- a/Tests/UnitTests/Identity/CustomerInfoManagerSimulatedStoreTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerSimulatedStoreTests.swift
@@ -27,6 +27,18 @@ class CustomerInfoManagerSimulatedStoreTests: BaseCustomerInfoManagerTests {
         )
 
         try super.setUpWithError()
+
+        // Mirror production: in Simulated Store mode the `SimulatedStoreTransactionFetcher` is
+        // injected, which never returns any StoreKit transactions.
+        self.customerInfoManager = CustomerInfoManager(
+            offlineEntitlementsManager: self.mockOfflineEntitlementsManager,
+            operationDispatcher: self.mockOperationDispatcher,
+            deviceCache: self.mockDeviceCache,
+            backend: self.mockBackend,
+            transactionFetcher: SimulatedStoreTransactionFetcher(),
+            transactionPoster: self.mockTransactionPoster,
+            systemInfo: self.mockSystemInfo
+        )
     }
 
     func testFetchCustomerInfoReachesBackendInSimulatedStoreMode() async throws {
@@ -40,7 +52,7 @@ class CustomerInfoManagerSimulatedStoreTests: BaseCustomerInfoManagerTests {
         expect(self.mockBackend.invokedGetSubscriberData) == true
     }
 
-    func testFetchCustomerInfoDoesNotReadStoreKitTransactionsInSimulatedStoreMode() async throws {
+    func testSimulatedStoreFetcherReturnsNoTransactionsSoCustomerInfoComesFromBackend() async throws {
         self.mockBackend.stubbedGetCustomerInfoResult = .success(self.mockCustomerInfo)
 
         _ = try await self.customerInfoManager.fetchAndCacheCustomerInfo(
@@ -48,32 +60,9 @@ class CustomerInfoManagerSimulatedStoreTests: BaseCustomerInfoManagerTests {
             isAppBackgrounded: false
         )
 
-        expect(self.mockTransationFetcher.invokedUnfinishedVerifiedTransactions.value) == false
-    }
-
-    func testUnfinishedTransactionsIgnoredInSimulatedStoreMode() async throws {
-        self.mockTransationFetcher.stubbedUnfinishedTransactions = [
-            Self.createTransaction(),
-            Self.createTransaction()
-        ]
-        self.mockBackend.stubbedGetCustomerInfoResult = .success(self.mockCustomerInfo)
-
-        _ = try await self.customerInfoManager.fetchAndCacheCustomerInfo(
-            appUserID: "any_user",
-            isAppBackgrounded: false
-        )
-
-        expect(self.mockTransationFetcher.invokedUnfinishedVerifiedTransactions.value) == false
+        // The `SimulatedStoreTransactionFetcher` returns no transactions, so CustomerInfo is
+        // fetched from the backend and no transaction is posted.
         expect(self.mockTransactionPoster.invokedHandlePurchasedTransaction.value) == false
         expect(self.mockBackend.invokedGetSubscriberData) == true
     }
-}
-
-@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
-private extension CustomerInfoManagerSimulatedStoreTests {
-
-    static func createTransaction() -> StoreTransaction {
-        return .init(sk1Transaction: MockTransaction())
-    }
-
 }

--- a/Tests/UnitTests/Identity/CustomerInfoManagerSimulatedStoreTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerSimulatedStoreTests.swift
@@ -1,0 +1,79 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CustomerInfoManagerSimulatedStoreTests.swift
+
+import Foundation
+import Nimble
+import XCTest
+
+@_spi(Internal) @testable import RevenueCat
+
+@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+class CustomerInfoManagerSimulatedStoreTests: BaseCustomerInfoManagerTests {
+
+    override func setUpWithError() throws {
+
+        // Use a Simulated Store ("Test Store") API key
+        self.mockSystemInfo = MockSystemInfo(
+            finishTransactions: true,
+            apiKeyValidationResult: .simulatedStore
+        )
+
+        try super.setUpWithError()
+    }
+
+    func testFetchCustomerInfoReachesBackendInSimulatedStoreMode() async throws {
+        self.mockBackend.stubbedGetCustomerInfoResult = .success(self.mockCustomerInfo)
+
+        _ = try await self.customerInfoManager.fetchAndCacheCustomerInfo(
+            appUserID: "any_user",
+            isAppBackgrounded: false
+        )
+
+        expect(self.mockBackend.invokedGetSubscriberData) == true
+    }
+
+    func testFetchCustomerInfoDoesNotReadStoreKitTransactionsInSimulatedStoreMode() async throws {
+        self.mockBackend.stubbedGetCustomerInfoResult = .success(self.mockCustomerInfo)
+
+        _ = try await self.customerInfoManager.fetchAndCacheCustomerInfo(
+            appUserID: "any_user",
+            isAppBackgrounded: false
+        )
+
+        expect(self.mockTransationFetcher.invokedUnfinishedVerifiedTransactions.value) == false
+    }
+
+    func testUnfinishedTransactionsIgnoredInSimulatedStoreMode() async throws {
+        self.mockTransationFetcher.stubbedUnfinishedTransactions = [
+            Self.createTransaction(),
+            Self.createTransaction()
+        ]
+        self.mockBackend.stubbedGetCustomerInfoResult = .success(self.mockCustomerInfo)
+
+        _ = try await self.customerInfoManager.fetchAndCacheCustomerInfo(
+            appUserID: "any_user",
+            isAppBackgrounded: false
+        )
+
+        expect(self.mockTransationFetcher.invokedUnfinishedVerifiedTransactions.value) == false
+        expect(self.mockTransactionPoster.invokedHandlePurchasedTransaction.value) == false
+        expect(self.mockBackend.invokedGetSubscriberData) == true
+    }
+}
+
+@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+private extension CustomerInfoManagerSimulatedStoreTests {
+
+    static func createTransaction() -> StoreTransaction {
+        return .init(sk1Transaction: MockTransaction())
+    }
+
+}

--- a/Tests/UnitTests/Misc/PurchasesDiagnosticsTests.swift
+++ b/Tests/UnitTests/Misc/PurchasesDiagnosticsTests.swift
@@ -93,7 +93,8 @@ class PurchasesDiagnosticsTests: TestCase {
     }
 
     func testFailingOfferingsRequest() async throws {
-        let error = OfferingsManager.Error.missingProducts(identifiers: ["a"]).asPublicError
+        let error = OfferingsManager.Error
+            .missingProducts(identifiers: ["a"], apiKeyValidationResult: .validApplePlatform).asPublicError
         self.purchases.mockedOfferingsResponse = .failure(error)
 
         do {
@@ -169,7 +170,8 @@ class PurchasesDiagnosticsTests: TestCase {
     }
 
     func testFailedFetchingOfferings() {
-        let underlyingError = OfferingsManager.Error.missingProducts(identifiers: ["a"]).asPublicError
+        let underlyingError = OfferingsManager.Error
+            .missingProducts(identifiers: ["a"], apiKeyValidationResult: .validApplePlatform).asPublicError
         let error = PurchasesDiagnostics.Error.failedFetchingOfferings(underlyingError)
 
         expect(error.errorUserInfo[NSUnderlyingErrorKey] as? NSError).to(matchError(underlyingError))

--- a/Tests/UnitTests/Mocks/MockOfferingsFactory.swift
+++ b/Tests/UnitTests/Mocks/MockOfferingsFactory.swift
@@ -10,11 +10,14 @@ class MockOfferingsFactory: OfferingsFactory {
     var emptyOfferings = false
     var nilOfferings = false
 
+    override init(systemInfo: SystemInfo = MockSystemInfo(finishTransactions: true)) {
+        super.init(systemInfo: systemInfo)
+    }
+
     override func createOfferings(
         from storeProductsByID: [String: StoreProduct],
         contents: Offerings.Contents,
-        loadedFromDiskCache: Bool,
-        apiKeyValidationResult: Configuration.APIKeyValidationResult = .validApplePlatform
+        loadedFromDiskCache: Bool
     ) -> Offerings? {
         if emptyOfferings {
             let response = OfferingsResponse(currentOfferingId: "base",

--- a/Tests/UnitTests/Mocks/MockOfferingsFactory.swift
+++ b/Tests/UnitTests/Mocks/MockOfferingsFactory.swift
@@ -13,7 +13,8 @@ class MockOfferingsFactory: OfferingsFactory {
     override func createOfferings(
         from storeProductsByID: [String: StoreProduct],
         contents: Offerings.Contents,
-        loadedFromDiskCache: Bool
+        loadedFromDiskCache: Bool,
+        apiKeyValidationResult: Configuration.APIKeyValidationResult = .validApplePlatform
     ) -> Offerings? {
         if emptyOfferings {
             let response = OfferingsResponse(currentOfferingId: "base",

--- a/Tests/UnitTests/Mocks/MockStoreKit2TransactionFetcher.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKit2TransactionFetcher.swift
@@ -54,9 +54,14 @@ final class MockStoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
         set { self._stubbedAppTransactionJWS.value = newValue }
     }
 
+    let invokedUnfinishedVerifiedTransactions = Atomic<Bool>(false)
+    let invokedUnfinishedVerifiedTransactionsCount = Atomic<Int>(0)
+
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     var unfinishedVerifiedTransactions: [StoreTransaction] {
         get async {
+            self.invokedUnfinishedVerifiedTransactions.value = true
+            self.invokedUnfinishedVerifiedTransactionsCount.modify { $0 += 1 }
             return self.stubbedUnfinishedTransactions
         }
     }

--- a/Tests/UnitTests/Purchasing/ConfigureStringsTests.swift
+++ b/Tests/UnitTests/Purchasing/ConfigureStringsTests.swift
@@ -1,0 +1,45 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ConfigureStringsTests.swift
+//
+
+import Foundation
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+final class ConfigureStringsTests: TestCase {
+
+    func testIsSimulatorAppStoreReferencesStoreKitConfig() {
+        let subject = Strings.configure.is_simulator(true, apiKeyValidationResult: .validApplePlatform)
+
+        expect(subject.category).to(equal("configure"))
+        expect(subject.description).to(contain("StoreKit Config"))
+        expect(subject.description).to(contain("https://errors.rev.cat/testing-in-simulator"))
+    }
+
+    func testIsSimulatorSimulatedStoreDoesNotReferenceStoreKitConfig() {
+        let subject = Strings.configure.is_simulator(true, apiKeyValidationResult: .simulatedStore)
+
+        expect(subject.category).to(equal("configure"))
+        expect(subject.description).to(contain("Test Store"))
+        expect(subject.description).toNot(contain("StoreKit Config"))
+        expect(subject.description).toNot(contain("StoreKit Configuration"))
+    }
+
+    func testIsSimulatorFalseDoesNotReferenceStoreKit() {
+        let subject = Strings.configure.is_simulator(false, apiKeyValidationResult: .simulatedStore)
+
+        expect(subject.category).to(equal("configure"))
+        expect(subject.description).to(equal("Not using a simulator."))
+    }
+
+}

--- a/Tests/UnitTests/Purchasing/OfferingStringsTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingStringsTests.swift
@@ -95,15 +95,26 @@ final class OfferingStringsTests: TestCase {
             .known_issue_ios_18_4_simulator_products_not_found(apiKeyValidationResult: .validApplePlatform)
 
         expect(subject.description).to(contain("App Store Connect"))
+        expect(subject.description).to(contain("18.4"))
     }
 
-    func testKnownIssue1840SimulatorProductsNotFoundSimulatedStoreDoesNotReferenceAppStore() {
+    func testKnownIssue1840SimulatorProductsNotFoundSimulatedStoreDoesNotReferenceAppStoreNorTheKnownIssue() {
         let subject = Strings.offering
             .known_issue_ios_18_4_simulator_products_not_found(apiKeyValidationResult: .simulatedStore)
 
         expect(subject.description).to(contain("Test Store"))
         expect(subject.description).toNot(contain("App Store Connect"))
         expect(subject.description).toNot(contain("StoreKit Config"))
+        expect(subject.description).toNot(contain("18.4"))
+    }
+
+    func testKnownIssue1840SimulatorProductsNotFoundOtherPlatformsDoesNotReferenceTheKnownIssue() {
+        let subject = Strings.offering
+            .known_issue_ios_18_4_simulator_products_not_found(apiKeyValidationResult: .otherPlatforms)
+
+        expect(subject.description).toNot(contain("App Store Connect"))
+        expect(subject.description).toNot(contain("StoreKit Config"))
+        expect(subject.description).toNot(contain("18.4"))
     }
 
 }

--- a/Tests/UnitTests/Purchasing/OfferingStringsTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingStringsTests.swift
@@ -48,4 +48,62 @@ final class OfferingStringsTests: TestCase {
         expect(subject.description).toNot(contain("StoreKit Configuration"))
     }
 
+    // MARK: - cannot_find_product_configuration_error
+
+    func testCannotFindProductConfigurationErrorAppStoreReferencesAppStoreConnect() {
+        let subject = Strings.offering
+            .cannot_find_product_configuration_error(identifiers: ["com.x.product"],
+                                                     apiKeyValidationResult: .validApplePlatform)
+
+        expect(subject.description).to(contain("com.x.product"))
+        expect(subject.description).to(contain("App Store Connect"))
+    }
+
+    func testCannotFindProductConfigurationErrorSimulatedStoreDoesNotReferenceAppStore() {
+        let subject = Strings.offering
+            .cannot_find_product_configuration_error(identifiers: ["com.x.product"],
+                                                     apiKeyValidationResult: .simulatedStore)
+
+        expect(subject.description).to(contain("com.x.product"))
+        expect(subject.description).to(contain("Test Store"))
+        expect(subject.description).toNot(contain("App Store Connect"))
+        expect(subject.description).toNot(contain("StoreKit Config"))
+    }
+
+    // MARK: - configuration_error_products_not_found
+
+    func testConfigurationErrorProductsNotFoundAppStoreReferencesAppStoreConnect() {
+        let subject = Strings.offering
+            .configuration_error_products_not_found(apiKeyValidationResult: .validApplePlatform)
+
+        expect(subject.description).to(contain("App Store Connect"))
+    }
+
+    func testConfigurationErrorProductsNotFoundSimulatedStoreDoesNotReferenceAppStore() {
+        let subject = Strings.offering
+            .configuration_error_products_not_found(apiKeyValidationResult: .simulatedStore)
+
+        expect(subject.description).to(contain("Test Store"))
+        expect(subject.description).toNot(contain("App Store Connect"))
+        expect(subject.description).toNot(contain("StoreKit Config"))
+    }
+
+    // MARK: - known_issue_ios_18_4_simulator_products_not_found
+
+    func testKnownIssue1840SimulatorProductsNotFoundAppStoreReferencesAppStoreConnect() {
+        let subject = Strings.offering
+            .known_issue_ios_18_4_simulator_products_not_found(apiKeyValidationResult: .validApplePlatform)
+
+        expect(subject.description).to(contain("App Store Connect"))
+    }
+
+    func testKnownIssue1840SimulatorProductsNotFoundSimulatedStoreDoesNotReferenceAppStore() {
+        let subject = Strings.offering
+            .known_issue_ios_18_4_simulator_products_not_found(apiKeyValidationResult: .simulatedStore)
+
+        expect(subject.description).to(contain("Test Store"))
+        expect(subject.description).toNot(contain("App Store Connect"))
+        expect(subject.description).toNot(contain("StoreKit Config"))
+    }
+
 }

--- a/Tests/UnitTests/Purchasing/OfferingStringsTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingStringsTests.swift
@@ -1,0 +1,51 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  OfferingStringsTests.swift
+//
+
+import Foundation
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+final class OfferingStringsTests: TestCase {
+
+    func testOfferingEmptyAppStoreReferencesAppStoreConnect() {
+        let subject = Strings.offering
+            .offering_empty(offeringIdentifier: "my_offering", apiKeyValidationResult: .validApplePlatform)
+
+        expect(subject.category).to(equal("offering"))
+        expect(subject.description).to(contain("my_offering"))
+        expect(subject.description).to(contain("App Store Connect"))
+    }
+
+    func testOfferingEmptySimulatedStoreDoesNotReferenceAppStore() {
+        let subject = Strings.offering
+            .offering_empty(offeringIdentifier: "my_offering", apiKeyValidationResult: .simulatedStore)
+
+        expect(subject.category).to(equal("offering"))
+        expect(subject.description).to(contain("my_offering"))
+        expect(subject.description).to(contain("Test Store"))
+        expect(subject.description).toNot(contain("App Store Connect"))
+        expect(subject.description).toNot(contain("StoreKit Configuration"))
+    }
+
+    func testOfferingEmptyOtherPlatformsDoesNotReferenceAppStore() {
+        let subject = Strings.offering
+            .offering_empty(offeringIdentifier: "my_offering", apiKeyValidationResult: .otherPlatforms)
+
+        expect(subject.category).to(equal("offering"))
+        expect(subject.description).to(contain("my_offering"))
+        expect(subject.description).toNot(contain("App Store Connect"))
+        expect(subject.description).toNot(contain("StoreKit Configuration"))
+    }
+
+}

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -117,7 +117,10 @@ extension OfferingsManagerTests {
         expect(offerings["base"]!.monthly?.storeProduct).toNot(beNil())
 
         self.logger.verifyMessageWasLogged(
-            Strings.offering.cannot_find_product_configuration_error(identifiers: ["yearly_freetrial"]),
+            Strings.offering.cannot_find_product_configuration_error(
+                identifiers: ["yearly_freetrial"],
+                apiKeyValidationResult: .validApplePlatform
+            ),
             level: .warn
         )
     }
@@ -140,7 +143,10 @@ extension OfferingsManagerTests {
 
         // then
         expect(result).to(beFailure { error in
-            expect(error).to(matchError(OfferingsManager.Error.missingProducts(identifiers: ["yearly_freetrial"])))
+            expect(error).to(matchError(OfferingsManager.Error.missingProducts(
+                identifiers: ["yearly_freetrial"],
+                apiKeyValidationResult: .validApplePlatform
+            )))
         })
     }
 
@@ -401,7 +407,8 @@ extension OfferingsManagerTests {
 
         switch result?.error {
         case let .configurationError(message, underlyingError, _):
-            expect(message) == Strings.offering.configuration_error_products_not_found.description
+            expect(message) == Strings.offering
+                .configuration_error_products_not_found(apiKeyValidationResult: .validApplePlatform).description
             expect(underlyingError).to(beNil())
         default:
             fail("Unexpected result")
@@ -427,7 +434,8 @@ extension OfferingsManagerTests {
 
         switch result?.error {
         case let .configurationError(message, underlyingError, _):
-            expect(message) == Strings.offering.configuration_error_products_not_found.description
+            expect(message) == Strings.offering
+                .configuration_error_products_not_found(apiKeyValidationResult: .validApplePlatform).description
             expect(underlyingError).to(matchError(error))
         default:
             fail("Unexpected result")

--- a/Tests/UnitTests/Purchasing/OfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsTests.swift
@@ -15,7 +15,7 @@ import XCTest
 
 class OfferingsTests: TestCase {
 
-    private let offeringsFactory = OfferingsFactory()
+    private let offeringsFactory = OfferingsFactory(systemInfo: MockSystemInfo(finishTransactions: true))
 
     func testPackageIsNotCreatedIfNoValidProducts() {
         let package = self.offeringsFactory.createPackage(

--- a/Tests/UnitTests/SimulatedStore/PurchasesOrchestratorSimulatedStoreTests.swift
+++ b/Tests/UnitTests/SimulatedStore/PurchasesOrchestratorSimulatedStoreTests.swift
@@ -109,7 +109,9 @@ class PurchasesOrchestratorSimulatedStoreTests: TestCase {
                                                          operationDispatcher: self.operationDispatcher,
                                                          systemInfo: self.systemInfo,
                                                          backend: self.backend,
-                                                         offeringsFactory: OfferingsFactory(),
+                                                         offeringsFactory: OfferingsFactory(
+                                                            systemInfo: self.systemInfo
+                                                         ),
                                                          productsManager: self.productsManager,
                                                          diagnosticsTracker: self.diagnosticsTracker)
 

--- a/Tests/UnitTests/SimulatedStore/SimulatedStoreTransactionFetcherTests.swift
+++ b/Tests/UnitTests/SimulatedStore/SimulatedStoreTransactionFetcherTests.swift
@@ -1,0 +1,81 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SimulatedStoreTransactionFetcherTests.swift
+
+import Nimble
+@testable import RevenueCat
+import XCTest
+
+class SimulatedStoreTransactionFetcherTests: TestCase {
+
+    private var fetcher: SimulatedStoreTransactionFetcher!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        self.fetcher = SimulatedStoreTransactionFetcher()
+    }
+
+    func testUnfinishedVerifiedTransactionsIsEmpty() async throws {
+        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+            let transactions = await self.fetcher.unfinishedVerifiedTransactions
+            expect(transactions).to(beEmpty())
+        }
+    }
+
+    func testHasPendingConsumablePurchaseIsFalse() async throws {
+        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+            let hasPending = await self.fetcher.hasPendingConsumablePurchase
+            expect(hasPending) == false
+        }
+    }
+
+    func testFirstVerifiedAutoRenewableTransactionIsNil() async throws {
+        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+            let transaction = await self.fetcher.firstVerifiedAutoRenewableTransaction
+            expect(transaction).to(beNil())
+        }
+    }
+
+    func testFirstVerifiedTransactionIsNil() async throws {
+        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+            let transaction = await self.fetcher.firstVerifiedTransaction
+            expect(transaction).to(beNil())
+        }
+    }
+
+    func testOldestVerifiedTransactionIsNil() async throws {
+        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+            let transaction = await self.fetcher.oldestVerifiedTransaction
+            expect(transaction).to(beNil())
+        }
+    }
+
+    func testAppTransactionJWSAsyncIsNil() async throws {
+        let jws = await self.fetcher.appTransactionJWS
+        expect(jws).to(beNil())
+    }
+
+    func testAppTransactionJWSCompletionHandlerIsNil() throws {
+        let expectation = self.expectation(description: "appTransactionJWS completion called")
+        var receivedJWS: String?
+        var receivedNonNil = false
+
+        self.fetcher.appTransactionJWS { jws in
+            receivedJWS = jws
+            receivedNonNil = jws != nil
+            expectation.fulfill()
+        }
+
+        self.wait(for: [expectation], timeout: 1)
+        expect(receivedJWS).to(beNil())
+        expect(receivedNonNil) == false
+    }
+
+}

--- a/Tests/UnitTests/SimulatedStore/SimulatedStoreTransactionFetcherTests.swift
+++ b/Tests/UnitTests/SimulatedStore/SimulatedStoreTransactionFetcherTests.swift
@@ -78,4 +78,20 @@ class SimulatedStoreTransactionFetcherTests: TestCase {
         expect(receivedNonNil) == false
     }
 
+    func testFetchReceiptReturnsEmptyReceiptAndLogsWarning() async throws {
+        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+            let receipt = await self.fetcher.fetchReceipt(containing: MockStoreTransaction())
+
+            expect(receipt.transactions).to(beEmpty())
+            expect(receipt.subscriptionStatusBySubscriptionGroupId).to(beEmpty())
+            expect(receipt.bundleId).to(beEmpty())
+            expect(receipt.originalApplicationVersion).to(beNil())
+            expect(receipt.originalPurchaseDate).to(beNil())
+            self.logger.verifyMessageWasLogged(
+                Strings.purchase.simulated_store_unexpected_receipt_fetch,
+                level: .warn
+            )
+        }
+    }
+
 }


### PR DESCRIPTION
When using a test store API key we were still making some StoreKit calls and logging it’s errors (which is quite likely when using test store, since chances are high that the product’s haven’t been configured on the ASC / StoreKit config side yet) . 

This was confusing, as you’d use test store in cases where you actually don’t want to use StoreKit. 

## Changes made
- When using test store we’re no longer looking at the StoreKit Transaction updates on configure and are no longer listening for transaction updates
- Updated a bunch of info/warning/error logging strings to have variants that don’t mention the App Store / ASC / StoreKit when using test store

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches configure-time transaction fetching and customer-info paths plus widespread offering error messages; behavior change is intentional for Test Store but affects core purchase/offering flows.
> 
> **Overview**
> Test Store API keys now avoid StoreKit transaction plumbing and surface configuration messages that match how that mode works.
> 
> **StoreKit bypass:** `Purchases` wires in `SimulatedStoreTransactionFetcher` instead of `StoreKit2TransactionFetcher` when the key is simulated. That fetcher always returns empty/nil transaction data (with a warning if a receipt fetch is attempted). `PurchasesOrchestrator` skips starting `StoreKit.Transaction.updates` listening and SK2 purchase-intent listening in simulated-store mode. Customer info still goes through the backend when there are no unfinished transactions (covered by new tests).
> 
> **Logging:** Configure, offering, and purchase log strings now take `apiKeyValidationResult` and branch copy for **Test Store** vs App Store / legacy vs other platforms—e.g. simulator setup no longer tells you to use a StoreKit Configuration file when using a Test Store key; offering empty/missing-product errors point at RevenueCat Test Store config instead of App Store Connect; the iOS 18.4 simulator workaround text is suppressed for Test Store.
> 
> **Offerings:** `OfferingsFactory` holds `SystemInfo` so empty-offering warnings use the same API-key-aware messages. `OfferingsManager` passes validation result through empty-product and missing-product errors.
> 
> **Tests:** New/updated unit tests for string variants, transaction fetcher, orchestrator SK2 behavior, and customer info with simulated store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d87d1feac2c993000ef4f6ba21fca2899df7a4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->