### PR TITLE
fix(workflows): Don't serve stale workflows when the backend rejects the request

### DIFF
--- a/Sources/Error Handling/BackendError.swift
+++ b/Sources/Error Handling/BackendError.swift
@@ -326,9 +326,4 @@ extension BackendError {
         }
     }
 
-    /// Whether to fall back to cached offerings in case of this error when fetching offerings.
-    var shouldFallBackToCachedOfferings: Bool {
-        return self.shouldFallBackToCache
-    }
-
 }

--- a/Sources/Error Handling/BackendError.swift
+++ b/Sources/Error Handling/BackendError.swift
@@ -315,14 +315,20 @@ extension BackendError {
 
 extension BackendError {
 
-    /// Whether to fall back to cached offerings in case of this error when fetching offerings.
-    var shouldFallBackToCachedOfferings: Bool {
+    /// Whether to fall back to the last cached response for this error. See
+    /// ``NetworkError/shouldFallBackToCache``.
+    var shouldFallBackToCache: Bool {
         switch self {
         case .networkError(let networkError):
-            return networkError.shouldFallBackToCachedOfferings
+            return networkError.shouldFallBackToCache
         default:
             return true
         }
+    }
+
+    /// Whether to fall back to cached offerings in case of this error when fetching offerings.
+    var shouldFallBackToCachedOfferings: Bool {
+        return self.shouldFallBackToCache
     }
 
 }

--- a/Sources/Networking/HTTPClient/NetworkError.swift
+++ b/Sources/Networking/HTTPClient/NetworkError.swift
@@ -260,11 +260,6 @@ extension NetworkError {
         }
     }
 
-    /// Whether to fall back to cached offerings in case of this error when fetching offerings.
-    var shouldFallBackToCachedOfferings: Bool {
-        return self.shouldFallBackToCache
-    }
-
 }
 
 extension NetworkError {

--- a/Sources/Networking/HTTPClient/NetworkError.swift
+++ b/Sources/Networking/HTTPClient/NetworkError.swift
@@ -249,13 +249,20 @@ extension NetworkError {
         return self.errorStatusCode?.isServerError == true
     }
 
-    /// Whether to fall back to cached offerings in case of this error when fetching offerings.
-    var shouldFallBackToCachedOfferings: Bool {
+    /// Whether to fall back to the last cached response for this error. A 5xx or a connection-level
+    /// failure (no status code) is transient, so serving the last cached copy is appropriate; a 4xx
+    /// is the backend authoritatively rejecting the request, so stale data should not be served.
+    var shouldFallBackToCache: Bool {
         if let errorStatusCode {
             return errorStatusCode.isServerError
         } else {
             return true
         }
+    }
+
+    /// Whether to fall back to cached offerings in case of this error when fetching offerings.
+    var shouldFallBackToCachedOfferings: Bool {
+        return self.shouldFallBackToCache
     }
 
 }

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -142,7 +142,7 @@ class OfferingsManager {
                                                   preferredLocales: preferredLocales,
                                                   completion: completion)
 
-            case let .failure(backendError) where backendError.shouldFallBackToCachedOfferings:
+            case let .failure(backendError) where backendError.shouldFallBackToCache:
 
                 // If error fetching offerings, attempt to load them from disk cache.
                 self.fetchCachedOfferingsFromDisk(appUserID: appUserID,

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -118,7 +118,7 @@ class WorkflowManager {
                     // A 4xx means the backend authoritatively rejected the request (workflows
                     // disabled for the app, unauthorized for this user, ...), so don't serve stale
                     // prefetched data from disk. Only transient errors (5xx / offline) restore below.
-                    // Mirrors how offerings gate their disk fallback on `shouldFallBackToCachedOfferings`.
+                    // Mirrors how offerings gate their disk fallback on `shouldFallBackToCache`.
                     onComplete()
                     return
                 }

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -114,6 +114,14 @@ class WorkflowManager {
                                        onComplete: onComplete)
             case let .failure(error):
                 Logger.error(Strings.paywalls.error_fetching_workflows_list(error))
+                guard error.shouldFallBackToCache else {
+                    // A 4xx means the backend authoritatively rejected the request (workflows
+                    // disabled for the app, unauthorized for this user, ...), so don't serve stale
+                    // prefetched data from disk. Only transient errors (5xx / offline) restore below.
+                    // Mirrors how offerings gate their disk fallback on `shouldFallBackToCachedOfferings`.
+                    onComplete()
+                    return
+                }
                 // Restore the in-memory offeringId -> workflowId map from the last list persisted on
                 // disk, so `cachedWorkflowId(forOfferingId:)` keeps resolving previously-fetched data after
                 // a backend failure instead of returning nil. The entry stays stale so the next

--- a/Tests/UnitTests/Networking/BackendErrorTests.swift
+++ b/Tests/UnitTests/Networking/BackendErrorTests.swift
@@ -80,7 +80,7 @@ class BackendErrorTests: BaseErrorTests {
         expect(error.successfullySynced) == false
     }
 
-    func testShouldFallBackToCachedOfferingsTrue() {
+    func testShouldFallBackToCacheTrue() {
         let errors = [
             error(.missingAppUserID()),
             error(.emptySubscriberAttributes()),
@@ -90,15 +90,15 @@ class BackendErrorTests: BaseErrorTests {
         ]
 
         for error in errors {
-            check(error.0.shouldFallBackToCachedOfferings,
+            check(error.0.shouldFallBackToCache,
                   condition: beTrue(),
-                  description: "Expected error's shouldFallBackToCachedOfferings to be true",
+                  description: "Expected error's shouldFallBackToCache to be true",
                   file: error.1,
                   line: error.2)
         }
     }
 
-    func testShouldFallBackToCachedOfferingsFalse() {
+    func testShouldFallBackToCacheFalse() {
         let errors = [
             error(.networkError(.errorResponse(ErrorResponse(code: .invalidAPIKey,
                                                              originalCode: BackendErrorCode.invalidAPIKey.rawValue,
@@ -107,9 +107,9 @@ class BackendErrorTests: BaseErrorTests {
         ]
 
         for error in errors {
-            check(error.0.shouldFallBackToCachedOfferings,
+            check(error.0.shouldFallBackToCache,
                   condition: beFalse(),
-                  description: "Expected error's shouldFallBackToCachedOfferings to be false",
+                  description: "Expected error's shouldFallBackToCache to be false",
                   file: error.1,
                   line: error.2)
         }

--- a/Tests/UnitTests/Networking/NetworkErrorTests.swift
+++ b/Tests/UnitTests/Networking/NetworkErrorTests.swift
@@ -318,7 +318,7 @@ class NetworkErrorTests: TestCase {
         }
     }
 
-    func testShouldFallBackToCachedOfferingsTrue() {
+    func testShouldFallBackToCacheTrue() {
         let errors = [
             error(NetworkError.decodingError()),
             error(Self.offlineError),
@@ -333,15 +333,15 @@ class NetworkErrorTests: TestCase {
         ]
 
         for error in errors {
-            check(error.0.shouldFallBackToCachedOfferings,
+            check(error.0.shouldFallBackToCache,
                   condition: beTrue(),
-                  descrition: "Expected error's shouldFallBackToCachedOfferings to be true",
+                  descrition: "Expected error's shouldFallBackToCache to be true",
                   file: error.1,
                   line: error.2)
         }
     }
 
-    func testShouldFallBackToCachedOfferingsFalse() {
+    func testShouldFallBackToCacheFalse() {
         let errors = [
             error(Self.responseError(.invalidRequest)),
             error(Self.responseError(.unauthorized)),
@@ -351,9 +351,9 @@ class NetworkErrorTests: TestCase {
         ]
 
         for error in errors {
-            check(error.0.shouldFallBackToCachedOfferings,
+            check(error.0.shouldFallBackToCache,
                   condition: beFalse(),
-                  descrition: "Expected error's shouldFallBackToCachedOfferings to be false",
+                  descrition: "Expected error's shouldFallBackToCache to be false",
                   file: error.1,
                   line: error.2)
         }

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -236,6 +236,24 @@ class WorkflowManagerTests: TestCase {
         expect(self.manager.cachedWorkflowId(forOfferingId: "default")) == "wf_1"
     }
 
+    func testGetWorkflowsListRestoresDetailsFromDiskOnServerError() throws {
+        // A 5xx is transient: both the list mapping AND prefetched details must be restored so the
+        // next render can serve them offline. Complements testGetWorkflowsListRestoresFromDiskOnServerError
+        // which only asserts on the list mapping.
+        let restored = try Self.workflowDataResult(id: "wf_1")
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .failure(
+            .networkError(.errorResponse(.init(code: .unknownError, originalCode: 0), .internalServerError))
+        )
+        self.mockDeviceCache.stubbedCachedWorkflowsListResponse = .init(workflows: [
+            .init(id: "wf_1", displayName: "Flow", offeringId: "default", prefetch: false)
+        ])
+        self.mockDeviceCache.stubbedCachedWorkflowDetails = ["wf_1": restored]
+
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        expect(self.workflowsCache.cachedWorkflow(workflowId: "wf_1")) == restored
+    }
+
     func testGetWorkflowsListWithDuplicateOfferingIdKeepsLastEntry() {
         self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: [
             .init(id: "wf_first", displayName: "First", offeringId: "shared", prefetch: false),
@@ -411,6 +429,19 @@ class WorkflowManagerTests: TestCase {
 
     func testGetWorkflowsListCallsOnCompleteAfterNetworkError() {
         self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .failure(.missingAppUserID())
+
+        var completed = false
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false) { completed = true }
+
+        expect(completed) == true
+    }
+
+    func testGetWorkflowsListCallsOnCompleteOnClientError() {
+        // A 4xx skips disk restoration and returns early. onComplete must still fire so
+        // callers (e.g. offerings delivery) are not blocked.
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .failure(
+            .networkError(.errorResponse(.init(code: .invalidAPIKey, originalCode: 0), .invalidRequest))
+        )
 
         var completed = false
         self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false) { completed = true }

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -205,6 +205,37 @@ class WorkflowManagerTests: TestCase {
         expect(self.mockDeviceCache.cacheWorkflowsListResponseCount) == 0
     }
 
+    func testGetWorkflowsListDoesNotRestoreFromDiskOnClientError() throws {
+        // A 4xx means the backend rejected the request (workflows disabled, unauthorized, ...), so
+        // stale prefetched data must not be served.
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .failure(
+            .networkError(.errorResponse(.init(code: .invalidAPIKey, originalCode: 0), .invalidRequest))
+        )
+        self.mockDeviceCache.stubbedCachedWorkflowsListResponse = .init(workflows: [
+            .init(id: "wf_1", displayName: "Flow", offeringId: "default", prefetch: false)
+        ])
+        self.mockDeviceCache.stubbedCachedWorkflowDetails = ["wf_1": try Self.workflowDataResult(id: "wf_1")]
+
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        expect(self.manager.cachedWorkflowId(forOfferingId: "default")).to(beNil())
+        expect(self.workflowsCache.cachedWorkflow(workflowId: "wf_1")).to(beNil())
+    }
+
+    func testGetWorkflowsListRestoresFromDiskOnServerError() {
+        // A 5xx is transient, so the last cached list is restored to keep resolving offline.
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .failure(
+            .networkError(.errorResponse(.init(code: .unknownError, originalCode: 0), .internalServerError))
+        )
+        self.mockDeviceCache.stubbedCachedWorkflowsListResponse = .init(workflows: [
+            .init(id: "wf_1", displayName: "Flow", offeringId: "default", prefetch: false)
+        ])
+
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        expect(self.manager.cachedWorkflowId(forOfferingId: "default")) == "wf_1"
+    }
+
     func testGetWorkflowsListWithDuplicateOfferingIdKeepsLastEntry() {
         self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: [
             .init(id: "wf_first", displayName: "First", offeringId: "shared", prefetch: false),


### PR DESCRIPTION
Follow-up to #6917.

### What

#6917 made the workflows list survive the backend being down: if the `/workflows` fetch fails, we fall back to the last copy on disk so a cold start can still render the prefetched paywalls.

The problem is we did that on *any* failure, including a 4xx. A 4xx isn't "the backend is down", it's the backend telling us no (workflows turned off for the app, this user isn't allowed, etc). Serving the stale prefetched data we just got rejected for is the wrong move. So now we only fall back on the transient stuff (5xx, offline); a 4xx skips the restore.

Nothing new to decide here. Offerings already draw this exact line, so I reused their rule instead of inventing one: pulled the classification up into `shouldFallBackToCache` on `NetworkError`/`BackendError`, and the offerings property just delegates to it now (so offerings behaviour is identical, `OfferingsManager` untouched).

```mermaid
flowchart TD
    A["getWorkflowsList: /workflows fetch"] --> B{result}
    B -->|success| C[cache list + prefetch details]
    B -->|failure| D{4xx?}
    D -->|"yes, backend rejected it"| E["skip restore<br/>(don't serve stale)"]
    D -->|"no, 5xx / offline"| F["restore list + details from disk<br/>(render offline)"]
    E --> G([onComplete])
    F --> G
    C --> G
```

It only gates the disk restore, it doesn't wipe anything already in memory (same as offerings).

<details>
<summary>AI session context</summary>

## Metadata

- PR: `facu/workflow-list-4xx-no-stale` (follow-up to #6917)
- Branch base: `main`
- Author / human owner: facumenzella
- Agent(s): Claude Code (Opus 4.8, 1M context)
- Session source: current conversation
- Generated: 2026-06-08
- Context document version: 1

## Goal

Stop the workflows list-fetch failure path from restoring stale prefetched data on a 4xx, while keeping the 5xx / offline backend-down recovery from #6917. Workflows-side + shared error helper only.

## Initial Prompt

Identified as a missing follow-up from #6917 (its original body listed a "status-based fallback gate so a 4xx doesn't restore" non-goal). The human picked it up: "Let's tackle 2."

## Agent Contribution

- Found the SDK's existing offerings classification (`shouldFallBackToCachedOfferings`: 5xx/offline fall back, 4xx doesn't) and reused it rather than inventing a rule.
- Renamed it to a generic `NetworkError.shouldFallBackToCache` / `BackendError.shouldFallBackToCache` and pointed all callers (`OfferingsManager` + the error tests) at it directly. Behavior-preserving (the old offerings name only ever returned the same value).
- Gated `WorkflowManager.getWorkflowsList`'s failure-branch disk restore on `error.shouldFallBackToCache`.
- Added two tests: 4xx skips restore (list + detail), 5xx restores.
- Review follow-up (vegaro): the interim `shouldFallBackToCachedOfferings` delegating alias was redundant, so it was removed entirely instead of kept.

## Human Decisions

- Tackle this follow-up now; keep the change scoped to workflows + the shared error helper.

## Key Implementation Decisions

- Reuse the offerings classification via a generalized `shouldFallBackToCache` instead of a workflows-specific rule, so both paths treat backend errors consistently. Per review, the old `shouldFallBackToCachedOfferings` name was dropped (not kept as an alias) and callers use `shouldFallBackToCache` directly.
- Gate the disk restore only; don't evict live in-memory state on a 4xx (matches how offerings scope their fallback).

## Files / Symbols Touched

- `Sources/Networking/HTTPClient/NetworkError.swift` — `shouldFallBackToCachedOfferings` renamed to `shouldFallBackToCache`.
- `Sources/Error Handling/BackendError.swift` — same rename.
- `Sources/Purchasing/OfferingsManager.swift` — uses `shouldFallBackToCache`.
- `Sources/Purchasing/WorkflowManager.swift` — `getWorkflowsList` failure branch guards restore on `shouldFallBackToCache`.
- `Tests/UnitTests/Purchasing/WorkflowManagerTests.swift` — 4xx-no-restore + 5xx-restore tests.
- `Tests/UnitTests/Networking/{BackendError,NetworkError}Tests.swift` — updated to `shouldFallBackToCache`.

## Validation

- `swift build`: clean.
- `swiftlint` on changed files: no violations.
- `xcodebuild test -scheme UnitTests`: `BackendErrorTests` 9, `NetworkErrorTests` 8, `OfferingsManagerTests` 39, `WorkflowManagerTests` 39 all passing (95 total, 0 failures) after the rename, iPhone 16 Pro sim.

## Validation Gaps

- Covers the manager-level decision deterministically; not an end-to-end device test of a live 4xx.

## Review Focus

- `shouldFallBackToCache` semantics match the prior `shouldFallBackToCachedOfferings` exactly (4xx → false, 5xx/no-status → true); offerings now call it directly, so no offerings behavior change.
- Gate is on the disk restore only; in-memory state is left as-is on a 4xx.

## Non-goals / Out of Scope

- Evicting already-cached in-memory workflows on a 4xx.
- Any offerings behavior change.

## Omitted Context

- Raw transcript, unrelated exploration, and chain-of-thought content omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes offline/paywall behavior when `/workflows` returns 4xx and touches shared cache-fallback rules used by offerings, though offerings semantics are intended to stay the same.
> 
> **Overview**
> Fixes workflows list fetch failures **restoring stale disk cache on 4xx** responses, which could show prefetched paywalls after the backend had explicitly rejected the request.
> 
> **`shouldFallBackToCachedOfferings`** is renamed and generalized to **`shouldFallBackToCache`** on `NetworkError` and `BackendError` (5xx / connection failures → allow cache fallback; 4xx → do not). `OfferingsManager` now gates disk fallback on the same property with **unchanged** semantics.
> 
> **`WorkflowManager.getWorkflowsList`** only runs list/detail disk restore when `error.shouldFallBackToCache` is true; on 4xx it skips restore and still calls **`onComplete`**. Unit tests cover 4xx vs 5xx restore behavior and completion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88491a6cedcc863ce25d652b41793baa36ce2f62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
