### PR TITLE
Track web checkout opened paywall event

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -512,6 +512,8 @@ struct LoadedOfferingPaywallView: View {
                         value: self.purchaseHandler.purchaseError as NSError?)
             .preference(key: RestoreErrorPreferenceKey.self,
                         value: self.purchaseHandler.restoreError as NSError?)
+            .preference(key: WebCheckoutOpenedPreferenceKey.self,
+                        value: self.purchaseHandler.webCheckoutOpened)
     }
 
     @ViewBuilder

--- a/RevenueCatUI/Purchasing/PaywallEventTracker.swift
+++ b/RevenueCatUI/Purchasing/PaywallEventTracker.swift
@@ -157,6 +157,27 @@ final class PaywallEventTracker: @unchecked Sendable {
         return true
     }
 
+    /// Tracks a web checkout opened event.
+    /// - Parameters:
+    ///   - package: The package associated with the web checkout CTA, if known.
+    /// - Returns: whether the event was tracked
+    @discardableResult
+    func trackWebCheckoutOpened(package: Package?, sessionID: SessionID) -> Bool {
+        guard let data = self.stateLock.withLock({ self.sessions[sessionID]?.eventData }) else {
+            Logger.warning(Strings.attempted_to_track_event_with_missing_data)
+            return false
+        }
+
+        let eventData = data.withPurchaseInfo(
+            packageId: package?.identifier,
+            productId: package?.storeProduct.productIdentifier,
+            errorCode: nil,
+            errorMessage: nil
+        )
+        self.track(.webCheckoutOpened(.init(), eventData))
+        return true
+    }
+
     /// Drops stored paywall state for `sessionID` (e.g. when the host resets purchase session state).
     func discardSession(sessionID: SessionID) {
         _ = self.stateLock.withLock {

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -100,6 +100,12 @@ final class PurchaseHandler: ObservableObject {
     @Published
     fileprivate(set) var consecutiveCancellationRequestID: UUID?
 
+    /// Set to a new UUID each time the user taps a web checkout CTA.
+    /// Used to propagate the ``WebCheckoutOpenedPreferenceKey`` so callers can distinguish
+    /// "web checkout opened" from a regular cancellation.
+    @Published
+    fileprivate(set) var webCheckoutOpened: UUID?
+
     /// Whether a purchase was successfully completed in the current session.
     /// Convenience property for checking if we should skip exit offers.
     var hasPurchasedInSession: Bool {
@@ -243,6 +249,7 @@ final class PurchaseHandler: ObservableObject {
         self.sessionPurchaseResult = nil
         self.consecutiveCancellationRequestID = nil
         self.purchaseResult = nil
+        self.webCheckoutOpened = nil
         self.activePaywallSessionID = nil
     }
 
@@ -699,6 +706,24 @@ extension PurchaseHandler {
         return self.paywallEventTracker.createPurchaseInitiatedEvent(package: package, sessionID: sessionID)
     }
 
+    /// Signals that the user tapped a web checkout CTA and the paywall was dismissed to open the browser.
+    /// Sets a new UUID on ``webCheckoutOpened`` so the ``WebCheckoutOpenedPreferenceKey`` fires,
+    /// and tracks a ``PaywallEvent/webCheckoutOpened(_:_:)`` analytics event.
+    /// - Parameter package: The package associated with the web checkout CTA, if known.
+    func signalWebCheckoutOpened(package: Package?) {
+        self.webCheckoutOpened = UUID()
+        self.trackWebCheckoutOpened(package: package)
+    }
+
+    /// - Returns: whether the event was tracked
+    @discardableResult
+    fileprivate func trackWebCheckoutOpened(package: Package?) -> Bool {
+        guard let sessionID = self.activePaywallSessionID else {
+            return false
+        }
+        return self.paywallEventTracker.trackWebCheckoutOpened(package: package, sessionID: sessionID)
+    }
+
     /// Tracks a purchase error event.
     /// - Parameters:
     ///   - package: The package that was being purchased
@@ -960,6 +985,19 @@ struct RestoreErrorPreferenceKey: PreferenceKey {
     static var defaultValue: NSError?
 
     static func reduce(value: inout NSError?, nextValue: () -> NSError?) {
+        value = nextValue()
+    }
+
+}
+
+/// Preference key emitted whenever the user taps a web checkout CTA.
+/// Each new UUID represents a distinct tap, allowing consecutive taps to both fire the callback.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct WebCheckoutOpenedPreferenceKey: PreferenceKey {
+
+    static var defaultValue: UUID?
+
+    static func reduce(value: inout UUID?, nextValue: () -> UUID?) {
         value = nextValue()
     }
 

--- a/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
@@ -191,6 +191,8 @@ struct PurchaseButtonComponentView: View {
                            openURL: self.openURL,
                            inAppBrowserURL: self.$inAppBrowserURL)
 
+        self.purchaseHandler.signalWebCheckoutOpened(package: self.packageContext.package)
+
         if launchWebCheckout.autoDismiss {
             self.onDismiss()
         }

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -691,6 +691,12 @@ public protocol PaywallViewControllerDelegate: AnyObject {
     optional func paywallViewController(_ controller: PaywallViewController,
                                         willPresentExitOfferController exitOfferController: PaywallViewController)
 
+    /// Notifies that the user tapped a web checkout CTA and has left the app to complete payment externally.
+    /// This is distinct from ``paywallViewControllerDidCancelPurchase(_:)`` — the user has not cancelled;
+    /// they have initiated a purchase flow outside of the app.
+    @objc(paywallViewControllerDidOpenWebCheckout:)
+    optional func paywallViewControllerDidOpenWebCheckout(_ controller: PaywallViewController)
+
     /// Notifies that a purchase is about to be initiated, before the payment sheet is displayed.
     /// This allows the delegate to gate the purchase flow (e.g., requiring authentication).
     /// The `resume` closure **must** be called to either proceed (`true`) or cancel (`false`) the purchase.
@@ -739,6 +745,10 @@ private extension PaywallViewController {
             purchaseCancelled: { [weak self] in
                 guard let self else { return }
                 self.delegate?.paywallViewControllerDidCancelPurchase?(self)
+            },
+            webCheckoutOpened: { [weak self] in
+                guard let self else { return }
+                self.delegate?.paywallViewControllerDidOpenWebCheckout?(self)
             },
             restoreCompleted: { [weak self] customerInfo in
                 guard let self else { return }
@@ -870,6 +880,7 @@ private struct PaywallContainerView: View {
     let purchaseStarted: PurchaseOfPackageStartedHandler
     let purchaseCompleted: PurchaseCompletedHandler
     let purchaseCancelled: PurchaseCancelledHandler
+    let webCheckoutOpened: WebCheckoutOpenedHandler
     let restoreCompleted: PurchaseOrRestoreCompletedHandler
     let purchaseFailure: PurchaseFailureHandler
     let restoreStarted: RestoreStartedHandler
@@ -887,6 +898,7 @@ private struct PaywallContainerView: View {
             .onPurchaseStarted(self.purchaseStarted)
             .onPurchaseCompleted(self.purchaseCompleted)
             .onPurchaseCancelled(self.purchaseCancelled)
+            .onWebCheckoutOpened(self.webCheckoutOpened)
             .onPurchaseFailure(self.purchaseFailure)
             .onRestoreStarted(self.restoreStarted)
             .onRestoreCompleted(self.restoreCompleted)

--- a/RevenueCatUI/View+PurchaseRestoreCompleted.swift
+++ b/RevenueCatUI/View+PurchaseRestoreCompleted.swift
@@ -39,6 +39,11 @@ public typealias PurchaseOfPackageStartedHandler = @MainActor @Sendable (_ packa
 /// A closure used for notifying of purchase cancellation.
 public typealias PurchaseCancelledHandler = @MainActor @Sendable () -> Void
 
+/// A closure invoked when the user taps a web checkout CTA and leaves the app to complete payment externally.
+/// - Note: This is emitted for both `webCheckout` and `webProductSelection` purchase button methods.
+///   It does **not** indicate that a purchase was completed; use `onPurchaseCompleted` for that.
+public typealias WebCheckoutOpenedHandler = @MainActor @Sendable () -> Void
+
 /// A closure used to perform custom purchase logic implemented by your app.
 /// - Parameters:
 ///   - package: The package to be purchased.
@@ -242,6 +247,25 @@ extension View {
         _ handler: @escaping PurchaseCancelledHandler
     ) -> some View {
         return self.modifier(OnPurchaseCancelledModifier(handler: handler))
+    }
+
+    /// Invokes the given closure when the user taps a web checkout CTA and is taken out of the app
+    /// to complete payment externally (e.g. via browser or in-app browser).
+    ///
+    /// This is distinct from ``onPurchaseCancelled(_:)`` — the user has not cancelled;
+    /// they have initiated a purchase flow outside of the app.
+    ///
+    /// Example:
+    /// ```swift
+    ///  PaywallView()
+    ///     .onWebCheckoutOpened {
+    ///         print("User left to complete web checkout")
+    ///     }
+    /// ```
+    public func onWebCheckoutOpened(
+        _ handler: @escaping WebCheckoutOpenedHandler
+    ) -> some View {
+        return self.modifier(OnWebCheckoutOpenedModifier(handler: handler))
     }
 
     /// Invokes the given closure when a restore begins.
@@ -507,6 +531,22 @@ private struct OnPurchaseCancelledModifier: ViewModifier {
         content
             .onPreferenceChange(PurchasedResultPreferenceKey.self) { result in
                 if let result, result.userCancelled {
+                    self.handler()
+                }
+            }
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private struct OnWebCheckoutOpenedModifier: ViewModifier {
+
+    let handler: WebCheckoutOpenedHandler
+
+    func body(content: Content) -> some View {
+        content
+            .onPreferenceChange(WebCheckoutOpenedPreferenceKey.self) { uuid in
+                if uuid != nil {
                     self.handler()
                 }
             }

--- a/Sources/Events/FeatureEvents/FeatureEvent.swift
+++ b/Sources/Events/FeatureEvents/FeatureEvent.swift
@@ -77,6 +77,7 @@ private extension PaywallEvent {
             case .purchaseInitiated: return "paywall_purchase_initiated"
             case .purchaseError: return "paywall_purchase_error"
             case .componentInteraction: return "paywall_component_interacted"
+            case .webCheckoutOpened: return "paywall_web_checkout_opened"
             }
         }()
 

--- a/Sources/Paywalls/Events/Networking/EventsRequest+Paywall.swift
+++ b/Sources/Paywalls/Events/Networking/EventsRequest+Paywall.swift
@@ -96,6 +96,7 @@ extension FeatureEventsRequest.PaywallEvent {
         case purchaseInitiated = "paywall_purchase_initiated"
         case purchaseError = "paywall_purchase_error"
         case componentInteraction = "paywall_component_interacted"
+        case webCheckoutOpened = "paywall_web_checkout_opened"
 
     }
 
@@ -185,6 +186,7 @@ private extension PaywallEvent {
         case .purchaseInitiated: return .purchaseInitiated
         case .purchaseError: return .purchaseError
         case .componentInteraction: return .componentInteraction
+        case .webCheckoutOpened: return .webCheckoutOpened
         }
 
     }

--- a/Sources/Paywalls/Events/PaywallEvent.swift
+++ b/Sources/Paywalls/Events/PaywallEvent.swift
@@ -74,7 +74,7 @@ import Foundation
         switch self {
         case .purchaseInitiated, .purchaseError:
             return false
-        case .impression, .cancel, .close, .exitOffer, .componentInteraction:
+        case .impression, .cancel, .close, .exitOffer, .componentInteraction, .webCheckoutOpened:
             return true
         }
     }
@@ -83,7 +83,8 @@ import Foundation
         switch self {
         case .impression:
             return true
-        case .cancel, .close, .exitOffer, .componentInteraction, .purchaseInitiated, .purchaseError:
+        case .cancel, .close, .exitOffer, .componentInteraction,
+             .purchaseInitiated, .purchaseError, .webCheckoutOpened:
             return false
         }
     }
@@ -108,6 +109,11 @@ import Foundation
 
     /// User interacted with a paywall control (tabs, carousel, non-purchase button, etc.).
     case componentInteraction(CreationData, Data, ComponentInteractionData)
+
+    /// The user tapped a web checkout CTA and left the app to complete payment externally.
+    /// Emitted for `webCheckout`, `webProductSelection`, and `customWebCheckout` button methods.
+    /// This does not indicate a completed purchase — use ``impression`` / purchase completion events for that.
+    case webCheckoutOpened(CreationData, Data)
 
 }
 
@@ -416,6 +422,7 @@ extension PaywallEvent {
         case let .purchaseInitiated(creationData, _): return creationData
         case let .purchaseError(creationData, _): return creationData
         case let .componentInteraction(creationData, _, _): return creationData
+        case let .webCheckoutOpened(creationData, _): return creationData
         }
     }
 
@@ -429,13 +436,15 @@ extension PaywallEvent {
         case let .purchaseInitiated(_, data): return data
         case let .purchaseError(_, data): return data
         case let .componentInteraction(_, data, _): return data
+        case let .webCheckoutOpened(_, data): return data
         }
     }
 
     /// - Returns: the underlying ``PaywallEvent/ExitOfferData-swift.struct`` for exit offer events, nil otherwise.
     @_spi(Internal) public var exitOfferData: ExitOfferData? {
         switch self {
-        case .impression, .cancel, .close, .purchaseInitiated, .purchaseError, .componentInteraction: return nil
+        case .impression, .cancel, .close, .purchaseInitiated, .purchaseError,
+             .componentInteraction, .webCheckoutOpened: return nil
         case let .exitOffer(_, _, exitOfferData): return exitOfferData
         }
     }
@@ -443,7 +452,8 @@ extension PaywallEvent {
     /// - Returns: control interaction payload for ``PaywallEvent/componentInteraction(_:_:_:)``, nil for other events.
     @_spi(Internal) public var componentInteractionData: ComponentInteractionData? {
         switch self {
-        case .impression, .cancel, .close, .exitOffer, .purchaseInitiated, .purchaseError: return nil
+        case .impression, .cancel, .close, .exitOffer, .purchaseInitiated,
+             .purchaseError, .webCheckoutOpened: return nil
         case let .componentInteraction(_, _, interactionData): return interactionData
         }
     }

--- a/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/PaywallViewAPI.swift
+++ b/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/PaywallViewAPI.swift
@@ -21,6 +21,7 @@ struct App: View {
     private var purchaseOfPackageStarted: PurchaseOfPackageStartedHandler = { (_: Package) in }
     private var purchaseCompleted: PurchaseCompletedHandler = { (_: StoreTransaction?, _: CustomerInfo) in }
     private var purchaseCancelled: PurchaseCancelledHandler = { () in }
+    private var webCheckoutOpened: WebCheckoutOpenedHandler = { }
     private var restoreStarted: RestoreStartedHandler = { }
     private var failureHandler: PurchaseFailureHandler = { (_: NSError) in }
 
@@ -793,6 +794,7 @@ struct App: View {
             .onPurchaseCompleted(self.purchaseOrRestoreCompleted)
             .onPurchaseCompleted(self.purchaseCompleted)
             .onPurchaseCancelled(self.purchaseCancelled)
+            .onWebCheckoutOpened(self.webCheckoutOpened)
             .onRestoreStarted(self.restoreStarted)
             .onRestoreCompleted(self.purchaseOrRestoreCompleted)
             .onRequestedDismissal(self.requestedDismissal)

--- a/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/PaywallViewControllerAPI.swift
+++ b/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/PaywallViewControllerAPI.swift
@@ -203,6 +203,8 @@ final class Delegate: PaywallViewControllerDelegate {
 
     func paywallViewControllerDidCancelPurchase(_ controller: PaywallViewController) {}
 
+    func paywallViewControllerDidOpenWebCheckout(_ controller: PaywallViewController) {}
+
     func paywallViewController(_ controller: PaywallViewController,
                                didFailPurchasingWith error: NSError) {}
 

--- a/Tests/RevenueCatUITests/PaywallViewEventsTests.swift
+++ b/Tests/RevenueCatUITests/PaywallViewEventsTests.swift
@@ -213,6 +213,7 @@ private extension BasePaywallViewEventsTests {
         case .purchaseInitiated: break
         case .purchaseError: break
         case .componentInteraction: break
+        case .webCheckoutOpened: break
         }
     }
 
@@ -262,6 +263,7 @@ private extension PaywallEvent {
         case purchaseInitiated
         case purchaseError
         case componentInteraction
+        case webCheckoutOpened
 
     }
 
@@ -274,6 +276,7 @@ private extension PaywallEvent {
         case .purchaseInitiated: return .purchaseInitiated
         case .purchaseError: return .purchaseError
         case .componentInteraction: return .componentInteraction
+        case .webCheckoutOpened: return .webCheckoutOpened
         }
     }
 

--- a/Tests/RevenueCatUITests/Purchasing/PaywallEventTrackerTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/PaywallEventTrackerTests.swift
@@ -407,6 +407,56 @@ class PaywallEventTrackerTests: TestCase {
         }
     }
 
+    func testTrackWebCheckoutOpenedAddsPurchaseInfoFromSession() async throws {
+        let (tracker, trackedEvents) = Self.makeTracker()
+        let sessionID = Self.eventData.sessionIdentifier
+
+        expect(tracker.trackWebCheckoutOpened(package: TestData.packageWithIntroOffer, sessionID: sessionID)) == false
+
+        tracker.trackPaywallImpression(Self.eventData)
+
+        expect(tracker.trackWebCheckoutOpened(package: TestData.packageWithIntroOffer, sessionID: sessionID)) == true
+
+        await expect(trackedEvents.value).toEventually(haveCount(2), timeout: .seconds(2))
+
+        let webCheckoutEvent = try XCTUnwrap(trackedEvents.value.first(where: {
+            if case .webCheckoutOpened = $0 { return true }
+            return false
+        }))
+
+        if case .webCheckoutOpened = webCheckoutEvent {
+            expect(webCheckoutEvent.data.packageId) == TestData.packageWithIntroOffer.identifier
+            expect(webCheckoutEvent.data.productId) == TestData.packageWithIntroOffer.storeProduct.productIdentifier
+            expect(webCheckoutEvent.data.errorCode).to(beNil())
+            expect(webCheckoutEvent.data.errorMessage).to(beNil())
+            expect(webCheckoutEvent.data.sessionIdentifier) == Self.eventData.sessionIdentifier
+        } else {
+            fail("Expected webCheckoutOpened event")
+        }
+    }
+
+    func testTrackWebCheckoutOpenedWithNilPackageOmitsPackageInfo() async throws {
+        let (tracker, trackedEvents) = Self.makeTracker()
+        let sessionID = Self.eventData.sessionIdentifier
+
+        tracker.trackPaywallImpression(Self.eventData)
+        expect(tracker.trackWebCheckoutOpened(package: nil, sessionID: sessionID)) == true
+
+        await expect(trackedEvents.value).toEventually(haveCount(2), timeout: .seconds(2))
+
+        let webCheckoutEvent = try XCTUnwrap(trackedEvents.value.first(where: {
+            if case .webCheckoutOpened = $0 { return true }
+            return false
+        }))
+
+        if case .webCheckoutOpened = webCheckoutEvent {
+            expect(webCheckoutEvent.data.packageId).to(beNil())
+            expect(webCheckoutEvent.data.productId).to(beNil())
+        } else {
+            fail("Expected webCheckoutOpened event")
+        }
+    }
+
     func testTrackComponentInteraction_IncludesPurchaseButtonMetadataWhenProvided() async throws {
         let (tracker, trackedEvents) = Self.makeTracker()
         let sessionID = Self.eventData.sessionIdentifier

--- a/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
@@ -38,6 +38,48 @@ class PurchaseHandlerTests: TestCase {
         expect(handler.actionInProgress) == false
         expect(handler.purchaseError).to(beNil())
         expect(handler.restoreError).to(beNil())
+        expect(handler.webCheckoutOpened).to(beNil())
+    }
+
+    func testSignalWebCheckoutOpenedSetsUUID() {
+        let handler: PurchaseHandler = .mock()
+
+        expect(handler.webCheckoutOpened).to(beNil())
+        handler.signalWebCheckoutOpened(package: nil)
+        expect(handler.webCheckoutOpened).toNot(beNil())
+    }
+
+    func testSignalWebCheckoutOpenedProducesDistinctUUIDsOnConsecutiveTaps() {
+        let handler: PurchaseHandler = .mock()
+
+        handler.signalWebCheckoutOpened(package: nil)
+        let firstID = handler.webCheckoutOpened
+
+        handler.signalWebCheckoutOpened(package: nil)
+        let secondID = handler.webCheckoutOpened
+
+        expect(firstID).toNot(beNil())
+        expect(secondID).toNot(beNil())
+        expect(firstID) != secondID
+    }
+
+    func testWebCheckoutOpenedIsResetOnNewSession() {
+        let handler: PurchaseHandler = .mock()
+
+        handler.signalWebCheckoutOpened(package: nil)
+        expect(handler.webCheckoutOpened).toNot(beNil())
+
+        handler.resetForNewSession()
+        expect(handler.webCheckoutOpened).to(beNil())
+    }
+
+    func testWebCheckoutOpenedDoesNotAffectHasPurchasedInSession() {
+        let handler: PurchaseHandler = .mock()
+
+        handler.signalWebCheckoutOpened(package: nil)
+
+        expect(handler.hasPurchasedInSession) == false
+        expect(handler.purchaseResult).to(beNil())
     }
 
     func testPurchaseSetsCustomerInfo() async throws {


### PR DESCRIPTION
Add support for a "web checkout opened" flow: introduce WebCheckoutOpenedPreferenceKey and a published UUID (PurchaseHandler.webCheckoutOpened) to signal distinct web-checkout taps; add PurchaseHandler.signalWebCheckoutOpened to emit the preference and track a paywall_web_checkout_opened analytics event. Wire the signal from the purchase button, expose an onWebCheckoutOpened View modifier and WebCheckoutOpenedHandler, and add a PaywallViewController delegate callback. Extend PaywallEvent and networking enums to include webCheckoutOpened and add tests covering event tracking and PurchaseHandler behavior. Reset webCheckoutOpened on new sessions.

<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public delegate/modifier APIs and a persisted paywall analytics event; behavior is isolated to web-checkout CTAs but affects host integrations and event pipelines.
> 
> **Overview**
> Adds a dedicated **web checkout opened** path so hosts can react when users leave the app for external checkout instead of treating it as a purchase cancel.
> 
> `PurchaseHandler` now exposes `signalWebCheckoutOpened(package:)`, which assigns a fresh UUID on `webCheckoutOpened`, emits `WebCheckoutOpenedPreferenceKey`, and records a stored `PaywallEvent.webCheckoutOpened` (`paywall_web_checkout_opened`) with optional package/product IDs. Session reset clears that UUID without affecting `hasPurchasedInSession`.
> 
> V2 `PurchaseButtonComponentView` calls the signal after launching the browser. SwiftUI gains `onWebCheckoutOpened` / `WebCheckoutOpenedHandler`; UIKit gains optional `paywallViewControllerDidOpenWebCheckout`. Event plumbing and API testers are updated; unit tests cover tracking and handler behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c80491e098aff41328f43c8f30fe617a067cbb40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->