### PR TITLE
Fix badge stack shadow not being rendered

### DIFF
--- a/RevenueCatUI/Templates/V2/ViewHelpers/BadgeModifier.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/BadgeModifier.swift
@@ -21,6 +21,9 @@ import SwiftUI
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct BadgeModifier: ViewModifier {
 
+    @Environment(\.colorScheme)
+    private var colorScheme
+
     let badge: BadgeInfo?
 
     struct BadgeInfo {
@@ -40,7 +43,13 @@ struct BadgeModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         if let badge = badge {
-            content.apply(badge: badge)
+            content.apply(
+                badge: badge,
+                shadow: badge.stack.shadow?.shadow(
+                    uiConfigProvider: badge.uiConfigProvider,
+                    colorScheme: self.colorScheme
+                )
+            )
         } else {
             content
         }
@@ -51,10 +60,10 @@ struct BadgeModifier: ViewModifier {
 fileprivate extension View {
 
     @ViewBuilder
-    func apply(badge: BadgeModifier.BadgeInfo) -> some View {
+    func apply(badge: BadgeModifier.BadgeInfo, shadow: ShadowModifier.ShadowInfo?) -> some View {
         switch badge.style {
         case .edgeToEdge:
-            self.applyBadgeEdgeToEdge(badge: badge)
+            self.applyBadgeEdgeToEdge(badge: badge, shadow: shadow)
         case .overlaid:
             self.overlay(
                 VStack(alignment: .leading) {
@@ -63,6 +72,7 @@ fileprivate extension View {
                             .padding(badge.stack.padding.edgeInsets)
                             .backgroundStyle(badge.backgroundStyle)
                             .shape(border: badge.stackBorder, shape: effectiveShape(badge: badge))
+                            .shadow(shadow: shadow, shape: effectiveShape(badge: badge)?.toInsettableShape())
                     }
                     .fixedSize()
                     .padding(effectiveMargin(badge: badge).edgeInsets)
@@ -82,6 +92,7 @@ fileprivate extension View {
                             .padding(badge.stack.padding.edgeInsets)
                             .backgroundStyle(badge.backgroundStyle)
                             .shape(border: badge.stackBorder, shape: effectiveShape(badge: badge))
+                            .shadow(shadow: shadow, shape: effectiveShape(badge: badge)?.toInsettableShape())
                     }
                     .fixedSize()
                     .padding(effectiveMargin(badge: badge).edgeInsets)
@@ -98,10 +109,10 @@ fileprivate extension View {
 
     // Helper to apply the edge-to-edge badge style
     @ViewBuilder
-    private func applyBadgeEdgeToEdge(badge: BadgeModifier.BadgeInfo) -> some View {
+    private func applyBadgeEdgeToEdge(badge: BadgeModifier.BadgeInfo, shadow: ShadowModifier.ShadowInfo?) -> some View {
         switch badge.alignment {
         case .top, .bottom:
-            self.modifier(EdgeToEdgeTopBottomModifier(badge: badge))
+            self.modifier(EdgeToEdgeTopBottomModifier(badge: badge, shadow: shadow))
         case .bottomLeading, .bottomTrailing, .topLeading, .topTrailing:
             self.overlay(
                 VStack(alignment: .leading) {
@@ -110,6 +121,7 @@ fileprivate extension View {
                             .padding(badge.stack.padding.edgeInsets)
                             .backgroundStyle(badge.backgroundStyle)
                             .shape(border: badge.stackBorder, shape: effectiveShape(badge: badge))
+                            .shadow(shadow: shadow, shape: effectiveShape(badge: badge)?.toInsettableShape())
                     }
                     .fixedSize()
                 }
@@ -296,6 +308,7 @@ struct EdgeToEdgeTopBottomModifier: ViewModifier {
 
     @State private var stackSize: CGSize = .zero
     var badge: BadgeModifier.BadgeInfo
+    var shadow: ShadowModifier.ShadowInfo?
 
     var badgeView: some View {
         VStack {
@@ -324,6 +337,10 @@ struct EdgeToEdgeTopBottomModifier: ViewModifier {
                 .shape(border: badge.stackBorder,
                        shape: effectiveShape(badge: badge,
                                              pillStackRadius: min(stackSize.width, stackSize.height)/2))
+                .shadow(shadow: shadow,
+                        shape: effectiveShape(badge: badge,
+                                              pillStackRadius: min(stackSize.width, stackSize.height)/2)?
+                    .toInsettableShape())
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
A drop shadow configured on a paywall badge (the badge's inner stack `shadow`) rendered on Android but was silently dropped on iOS, badge shadows have never rendered on iOS.

**Root cause:** `BadgeModifier` applied the badge stack's `padding`, `background`, `border` and `shape`, but never its `shadow`, in all four render paths (overlaid, nested, edge-to-edge corners, edge-to-edge top/bottom). 

Resolves: PWENG-104

### Testing
- Verified on device against a paywall with a shadow on the selected-state override badge: previously missing on iOS, now matches Android.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped SwiftUI presentation fix in BadgeModifier with no auth, data, or purchase-flow changes.
> 
> **Overview**
> **Paywalls V2 badge stacks now render configured drop shadows on iOS**, matching Android and other stack components.
> 
> `BadgeModifier` reads `colorScheme`, resolves the inner badge stack’s `shadow` into `ShadowModifier.ShadowInfo`, and passes it through **overlaid**, **nested**, **edge-to-edge corner**, and **edge-to-edge top/bottom** (`EdgeToEdgeTopBottomModifier`) paths via `.shadow(shadow:shape:)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80ab19aef48b7028090fe2be2ae14ba949d25d4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->