### PR TITLE
[Billing Plans]: Use total commitment price for StoreProduct.price when representing a billing plan

### DIFF
--- a/Sources/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -76,7 +76,16 @@ internal typealias SK2BillingPlanType = StoreKit.Product.SubscriptionInfo.Billin
     @objc public var currencyCode: String? { self.product.currencyCode }
 
     // See also `priceDecimalNumber` for Objective-C
-    public var price: Decimal { self.product.price }
+    public var price: Decimal {
+        if #available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *),
+           let installmentsInfo {
+            // This product represents a billing plan, so use the billing plan's
+            // total commitment price
+            return installmentsInfo.commitmentTotalPrice
+        } else {
+            return self.product.price
+        }
+    }
 
     @objc public var localizedPriceString: String { self.product.localizedPriceString}
 

--- a/Tests/StoreKitUnitTests/StoreProductTests.swift
+++ b/Tests/StoreKitUnitTests/StoreProductTests.swift
@@ -549,6 +549,49 @@ extension StoreProductTests {
         expect(storeProduct.id) == productIdentifier
     }
 
+    func testPriceUsesProductPriceWhenInstallmentsInfoIsNil() throws {
+        let storeProduct = Self.testProduct(
+            productIdentifier: "com.revenuecat.product",
+            price: 3.99,
+            installmentsInfo: nil
+        )
+
+        expect(storeProduct.price) == 3.99
+    }
+
+    func testPriceUsesProductPriceBelowIOS264EvenWithInstallmentsInfo() throws {
+        // InstallmentsInfo shouldn't be populated below iOS 26.4, but it's a good thing to check
+        // just in case.
+        try AvailabilityChecks.iOS264APINotAvailableOrSkipTest()
+
+        let storeProduct = Self.testProduct(
+            productIdentifier: "com.revenuecat.product",
+            price: 3.99,
+            installmentsInfo: Self.installmentsInfo(
+                commitmentInstallmentsCount: 12,
+                commitmentTotalPrice: 11.97
+            )
+        )
+
+        expect(storeProduct.price) == 3.99
+    }
+
+    @available(iOS 26.4, tvOS 26.4, macOS 26.4, watchOS 26.4, visionOS 26.4, *)
+    func testPriceUsesCommitmentTotalPriceOnIOS264WhenInstallmentsInfoIsPresent() throws {
+        try AvailabilityChecks.iOS264APIAvailableOrSkipTest()
+
+        let storeProduct = Self.testProduct(
+            productIdentifier: "com.revenuecat.product",
+            price: 3.99,
+            installmentsInfo: Self.installmentsInfo(
+                commitmentInstallmentsCount: 12,
+                commitmentTotalPrice: 11.97
+            )
+        )
+
+        expect(storeProduct.price) == 11.97
+    }
+
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testIdReturnsProductIdentifierForSK2ProductWithoutInstallmentsInfo() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
@@ -646,11 +689,12 @@ private extension StoreProductTests {
 
     static func testProduct(
         productIdentifier: String,
+        price: Decimal = 3.99,
         installmentsInfo: InstallmentsInfo?
     ) -> StoreProduct {
         return TestStoreProduct(
             localizedTitle: "product",
-            price: 3.99,
+            price: price,
             currencyCode: "USD",
             localizedPriceString: "$3.99",
             productIdentifier: productIdentifier,
@@ -664,6 +708,7 @@ private extension StoreProductTests {
 
     static func installmentsInfo(
         commitmentInstallmentsCount: Int,
+        commitmentTotalPrice: Decimal? = nil,
         billingPlanType: BillingPlanType = .monthly
     ) -> InstallmentsInfo {
         return InstallmentsInfo(
@@ -672,7 +717,7 @@ private extension StoreProductTests {
             installmentBillingPrice: 3.99,
             installmentBillingDisplayPrice: "$3.99",
             commitmentTotalPeriod: SubscriptionPeriod(value: commitmentInstallmentsCount, unit: .month),
-            commitmentTotalPrice: Decimal(commitmentInstallmentsCount) * 3.99,
+            commitmentTotalPrice: commitmentTotalPrice ?? Decimal(commitmentInstallmentsCount) * 3.99,
             commitmentTotalDisplayPrice: "$\(commitmentInstallmentsCount * 399 / 100).99",
             billingPlanType: billingPlanType
         )


### PR DESCRIPTION
### Description
This PR modifies `StoreProduct.price` to return the billing plan's total commitment price when a product represents a billing plan. Previously, this returned the product's price (upFront price), which is often the same as a monthly commitment's total price, but can differ in some cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public `price` value for billing-plan products on iOS 26.4+, which can affect pricing display and derived per-period calculations that use `price`.
> 
> **Overview**
> On **iOS 26.4+**, when a `StoreProduct` has **`installmentsInfo`** (billing-plan product), **`price`** now returns **`commitmentTotalPrice`** instead of the underlying StoreKit **up-front** price. Without installments info, or on older OS versions, behavior is unchanged and still uses **`product.price`**.
> 
> Unit tests cover the nil-installments case, pre-26.4 behavior even if installments data is present, and the 26.4+ commitment-total path. Test helpers accept an explicit **`price`** and optional **`commitmentTotalPrice`** for fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e2e697fc6acce807a5f4db24a5912ba9620aeaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->