### PR TITLE
feat(workflows): bridge workflow exit offer into PaywallViewController

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -2932,6 +2932,7 @@
 		B807748D6D88B7836EC273ED /* EqualityOperators.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EqualityOperators.swift; sourceTree = "<group>"; };
 		B8BCBA1A622A35B377B35254 /* ValueTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ValueTests.swift; sourceTree = "<group>"; };
 		C812AE8BAE0546D2F4ACEF35 /* MinMaxOperators.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MinMaxOperators.swift; sourceTree = "<group>"; };
+		FACE0000000000000000F001 /* PaywallViewControllerExitOfferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallViewControllerExitOfferTests.swift; sourceTree = "<group>"; };
 		C41FD75CE31F51BBE614F9B0 /* WorkflowsCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowsCache.swift; sourceTree = "<group>"; };
 		CC1A2B3C2E1234AB00AABBCC /* CustomVariablesEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomVariablesEditorView.swift; sourceTree = "<group>"; };
 		CF01A0F868569B5E2D5CA465 /* PaywallsV2LayoutFixtures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaywallsV2LayoutFixtures.swift; path = Tests/RevenueCatUITests/PaywallsV2/PaywallsV2LayoutFixtures.swift; sourceTree = SOURCE_ROOT; };
@@ -5975,6 +5976,7 @@
 				887A61382C1D168B00E1A461 /* Purchasing */,
 				887A613B2C1D168B00E1A461 /* Resources */,
 				887A62172C1D168B00E1A461 /* Templates */,
+				FACE0000000000000000F003 /* UIKit */,
 				887A621C2C1D168B00E1A461 /* TestPlans */,
 				887A621D2C1D168B00E1A461 /* BaseSnapshotTest.swift */,
 				887A621E2C1D168B00E1A461 /* ImageLoaderTests.swift */,
@@ -5988,6 +5990,14 @@
 			name = RevenueCatUITests;
 			path = Tests/RevenueCatUITests;
 			sourceTree = SOURCE_ROOT;
+		};
+		FACE0000000000000000F003 /* UIKit */ = {
+			isa = PBXGroup;
+			children = (
+				FACE0000000000000000F001 /* PaywallViewControllerExitOfferTests.swift */,
+			);
+			path = UIKit;
+			sourceTree = "<group>";
 		};
 		88AD010B2C740CF400AA1F2B /* Components */ = {
 			isa = PBXGroup;

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -953,10 +953,16 @@ private struct PaywallContainerView: View {
                     }
                 }
             }
