### PR TITLE
Skip release-or-main when manual snapshot workflows run

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -2586,6 +2586,9 @@ workflows:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
         - not:
             equal: [bump, << pipeline.parameters.action >>]
+        - not: << pipeline.parameters.generate_snapshots >>
+        - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
+        - not: << pipeline.parameters.generate_swiftinterface >>
         - matches:
             pattern: "^(release/.*|main)$"
             value: << pipeline.git.branch >>


### PR DESCRIPTION
### Motivation
Triggering `generate_revenuecatui_snapshots` on `main` (e.g. pipeline [38929](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/38929)) ran both `release-or-main` and `generate_revenuecatui_snapshots`, so RevenueCatUI snapshot jobs executed twice and opened duplicate PRs.

### Description
- Skip `release-or-main` when `generate_snapshots`, `generate_revenuecatui_snapshots`, or `generate_swiftinterface` is true, matching the guards already used by `run-all-tests`.
- Manual snapshot/swiftinterface pipelines on `main` or `release/*` should now run only their dedicated workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow gating only; no application code or release artifact logic changes.
> 
> **Overview**
> Adds three pipeline-parameter guards to the **`release-or-main`** workflow so it does not run when `generate_snapshots`, `generate_revenuecatui_snapshots`, or `generate_swiftinterface` is enabled—same exclusions **`run-all-tests`** already uses.
> 
> Manual snapshot or swiftinterface pipelines on **`main`** or **`release/*`** should now execute only their dedicated workflows (e.g. `generate_revenuecatui_snapshots`), avoiding a second pass through `release-or-main` that duplicated RevenueCatUI snapshot work and opened duplicate PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d1ac379f2d59d34ee75cd1482d77d496853b3d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->