### PR TITLE
Fix decoded image cache concurrency deadlock

### DIFF
--- a/RevenueCatUI/Helpers/FileImageLoader.swift
+++ b/RevenueCatUI/Helpers/FileImageLoader.swift
@@ -113,14 +113,13 @@ final class DecodedImageCache {
     static let shared = DecodedImageCache()
 
     private let cache = NSCache<NSURL, Entry>()
-    private let queue = DispatchQueue(label: "com.revenuecat.DecodedImageCache", attributes: .concurrent)
 
     private init() {}
 
     func imageAndSize(for url: URL) -> (Image, CGSize)? {
         let key = url as NSURL
 
-        if let hit = self.queue.sync(execute: { self.cache.object(forKey: key) }) {
+        if let hit = self.cache.object(forKey: key) {
             return (hit.image, hit.size)
         }
 
@@ -128,9 +127,7 @@ final class DecodedImageCache {
             return nil
         }
 
-        self.queue.async(flags: .barrier) {
-            self.cache.setObject(Entry(image: decoded.0, size: decoded.1), forKey: key)
-        }
+        self.cache.setObject(Entry(image: decoded.0, size: decoded.1), forKey: key)
 
         return decoded
     }

--- a/Tests/RevenueCatUITests/PaywallsV2/FileImageLoaderTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/FileImageLoaderTests.swift
@@ -154,22 +154,39 @@ final class FileImageLoaderTests: TestCase {
         expect(backToFirstImageData) == firstImageData
     }
 
-    func testConcurrentDecodedImageLoadsComplete() async throws {
-        let url = Self.makeLocalURL(filename: "test-concurrent-\(UUID().uuidString).png")
+    func testConcurrentDecodedImageLoadsDoNotDeadlockSwiftConcurrency() async throws {
+        let imageCount = max(ProcessInfo.processInfo.activeProcessorCount * 8, 128)
         let data = try Self.makeImageData(variant: .red)
-        try Self.writeImageData(data, to: url)
-
-        await withTaskGroup(of: Bool.self) { group in
-            for _ in 0..<64 {
-                group.addTask {
-                    return url.asImageAndSize != nil
-                }
-            }
-
-            for await didLoadImage in group {
-                expect(didLoadImage) == true
-            }
+        let urls = try (0..<imageCount).map { index -> URL in
+            let url = Self.makeLocalURL(filename: "test-concurrent-\(UUID().uuidString)-\(index).png")
+            try Self.writeImageData(data, to: url)
+            return url
         }
+
+        let completion = self.expectation(description: "Concurrent decoded image loads complete")
+        let task = Task {
+            // Simulates first paywall presentation loading many images from Swift concurrency.
+            let allImagesLoaded = await withTaskGroup(of: Bool.self, returning: Bool.self) { group in
+                for url in urls {
+                    group.addTask {
+                        return url.asImageAndSize != nil
+                    }
+                }
+
+                var allImagesLoaded = true
+                for await didLoadImage in group {
+                    allImagesLoaded = allImagesLoaded && didLoadImage
+                }
+
+                return allImagesLoaded
+            }
+
+            expect(allImagesLoaded) == true
+            completion.fulfill()
+        }
+        defer { task.cancel() }
+
+        await self.fulfillment(of: [completion], timeout: 5)
     }
 
     // MARK: - Helpers

--- a/Tests/RevenueCatUITests/PaywallsV2/FileImageLoaderTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/FileImageLoaderTests.swift
@@ -154,6 +154,24 @@ final class FileImageLoaderTests: TestCase {
         expect(backToFirstImageData) == firstImageData
     }
 
+    func testConcurrentDecodedImageLoadsComplete() async throws {
+        let url = Self.makeLocalURL(filename: "test-concurrent-\(UUID().uuidString).png")
+        let data = try Self.makeImageData(variant: .red)
+        try Self.writeImageData(data, to: url)
+
+        await withTaskGroup(of: Bool.self) { group in
+            for _ in 0..<64 {
+                group.addTask {
+                    return url.asImageAndSize != nil
+                }
+            }
+
+            for await didLoadImage in group {
+                expect(didLoadImage) == true
+            }
+        }
+    }
+
     // MARK: - Helpers
 
     private func makeFileRepository() -> FileRepository {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Motivation
Paywalls can request several cached images from Swift concurrency tasks during first presentation. `DecodedImageCache` wrapped `NSCache` access in a concurrent `DispatchQueue` using synchronous reads and asynchronous barrier writes. Blocking Swift cooperative pool threads on that GCD queue can starve the pool and deadlock image loading, which can also prevent subscriber actions from running.

### Description
- Removed the extra GCD queue from `DecodedImageCache` and use `NSCache` directly, since `NSCache` is thread-safe.
- Added a regression test that launches many unique decoded image loads from Swift concurrency and asserts they complete. This reproduced a deadlock as a timeout without the fix

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://revenuecat.slack.com/archives/C093NCRHZ0T/p1780563465309669?thread_ts=1780563465.309669&cid=C093NCRHZ0T)

<div><a href="https://cursor.com/agents/bc-01347e2e-29d8-5466-9e36-6f12af27fb06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01347e2e-29d8-5466-9e36-6f12af27fb06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