-            // Binding is the reliable path; preference is a fallback. Both feed `exitOfferOffering`.
+            // Binding is the reliable path; preference is a set-only fallback. Both feed `exitOfferOffering`.
             .environment(\.workflowExitOfferOfferingBinding, self.workflowExitOfferBinding)
             .onPreferenceChange(WorkflowExitOfferPreferenceKey.self) { context in
-                self.workflowExitOfferBinding.wrappedValue = context?.exitOfferOffering
+                // Only forward a non-nil offer. Clears are owned by the direct binding
+                // (WorkflowPaywallView.syncExitOfferBinding fires on step change), so a nil here is
+                // either redundant or a transient default emitted while the host rebuilds (e.g. on
+                // update(with:displayCloseButton:) / updateFont). Forwarding it would momentarily drop
+                // a still-valid exit offer.
+                guard let offering = context?.exitOfferOffering else { return }
+                self.workflowExitOfferBinding.wrappedValue = offering
             }
     }
 

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -103,10 +103,9 @@ public class PaywallViewController: UIViewController {
     private var configuration: PaywallViewConfiguration {
         didSet {
             // Drop the previous workflow's exit offer before the rebuild; the new paywall re-emits it.
-            // (Legacy keeps its prefetched offer, which isn't re-fetched on update.)
-            if ProcessInfo.processInfo.workflowsEndpointEnabled {
-                self.exitOfferOffering = nil
-            }
+            // Routed through updateWorkflowExitOffer so it keeps the "don't clear while presenting"
+            // guard and is a no-op under the legacy (non-workflow) path.
+            self.updateWorkflowExitOffer(nil)
 
             // Overriding the configuration requires re-creating the `HostingViewController`.
             // This is used by some Hybrid SDKs that require modifying the content after creation.

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -102,6 +102,12 @@ public class PaywallViewController: UIViewController {
 
     private var configuration: PaywallViewConfiguration {
         didSet {
+            // Drop the previous workflow's exit offer before the rebuild; the new paywall re-emits it.
+            // (Legacy keeps its prefetched offer, which isn't re-fetched on update.)
+            if ProcessInfo.processInfo.workflowsEndpointEnabled {
+                self.exitOfferOffering = nil
+            }
+
             // Overriding the configuration requires re-creating the `HostingViewController`.
             // This is used by some Hybrid SDKs that require modifying the content after creation.
             self.hostingController = self.createHostingController()
@@ -418,18 +424,26 @@ public class PaywallViewController: UIViewController {
     /// Prefetches the exit offer for the current offering.
     @MainActor
     private func prefetchExitOffer() async {
-        // When the workflows endpoint is enabled, the workflow exit offer is step-aware and
-        // emitted by the embedded SwiftUI WorkflowPaywallView, so this legacy up-front prefetch
-        // is skipped. Today only the SwiftUI presentation layer (View+PresentPaywall) consumes it;
-        // this UIKit controller does not yet bridge it, so swipe-to-dismiss here won't surface the
-        // workflow exit offer. A follow-up will bridge it into this controller (feeding
-        // exitOfferOffering from the WorkflowContext binding) so swipe-to-dismiss surfaces it.
+        // Under workflows the exit offer comes from the embedded paywall (see updateWorkflowExitOffer),
+        // so skip this legacy prefetch.
         guard !ProcessInfo.processInfo.workflowsEndpointEnabled else { return }
 
         guard let offering = await self.purchaseHandler.resolveOffering(for: self.configuration.content) else {
             return
         }
         self.exitOfferOffering = await ExitOfferHelper.fetchValidExitOffer(for: offering)
+    }
+
+    /// Feeds the embedded workflow paywall's exit offer into `exitOfferOffering` so swipe/close can
+    /// surface it. Render-dependent, so verified manually like `prefetchExitOffer`.
+    private func updateWorkflowExitOffer(_ offering: Offering?) {
+        // The legacy prefetch owns the offer when workflows are off; don't clobber it.
+        guard ProcessInfo.processInfo.workflowsEndpointEnabled else { return }
+
+        // Keep the offer once we're presenting it, even if a late nil arrives mid-dismiss.
+        guard offering != nil || !self.isShowingExitOffer else { return }
+
+        self.exitOfferOffering = offering
     }
 
     /// Handles dismissal requests, checking for exit offers before calling the original handler.
@@ -729,6 +743,12 @@ private extension PaywallViewController {
             self.handleDismissalRequest()
         }
 
+        // Bridges the embedded paywall's workflow exit offer into `exitOfferOffering`.
+        let workflowExitOfferBinding = Binding<Offering?>(
+            get: { [weak self] in self?.exitOfferOffering },
+            set: { [weak self] offering in self?.updateWorkflowExitOffer(offering) }
+        )
+
         let container = PaywallContainerView(
             configuration: self.configuration,
             customVariables: self.customVariables,
@@ -770,7 +790,8 @@ private extension PaywallViewController {
                 self.delegate?.paywallViewController?(self, didChangeSizeTo: $0)
             },
             purchaseInitiated: self.createPurchaseInitiatedHandler(),
-            restoreInitiated: self.createRestoreInitiatedHandler()
+            restoreInitiated: self.createRestoreInitiatedHandler(),
+            workflowExitOfferBinding: workflowExitOfferBinding
         )
 
         let controller = UIHostingController(rootView: container)
@@ -889,6 +910,9 @@ private struct PaywallContainerView: View {
     let purchaseInitiated: (Package, @escaping (Bool) -> Void) -> Void
     let restoreInitiated: (@escaping (Bool) -> Void) -> Void
 
+    /// Receives the workflow exit offer from the embedded paywall (binding + preference below).
+    let workflowExitOfferBinding: Binding<Offering?>
+
     var body: some View {
         PaywallView(configuration: self.configuration)
             .customPaywallVariables(self.customVariables)
@@ -914,6 +938,11 @@ private struct PaywallContainerView: View {
                         resumeAction(shouldProceed: shouldProceed)
                     }
                 }
+            }
+            // Binding is the reliable path; preference is a fallback. Both feed `exitOfferOffering`.
+            .environment(\.workflowExitOfferOfferingBinding, self.workflowExitOfferBinding)
+            .onPreferenceChange(WorkflowExitOfferPreferenceKey.self) { context in
+                self.workflowExitOfferBinding.wrappedValue = context?.exitOfferOffering
             }
     }
 

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -118,6 +118,19 @@ public class PaywallViewController: UIViewController {
     /// The prefetched exit offer, loaded while the main paywall is showing.
     private var exitOfferOffering: Offering?
 
+    // MARK: - Testing Hooks
+
+    /// Override in tests to simulate workflows being enabled without a scheme launch argument.
+    var workflowsEndpointEnabled: Bool { ProcessInfo.processInfo.workflowsEndpointEnabled }
+
+    @_spi(Internal)
+    public var exitOfferOfferingForTesting: Offering? { self.exitOfferOffering }
+
+    @_spi(Internal)
+    public func simulateWorkflowExitOfferUpdate(_ offering: Offering?) {
+        self.updateWorkflowExitOffer(offering)
+    }
+
     /// Whether we're currently showing an exit offer (to prevent multiple presentations).
     private var isShowingExitOffer: Bool = false
 
@@ -425,7 +438,7 @@ public class PaywallViewController: UIViewController {
     private func prefetchExitOffer() async {
         // Under workflows the exit offer comes from the embedded paywall (see updateWorkflowExitOffer),
         // so skip this legacy prefetch.
-        guard !ProcessInfo.processInfo.workflowsEndpointEnabled else { return }
+        guard !self.workflowsEndpointEnabled else { return }
 
         guard let offering = await self.purchaseHandler.resolveOffering(for: self.configuration.content) else {
             return
@@ -437,7 +450,7 @@ public class PaywallViewController: UIViewController {
     /// surface it. Render-dependent, so verified manually like `prefetchExitOffer`.
     private func updateWorkflowExitOffer(_ offering: Offering?) {
         // The legacy prefetch owns the offer when workflows are off; don't clobber it.
-        guard ProcessInfo.processInfo.workflowsEndpointEnabled else { return }
+        guard self.workflowsEndpointEnabled else { return }
 
         // Keep the offer once we're presenting it, even if a late nil arrives mid-dismiss.
         guard offering != nil || !self.isShowingExitOffer else { return }

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -120,14 +120,12 @@ public class PaywallViewController: UIViewController {
 
     // MARK: - Testing Hooks
 
-    /// Override in tests to simulate workflows being enabled without a scheme launch argument.
-    var workflowsEndpointEnabled: Bool { ProcessInfo.processInfo.workflowsEndpointEnabled }
+    /// Settable in tests to simulate workflows being enabled without a scheme launch argument.
+    var workflowsEndpointEnabled: Bool = ProcessInfo.processInfo.workflowsEndpointEnabled
 
-    @_spi(Internal)
-    public var exitOfferOfferingForTesting: Offering? { self.exitOfferOffering }
+    var exitOfferOfferingForTesting: Offering? { self.exitOfferOffering }
 
-    @_spi(Internal)
-    public func simulateWorkflowExitOfferUpdate(_ offering: Offering?) {
+    func simulateWorkflowExitOfferUpdate(_ offering: Offering?) {
         self.updateWorkflowExitOffer(offering)
     }
 

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -102,11 +102,6 @@ public class PaywallViewController: UIViewController {
 
     private var configuration: PaywallViewConfiguration {
         didSet {
-            // Drop the previous workflow's exit offer before the rebuild; the new paywall re-emits it.
-            // Routed through updateWorkflowExitOffer so it keeps the "don't clear while presenting"
-            // guard and is a no-op under the legacy (non-workflow) path.
-            self.updateWorkflowExitOffer(nil)
-
             // Overriding the configuration requires re-creating the `HostingViewController`.
             // This is used by some Hybrid SDKs that require modifying the content after creation.
             self.hostingController = self.createHostingController()
@@ -368,6 +363,10 @@ public class PaywallViewController: UIViewController {
     /// - Warning: For internal use only
     @objc(updateWithOffering:)
     public func update(with offering: Offering) {
+        // Replacing the offering invalidates the previous workflow's exit offer; the rebuilt
+        // paywall re-emits its own. Routed through updateWorkflowExitOffer so it keeps the
+        // "don't clear while presenting" guard and is a no-op under the legacy (non-workflow) path.
+        self.updateWorkflowExitOffer(nil)
         self.configuration.content = .offering(offering)
     }
 
@@ -375,6 +374,7 @@ public class PaywallViewController: UIViewController {
     @available(*, deprecated, message: "use init with Offering instead")
     @objc(updateWithOfferingIdentifier:)
     public func update(with offeringIdentifier: String) {
+        self.updateWorkflowExitOffer(nil)
         self.configuration.content = .offeringIdentifier(offeringIdentifier, presentedOfferingContext: nil)
     }
 
@@ -382,6 +382,7 @@ public class PaywallViewController: UIViewController {
     @_spi(Internal)
     @objc(updateWithOfferingIdentifier:presentedOfferingContext:)
     public func update(with offeringIdentifier: String, presentedOfferingContext: PresentedOfferingContext?) {
+        self.updateWorkflowExitOffer(nil)
         self.configuration.content = .offeringIdentifier(offeringIdentifier,
                                                          presentedOfferingContext: presentedOfferingContext)
     }
@@ -754,6 +755,9 @@ private extension PaywallViewController {
         }
 
         // Bridges the embedded paywall's workflow exit offer into `exitOfferOffering`.
+        // The embedded `WorkflowPaywallView` only ever writes through this binding, so the
+        // getter is unused in practice; it stays because `Binding` requires one and the
+        // SwiftUI presentation path injects a real two-way binding into the same env key.
         let workflowExitOfferBinding = Binding<Offering?>(
             get: { [weak self] in self?.exitOfferOffering },
             set: { [weak self] offering in self?.updateWorkflowExitOffer(offering) }

--- a/Tests/RevenueCatUITests/UIKit/PaywallViewControllerExitOfferTests.swift
+++ b/Tests/RevenueCatUITests/UIKit/PaywallViewControllerExitOfferTests.swift
@@ -12,7 +12,7 @@
 
 import Nimble
 @_spi(Internal) @testable import RevenueCat
-@_spi(Internal) @testable import RevenueCatUI
+@testable import RevenueCatUI
 import XCTest
 
 #if canImport(UIKit) && !os(tvOS) && !os(watchOS)
@@ -20,16 +20,11 @@ import XCTest
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
 final class PaywallViewControllerExitOfferTests: TestCase {
 
-    // Subclass that forces workflowsEndpointEnabled = true without a scheme launch argument.
-    private final class WorkflowPaywallViewController: PaywallViewController {
-        override var workflowsEndpointEnabled: Bool { true }
-    }
-
     func testUpdateDisplayCloseButtonDoesNotClearWorkflowExitOffer() {
-        let offering = Self.makeOffering(identifier: "main_offering")
-        let controller = WorkflowPaywallViewController(offering: offering)
+        let controller = PaywallViewController(offering: Self.makeOffering(identifier: "main"))
+        controller.workflowsEndpointEnabled = true
 
-        controller.simulateWorkflowExitOfferUpdate(Self.makeOffering(identifier: "exit_offering"))
+        controller.simulateWorkflowExitOfferUpdate(Self.makeOffering(identifier: "exit"))
         expect(controller.exitOfferOfferingForTesting).notTo(beNil(), description: "precondition")
 
         controller.update(with: true) // displayCloseButton — non-content mutation
@@ -41,10 +36,10 @@ final class PaywallViewControllerExitOfferTests: TestCase {
     }
 
     func testUpdateFontDoesNotClearWorkflowExitOffer() {
-        let offering = Self.makeOffering(identifier: "main_offering")
-        let controller = WorkflowPaywallViewController(offering: offering)
+        let controller = PaywallViewController(offering: Self.makeOffering(identifier: "main"))
+        controller.workflowsEndpointEnabled = true
 
-        controller.simulateWorkflowExitOfferUpdate(Self.makeOffering(identifier: "exit_offering"))
+        controller.simulateWorkflowExitOfferUpdate(Self.makeOffering(identifier: "exit"))
         expect(controller.exitOfferOfferingForTesting).notTo(beNil(), description: "precondition")
 
         controller.updateFont(with: "Papyrus")
@@ -58,9 +53,10 @@ final class PaywallViewControllerExitOfferTests: TestCase {
     func testUpdateOfferingClearsWorkflowExitOffer() {
         // Replacing the offering is a legitimate reason to drop the previous exit offer —
         // the new paywall will re-emit one.
-        let controller = WorkflowPaywallViewController(offering: Self.makeOffering(identifier: "original"))
+        let controller = PaywallViewController(offering: Self.makeOffering(identifier: "original"))
+        controller.workflowsEndpointEnabled = true
 
-        controller.simulateWorkflowExitOfferUpdate(Self.makeOffering(identifier: "exit_offering"))
+        controller.simulateWorkflowExitOfferUpdate(Self.makeOffering(identifier: "exit"))
         expect(controller.exitOfferOfferingForTesting).notTo(beNil(), description: "precondition")
 
         controller.update(with: Self.makeOffering(identifier: "replacement"))

--- a/Tests/RevenueCatUITests/UIKit/PaywallViewControllerExitOfferTests.swift
+++ b/Tests/RevenueCatUITests/UIKit/PaywallViewControllerExitOfferTests.swift
@@ -1,0 +1,92 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PaywallViewControllerExitOfferTests.swift
+//
+
+import Nimble
+@_spi(Internal) @testable import RevenueCat
+@_spi(Internal) @testable import RevenueCatUI
+import XCTest
+
+#if canImport(UIKit) && !os(tvOS) && !os(watchOS)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+final class PaywallViewControllerExitOfferTests: TestCase {
+
+    // Subclass that forces workflowsEndpointEnabled = true without a scheme launch argument.
+    private final class WorkflowPaywallViewController: PaywallViewController {
+        override var workflowsEndpointEnabled: Bool { true }
+    }
+
+    func testUpdateDisplayCloseButtonDoesNotClearWorkflowExitOffer() {
+        let offering = Self.makeOffering(identifier: "main_offering")
+        let controller = WorkflowPaywallViewController(offering: offering)
+
+        controller.simulateWorkflowExitOfferUpdate(Self.makeOffering(identifier: "exit_offering"))
+        expect(controller.exitOfferOfferingForTesting).notTo(beNil(), description: "precondition")
+
+        controller.update(with: true) // displayCloseButton — non-content mutation
+
+        expect(controller.exitOfferOfferingForTesting).notTo(
+            beNil(),
+            description: "update(with displayCloseButton:) must not clear the workflow exit offer"
+        )
+    }
+
+    func testUpdateFontDoesNotClearWorkflowExitOffer() {
+        let offering = Self.makeOffering(identifier: "main_offering")
+        let controller = WorkflowPaywallViewController(offering: offering)
+
+        controller.simulateWorkflowExitOfferUpdate(Self.makeOffering(identifier: "exit_offering"))
+        expect(controller.exitOfferOfferingForTesting).notTo(beNil(), description: "precondition")
+
+        controller.updateFont(with: "Papyrus")
+
+        expect(controller.exitOfferOfferingForTesting).notTo(
+            beNil(),
+            description: "updateFont(with:) must not clear the workflow exit offer"
+        )
+    }
+
+    func testUpdateOfferingClearsWorkflowExitOffer() {
+        // Replacing the offering is a legitimate reason to drop the previous exit offer —
+        // the new paywall will re-emit one.
+        let controller = WorkflowPaywallViewController(offering: Self.makeOffering(identifier: "original"))
+
+        controller.simulateWorkflowExitOfferUpdate(Self.makeOffering(identifier: "exit_offering"))
+        expect(controller.exitOfferOfferingForTesting).notTo(beNil(), description: "precondition")
+
+        controller.update(with: Self.makeOffering(identifier: "replacement"))
+
+        expect(controller.exitOfferOfferingForTesting).to(
+            beNil(),
+            description: "Replacing the offering should clear the stale exit offer"
+        )
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+private extension PaywallViewControllerExitOfferTests {
+
+    static func makeOffering(identifier: String) -> Offering {
+        return Offering(
+            identifier: identifier,
+            serverDescription: "Offering \(identifier)",
+            metadata: [:],
+            paywall: nil,
+            availablePackages: [],
+            webCheckoutUrl: nil
+        )
+    }
+
+}
+
+#endif

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
@@ -12,6 +12,9 @@
 import RevenueCatUI
 #endif
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
 
 struct APIKeyDashboardList: View {
 
@@ -333,6 +336,36 @@ struct APIKeyDashboardList: View {
         ForEach(PaywallTesterViewMode.allCases, id: \.self) { mode in
             self.button(for: mode, offering: offering)
         }
+
+        #if os(iOS)
+        // Presents through the UIKit `PaywallViewController` so its dismissal handling and the
+        // workflow exit-offer bridge can be exercised.
+        Button {
+            self.isLoadingPaywall = true
+            self.presentUIKitPaywall(for: offering)
+        } label: {
+            Text("UIKit View Controller")
+            Image(systemName: "rectangle.portrait.on.rectangle.portrait")
+        }
+        #endif
+    }
+    #endif
+
+    #if os(iOS)
+    @MainActor
+    private func presentUIKitPaywall(for offering: Offering) {
+        let windows = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+        guard var top = (windows.first(where: \.isKeyWindow) ?? windows.first)?.rootViewController else {
+            self.isLoadingPaywall = false
+            return
+        }
+        while let presented = top.presentedViewController {
+            top = presented
+        }
+        top.present(PaywallViewController(offering: offering, displayCloseButton: true), animated: true)
+        self.isLoadingPaywall = false
     }
     #endif
 


### PR DESCRIPTION
## Summary

Follow-up to #6887, which wired workflow exit offers into the SwiftUI presentation layer but explicitly left the UIKit side as a TODO (the comment in `prefetchExitOffer` even said so). So today, with workflows on, presenting through `PaywallViewController` and swiping to dismiss just closes the paywall, the step-aware workflow exit offer never shows up.

This bridges it 🚀 

This PR also adds a "UIKit View Controller" entry to PaywallsTester's Live Paywalls menu.

Known gap, separate follow-up (not in this PR): the SwiftUI `.presentPaywall(offering:)` modifier (`PresentingPaywallBindingModifier`) still uses the legacy offering-level exit offer.

https://github.com/user-attachments/assets/edcb1475-d87b-413a-9a31-a96e553d9d16

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: 6911
- Branch: `facu/workflow-exit-offer-uikit-bridge`
- Author / human owner: facumenzella (Facundo Menzella)
- Agent(s): Claude Code (Opus 4.8, 1M context)
- Session source: current conversation
- Generated: 2026-06-05
- Context document version: 4

## Goal

Bridge the step-aware workflow exit offer into the UIKit `PaywallViewController` so swipe-to-dismiss and the close button surface it when the workflows endpoint is enabled. Follow-up to the TODO left in #6887. Requirement added mid-session: WorkflowA must be able to open WorkflowB as an exit offer (and chain further). Later iteration (this session): fix a code-review regression where reconfiguring the controller dropped a valid workflow exit offer.

## Initial Prompt

"Check #6887. We need to add support for ExitOffers + Workflows in PaywallViewController. Take a look at how that works, and let's pick it up from there." (Resolved to: implement the UIKit exit-offer bridge that #6887 deferred.) Follow-up session: "Check #6911" resolved to addressing reviewer (vegaro) feedback on the bridge.

## Important Follow-up Prompts

- "WorkflowA must be able to open WorkflowB as an exitOffer" — rejected SwiftUI-style nested-offer suppression; mandated chaining, which drove the always-bridge (no suppression flag) design.
- "I wonder if it would be simpler to handle everything within the SwiftUI world" — evaluated; rejected because swipe-to-dismiss interception must stay in UIKit and the SwiftUI sheet path can't chain. Chose the UIKit bridge (Option A).
- Codex review surfaced a P2 (stale offer on host rebuild); addressed.
- Review feedback from vegaro (this session): (1) `configuration.didSet` cleared the exit offer on *every* mutation, including non-content ones; (2) the binding `get` is never read. Decided: bring vegaro's regression tests (#6919) into this branch and fix here (Option A), using the "more targeted" fix rather than making `Content` Equatable.

## Agent Contribution

- Traced both exit-offer paths (UIKit `PaywallViewController` and SwiftUI `View+PresentPaywall` / `WorkflowPaywallView` / `WorkflowExitOfferPreferenceKey` / `workflowExitOfferOfferingBinding`).
- Implemented the original bridge in `RevenueCatUI/UIKit/PaywallViewController.swift`: env-binding injection + preference fallback into `exitOfferOffering`, a guarded `updateWorkflowExitOffer`, and a stale-offer clear.
- This session: diagnosed vegaro's comment 1, confirmed `PaywallViewConfiguration.Content` is not `Equatable` (so her literal `content != oldValue.content` would not compile and would cascade conformance into `Offering`/`PresentedOfferingContext`), and implemented the targeted alternative.
- Cherry-picked vegaro's two commits (regression tests + test hooks) onto this branch, preserving her authorship.
- Ran the cherry-picked tests RED (2 failures) against the buggy code, applied the fix, re-ran GREEN (0 failures).
- Replied to both review threads; added a clarifying comment on the binding `get`.

## Human Decisions

- Chose Option A (UIKit bridge reusing existing machinery) over handling it all in SwiftUI.
- Mandated workflow-as-exit-offer chaining (no suppression).
- This session: chose to merge vegaro's regression test into this branch and fix here (not in #6919); chose the "better"/targeted fix for comment 1; chose to reply to comment 2 (keep the getter) rather than remove it; authorized push.

## Key Implementation Decisions

- Decision: feed the offer up into the existing UIKit `exitOfferOffering` and reuse `presentationControllerShouldDismiss` / `handleDismissalRequest` / `presentExitOffer`.
  - Rationale: the VC is presented by UIKit, so swipe-to-dismiss interception must use `UIAdaptivePresentationControllerDelegate`; SwiftUI inside a `UIHostingController` can't intercept the parent sheet's interactive dismissal.
  - Rejected: SwiftUI-owned presentation (Option B) — still needs UIKit swipe interception, can't chain, and drops the `willPresentExitOfferController` delegate callback.
- Decision: environment binding primary, preference key fallback.
  - Rationale: environment propagates downward deterministically; `WorkflowPaywallView` writes the binding in onAppear/onChange.
- Decision: no suppression flag — exit-offer children bridge too (enables WorkflowA -> WorkflowB chaining).
- Decision (this session): clear the workflow exit offer only on offering/content change, by moving `updateWorkflowExitOffer(nil)` out of `configuration.didSet` and into the three content mutators (`update(with:offering)`, `update(with:offeringIdentifier)`, `update(with:offeringIdentifier:presentedOfferingContext:)`), before the assignment.
  - Rationale: `didSet` fires on all mutations, so `update(with displayCloseButton:)` and `updateFont(with:)` were wiping a valid exit offer. Placing the clear in only the content mutators is precise and needs no new conformances. Kept routed through `updateWorkflowExitOffer`, so the "don't clear while presenting" guard (from the earlier Codex P2 fix) and the legacy no-op still hold.
  - Rejected: vegaro's literal `if configuration.content != oldValue.content` — `Content` is not `Equatable`; conforming it cascades into `Offering` (NSObject, reference equality) and `PresentedOfferingContext`.
- Decision (this session): keep the binding `get` even though it is never read.
  - Rationale: the env key is `Binding<Offering?>` because the SwiftUI path (`View+PresentPaywall.swift:643`) injects a real two-way `$exitOfferOffering`; `Binding` structurally requires a `get`. Added a comment marking it write-only here.
- Decision (this session): in `PaywallContainerView`, forward only non-nil values from the `WorkflowExitOfferPreferenceKey` `onPreferenceChange` into the binding (`guard let offering = context?.exitOfferOffering else { return }`).
  - Rationale: addresses a bug introduced by this PR's bridge commit (not in `main`): on a host rebuild (`update(with:displayCloseButton:)` / `updateFont`), the new container can emit a default-nil preference before `WorkflowPaywallView` re-syncs, momentarily clearing a still-valid exit offer. The preference is a set-only fallback; clears are owned by the direct binding (`syncExitOfferBinding` on step change), so ignoring nil is safe.
  - Note: render-path behavior, so verified by no-regression on the binding-path tests + manual; not separately unit-tested (a helper would only assert a tautological `guard let`).

## Files / Symbols Touched

- `RevenueCatUI/UIKit/PaywallViewController.swift`
  - Why: the bridge + this session's regression fix.
  - Symbols: `updateWorkflowExitOffer(_:)`, `configuration` didSet (clear removed), `update(with:)` content mutators (clear added), `createHostingController()` (binding + comment), `PaywallContainerView` (`onPreferenceChange` now forwards non-nil only), `prefetchExitOffer()`, and the test hooks (`workflowsEndpointEnabled` var, `exitOfferOfferingForTesting`, `simulateWorkflowExitOfferUpdate`).
  - Review relevance: the clear now lives only in content mutators; confirm cosmetic reconfigures (close button, font) keep the offer and replacing the offering clears it; the preference forwarding ignores nil.
- `RevenueCat.xcodeproj/project.pbxproj`
  - Why: register the new test file (danger requires it). Added as a file reference under a new `UIKit` group, NOT in the `UnitTests` target (RevenueCatUITests files build via SPM/Tuist; adding it to `UnitTests` broke `run-test-ios-26` with `Unable to find module dependency: 'RevenueCatUI'`, since that target doesn't link RevenueCatUI).
- `Tests/RevenueCatUITests/UIKit/PaywallViewControllerExitOfferTests.swift`
  - Why: vegaro's regression tests covering exit-offer retention vs clearing on reconfigure (cherry-picked, her authorship).
  - Symbols: `testUpdateDisplayCloseButtonDoesNotClearWorkflowExitOffer`, `testUpdateFontDoesNotClearWorkflowExitOffer`, `testUpdateOfferingClearsWorkflowExitOffer`.
- `Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift`
  - Why: adds a "UIKit View Controller" Live Paywalls menu entry that modally presents `PaywallViewController`.

## Dependencies / Config / Migrations

- Feature flag: `-EnableWorkflowsEndpoint` (`ProcessInfo.processInfo.workflowsEndpointEnabled`). No new deps, no public API change.

## Validation

- Commands run:
  - `xcodebuild test -scheme RevenueCatUI -destination 'platform=iOS Simulator,id=…iPhone 16 Pro' -only-testing:RevenueCatUITests/PaywallViewControllerExitOfferTests` (RED, before fix): Executed 3 tests, 2 failures (`…DisplayCloseButton…` and `…Font…` failed; `…Offering…` passed).
  - Same command after the fix (GREEN): Executed 3 tests, 0 failures.
  - `swiftlint lint RevenueCatUI/UIKit/PaywallViewController.swift`: no violations.
  - After the preference-nil guard: same command, Executed 3 tests, 0 failures (no regression on the binding path).
- Manual verification:
  - Original bridge exercised on a simulator via the PaywallsTester "UIKit View Controller" mode; the workflow exit offer surfaced on swipe-to-dismiss / close.
- Source control:
  - Rebased onto `origin/main` (resolved a `project.pbxproj` conflict: kept only the new file ref; `WorkflowsCacheTests` was relocated upstream). Force-pushed.
- CI:
  - `run-test-ios-26` initially failed because the test file was added to the `UnitTests` target; fixed by making it a file reference only. Full suite re-runs on push; the `run-all-tests` job stays on its manual-approval hold by design.

## Validation Gaps

- Local run covered only `PaywallViewControllerExitOfferTests`, not the full suite (CI is the backstop). No-regression argument for the rest is structural: `updateWorkflowExitOffer` is a no-op when `workflowsEndpointEnabled` is false, so legacy-path behavior is unchanged by both the `didSet` removal and the new calls.
- No automated test for the SwiftUI-presented bridge path itself (render/UIKit-presentation dependent); covered manually.

## Review Focus

- Confirm the clear now fires only for offering/content changes: `update(with displayCloseButton:)` and `updateFont(with:)` must keep a valid workflow exit offer; `update(with: offering)` must clear it.
- Confirm the "don't clear while presenting" guard still holds for a content update during an active exit-offer presentation.
- Chaining: dismissing WorkflowB-as-exit-offer should present its own exit offer with no leak across the fresh child VCs.

## Risks / Reviewer Notes

- Risk: a content update arriving mid-dismiss could clear the offer.
  - Evidence: routed through `updateWorkflowExitOffer`, which no-ops a nil clear while `isShowingExitOffer` is true.
  - Mitigation: covered by the guard; bugbot's earlier P2 on direct `= nil` no longer applies (the direct `didSet` clear was removed).
- Risk: preference doesn't propagate up through the `UIHostingController`.
  - Mitigation: environment binding is the primary mechanism; preference is a fallback.

## Non-goals / Out of Scope

- Removing the workflows flag.
- Wiring workflow exit offers into the SwiftUI `.presentPaywall(offering:)` modifier (`PresentingPaywallBindingModifier`). Separate follow-up.

## Omitted Context

- Raw transcript, unrelated exploration, sensitive details, repetitive attempts, and chain-of-thought-style content were omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches paywall dismissal and exit-offer state in a core UIKit path; behavior is gated on workflows being enabled and legacy prefetch is unchanged when off.
> 
> **Overview**
> **Workflow exit offers now reach UIKit `PaywallViewController`**, so swipe-to-dismiss and the close button can show step-aware exit offers when the workflows endpoint is on (previously only the SwiftUI path had this).
> 
> The embedded paywall feeds offers into existing `exitOfferOffering` via an environment **binding** (primary) and **preference** fallback (non-nil only, so host rebuilds from `update(with displayCloseButton:)` / `updateFont` don’t briefly wipe a valid offer). Legacy prefetch is skipped when workflows are enabled; **offering/content** `update` calls clear the stale offer, while cosmetic reconfigures do not. Test hooks and **PaywallViewControllerExitOfferTests** cover that behavior.
> 
> PaywallsTester adds a **UIKit View Controller** Live Paywalls menu action to present `PaywallViewController` for manual QA.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67162d5acca76f6a3f5e573529c713ca4a5aeaea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


