### PR TITLE
[EXTERNAL] feat: expose revocationDate and revocationReason on StoreTransaction

### DIFF
--- a/Sources/Logging/Strings/StoreKitStrings.swift
+++ b/Sources/Logging/Strings/StoreKitStrings.swift
@@ -77,6 +77,8 @@ enum StoreKitStrings {
 
     case sk2_unknown_transaction_reason(String)
 
+    case sk2_unknown_revocation_reason(String)
+
     case sk2_error_encoding_receipt(Error)
 
     case sk2_error_fetching_app_transaction(Error)
@@ -233,6 +235,9 @@ extension StoreKitStrings: LogMessage {
 
         case let .sk2_unknown_transaction_reason(reason):
             return "Unrecognized StoreKit Transaction Reason: \(reason)"
+
+        case let .sk2_unknown_revocation_reason(reason):
+            return "Unrecognized StoreKit Transaction Revocation Reason: \(reason)"
 
         case let .sk2_error_encoding_receipt(error):
             return "Error encoding SK2 receipt: '\(error)'"

--- a/Sources/Misc/Deprecations.swift
+++ b/Sources/Misc/Deprecations.swift
@@ -315,6 +315,8 @@ extension CustomerInfo {
         internal var jwsRepresentation: String? { return nil }
         internal var environment: StoreEnvironment? { return nil }
         var reason: TransactionReason? { return nil }
+        var revocationDate: Date? { return nil }
+        var revocationReason: RevocationReason? { return nil }
 
         var hasKnownPurchaseDate: Bool { true }
         var hasKnownTransactionIdentifier: Bool { return true }

--- a/Sources/Purchasing/SimulatedStore/SimulatedStoreTransaction.swift
+++ b/Sources/Purchasing/SimulatedStore/SimulatedStoreTransaction.swift
@@ -24,6 +24,8 @@ struct SimulatedStoreTransaction: StoreTransactionType, Equatable {
 
     let environment: StoreEnvironment? = nil
     let reason: TransactionReason? = nil
+    let revocationDate: Date? = nil
+    let revocationReason: RevocationReason? = nil
 
     func finish(_ wrapper: any PaymentQueueWrapperType, completion: @escaping @Sendable () -> Void) {
         // no-op

--- a/Sources/Purchasing/StoreKitAbstractions/RevocationReason.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/RevocationReason.swift
@@ -1,0 +1,60 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  RevocationReason.swift
+
+import Foundation
+import StoreKit
+
+/// Indicates the reason for a transaction revocation.
+///
+/// This mirrors StoreKit 2's `Transaction.RevocationReason` (available on iOS 15+, macOS 12+,
+/// tvOS 15+, watchOS 8+).
+///
+/// When the revocation reason cannot be determined, the property is `nil`. This happens for:
+/// - All StoreKit 1 transactions (SK1 does not expose revocation metadata).
+/// - StoreKit 2 transactions that were not revoked.
+public struct RevocationReason: RawRepresentable, Equatable, Sendable {
+
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public static let developerIssue = RevocationReason(rawValue: "developer_issue")
+    public static let other = RevocationReason(rawValue: "other")
+
+}
+
+// MARK: - StoreKit 2
+
+#if swift(>=5.9)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevocationReason {
+
+    /// Creates a ``RevocationReason`` from a StoreKit 2 `Transaction.RevocationReason`.
+    ///
+    /// Returns `nil` for unrecognized reasons.
+    init?(sk2RevocationReason reason: SK2Transaction.RevocationReason) {
+        switch reason {
+        case .developerIssue:
+            self = .developerIssue
+        case .other:
+            self = .other
+        default:
+            Logger.appleWarning(
+                Strings.storeKit.sk2_unknown_revocation_reason(String(describing: reason))
+            )
+            return nil
+        }
+    }
+
+}
+#endif

--- a/Sources/Purchasing/StoreKitAbstractions/SK1StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK1StoreTransaction.swift
@@ -51,6 +51,16 @@ internal struct SK1StoreTransaction: StoreTransactionType {
         return nil
     }
 
+    var revocationDate: Date? {
+        // StoreKit 1 does not expose revocation metadata.
+        return nil
+    }
+
+    var revocationReason: RevocationReason? {
+        // StoreKit 1 does not expose revocation metadata.
+        return nil
+    }
+
     var hasKnownPurchaseDate: Bool {
         return self.underlyingSK1Transaction.transactionDate != nil
     }

--- a/Sources/Purchasing/StoreKitAbstractions/SK2StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK2StoreTransaction.swift
@@ -29,6 +29,8 @@ internal struct SK2StoreTransaction: StoreTransactionType {
         self.quantity = sk2Transaction.purchasedQuantity
         self.jwsRepresentation = jwsRepresentation
         self.environment = environmentOverride ?? .init(sk2Transaction: sk2Transaction)
+        self.revocationDate = sk2Transaction.revocationDate
+        self.revocationReason = sk2Transaction.revocationReason.flatMap { RevocationReason(sk2RevocationReason: $0) }
 
         #if swift(>=5.9)
         if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
@@ -54,6 +56,8 @@ internal struct SK2StoreTransaction: StoreTransactionType {
     let jwsRepresentation: String?
     var environment: StoreEnvironment?
     let reason: TransactionReason?
+    let revocationDate: Date?
+    let revocationReason: RevocationReason?
 
     var hasKnownPurchaseDate: Bool { return true }
     var hasKnownTransactionIdentifier: Bool { return true }

--- a/Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift
@@ -45,6 +45,9 @@ public typealias SK2Transaction = StoreKit.Transaction
     @objc internal var jwsRepresentation: String? { self.transaction.jwsRepresentation }
     internal var environment: StoreEnvironment? { self.transaction.environment }
     internal var reason: TransactionReason? { self.transaction.reason }
+    @objc public var revocationDate: Date? { self.transaction.revocationDate }
+    // Not exposed to Objective-C: `RevocationReason` is a Swift struct and cannot be represented as `@objc`.
+    public var revocationReason: RevocationReason? { self.transaction.revocationReason }
 
     var hasKnownPurchaseDate: Bool { return self.transaction.hasKnownPurchaseDate }
     var hasKnownTransactionIdentifier: Bool { self.transaction.hasKnownTransactionIdentifier }
@@ -126,6 +129,14 @@ internal protocol StoreTransactionType: Sendable {
     /// The reason for the transaction, if known.
     /// - Note: this is only available for StoreKit 2 transactions starting with iOS 17.
     var reason: TransactionReason? { get }
+
+    /// The date the App Store refunded or revoked the transaction, if it was revoked; `nil` otherwise.
+    /// - Note: this is only available for StoreKit 2 transactions.
+    var revocationDate: Date? { get }
+
+    /// The reason the transaction was revoked, if it was revoked; `nil` otherwise.
+    /// - Note: this is only available for StoreKit 2 transactions.
+    var revocationReason: RevocationReason? { get }
 
     /// Indicates to the App Store that the app delivered the purchased content
     /// or enabled the service to finish the transaction.

--- a/Sources/Purchasing/StoreKitAbstractions/TestStoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/TestStoreTransaction.swift
@@ -23,6 +23,8 @@ struct TestStoreTransaction: StoreTransactionType {
     let jwsRepresentation: String? = nil
     let environment: StoreEnvironment? = nil
     let reason: TransactionReason? = nil
+    let revocationDate: Date? = nil
+    let revocationReason: RevocationReason? = nil
 
     func finish(_ wrapper: any PaymentQueueWrapperType, completion: @escaping @Sendable () -> Void) {
         // no-op

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCStoreTransactionAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCStoreTransactionAPI.m
@@ -20,6 +20,7 @@
     NSString *transactionIdentifier __unused = transaction.transactionIdentifier;
     NSInteger quantity __unused = transaction.quantity;
     RCStorefront *__nullable storefront __unused = transaction.storefront;
+    NSDate *__nullable revocationDate __unused = transaction.revocationDate;
 
     SKPaymentTransaction *sk1 __unused = transaction.sk1Transaction;
 }

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/StoreTransactionAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/StoreTransactionAPI.swift
@@ -17,6 +17,12 @@ func checkStoreTransactionAPI(storefront: RevenueCat.Storefront?) {
     let _: String = transaction.transactionIdentifier
     let _: Int = transaction.quantity
     let _: RevenueCat.Storefront? = transaction.storefront
+    let _: Date? = transaction.revocationDate
+    let _: RevocationReason? = transaction.revocationReason
+    let _: RevocationReason = .developerIssue
+    let _: RevocationReason = .other
+    let _: RevocationReason = RevocationReason(rawValue: "x")
+    let _: String = RevocationReason.other.rawValue
 
     let _: SKPaymentTransaction? = transaction.sk1Transaction
 

--- a/Tests/RevenueCatUITests/Purchasing/MockStoreTransaction.swift
+++ b/Tests/RevenueCatUITests/Purchasing/MockStoreTransaction.swift
@@ -29,6 +29,8 @@ final class MockStoreTransaction: StoreTransactionType {
     let jwsRepresentation: String?
     let environment: StoreEnvironment?
     let reason: TransactionReason?
+    let revocationDate: Date? = nil
+    let revocationReason: RevocationReason? = nil
 
     init(jwsRepresentation: String? = nil, environment: StoreEnvironment = .sandbox) {
         self.productIdentifier = UUID().uuidString

--- a/Tests/StoreKitUnitTests/StoreTransactionTests.swift
+++ b/Tests/StoreKitUnitTests/StoreTransactionTests.swift
@@ -43,6 +43,22 @@ class StoreTransactionTests: StoreKitConfigTestCase {
         expect(transaction.environment).to(beNil())
     }
 
+    func testSK1TransactionReturnsNilRevocationFields() async throws {
+        let product = MockSK1Product(mockProductIdentifier: Self.productID)
+        let payment = SKPayment(product: product)
+
+        let sk1Transaction = MockTransaction()
+        sk1Transaction.mockPayment = payment
+        sk1Transaction.mockTransactionDate = Date()
+        sk1Transaction.mockTransactionIdentifier = UUID().uuidString
+        sk1Transaction.mockState = .purchased
+
+        let transaction = StoreTransaction(sk1Transaction: sk1Transaction)
+
+        expect(transaction.revocationDate).to(beNil())
+        expect(transaction.revocationReason).to(beNil())
+    }
+
     func testSK1TransactionWithMissingDate() async throws {
         let product = MockSK1Product(mockProductIdentifier: Self.productID)
         let payment = SKPayment(product: product)
@@ -97,6 +113,12 @@ class StoreTransactionTests: StoreKitConfigTestCase {
         } else {
             expect(transaction.storefront).to(beNil())
         }
+    }
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func testRevocationReasonMapsKnownSK2Reasons() throws {
+        expect(RevocationReason(sk2RevocationReason: .developerIssue)).to(equal(.developerIssue))
+        expect(RevocationReason(sk2RevocationReason: .other)).to(equal(.other))
     }
 
     func testSk1TransactionDateBecomesAnInvalidDateIfNoDate() {

--- a/Tests/UnitTests/Mocks/MockStoreTransaction.swift
+++ b/Tests/UnitTests/Mocks/MockStoreTransaction.swift
@@ -29,6 +29,8 @@ final class MockStoreTransaction: StoreTransactionType {
     let jwsRepresentation: String?
     let environment: StoreEnvironment?
     let reason: TransactionReason?
+    let revocationDate: Date? = nil
+    let revocationReason: RevocationReason? = nil
 
     init(
         productIdentifier: String = UUID().uuidString,


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Resolves #6515.

StoreKit 2 exposes `Transaction.revocationDate` and `Transaction.revocationReason`, but `StoreTransaction` does not surface either. Apps using `CustomEntitlementComputation`, transaction-history UIs, and custom refund analytics need to read revocation data directly off the transaction. A maintainer responded positively to the reporter's proposal.

### Description
Adds `revocationDate` and `revocationReason` to `StoreTransaction`, mirroring the existing `TransactionReason` pattern.

- `revocationDate` is exposed as `@objc public var revocationDate: Date?`.
- `revocationReason` is a new public `RevocationReason` value type. Per the repo's `no_new_public_enums` rule, it is a `RawRepresentable` struct (not an enum) with `.developerIssue` / `.other` constants, so adding cases later stays source-compatible. Because it is a Swift struct it cannot be `@objc`, so the property is Swift-only (documented inline); `revocationDate` remains Obj-C accessible.
- Populated from the underlying transaction in `SK2StoreTransaction` (iOS 15+); `nil` for SK1, test, simulated, and mock conformers.

Both fields are additive and `nil`-defaulted — no breaking change. `swift build` of the `RevenueCat` target passes.

Note: I was not able to regenerate the `api/*.swiftinterface` baselines locally (they require the multi-platform API digester). The `check-api-changes` job will flag the additive public surface; the baselines need to be regenerated for these intentional additions.

This PR scopes to `revocationReason` (`.developerIssue` / `.other`, iOS 15+). The separate iOS 26.4 `Transaction.RevocationType` (`.proratedRefund` etc.) is intentionally left for a follow-up.

AI was used for assistance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, nil-defaulted public API with no changes to purchase or entitlement logic; only surfaces existing SK2 metadata.
> 
> **Overview**
> **`StoreTransaction`** now exposes **`revocationDate`** and **`revocationReason`** so apps can read App Store refund/revocation metadata from StoreKit 2, matching the existing **`TransactionReason`** pattern.
> 
> A new public **`RevocationReason`** `RawRepresentable` struct (`.developerIssue`, `.other`) maps from SK2 and logs unknown values via **`sk2_unknown_revocation_reason`**. **`SK2StoreTransaction`** copies **`revocationDate`** and mapped **`revocationReason`** from the underlying transaction; SK1, mocks, simulated, test, and deprecated backend-parsed transactions return **`nil`**. **`revocationDate`** is **`@objc`**; **`revocationReason`** is Swift-only. API testers and unit tests cover the new surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2986c957bc4792ba4d942049a7f2d75503f66911. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->