### PR TITLE
Fix initial iOS 27 compilation failure in PaywallColor initializer

### DIFF
--- a/Sources/Paywalls/PaywallColor.swift
+++ b/Sources/Paywalls/PaywallColor.swift
@@ -35,6 +35,11 @@ public struct PaywallColor {
     public var stringRepresentation: String
 
     #if canImport(SwiftUI)
+    /// Creates a color from a Hex string: `#RRGGBB` or `#RRGGBBAA`.
+    public init(stringRepresentation: String) throws {
+        self.init(stringRepresentation: stringRepresentation, color: try Self.parseColor(stringRepresentation))
+    }
+
     /// The underlying SwiftUI `Color`.
     public var underlyingColor: Color {
         // swiftlint:disable:next force_cast
@@ -52,11 +57,6 @@ public struct PaywallColor {
 extension PaywallColor {
 
     #if canImport(SwiftUI)
-
-    /// Creates a color from a Hex string: `#RRGGBB` or `#RRGGBBAA`.
-    public init(stringRepresentation: String) throws {
-        self.init(stringRepresentation: stringRepresentation, color: try Self.parseColor(stringRepresentation))
-    }
 
         #if canImport(UIKit)
 


### PR DESCRIPTION
Fixes the `Ambiguous use of 'init(stringRepresentation:)` compilation error when compiling for iOS 27 using Xcode 27 beta 1.

Apple may have added a similar initializer in iOS 27, causing it to take precedence over our initializer defined in the extension of `PaywallColor`