### PR TITLE
feat(workflows): persist prefetched workflow detail on disk

### DIFF
--- a/Sources/Caching/DeviceCache.swift
+++ b/Sources/Caching/DeviceCache.swift
@@ -287,6 +287,23 @@ class DeviceCache {
         self.largeItemCache.removeObject(forKey: CacheKey.workflowsListResponse.rawValue)
     }
 
+    // MARK: - Workflow details
+    // The prefetched workflow details are persisted under a single, non-user-scoped key as a
+    // `workflowId -> WorkflowDataResult` map, mirroring how the workflows list is stored above.
+    // Cross-user safety is handled by clearing it on identity transitions.
+
+    func cachedWorkflowDetails() -> [String: WorkflowDataResult]? {
+        return self.value(for: CacheKey.workflowDetails)
+    }
+
+    func cache(workflowDetails: [String: WorkflowDataResult]) {
+        self.largeItemCache.set(codable: workflowDetails, forKey: CacheKey.workflowDetails.rawValue)
+    }
+
+    func clearWorkflowDetailsCache() {
+        self.largeItemCache.removeObject(forKey: CacheKey.workflowDetails.rawValue)
+    }
+
     // MARK: - subscriber attributes
     // Write operations use `lockingUserDefaults` to ensure atomic read-modify-write.
     // Read operations use the lock-free `userDefaults` since they don't modify data.
