### PR TITLE
Skip Swift Testing predicate tests on Xcode 14/15

### DIFF
--- a/Tests/RulesEngineInternalTests/Helpers/PredicateConformanceRunner.swift
+++ b/Tests/RulesEngineInternalTests/Helpers/PredicateConformanceRunner.swift
@@ -4,6 +4,7 @@
 //  Created by Antonio Pallares.
 //
 
+// Swift Testing is only available with the Xcode 16+ toolchain
 #if canImport(Testing)
 
 import Testing

--- a/Tests/RulesEngineInternalTests/Helpers/PredicateConformanceRunner.swift
+++ b/Tests/RulesEngineInternalTests/Helpers/PredicateConformanceRunner.swift
@@ -4,7 +4,11 @@
 //  Created by Antonio Pallares.
 //
 
-// Swift Testing is only available with the Xcode 16+ toolchain
+// Swift Testing is only available with the Xcode 16+ toolchain. The outer
+// `compiler(>=5.9)` guard keeps Swift 5.8 (Xcode 14) from parsing the
+// `#expect`/`#require` macros below, which it rejects as unknown directives
+// even inside an inactive `canImport` branch.
+#if compiler(>=5.9)
 #if canImport(Testing)
 
 import Testing
@@ -104,4 +108,5 @@ enum PredicateConformanceRunner {
     }
 }
 
+#endif
 #endif

--- a/Tests/RulesEngineInternalTests/Helpers/PredicateConformanceRunner.swift
+++ b/Tests/RulesEngineInternalTests/Helpers/PredicateConformanceRunner.swift
@@ -4,10 +4,7 @@
 //  Created by Antonio Pallares.
 //
 
-// Swift Testing is only available with the Xcode 16+ toolchain. The outer
-// `compiler(>=5.9)` guard keeps Swift 5.8 (Xcode 14) from parsing the
-// `#expect`/`#require` macros below, which it rejects as unknown directives
-// even inside an inactive `canImport` branch.
+// Swift Testing is only available with the Xcode 16+ toolchain
 #if compiler(>=5.9)
 #if canImport(Testing)
 

--- a/Tests/RulesEngineInternalTests/Helpers/PredicateConformanceRunner.swift
+++ b/Tests/RulesEngineInternalTests/Helpers/PredicateConformanceRunner.swift
@@ -4,6 +4,12 @@
 //  Created by Antonio Pallares.
 //
 
+// Swift Testing is only available with the Xcode 16+ toolchain. On older
+// toolchains (e.g. CI's Xcode 14/15 jobs) the `Testing` module is absent, so
+// this file compiles to nothing. Its only caller, `PredicateFixtureTests`, is
+// gated the same way.
+#if canImport(Testing)
+
 import Testing
 
 @testable import RulesEngineInternal
@@ -100,3 +106,5 @@ enum PredicateConformanceRunner {
         }
     }
 }
+
+#endif

--- a/Tests/RulesEngineInternalTests/Helpers/PredicateConformanceRunner.swift
+++ b/Tests/RulesEngineInternalTests/Helpers/PredicateConformanceRunner.swift
@@ -4,10 +4,6 @@
 //  Created by Antonio Pallares.
 //
 
-// Swift Testing is only available with the Xcode 16+ toolchain. On older
-// toolchains (e.g. CI's Xcode 14/15 jobs) the `Testing` module is absent, so
-// this file compiles to nothing. Its only caller, `PredicateFixtureTests`, is
-// gated the same way.
 #if canImport(Testing)
 
 import Testing

--- a/Tests/RulesEngineInternalTests/PredicateFixtureTests.swift
+++ b/Tests/RulesEngineInternalTests/PredicateFixtureTests.swift
@@ -4,6 +4,7 @@
 //  Created by Antonio Pallares.
 //
 
+// Swift Testing is only available with the Xcode 16+ toolchain
 #if canImport(Testing)
 
 import Testing

--- a/Tests/RulesEngineInternalTests/PredicateFixtureTests.swift
+++ b/Tests/RulesEngineInternalTests/PredicateFixtureTests.swift
@@ -4,9 +4,6 @@
 //  Created by Antonio Pallares.
 //
 
