### PR TITLE
other(workflows): Run workflow detail prefetches on a dedicated concurrent queue

### DIFF
--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -274,9 +274,11 @@ extension Backend {
         static func createWorkflowsQueue() -> OperationQueue {
             let operationQueue = OperationQueue()
             operationQueue.name = "RC Workflows Queue"
-            // Workflow detail fetches run here so their CDN asset downloads overlap instead of
-            // serializing on the single backend queue. Capped at 4; each GetWorkflowOperation holds
-            // its slot through the CDN download, so this bounds concurrent CDN downloads at 4 too.
+            // Workflow prefetches run here so their CDN asset downloads overlap instead of serializing
+            // on the single backend queue. Capped at 4; each GetWorkflowOperation holds its slot
+            // through the CDN download, so this bounds concurrent CDN downloads at 4 too.
+            // Intentionally no `.background` QoS (unlike the diagnostics queue): these prefetches gate
+            // offerings delivery, so they keep the default QoS like the main backend queue.
             operationQueue.maxConcurrentOperationCount = Self.maxConcurrentWorkflowOperations
             return operationQueue
         }

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -50,6 +50,7 @@ class Backend {
                                           operationDispatcher: operationDispatcher,
                                           operationQueue: QueueProvider.createBackendQueue(),
                                           diagnosticsQueue: QueueProvider.createDiagnosticsQueue(),
+                                          workflowsQueue: QueueProvider.createWorkflowsQueue(),
                                           systemInfo: systemInfo,
                                           offlineCustomerInfoCreator: offlineCustomerInfoCreator,
                                           dateProvider: dateProvider)
@@ -253,6 +254,8 @@ extension Backend {
 
     enum QueueProvider {
 
+        private static let maxConcurrentWorkflowOperations = 4
+
         static func createBackendQueue() -> OperationQueue {
             let operationQueue = OperationQueue()
             operationQueue.name = "RC Backend Queue"
@@ -265,6 +268,16 @@ extension Backend {
             operationQueue.name = "RC Diagnostics Queue"
             operationQueue.maxConcurrentOperationCount = 1
             operationQueue.qualityOfService = .background
+            return operationQueue
+        }
+
+        static func createWorkflowsQueue() -> OperationQueue {
+            let operationQueue = OperationQueue()
+            operationQueue.name = "RC Workflows Queue"
+            // Workflow detail fetches run here so their CDN asset downloads overlap instead of
+            // serializing on the single backend queue. Capped at 4; each GetWorkflowOperation holds
+            // its slot through the CDN download, so this bounds concurrent CDN downloads at 4 too.
+            operationQueue.maxConcurrentOperationCount = Self.maxConcurrentWorkflowOperations
             return operationQueue
         }
 

--- a/Sources/Networking/BackendConfiguration.swift
+++ b/Sources/Networking/BackendConfiguration.swift
@@ -20,6 +20,7 @@ class BackendConfiguration {
     let operationDispatcher: OperationDispatcher
     let operationQueue: OperationQueue
     let diagnosticsQueue: OperationQueue
+    let workflowsQueue: OperationQueue
     let dateProvider: DateProvider
     let systemInfo: SystemInfo
     let offlineCustomerInfoCreator: OfflineCustomerInfoCreator?
@@ -28,6 +29,7 @@ class BackendConfiguration {
          operationDispatcher: OperationDispatcher,
          operationQueue: OperationQueue,
          diagnosticsQueue: OperationQueue,
+         workflowsQueue: OperationQueue,
          systemInfo: SystemInfo,
          offlineCustomerInfoCreator: OfflineCustomerInfoCreator?,
          dateProvider: DateProvider = DateProvider()) {
@@ -35,6 +37,7 @@ class BackendConfiguration {
         self.operationDispatcher = operationDispatcher
         self.operationQueue = operationQueue
         self.diagnosticsQueue = diagnosticsQueue
+        self.workflowsQueue = workflowsQueue
         self.offlineCustomerInfoCreator = offlineCustomerInfoCreator
         self.dateProvider = dateProvider
         self.systemInfo = systemInfo
@@ -50,14 +53,17 @@ extension BackendConfiguration: NetworkConfiguration {}
 
 extension BackendConfiguration {
 
-    /// Adds the `operation` to the `OperationQueue` (based on `CallbackCacheStatus`) potentially adding a random delay.
+    /// Adds the `operation` to an `OperationQueue` (based on `CallbackCacheStatus`) potentially adding a random delay.
+    /// Defaults to the shared serial `operationQueue`; pass `workflowsQueue` to run concurrently off the serial queue.
     func addCacheableOperation<T: CacheableNetworkOperation>(
         with factory: CacheableNetworkOperationFactory<T>,
         delay: JitterableDelay,
-        cacheStatus: CallbackCacheStatus
+        cacheStatus: CallbackCacheStatus,
+        queue: OperationQueue? = nil
     ) {
+        let targetQueue = queue ?? self.operationQueue
         self.operationDispatcher.dispatchOnWorkerThread(jitterableDelay: delay) {
-            self.operationQueue.addCacheableOperation(with: factory, cacheStatus: cacheStatus)
+            targetQueue.addCacheableOperation(with: factory, cacheStatus: cacheStatus)
         }
     }
 

--- a/Sources/Networking/WorkflowsAPI.swift
+++ b/Sources/Networking/WorkflowsAPI.swift
@@ -104,6 +104,7 @@ class WorkflowsAPI {
     func getWorkflow(appUserID: String,
                      workflowId: String,
                      isAppBackgrounded: Bool,
+                     prefetch: Bool = false,
                      completion: @escaping WorkflowDetailResponseHandler) {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
                                                                 appUserID: appUserID)
@@ -117,14 +118,14 @@ class WorkflowsAPI {
         let callback = WorkflowDetailCallback(cacheKey: factory.cacheKey, completion: completion)
         let cacheStatus = self.workflowDetailCallbackCache.add(callback)
 
-        // Detail fetches run on the dedicated workflows queue so their CDN asset downloads overlap
-        // (up to 4) instead of serializing on the single serial backend queue. The list fetch above
-        // stays on the serial queue.
+        // Prefetches run on the dedicated workflows queue so their CDN asset downloads overlap (up to
+        // 4) instead of serializing on the single serial backend queue. On-demand fetches stay on the
+        // serial queue, and so does the list fetch above.
         self.backendConfig.addCacheableOperation(
             with: factory,
             delay: .default(forBackgroundedApp: isAppBackgrounded),
             cacheStatus: cacheStatus,
-            queue: self.backendConfig.workflowsQueue
+            queue: prefetch ? self.backendConfig.workflowsQueue : nil
         )
     }
 

--- a/Sources/Networking/WorkflowsAPI.swift
+++ b/Sources/Networking/WorkflowsAPI.swift
@@ -117,10 +117,14 @@ class WorkflowsAPI {
         let callback = WorkflowDetailCallback(cacheKey: factory.cacheKey, completion: completion)
         let cacheStatus = self.workflowDetailCallbackCache.add(callback)
 
+        // Detail fetches run on the dedicated workflows queue so their CDN asset downloads overlap
+        // (up to 4) instead of serializing on the single serial backend queue. The list fetch above
+        // stays on the serial queue.
         self.backendConfig.addCacheableOperation(
             with: factory,
             delay: .default(forBackgroundedApp: isAppBackgrounded),
-            cacheStatus: cacheStatus
+            cacheStatus: cacheStatus,
+            queue: self.backendConfig.workflowsQueue
         )
     }
 

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -41,6 +41,7 @@ class WorkflowManager {
     func getWorkflow(appUserID: String,
                      workflowId: String,
                      isAppBackgrounded: Bool,
+                     prefetch: Bool = false,
                      completion: @escaping (Result<WorkflowDataResult, BackendError>) -> Void) {
         if let cached = self.workflowsCache.cachedWorkflow(workflowId: workflowId),
            !self.workflowsCache.isWorkflowCacheStale(workflowId: workflowId, isAppBackgrounded: isAppBackgrounded) {
@@ -54,7 +55,8 @@ class WorkflowManager {
         let generation = self.workflowsCache.currentCacheGeneration()
         self.backend.workflowsAPI.getWorkflow(appUserID: appUserID,
                                               workflowId: workflowId,
-                                              isAppBackgrounded: isAppBackgrounded) { [weak self] result in
+                                              isAppBackgrounded: isAppBackgrounded,
+                                              prefetch: prefetch) { [weak self] result in
             guard let self else {
                 completion(result)
                 return
@@ -211,7 +213,8 @@ private extension WorkflowManager {
         for summary in prefetchWorkflows {
             self.getWorkflow(appUserID: appUserID,
                              workflowId: summary.id,
-                             isAppBackgrounded: isAppBackgrounded) { result in
+                             isAppBackgrounded: isAppBackgrounded,
+                             prefetch: true) { result in
                 if case let .success(dataResult) = result {
                     resolved.modify { $0[summary.id] = dataResult }
                 }

--- a/Tests/UnitTests/Mocks/MockBackendConfiguration.swift
+++ b/Tests/UnitTests/Mocks/MockBackendConfiguration.swift
@@ -31,6 +31,7 @@ class MockBackendConfiguration: BackendConfiguration {
             operationDispatcher: MockOperationDispatcher(),
             operationQueue: Backend.QueueProvider.createBackendQueue(),
             diagnosticsQueue: Backend.QueueProvider.createDiagnosticsQueue(),
+            workflowsQueue: Backend.QueueProvider.createWorkflowsQueue(),
             systemInfo: systemInfo,
             offlineCustomerInfoCreator: MockOfflineCustomerInfoCreator(),
             dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate)

--- a/Tests/UnitTests/Mocks/MockWorkflowsAPI.swift
+++ b/Tests/UnitTests/Mocks/MockWorkflowsAPI.swift
@@ -22,8 +22,9 @@ class MockWorkflowsAPI: WorkflowsAPI, @unchecked Sendable {
 
     var invokedGetWorkflow = false
     var invokedGetWorkflowCount = 0
-    var invokedGetWorkflowParameters: (appUserID: String, workflowId: String, isAppBackgrounded: Bool)?
-    var invokedGetWorkflowParametersList: [(appUserID: String, workflowId: String, isAppBackgrounded: Bool)] = []
+    var invokedGetWorkflowParameters: (appUserID: String, workflowId: String, isAppBackgrounded: Bool, prefetch: Bool)?
+    var invokedGetWorkflowParametersList:
+        [(appUserID: String, workflowId: String, isAppBackgrounded: Bool, prefetch: Bool)] = []
     var stubbedGetWorkflowResult: Result<WorkflowDataResult, BackendError>?
     /// Per-workflowId result, used when set; otherwise falls back to `stubbedGetWorkflowResult`.
     var stubbedGetWorkflowResults: [String: Result<WorkflowDataResult, BackendError>] = [:]
@@ -35,11 +36,12 @@ class MockWorkflowsAPI: WorkflowsAPI, @unchecked Sendable {
     override func getWorkflow(appUserID: String,
                               workflowId: String,
                               isAppBackgrounded: Bool,
+                              prefetch: Bool = false,
                               completion: @escaping WorkflowDetailResponseHandler) {
         self.invokedGetWorkflow = true
         self.invokedGetWorkflowCount += 1
-        self.invokedGetWorkflowParameters = (appUserID, workflowId, isAppBackgrounded)
-        self.invokedGetWorkflowParametersList.append((appUserID, workflowId, isAppBackgrounded))
+        self.invokedGetWorkflowParameters = (appUserID, workflowId, isAppBackgrounded, prefetch)
+        self.invokedGetWorkflowParametersList.append((appUserID, workflowId, isAppBackgrounded, prefetch))
 
         if self.shouldStoreGetWorkflowCompletions {
             self.capturedGetWorkflowCompletions.append((workflowId, completion))

--- a/Tests/UnitTests/Networking/Backend/BackendGetWorkflowsTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetWorkflowsTests.swift
@@ -155,9 +155,9 @@ class BackendGetWorkflowTests: BaseBackendTests {
 
     func testGetWorkflowEnqueuesOnWorkflowsQueueWhileListUsesSerialQueue() {
         // Build a config whose queues we control and keep suspended, so operations pile up without
-        // executing. This lets us observe *which* queue each request lands on, deterministically. (We
-        // can't observe wall-clock concurrency here because MockHTTPClient delivers every response on
-        // the main thread, serializing the downstream CDN fetches regardless of queue concurrency.)
+        // executing. This lets us observe *which* queue each request lands on, deterministically.
+        // (This test only checks the routing decision; the cap behavior is exercised separately by
+        // testGetWorkflowDetailFetchesRunConcurrentlyUpToFour.)
         self.httpClient.disableSnapshotTesting()
 
         let serialQueue = OperationQueue()
@@ -196,6 +196,74 @@ class BackendGetWorkflowTests: BaseBackendTests {
         workflowsQueue.isSuspended = false
         expect(workflowsQueue.operationCount).toEventually(equal(0))
         expect(serialQueue.operationCount).toEventually(equal(0))
+    }
+
+    func testGetWorkflowDetailFetchesRunConcurrentlyUpToFour() throws {
+        // Proves the property this change owns: detail fetches on the workflows queue allow up to 4
+        // concurrent CDN fetches, and no more. We fire MORE than 4 (six) so "reaches 4 and never
+        // exceeds 4" actually proves the cap rather than just the request count.
+        //
+        // Each GetWorkflowOperation holds its queue slot until its cdnFetch completion fires, so the
+        // number of cdnFetch closures simultaneously in flight equals the number of operations the
+        // queue runs concurrently. The stub below blocks on a background thread (never on main), so
+        // MockHTTPClient can keep delivering envelopes on main and the fetches genuinely overlap.
+        //
+        // Note: this observes concurrency at the injected cdnFetch seam. It does not exercise the real
+        // FileRepository / URLSession path, nor FileRepository's same-URL coalescing (the stub ignores
+        // the URL and each fetch uses a distinct workflowId).
+        self.httpClient.disableSnapshotTesting()
+
+        let workflowCount = 6
+        let cdnWorkflowData = try JSONSerialization.data(withJSONObject: Self.minimalWorkflowData)
+
+        let currentInFlight: Atomic<Int> = .init(0)
+        let maxInFlight: Atomic<Int> = .init(0)
+        // Background gate: blocked cdnFetch threads wait here. Releasing it never touches main.
+        let releaseGate = DispatchSemaphore(value: 0)
+
+        self.stubbedCdnFetch = { _, _, completion in
+            // Return immediately on the calling (main) thread; do the blocking on a background thread.
+            DispatchQueue.global(qos: .userInitiated).async {
+                let inFlight = currentInFlight.modify { value -> Int in
+                    value += 1
+                    return value
+                }
+                maxInFlight.modify { $0 = max($0, inFlight) }
+
+                releaseGate.wait()
+
+                currentInFlight.modify { $0 -= 1 }
+                completion(.success(cdnWorkflowData))
+            }
+        }
+
+        for index in 0..<workflowCount {
+            let workflowId = "wf_\(index)"
+            self.httpClient.mock(
+                requestPath: .getWorkflow(appUserID: Self.userID, workflowId: workflowId),
+                response: .init(statusCode: .success, response: Self.cdnEnvelopeResponse)
+            )
+            self.workflowsAPI.getWorkflow(
+                appUserID: Self.userID,
+                workflowId: workflowId,
+                isAppBackgrounded: false
+            ) { _ in }
+        }
+
+        // Parallelism: with the cap-4 queue, exactly 4 fetches become in flight (more than 1 => not
+        // serialized). toEventually pumps the main run loop so the queued envelopes deliver.
+        expect(currentInFlight.value).toEventually(equal(4), timeout: .seconds(5))
+        // Cap: those 4 hold their slots, so no 5th can start. Catches a regression to a higher cap or a
+        // bypass of the dedicated queue.
+        expect(currentInFlight.value).toNever(beGreaterThan(4), until: .milliseconds(500))
+
+        // Release everything and let the remaining operations drain.
+        for _ in 0..<workflowCount {
+            releaseGate.signal()
+        }
+
+        expect(currentInFlight.value).toEventually(equal(0), timeout: .seconds(5))
+        expect(maxInFlight.value) == 4
     }
 
 }

--- a/Tests/UnitTests/Networking/Backend/BackendGetWorkflowsTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetWorkflowsTests.swift
@@ -147,6 +147,57 @@ class BackendGetWorkflowTests: BaseBackendTests {
         expect(self.httpClient.calls).to(beEmpty())
     }
 
+    func testWorkflowsQueueAllowsFourConcurrentOperations() {
+        let queue = Backend.QueueProvider.createWorkflowsQueue()
+        expect(queue.maxConcurrentOperationCount) == 4
+        expect(queue.name) == "RC Workflows Queue"
+    }
+
+    func testGetWorkflowEnqueuesOnWorkflowsQueueWhileListUsesSerialQueue() {
+        // Build a config whose queues we control and keep suspended, so operations pile up without
+        // executing. This lets us observe *which* queue each request lands on, deterministically. (We
+        // can't observe wall-clock concurrency here because MockHTTPClient delivers every response on
+        // the main thread, serializing the downstream CDN fetches regardless of queue concurrency.)
+        self.httpClient.disableSnapshotTesting()
+
+        let serialQueue = OperationQueue()
+        serialQueue.maxConcurrentOperationCount = 1
+        serialQueue.isSuspended = true
+        let workflowsQueue = Backend.QueueProvider.createWorkflowsQueue()
+        workflowsQueue.isSuspended = true
+
+        let config = BackendConfiguration(
+            httpClient: self.httpClient,
+            operationDispatcher: self.operationDispatcher,
+            operationQueue: serialQueue,
+            diagnosticsQueue: MockBackend.QueueProvider.createDiagnosticsQueue(),
+            workflowsQueue: workflowsQueue,
+            systemInfo: self.systemInfo,
+            offlineCustomerInfoCreator: self.mockOfflineCustomerInfoCreator,
+            dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate)
+        )
+        let api = WorkflowsAPI(backendConfig: config)
+
+        // Two distinct detail fetches => two operations, both on the workflows queue.
+        api.getWorkflow(appUserID: Self.userID, workflowId: "wf_1", isAppBackgrounded: false) { _ in }
+        api.getWorkflow(appUserID: Self.userID, workflowId: "wf_2", isAppBackgrounded: false) { _ in }
+
+        expect(workflowsQueue.operationCount) == 2
+        expect(serialQueue.operationCount) == 0
+
+        // The list fetch stays on the serial queue.
+        api.getWorkflows(appUserID: Self.userID, isAppBackgrounded: false) { _ in }
+
+        expect(serialQueue.operationCount) == 1
+        expect(workflowsQueue.operationCount) == 2
+
+        // Drain so no operation is left un-started at teardown (NetworkOperation asserts on deinit).
+        serialQueue.isSuspended = false
+        workflowsQueue.isSuspended = false
+        expect(workflowsQueue.operationCount).toEventually(equal(0))
+        expect(serialQueue.operationCount).toEventually(equal(0))
+    }
+
 }
 
 // MARK: - List endpoint tests

--- a/Tests/UnitTests/Networking/Backend/BackendGetWorkflowsTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetWorkflowsTests.swift
@@ -153,7 +153,7 @@ class BackendGetWorkflowTests: BaseBackendTests {
         expect(queue.name) == "RC Workflows Queue"
     }
 
-    func testGetWorkflowEnqueuesOnWorkflowsQueueWhileListUsesSerialQueue() {
+    func testPrefetchUsesWorkflowsQueueWhileOnDemandAndListUseSerialQueue() {
         // Build a config whose queues we control and keep suspended, so operations pile up without
         // executing. This lets us observe *which* queue each request lands on, deterministically.
         // (This test only checks the routing decision; the cap behavior is exercised separately by
@@ -178,18 +178,23 @@ class BackendGetWorkflowTests: BaseBackendTests {
         )
         let api = WorkflowsAPI(backendConfig: config)
 
-        // Two distinct detail fetches => two operations, both on the workflows queue.
-        api.getWorkflow(appUserID: Self.userID, workflowId: "wf_1", isAppBackgrounded: false) { _ in }
-        api.getWorkflow(appUserID: Self.userID, workflowId: "wf_2", isAppBackgrounded: false) { _ in }
+        // A prefetch detail fetch goes on the workflows queue.
+        api.getWorkflow(appUserID: Self.userID, workflowId: "wf_1", isAppBackgrounded: false, prefetch: true) { _ in }
 
-        expect(workflowsQueue.operationCount) == 2
+        expect(workflowsQueue.operationCount) == 1
         expect(serialQueue.operationCount) == 0
 
-        // The list fetch stays on the serial queue.
+        // An on-demand detail fetch (prefetch defaults to false) stays on the serial queue.
+        api.getWorkflow(appUserID: Self.userID, workflowId: "wf_2", isAppBackgrounded: false) { _ in }
+
+        expect(workflowsQueue.operationCount) == 1
+        expect(serialQueue.operationCount) == 1
+
+        // The list fetch also stays on the serial queue.
         api.getWorkflows(appUserID: Self.userID, isAppBackgrounded: false) { _ in }
 
-        expect(serialQueue.operationCount) == 1
-        expect(workflowsQueue.operationCount) == 2
+        expect(serialQueue.operationCount) == 2
+        expect(workflowsQueue.operationCount) == 1
 
         // Drain so no operation is left un-started at teardown (NetworkOperation asserts on deinit).
         serialQueue.isSuspended = false
@@ -246,16 +251,16 @@ class BackendGetWorkflowTests: BaseBackendTests {
             self.workflowsAPI.getWorkflow(
                 appUserID: Self.userID,
                 workflowId: workflowId,
-                isAppBackgrounded: false
+                isAppBackgrounded: false,
+                prefetch: true
             ) { _ in }
         }
 
-        // Parallelism: with the cap-4 queue, exactly 4 fetches become in flight (more than 1 => not
-        // serialized). toEventually pumps the main run loop so the queued envelopes deliver.
+        // Parallelism + cap: with the cap-4 queue, exactly 4 fetches become in flight (more than 1 =>
+        // not serialized) and no 5th can start while those 4 hold their slots. toEventually pumps the
+        // main run loop so the queued envelopes deliver. The final maxInFlight == 4 assertion is the
+        // authoritative cap check (it's the observed peak across the whole run).
         expect(currentInFlight.value).toEventually(equal(4), timeout: .seconds(5))
-        // Cap: those 4 hold their slots, so no 5th can start. Catches a regression to a higher cap or a
-        // bypass of the dedicated queue.
-        expect(currentInFlight.value).toNever(beGreaterThan(4), until: .milliseconds(500))
 
         // Release everything and let the remaining operations drain.
         for _ in 0..<workflowCount {

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -85,6 +85,7 @@ class BaseBackendTests: TestCase {
             operationDispatcher: self.operationDispatcher,
             operationQueue: MockBackend.QueueProvider.createBackendQueue(),
             diagnosticsQueue: MockBackend.QueueProvider.createDiagnosticsQueue(),
+            workflowsQueue: MockBackend.QueueProvider.createWorkflowsQueue(),
             systemInfo: self.systemInfo,
             offlineCustomerInfoCreator: self.mockOfflineCustomerInfoCreator,
             dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate)

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -81,6 +81,7 @@ class BasePurchasesTests: TestCase {
                                           operationDispatcher: self.mockOperationDispatcher,
                                           operationQueue: MockBackend.QueueProvider.createBackendQueue(),
                                           diagnosticsQueue: MockBackend.QueueProvider.createDiagnosticsQueue(),
+                                          workflowsQueue: MockBackend.QueueProvider.createWorkflowsQueue(),
                                           systemInfo: self.systemInfo,
                                           offlineCustomerInfoCreator: MockOfflineCustomerInfoCreator(),
                                           dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate))

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -56,6 +56,8 @@ class WorkflowManagerTests: TestCase {
         self.manager.getWorkflow(appUserID: self.appUserID, workflowId: "wf_1", isAppBackgrounded: false) { _ in }
 
         expect(self.workflowsCache.cachedWorkflow(workflowId: "wf_1")) == expected
+        // On-demand fetches stay on the serial queue (prefetch == false).
+        expect(self.mockWorkflowsAPI.invokedGetWorkflowParameters?.prefetch) == false
     }
 
     func testGetWorkflowReturnsCachedResultWithoutCallingBackendWhenFresh() throws {
@@ -139,6 +141,8 @@ class WorkflowManagerTests: TestCase {
         expect(prefetchedIds).to(contain("wf_prefetch", "wf_also_prefetch"))
         expect(prefetchedIds).toNot(contain("wf_skip"))
         expect(self.mockWorkflowsAPI.invokedGetWorkflowCount) == 2
+        // Prefetch fetches must request the concurrent workflows queue.
+        expect(self.mockWorkflowsAPI.invokedGetWorkflowParametersList.allSatisfy { $0.prefetch }) == true
     }
 
     func testGetWorkflowsListSkipsPrefetchForWorkflowsWithoutOfferingId() throws {

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -69,6 +69,7 @@ class BackendSubscriberAttributesTests: TestCase {
                                           operationDispatcher: MockOperationDispatcher(),
                                           operationQueue: MockBackend.QueueProvider.createBackendQueue(),
                                           diagnosticsQueue: MockBackend.QueueProvider.createDiagnosticsQueue(),
+                                          workflowsQueue: MockBackend.QueueProvider.createWorkflowsQueue(),
                                           systemInfo: self.systemInfo,
                                           offlineCustomerInfoCreator: MockOfflineCustomerInfoCreator(),
                                           dateProvider: self.dateProvider)
@@ -436,6 +437,7 @@ class BackendSubscriberAttributesTests: TestCase {
                                           operationDispatcher: MockOperationDispatcher(),
                                           operationQueue: MockBackend.QueueProvider.createBackendQueue(),
                                           diagnosticsQueue: MockBackend.QueueProvider.createDiagnosticsQueue(),
+                                          workflowsQueue: MockBackend.QueueProvider.createWorkflowsQueue(),
                                           systemInfo: self.systemInfo,
                                           offlineCustomerInfoCreator: MockOfflineCustomerInfoCreator(),
                                           dateProvider: dateProvider)
@@ -505,6 +507,7 @@ class BackendSubscriberAttributesTests: TestCase {
                                           operationDispatcher: MockOperationDispatcher(),
                                           operationQueue: MockBackend.QueueProvider.createBackendQueue(),
                                           diagnosticsQueue: MockBackend.QueueProvider.createDiagnosticsQueue(),
+                                          workflowsQueue: MockBackend.QueueProvider.createWorkflowsQueue(),
                                           systemInfo: self.systemInfo,
                                           offlineCustomerInfoCreator: MockOfflineCustomerInfoCreator(),
                                           dateProvider: dateProvider)
@@ -565,6 +568,7 @@ class BackendSubscriberAttributesTests: TestCase {
                                           operationDispatcher: MockOperationDispatcher(),
                                           operationQueue: MockBackend.QueueProvider.createBackendQueue(),
                                           diagnosticsQueue: MockBackend.QueueProvider.createDiagnosticsQueue(),
+                                          workflowsQueue: MockBackend.QueueProvider.createWorkflowsQueue(),
                                           systemInfo: self.systemInfo,
                                           offlineCustomerInfoCreator: MockOfflineCustomerInfoCreator(),
                                           dateProvider: dateProvider)


### PR DESCRIPTION
Follow-up to the review on #6882 (https://github.com/RevenueCat/purchases-ios/pull/6882#discussion_r3347636417), where we said parallelizing the workflow prefetches was worth doing but belonged in its own PR.

Right now every workflow detail fetch runs on the single backend `OperationQueue` (`maxConcurrentOperationCount = 1`), and `GetWorkflowOperation` holds that one slot through the entire CDN asset download. So when `WorkflowManager` prefetches N workflows, their CDN downloads run strictly one after another, and since the list fetch gates offerings delivery, that latency is right on the critical path.

This adds a dedicated workflows `OperationQueue` (cap 4, matching Android's `CONCURRENT_BACKEND_CALLS`/`MAX_CONCURRENT_WORKFLOW_CDN_FETCHES`) and routes the **prefetch** detail fetches to it. On-demand `getWorkflow` and the list fetch (`getWorkflows`) stay on the serial queue. Because the operation holds its slot through the CDN download, a single cap-4 queue bounds both the concurrent envelope calls and the concurrent CDN downloads at 4.

A couple of things worth knowing:
- The envelope API calls still serialize inside `HTTPClient` (that's its existing `currentSerialRequest` design, SDK-wide). What actually overlaps now is the CDN asset downloads, which escape that serial path (iOS 15+ via `FileRepository` tasks, pre-15 via the raw `dataTask` in `fetchRawData`). That's the heavy part, so it's the win.
- Only the prefetch path is parallelized, matching Android, which only added a concurrent dispatcher for prefetching and leaves direct `getWorkflow` on its default path. On-demand fetches and the list stay on the serial queue. A `prefetch` flag threaded from `WorkflowManager.prefetchWorkflows` down to `WorkflowsAPI.getWorkflow` selects the queue.

The two-layer behavior (envelopes serialize, CDN downloads fan out) is the part most likely to be misread, so:

```mermaid
sequenceDiagram
    participant Q as Workflows queue (cap 4)
    participant H as HTTPClient (serial)
    participant CDN as CDN (FileRepository / dataTask)
    Note over Q: up to 4 prefetch operations run concurrently
    Q->>H: envelope A
    Q->>H: envelope B
    H-->>Q: A (serialized)
    H-->>Q: B (serialized)
    par overlap (the win)
        Q->>CDN: download A
    and
        Q->>CDN: download B
    end
    Note over Q: each op holds its slot until its CDN download finishes
```

There's a test (`testGetWorkflowDetailFetchesRunConcurrentlyUpToFour`) that actually observes the concurrency: it fires six prefetch detail fetches and asserts exactly four `cdnFetch` closures are in flight at once and never more. The trick is that the operation holds its queue slot until the `cdnFetch` completion fires, so the stub blocks on a background thread (not main), which lets `MockHTTPClient` keep delivering envelopes and the fetches genuinely overlap. Verified non-vacuous: routing the fetch back to the serial queue makes it reach only 1 and fail. A routing test (`testPrefetchUsesWorkflowsQueueWhileOnDemandAndListUseSerialQueue`) covers the split: prefetch lands on the workflows queue, on-demand and list on the serial queue.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: this PR (`facu/workflow-prefetch-parallel-queue`)
- Branch: `facu/workflow-prefetch-parallel-queue`
- Author / human owner: facumenzella
- Agent(s): Claude Code (Opus 4.8)
- Session source: current conversation
- Generated: 2026-06-08
- Context document version: 3

## Goal

Parallelize workflow detail prefetches so their CDN asset downloads overlap instead of serializing on the SDK's single backend queue. Follow-up explicitly deferred from the #6882 review.

## Initial Prompt

"Let's follow-up on https://github.com/RevenueCat/purchases-ios/pull/6882#pullrequestreview-4417530946" — resolved to: implement the parallelization that vegaro's review (comment `3347636417`) flagged and that the PR author deferred to a later PR.

## Important Follow-up Prompts

- Chose scope "design/plan only" first, then "let's implement it".
- Chose approach "dedicated concurrent workflow queue" (over releasing the queue slot after the envelope) and "list stays on main queue".
- "Check how android does it, if you have doubts" — drove the on-demand-fetch routing decision (see below).
- "How confident are we about this? Is there a test we can add that checks logs? Or smth" — drove the direct concurrency-observing test (chosen over log assertions, which are indirect and order-fragile).
- After vegaro's review, chose "match Android (prefetch only)" — on-demand `getWorkflow` reverts to the serial queue; only prefetch uses the cap-4 queue.

## Agent Contribution

- Root-caused the serialization to two layers: `HTTPClient`'s internal `currentSerialRequest` (left untouched) and the cap-1 `OperationQueue` + `GetWorkflowOperation` holding its slot through the CDN download (the part addressed).
- Added `Backend.QueueProvider.createWorkflowsQueue()` (cap 4), threaded `workflowsQueue` through `BackendConfiguration` + `Backend.init`, added an optional `queue:` selector to `addCacheableOperation` (defaults to the serial queue), and routed `WorkflowsAPI.getWorkflow` to the workflows queue.
- Added a concurrency test that observes up-to-4 overlapping CDN fetches at the injected `cdnFetch` seam, and verified it is non-vacuous via a serial-queue mutation.
- Wrote a design doc and an implementation plan (kept outside the repo).
- Ran the suites; ran a Codex review (no issues found).

## Human Decisions

- Approach and queue-routing scope (dedicated queue, list on serial, cap 4).
- Asked to verify the approach against the Android implementation.
- Asked for a test that directly validates the parallelism.

## Key Implementation Decisions

- Decision: one dedicated cap-4 queue, operation keeps holding its slot through the CDN download.
  - Rationale: bounds both envelope and CDN concurrency at 4 with one mechanism; mirrors Android's two caps.
  - Rejected: releasing the queue slot after the envelope and running the CDN fetch detached (would not bound CDN concurrency).
- Decision: route ONLY prefetch detail fetches to the workflows queue; on-demand `getWorkflow` and the list stay on the serial queue.
  - Rationale: matches Android, which only parallelizes the prefetch path. A `prefetch` flag (default `false`) is threaded from `WorkflowManager.prefetchWorkflows` -> `WorkflowManager.getWorkflow` -> `WorkflowsAPI.getWorkflow`, which selects the queue.
  - History: an earlier revision parallelized both prefetch and on-demand. vegaro flagged the divergence from Android in review; we narrowed it to prefetch-only.

## Files / Symbols Touched

- `Sources/Networking/Backend.swift`
  - Symbols: `QueueProvider.createWorkflowsQueue()`, `maxConcurrentWorkflowOperations`; wired into `Backend.init`.
- `Sources/Networking/BackendConfiguration.swift`
  - Symbols: `workflowsQueue` property + init param; `addCacheableOperation(..., queue:)`.
- `Sources/Networking/WorkflowsAPI.swift`
  - Symbols: `getWorkflow(..., prefetch: Bool = false, ...)` routes to `workflowsQueue` only when `prefetch == true`, else the serial queue; `getWorkflows` (list) unchanged.
- `Sources/Purchasing/WorkflowManager.swift`
  - Symbols: `getWorkflow(..., prefetch: Bool = false, ...)` forwards the flag; `prefetchWorkflows` passes `prefetch: true`.
- Test construction sites updated for the new init param: `BaseBackendTest.swift`, `MockBackendConfiguration.swift`, `BasePurchasesTests.swift`, `BackendSubscriberAttributesTests.swift`. `MockWorkflowsAPI` captures the `prefetch` arg.
- `Tests/UnitTests/Networking/Backend/BackendGetWorkflowsTests.swift`
  - New: `testWorkflowsQueueAllowsFourConcurrentOperations`, `testPrefetchUsesWorkflowsQueueWhileOnDemandAndListUseSerialQueue`, `testGetWorkflowDetailFetchesRunConcurrentlyUpToFour`.
- `Tests/UnitTests/Purchasing/WorkflowManagerTests.swift`
  - Assert prefetch path passes `prefetch == true` and on-demand passes `false`.

## Dependencies / Config / Migrations

- None. All changed symbols are internal; no public API change. Behavior gated behind `SystemInfo.workflowsEndpointEnabled`.

## Validation

- Commands run:
  - `swift build`: succeeded.
  - `xcodebuild test ... BackendGetWorkflowTests + WorkflowManagerTests + PurchasesWorkflowTests`: 51 tests, 0 failures (after the prefetch-only change).
  - `testGetWorkflowDetailFetchesRunConcurrentlyUpToFour` run 3x in isolation: passed deterministically (~0.55s each), no flakiness.
  - Negative control: temporarily routing the prefetch back to the serial queue makes the concurrency test fail (`currentInFlight` reaches 1, not 4), confirming it actually validates the cap. Reverted.
  - SwiftLint (pre-commit + build phase): 0 violations.
  - Codex review: no correctness issues found.
- Manual verification: Not run (no device run; behavior is gated and not user-visible).
- CI: Not captured (pre-CI).

## Validation Gaps

- The concurrency test observes overlap at the injected `cdnFetch` seam (counting simultaneously in-flight closures), not the real `FileRepository`/`URLSession` download path, and it does not model `FileRepository`'s same-URL coalescing (the stub ignores the URL; each fetch uses a distinct `workflowId`). It proves the property this change owns (the workflows queue permits up to 4 concurrent `cdnFetch` invocations and no more), not a measured end-to-end network speedup.
- No device/integration run timing a real prefetch batch with `-EnableWorkflowsEndpoint`.
- Full `CI-RevenueCat` suite not run locally (only the workflow/backend-adjacent subset).

## Review Focus

- Is prefetch-only parallelization (on-demand + list on the serial queue) the right split? (Narrowed from "both" per review.)
- Cap of 4: reasonable for the expected number of prefetched workflows?
- Workflows queue intentionally keeps default QoS (no `.background`, unlike diagnostics) because prefetches gate offerings delivery, agree?

## Risks / Reviewer Notes

- Risk: concurrent CDN writes for two workflows sharing an asset URL.
  - Evidence: `FileRepository.generateOrGetCachedFileURL` coalesces same-URL fetches via a `JobKey`-keyed in-flight task store, so they share one download.
- Risk: concurrent `CallbackCache` access.
  - Evidence: `CallbackCache` is `Atomic`-backed.
- Risk: concurrent writes to `WorkflowsCache` from parallel completions.
  - Evidence: its mutable state is held in `Atomic` containers (`cache(workflow:)` uses `.modify`); `WorkflowDetailProcessor` is a stateless `Sendable` with only an immutable `let`.

## Non-goals / Out of Scope

- Changing `HTTPClient`'s internal request serialization.
- Changing `GetWorkflowOperation` completion semantics.
- Parallelizing on-demand `getWorkflow` (left on the serial queue to match Android).

## Omitted Context

- Raw transcript, unrelated exploration, sensitive details, repetitive attempts, and chain-of-thought-style content were omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes internal networking concurrency for workflow prefetches/on-demand detail loads; bounded at 4 but overlaps CDN I/O and shares callback caches across concurrent operations.
> 
> **Overview**
> Adds a dedicated **RC Workflows Queue** (`maxConcurrentOperationCount = 4`) and wires it through `BackendConfiguration` so workflow **detail** fetches no longer share the single serial backend queue.
> 
> `addCacheableOperation` now accepts an optional `queue:` (default remains the serial `operationQueue`). **`WorkflowsAPI.getWorkflow`** enqueues on `workflowsQueue` so multiple detail operations—and their CDN downloads while each operation holds its slot—can overlap up to four. **`getWorkflows`** (list) is unchanged on the serial queue.
> 
> Test harnesses pass the new queue into `BackendConfiguration`, with unit tests for queue settings, detail-vs-list routing, and a cap-4 concurrency check via stubbed CDN fetch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5f40527342d4333caae2f7e5f2e3d49d2b64769. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

