### PR TITLE
Workflow preview injection via (@_spi)

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1296,6 +1296,7 @@
 		B3F8418F26F3A93400E560FB /* ErrorCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F8418E26F3A93400E560FB /* ErrorCodeTests.swift */; };
 		B8A6F391F64046E96A343339 /* PredicateConformanceFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60BA9A763EB70A332E2C63CE /* PredicateConformanceFixture.swift */; };
 		C074AAE036B449898E1FEF58 /* CustomPaywallVariables.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93B46553B99148F3A60B8BFB /* CustomPaywallVariables.swift */; };
+		C1311C20A12B3813D86A2EDF /* WorkflowPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA3AA2BC4C1B8CE7E9A3B59 /* WorkflowPreview.swift */; };
 		C53CDAA4FC3E6B51CC70D724 /* WorkflowPaywallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800A129055A298C390AED0B5 /* WorkflowPaywallView.swift */; };
 		C808D299537245E695865C31 /* CapturingLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = E51CFC7D19BE49D2BA1A79CC /* CapturingLogger.swift */; };
 		D072B9ED04C331CA7DF878A5 /* PredicateFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E47E21986D2C234ADB62E8 /* PredicateFixtureTests.swift */; };
@@ -2828,6 +2829,7 @@
 		9D8A2C402AB81F3C35672B14 /* WorkflowsCacheTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowsCacheTests.swift; sourceTree = "<group>"; };
 		9E174FCB9B889D4CACED0088 /* Value.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Value.swift; sourceTree = "<group>"; };
 		9F576269BC7130E5B553FB5A /* StringArrayOperatorsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StringArrayOperatorsTests.swift; sourceTree = "<group>"; };
+		9FA3AA2BC4C1B8CE7E9A3B59 /* WorkflowPreview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowPreview.swift; sourceTree = "<group>"; };
 		A0C4BF8C5116F4DC73C116C0 /* ComparisonOperators.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ComparisonOperators.swift; sourceTree = "<group>"; };
 		A1D3F80D2D524F51BA60157C /* ButtonComponentViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponentViewTests.swift; sourceTree = "<group>"; };
 		A1E0F0012F297A0100000001 /* EventsManagerStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsManagerStrings.swift; sourceTree = "<group>"; };
@@ -2968,6 +2970,7 @@
 		E51CFC7D19BE49D2BA1A79CC /* CapturingLogger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CapturingLogger.swift; sourceTree = "<group>"; };
 		E78770053AB84EF380CC0C1D /* TextComponentViewLoadingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextComponentViewLoadingTests.swift; sourceTree = "<group>"; };
 		E7EAAD1DC166ABD68E484EAA /* RootViewSheetDismissalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewSheetDismissalTests.swift; sourceTree = "<group>"; };
+		ECEA10EF63BC10F9BE6DB9F5 /* WorkflowPreviewTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowPreviewTests.swift; sourceTree = "<group>"; };
 		EF970D13102945639A882002 /* ATTConsentStatusIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTConsentStatusIntegrationTests.swift; sourceTree = "<group>"; };
 		EFB3CBAA73855779FE828CE2 /* ProductsFetcherSK1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsFetcherSK1.swift; sourceTree = "<group>"; };
 		F1A05E9E1B04B32B832DB194 /* PaywallCountdownComponent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaywallCountdownComponent.swift; sourceTree = "<group>"; };
@@ -5725,6 +5728,7 @@
 				887A5FEF2C1D037000E1A461 /* PurchaseHandler.swift */,
 				887A5FF02C1D037000E1A461 /* PurchaseHandler+TestData.swift */,
 				F598F832810DB534092FBED3 /* WorkflowContext.swift */,
+				9FA3AA2BC4C1B8CE7E9A3B59 /* WorkflowPreview.swift */,
 			);
 			path = Purchasing;
 			sourceTree = "<group>";
@@ -5916,6 +5920,7 @@
 				887A61372C1D168B00E1A461 /* PurchaseHandlerTests.swift */,
 				7AA86A1D9F5AE92988B20230 /* WorkflowContextTests.swift */,
 				F1C01B0B88766F8B092C30BC /* DefaultWorkflowStubData.swift */,
