### PR TITLE
Fix DecodedImageCache deadlocking the Swift Concurrency cooperative pool

### DIFF
--- a/RevenueCatUI/Helpers/FileImageLoader.swift
+++ b/RevenueCatUI/Helpers/FileImageLoader.swift
@@ -112,15 +112,21 @@ final class DecodedImageCache {
 
     static let shared = DecodedImageCache()
 
+    // `NSCache` is already thread-safe, so concurrent reads/writes need no extra synchronization.
+    //
+    // Important: do NOT guard this with a blocking `DispatchQueue.sync` / `.barrier`. `imageAndSize`
+    // is called from `async` image loads (`RemoteImage` / `FileImageLoader`) that run on the Swift
+    // Concurrency cooperative thread pool. A blocking `sync` from those tasks can exhaust and
+    // deadlock that (process-wide) pool when many images decode at once — e.g. an image-heavy
+    // paywall on first render — hanging the host app with no crash. See #6694.
     private let cache = NSCache<NSURL, Entry>()
-    private let queue = DispatchQueue(label: "com.revenuecat.DecodedImageCache", attributes: .concurrent)
 
     private init() {}
 
     func imageAndSize(for url: URL) -> (Image, CGSize)? {
         let key = url as NSURL
 
-        if let hit = self.queue.sync(execute: { self.cache.object(forKey: key) }) {
+        if let hit = self.cache.object(forKey: key) {
             return (hit.image, hit.size)
         }
 
@@ -128,9 +134,7 @@ final class DecodedImageCache {
             return nil
         }
 
-        self.queue.async(flags: .barrier) {
-            self.cache.setObject(Entry(image: decoded.0, size: decoded.1), forKey: key)
-        }
+        self.cache.setObject(Entry(image: decoded.0, size: decoded.1), forKey: key)
 
         return decoded
     }


### PR DESCRIPTION
## Motivation

`DecodedImageCache` (introduced in #6694) guards an `NSCache` with a **concurrent `DispatchQueue`**, reading via a blocking `queue.sync` and writing via `queue.async(flags: .barrier)`. `imageAndSize(_:)` is called from `async` image loads (`RemoteImage` / `FileImageLoader`) that run on the **Swift Concurrency cooperative thread pool**.

A blocking `DispatchQueue.sync` from those async tasks can **exhaust and permanently deadlock the cooperative pool** when many images decode at once — e.g. an image-heavy Paywalls V2 paywall on first render (cold in-memory cache, warm disk). Because the pool is process-global, **all** of the app's async work stalls; the main thread stays idle, so the app **hangs with no crash**.

This is a regression since **5.70.0** (#6694) — apps on 5.69.0 are unaffected.

### Evidence
- **Field `bt all`** (real device, during the freeze): the whole cooperative pool is parked in `DecodedImageCache.imageAndSize → DispatchQueue.sync`, with the main thread idle in `__CFRunLoopRun`.
- **Isolated A/B harness** (pure Swift/Dispatch): the `queue.sync` + `.barrier` pattern **deadlocks** under concurrency, while direct `NSCache` access completes immediately. Deterministic across runs, even on a 14-core machine (a wider pool than the affected phones).

## Change

`NSCache` is already thread-safe — concurrent reads/writes need no external synchronization, so the `DispatchQueue` is unnecessary (and, called from the cooperative pool, harmful). Remove it and access the cache directly. This **keeps** the decoded-image caching that #6694 added (the perf win) while removing the blocking `sync`.

```diff
-    private let cache = NSCache<NSURL, Entry>()
-    private let queue = DispatchQueue(label: "com.revenuecat.DecodedImageCache", attributes: .concurrent)
+    private let cache = NSCache<NSURL, Entry>()
 ...
-        if let hit = self.queue.sync(execute: { self.cache.object(forKey: key) }) {
+        if let hit = self.cache.object(forKey: key) {
 ...
-        self.queue.async(flags: .barrier) {
-            self.cache.setObject(Entry(image: decoded.0, size: decoded.1), forKey: key)
-        }
+        self.cache.setObject(Entry(image: decoded.0, size: decoded.1), forKey: key)
```

## Testing
- `swift build` ✅
- Verified against the isolated deadlock harness: buggy (`queue.sync`) → deadlock, fixed (direct `NSCache`) → completes.
- Manual repro app: image-heavy paywall, first render on a real device.

## Possible follow-ups (not in this PR)
- Coalesce duplicate in-flight loads of the same URL (traces show several tasks decoding the same file).
- Consider moving decode off the cooperative pool.

Resolves PW-1276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared image caching on the async load path; fix is narrow but affects all paywall/UI image decoding and concurrency behavior.
> 
> **Overview**
> **`DecodedImageCache`** no longer wraps its **`NSCache`** in a concurrent **`DispatchQueue`** (`sync` on read, barrier `async` on write). Lookups and inserts now hit **`NSCache`** directly, with comments explaining why blocking queue access from async image loads must be avoided.
> 
> This fixes a **5.70.0** regression where many concurrent decodes (e.g. image-heavy Paywalls V2) could **deadlock the Swift Concurrency cooperative thread pool** and freeze the app without crashing, while keeping the decoded-image caching behavior from #6694.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e50a9421c363c69bd3951093d93443c93cba6fca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->