### PR TITLE
test(workflows): fill test gaps from code review of 4xx stale-restore fix

### DIFF
--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -236,6 +236,24 @@ class WorkflowManagerTests: TestCase {
         expect(self.manager.cachedWorkflowId(forOfferingId: "default")) == "wf_1"
     }
 
+    func testGetWorkflowsListRestoresDetailsFromDiskOnServerError() throws {
+        // A 5xx is transient: both the list mapping AND prefetched details must be restored so the
+        // next render can serve them offline. Complements testGetWorkflowsListRestoresFromDiskOnServerError
+        // which only asserts on the list mapping.
+        let restored = try Self.workflowDataResult(id: "wf_1")
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .failure(
+            .networkError(.errorResponse(.init(code: .unknownError, originalCode: 0), .internalServerError))
+        )
+        self.mockDeviceCache.stubbedCachedWorkflowsListResponse = .init(workflows: [
+            .init(id: "wf_1", displayName: "Flow", offeringId: "default", prefetch: false)
+        ])
+        self.mockDeviceCache.stubbedCachedWorkflowDetails = ["wf_1": restored]
+
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        expect(self.workflowsCache.cachedWorkflow(workflowId: "wf_1")) == restored
+    }
+
     func testGetWorkflowsListWithDuplicateOfferingIdKeepsLastEntry() {
         self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: [
             .init(id: "wf_first", displayName: "First", offeringId: "shared", prefetch: false),
@@ -411,6 +429,19 @@ class WorkflowManagerTests: TestCase {
 
     func testGetWorkflowsListCallsOnCompleteAfterNetworkError() {
         self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .failure(.missingAppUserID())
+
+        var completed = false
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false) { completed = true }
+
+        expect(completed) == true
+    }
+
+    func testGetWorkflowsListCallsOnCompleteOnClientError() {
+        // A 4xx skips disk restoration and returns early. onComplete must still fire so
+        // callers (e.g. offerings delivery) are not blocked.
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .failure(
+            .networkError(.errorResponse(.init(code: .invalidAPIKey, originalCode: 0), .invalidRequest))
+        )
 
         var completed = false
         self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false) { completed = true }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Code review of #<!-- parent PR --> surfaced two test gaps in the 4xx stale-restore fix:

1. `testGetWorkflowsListDoesNotRestoreFromDiskOnClientError` never asserted `onComplete()` fires on 4xx — if that call were accidentally dropped, callers would hang with no test catching it.
2. `testGetWorkflowsListRestoresFromDiskOnServerError` only checked that the list mapping was restored on 5xx, but not that workflow details were also restored from disk.

### Description
Adds two targeted tests to close those gaps:

- **`testGetWorkflowsListCallsOnCompleteOnClientError`**: verifies `onComplete()` fires on a 4xx even though disk restore is skipped.
- **`testGetWorkflowsListRestoresDetailsFromDiskOnServerError`**: verifies that on 5xx both the list mapping and workflow details are restored from disk, not just the list.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code modifications.
> 
> **Overview**
> Adds two unit tests in `WorkflowManagerTests` to cover behaviors from the workflows **4xx stale-restore** fix that were missing from review.
> 
> **`testGetWorkflowsListRestoresDetailsFromDiskOnServerError`** asserts that on a **5xx** workflows-list failure, prefetched workflow **details** on disk are restored into `WorkflowsCache`, not only the offering→workflow list mapping (which an existing test already covered).
> 
> **`testGetWorkflowsListCallsOnCompleteOnClientError`** asserts that **`onComplete`** still runs on a **4xx** when disk restore is skipped, so callers such as offerings delivery are not left waiting indefinitely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e3f9248c76446b5c3b8e3f7295e2027ab1f9dde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->