-// Swift Testing is only available with the Xcode 16+ toolchain. On older
-// toolchains (e.g. CI's Xcode 14/15 jobs) the `Testing` module is absent, so
-// this file compiles to nothing and its tests are skipped there.
 #if canImport(Testing)
 
 import Testing

--- a/Tests/RulesEngineInternalTests/PredicateFixtureTests.swift
+++ b/Tests/RulesEngineInternalTests/PredicateFixtureTests.swift
@@ -4,7 +4,11 @@
 //  Created by Antonio Pallares.
 //
 
-// Swift Testing is only available with the Xcode 16+ toolchain
+// Swift Testing is only available with the Xcode 16+ toolchain. The outer
+// `compiler(>=5.9)` guard keeps Swift 5.8 (Xcode 14) from parsing the
+// `#expect`/`#require` macros below, which it rejects as unknown directives
+// even inside an inactive `canImport` branch.
+#if compiler(>=5.9)
 #if canImport(Testing)
 
 import Testing
@@ -49,4 +53,5 @@ extension PredicateConformanceFixtureCase: CustomTestStringConvertible {
     var testDescription: String { id }
 }
 
+#endif
 #endif

--- a/Tests/RulesEngineInternalTests/PredicateFixtureTests.swift
+++ b/Tests/RulesEngineInternalTests/PredicateFixtureTests.swift
@@ -4,6 +4,11 @@
 //  Created by Antonio Pallares.
 //
 
+// Swift Testing is only available with the Xcode 16+ toolchain. On older
+// toolchains (e.g. CI's Xcode 14/15 jobs) the `Testing` module is absent, so
+// this file compiles to nothing and its tests are skipped there.
+#if canImport(Testing)
+
 import Testing
 
 @testable import RulesEngineInternal
@@ -45,3 +50,5 @@ extension PredicateConformanceFixtureCase: CustomTestStringConvertible {
 
     var testDescription: String { id }
 }
+
+#endif

--- a/Tests/RulesEngineInternalTests/PredicateFixtureTests.swift
+++ b/Tests/RulesEngineInternalTests/PredicateFixtureTests.swift
@@ -4,10 +4,7 @@
 //  Created by Antonio Pallares.
 //
 
-// Swift Testing is only available with the Xcode 16+ toolchain. The outer
-// `compiler(>=5.9)` guard keeps Swift 5.8 (Xcode 14) from parsing the
-// `#expect`/`#require` macros below, which it rejects as unknown directives
-// even inside an inactive `canImport` branch.
+// Swift Testing is only available with the Xcode 16+ toolchain
 #if compiler(>=5.9)
 #if canImport(Testing)
 


### PR DESCRIPTION
### Motivation
The `run-test-ios-16` (Xcode 15.4) and `run-test-ios-15-and-14` (Xcode 14.3.1) CI jobs fail to compile the new `RulesEngineInternal` tests because Swift Testing's `Testing` module only ships with the Xcode 16+ toolchain.

### Description
Gate the two Swift Testing files behind `#if compiler(>=5.9) && canImport(Testing)` so they compile only where the toolchain provides it; the remaining XCTest tests still run everywhere.

### Notes
The outer `#if compiler(>=5.9)` is required in addition to `canImport(Testing)`. With only `canImport`, Swift 5.8 (Xcode 14) still parses the inactive branch and rejects the `#expect`/`#require` macros as unknown directives. The version check makes the pre-macro compiler skip the body without parsing it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only conditional compilation with no production or runtime behavior changes.
> 
> **Overview**
> Wraps **`PredicateConformanceRunner.swift`** and **`PredicateFixtureTests.swift`** in `#if compiler(>=5.9)` and `#if canImport(Testing)` … `#endif` so Swift Testing code (including `#expect` / `#require`) is only compiled on Xcode 16+ toolchains.
> 
> Older CI (Xcode 14/15) no longer fails on those files; **XCTest** tests in the same target are unchanged and still build and run everywhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4380dee0fad437f687574108c6e91e830403a73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->