@@ -551,6 +568,7 @@ class DeviceCache {
         case customerInfoLastUpdated(String)
         case offerings(String)
         case workflowsListResponse
+        case workflowDetails
         case legacySubscriberAttributes(String)
         case attributionDataDefaults(String)
         case syncedSK2ObserverModeTransactionIDs
@@ -563,6 +581,7 @@ class DeviceCache {
             case let .customerInfoLastUpdated(userID): return "\(Self.base)purchaserInfoLastUpdated.\(userID)"
             case let .offerings(userID): return "\(Self.base)offerings.\(userID)"
             case .workflowsListResponse: return "\(Self.base)workflowsListResponse"
+            case .workflowDetails: return "\(Self.base)workflowDetails"
             case let .legacySubscriberAttributes(userID): return "\(Self.legacySubscriberAttributesBase)\(userID)"
             case let .attributionDataDefaults(userID): return "\(Self.base)attribution.\(userID)"
             case .syncedSK2ObserverModeTransactionIDs:

--- a/Sources/Caching/WorkflowsCache.swift
+++ b/Sources/Caching/WorkflowsCache.swift
@@ -122,8 +122,13 @@ final class WorkflowsCache {
 
     /// Restores the persisted prefetched details into the in-memory cache, stamped fresh so
     /// ``cachedWorkflow(workflowId:)`` serves them without a backend round-trip. Used to recover after
-    /// a list-fetch failure; the list is restored stale separately so it refetches once the backend is
-    /// back. No-op when nothing is persisted. Mirrors ``restoreWorkflowsListFromDisk()``.
+    /// a list-fetch failure. No-op when nothing is persisted. Mirrors ``restoreWorkflowsListFromDisk()``.
+    ///
+    /// Fresh, not stale: stamping them stale would make ``WorkflowManager.getWorkflow`` try the backend
+    /// (which is down, with no disk fallback) instead of serving them, defeating the recovery. The cost
+    /// is that once the backend is back these details keep being served as cache hits until their own
+    /// foreground TTL expires, only then does `getWorkflow` refetch them, so recovery refreshes the
+    /// list/map promptly but the details ride their TTL.
     ///
     /// Only fills ids not already in memory: an on-demand ``cachedWorkflow(workflowId:)`` miss may have
     /// fetched a fresher detail that was never persisted, so the older disk snapshot must not clobber it.

--- a/Sources/Caching/WorkflowsCache.swift
+++ b/Sources/Caching/WorkflowsCache.swift
@@ -71,20 +71,6 @@ final class WorkflowsCache {
         return self.isStale(lastUpdated: cached.lastUpdated, isAppBackgrounded: isAppBackgrounded)
     }
 
-    func cache(workflow: WorkflowDataResult, workflowId: String) {
-        self.cache(workflows: [workflowId: workflow])
-    }
-
-    /// Caches a batch of resolved workflows in memory in one pass, all stamped with the same `now()`.
-    func cache(workflows: [String: WorkflowDataResult]) {
-        let now = self.dateProvider.now()
-        self.cachedWorkflows.modify { cache in
-            for (workflowId, result) in workflows {
-                cache[workflowId] = CachedWorkflow(result: result, lastUpdated: now)
-            }
-        }
-    }
-
     /// Caches a freshly fetched workflow in memory, but only if `generation` still matches the current
     /// one. The caller captures ``currentCacheGeneration()`` when it issues the fetch; if
     /// ``clearCache()`` bumped it in between (a log-in/log-out), the write is dropped so a request

--- a/Sources/Caching/WorkflowsCache.swift
+++ b/Sources/Caching/WorkflowsCache.swift
@@ -41,13 +41,16 @@ final class WorkflowsCache {
     private let cachedWorkflows: Atomic<[String: CachedWorkflow]> = .init([:])
     private let cachedList: Atomic<CachedList?> = .init(nil)
 
-    /// Serializes the read-modify-write of the on-disk workflow detail map so concurrent prefetch
-    /// persists (and a list-write prune) don't clobber each other.
-    private let detailsDiskLock = Lock()
+    /// Serializes the generation check together with the in-memory and on-disk detail writes against
+    /// ``clearCache()``, so a late fetch completion (and a list-write prune) can't clobber each other
+    /// or repopulate a since-cleared store.
+    private let detailsLock = Lock()
 
-    /// Bumped whenever the on-disk detail store is cleared (identity transitions). Lets an in-flight
-    /// prefetch detect that its results belong to a since-cleared user and skip persisting them.
-    private let diskGeneration: Atomic<Int> = .init(0)
+    /// Bumped whenever the workflow detail stores (memory and disk) are cleared on an identity
+    /// transition. A fetch captures it when issued and re-checks it before writing, so a result for a
+    /// since-changed user is dropped rather than repopulating the cache with that user's (potentially
+    /// targeted) workflow.
+    private let cacheGeneration: Atomic<Int> = .init(0)
 
     init(deviceCache: DeviceCache,
          dateProvider: DateProvider = DateProvider()) {
@@ -82,6 +85,19 @@ final class WorkflowsCache {
         }
     }
 
+    /// Caches a freshly fetched workflow in memory, but only if `generation` still matches the current
+    /// one. The caller captures ``currentCacheGeneration()`` when it issues the fetch; if
+    /// ``clearCache()`` bumped it in between (a log-in/log-out), the write is dropped so a request
+    /// issued for the previous user can't repopulate memory with that user's targeted workflow.
+    func cache(workflow: WorkflowDataResult, workflowId: String, ifGeneration generation: Int) {
+        self.detailsLock.perform {
+            guard self.cacheGeneration.value == generation else { return }
+            self.cachedWorkflows.modify {
+                $0[workflowId] = CachedWorkflow(result: workflow, lastUpdated: self.dateProvider.now())
+            }
+        }
+    }
+
     // MARK: - Workflow detail disk cache
 
     /// Persists a batch of resolved workflow details to disk, merging into whatever is already there.
@@ -89,48 +105,77 @@ final class WorkflowsCache {
     /// one we can render offline. Mirrors how ``cache(workflowsList:)`` writes the list to disk.
     ///
     /// `generation` guards against an identity change mid-prefetch: the caller captures
-    /// ``currentDiskGeneration()`` before fetching and passes it back here; if ``clearCache()`` bumped
+    /// ``currentCacheGeneration()`` before fetching and passes it back here; if ``clearCache()`` bumped
     /// it in between (a log-in/log-out), the write is dropped so the previous user's details can't be
     /// written back after the store was cleared.
     func persistWorkflowDetailsToDisk(_ details: [String: WorkflowDataResult], ifGeneration generation: Int) {
         guard !details.isEmpty else { return }
-        self.detailsDiskLock.perform {
-            guard self.diskGeneration.value == generation else { return }
+        self.detailsLock.perform {
+            guard self.cacheGeneration.value == generation else { return }
             var current = self.deviceCache.cachedWorkflowDetails() ?? [:]
             for (workflowId, result) in details {
                 current[workflowId] = result
+            }
+            // Keep the on-disk map a subset of the latest list: a slower prefetch from an earlier,
+            // overlapping list fetch must not write back an id a newer list already pruned.
+            if let listIds = self.cachedListWorkflowIds() {
+                current = current.filter { listIds.contains($0.key) }
             }
             self.deviceCache.cache(workflowDetails: current)
         }
     }
 
-    /// A token that changes whenever the on-disk detail store is cleared (on identity transitions).
-    /// Captured before a prefetch and re-checked at ``persistWorkflowDetailsToDisk(_:ifGeneration:)``
-    /// time to drop writes that would land after a user change.
-    func currentDiskGeneration() -> Int {
-        return self.diskGeneration.value
+    /// A token that changes whenever the workflow detail stores (memory and disk) are cleared on an
+    /// identity transition. Captured when a fetch is issued and re-checked before its in-memory write
+    /// (``cache(workflow:workflowId:ifGeneration:)``) and its disk write
+    /// (``persistWorkflowDetailsToDisk(_:ifGeneration:)``) to drop writes that would land after a user
+    /// change.
+    func currentCacheGeneration() -> Int {
+        return self.cacheGeneration.value
     }
 
     /// Restores the persisted prefetched details into the in-memory cache, stamped fresh so
     /// ``cachedWorkflow(workflowId:)`` serves them without a backend round-trip. Used to recover after
     /// a list-fetch failure; the list is restored stale separately so it refetches once the backend is
     /// back. No-op when nothing is persisted. Mirrors ``restoreWorkflowsListFromDisk()``.
+    ///
+    /// Only fills ids not already in memory: an on-demand ``cachedWorkflow(workflowId:)`` miss may have
+    /// fetched a fresher detail that was never persisted, so the older disk snapshot must not clobber it.
+    ///
+    /// The disk read and memory write are held under ``detailsLock`` together so they're atomic w.r.t.
+    /// ``clearCache()``: this runs on the list-fetch failure thread while a log-in/log-out can clear on
+    /// another, and without the lock a clear landing between the read and the write would restore the
+    /// previous user's (user-scoped) details into the new user's cache.
     func restoreWorkflowDetailsFromDisk() {
-        guard let details = self.deviceCache.cachedWorkflowDetails() else { return }
-        self.cache(workflows: details)
+        self.detailsLock.perform {
+            guard let details = self.deviceCache.cachedWorkflowDetails() else { return }
+            let now = self.dateProvider.now()
+            self.cachedWorkflows.modify { cache in
+                for (workflowId, result) in details where cache[workflowId] == nil {
+                    cache[workflowId] = CachedWorkflow(result: result, lastUpdated: now)
+                }
+            }
+        }
     }
 
     /// Drops persisted details whose workflowId is no longer in the latest list, so workflows the
     /// backend stopped sending don't linger on disk. The persisted set always stays a subset of what
     /// the latest list says exists. No-op (no rewrite) when nothing is pruned.
     private func pruneWorkflowDetails(toListIds workflowIds: Set<String>) {
-        self.detailsDiskLock.perform {
+        self.detailsLock.perform {
             guard let current = self.deviceCache.cachedWorkflowDetails() else { return }
             let pruned = current.filter { workflowIds.contains($0.key) }
             if pruned.count != current.count {
                 self.deviceCache.cache(workflowDetails: pruned)
             }
         }
+    }
+
+    /// The workflow ids in the currently cached list, or `nil` when no list is cached. Used to keep
+    /// the on-disk detail map a subset of the latest list when persisting.
+    private func cachedListWorkflowIds() -> Set<String>? {
+        guard let response = self.cachedList.value?.response else { return nil }
+        return Set(response.workflows.map { $0.id })
     }
 
     // MARK: - Workflows list cache
@@ -193,13 +238,14 @@ final class WorkflowsCache {
     // MARK: -
 
     func clearCache() {
-        self.cachedWorkflows.value = [:]
         self.cachedList.value = nil
         self.deviceCache.clearWorkflowsListResponseCache()
-        // Bump the generation and clear the disk store atomically, so a prefetch that started before
-        // this clear (and captured the old generation) can't write the previous user's details back.
-        self.detailsDiskLock.perform {
-            self.diskGeneration.modify { $0 += 1 }
+        // Bump the generation and clear both detail stores together, so a fetch issued before this
+        // clear (and capturing the old generation) can't write the previous user's details back into
+        // memory or disk.
+        self.detailsLock.perform {
+            self.cacheGeneration.modify { $0 += 1 }
+            self.cachedWorkflows.value = [:]
             self.deviceCache.clearWorkflowDetailsCache()
         }
     }

--- a/Sources/Caching/WorkflowsCache.swift
+++ b/Sources/Caching/WorkflowsCache.swift
@@ -41,6 +41,10 @@ final class WorkflowsCache {
     private let cachedWorkflows: Atomic<[String: CachedWorkflow]> = .init([:])
     private let cachedList: Atomic<CachedList?> = .init(nil)
 
+    /// Serializes the read-modify-write of the on-disk workflow detail map so concurrent prefetch
+    /// persists (and a list-write prune) don't clobber each other.
+    private let detailsDiskLock = Lock()
+
     init(deviceCache: DeviceCache,
          dateProvider: DateProvider = DateProvider()) {
         self.deviceCache = deviceCache
@@ -66,6 +70,40 @@ final class WorkflowsCache {
         }
     }
 
+    // MARK: - Workflow detail disk cache
+
+    /// Persists `result` under `workflowId` in the on-disk detail map, merging with whatever is
+    /// already there. Called only from the prefetch path after a successful fetch, so a persisted
+    /// detail is always one we can render offline. Mirrors how ``cache(workflowsList:)`` writes the
+    /// list to disk.
+    func cache(workflowDetail result: WorkflowDataResult, workflowId: String) {
+        self.detailsDiskLock.perform {
+            var current = self.deviceCache.cachedWorkflowDetails() ?? [:]
+            current[workflowId] = result
+            self.deviceCache.cache(workflowDetails: current)
+        }
+    }
+
+    /// Reads the persisted detail map, or `nil` when nothing is cached or the payload can't be
+    /// parsed. Used to recover prefetched workflows after a backend failure, mirroring
+    /// ``cachedWorkflowsListResponseFromDisk()``.
+    func cachedWorkflowDetailsFromDisk() -> [String: WorkflowDataResult]? {
+        return self.deviceCache.cachedWorkflowDetails()
+    }
+
+    /// Drops persisted details whose workflowId is no longer in the latest list, so workflows the
+    /// backend stopped sending don't linger on disk. The persisted set always stays a subset of what
+    /// the latest list says exists. No-op (no rewrite) when nothing is pruned.
+    private func pruneWorkflowDetails(toListIds workflowIds: Set<String>) {
+        self.detailsDiskLock.perform {
+            guard let current = self.deviceCache.cachedWorkflowDetails() else { return }
+            let pruned = current.filter { workflowIds.contains($0.key) }
+            if pruned.count != current.count {
+                self.deviceCache.cache(workflowDetails: pruned)
+            }
+        }
+    }
+
     // MARK: - Workflows list cache
 
     func isWorkflowsListCacheStale(isAppBackgrounded: Bool) -> Bool {
@@ -75,12 +113,15 @@ final class WorkflowsCache {
         return self.isStale(lastUpdated: cached.lastUpdated, isAppBackgrounded: isAppBackgrounded)
     }
 
-    /// Caches the workflows list in memory and persists it to disk.
+    /// Caches the workflows list in memory and persists it to disk. Also prunes any persisted
+    /// workflow details whose workflowId is no longer in the latest list, keeping the on-disk detail
+    /// store bounded by what the backend currently says exists.
     func cache(workflowsList response: WorkflowsListResponse) {
         self.cachedList.value = CachedList(response: response,
                                            offeringIdToWorkflowId: Self.offeringIdToWorkflowId(from: response),
                                            lastUpdated: self.dateProvider.now())
         self.deviceCache.cache(workflowsListResponse: response)
+        self.pruneWorkflowDetails(toListIds: Set(response.workflows.map { $0.id }))
     }
 
     /// Reads the last persisted workflows list, or `nil` when nothing is cached or the payload
@@ -126,6 +167,7 @@ final class WorkflowsCache {
         self.cachedWorkflows.value = [:]
         self.cachedList.value = nil
         self.deviceCache.clearWorkflowsListResponseCache()
+        self.deviceCache.clearWorkflowDetailsCache()
     }
 
     private func isStale(lastUpdated: Date, isAppBackgrounded: Bool) -> Bool {

--- a/Sources/Caching/WorkflowsCache.swift
+++ b/Sources/Caching/WorkflowsCache.swift
@@ -45,6 +45,10 @@ final class WorkflowsCache {
     /// persists (and a list-write prune) don't clobber each other.
     private let detailsDiskLock = Lock()
 
+    /// Bumped whenever the on-disk detail store is cleared (identity transitions). Lets an in-flight
+    /// prefetch detect that its results belong to a since-cleared user and skip persisting them.
+    private let diskGeneration: Atomic<Int> = .init(0)
+
     init(deviceCache: DeviceCache,
          dateProvider: DateProvider = DateProvider()) {
         self.deviceCache = deviceCache
@@ -65,30 +69,55 @@ final class WorkflowsCache {
     }
 
     func cache(workflow: WorkflowDataResult, workflowId: String) {
-        self.cachedWorkflows.modify {
-            $0[workflowId] = CachedWorkflow(result: workflow, lastUpdated: self.dateProvider.now())
+        self.cache(workflows: [workflowId: workflow])
+    }
+
+    /// Caches a batch of resolved workflows in memory in one pass, all stamped with the same `now()`.
+    func cache(workflows: [String: WorkflowDataResult]) {
+        let now = self.dateProvider.now()
+        self.cachedWorkflows.modify { cache in
+            for (workflowId, result) in workflows {
+                cache[workflowId] = CachedWorkflow(result: result, lastUpdated: now)
+            }
         }
     }
 
     // MARK: - Workflow detail disk cache
 
-    /// Persists `result` under `workflowId` in the on-disk detail map, merging with whatever is
-    /// already there. Called only from the prefetch path after a successful fetch, so a persisted
-    /// detail is always one we can render offline. Mirrors how ``cache(workflowsList:)`` writes the
-    /// list to disk.
-    func cache(workflowDetail result: WorkflowDataResult, workflowId: String) {
+    /// Persists a batch of resolved workflow details to disk, merging into whatever is already there.
+    /// Called only from the prefetch path after a successful fetch, so a persisted detail is always
+    /// one we can render offline. Mirrors how ``cache(workflowsList:)`` writes the list to disk.
+    ///
+    /// `generation` guards against an identity change mid-prefetch: the caller captures
+    /// ``currentDiskGeneration()`` before fetching and passes it back here; if ``clearCache()`` bumped
+    /// it in between (a log-in/log-out), the write is dropped so the previous user's details can't be
+    /// written back after the store was cleared.
+    func persistWorkflowDetailsToDisk(_ details: [String: WorkflowDataResult], ifGeneration generation: Int) {
+        guard !details.isEmpty else { return }
         self.detailsDiskLock.perform {
+            guard self.diskGeneration.value == generation else { return }
             var current = self.deviceCache.cachedWorkflowDetails() ?? [:]
-            current[workflowId] = result
+            for (workflowId, result) in details {
+                current[workflowId] = result
+            }
             self.deviceCache.cache(workflowDetails: current)
         }
     }
 
-    /// Reads the persisted detail map, or `nil` when nothing is cached or the payload can't be
-    /// parsed. Used to recover prefetched workflows after a backend failure, mirroring
-    /// ``cachedWorkflowsListResponseFromDisk()``.
-    func cachedWorkflowDetailsFromDisk() -> [String: WorkflowDataResult]? {
-        return self.deviceCache.cachedWorkflowDetails()
+    /// A token that changes whenever the on-disk detail store is cleared (on identity transitions).
+    /// Captured before a prefetch and re-checked at ``persistWorkflowDetailsToDisk(_:ifGeneration:)``
+    /// time to drop writes that would land after a user change.
+    func currentDiskGeneration() -> Int {
+        return self.diskGeneration.value
+    }
+
+    /// Restores the persisted prefetched details into the in-memory cache, stamped fresh so
+    /// ``cachedWorkflow(workflowId:)`` serves them without a backend round-trip. Used to recover after
+    /// a list-fetch failure; the list is restored stale separately so it refetches once the backend is
+    /// back. No-op when nothing is persisted. Mirrors ``restoreWorkflowsListFromDisk()``.
+    func restoreWorkflowDetailsFromDisk() {
+        guard let details = self.deviceCache.cachedWorkflowDetails() else { return }
+        self.cache(workflows: details)
     }
 
     /// Drops persisted details whose workflowId is no longer in the latest list, so workflows the
@@ -167,7 +196,12 @@ final class WorkflowsCache {
         self.cachedWorkflows.value = [:]
         self.cachedList.value = nil
         self.deviceCache.clearWorkflowsListResponseCache()
-        self.deviceCache.clearWorkflowDetailsCache()
+        // Bump the generation and clear the disk store atomically, so a prefetch that started before
+        // this clear (and captured the old generation) can't write the previous user's details back.
+        self.detailsDiskLock.perform {
+            self.diskGeneration.modify { $0 += 1 }
+            self.deviceCache.clearWorkflowDetailsCache()
+        }
     }
 
     private func isStale(lastUpdated: Date, isAppBackgrounded: Bool) -> Bool {

--- a/Sources/Networking/Responses/WorkflowsResponse.swift
+++ b/Sources/Networking/Responses/WorkflowsResponse.swift
@@ -167,7 +167,7 @@ extension WorkflowScreen: Codable, Equatable, Sendable {
 }
 
 extension PublishedWorkflow: Codable, Equatable, Sendable {}
-extension WorkflowDataResult: Equatable, Sendable {}
+extension WorkflowDataResult: Codable, Equatable, Sendable {}
 
 extension PublishedWorkflow: HTTPResponseBody {}
 

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -85,6 +85,11 @@ class WorkflowManager {
             return
         }
 
+        // Capture the cache generation when the request is issued. If an identity change clears the
+        // cache while this list fetch is in flight, the success path below is dropped, so a list
+        // (and its prefetched, user-scoped details) fetched for the previous user can't populate the
+        // new session's cache.
+        let generation = self.workflowsCache.currentCacheGeneration()
         self.backend.workflowsAPI.getWorkflows(appUserID: appUserID,
                                                isAppBackgrounded: isAppBackgrounded,
                                                type: Self.paywallWorkflowType) { [weak self] result in
@@ -94,10 +99,18 @@ class WorkflowManager {
             }
             switch result {
             case let .success(response):
+                guard self.workflowsCache.currentCacheGeneration() == generation else {
+                    // Identity changed mid-flight: this response is the previous user's. Drop it
+                    // (don't cache the list or prefetch its details) but still fire onComplete so
+                    // callers waiting on it aren't blocked, mirroring the failure branch.
+                    onComplete()
+                    return
+                }
                 self.workflowsCache.cache(workflowsList: response)
                 self.prefetchWorkflows(response.workflows,
                                        appUserID: appUserID,
                                        isAppBackgrounded: isAppBackgrounded,
+                                       generation: generation,
                                        onComplete: onComplete)
             case let .failure(error):
                 Logger.error(Strings.paywalls.error_fetching_workflows_list(error))
@@ -167,12 +180,15 @@ private extension WorkflowManager {
     /// offline. Only prefetched workflows are persisted: they're the curated, bounded set the backend
     /// marked as mattering, so persisting all of them is safe. On-demand fetches are not persisted, to
     /// avoid unbounded disk growth (a session can open many distinct paywalls); persisting those
-    /// behind an LRU cap is a planned follow-up. The cache generation captured before fetching guards
-    /// the disk write against an identity change mid-prefetch; each ``getWorkflow`` call guards its own
-    /// in-memory write the same way.
+    /// behind an LRU cap is a planned follow-up. `generation` is the cache generation captured when the
+    /// list fetch was issued (see ``getWorkflowsList(appUserID:isAppBackgrounded:onComplete:)``); it
+    /// guards the disk write against an identity change landing mid-prefetch, so the previous user's
+    /// details can't be written back after the store was cleared. Each ``getWorkflow`` call guards its
+    /// own in-memory write the same way.
     func prefetchWorkflows(_ workflows: [WorkflowSummary],
                            appUserID: String,
                            isAppBackgrounded: Bool,
+                           generation: Int,
                            onComplete: @escaping () -> Void) {
         let prefetchWorkflows = workflows.filter { $0.prefetch && $0.offeringId != nil }
         guard !prefetchWorkflows.isEmpty else {
@@ -180,7 +196,6 @@ private extension WorkflowManager {
             return
         }
 
-        let generation = self.workflowsCache.currentCacheGeneration()
         // Lock-guarded counter so the batch persist + `onComplete` fire exactly once, after the last
         // prefetch lands, regardless of which thread each completion arrives on.
         let remaining: Atomic<Int> = .init(prefetchWorkflows.count)

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -35,19 +35,12 @@ class WorkflowManager {
     }
 
     /// Resolves a workflow, serving a fresh cached result without a backend round-trip when possible.
-    /// On a cache miss (or stale entry) it fetches from the backend, caches the result, and warms up
-    /// its assets before delivering it.
-    ///
-    /// When `persistDetail` is `true` (the prefetch path) a successful fetch is also persisted to
-    /// disk, so a later cold start with the backend down can restore and render it offline. Only the
-    /// prefetch path sets this: prefetched workflows are the curated, bounded set the backend marked
-    /// as mattering, so persisting all of them is safe. The on-demand path leaves it `false` to avoid
-    /// unbounded disk growth (a session can open many distinct paywalls); persisting those behind an
-    /// LRU cap is a planned follow-up.
+    /// On a cache miss (or stale entry) it fetches from the backend, caches the result in memory, and
+    /// warms up its assets before delivering it. Disk persistence of prefetched details is handled by
+    /// ``prefetchWorkflows(_:appUserID:isAppBackgrounded:onComplete:)``, not here.
     func getWorkflow(appUserID: String,
                      workflowId: String,
                      isAppBackgrounded: Bool,
-                     persistDetail: Bool = false,
                      completion: @escaping (Result<WorkflowDataResult, BackendError>) -> Void) {
         if let cached = self.workflowsCache.cachedWorkflow(workflowId: workflowId),
            !self.workflowsCache.isWorkflowCacheStale(workflowId: workflowId, isAppBackgrounded: isAppBackgrounded) {
@@ -64,9 +57,6 @@ class WorkflowManager {
             }
             if case let .success(dataResult) = result {
                 self.workflowsCache.cache(workflow: dataResult, workflowId: workflowId)
-                if persistDetail {
-                    self.workflowsCache.cache(workflowDetail: dataResult, workflowId: workflowId)
-                }
                 self.warmUpAssets(for: dataResult)
             }
             completion(result)
@@ -114,7 +104,7 @@ class WorkflowManager {
                 // so a cold start with the backend down can still render them. They're restored fresh
                 // (like a normal fetch) so `getWorkflow` serves them offline; the refresh is driven by
                 // the list being restored stale above, which refetches once the backend is back.
-                self.restoreWorkflowDetailsFromDisk()
+                self.workflowsCache.restoreWorkflowDetailsFromDisk()
                 onComplete()
             }
         }
@@ -164,6 +154,14 @@ private extension WorkflowManager {
     /// `onComplete` once every prefetch finishes (success or failure). Workflows without an
     /// `offeringId` can't be resolved via ``cachedWorkflowId(forOfferingId:)``, so they're skipped.
     /// When there is nothing to prefetch, `onComplete` fires right away.
+    ///
+    /// Successful results are accumulated and persisted to disk in a single batch once the last
+    /// prefetch lands, so a later cold start with the backend down can restore and render them
+    /// offline. Only prefetched workflows are persisted: they're the curated, bounded set the backend
+    /// marked as mattering, so persisting all of them is safe. On-demand fetches are not persisted, to
+    /// avoid unbounded disk growth (a session can open many distinct paywalls); persisting those
+    /// behind an LRU cap is a planned follow-up. The disk generation captured before fetching guards
+    /// the write against an identity change mid-prefetch.
     func prefetchWorkflows(_ workflows: [WorkflowSummary],
                            appUserID: String,
                            isAppBackgrounded: Bool,
@@ -174,32 +172,27 @@ private extension WorkflowManager {
             return
         }
 
-        // Lock-guarded counter so `onComplete` fires exactly once, after the last prefetch lands,
-        // regardless of which thread each completion arrives on.
+        let generation = self.workflowsCache.currentDiskGeneration()
+        // Lock-guarded counter so the batch persist + `onComplete` fire exactly once, after the last
+        // prefetch lands, regardless of which thread each completion arrives on.
         let remaining: Atomic<Int> = .init(prefetchWorkflows.count)
+        let resolved: Atomic<[String: WorkflowDataResult]> = .init([:])
         for summary in prefetchWorkflows {
             self.getWorkflow(appUserID: appUserID,
                              workflowId: summary.id,
-                             isAppBackgrounded: isAppBackgrounded,
-                             persistDetail: true) { _ in
+                             isAppBackgrounded: isAppBackgrounded) { result in
+                if case let .success(dataResult) = result {
+                    resolved.modify { $0[summary.id] = dataResult }
+                }
                 let left = remaining.modify { value -> Int in
                     value -= 1
                     return value
                 }
                 if left == 0 {
+                    self.workflowsCache.persistWorkflowDetailsToDisk(resolved.value, ifGeneration: generation)
                     onComplete()
                 }
             }
-        }
-    }
-
-    /// Restores the prefetched workflow details persisted on disk into the in-memory cache, so a
-    /// later ``getWorkflow(appUserID:workflowId:isAppBackgrounded:persistDetail:completion:)`` is a
-    /// cache hit with no failed network call on the render path. No-op when nothing is persisted.
-    func restoreWorkflowDetailsFromDisk() {
-        guard let details = self.workflowsCache.cachedWorkflowDetailsFromDisk() else { return }
-        for (workflowId, result) in details {
-            self.workflowsCache.cache(workflow: result, workflowId: workflowId)
         }
     }
 

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -37,9 +37,17 @@ class WorkflowManager {
     /// Resolves a workflow, serving a fresh cached result without a backend round-trip when possible.
     /// On a cache miss (or stale entry) it fetches from the backend, caches the result, and warms up
     /// its assets before delivering it.
+    ///
+    /// When `persistDetail` is `true` (the prefetch path) a successful fetch is also persisted to
+    /// disk, so a later cold start with the backend down can restore and render it offline. Only the
+    /// prefetch path sets this: prefetched workflows are the curated, bounded set the backend marked
+    /// as mattering, so persisting all of them is safe. The on-demand path leaves it `false` to avoid
+    /// unbounded disk growth (a session can open many distinct paywalls); persisting those behind an
+    /// LRU cap is a planned follow-up.
     func getWorkflow(appUserID: String,
                      workflowId: String,
                      isAppBackgrounded: Bool,
+                     persistDetail: Bool = false,
                      completion: @escaping (Result<WorkflowDataResult, BackendError>) -> Void) {
         if let cached = self.workflowsCache.cachedWorkflow(workflowId: workflowId),
            !self.workflowsCache.isWorkflowCacheStale(workflowId: workflowId, isAppBackgrounded: isAppBackgrounded) {
@@ -56,6 +64,9 @@ class WorkflowManager {
             }
             if case let .success(dataResult) = result {
                 self.workflowsCache.cache(workflow: dataResult, workflowId: workflowId)
+                if persistDetail {
+                    self.workflowsCache.cache(workflowDetail: dataResult, workflowId: workflowId)
+                }
                 self.warmUpAssets(for: dataResult)
             }
             completion(result)
@@ -99,6 +110,11 @@ class WorkflowManager {
                 // a backend failure instead of returning nil. The entry stays stale so the next
                 // fetch still retries the backend.
                 self.workflowsCache.restoreWorkflowsListFromDisk()
+                // Restore the prefetched workflow details persisted on disk into the in-memory cache
+                // so a cold start with the backend down can still render them. They're restored fresh
+                // (like a normal fetch) so `getWorkflow` serves them offline; the refresh is driven by
+                // the list being restored stale above, which refetches once the backend is back.
+                self.restoreWorkflowDetailsFromDisk()
                 onComplete()
             }
         }
@@ -164,7 +180,8 @@ private extension WorkflowManager {
         for summary in prefetchWorkflows {
             self.getWorkflow(appUserID: appUserID,
                              workflowId: summary.id,
-                             isAppBackgrounded: isAppBackgrounded) { _ in
+                             isAppBackgrounded: isAppBackgrounded,
+                             persistDetail: true) { _ in
                 let left = remaining.modify { value -> Int in
                     value -= 1
                     return value
@@ -173,6 +190,16 @@ private extension WorkflowManager {
                     onComplete()
                 }
             }
+        }
+    }
+
+    /// Restores the prefetched workflow details persisted on disk into the in-memory cache, so a
+    /// later ``getWorkflow(appUserID:workflowId:isAppBackgrounded:persistDetail:completion:)`` is a
+    /// cache hit with no failed network call on the render path. No-op when nothing is persisted.
+    func restoreWorkflowDetailsFromDisk() {
+        guard let details = self.workflowsCache.cachedWorkflowDetailsFromDisk() else { return }
+        for (workflowId, result) in details {
+            self.workflowsCache.cache(workflow: result, workflowId: workflowId)
         }
     }
 

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -108,8 +108,9 @@ class WorkflowManager {
                 self.workflowsCache.restoreWorkflowsListFromDisk()
                 // Restore the prefetched workflow details persisted on disk into the in-memory cache
                 // so a cold start with the backend down can still render them. They're restored fresh
-                // (like a normal fetch) so `getWorkflow` serves them offline; the refresh is driven by
-                // the list being restored stale above, which refetches once the backend is back.
+                // (like a normal fetch) so `getWorkflow` serves them offline. The stale list above
+                // drives the next list/map refetch when the backend is back; the details themselves
+                // keep serving as cache hits until their own TTL expires (see `restoreWorkflowDetailsFromDisk`).
                 self.workflowsCache.restoreWorkflowDetailsFromDisk()
                 onComplete()
             }

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -48,6 +48,10 @@ class WorkflowManager {
             return
         }
 
+        // Capture the cache generation when the request is issued. If an identity change clears the
+        // cache while this fetch is in flight, the in-memory write below is dropped, so a result
+        // fetched for the previous user (workflow detail is user-scoped) can't repopulate memory.
+        let generation = self.workflowsCache.currentCacheGeneration()
         self.backend.workflowsAPI.getWorkflow(appUserID: appUserID,
                                               workflowId: workflowId,
                                               isAppBackgrounded: isAppBackgrounded) { [weak self] result in
@@ -56,7 +60,9 @@ class WorkflowManager {
                 return
             }
             if case let .success(dataResult) = result {
-                self.workflowsCache.cache(workflow: dataResult, workflowId: workflowId)
+                self.workflowsCache.cache(workflow: dataResult,
+                                          workflowId: workflowId,
+                                          ifGeneration: generation)
                 self.warmUpAssets(for: dataResult)
             }
             completion(result)
@@ -160,8 +166,9 @@ private extension WorkflowManager {
     /// offline. Only prefetched workflows are persisted: they're the curated, bounded set the backend
     /// marked as mattering, so persisting all of them is safe. On-demand fetches are not persisted, to
     /// avoid unbounded disk growth (a session can open many distinct paywalls); persisting those
-    /// behind an LRU cap is a planned follow-up. The disk generation captured before fetching guards
-    /// the write against an identity change mid-prefetch.
+    /// behind an LRU cap is a planned follow-up. The cache generation captured before fetching guards
+    /// the disk write against an identity change mid-prefetch; each ``getWorkflow`` call guards its own
+    /// in-memory write the same way.
     func prefetchWorkflows(_ workflows: [WorkflowSummary],
                            appUserID: String,
                            isAppBackgrounded: Bool,
@@ -172,7 +179,7 @@ private extension WorkflowManager {
             return
         }
 
-        let generation = self.workflowsCache.currentDiskGeneration()
+        let generation = self.workflowsCache.currentCacheGeneration()
         // Lock-guarded counter so the batch persist + `onComplete` fire exactly once, after the last
         // prefetch lands, regardless of which thread each completion arrives on.
         let remaining: Atomic<Int> = .init(prefetchWorkflows.count)

--- a/Tests/UnitTests/Caching/DeviceCacheTests.swift
+++ b/Tests/UnitTests/Caching/DeviceCacheTests.swift
@@ -541,6 +541,45 @@ class DeviceCacheTests: TestCase {
         expect(self.mockFileCache.saveDataInvocations.count) == 1
     }
 
+    // MARK: - Workflow details
+
+    func testWorkflowDetailsAreProperlyCachedToDisk() throws {
+        self.mockFileCache.stubSaveData(with: .success(.init(data: .init(), url: .mockFileLocation)))
+
+        expect(self.mockFileCache.saveDataInvocations.count) == 0
+
+        self.deviceCache.cache(workflowDetails: ["wf_1": try Self.workflowDataResult(id: "wf_1")])
+
+        expect(self.mockFileCache.saveDataInvocations.count) == 1
+    }
+
+    func testCachedWorkflowDetailsRoundTripThroughDisk() throws {
+        let details = ["wf_1": try Self.workflowDataResult(id: "wf_1")]
+
+        self.mockFileCache.stubSaveData(with: .success(.init(data: .init(), url: .mockFileLocation)))
+        self.mockFileCache.stubCachedContentExists(with: true)
+        self.mockFileCache.stubLoadFile(with: .success(try details.jsonEncodedData))
+
+        self.deviceCache.cache(workflowDetails: details)
+
+        let cached = self.deviceCache.cachedWorkflowDetails()
+        expect(cached) == details
+    }
+
+    func testCachedWorkflowDetailsReturnsNilWhenNothingCached() {
+        expect(self.deviceCache.cachedWorkflowDetails()).to(beNil())
+    }
+
+    func testWorkflowDetailsAreNeverSavedToUserDefaults() throws {
+        let workflowDetailsKey = "com.revenuecat.userdefaults.workflowDetails"
+        self.mockFileCache.stubSaveData(with: .success(.init(data: .init(), url: .mockFileLocation)))
+
+        self.deviceCache.cache(workflowDetails: ["wf_1": try Self.workflowDataResult(id: "wf_1")])
+
+        expect(self.mockUserDefaults.mockValues[workflowDetailsKey]).to(beNil())
+        expect(self.mockFileCache.saveDataInvocations.count) == 1
+    }
+
     func testSetLatestAdvertisingIdsByNetworkSentMapsAttributionNetworksToStringKeys() {
         let userId = "asdf"
         let token = "token"
@@ -1252,6 +1291,51 @@ private extension DeviceCacheTests {
             userDefaults: self.mockUserDefaults,
             cache: self.mockFileCache
         )
+    }
+
+    static func workflowDataResult(id: String) throws -> WorkflowDataResult {
+        let json = """
+        {
+          "id": "\(id)",
+          "display_name": "Test",
+          "initial_step_id": "step_1",
+          "steps": {
+            "step_1": { "id": "step_1", "type": "screen", "screen_id": "screen_1" }
+          },
+          "screens": {
+            "screen_1": {
+              "template_name": "tmpl",
+              "asset_base_url": "https://assets.revenuecat.com",
+              "default_locale": "en_US",
+              "components_localizations": {},
+              "components_config": {
+                "base": {
+                  "stack": {
+                    "type": "stack",
+                    "components": [],
+                    "dimension": { "type": "vertical", "alignment": "center", "distribution": "center" },
+                    "size": { "width": { "type": "fill" }, "height": { "type": "fill" } },
+                    "padding": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 },
+                    "margin": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 }
+                  },
+                  "background": {
+                    "type": "color",
+                    "value": { "light": { "type": "hex", "value": "#FFFFFF" } }
+                  }
+                }
+              },
+              "offering_identifier": "default"
+            }
+          },
+          "ui_config": {
+            "app": { "colors": {}, "fonts": {} },
+            "localizations": {}
+          }
+        }
+        """
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let workflow = try JSONDecoder.default.decode(PublishedWorkflow.self, from: data)
+        return .init(workflow: workflow, enrolledVariants: nil)
     }
 
     func makeIsolatedUserDefaults(file: StaticString = #fileID,

--- a/Tests/UnitTests/Caching/WorkflowsCacheTests.swift
+++ b/Tests/UnitTests/Caching/WorkflowsCacheTests.swift
@@ -232,7 +232,7 @@ class WorkflowsCacheTests: TestCase {
     func testPersistWorkflowDetailsToDiskPersistsKeyedByWorkflowId() throws {
         let result = try Self.workflowDataResult(id: "wf_1")
         self.cache.persistWorkflowDetailsToDisk(["wf_1": result],
-                                                ifGeneration: self.cache.currentDiskGeneration())
+                                                ifGeneration: self.cache.currentCacheGeneration())
 
         expect(self.deviceCache.cacheWorkflowDetailsCount) == 1
         expect(self.deviceCache.cachedWorkflowDetailsParameter?["wf_1"]) == result
@@ -244,7 +244,7 @@ class WorkflowsCacheTests: TestCase {
 
         let new = try Self.workflowDataResult(id: "wf_new")
         self.cache.persistWorkflowDetailsToDisk(["wf_new": new],
-                                                ifGeneration: self.cache.currentDiskGeneration())
+                                                ifGeneration: self.cache.currentCacheGeneration())
 
         let persisted = try XCTUnwrap(self.deviceCache.cachedWorkflowDetailsParameter)
         expect(persisted.keys).to(contain("wf_existing", "wf_new"))
@@ -253,14 +253,14 @@ class WorkflowsCacheTests: TestCase {
     }
 
     func testPersistWorkflowDetailsToDiskIsNoOpForEmptyBatch() {
-        self.cache.persistWorkflowDetailsToDisk([:], ifGeneration: self.cache.currentDiskGeneration())
+        self.cache.persistWorkflowDetailsToDisk([:], ifGeneration: self.cache.currentCacheGeneration())
         expect(self.deviceCache.cacheWorkflowDetailsCount) == 0
     }
 
     func testPersistWorkflowDetailsToDiskIsDroppedWhenGenerationChanged() throws {
         // A prefetch captures the generation, then an identity change clears the cache (bumping it),
         // then the prefetch's batch write lands: it must be dropped rather than reviving the old data.
-        let staleGeneration = self.cache.currentDiskGeneration()
+        let staleGeneration = self.cache.currentCacheGeneration()
         self.cache.clearCache()
 
         self.cache.persistWorkflowDetailsToDisk(["wf_1": try Self.workflowDataResult(id: "wf_1")],
@@ -274,7 +274,7 @@ class WorkflowsCacheTests: TestCase {
         self.cache.clearCache()
         // A fresh prefetch (post-clear) captures the new generation and persists normally.
         self.cache.persistWorkflowDetailsToDisk(["wf_1": try Self.workflowDataResult(id: "wf_1")],
-                                                ifGeneration: self.cache.currentDiskGeneration())
+                                                ifGeneration: self.cache.currentCacheGeneration())
 
         expect(self.deviceCache.cachedWorkflowDetailsParameter?["wf_1"]).toNot(beNil())
     }
@@ -339,6 +339,71 @@ class WorkflowsCacheTests: TestCase {
         expect(self.deviceCache.clearWorkflowDetailsCacheCount) == 1
     }
 
+    // MARK: - Generation-guarded in-memory cache
+
+    func testCacheWorkflowWithCurrentGenerationStoresInMemory() throws {
+        let result = try Self.workflowDataResult(id: "wf_1")
+        self.cache.cache(workflow: result,
+                         workflowId: "wf_1",
+                         ifGeneration: self.cache.currentCacheGeneration())
+
+        expect(self.cache.cachedWorkflow(workflowId: "wf_1")) == result
+    }
+
+    func testCacheWorkflowIsDroppedFromMemoryWhenGenerationChanged() throws {
+        // A fetch captures the generation, then an identity change clears the cache (bumping it),
+        // then the fetch's in-memory write lands: it must be dropped so the previous user's
+        // (user-scoped) workflow detail can't repopulate memory for the new user.
+        let staleGeneration = self.cache.currentCacheGeneration()
+        self.cache.clearCache()
+
+        self.cache.cache(workflow: try Self.workflowDataResult(id: "wf_1"),
+                         workflowId: "wf_1",
+                         ifGeneration: staleGeneration)
+
+        expect(self.cache.cachedWorkflow(workflowId: "wf_1")).to(beNil())
+    }
+
+    // MARK: - Restore from disk does not clobber fresher memory
+
+    func testRestoreWorkflowDetailsFromDiskFillsOnlyMissingIds() throws {
+        let memoryValue = try Self.workflowDataResult(id: "wf_1", enrolledVariants: ["src": "memory"])
+        let diskValue = try Self.workflowDataResult(id: "wf_1", enrolledVariants: ["src": "disk"])
+        let filledValue = try Self.workflowDataResult(id: "wf_2")
+
+        // An on-demand fetch already put a fresher wf_1 in memory that was never persisted.
+        self.cache.cache(workflows: ["wf_1": memoryValue])
+        self.deviceCache.stubbedCachedWorkflowDetails = ["wf_1": diskValue, "wf_2": filledValue]
+
+        self.cache.restoreWorkflowDetailsFromDisk()
+
+        // wf_1 keeps the fresher in-memory value; wf_2 is filled from disk.
+        expect(self.cache.cachedWorkflow(workflowId: "wf_1")) == memoryValue
+        expect(self.cache.cachedWorkflow(workflowId: "wf_2")) == filledValue
+    }
+
+    // MARK: - Disk persistence stays a subset of the latest list
+
+    func testPersistWorkflowDetailsToDiskDropsIdsNotInCurrentList() throws {
+        // The latest list only knows wf_keep.
+        self.cache.cache(workflowsList: .init(workflows: [
+            .init(id: "wf_keep", displayName: "Keep", offeringId: "default", prefetch: true)
+        ]))
+
+        // A slower prefetch from an earlier list tries to persist a since-pruned id alongside it.
+        self.cache.persistWorkflowDetailsToDisk(
+            [
+                "wf_keep": try Self.workflowDataResult(id: "wf_keep"),
+                "wf_stale": try Self.workflowDataResult(id: "wf_stale")
+            ],
+            ifGeneration: self.cache.currentCacheGeneration()
+        )
+
+        let persisted = try XCTUnwrap(self.deviceCache.cachedWorkflowDetailsParameter)
+        expect(persisted.keys).to(contain("wf_keep"))
+        expect(persisted.keys).toNot(contain("wf_stale"))
+    }
+
     // MARK: - WorkflowDataResult Codable round-trip
     // The disk cache encodes/decodes `WorkflowDataResult` as JSON, so it must round-trip losslessly,
     // including the `AnyDecodable`-backed fields (metadata, config, param values).
@@ -369,6 +434,11 @@ class WorkflowsCacheTests: TestCase {
 
     private static func workflowDataResult(id: String) throws -> WorkflowDataResult {
         return .init(workflow: try self.publishedWorkflow(id: id), enrolledVariants: nil)
+    }
+
+    private static func workflowDataResult(id: String,
+                                           enrolledVariants: [String: String]?) throws -> WorkflowDataResult {
+        return .init(workflow: try self.publishedWorkflow(id: id), enrolledVariants: enrolledVariants)
     }
 
     private static func publishedWorkflow(id: String) throws -> PublishedWorkflow {

--- a/Tests/UnitTests/Caching/WorkflowsCacheTests.swift
+++ b/Tests/UnitTests/Caching/WorkflowsCacheTests.swift
@@ -213,22 +213,38 @@ class WorkflowsCacheTests: TestCase {
         expect(self.cache.cachedWorkflowsListResponseFromDisk()).to(beNil())
     }
 
+    // MARK: - Batched in-memory cache
+
+    func testCacheWorkflowsBatchStoresEachEntryRetrievable() throws {
+        let first = try Self.workflowDataResult(id: "wf_1")
+        let second = try Self.workflowDataResult(id: "wf_2")
+
+        self.cache.cache(workflows: ["wf_1": first, "wf_2": second])
+
+        expect(self.cache.cachedWorkflow(workflowId: "wf_1")) == first
+        expect(self.cache.cachedWorkflow(workflowId: "wf_2")) == second
+        expect(self.cache.isWorkflowCacheStale(workflowId: "wf_1", isAppBackgrounded: false)) == false
+        expect(self.cache.isWorkflowCacheStale(workflowId: "wf_2", isAppBackgrounded: false)) == false
+    }
+
     // MARK: - Workflow detail disk persistence
 
-    func testCacheWorkflowDetailPersistsKeyedByWorkflowId() throws {
+    func testPersistWorkflowDetailsToDiskPersistsKeyedByWorkflowId() throws {
         let result = try Self.workflowDataResult(id: "wf_1")
-        self.cache.cache(workflowDetail: result, workflowId: "wf_1")
+        self.cache.persistWorkflowDetailsToDisk(["wf_1": result],
+                                                ifGeneration: self.cache.currentDiskGeneration())
 
         expect(self.deviceCache.cacheWorkflowDetailsCount) == 1
         expect(self.deviceCache.cachedWorkflowDetailsParameter?["wf_1"]) == result
     }
 
-    func testCacheWorkflowDetailMergesIntoExistingPersisted() throws {
+    func testPersistWorkflowDetailsToDiskMergesIntoExistingPersisted() throws {
         let existing = try Self.workflowDataResult(id: "wf_existing")
         self.deviceCache.stubbedCachedWorkflowDetails = ["wf_existing": existing]
 
         let new = try Self.workflowDataResult(id: "wf_new")
-        self.cache.cache(workflowDetail: new, workflowId: "wf_new")
+        self.cache.persistWorkflowDetailsToDisk(["wf_new": new],
+                                                ifGeneration: self.cache.currentDiskGeneration())
 
         let persisted = try XCTUnwrap(self.deviceCache.cachedWorkflowDetailsParameter)
         expect(persisted.keys).to(contain("wf_existing", "wf_new"))
@@ -236,16 +252,50 @@ class WorkflowsCacheTests: TestCase {
         expect(persisted["wf_new"]) == new
     }
 
-    func testCachedWorkflowDetailsFromDiskReturnsPersisted() throws {
+    func testPersistWorkflowDetailsToDiskIsNoOpForEmptyBatch() {
+        self.cache.persistWorkflowDetailsToDisk([:], ifGeneration: self.cache.currentDiskGeneration())
+        expect(self.deviceCache.cacheWorkflowDetailsCount) == 0
+    }
+
+    func testPersistWorkflowDetailsToDiskIsDroppedWhenGenerationChanged() throws {
+        // A prefetch captures the generation, then an identity change clears the cache (bumping it),
+        // then the prefetch's batch write lands: it must be dropped rather than reviving the old data.
+        let staleGeneration = self.cache.currentDiskGeneration()
+        self.cache.clearCache()
+
+        self.cache.persistWorkflowDetailsToDisk(["wf_1": try Self.workflowDataResult(id: "wf_1")],
+                                                ifGeneration: staleGeneration)
+
+        expect(self.deviceCache.cacheWorkflowDetailsCount) == 0
+        expect(self.deviceCache.cachedWorkflowDetailsParameter).to(beNil())
+    }
+
+    func testPersistWorkflowDetailsToDiskWritesWithCurrentGenerationAfterClear() throws {
+        self.cache.clearCache()
+        // A fresh prefetch (post-clear) captures the new generation and persists normally.
+        self.cache.persistWorkflowDetailsToDisk(["wf_1": try Self.workflowDataResult(id: "wf_1")],
+                                                ifGeneration: self.cache.currentDiskGeneration())
+
+        expect(self.deviceCache.cachedWorkflowDetailsParameter?["wf_1"]).toNot(beNil())
+    }
+
+    // MARK: - Restore from disk
+
+    func testRestoreWorkflowDetailsFromDiskRestoresFreshIntoMemory() throws {
         let result = try Self.workflowDataResult(id: "wf_1")
         self.deviceCache.stubbedCachedWorkflowDetails = ["wf_1": result]
 
-        expect(self.cache.cachedWorkflowDetailsFromDisk()?["wf_1"]) == result
+        self.cache.restoreWorkflowDetailsFromDisk()
+
+        expect(self.cache.cachedWorkflow(workflowId: "wf_1")) == result
+        // Restored fresh, so it is served offline without a refetch.
+        expect(self.cache.isWorkflowCacheStale(workflowId: "wf_1", isAppBackgrounded: false)) == false
     }
 
-    func testCachedWorkflowDetailsFromDiskReturnsNilWhenNothingCached() {
+    func testRestoreWorkflowDetailsFromDiskIsNoOpWhenNothingPersisted() {
         self.deviceCache.stubbedCachedWorkflowDetails = nil
-        expect(self.cache.cachedWorkflowDetailsFromDisk()).to(beNil())
+        self.cache.restoreWorkflowDetailsFromDisk()
+        expect(self.cache.cachedWorkflow(workflowId: "wf_1")).to(beNil())
     }
 
     func testCacheWorkflowsListPrunesDetailsNotInNewList() throws {

--- a/Tests/UnitTests/Caching/WorkflowsCacheTests.swift
+++ b/Tests/UnitTests/Caching/WorkflowsCacheTests.swift
@@ -44,7 +44,7 @@ class WorkflowsCacheTests: TestCase {
 
     func testCachedWorkflowReturnsCachedValueAfterCaching() throws {
         let result = try Self.workflowDataResult(id: "wf_1")
-        self.cache.cache(workflow: result, workflowId: "wf_1")
+        self.seedWorkflow(result, workflowId: "wf_1")
         expect(self.cache.cachedWorkflow(workflowId: "wf_1")) == result
     }
 
@@ -54,31 +54,31 @@ class WorkflowsCacheTests: TestCase {
     }
 
     func testIsWorkflowCacheStaleIsFalseRightAfterCachingInForeground() throws {
-        self.cache.cache(workflow: try Self.workflowDataResult(id: "wf_1"), workflowId: "wf_1")
+        self.seedWorkflow(try Self.workflowDataResult(id: "wf_1"), workflowId: "wf_1")
         expect(self.cache.isWorkflowCacheStale(workflowId: "wf_1", isAppBackgrounded: false)) == false
     }
 
     func testIsWorkflowCacheStaleIsTrueAfterForegroundTTLExpires() throws {
-        self.cache.cache(workflow: try Self.workflowDataResult(id: "wf_1"), workflowId: "wf_1")
+        self.seedWorkflow(try Self.workflowDataResult(id: "wf_1"), workflowId: "wf_1")
         self.dateProvider.advance(by: 6 * 60)
         expect(self.cache.isWorkflowCacheStale(workflowId: "wf_1", isAppBackgrounded: false)) == true
     }
 
     func testIsWorkflowCacheStaleIsFalseAfterForegroundTTLWhenBackgrounded() throws {
-        self.cache.cache(workflow: try Self.workflowDataResult(id: "wf_1"), workflowId: "wf_1")
+        self.seedWorkflow(try Self.workflowDataResult(id: "wf_1"), workflowId: "wf_1")
         self.dateProvider.advance(by: 6 * 60)
         expect(self.cache.isWorkflowCacheStale(workflowId: "wf_1", isAppBackgrounded: true)) == false
     }
 
     func testIsWorkflowCacheStaleIsTrueAfterBackgroundTTLExpires() throws {
-        self.cache.cache(workflow: try Self.workflowDataResult(id: "wf_1"), workflowId: "wf_1")
+        self.seedWorkflow(try Self.workflowDataResult(id: "wf_1"), workflowId: "wf_1")
         self.dateProvider.advance(by: 26 * 60 * 60)
         expect(self.cache.isWorkflowCacheStale(workflowId: "wf_1", isAppBackgrounded: true)) == true
     }
 
     func testClearCacheRemovesAllCachedWorkflows() throws {
-        self.cache.cache(workflow: try Self.workflowDataResult(id: "wf_1"), workflowId: "wf_1")
-        self.cache.cache(workflow: try Self.workflowDataResult(id: "wf_2"), workflowId: "wf_2")
+        self.seedWorkflow(try Self.workflowDataResult(id: "wf_1"), workflowId: "wf_1")
+        self.seedWorkflow(try Self.workflowDataResult(id: "wf_2"), workflowId: "wf_2")
 
         self.cache.clearCache()
 
@@ -90,10 +90,10 @@ class WorkflowsCacheTests: TestCase {
 
     func testDifferentWorkflowIdsAreCachedIndependently() throws {
         let first = try Self.workflowDataResult(id: "wf_1")
-        self.cache.cache(workflow: first, workflowId: "wf_1")
+        self.seedWorkflow(first, workflowId: "wf_1")
         self.dateProvider.advance(by: 6 * 60)
         let second = try Self.workflowDataResult(id: "wf_2")
-        self.cache.cache(workflow: second, workflowId: "wf_2")
+        self.seedWorkflow(second, workflowId: "wf_2")
 
         // Both values remain retrievable.
         expect(self.cache.cachedWorkflow(workflowId: "wf_1")) == first
@@ -211,20 +211,6 @@ class WorkflowsCacheTests: TestCase {
     func testCachedWorkflowsListResponseFromDiskReturnsNilWhenNothingCached() {
         self.deviceCache.stubbedCachedWorkflowsListResponse = nil
         expect(self.cache.cachedWorkflowsListResponseFromDisk()).to(beNil())
-    }
-
-    // MARK: - Batched in-memory cache
-
-    func testCacheWorkflowsBatchStoresEachEntryRetrievable() throws {
-        let first = try Self.workflowDataResult(id: "wf_1")
-        let second = try Self.workflowDataResult(id: "wf_2")
-
-        self.cache.cache(workflows: ["wf_1": first, "wf_2": second])
-
-        expect(self.cache.cachedWorkflow(workflowId: "wf_1")) == first
-        expect(self.cache.cachedWorkflow(workflowId: "wf_2")) == second
-        expect(self.cache.isWorkflowCacheStale(workflowId: "wf_1", isAppBackgrounded: false)) == false
-        expect(self.cache.isWorkflowCacheStale(workflowId: "wf_2", isAppBackgrounded: false)) == false
     }
 
     // MARK: - Workflow detail disk persistence
@@ -372,7 +358,7 @@ class WorkflowsCacheTests: TestCase {
         let filledValue = try Self.workflowDataResult(id: "wf_2")
 
         // An on-demand fetch already put a fresher wf_1 in memory that was never persisted.
-        self.cache.cache(workflows: ["wf_1": memoryValue])
+        self.seedWorkflow(memoryValue, workflowId: "wf_1")
         self.deviceCache.stubbedCachedWorkflowDetails = ["wf_1": diskValue, "wf_2": filledValue]
 
         self.cache.restoreWorkflowDetailsFromDisk()
@@ -431,6 +417,12 @@ class WorkflowsCacheTests: TestCase {
     }
 
     // MARK: - Helpers
+
+    /// Seeds the in-memory detail cache. The production write is generation-guarded, so tests seed
+    /// with the current generation, which always matches and lets the write land.
+    private func seedWorkflow(_ result: WorkflowDataResult, workflowId: String) {
+        self.cache.cache(workflow: result, workflowId: workflowId, ifGeneration: self.cache.currentCacheGeneration())
+    }
 
     private static func workflowDataResult(id: String) throws -> WorkflowDataResult {
         return .init(workflow: try self.publishedWorkflow(id: id), enrolledVariants: nil)

--- a/Tests/UnitTests/Caching/WorkflowsCacheTests.swift
+++ b/Tests/UnitTests/Caching/WorkflowsCacheTests.swift
@@ -213,6 +213,108 @@ class WorkflowsCacheTests: TestCase {
         expect(self.cache.cachedWorkflowsListResponseFromDisk()).to(beNil())
     }
 
+    // MARK: - Workflow detail disk persistence
+
+    func testCacheWorkflowDetailPersistsKeyedByWorkflowId() throws {
+        let result = try Self.workflowDataResult(id: "wf_1")
+        self.cache.cache(workflowDetail: result, workflowId: "wf_1")
+
+        expect(self.deviceCache.cacheWorkflowDetailsCount) == 1
+        expect(self.deviceCache.cachedWorkflowDetailsParameter?["wf_1"]) == result
+    }
+
+    func testCacheWorkflowDetailMergesIntoExistingPersisted() throws {
+        let existing = try Self.workflowDataResult(id: "wf_existing")
+        self.deviceCache.stubbedCachedWorkflowDetails = ["wf_existing": existing]
+
+        let new = try Self.workflowDataResult(id: "wf_new")
+        self.cache.cache(workflowDetail: new, workflowId: "wf_new")
+
+        let persisted = try XCTUnwrap(self.deviceCache.cachedWorkflowDetailsParameter)
+        expect(persisted.keys).to(contain("wf_existing", "wf_new"))
+        expect(persisted["wf_existing"]) == existing
+        expect(persisted["wf_new"]) == new
+    }
+
+    func testCachedWorkflowDetailsFromDiskReturnsPersisted() throws {
+        let result = try Self.workflowDataResult(id: "wf_1")
+        self.deviceCache.stubbedCachedWorkflowDetails = ["wf_1": result]
+
+        expect(self.cache.cachedWorkflowDetailsFromDisk()?["wf_1"]) == result
+    }
+
+    func testCachedWorkflowDetailsFromDiskReturnsNilWhenNothingCached() {
+        self.deviceCache.stubbedCachedWorkflowDetails = nil
+        expect(self.cache.cachedWorkflowDetailsFromDisk()).to(beNil())
+    }
+
+    func testCacheWorkflowsListPrunesDetailsNotInNewList() throws {
+        self.deviceCache.stubbedCachedWorkflowDetails = [
+            "wf_old": try Self.workflowDataResult(id: "wf_old"),
+            "wf_keep": try Self.workflowDataResult(id: "wf_keep")
+        ]
+
+        self.cache.cache(workflowsList: .init(workflows: [
+            .init(id: "wf_keep", displayName: "Keep", offeringId: "default", prefetch: true)
+        ]))
+
+        let persisted = try XCTUnwrap(self.deviceCache.cachedWorkflowDetailsParameter)
+        expect(persisted.keys).to(contain("wf_keep"))
+        expect(persisted.keys).toNot(contain("wf_old"))
+    }
+
+    func testCacheWorkflowsListDoesNotRewriteDetailsWhenNothingPruned() throws {
+        self.deviceCache.stubbedCachedWorkflowDetails = [
+            "wf_keep": try Self.workflowDataResult(id: "wf_keep")
+        ]
+
+        self.cache.cache(workflowsList: .init(workflows: [
+            .init(id: "wf_keep", displayName: "Keep", offeringId: "default", prefetch: true)
+        ]))
+
+        // Nothing to prune, so the detail store is left untouched (no rewrite).
+        expect(self.deviceCache.cacheWorkflowDetailsCount) == 0
+    }
+
+    func testCacheWorkflowsListPruneIsNoOpWhenNoDetailsPersisted() {
+        self.deviceCache.stubbedCachedWorkflowDetails = nil
+        self.cache.cache(workflowsList: .init(workflows: [
+            .init(id: "wf_1", displayName: "Flow", offeringId: "default", prefetch: true)
+        ]))
+        expect(self.deviceCache.cacheWorkflowDetailsCount) == 0
+    }
+
+    func testClearCacheClearsPersistedWorkflowDetails() {
+        self.cache.clearCache()
+        expect(self.deviceCache.clearWorkflowDetailsCacheCount) == 1
+    }
+
+    // MARK: - WorkflowDataResult Codable round-trip
+    // The disk cache encodes/decodes `WorkflowDataResult` as JSON, so it must round-trip losslessly,
+    // including the `AnyDecodable`-backed fields (metadata, config, param values).
+
+    func testWorkflowDataResultRoundTripsThroughCodable() throws {
+        let original = WorkflowDataResult(
+            workflow: try Self.richPublishedWorkflow(id: "wf_round_trip"),
+            enrolledVariants: ["experiment_a": "variant_b"]
+        )
+
+        let encoded = try JSONEncoder.default.encode(original)
+        let decoded = try JSONDecoder.default.decode(WorkflowDataResult.self, from: encoded)
+
+        expect(decoded) == original
+    }
+
+    func testWorkflowDataResultRoundTripsWithoutEnrolledVariants() throws {
+        let original = try Self.workflowDataResult(id: "wf_no_variants")
+
+        let encoded = try JSONEncoder.default.encode(original)
+        let decoded = try JSONDecoder.default.decode(WorkflowDataResult.self, from: encoded)
+
+        expect(decoded) == original
+        expect(decoded.enrolledVariants).to(beNil())
+    }
+
     // MARK: - Helpers
 
     private static func workflowDataResult(id: String) throws -> WorkflowDataResult {
@@ -234,6 +336,61 @@ class WorkflowsCacheTests: TestCase {
               "asset_base_url": "https://assets.revenuecat.com",
               "default_locale": "en_US",
               "components_localizations": {},
+              "components_config": {
+                "base": {
+                  "stack": {
+                    "type": "stack",
+                    "components": [],
+                    "dimension": { "type": "vertical", "alignment": "center", "distribution": "center" },
+                    "size": { "width": { "type": "fill" }, "height": { "type": "fill" } },
+                    "padding": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 },
+                    "margin": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 }
+                  },
+                  "background": {
+                    "type": "color",
+                    "value": { "light": { "type": "hex", "value": "#FFFFFF" } }
+                  }
+                }
+              },
+              "offering_identifier": "default"
+            }
+          },
+          "ui_config": {
+            "app": { "colors": {}, "fonts": {} },
+            "localizations": {}
+          }
+        }
+        """
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        return try JSONDecoder.default.decode(PublishedWorkflow.self, from: data)
+    }
+
+    /// Like ``publishedWorkflow(id:)`` but with the `AnyDecodable`-backed fields (`metadata`, step
+    /// `config`/`param_values`) populated with nested values, so the Codable round-trip exercises
+    /// `AnyDecodable` encoding rather than just empty dictionaries.
+    private static func richPublishedWorkflow(id: String) throws -> PublishedWorkflow {
+        let json = """
+        {
+          "id": "\(id)",
+          "display_name": "Test",
+          "initial_step_id": "step_1",
+          "metadata": { "source": "cdn", "version": 3, "flags": ["a", "b"] },
+          "steps": {
+            "step_1": {
+              "id": "step_1",
+              "type": "screen",
+              "screen_id": "screen_1",
+              "param_values": { "count": 2, "label": "hello", "nested": { "k": true } },
+              "metadata": { "note": "step-meta" }
+            }
+          },
+          "screens": {
+            "screen_1": {
+              "template_name": "tmpl",
+              "asset_base_url": "https://assets.revenuecat.com",
+              "default_locale": "en_US",
+              "components_localizations": {},
+              "config": { "theme": "dark", "scale": 1.5 },
               "components_config": {
                 "base": {
                   "stack": {

--- a/Tests/UnitTests/Mocks/MockDeviceCache.swift
+++ b/Tests/UnitTests/Mocks/MockDeviceCache.swift
@@ -169,6 +169,29 @@ class MockDeviceCache: DeviceCache {
         self.clearWorkflowsListResponseCacheCount += 1
     }
 
+    // MARK: Workflow details
+
+    var cacheWorkflowDetailsCount = 0
+    var clearWorkflowDetailsCacheCount = 0
+    var stubbedCachedWorkflowDetails: [String: WorkflowDataResult]?
+    private(set) var cachedWorkflowDetailsParameter: [String: WorkflowDataResult]?
+
+    override func cachedWorkflowDetails() -> [String: WorkflowDataResult]? {
+        return self.stubbedCachedWorkflowDetails
+    }
+
+    override func cache(workflowDetails: [String: WorkflowDataResult]) {
+        self.cacheWorkflowDetailsCount += 1
+        self.cachedWorkflowDetailsParameter = workflowDetails
+        // Reflect the write so read-after-write returns it, letting tests exercise merge/prune.
+        self.stubbedCachedWorkflowDetails = workflowDetails
+    }
+
+    override func clearWorkflowDetailsCache() {
+        self.clearWorkflowDetailsCacheCount += 1
+        self.stubbedCachedWorkflowDetails = nil
+    }
+
     // MARK: SubscriberAttributes
 
     var invokedStore = false

--- a/Tests/UnitTests/Mocks/MockWorkflowsAPI.swift
+++ b/Tests/UnitTests/Mocks/MockWorkflowsAPI.swift
@@ -65,6 +65,9 @@ class MockWorkflowsAPI: WorkflowsAPI, @unchecked Sendable {
     var invokedGetWorkflowsCount = 0
     var invokedGetWorkflowsParameters: (appUserID: String, isAppBackgrounded: Bool, type: String?)?
     var stubbedGetWorkflowsResult: Result<WorkflowsListResponse, BackendError>?
+    /// Invoked right before the `getWorkflows` completion fires, letting a test simulate an event
+    /// (e.g. an identity change clearing the cache) that lands while the list fetch is in flight.
+    var onGetWorkflowsBeforeCompletion: (() -> Void)?
 
     override func getWorkflows(appUserID: String,
                                isAppBackgrounded: Bool,
@@ -74,6 +77,7 @@ class MockWorkflowsAPI: WorkflowsAPI, @unchecked Sendable {
         self.invokedGetWorkflowsCount += 1
         self.invokedGetWorkflowsParameters = (appUserID, isAppBackgrounded, type)
 
+        self.onGetWorkflowsBeforeCompletion?()
         completion(self.stubbedGetWorkflowsResult ?? .failure(.missingAppUserID()))
     }
 

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -458,6 +458,26 @@ class WorkflowManagerTests: TestCase {
         expect(self.mockDeviceCache.clearWorkflowDetailsCacheCount) == clearCount
     }
 
+    func testPrefetchDoesNotRepopulateMemoryWhenIdentityChangesMidFlight() throws {
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: [
+            .init(id: "wf_a", displayName: "A", offeringId: "off_a", prefetch: true)
+        ]))
+        self.mockWorkflowsAPI.shouldStoreGetWorkflowCompletions = true
+
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        // Identity change mid-prefetch clears the cache (bumping the generation).
+        self.workflowsCache.clearCache()
+
+        // The in-flight prefetch from the previous user now lands.
+        self.mockWorkflowsAPI.completeStoredGetWorkflow(workflowId: "wf_a",
+                                                        with: .success(try Self.workflowDataResult(id: "wf_a")))
+
+        // Its in-memory write is dropped, so the previous user's (user-scoped) detail does not
+        // repopulate memory for the new user.
+        expect(self.workflowsCache.cachedWorkflow(workflowId: "wf_a")).to(beNil())
+    }
+
     func testGetWorkflowsListRestoresPersistedDetailsIntoInMemoryCacheOnBackendFailure() throws {
         let restored = try Self.workflowDataResult(id: "wf_1")
         self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .failure(.missingAppUserID())

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -387,6 +387,82 @@ class WorkflowManagerTests: TestCase {
         expect(completed) == true
     }
 
+    // MARK: - Detail disk persistence
+
+    func testPrefetchPersistsWorkflowDetailToDisk() throws {
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: [
+            .init(id: "wf_prefetch", displayName: "A", offeringId: "off_a", prefetch: true)
+        ]))
+        self.mockWorkflowsAPI.stubbedGetWorkflowResult = .success(try Self.workflowDataResult(id: "wf_prefetch"))
+
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        expect(self.mockDeviceCache.cacheWorkflowDetailsCount) >= 1
+        expect(self.mockDeviceCache.cachedWorkflowDetailsParameter?.keys).to(contain("wf_prefetch"))
+    }
+
+    func testOnDemandGetWorkflowDoesNotPersistDetailToDisk() throws {
+        self.mockWorkflowsAPI.stubbedGetWorkflowResult = .success(try Self.workflowDataResult(id: "wf_1"))
+
+        self.manager.getWorkflow(appUserID: self.appUserID, workflowId: "wf_1", isAppBackgrounded: false) { _ in }
+
+        expect(self.mockDeviceCache.cacheWorkflowDetailsCount) == 0
+    }
+
+    func testPrefetchDoesNotPersistDetailWhenFetchFails() throws {
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: [
+            .init(id: "wf_prefetch", displayName: "A", offeringId: "off_a", prefetch: true)
+        ]))
+        self.mockWorkflowsAPI.stubbedGetWorkflowResult = .failure(.missingAppUserID())
+
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        expect(self.mockDeviceCache.cacheWorkflowDetailsCount) == 0
+    }
+
+    func testGetWorkflowsListRestoresPersistedDetailsIntoInMemoryCacheOnBackendFailure() throws {
+        let restored = try Self.workflowDataResult(id: "wf_1")
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .failure(.missingAppUserID())
+        self.mockDeviceCache.stubbedCachedWorkflowsListResponse = .init(workflows: [
+            .init(id: "wf_1", displayName: "Flow", offeringId: "default", prefetch: true)
+        ])
+        self.mockDeviceCache.stubbedCachedWorkflowDetails = ["wf_1": restored]
+
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        expect(self.workflowsCache.cachedWorkflow(workflowId: "wf_1")) == restored
+    }
+
+    func testRestoredDetailIsServedOfflineWithoutHittingBackend() throws {
+        let restored = try Self.workflowDataResult(id: "wf_1")
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .failure(.missingAppUserID())
+        self.mockDeviceCache.stubbedCachedWorkflowsListResponse = .init(workflows: [
+            .init(id: "wf_1", displayName: "Flow", offeringId: "default", prefetch: true)
+        ])
+        self.mockDeviceCache.stubbedCachedWorkflowDetails = ["wf_1": restored]
+
+        // Backend-down recovery restores the detail into the in-memory cache (fresh)...
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        // ...so a later render is a cache hit with no backend round-trip.
+        var served: WorkflowDataResult?
+        self.manager.getWorkflow(appUserID: self.appUserID, workflowId: "wf_1", isAppBackgrounded: false) {
+            served = try? $0.get()
+        }
+
+        expect(served) == restored
+        expect(self.mockWorkflowsAPI.invokedGetWorkflowCount) == 0
+    }
+
+    func testGetWorkflowsListRestoreIsNoOpWhenNoDetailsPersisted() {
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .failure(.missingAppUserID())
+        self.mockDeviceCache.stubbedCachedWorkflowDetails = nil
+
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        expect(self.workflowsCache.cachedWorkflow(workflowId: "wf_1")).to(beNil())
+    }
+
     // MARK: - Helpers
 
     private static func workflowDataResult(id: String) throws -> WorkflowDataResult {

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -420,6 +420,44 @@ class WorkflowManagerTests: TestCase {
         expect(self.mockDeviceCache.cacheWorkflowDetailsCount) == 0
     }
 
+    func testPrefetchPersistsAllDetailsInASingleDiskWrite() throws {
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: [
+            .init(id: "wf_a", displayName: "A", offeringId: "off_a", prefetch: true),
+            .init(id: "wf_b", displayName: "B", offeringId: "off_b", prefetch: true)
+        ]))
+        self.mockWorkflowsAPI.stubbedGetWorkflowResults = [
+            "wf_a": .success(try Self.workflowDataResult(id: "wf_a")),
+            "wf_b": .success(try Self.workflowDataResult(id: "wf_b"))
+        ]
+
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        // Two prefetches, but the details are batched into one disk write.
+        expect(self.mockDeviceCache.cacheWorkflowDetailsCount) == 1
+        expect(self.mockDeviceCache.cachedWorkflowDetailsParameter?.keys).to(contain("wf_a", "wf_b"))
+    }
+
+    func testPrefetchDropsDiskWriteWhenIdentityChangesMidFlight() throws {
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: [
+            .init(id: "wf_a", displayName: "A", offeringId: "off_a", prefetch: true)
+        ]))
+        self.mockWorkflowsAPI.shouldStoreGetWorkflowCompletions = true
+
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        // Identity change mid-prefetch clears the cache (bumping the disk generation).
+        self.workflowsCache.clearCache()
+        let clearCount = self.mockDeviceCache.clearWorkflowDetailsCacheCount
+
+        // The in-flight prefetch from the previous user now lands.
+        self.mockWorkflowsAPI.completeStoredGetWorkflow(workflowId: "wf_a",
+                                                        with: .success(try Self.workflowDataResult(id: "wf_a")))
+
+        // Its detail write is dropped, so the previous user's payload is not written back after clear.
+        expect(self.mockDeviceCache.cacheWorkflowDetailsCount) == 0
+        expect(self.mockDeviceCache.clearWorkflowDetailsCacheCount) == clearCount
+    }
+
     func testGetWorkflowsListRestoresPersistedDetailsIntoInMemoryCacheOnBackendFailure() throws {
         let restored = try Self.workflowDataResult(id: "wf_1")
         self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .failure(.missingAppUserID())

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -478,6 +478,31 @@ class WorkflowManagerTests: TestCase {
         expect(self.workflowsCache.cachedWorkflow(workflowId: "wf_a")).to(beNil())
     }
 
+    func testGetWorkflowsListDropsListAndPrefetchWhenIdentityChangesWhileListFetchInFlight() throws {
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: [
+            .init(id: "wf_a", displayName: "A", offeringId: "off_a", prefetch: true)
+        ]))
+        self.mockWorkflowsAPI.stubbedGetWorkflowResult = .success(try Self.workflowDataResult(id: "wf_a"))
+
+        // Identity change lands while the list fetch is in flight: clearCache bumps the generation
+        // before the success completion runs, so the response belongs to the previous user.
+        self.mockWorkflowsAPI.onGetWorkflowsBeforeCompletion = { [weak self] in
+            self?.workflowsCache.clearCache()
+        }
+
+        var completed = false
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false) { completed = true }
+
+        // The previous user's list must not be cached, no prefetch must run or persist its detail,
+        // and onComplete still fires so callers (e.g. offerings delivery) are never blocked.
+        expect(self.mockDeviceCache.cacheWorkflowsListResponseCount) == 0
+        expect(self.mockWorkflowsAPI.invokedGetWorkflowCount) == 0
+        expect(self.mockDeviceCache.cacheWorkflowDetailsCount) == 0
+        expect(self.workflowsCache.cachedWorkflow(workflowId: "wf_a")).to(beNil())
+        expect(self.manager.cachedWorkflowId(forOfferingId: "off_a")).to(beNil())
+        expect(completed) == true
+    }
+
     func testGetWorkflowsListRestoresPersistedDetailsIntoInMemoryCacheOnBackendFailure() throws {
         let restored = try Self.workflowDataResult(id: "wf_1")
         self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .failure(.missingAppUserID())


### PR DESCRIPTION
Port of https://github.com/RevenueCat/purchases-android/pull/3537.

### What

#6882/#6883 persist the `/workflows` list to disk and restore the `offeringId → workflowId` map when the backend is down. But each prefetched workflow's detail was kept in memory only, so a cold start with the backend down could restore the map yet not render a single workflow. The list disk cache was half a resilience feature on its own.

This persists each prefetched workflow's detail too, so a cold start with the backend down renders the workflows we told the SDK mattered.

### Flow

```mermaid
flowchart TD
    Start([getWorkflowsList]) --> Stale{list cache stale?}
    Stale -->|no| Done([onComplete])
    Stale -->|yes| Fetch[backend.getWorkflows]

    Fetch -->|success| CacheList[cache list: memory + disk]
    CacheList --> Prune[prune disk details<br/>not in latest list]
    CacheList --> Prefetch[prefetch each prefetch=true workflow]
    Prefetch --> GW["getWorkflow: capture cacheGeneration,<br/>resolve, cache in memory if gen still matches"]
    GW --> Accum[accumulate resolved results]
    Accum --> LastOne{last prefetch landed?}
    LastOne -->|yes| Persist["batch-persist details to disk<br/>if gen matches, filtered to current list ids"]
    Persist --> Done

    Fetch -->|failure| RestoreList["restore list from disk → stale<br/>(drives refetch when backend is back)"]
    RestoreList --> RestoreDetails["restore details from disk → fresh<br/>(fill only ids missing in memory)"]
    RestoreDetails --> Done2([onComplete])
    RestoreDetails -.enables.-> Offline["later getWorkflow → in-memory hit,<br/>no backend round-trip"]

    Clear([clearCache on identity change]) ==> Bump["under detailsLock: bump cacheGeneration,<br/>clear in-memory + on-disk details"]

    classDef new fill:#e8f5e9,stroke:#43a047,color:#1b5e20;
    class CacheList,Prune,Accum,Persist,RestoreDetails,Offline,Bump new
```

<sub>Green = added/changed by this PR. Everything else is the existing list-cache flow from #6882/#6883.</sub>

### Divergences from Android

The Android PR persists the *envelope* (`url`/`hash`/`enrolled_variants`) and re-resolves it offline, re-reading the CDN file. On iOS the envelope never reaches `WorkflowManager`: the networking layer consumes the raw response and hands back a fully-resolved `WorkflowDataResult`, for consistency with how every other endpoint works on iOS. So iOS persists the resolved result and restores it directly.

Consequences of that fork:
- For `use_cdn` workflows the compiled JSON is duplicated on disk (the prefetch set is small). Android avoids this; iOS can't cheaply.
- Restore needs no CDN round-trip or hash re-verification. It's our own cache and the doc was verified when first fetched. Android's re-resolve can still hit the CDN (and fail) while the backend is down.

Where iOS is deliberately stricter than Android (driven by Bugbot + review on this PR):
- **Cross-user guard.** Android's `cacheWorkflowsList` intentionally leaves the identity-transition race unguarded (last-write-wins, self-heals on the next fetch, same as the offerings cache). iOS guards the detail writes with a `cacheGeneration` token so an in-flight fetch for the previous user can't repopulate memory or disk after `clearCache()`. Workflow detail is user-scoped (`subscribers/{appUserID}/workflows/{id}`), so this closes a real wrong-user window.
- **Restore is fill-gaps.** Android's restore overwrites in-memory entries; iOS fills only ids missing from memory, so a fresher on-demand fetch isn't clobbered by an older disk snapshot.
- **Persist is list-filtered.** Android prunes only on list-write; iOS also filters the persisted map to the current list ids, so a slow prefetch from an earlier list can't revive a since-pruned id.

Same as Android: prefetch-only persistence (on-demand stays memory-only, LRU cap is a follow-up), prune-to-list on each list write, clear-on-identity, details restored fresh, and `onComplete` firing exactly once.

Known follow-up (not in this PR): a late list fetch from a previous user is now dropped on identity change (the generation is captured when the list request is issued), so the common race no longer caches the wrong user's list or persists their details. A narrow residual window remains between the success-path generation re-check and the still-unguarded `cache(workflowsList:)` write; it only affects the `offeringId → workflowId` map (details stay fully guarded) and self-heals on the next offerings refresh / list TTL. Closing it fully means a generation-guarded list write under `detailsLock`, done consistently with the offerings cache rather than bolted on here.

<details>
<summary>AI session context</summary>

## Metadata

- PR: #6917 (`facu/workflow-persist-detail-cache`)
- Branch: `facu/workflow-persist-detail-cache` (base: `main`; originally stacked on #6905, which has since merged, so the branch was rebased onto `main`)
- Author / human owner: facumenzella
- Agent(s): Claude Code (Opus 4.8, 1M context)
- Session source: current conversation
- Generated: 2026-06-08
- Context document version: 3

## Goal

Port purchases-android#3537 (persist prefetched workflow detail for backend-down recovery) to iOS, then address Bugbot/review findings and keep the branch current with `main`.

## Initial Prompt

"let's port purchases-android#3537 to iOS. Take #6905 into account when integrating that. Most likely useful to branch off #6905."

## Important Follow-up Prompts

- Asked how iOS already persists other things to disk before choosing an approach (drove persisting a resolved Codable model via the existing large-item cache).
- "let's go with 2 then" — chose Approach 2 (persist resolved `WorkflowDataResult`) over strict Android parity (raw envelope + re-resolve).
- "vegaro has made a bunch of comments, let's analyse them" → chose: keep restore-fresh, full generation-token fix for the logout race, and refactors (move restore into the cache, batched `cache(workflows:)`, prefetch uses the batched path).
- "Let's address cursorbot" → fixed the three open Bugbot findings (+ a fourth instance found during review).
- "make sure we're up-to-date with main, there are conflicts" → rebased onto `main` after #6905 merged.
- "validate behavior against android" + add a diagram → this writeup.
- Bugbot `r3374267695` (High: "Late fetch persists prior user details") → confirmed real with a RED test, then "keep it proportionate" (vs. the heavier lock-guarded list write): manager-level drop of a late list fetch + thread the issue-time generation into the prefetch persist.

## Agent Contribution

- Read the Android diff and the iOS workflow stack (`WorkflowManager`, `WorkflowsCache`, `DeviceCache`, `WorkflowDetailProcessor`, `WorkflowsAPI`, `GetWorkflowOperation`) and identified the architectural fork: the envelope never reaches `WorkflowManager` on iOS.
- Implemented Approach 2: new `DeviceCache` workflow-details region, `WorkflowsCache` disk methods (persist/merge/prune/restore/clear), prefetch-path persistence in `WorkflowManager`, disk restore on list-fetch failure.
- Added `Codable` to `WorkflowDataResult` with a populated-`AnyDecodable` encode→decode round-trip test to prove lossless persistence.
- Addressed Bugbot findings: extended the `cacheGeneration` guard to the in-memory write and moved the in-memory clear under `detailsLock` (cross-user race); made restore fill-gaps-only; filtered the persisted map to the current list ids; closed the same race on the restore path by holding the disk-read + memory-write under the lock.
- Re-validated against the merged Android PR and rebased the branch onto `main`.
- Closed Bugbot's late-list-fetch race: the prefetch path re-captured the generation *after* the list fetch completed, so a `clearCache()` landing while the list request was in flight was already baked into that generation and the prior user's detail writes passed the guard. Moved the capture to list-issue time, added a success-path generation re-check that drops the response (no list cache, no prefetch) while still firing `onComplete`, and threaded the issue-time generation into the prefetch disk persist. Proven RED then GREEN with a new manager test (+ a `MockWorkflowsAPI` before-completion hook seam).

## Human Decisions

- Approach 2 (persist resolved result) over strict Android parity.
- Restore details fresh, restore list stale.
- Full cross-user fix via the generation token (rather than accepting Android's self-heal).
- Refactor shape: restore lives in `WorkflowsCache`, batched `cache(workflows:)`, prefetch uses the batched path.

## Key Implementation Decisions

- Persist the resolved `WorkflowDataResult`, not the raw envelope. Rationale: iOS never surfaces the envelope to the manager; matches every existing cache region; self-contained offline render with no CDN dependency. Rejected: persist raw envelope + re-resolve (faithful to Android but forces signature churn through the networking layer).
- Restore details fresh, list stale. Fresh details let `getWorkflow` serve offline; the stale list drives a refetch once the backend is back.
- Generation guard (`cacheGeneration` + `detailsLock`) covers both memory and disk detail writes; bumped on `clearCache()` so a fetch issued for the previous user is dropped. Scope is the detail cache only (see the list follow-up note above).
- Late-list-fetch fix: capture the generation when the list request is *issued* (not when prefetch starts), re-check it on the success path and drop the whole response if it changed (still firing `onComplete`), and pass that issue-time generation into the prefetch persist. Rationale: the prior re-capture happened after any in-flight clear, so it could not detect it. De-scoped (per "keep it proportionate"): a fully airtight, generation-guarded `cache(workflowsList:ifGeneration:)` under `detailsLock` (would also need `pruneWorkflowDetails` de-nested to avoid a re-entrant deadlock and the list clear moved under the lock). The residual list-map TOCTOU is pre-existing and narrow; details are unaffected.

## Files / Symbols Touched

- `Sources/Networking/Responses/WorkflowsResponse.swift` — `WorkflowDataResult: Codable`. Review: lossless round-trip of `AnyDecodable`-backed fields.
- `Sources/Caching/DeviceCache.swift` — `CacheKey.workflowDetails`, `cachedWorkflowDetails()` / `cache(workflowDetails:)` / `clearWorkflowDetailsCache()`.
- `Sources/Caching/WorkflowsCache.swift` — `cache(workflows:)`, `cache(workflow:workflowId:ifGeneration:)`, `persistWorkflowDetailsToDisk(_:ifGeneration:)`, `currentCacheGeneration()`, `restoreWorkflowDetailsFromDisk()` (fill-gaps, under lock), `pruneWorkflowDetails(toListIds:)`, `cachedListWorkflowIds()`, `cacheGeneration`/`detailsLock`, clear-on-identity. Review: lock scope, list-id filter on persist, fill-gaps restore.
- `Sources/Purchasing/WorkflowManager.swift` — `getWorkflow` captures `currentCacheGeneration()` and writes via the `ifGeneration:` path; `getWorkflowsList` now captures the generation at request-issue time and drops the success path if it changed; prefetch accumulates results and batch-persists once the last lands (now takes the issue-time `generation` instead of re-capturing); restore on list-fetch failure. Review: the success-path re-check + the threaded generation.
- `Tests/UnitTests/Caching/WorkflowsCacheTests.swift`, `Tests/UnitTests/Caching/DeviceCacheTests.swift`, `Tests/UnitTests/Purchasing/WorkflowManagerTests.swift` (+ `testGetWorkflowsListDropsListAndPrefetchWhenIdentityChangesWhileListFetchInFlight`), `Tests/UnitTests/Mocks/MockDeviceCache.swift`, `Tests/UnitTests/Mocks/MockWorkflowsAPI.swift` (`onGetWorkflowsBeforeCompletion` hook).

## Dependencies / Config / Migrations

- None. No new dependencies, flags, or schema. (`Package.resolved` touched only locally by tooling and reverted; not in the diff.)

## Validation

- `swift build`: success.
- `swiftlint` on changed files: no violations.
- `xcodebuild test -scheme UnitTests` for `WorkflowsCacheTests` (41) + `WorkflowManagerTests` (36): 77 passing, 0 failures, on iPhone 16 (latest sim), after rebasing onto `main`.
- Late-list-fetch fix: `WorkflowManagerTests` ran RED (5 failures: wrong-user list cached, prefetch ran, detail persisted to disk + memory, offering map populated) before the fix, then GREEN (37/37, including the two existing mid-prefetch identity tests) after. `swiftlint` clean on the changed files.
- CI: green on the prior commit except the Emerge size gate (action_required, +0.09% download / +0.1% install) which is a manual size-approval, not a failure.

## Validation Gaps

- End-to-end "cold start with backend unreachable renders a prefetched workflow" not exercised on device; covered at the unit level (restore into memory → served without backend round-trip).
- The cross-user races are covered by deterministic unit tests at the cache layer and a mid-flight manager test; the true concurrent interleaving is closed by the lock, not reproduced under threads.

## Review Focus

- Restore avoids serving stale data once the backend is back (list restored stale → refetch; details fresh → served offline meanwhile).
- Prune-on-list + filter-on-persist keep on-disk details a subset of the latest list.
- `detailsLock` scope: generation-check + memory/disk writes atomic against `clearCache()`; no nested-lock deadlock (lock order `detailsLock → cachedWorkflows`).
- Interaction with #6905's `cachedWorkflow(forOfferingId:)`: after recovery the list is stale, so the sync seed bails to the async path.

## Risks / Reviewer Notes

- Risk: CDN-compiled JSON duplicated on disk for prefetched `use_cdn` workflows. Mitigation: pruned to the current list on each list write; cleared on identity changes; prefetch set is small.
- Risk: a narrow list-map TOCTOU remains between the success-path generation re-check and the unguarded `cache(workflowsList:)` write. Evidence: those two statements are adjacent and synchronous (no await between them), so the window is a few instructions; details are unaffected (their writes re-check the generation under `detailsLock`). Mitigation: self-heals on the next offerings refresh / list TTL. Tracked as the follow-up noted above. The common race (clear before the list completion) is now closed by the success-path drop.

## Non-goals / Out of Scope

- On-demand (non-prefetch) detail persistence + LRU cap.
- Fully closing the narrow residual list-map TOCTOU with a generation-guarded `cache(workflowsList:ifGeneration:)` under `detailsLock` (do it consistently with the offerings cache). The common identity-transition race is handled in this PR.

## Omitted Context

- Raw transcript, unrelated exploration, sensitive details, and chain-of-thought content were omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches paywall workflow caching, cross-user identity races, and persisted user-targeted workflow JSON; mitigated by generation guards, pruning, and broad unit tests, but wrong-user list cache remains unguarded as noted in the PR.
> 
> **Overview**
> Adds **disk persistence for prefetched workflow details** so a cold start with the backend down can still render paywalls after the workflows list is restored from disk.
> 
> **`DeviceCache`** gains a non-user-scoped `workflowDetails` large-item region (`workflowId` → `WorkflowDataResult`), cleared on identity changes like the workflows list.
> 
> **`WorkflowsCache`** batches prefetched details to disk after prefetch completes, **restores** them into memory (fresh TTL, fill-gaps only) when the list fetch fails, and **prunes** on-disk details when the list no longer includes those ids. A **`cacheGeneration`** token plus **`detailsLock`** drop in-flight memory/disk writes after `clearCache()` so the previous user’s user-scoped workflow payloads cannot repopulate the cache mid login/logout.
> 
> **`WorkflowManager`** accumulates successful prefetch results into one disk write, skips persisting on-demand `getWorkflow` fetches, drops stale list responses if identity changed mid-flight, and restores list + details from disk on list failure.
> 
> **`WorkflowDataResult`** is **`Codable`** for JSON persistence (with round-trip tests for `AnyDecodable` fields).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c06fba99804ead2ad8e2dad114955682c2c231d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


