### PR TITLE
Xcode 27 Beta Compilation Fix

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,6 +8,8 @@ excluded:
   - vendor
   - scan_derived_data
   - .git
+  - build
+  - "**/DerivedSources/GeneratedAssetSymbols.swift"
   - .build
   - ./**/Project.swift
 

--- a/Sources/Paywalls/PaywallColor.swift
+++ b/Sources/Paywalls/PaywallColor.swift
@@ -45,6 +45,11 @@ public struct PaywallColor {
     // Only available from iOS 13
     fileprivate var _underlyingColor: (any Sendable)?
 
+    /// "Designated" initializer
+    private init(stringRepresentation: String, underlyingColor: (any Sendable)?) {
+        self.stringRepresentation = stringRepresentation
+        self._underlyingColor = underlyingColor
+    }
 }
 
 // MARK: - Public constructors
@@ -119,12 +124,6 @@ private extension PaywallColor {
     }
 
     #endif
-
-    /// "Designated" initializer
-    private init(stringRepresentation: String, underlyingColor: (any Sendable)?) {
-        self.stringRepresentation = stringRepresentation
-        self._underlyingColor = underlyingColor
-    }
 
 }
 


### PR DESCRIPTION
## Summary
Fixes an Xcode 27 beta build failure in `PaywallColor.swift`, and prevents SwiftLint from reporting violations in Xcode-generated asset symbol files.

## Description
### Fix `PaywallColor` initializer collision
Xcode 27 reports a build failure in PaywallColor:

```
Invalid redeclaration of synthesized memberwise 'init(stringRepresentation:)'
```
The fix moves the private designated initializer into the primary PaywallColor struct declaration. Declaring an initializer in the primary type suppresses memberwise initializer synthesis, avoiding the collision while preserving the existing public API.

### Exclude generated asset symbol files from SwiftLint
SwiftLint was recursively scanning the local Xcode build/ directory and reporting errors in generated files such as:
```
GeneratedAssetSymbols.swift: error: Force Cast Violation
GeneratedAssetSymbols.swift: error: Type Name Violation: _ACResourceInitProtocol
```

This change excludes generated build output from SwiftLint:
```
build
**/DerivedSources/GeneratedAssetSymbols.swift
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint config and internal initializer placement only; no public API or runtime behavior changes.
> 
> **Overview**
> Addresses **Xcode 27 beta** build/lint friction in two places.
> 
> **SwiftLint** now ignores the `build` tree and Xcode-generated `GeneratedAssetSymbols.swift` under `DerivedSources`, so lint does not run on artifacts the new toolchain emits.
> 
> **`PaywallColor`** moves the private designated `init(stringRepresentation:underlyingColor:)` from the public-constructors extension into the main struct body. Behavior is unchanged; the reorder satisfies stricter visibility/initialization rules in the beta compiler so paywall color construction still compiles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 508142cc69b4d0f689ecfd12018d5ccd369e138e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->