### PR TITLE
Add `contains` operator (case-insensitive substring)

### DIFF
--- a/RulesEngineInternal/Operators/Operators.swift
+++ b/RulesEngineInternal/Operators/Operators.swift
@@ -83,6 +83,8 @@ enum Operators {
         // String and array
         case "in":
             return try StringArrayOperators.opIn(args: args, vars: vars)
+        case "contains":
+            return try StringArrayOperators.opContains(args: args, vars: vars)
         case "cat":
             return try StringArrayOperators.opCat(args: args, vars: vars)
         case "substr":

--- a/RulesEngineInternal/Operators/StringArrayOperators.swift
+++ b/RulesEngineInternal/Operators/StringArrayOperators.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-/// String + array operators: `in`, `cat`, `substr`, `merge`.
+/// String + array operators: `in`, `contains`, `cat`, `substr`, `merge`.
 ///
 /// Behavior follows the JSON Logic JS reference (`json-logic-js`).
 /// `substr` slices by Unicode code points, not UTF-16 code units —
@@ -37,6 +37,31 @@ enum StringArrayOperators {
             return .bool(haystackString.contains(jsString(needle)))
         case .array(let items):
             return .bool(items.contains { strictEq(needle, $0) })
+        default:
+            return .bool(false)
+        }
+    }
+
+    /// `{"contains": [haystack, needle]}` — case-insensitive substring
+    /// test (khepri-specific, not part of JSON Logic). The haystack must
+    /// be a `.string`; non-string haystacks return `false`. The needle is
+    /// stringified via [`jsString`] and matched with locale-independent
+    /// Unicode lowercasing (`String.lowercased()`). Unlike `in`, there is
+    /// no json-logic falsy guard on the haystack — an empty needle matches
+    /// any string haystack. Argument order is reversed from `in`:
+    /// `function(haystack, needle)`. Extra operands beyond the second are
+    /// ignored.
+    static func opContains(args: Value, vars: Value) throws -> Value {
+        let evaluated = try Operators.evalArgs(args, vars: vars)
+        let haystack = evaluated.first ?? .null
+        let needle = evaluated.indices.contains(1) ? evaluated[1] : .null
+        switch haystack {
+        case .string(let haystackString):
+            let needleString = jsString(needle)
+            if needleString.isEmpty {
+                return .bool(true)
+            }
+            return .bool(haystackString.lowercased().contains(needleString.lowercased()))
         default:
             return .bool(false)
         }

--- a/Tests/RulesEngineInternalTests/PredicateFixtureTests.swift
+++ b/Tests/RulesEngineInternalTests/PredicateFixtureTests.swift
@@ -28,7 +28,7 @@ struct PredicateFixtureTests {
     /// fixtures are added or removed.
     @Test
     func fixtureCountMatchesExpected() {
-        let expectedCount = 347
+        let expectedCount = 367
         #expect(
             Self.fixtures.count == expectedCount,
             "Expected \(expectedCount) fixtures, loaded \(Self.fixtures.count)"

--- a/Tests/RulesEngineInternalTests/PredicateFixtures/contains.json
+++ b/Tests/RulesEngineInternalTests/PredicateFixtures/contains.json
@@ -1,0 +1,130 @@
+{
+  "fixtures": [
+    {
+      "id": "contains_case_insensitive_substring_match",
+      "predicate": { "contains": ["FooBar", "oob"] },
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "contains_exact_case_substring_match",
+      "predicate": { "contains": ["foobar", "bar"] },
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "contains_no_match",
+      "predicate": { "contains": ["foobar", "baz"] },
+      "variables": {},
+      "expected": false
+    },
+    {
+      "id": "contains_uppercase_needle_lowercase_haystack",
+      "predicate": { "contains": ["foobar", "BAR"] },
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "contains_lowercase_needle_uppercase_haystack",
+      "predicate": { "contains": ["FOOBAR", "bar"] },
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "contains_full_string_case_insensitive",
+      "predicate": { "contains": ["ABC", "abc"] },
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "contains_unicode_accented_case_folding",
+      "description": "locale-independent Unicode lowercasing folds accented letters",
+      "predicate": { "contains": ["CAFÉ", "café"] },
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "contains_empty_needle_matches_any_string",
+      "description": "every string contains the empty substring; no json-logic falsy guard (unlike in)",
+      "predicate": { "contains": ["abc", ""] },
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "contains_empty_needle_matches_empty_haystack",
+      "predicate": { "contains": ["", ""] },
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "contains_empty_haystack_nonempty_needle",
+      "predicate": { "contains": ["", "x"] },
+      "variables": {},
+      "expected": false
+    },
+    {
+      "id": "contains_needle_longer_than_haystack",
+      "predicate": { "contains": ["ab", "abc"] },
+      "variables": {},
+      "expected": false
+    },
+    {
+      "id": "contains_coerces_non_string_needle",
+      "description": "needle is stringified (mirrors in): 2 becomes \"2\"",
+      "predicate": { "contains": ["a1b2c3", 2] },
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "contains_non_string_haystack_number",
+      "description": "case-insensitive substring is only defined on string haystacks; non-string returns false",
+      "predicate": { "contains": [12345, "234"] },
+      "variables": {},
+      "expected": false
+    },
+    {
+      "id": "contains_non_string_haystack_null",
+      "predicate": { "contains": [null, "x"] },
+      "variables": {},
+      "expected": false
+    },
+    {
+      "id": "contains_non_string_haystack_bool",
+      "predicate": { "contains": [true, "tru"] },
+      "variables": {},
+      "expected": false
+    },
+    {
+      "id": "contains_non_string_haystack_array",
+      "predicate": { "contains": [["a", "b"], "a"] },
+      "variables": {},
+      "expected": false
+    },
+    {
+      "id": "contains_non_string_haystack_object",
+      "predicate": { "contains": [{}, "x"] },
+      "variables": {},
+      "expected": false
+    },
+    {
+      "id": "contains_zero_args",
+      "description": "contains is function(haystack, needle); a missing haystack is null, so non-string short-circuits to false",
+      "predicate": { "contains": [] },
+      "variables": {},
+      "expected": false
+    },
+    {
+      "id": "contains_one_arg_missing_needle",
+      "description": "a missing needle becomes null, stringified to \"null\", which is not a substring of the haystack",
+      "predicate": { "contains": ["only-one"] },
+      "variables": {},
+      "expected": false
+    },
+    {
+      "id": "contains_ignores_args_beyond_second",
+      "predicate": { "contains": ["foobar", "foo", 999] },
+      "variables": {},
+      "expected": true
+    }
+  ]
+}


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Adds the khepri-specific `contains` operator for case-insensitive substring checks in workflow predicates ([SDK-4345](https://linear.app/revenuecat/issue/SDK-4345)). Companion Android PR: https://github.com/RevenueCat/purchases-android/pull/3560

### Description
Implemented as `function(haystack, needle)` with locale-independent lowercasing; empty needle matches any string haystack (explicit guard because macOS 26 `String.contains("")` is false). Validated via xcodebuild `RulesEngineInternalTests`; SPM `swift test` is blocked by unrelated `RevenueCatUITests` compile errors in this branch.

Made with [Cursor](https://cursor.com)