+				ECEA10EF63BC10F9BE6DB9F5 /* WorkflowPreviewTests.swift */,
 			);
 			path = Purchasing;
 			sourceTree = "<group>";
@@ -8598,6 +8603,7 @@
 				97B9F00926E0977B0DAAD7D7 /* EnvironmentValues+Workflow.swift in Sources */,
 				150BEBF14F59182317CDA8DA /* WorkflowContext.swift in Sources */,
 				C53CDAA4FC3E6B51CC70D724 /* WorkflowPaywallView.swift in Sources */,
+				C1311C20A12B3813D86A2EDF /* WorkflowPreview.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RevenueCatUI/Data/PaywallViewConfiguration.swift
+++ b/RevenueCatUI/Data/PaywallViewConfiguration.swift
@@ -26,6 +26,12 @@ struct PaywallViewConfiguration {
     var introEligibility: TrialOrIntroEligibilityChecker?
     var purchaseHandler: PurchaseHandler
     var promoOfferCache: PaywallPromoOfferCache?
+    #if !os(tvOS)
+    /// A pre-built workflow context to seed directly (injection/preview path), bypassing the
+    /// backend fetch. When set, `PaywallView` renders the workflow paywall immediately. Set by the
+    /// `PaywallView(workflowContext:)` initializer; tvOS has no workflow paywall UI.
+    var injectedWorkflowContext: WorkflowContext?
+    #endif
 
     init(
         content: Content,

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -145,6 +145,33 @@ public struct PaywallView: View {
         )
     }
 
+    /// Renders a workflow paywall from an injected ``WorkflowContext`` (built via
+    /// `WorkflowPreview.makeContext`), bypassing the backend `/workflows` fetch. Used to preview
+    /// dashboard workflows (including drafts) in a companion app.
+    // swiftlint:disable:next missing_docs
+    @_spi(Internal) public init(
+        workflowContext: WorkflowContext,
+        fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
+        displayCloseButton: Bool = false,
+        introEligibility: TrialOrIntroEligibilityChecker? = nil,
+        performPurchase: PerformPurchase? = nil,
+        performRestore: PerformRestore? = nil
+    ) {
+        let purchaseHandler = PurchaseHandler.default(performPurchase: performPurchase, performRestore: performRestore)
+
+        var configuration = PaywallViewConfiguration(
+            content: .offering(workflowContext.initialOffering),
+            mode: .fullScreen,
+            fonts: fonts,
+            displayCloseButton: displayCloseButton,
+            introEligibility: introEligibility,
+            purchaseHandler: purchaseHandler
+        )
+        configuration.injectedWorkflowContext = workflowContext
+
+        self.init(configuration: configuration)
+    }
+
     init(configuration: PaywallViewConfiguration, paywallViewOwnsPurchaseHandler: Bool = true) {
         self.paywallViewOwnsPurchaseHandler = paywallViewOwnsPurchaseHandler
         if paywallViewOwnsPurchaseHandler {
@@ -159,15 +186,15 @@ public struct PaywallView: View {
 
         self._introEligibility = .init(wrappedValue: configuration.introEligibility ?? .default())
 
-        // When the workflow + offerings are already cached, seed the workflow context (and its
-        // mapped offering) synchronously so a warm cache renders without a loading state. On a
-        // cold/stale/partial cache the seed is nil and the async resolve path takes over.
+        // Seed the workflow context (and its mapped offering) synchronously so the workflow paywall
+        // renders without a loading state. An injected context (preview/injection path) is used
+        // directly; otherwise a warm cache seeds it, and on a cold/stale/partial cache the seed is
+        // nil and the async resolve path takes over.
         // This @State init wiring isn't unit-tested directly (SwiftUI @State can't be seeded outside
         // a view init); the seeding logic lives in the unit-tested cachedInitialWorkflowContext, and
         // the rendered result is covered by the existing PaywallView snapshot tests.
-        let seededWorkflowContext = configuration.purchaseHandler.cachedInitialWorkflowContext(
-            for: configuration.content
-        )
+        let seededWorkflowContext = configuration.injectedWorkflowContext
+            ?? configuration.purchaseHandler.cachedInitialWorkflowContext(for: configuration.content)
         self._workflowContext = .init(initialValue: seededWorkflowContext)
         self._offering = .init(
             initialValue: seededWorkflowContext?.initialOffering

--- a/RevenueCatUI/Purchasing/WorkflowContext.swift
+++ b/RevenueCatUI/Purchasing/WorkflowContext.swift
@@ -14,8 +14,11 @@ import Foundation
 
 #if !os(tvOS)
 
+/// Render-ready input for a workflow paywall. Built internally (from a backend fetch, a warm cache,
+/// or `WorkflowPreview.makeContext` for injected data) and passed into ``PaywallView``; it has no
+/// public initializer because callers never assemble it directly.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-struct WorkflowContext {
+@_spi(Internal) public struct WorkflowContext {
     let workflow: PublishedWorkflow
     let allOfferings: Offerings
     let initialOffering: Offering

--- a/RevenueCatUI/Purchasing/WorkflowPreview.swift
+++ b/RevenueCatUI/Purchasing/WorkflowPreview.swift
@@ -1,0 +1,50 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WorkflowPreview.swift
+
+import Foundation
+@_spi(Internal) import RevenueCat
+
+#if !os(tvOS)
+
+/// Injection seam for previewing workflows from data supplied by a companion app (e.g. dashboard
+/// drafts), without going through the SDK's `/workflows` fetch. Build a ``WorkflowContext`` here and
+/// pass it to `PaywallView(workflowContext:)`.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@_spi(Internal) public enum WorkflowPreview {
+
+    /// Builds a render-ready ``WorkflowContext`` from injected data, with no backend fetch.
+    ///
+    /// - Parameters:
+    ///   - workflow: The workflow to render, assembled from dashboard data.
+    ///   - offerings: One offering per `offeringIdentifier` referenced by the workflow's screens.
+    ///     They carry PACKAGES/PRICING ONLY: per-screen paywall components come from
+    ///     `workflow.screens` and override each offering's components, so the supplied offerings
+    ///     must NOT carry paywall components.
+    ///   - presentedOfferingContext: Optional placement/targeting metadata to propagate.
+    /// - Throws: `PaywallError.offeringNotFound` when the workflow has no initial screen, or a
+    ///   screen references an offering id absent from `offerings`.
+    @_spi(Internal) public static func makeContext(
+        workflow: PublishedWorkflow,
+        offerings: [Offering],
+        presentedOfferingContext: PresentedOfferingContext? = nil
+    ) throws -> WorkflowContext {
+        let allOfferings = Offerings.preview(offerings: offerings)
+        return try PurchaseHandler.makeWorkflowContext(
+            workflow: workflow,
+            allOfferings: allOfferings,
+            presentedOfferingContext: presentedOfferingContext,
+            triggerOfferingIdentifier: workflow.id
+        )
+    }
+
+}
+
+#endif

--- a/RevenueCatUI/Purchasing/WorkflowPreview.swift
+++ b/RevenueCatUI/Purchasing/WorkflowPreview.swift
@@ -14,23 +14,14 @@ import Foundation
 
 #if !os(tvOS)
 
-/// Injection seam for previewing workflows from data supplied by a companion app (e.g. dashboard
-/// drafts), without going through the SDK's `/workflows` fetch. Build a ``WorkflowContext`` here and
-/// pass it to `PaywallView(workflowContext:)`.
+/// Used to preview workflows from the RC mobile app, without going through the SDK's `/workflows`
+/// fetch. Build a ``WorkflowContext`` here and pass it to `PaywallView(workflowContext:)`.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @_spi(Internal) public enum WorkflowPreview {
 
     /// Builds a render-ready ``WorkflowContext`` from injected data, with no backend fetch.
-    ///
-    /// - Parameters:
-    ///   - workflow: The workflow to render, assembled from dashboard data.
-    ///   - offerings: One offering per `offeringIdentifier` referenced by the workflow's screens.
-    ///     They carry PACKAGES/PRICING ONLY: per-screen paywall components come from
-    ///     `workflow.screens` and override each offering's components, so the supplied offerings
-    ///     must NOT carry paywall components.
-    ///   - presentedOfferingContext: Optional placement/targeting metadata to propagate.
-    /// - Throws: `PaywallError.offeringNotFound` when the workflow has no initial screen, or a
-    ///   screen references an offering id absent from `offerings`.
+    /// `offerings` carry packages/pricing only (one per offering id the workflow references); the
+    /// paywall components come from `workflow.screens`, so the offerings must not carry components.
     @_spi(Internal) public static func makeContext(
         workflow: PublishedWorkflow,
         offerings: [Offering],

--- a/Sources/Networking/Responses/WorkflowsResponse.swift
+++ b/Sources/Networking/Responses/WorkflowsResponse.swift
@@ -40,6 +40,18 @@ import Foundation
     public let actionId: String?
     public let componentId: String?
 
+    @_spi(Internal) public init(
+        name: String?,
+        type: WorkflowTriggerType,
+        actionId: String?,
+        componentId: String?
+    ) {
+        self.name = name
+        self.type = type
+        self.actionId = actionId
+        self.componentId = componentId
+    }
+
 }
 
 @_spi(Internal) public enum WorkflowTriggerAction: Equatable, Sendable {
@@ -68,6 +80,27 @@ import Foundation
     public var stepScreenType: [String] { screenType }
     let metadata: [String: AnyDecodable]?
 
+    // `screenType`, `paramValues`, `outputs`, and `metadata` carry backend step config that the
+    // renderer doesn't read, and `paramValues`/`outputs`/`metadata` are typed with the internal
+    // `AnyDecodable`, so they're defaulted rather than exposed.
+    @_spi(Internal) public init(
+        id: String,
+        type: String,
+        screenId: String?,
+        triggers: [WorkflowTrigger] = [],
+        triggerActions: [String: WorkflowTriggerAction] = [:]
+    ) {
+        self.id = id
+        self.type = type
+        self.screenId = screenId
+        self.screenType = []
+        self.paramValues = [:]
+        self.triggers = triggers
+        self.outputs = [:]
+        self.triggerActions = triggerActions
+        self.metadata = nil
+    }
+
 }
 
 @_spi(Internal) public struct WorkflowScreen {
@@ -87,6 +120,31 @@ import Foundation
     public let offeringIdentifier: String?
     public let exitOffers: ExitOffers?
 
+    // `config` carries backend screen config the renderer doesn't read and is typed with the
+    // internal `AnyDecodable`, so it's defaulted rather than exposed.
+    @_spi(Internal) public init(
+        name: String?,
+        templateName: String,
+        revision: Int = 0,
+        assetBaseURL: URL,
+        componentsConfig: PaywallComponentsData.ComponentsConfig,
+        componentsLocalizations: [PaywallComponent.LocaleID: PaywallComponent.LocalizationDictionary],
+        defaultLocale: PaywallComponent.LocaleID,
+        offeringIdentifier: String?,
+        exitOffers: ExitOffers? = nil
+    ) {
+        self.name = name
+        self.templateName = templateName
+        self._revision = revision
+        self.assetBaseURL = assetBaseURL
+        self.componentsConfig = componentsConfig
+        self.componentsLocalizations = componentsLocalizations
+        self.defaultLocale = defaultLocale
+        self.config = [:]
+        self.offeringIdentifier = offeringIdentifier
+        self.exitOffers = exitOffers
+    }
+
 }
 
 @_spi(Internal) public struct PublishedWorkflow {
@@ -100,6 +158,28 @@ import Foundation
     public let uiConfig: UIConfig
     let contentMaxWidth: Int?
     let metadata: [String: AnyDecodable]?
+
+    // `metadata` is typed with the internal `AnyDecodable`, so it's defaulted rather than exposed.
+    @_spi(Internal) public init(
+        id: String,
+        displayName: String,
+        initialStepId: String,
+        singleStepFallbackId: String?,
+        steps: [String: WorkflowStep],
+        screens: [String: WorkflowScreen],
+        uiConfig: UIConfig,
+        contentMaxWidth: Int? = nil
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.initialStepId = initialStepId
+        self.singleStepFallbackId = singleStepFallbackId
+        self.steps = steps
+        self.screens = screens
+        self.uiConfig = uiConfig
+        self.contentMaxWidth = contentMaxWidth
+        self.metadata = nil
+    }
 
 }
 

--- a/Sources/Purchasing/Offerings.swift
+++ b/Sources/Purchasing/Offerings.swift
@@ -251,3 +251,30 @@ extension Offerings.Contents: Codable {
     }
 
 }
+
+@_spi(Internal) public extension Offerings {
+
+    /// Builds an `Offerings` bundle from a list of offerings for injected/preview rendering, with no
+    /// network fetch. Only the offerings dictionary and `offering(identifier:)` lookups are used by
+    /// the workflow preview path, so the backing response is empty.
+    static func preview(offerings: [Offering], currentOfferingID: String? = nil) -> Offerings {
+        return Offerings(
+            offerings: Dictionary(offerings.map { ($0.identifier, $0) }, uniquingKeysWith: { first, _ in first }),
+            currentOfferingID: currentOfferingID,
+            placements: nil,
+            targeting: nil,
+            contents: .init(
+                response: .init(
+                    currentOfferingId: currentOfferingID,
+                    offerings: [],
+                    placements: nil,
+                    targeting: nil,
+                    uiConfig: nil
+                ),
+                httpResponseOriginalSource: .mainServer
+            ),
+            loadedFromDiskCache: false
+        )
+    }
+
+}

--- a/Tests/RevenueCatUITests/Purchasing/WorkflowContextTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/WorkflowContextTests.swift
@@ -11,7 +11,7 @@
 
 import Nimble
 @_spi(Internal) @testable import RevenueCat
-@testable import RevenueCatUI
+@_spi(Internal) @testable import RevenueCatUI
 import XCTest
 
 #if !os(tvOS) // For Paywalls V2

--- a/Tests/RevenueCatUITests/Purchasing/WorkflowPreviewTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/WorkflowPreviewTests.swift
@@ -1,0 +1,142 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WorkflowPreviewTests.swift
+//
+
+import Nimble
+@_spi(Internal) @testable import RevenueCat
+@_spi(Internal) @testable import RevenueCatUI
+import XCTest
+
+#if !os(tvOS)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+final class WorkflowPreviewTests: TestCase {
+
+    func testMakeContextBuildsWorkflowContextFromInjectedData() throws {
+        let baseOffering = Self.makeOffering(identifier: "offering_a")
+        let workflow = try Self.makeWorkflow(screenOfferingIdentifier: "offering_a")
+
+        let context = try WorkflowPreview.makeContext(workflow: workflow, offerings: [baseOffering])
+
+        // The rendered offering is the screen's offering with the workflow screen's components applied.
+        expect(context.initialOffering.identifier) == "offering_a"
+        expect(context.initialOffering.paywallComponents).toNot(beNil())
+        expect(context.workflow.id) == "wf_test"
+    }
+
+    func testMakeContextPropagatesPresentedOfferingContext() throws {
+        let baseOffering = Self.makeOffering(identifier: "offering_a")
+        let workflow = try Self.makeWorkflow(screenOfferingIdentifier: "offering_a")
+        let presentedOfferingContext = PresentedOfferingContext(offeringIdentifier: "offering_a")
+
+        let context = try WorkflowPreview.makeContext(
+            workflow: workflow,
+            offerings: [baseOffering],
+            presentedOfferingContext: presentedOfferingContext
+        )
+
+        expect(context.presentedOfferingContext?.offeringIdentifier) == "offering_a"
+    }
+
+    func testMakeContextThrowsWhenScreenOfferingMissingFromOfferings() throws {
+        // The workflow screen resolves to "offering_b", but only "offering_a" is supplied.
+        let workflow = try Self.makeWorkflow(screenOfferingIdentifier: "offering_b")
+
+        do {
+            _ = try WorkflowPreview.makeContext(
+                workflow: workflow,
+                offerings: [Self.makeOffering(identifier: "offering_a")]
+            )
+            XCTFail("Expected makeContext to throw")
+        } catch let PaywallError.offeringNotFound(identifier) {
+            expect(identifier) == "offering_b"
+        }
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension WorkflowPreviewTests {
+
+    /// A packages-only offering (no paywall components), as the preview seam expects.
+    static func makeOffering(identifier: String) -> Offering {
+        return Offering(
+            identifier: identifier,
+            serverDescription: "Offering \(identifier)",
+            metadata: [:],
+            paywall: nil,
+            availablePackages: TestData.packages,
+            webCheckoutUrl: nil
+        )
+    }
+
+    /// Builds a single-screen workflow using the `@_spi(Internal)` initializers (C-1), sourcing the
+    /// `componentsConfig`/`uiConfig` sub-objects from JSON since hand-building them is impractical.
+    static func makeWorkflow(screenOfferingIdentifier: String) throws -> PublishedWorkflow {
+        let screen = WorkflowScreen(
+            name: nil,
+            templateName: "tmpl",
+            assetBaseURL: try XCTUnwrap(URL(string: "https://assets.revenuecat.com")),
+            componentsConfig: try Self.makeComponentsConfig(),
+            componentsLocalizations: [:],
+            defaultLocale: "en_US",
+            offeringIdentifier: screenOfferingIdentifier
+        )
+        let step = WorkflowStep(id: "step_1", type: "screen", screenId: "screen_1")
+
+        return PublishedWorkflow(
+            id: "wf_test",
+            displayName: "Test",
+            initialStepId: "step_1",
+            singleStepFallbackId: nil,
+            steps: ["step_1": step],
+            screens: ["screen_1": screen],
+            uiConfig: try Self.makeUIConfig()
+        )
+    }
+
+    static func makeComponentsConfig() throws -> PaywallComponentsData.ComponentsConfig {
+        let json = """
+        {
+          "base": {
+            "stack": {
+              "type": "stack",
+              "components": [],
+              "dimension": { "type": "vertical", "alignment": "center", "distribution": "center" },
+              "size": { "width": { "type": "fill" }, "height": { "type": "fill" } },
+              "padding": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 },
+              "margin": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 }
+            },
+            "background": {
+              "type": "color",
+              "value": { "light": { "type": "hex", "value": "#FFFFFF" } }
+            }
+          }
+        }
+        """
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        return try JSONDecoder.default.decode(PaywallComponentsData.ComponentsConfig.self, from: data)
+    }
+
+    static func makeUIConfig() throws -> UIConfig {
+        let json = """
+        {
+          "app": { "colors": {}, "fonts": {} },
+          "localizations": {}
+        }
+        """
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        return try JSONDecoder.default.decode(UIConfig.self, from: data)
+    }
+
+}
+
+#endif


### PR DESCRIPTION
### Motivation
The rc mobile app needs to preview dashboard workflows natively, including drafts/specific revisions, the way it already injects draft v2 paywalls. 

Stacked on #6947 (workflows always-on).

### Description
Adds a thin `@_spi(Internal)` seam that lets injected dashboard data drive the existing workflow renderer with no backend fetch: app-constructible workflow models, an exposed `WorkflowContext`, a fetch-free `WorkflowPreview.makeContext` factory (reusing `PurchaseHandler.makeWorkflowContext`), and a `PaywallView(workflowContext:)` initializer. No new endpoints, no rendering changes, no backend changes; the production `/workflows` fetch path is untouched.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata
- PR: Not captured (draft); stacked on #6947
- Branch: `facu/workflow-preview-injection` (base `facu/workflows-remove-runtime-flag`)
- Author / human owner: facumenzella
- Agent(s): Claude Code (Opus 4.8, 1M context)
- Session source: current conversation
- Generated: 2026-06-09
- Context document version: 1

## Goal
Implement the `~/Developer/rc/plans/purchases-ios-workflow-preview-injection.md` seam so a companion app can render dashboard workflows (incl. drafts) via injection, no backend fetch.

## Initial Prompt
"Check ~/Developer/rc/plans/purchases-ios-workflow-preview-injection.md. We need to do this." Clarified to stack as a follow-up PR (the plan's own header), not bundle into #6947.

## Agent Contribution
- Implemented C-1…C-5 per the plan; verified macOS + tvOS builds, test-target compile, and SwiftLint.
- Caught two gaps the plan glossed: `Offerings.init`/`Contents` are RevenueCat-internal (added an `@_spi(Internal) public Offerings.preview` factory), and `WorkflowContext` becoming `@_spi(Internal) public` required adding `@_spi(Internal)` to `WorkflowContextTests`' import.

## Human Decisions
- Stack as a separate PR rather than bundling into #6947.

## Key Implementation Decisions
- Decision: explicit `injectedWorkflowContext` field on `PaywallViewConfiguration` (not a new `Content` case).
  - Rationale: the async load `.task` only runs when `offering == nil`; seeding `_offering = context.initialOffering` means the fetch can't clobber the injected context. Field gated `#if !os(tvOS)` since `WorkflowContext` is non-tvOS.
  - Rejected: new `Content.workflowContext` case (would thread through resolve/cache paths unnecessarily).
- Decision: `AnyDecodable`-typed fields (`paramValues`/`outputs`/`metadata`/`config`) are defaulted, not exposed.
  - Rationale: `AnyDecodable` is internal and the renderer doesn't read them.

## Files / Symbols Touched
- `Sources/Networking/Responses/WorkflowsResponse.swift` — C-1 `@_spi` inits.
- `Sources/Purchasing/Offerings.swift` — `@_spi(Internal) public static func preview(offerings:)`.
- `RevenueCatUI/Purchasing/WorkflowContext.swift` — `@_spi(Internal) public struct WorkflowContext`.
- `RevenueCatUI/Purchasing/WorkflowPreview.swift` (new) — `WorkflowPreview.makeContext`.
- `RevenueCatUI/Data/PaywallViewConfiguration.swift` — `injectedWorkflowContext` (`#if !os(tvOS)`).
- `RevenueCatUI/PaywallView.swift` — `@_spi(Internal) public init(workflowContext:)` + seeding.
- `Tests/RevenueCatUITests/Purchasing/WorkflowPreviewTests.swift` (new); `WorkflowContextTests.swift` (import).

## Dependencies / Config / Migrations
- Adds `@_spi(Internal)` public API → `api/*.swiftinterface` baseline regen required (CircleCI). No package/schema changes.

## Validation
- Commands run:
  - `swift build`: build complete.
  - `xcodebuild -scheme RevenueCatUI -destination 'generic/platform=tvOS' build`: EXIT 0, 0 errors.
  - `swift build --build-tests`: only pre-existing unrelated `.snapshot` errors (`TextComponentViewLoadingTests`, SPM-vs-Tuist); new code compiles.
  - `swiftlint` (changed files): no violations.
- Manual verification: Not run (no device/companion app here).
- CI: Not captured. `run_api_tests` expected to fail until swiftinterface regen.

## Validation Gaps
- Tests not run via the Tuist UnitTests scheme (compile-checked only).
- No snapshot/render test of `PaywallView(workflowContext:)` (needs the Tuist snapshot host); covered indirectly by `makeContext` tests + existing PaywallView snapshots.
- End-to-end injection from the companion app is unverified here.

## Review Focus
- Is `injectedWorkflowContext` seeding correct (no clobber by the async `.task`)? Does `PaywallView(workflowContext:)` render the `WorkflowPaywallView` branch (`.fullScreen`)?
- Are the C-1 inits sufficient for the app to build real dashboard workflows (given `paramValues`/`outputs`/`config`/`metadata` are defaulted)?
- Is `Offerings.preview(offerings:)` an acceptable `@_spi` addition on a public `@objc` class?

## Risks / Reviewer Notes
- Risk: `run_api_tests` fails until the swiftinterface baseline regenerates.
  - Mitigation: trigger CircleCI `generate_swiftinterface` and commit the baseline before merge.

## Non-goals / Out of Scope
- No backend changes; no PaywallsV2 changes; tvOS workflow support not added; companion-app side is separate.

## Omitted Context
- Raw transcript, unrelated exploration, and chain-of-thought omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SPI-only surface; production `/workflows` fetch and rendering paths are unchanged. Main follow-up is regenerating swiftinterface API baselines after new public SPI symbols.
> 
> **Overview**
> Adds an **`@_spi(Internal)` injection path** so the RC companion app can render dashboard workflows (including drafts) **without** calling `/workflows`, reusing the existing workflow renderer.
> 
> **`WorkflowPreview.makeContext`** builds a render-ready **`WorkflowContext`** from injected `PublishedWorkflow` + package-only `Offering` values (via new **`Offerings.preview`**), delegating to **`PurchaseHandler.makeWorkflowContext`**. **`PaywallView(workflowContext:)`** seeds **`injectedWorkflowContext`** on **`PaywallViewConfiguration`** so workflow UI shows immediately and the async load path does not replace injected data. Workflow model types gain **`@_spi`** programmatic initializers for app-side assembly; **`WorkflowContext`** is exposed under the same SPI. **`WorkflowPreviewTests`** cover success, presented-offering propagation, and missing-offering errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02208316f9ea3063490936796d34750938c3e51c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->