### PR TITLE
refactor(paywalls): share exit-offer presentation across SwiftUI present functions

### DIFF
--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -103,10 +103,9 @@ public class PaywallViewController: UIViewController {
     private var configuration: PaywallViewConfiguration {
         didSet {
             // Drop the previous workflow's exit offer before the rebuild; the new paywall re-emits it.
-            // (Legacy keeps its prefetched offer, which isn't re-fetched on update.)
-            if ProcessInfo.processInfo.workflowsEndpointEnabled {
-                self.exitOfferOffering = nil
-            }
+            // Routed through updateWorkflowExitOffer so it keeps the "don't clear while presenting"
+            // guard and is a no-op under the legacy (non-workflow) path.
+            self.updateWorkflowExitOffer(nil)
 
             // Overriding the configuration requires re-creating the `HostingViewController`.
             // This is used by some Hybrid SDKs that require modifying the content after creation.

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -102,6 +102,12 @@ public class PaywallViewController: UIViewController {
 
     private var configuration: PaywallViewConfiguration {
         didSet {
+            // Drop the previous workflow's exit offer before the rebuild; the new paywall re-emits it.
+            // (Legacy keeps its prefetched offer, which isn't re-fetched on update.)
+            if ProcessInfo.processInfo.workflowsEndpointEnabled {
+                self.exitOfferOffering = nil
+            }
+
             // Overriding the configuration requires re-creating the `HostingViewController`.
             // This is used by some Hybrid SDKs that require modifying the content after creation.
             self.hostingController = self.createHostingController()
@@ -418,18 +424,26 @@ public class PaywallViewController: UIViewController {
     /// Prefetches the exit offer for the current offering.
     @MainActor
     private func prefetchExitOffer() async {
-        // When the workflows endpoint is enabled, the workflow exit offer is step-aware and
-        // emitted by the embedded SwiftUI WorkflowPaywallView, so this legacy up-front prefetch
-        // is skipped. Today only the SwiftUI presentation layer (View+PresentPaywall) consumes it;
-        // this UIKit controller does not yet bridge it, so swipe-to-dismiss here won't surface the
-        // workflow exit offer. A follow-up will bridge it into this controller (feeding
-        // exitOfferOffering from the WorkflowContext binding) so swipe-to-dismiss surfaces it.
+        // Under workflows the exit offer comes from the embedded paywall (see updateWorkflowExitOffer),
+        // so skip this legacy prefetch.
         guard !ProcessInfo.processInfo.workflowsEndpointEnabled else { return }
 
         guard let offering = await self.purchaseHandler.resolveOffering(for: self.configuration.content) else {
             return
         }
         self.exitOfferOffering = await ExitOfferHelper.fetchValidExitOffer(for: offering)
+    }
+
+    /// Feeds the embedded workflow paywall's exit offer into `exitOfferOffering` so swipe/close can
+    /// surface it. Render-dependent, so verified manually like `prefetchExitOffer`.
+    private func updateWorkflowExitOffer(_ offering: Offering?) {
+        // The legacy prefetch owns the offer when workflows are off; don't clobber it.
+        guard ProcessInfo.processInfo.workflowsEndpointEnabled else { return }
+
+        // Keep the offer once we're presenting it, even if a late nil arrives mid-dismiss.
+        guard offering != nil || !self.isShowingExitOffer else { return }
+
+        self.exitOfferOffering = offering
     }
 
     /// Handles dismissal requests, checking for exit offers before calling the original handler.
@@ -729,6 +743,12 @@ private extension PaywallViewController {
             self.handleDismissalRequest()
         }
 
+        // Bridges the embedded paywall's workflow exit offer into `exitOfferOffering`.
+        let workflowExitOfferBinding = Binding<Offering?>(
+            get: { [weak self] in self?.exitOfferOffering },
+            set: { [weak self] offering in self?.updateWorkflowExitOffer(offering) }
+        )
+
         let container = PaywallContainerView(
             configuration: self.configuration,
             customVariables: self.customVariables,
@@ -770,7 +790,8 @@ private extension PaywallViewController {
                 self.delegate?.paywallViewController?(self, didChangeSizeTo: $0)
             },
             purchaseInitiated: self.createPurchaseInitiatedHandler(),
-            restoreInitiated: self.createRestoreInitiatedHandler()
+            restoreInitiated: self.createRestoreInitiatedHandler(),
+            workflowExitOfferBinding: workflowExitOfferBinding
         )
 
         let controller = UIHostingController(rootView: container)
@@ -889,6 +910,9 @@ private struct PaywallContainerView: View {
     let purchaseInitiated: (Package, @escaping (Bool) -> Void) -> Void
     let restoreInitiated: (@escaping (Bool) -> Void) -> Void
 
+    /// Receives the workflow exit offer from the embedded paywall (binding + preference below).
+    let workflowExitOfferBinding: Binding<Offering?>
+
     var body: some View {
         PaywallView(configuration: self.configuration)
             .customPaywallVariables(self.customVariables)
@@ -914,6 +938,11 @@ private struct PaywallContainerView: View {
                         resumeAction(shouldProceed: shouldProceed)
                     }
                 }
+            }
+            // Binding is the reliable path; preference is a fallback. Both feed `exitOfferOffering`.
+            .environment(\.workflowExitOfferOfferingBinding, self.workflowExitOfferBinding)
+            .onPreferenceChange(WorkflowExitOfferPreferenceKey.self) { context in
+                self.workflowExitOfferBinding.wrappedValue = context?.exitOfferOffering
             }
     }
 

--- a/RevenueCatUI/View+ExitOfferPresentation.swift
+++ b/RevenueCatUI/View+ExitOfferPresentation.swift
@@ -1,0 +1,165 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  View+ExitOfferPresentation.swift
+
+@_spi(Internal) import RevenueCat
+import SwiftUI
+
+#if !os(tvOS)
+
+/// Owns the exit-offer lifecycle for a single paywall presentation: how the offer is *sourced*
+/// (workflow step-aware, with a legacy offering-level fallback), the two pieces of state, and the
+/// transitions between them.
+///
+/// This is the single home for logic each `present…` entry point used to re-implement. A present
+/// function creates one and wires it via `workflowExitOfferSource` (onto the main paywall) and
+/// `exitOfferSheet` (onto the presenting view).
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@MainActor
+final class ExitOfferPresenter: ObservableObject {
+
+    /// The exit offer resolved for the current step (workflow) or prefetched (legacy). Updated as the
+    /// user navigates; read at dismissal time.
+    @Published private var exitOfferOffering: Offering?
+
+    /// The exit offer currently being presented. Drives the sheet/cover.
+    @Published private var presentedExitOffer: Offering?
+
+    private let purchaseHandler: PurchaseHandler
+
+    init(purchaseHandler: PurchaseHandler) {
+        self.purchaseHandler = purchaseHandler
+    }
+
+    /// Whether an exit offer is currently being presented.
+    var isPresentingExitOffer: Bool {
+        self.presentedExitOffer != nil
+    }
+
+    /// Binding handed to `WorkflowPaywallView` (via the environment) so it can write the step-aware
+    /// exit offer directly. This is the reliable path; the preference key below is a fallback.
+    var workflowBinding: Binding<Offering?> {
+        Binding(
+            get: { [weak self] in self?.exitOfferOffering },
+            set: { [weak self] in self?.exitOfferOffering = $0 }
+        )
+    }
+
+    /// Drives the exit-offer sheet/cover.
+    var presentedBinding: Binding<Offering?> {
+        Binding(
+            get: { [weak self] in self?.presentedExitOffer },
+            set: { [weak self] in self?.presentedExitOffer = $0 }
+        )
+    }
+
+    /// Workflow preference fallback. Mirrors the binding, but guarded so a final `nil` emitted during
+    /// the dismiss animation can't clear the offer after it's already being presented.
+    func updateFromWorkflowPreference(_ context: WorkflowExitOfferContext?) {
+        guard ProcessInfo.processInfo.workflowsEndpointEnabled else { return }
+        guard context != nil || self.presentedExitOffer == nil else { return }
+        self.exitOfferOffering = context?.exitOfferOffering
+    }
+
+    /// Legacy offering-level prefetch, used only when the workflows endpoint is disabled.
+    func prefetchLegacyExitOffer(resolveOffering: () async -> Offering?) async {
+        guard !ProcessInfo.processInfo.workflowsEndpointEnabled else { return }
+        guard let offering = await resolveOffering() else { return }
+        self.exitOfferOffering = await ExitOfferHelper.fetchValidExitOffer(for: offering)
+    }
+
+    /// Presents the exit offer if one is available. Returns `true` if it took over (the caller should
+    /// not dismiss), `false` if there's nothing to show (the caller should dismiss normally).
+    @discardableResult
+    func presentIfAvailable() -> Bool {
+        guard self.presentedExitOffer == nil else { return true }
+        guard let offering = self.exitOfferOffering else { return false }
+
+        Logger.debug(Strings.presentingExitOffer(offering.identifier))
+        self.purchaseHandler.trackExitOffer(
+            exitOfferType: .dismiss,
+            exitOfferingIdentifier: offering.identifier
+        )
+        self.presentedExitOffer = offering
+        return true
+    }
+
+    /// Dismisses the presented exit offer (e.g. after a successful purchase/restore on it). Clearing
+    /// `presentedExitOffer` fires the sheet's `onDismiss`, which calls `reset()`.
+    func dismissPresentedExitOffer() {
+        self.presentedExitOffer = nil
+    }
+
+    /// Tears down after the exit offer is dismissed (or when the offer should be discarded).
+    func reset() {
+        self.presentedExitOffer = nil
+        self.exitOfferOffering = nil
+        self.purchaseHandler.resetForNewSession()
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(tvOS, unavailable)
+extension View {
+
+    /// Sources the workflow exit offer onto the presenter. Apply to the *main* paywall view so the
+    /// environment binding reaches `WorkflowPaywallView` and its preference is observed without
+    /// crossing a sheet boundary.
+    func workflowExitOfferSource(
+        presenter: ExitOfferPresenter,
+        resolveLegacyOffering: @escaping () async -> Offering?
+    ) -> some View {
+        self
+            .environment(\.workflowExitOfferOfferingBinding, presenter.workflowBinding)
+            .onPreferenceChange(WorkflowExitOfferPreferenceKey.self) { context in
+                presenter.updateFromWorkflowPreference(context)
+            }
+            .task {
+                await presenter.prefetchLegacyExitOffer(resolveOffering: resolveLegacyOffering)
+            }
+    }
+
+    /// Attaches the exit-offer sheet/cover driven by the presenter. Apply to the *presenting* view
+    /// (sibling of the main paywall presentation) so the exit offer shows after the main paywall
+    /// dismisses, rather than nested inside it.
+    func exitOfferSheet<ExitOfferView: View>(
+        presenter: ExitOfferPresenter,
+        presentationMode: PaywallPresentationMode,
+        onDismiss: (() -> Void)?,
+        @ViewBuilder makeExitOfferView: @escaping (Offering) -> ExitOfferView
+    ) -> some View {
+        let handleDismiss: () -> Void = {
+            presenter.reset()
+            onDismiss?()
+        }
+
+        return Group {
+            switch presentationMode {
+            case .sheet:
+                self.sheet(item: presenter.presentedBinding, onDismiss: handleDismiss) { offering in
+                    makeExitOfferView(offering)
+                    #if targetEnvironment(macCatalyst) || os(macOS)
+                        .frame(minHeight: 667)
+                    #endif
+                }
+            #if !os(macOS)
+            case .fullScreen:
+                self.fullScreenCover(item: presenter.presentedBinding, onDismiss: handleDismiss) { offering in
+                    makeExitOfferView(offering)
+                }
+            #endif
+            }
+        }
+    }
+
+}
+
+#endif

--- a/RevenueCatUI/View+ExitOfferPresentation.swift
+++ b/RevenueCatUI/View+ExitOfferPresentation.swift
@@ -14,22 +14,16 @@ import SwiftUI
 
 #if !os(tvOS)
 
-/// Owns the exit-offer lifecycle for a single paywall presentation: how the offer is *sourced*
-/// (workflow step-aware, with a legacy offering-level fallback), the two pieces of state, and the
-/// transitions between them.
-///
-/// This is the single home for logic each `present…` entry point used to re-implement. A present
-/// function creates one and wires it via `workflowExitOfferSource` (onto the main paywall) and
-/// `exitOfferSheet` (onto the presenting view).
+/// Single owner of the exit-offer lifecycle (sourcing, state, present/dismiss/track), so present
+/// functions don't each re-implement it.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @MainActor
 final class ExitOfferPresenter: ObservableObject {
 
-    /// The exit offer resolved for the current step (workflow) or prefetched (legacy). Updated as the
-    /// user navigates; read at dismissal time.
+    /// Resolved exit offer for the current step (or legacy prefetch).
     @Published private var exitOfferOffering: Offering?
 
-    /// The exit offer currently being presented. Drives the sheet/cover.
+    /// The exit offer currently being presented.
     @Published private var presentedExitOffer: Offering?
 
     private let purchaseHandler: PurchaseHandler
@@ -38,13 +32,11 @@ final class ExitOfferPresenter: ObservableObject {
         self.purchaseHandler = purchaseHandler
     }
 
-    /// Whether an exit offer is currently being presented.
     var isPresentingExitOffer: Bool {
         self.presentedExitOffer != nil
     }
 
-    /// Binding handed to `WorkflowPaywallView` (via the environment) so it can write the step-aware
-    /// exit offer directly. This is the reliable path; the preference key below is a fallback.
+    /// Written by `WorkflowPaywallView` via the environment. Primary path; the preference is a fallback.
     var workflowBinding: Binding<Offering?> {
         Binding(
             get: { [weak self] in self?.exitOfferOffering },
@@ -60,23 +52,21 @@ final class ExitOfferPresenter: ObservableObject {
         )
     }
 
-    /// Workflow preference fallback. Mirrors the binding, but guarded so a final `nil` emitted during
-    /// the dismiss animation can't clear the offer after it's already being presented.
+    /// Guarded so a late `nil` during the dismiss animation can't clear an already-presented offer.
     func updateFromWorkflowPreference(_ context: WorkflowExitOfferContext?) {
         guard ProcessInfo.processInfo.workflowsEndpointEnabled else { return }
         guard context != nil || self.presentedExitOffer == nil else { return }
         self.exitOfferOffering = context?.exitOfferOffering
     }
 
-    /// Legacy offering-level prefetch, used only when the workflows endpoint is disabled.
+    /// Legacy offering-level prefetch, used only when workflows are disabled.
     func prefetchLegacyExitOffer(resolveOffering: () async -> Offering?) async {
         guard !ProcessInfo.processInfo.workflowsEndpointEnabled else { return }
         guard let offering = await resolveOffering() else { return }
         self.exitOfferOffering = await ExitOfferHelper.fetchValidExitOffer(for: offering)
     }
 
-    /// Presents the exit offer if one is available. Returns `true` if it took over (the caller should
-    /// not dismiss), `false` if there's nothing to show (the caller should dismiss normally).
+    /// Presents the exit offer if available. Returns `true` if it took over (caller shouldn't dismiss).
     @discardableResult
     func presentIfAvailable() -> Bool {
         guard self.presentedExitOffer == nil else { return true }
@@ -91,13 +81,11 @@ final class ExitOfferPresenter: ObservableObject {
         return true
     }
 
-    /// Dismisses the presented exit offer (e.g. after a successful purchase/restore on it). Clearing
-    /// `presentedExitOffer` fires the sheet's `onDismiss`, which calls `reset()`.
+    /// Dismisses the presented exit offer (fires the sheet's `onDismiss`, which calls `reset()`).
     func dismissPresentedExitOffer() {
         self.presentedExitOffer = nil
     }
 
-    /// Tears down after the exit offer is dismissed (or when the offer should be discarded).
     func reset() {
         self.presentedExitOffer = nil
         self.exitOfferOffering = nil
@@ -110,9 +98,8 @@ final class ExitOfferPresenter: ObservableObject {
 @available(tvOS, unavailable)
 extension View {
 
-    /// Sources the workflow exit offer onto the presenter. Apply to the *main* paywall view so the
-    /// environment binding reaches `WorkflowPaywallView` and its preference is observed without
-    /// crossing a sheet boundary.
+    /// Sources the workflow exit offer onto the presenter. Apply to the main paywall view (keeps the
+    /// binding/preference off the sheet boundary).
     func workflowExitOfferSource(
         presenter: ExitOfferPresenter,
         resolveLegacyOffering: @escaping () async -> Offering?
@@ -127,9 +114,7 @@ extension View {
             }
     }
 
-    /// Attaches the exit-offer sheet/cover driven by the presenter. Apply to the *presenting* view
-    /// (sibling of the main paywall presentation) so the exit offer shows after the main paywall
-    /// dismisses, rather than nested inside it.
+    /// Presents the exit offer as a sibling sheet/cover (after the main paywall dismisses, not nested).
     func exitOfferSheet<ExitOfferView: View>(
         presenter: ExitOfferPresenter,
         presentationMode: PaywallPresentationMode,

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -455,7 +455,6 @@ extension View {
 
 }
 
-// swiftlint:disable type_body_length
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(tvOS, unavailable)
 private struct PresentingPaywallModifier: ViewModifier {
@@ -521,6 +520,7 @@ private struct PresentingPaywallModifier: ViewModifier {
             PurchaseHandler.default(performPurchase: myAppPurchaseLogic?.performPurchase,
                                     performRestore: myAppPurchaseLogic?.performRestore)
         self._purchaseHandler = .init(wrappedValue: handler)
+        self._exitOfferPresenter = .init(wrappedValue: ExitOfferPresenter(purchaseHandler: handler))
         self._promoOfferCacheOwner = .init(wrappedValue:
             PromoOfferCacheOwner(
                 cache: PaywallPromoOfferCache(
@@ -539,16 +539,9 @@ private struct PresentingPaywallModifier: ViewModifier {
     @State
     private var data: Data?
 
-    /// The prefetched exit offer, loaded while the main paywall is showing.
-    /// This enables immediate presentation when the main paywall dismisses (no loading delay).
-    /// Copied to `presentedExitOffer` when ready to show.
-    @State
-    private var exitOfferOffering: Offering?
-
-    /// The exit offer currently being presented. Controls the sheet/fullScreenCover.
-    /// Set from `exitOfferOffering` when the main paywall dismisses without a purchase.
-    @State
-    private var presentedExitOffer: Offering?
+    /// Owns the exit-offer lifecycle (sourcing + presentation state + transitions).
+    @StateObject
+    private var exitOfferPresenter: ExitOfferPresenter
 
     func body(content: Content) -> some View {
         Group {
@@ -567,28 +560,21 @@ private struct PresentingPaywallModifier: ViewModifier {
                             .frame(height: 667)
                         #endif
                     }
-                    .sheet(item: self.$presentedExitOffer, onDismiss: self.handleExitOfferDismiss) { offering in
-                        self.exitOfferPaywallView(for: offering)
-                        #if targetEnvironment(macCatalyst) || os(macOS)
-                        // this should be minHeight, but for consistency with the first paywall it will be
-                        // like this for now
-                            .frame(height: 667)
-                        #endif
-                    }
             #if !os(macOS)
             case .fullScreen:
                 content
                     .fullScreenCover(item: self.$data, onDismiss: self.handleMainPaywallDismiss) { data in
                         self.paywallView(data)
                     }
-                    .fullScreenCover(
-                        item: self.$presentedExitOffer,
-                        onDismiss: self.handleExitOfferDismiss
-                    ) { offering in
-                        self.exitOfferPaywallView(for: offering)
-                    }
             #endif
             }
+        }
+        .exitOfferSheet(
+            presenter: self.exitOfferPresenter,
+            presentationMode: self.presentationMode,
+            onDismiss: self.onDismiss
+        ) { offering in
+            self.exitOfferPaywallView(for: offering)
         }
         .task {
             await self.updateCustomerInfo()
@@ -640,7 +626,6 @@ private struct PresentingPaywallModifier: ViewModifier {
                 promoOfferCache: self.promoOfferCacheOwner.cache
             )
         )
-        .environment(\.workflowExitOfferOfferingBinding, self.$exitOfferOffering)
         .onPurchaseStarted {
             self.purchaseStarted?($0)
         }
@@ -673,16 +658,8 @@ private struct PresentingPaywallModifier: ViewModifier {
             self.restoreFailure?($0)
         }
         .interactiveDismissDisabled(self.purchaseHandler.actionInProgress)
-        .onPreferenceChange(WorkflowExitOfferPreferenceKey.self) { context in
-            self.handleWorkflowExitOfferPreferenceChange(context)
-        }
-        .task {
-            // When the workflows endpoint is enabled, exit offers are resolved synchronously
-            // from WorkflowContext.allOfferings via the preference key above — no fetch needed.
-            guard !ProcessInfo.processInfo.workflowsEndpointEnabled else { return }
-
-            guard let offering = await self.purchaseHandler.resolveOffering(for: self.content) else { return }
-            self.exitOfferOffering = await ExitOfferHelper.fetchValidExitOffer(for: offering)
+        .workflowExitOfferSource(presenter: self.exitOfferPresenter) {
+            await self.purchaseHandler.resolveOffering(for: self.content)
         }
     }
 
@@ -692,13 +669,6 @@ private struct PresentingPaywallModifier: ViewModifier {
         self.data = nil
     }
 
-    private func closeExitOffer() {
-        Logger.debug(Strings.dismissing_paywall)
-
-        self.presentedExitOffer = nil
-        self.exitOfferOffering = nil
-    }
-
     /// Handles dismissal of the main paywall, checking for exit offers.
     ///
     /// We check `purchaseHandler.sessionPurchaseResult` to determine if exit offer should be shown:
@@ -706,7 +676,7 @@ private struct PresentingPaywallModifier: ViewModifier {
     /// - This ensures consistent behavior with how the first paywall decides to show/close
     private func handleMainPaywallDismiss() {
         // Prevent double processing
-        guard self.presentedExitOffer == nil else { return }
+        guard !self.exitOfferPresenter.isPresentingExitOffer else { return }
 
         guard !purchaseHandler.hasPurchasedInSession else {
             self.purchaseHandler.trackPaywallClose()
@@ -727,33 +697,11 @@ private struct PresentingPaywallModifier: ViewModifier {
 
         self.purchaseHandler.trackPaywallClose()
 
-        if let exitOffering = self.exitOfferOffering {
-            Logger.debug(Strings.presentingExitOffer(exitOffering.identifier))
-            self.purchaseHandler.trackExitOffer(
-                exitOfferType: .dismiss,
-                exitOfferingIdentifier: exitOffering.identifier
-            )
-            self.presentedExitOffer = exitOffering
-        } else {
+        // Present the exit offer if one is available; otherwise dismiss normally.
+        if !self.exitOfferPresenter.presentIfAvailable() {
             self.purchaseHandler.resetForNewSession()
             self.onDismiss?()
         }
-    }
-
-    private func handleExitOfferDismiss() {
-        self.presentedExitOffer = nil
-        self.exitOfferOffering = nil
-        self.purchaseHandler.resetForNewSession()
-        self.onDismiss?()
-    }
-
-    private func handleWorkflowExitOfferPreferenceChange(_ context: WorkflowExitOfferContext?) {
-        guard ProcessInfo.processInfo.workflowsEndpointEnabled else { return }
-        // Don't nil out exitOfferOffering once an exit offer is already being presented:
-        // SwiftUI may fire a final nil preference update during the dismiss animation, after
-        // handleMainPaywallDismiss has already copied exitOfferOffering into presentedExitOffer.
-        guard context != nil || self.presentedExitOffer == nil else { return }
-        self.exitOfferOffering = context?.exitOfferOffering
     }
 
     private func exitOfferPaywallView(for offering: Offering) -> some View {
@@ -774,7 +722,7 @@ private struct PresentingPaywallModifier: ViewModifier {
         .onPurchaseCompleted { customerInfo in
             self.purchaseCompleted?(customerInfo)
             // Always close on successful purchase - shouldDisplay drives when to show, not when to close
-            self.closeExitOffer()
+            self.exitOfferPresenter.dismissPresentedExitOffer()
         }
         .onPurchaseCancelled {
             self.purchaseCancelled?()
@@ -790,7 +738,7 @@ private struct PresentingPaywallModifier: ViewModifier {
 
             // For restore, check shouldDisplay since restore might succeed without granting the expected entitlement
             if result.success && !self.shouldDisplay(result.customerInfo) {
-                self.closeExitOffer()
+                self.exitOfferPresenter.dismissPresentedExitOffer()
             }
         }
         .onPurchaseFailure {
@@ -803,7 +751,6 @@ private struct PresentingPaywallModifier: ViewModifier {
     }
 
 }
-// swiftlint:enable type_body_length
 
 // MARK: - PresentingPaywallBindingModifier
 

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -836,16 +836,9 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
     var restoreFailure: PurchaseFailureHandler?
     var onDismiss: (() -> Void)?
 
-    /// The prefetched exit offer, loaded while the main paywall is showing.
-    /// This enables immediate presentation when the main paywall dismisses (no loading delay).
-    /// Copied to `presentedExitOffer` when ready to show.
-    @State
-    private var exitOfferOffering: Offering?
-
-    /// The exit offer currently being presented. Controls the sheet/fullScreenCover.
-    /// Set from `exitOfferOffering` when the main paywall dismisses without a purchase.
-    @State
-    private var presentedExitOffer: Offering?
+    /// Owns the exit-offer lifecycle (sourcing + presentation state + transitions).
+    @StateObject
+    private var exitOfferPresenter: ExitOfferPresenter
 
     @StateObject
     private var purchaseHandler: PurchaseHandler
@@ -881,6 +874,7 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
         let handler = PurchaseHandler.default(performPurchase: myAppPurchaseLogic?.performPurchase,
                                               performRestore: myAppPurchaseLogic?.performRestore)
         self._purchaseHandler = .init(wrappedValue: handler)
+        self._exitOfferPresenter = .init(wrappedValue: ExitOfferPresenter(purchaseHandler: handler))
         self._promoOfferCacheOwner = .init(wrappedValue:
             PromoOfferCacheOwner(
                 cache: PaywallPromoOfferCache(
@@ -901,26 +895,21 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
                             .frame(minHeight: 667)
                         #endif
                     }
-                    .sheet(item: self.$presentedExitOffer, onDismiss: self.handleExitOfferDismiss) { exitOffering in
-                        self.exitOfferPaywallView(for: exitOffering)
-                        #if targetEnvironment(macCatalyst) || os(macOS)
-                            .frame(minHeight: 667)
-                        #endif
-                    }
             #if !os(macOS)
             case .fullScreen:
                 content
                     .fullScreenCover(item: self.$offering, onDismiss: self.handleMainPaywallDismiss) { offering in
                         self.paywallView(for: offering)
                     }
-                    .fullScreenCover(
-                        item: self.$presentedExitOffer,
-                        onDismiss: self.handleExitOfferDismiss
-                    ) { exitOffering in
-                        self.exitOfferPaywallView(for: exitOffering)
-                    }
             #endif
             }
+        }
+        .exitOfferSheet(
+            presenter: self.exitOfferPresenter,
+            presentationMode: self.presentationMode,
+            onDismiss: self.onDismiss
+        ) { exitOffering in
+            self.exitOfferPaywallView(for: exitOffering)
         }
     }
 
@@ -963,8 +952,8 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
             self.restoreFailure?($0)
         }
         .interactiveDismissDisabled(self.purchaseHandler.actionInProgress)
-        .task {
-            self.exitOfferOffering = await ExitOfferHelper.fetchValidExitOffer(for: offering)
+        .workflowExitOfferSource(presenter: self.exitOfferPresenter) {
+            offering
         }
     }
 
@@ -985,8 +974,7 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
         .onPurchaseCompleted { customerInfo in
             self.purchaseCompleted?(customerInfo)
             // Always close on successful purchase
-            self.presentedExitOffer = nil
-            self.exitOfferOffering = nil
+            self.exitOfferPresenter.dismissPresentedExitOffer()
         }
         .onPurchaseCancelled {
             self.purchaseCancelled?()
@@ -1000,8 +988,7 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
         .onPreferenceChange(RestoredCustomerInfoPreferenceKey.self) { result in
             guard let result, result.success else { return }
             // Close on successful restore
-            self.presentedExitOffer = nil
-            self.exitOfferOffering = nil
+            self.exitOfferPresenter.dismissPresentedExitOffer()
         }
         .onPurchaseFailure {
             self.purchaseFailure?($0)
@@ -1019,7 +1006,7 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
     /// - Fetching `CustomerInfo` may return cached data that hasn't been updated yet
     private func handleMainPaywallDismiss() {
         // Prevent double processing
-        guard self.presentedExitOffer == nil else { return }
+        guard !self.exitOfferPresenter.isPresentingExitOffer else { return }
 
         guard !self.purchaseHandler.hasPurchasedInSession else {
             self.purchaseHandler.trackPaywallClose()
@@ -1036,24 +1023,11 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
 
         self.purchaseHandler.trackPaywallClose()
 
-        if let exitOffering = self.exitOfferOffering {
-            Logger.debug(Strings.presentingExitOffer(exitOffering.identifier))
-            self.purchaseHandler.trackExitOffer(
-                exitOfferType: .dismiss,
-                exitOfferingIdentifier: exitOffering.identifier
-            )
-            self.presentedExitOffer = exitOffering
-        } else {
+        // Present the exit offer if one is available; otherwise dismiss normally.
+        if !self.exitOfferPresenter.presentIfAvailable() {
             self.purchaseHandler.resetForNewSession()
             self.onDismiss?()
         }
-    }
-
-    private func handleExitOfferDismiss() {
-        self.presentedExitOffer = nil
-        self.exitOfferOffering = nil
-        self.purchaseHandler.resetForNewSession()
-        self.onDismiss?()
     }
 
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
@@ -12,6 +12,9 @@
 import RevenueCatUI
 #endif
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
 
 struct APIKeyDashboardList: View {
 
@@ -333,6 +336,36 @@ struct APIKeyDashboardList: View {
         ForEach(PaywallTesterViewMode.allCases, id: \.self) { mode in
             self.button(for: mode, offering: offering)
         }
+
+        #if os(iOS)
+        // Presents through the UIKit `PaywallViewController` so its dismissal handling and the
+        // workflow exit-offer bridge can be exercised.
+        Button {
+            self.isLoadingPaywall = true
+            self.presentUIKitPaywall(for: offering)
+        } label: {
+            Text("UIKit View Controller")
+            Image(systemName: "rectangle.portrait.on.rectangle.portrait")
+        }
+        #endif
+    }
+    #endif
+
+    #if os(iOS)
+    @MainActor
+    private func presentUIKitPaywall(for offering: Offering) {
+        let windows = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+        guard var top = (windows.first(where: \.isKeyWindow) ?? windows.first)?.rootViewController else {
+            self.isLoadingPaywall = false
+            return
+        }
+        while let presented = top.presentedViewController {
+            top = presented
+        }
+        top.present(PaywallViewController(offering: offering, displayCloseButton: true), animated: true)
+        self.isLoadingPaywall = false
     }
     #endif
 


### PR DESCRIPTION
## Summary

Stacked on #6911 (UIKit workflow exit-offer bridge) — review that one first; this PR's diff is just the SwiftUI refactor.

Both SwiftUI present functions used to re-implement the exit-offer half (the sheet, the exit-offer `PaywallView` builder, sourcing, and the dismiss/track logic). 

The UIKit `PaywallViewController` intentionally keeps its own thin bridge (from #6911): it presents a child view *controller* on swipe, not a SwiftUI sheet, so it shares no sheet/builder logic with these modifiers.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: 6918
- Branch: `facu/workflow-exit-offer-shared-presentation` (base: `facu/workflow-exit-offer-uikit-bridge`, PR #6911)
- Author / human owner: facumenzella (Facundo Menzella)
- Agent(s): Claude Code (Opus 4.8, 1M context)
- Session source: current conversation
- Generated: 2026-06-05
- Context document version: 1

## Goal

Stop each SwiftUI `present…` function re-implementing exit-offer handling; extract it into one shared, reusable unit, which also gives `.presentPaywall(offering:)` the workflow exit-offer support it was missing.

## Initial Prompt

"the thing is we can't use in UIKit because we would lose the swipe to dismiss" → "let's see how that looks. let's branch off the current pr and work on it" → "let's wrap up the missing pieces and open a follow-up draft." (The design conversation concluded that full self-containment in the workflow view is impossible because UIKit swipe-to-dismiss must be intercepted at the VC, so the workflow view stays the source and the consumers' handling is deduped.)

## Important Follow-up Prompts

- "Would it be possible to handle this within the workflow view?" — explored; rejected because UIKit swipe-to-dismiss can't be intercepted from inside the hosted view without disabling swipe.
- "we're still opening it on every step, let's make sure it's just because of the mock" — confirmed: the every-step behavior was the test mock; the real `exitOfferContext` gates on `stepId == triggeringStepId`.
- "Do you think its worth reusing the same PR? Or another one to keep it small" — chose a separate stacked PR.

## Agent Contribution

- Designed and implemented `ExitOfferPresenter` + `workflowExitOfferSource` / `exitOfferSheet` (`RevenueCatUI/View+ExitOfferPresentation.swift`).
- Converted both `PresentingPaywallBindingModifier` and `PresentingPaywallModifier` to use them; removed the duplicated state, sheets, dismiss handlers, and the now-superfluous `type_body_length` lint exception.
- Verified iOS-simulator build + SwiftLint; the binding path was runtime-tested via PaywallsTester.

## Human Decisions

- Keep UIKit swipe-to-dismiss → the offer must be liftable to the VC, so the workflow view stays the source (not self-contained).
- Separate stacked PR to keep #6911 small.

## Key Implementation Decisions

- Decision: one `ExitOfferPresenter` (ObservableObject) owns both exit-offer states + transitions; consumers apply two modifiers.
  - Rationale: the clobber guard couples sourcing to presentation state, so a single owner is cleaner than threading bindings. Consumers keep only their differing *main*-presentation trigger.
  - Rejected: a per-function shared free function (still leaves the two `@State`s and sheet wiring duplicated); a query-on-demand provider refactor (larger, and the staleness it targets wasn't the user's concern — duplication was).
- Decision: leave the UIKit `PaywallViewController` bridge as-is.
  - Rationale: it presents a child VC, not a SwiftUI sheet — no shared sheet/builder surface; forcing it onto the SwiftUI-oriented presenter would add coupling for little gain.

## Files / Symbols Touched

- `RevenueCatUI/View+ExitOfferPresentation.swift` (new)
  - Symbols: `ExitOfferPresenter` (`workflowBinding`, `presentedBinding`, `updateFromWorkflowPreference`, `prefetchLegacyExitOffer`, `presentIfAvailable`, `dismissPresentedExitOffer`, `reset`, `isPresentingExitOffer`); `View.workflowExitOfferSource`, `View.exitOfferSheet`.
  - Review relevance: the clobber guard, the workflows-on/off gating, and that `exitOfferSheet` presents as a sibling (not nested) sheet.
- `RevenueCatUI/View+PresentPaywall.swift`
  - Why: convert both modifiers; delete duplicated exit-offer code.
  - Review relevance: `PresentingPaywallModifier` preamble (`shouldDisplay`/`sessionPurchaseResult`) preserved; `PresentingPaywallBindingModifier` legacy `.task` now gated by `!workflowsEndpointEnabled`.

## Dependencies / Config / Migrations

- None. No new dependencies, flags, or public API. `Package.resolved` touched only locally by tuist and reverted.

## Validation

- Commands run:
  - `xcodebuild build -scheme RevenueCatUI -destination 'platform=iOS Simulator,...'`: BUILD SUCCEEDED.
  - `swiftlint` on both files: no violations.
- Manual verification:
  - `.presentPaywall(offering:)` exercised on a simulator; workflow exit offer surfaced on dismiss.
  - `.presentPaywallIfNeeded` not separately exercised (build-verified; structurally identical to the tested binding path).
- CI: pending on push.

## Validation Gaps

- No automated tests added yet (the extracted logic is now unit-testable — `presentIfAvailable`, `updateFromWorkflowPreference`; could add in this PR or a follow-up).
- `presentPaywallIfNeeded` runtime path not separately exercised.

## Review Focus

- `PresentingPaywallModifier`: is the `shouldDisplay`/`sessionPurchaseResult` preamble behavior identical to before?
- Mac Catalyst/macOS: `exitOfferSheet` uses `minHeight: 667` for both modifiers; `presentPaywallIfNeeded` previously used a fixed `height: 667` for its exit sheet (a comment there said it "should be minHeight"). Confirm that's acceptable.
- `exitOfferSheet` switch is exhaustive across `.sheet`/`.fullScreen` on all platforms (mirrors the prior per-modifier `#if !os(macOS)` gating).

## Risks / Reviewer Notes

- Risk: behavior drift in the shipped `presentPaywallIfNeeded`.
  - Evidence: the shared component is the same one the runtime-tested `presentPaywall` path uses; only the preamble differs and is preserved verbatim.
  - Mitigation: a ~1-minute "Present If Needed" smoke test closes the gap.

## Non-goals / Out of Scope

- UIKit `PaywallViewController` (its bridge ships in #6911; different presentation paradigm).
- Removing the workflows flag.

## Omitted Context

- Raw transcript, unrelated exploration, the temporary test mock/logs, and chain-of-thought were omitted.

</details>
