### PR TITLE
feat(workflows): serve stale workflows list while revalidating

### DIFF
--- a/Sources/Caching/WorkflowsCache.swift
+++ b/Sources/Caching/WorkflowsCache.swift
@@ -242,6 +242,13 @@ final class WorkflowsCache {
         return self.cachedList.value?.offeringIdToWorkflowId[offeringId]
     }
 
+    /// `true` when a workflows list is present in memory (fetched or restored this session), regardless
+    /// of staleness. Lets the manager serve a stale-but-present `offeringId → workflowId` map
+    /// immediately while refreshing in the background, and block only on a cold/empty cache.
+    var hasCachedWorkflowsList: Bool {
+        return self.cachedList.value != nil
+    }
+
     // MARK: -
 
     func clearCache() {

--- a/Sources/Logging/Strings/PaywallsStrings.swift
+++ b/Sources/Logging/Strings/PaywallsStrings.swift
@@ -23,6 +23,7 @@ enum PaywallsStrings {
     case warming_up_videos(videoURLs: Set<URLWithValidation>)
     case warming_up_workflow(screenCount: Int)
     case error_fetching_workflows_list(BackendError)
+    case error_refreshing_workflow(workflowId: String, error: BackendError)
     case error_prefetching_image(URL, Error)
     case font_download_already_in_progress(name: String, fontURL: URL)
     case font_downloaded_sucessfully(name: String, fontURL: URL)
@@ -172,6 +173,9 @@ extension PaywallsStrings: LogMessage {
 
         case let .error_fetching_workflows_list(error):
             return "Error fetching workflows list: \(error.localizedDescription)"
+
+        case let .error_refreshing_workflow(workflowId, error):
+            return "Background refresh failed for workflow \(workflowId): \(error.localizedDescription)"
 
         case let .background_task_started(taskName):
             return "Background task started: \(taskName)"

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -34,22 +34,77 @@ class WorkflowManager {
         self.operationDispatcher = operationDispatcher
     }
 
-    /// Resolves a workflow, serving a fresh cached result without a backend round-trip when possible.
-    /// On a cache miss (or stale entry) it fetches from the backend, caches the result in memory, and
-    /// warms up its assets before delivering it. Disk persistence of prefetched details is handled by
-    /// ``prefetchWorkflows(_:appUserID:isAppBackgrounded:onComplete:)``, not here.
+    /// Resolves a workflow using stale-while-revalidate, mirroring how ``OfferingsManager`` vends
+    /// offerings: a fresh cache hit is served directly; a stale-but-present hit is served immediately
+    /// and the cache is refreshed in the background (no callbacks, failures logged); a miss fetches
+    /// from the backend, caches the result, warms its assets, and delivers the outcome.
+    ///
+    /// - Parameter staleWhileRevalidate: when `true` (the default, used by the on-demand render path),
+    ///   a stale-but-present cached workflow is served immediately with a background refresh. When
+    ///   `false` (the prefetch path), a stale workflow blocks on a full refetch instead, so prefetch
+    ///   keeps forcing a fresh fetch and persisting its envelope rather than serving a stale value.
+    ///
+    /// Disk persistence of prefetched details is handled by
+    /// ``prefetchWorkflows(_:appUserID:isAppBackgrounded:generation:onComplete:)``, not here.
     func getWorkflow(appUserID: String,
                      workflowId: String,
                      isAppBackgrounded: Bool,
                      prefetch: Bool = false,
                      ifGeneration generation: Int? = nil,
+                     staleWhileRevalidate: Bool = true,
                      completion: @escaping (Result<WorkflowDataResult, BackendError>) -> Void) {
-        if let cached = self.workflowsCache.cachedWorkflow(workflowId: workflowId),
+        let cached = self.workflowsCache.cachedWorkflow(workflowId: workflowId)
+        if let cached,
            !self.workflowsCache.isWorkflowCacheStale(workflowId: workflowId, isAppBackgrounded: isAppBackgrounded) {
             completion(.success(cached))
             return
         }
 
+        if let cached, staleWhileRevalidate {
+            // Serve the stale value immediately, then refresh the cache in the background. The caller
+            // already has a usable value, so the refresh delivers no result: a success only updates the
+            // cache, a failure is logged and swallowed. Mirrors `OfferingsManager`'s stale offerings
+            // path. Concurrent stale callers each call this, but their network requests are coalesced
+            // by `WorkflowsAPI`'s callback cache (keyed by the request), so only one fetch fires.
+            //
+            // Capture the refresh's guarding generation *before* serving, so it reflects the generation
+            // observed at serve time rather than after `completion` runs. The background write is then
+            // dropped if a `clearCache()` (login/logout) bumps the generation before the response lands,
+            // exactly like the blocking path binds its write to the generation at fetch-issue time.
+            let refreshGeneration = generation ?? self.workflowsCache.currentCacheGeneration()
+            completion(.success(cached))
+            self.fetchAndCacheWorkflow(appUserID: appUserID,
+                                       workflowId: workflowId,
+                                       isAppBackgrounded: isAppBackgrounded,
+                                       prefetch: prefetch,
+                                       ifGeneration: refreshGeneration) { result in
+                if case let .failure(error) = result {
+                    Logger.error(Strings.paywalls.error_refreshing_workflow(workflowId: workflowId, error: error))
+                }
+            }
+            return
+        }
+
+        // Miss, or stale with stale-while-revalidate disabled (the prefetch path): block on the fetch.
+        self.fetchAndCacheWorkflow(appUserID: appUserID,
+                                   workflowId: workflowId,
+                                   isAppBackgrounded: isAppBackgrounded,
+                                   prefetch: prefetch,
+                                   ifGeneration: generation,
+                                   completion: completion)
+    }
+
+    /// Fetches a workflow from the backend, caches the result in memory (guarded by `generation`), and
+    /// warms its assets before delivering the outcome. Shared by the blocking miss path and the
+    /// stale-while-revalidate background refresh.
+    private func fetchAndCacheWorkflow(
+        appUserID: String,
+        workflowId: String,
+        isAppBackgrounded: Bool,
+        prefetch: Bool = false,
+        ifGeneration generation: Int? = nil,
+        completion: @escaping (Result<WorkflowDataResult, BackendError>) -> Void
+    ) {
         // The generation guarding the in-memory write: prefetch forwards the generation captured when
         // the list fetch was issued (`generation`), so a clear landing between caching the list and
         // issuing this prefetch still drops the write. On-demand callers pass `nil` and capture it
@@ -220,7 +275,8 @@ private extension WorkflowManager {
                              workflowId: summary.id,
                              isAppBackgrounded: isAppBackgrounded,
                              prefetch: true,
-                             ifGeneration: generation) { result in
+                             ifGeneration: generation,
+                             staleWhileRevalidate: false) { result in
                 if case let .success(dataResult) = result {
                     resolved.modify { $0[summary.id] = dataResult }
                 }

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -131,13 +131,15 @@ class WorkflowManager {
     }
 
     /// Fetches the workflows list, persists it, then prefetches every entry flagged `prefetch == true`.
-    /// `onComplete` fires only after the list fetch **and** all prefetch fetches finish (success or
-    /// failure), making it safe to call ``cachedWorkflowId(forOfferingId:)`` from `onComplete`.
+    /// It is always safe to call ``cachedWorkflowId(forOfferingId:)`` from `onComplete`: a cold fetch
+    /// only fires `onComplete` after the list (and its prefetches) land, and the stale-but-present and
+    /// fresh paths fire it while a usable map is already cached.
     ///
-    /// When the in-memory list cache is still fresh, no network request is made and `onComplete` fires
-    /// immediately. On a backend failure `onComplete` still fires (so callers waiting on it, e.g.
-    /// offerings delivery, are never blocked); ``cachedWorkflowId(forOfferingId:)`` keeps resolving from the
-    /// last list persisted on disk until the next fetch succeeds.
+    /// Uses stale-while-revalidate: when the list is fresh, or stale but already cached, `onComplete`
+    /// fires immediately and any refresh happens in the background. Only a cold/empty cache blocks
+    /// `onComplete` on the fetch. On a backend failure `onComplete` still fires (so callers waiting on
+    /// it, e.g. offerings delivery, are never blocked); ``cachedWorkflowId(forOfferingId:)`` keeps
+    /// resolving from the last list persisted on disk until the next fetch succeeds.
     func getWorkflowsList(appUserID: String,
                           isAppBackgrounded: Bool,
                           onComplete: @escaping () -> Void = {}) {
@@ -146,11 +148,42 @@ class WorkflowManager {
             return
         }
 
-        // Capture the cache generation when the request is issued. If an identity change clears the
-        // cache while this list fetch is in flight, the success path below is dropped, so a list
-        // (and its prefetched, user-scoped details) fetched for the previous user can't populate the
-        // new session's cache.
-        let generation = self.workflowsCache.currentCacheGeneration()
+        // Stale-while-revalidate, mirroring `getWorkflow` and `OfferingsManager`: when a usable
+        // `offeringId → workflowId` map is already cached (stale but present), serve it immediately and
+        // refresh in the background, so a caller waiting on `onComplete` (e.g. offerings delivery) isn't
+        // blocked on the network. Only a cold/empty cache blocks, since there's no map to serve yet and
+        // `cachedWorkflowId(forOfferingId:)` must resolve once `onComplete` fires.
+        if self.workflowsCache.hasCachedWorkflowsList {
+            // Capture the refresh's guarding generation *before* serving, so it reflects the generation
+            // observed now rather than after `onComplete` runs. The background list write is then
+            // dropped if a `clearCache()` (login/logout) bumps the generation before the response lands,
+            // keeping the previous user's offeringId -> workflowId map out of the new user's cache.
+            let refreshGeneration = self.workflowsCache.currentCacheGeneration()
+            onComplete()
+            self.fetchAndCacheWorkflowsList(appUserID: appUserID,
+                                            isAppBackgrounded: isAppBackgrounded,
+                                            ifGeneration: refreshGeneration)
+        } else {
+            self.fetchAndCacheWorkflowsList(appUserID: appUserID,
+                                            isAppBackgrounded: isAppBackgrounded,
+                                            onComplete: onComplete)
+        }
+    }
+
+    /// Fetches the workflows list from the backend, caches it (generation-guarded), prefetches its
+    /// flagged entries, and restores from disk on a transient failure. Shared by the blocking cold-cache
+    /// path and the stale-while-revalidate background refresh. `onComplete` defaults to a no-op for the
+    /// background refresh, whose caller was already served the stale map. The cold path passes
+    /// `ifGeneration: nil` and captures the generation here (request issued now); the background refresh
+    /// forwards the generation captured at serve time so its write binds to that, not a later value.
+    private func fetchAndCacheWorkflowsList(appUserID: String,
+                                            isAppBackgrounded: Bool,
+                                            ifGeneration generation: Int? = nil,
+                                            onComplete: @escaping () -> Void = {}) {
+        // The cache generation guarding this fetch's write. If an identity change clears the cache while
+        // the fetch is in flight, the success path below is dropped, so a list (and its prefetched,
+        // user-scoped details) fetched for the previous user can't populate the new session's cache.
+        let generation = generation ?? self.workflowsCache.currentCacheGeneration()
         self.backend.workflowsAPI.getWorkflows(appUserID: appUserID,
                                                isAppBackgrounded: isAppBackgrounded,
                                                type: Self.paywallWorkflowType) { [weak self] result in

--- a/Tests/UnitTests/Mocks/MockWorkflowsAPI.swift
+++ b/Tests/UnitTests/Mocks/MockWorkflowsAPI.swift
@@ -70,6 +70,9 @@ class MockWorkflowsAPI: WorkflowsAPI, @unchecked Sendable {
     /// Invoked right before the `getWorkflows` completion fires, letting a test simulate an event
     /// (e.g. an identity change clearing the cache) that lands while the list fetch is in flight.
     var onGetWorkflowsBeforeCompletion: (() -> Void)?
+    /// When `true`, completions are captured instead of fired so tests can control ordering.
+    var shouldStoreGetWorkflowsCompletions = false
+    private(set) var capturedGetWorkflowsCompletions: [WorkflowsListResponseHandler] = []
 
     override func getWorkflows(appUserID: String,
                                isAppBackgrounded: Bool,
@@ -80,7 +83,21 @@ class MockWorkflowsAPI: WorkflowsAPI, @unchecked Sendable {
         self.invokedGetWorkflowsParameters = (appUserID, isAppBackgrounded, type)
 
         self.onGetWorkflowsBeforeCompletion?()
+
+        if self.shouldStoreGetWorkflowsCompletions {
+            self.capturedGetWorkflowsCompletions.append(completion)
+            return
+        }
+
         completion(self.stubbedGetWorkflowsResult ?? .failure(.missingAppUserID()))
+    }
+
+    /// Fires (and removes) the oldest captured `getWorkflows` completion. Requires
+    /// `shouldStoreGetWorkflowsCompletions == true`.
+    func completeStoredGetWorkflows(with result: Result<WorkflowsListResponse, BackendError>) {
+        guard !self.capturedGetWorkflowsCompletions.isEmpty else { return }
+        let completion = self.capturedGetWorkflowsCompletions.removeFirst()
+        completion(result)
     }
 
 }

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -90,6 +90,139 @@ class WorkflowManagerTests: TestCase {
         expect(self.mockWorkflowsAPI.invokedGetWorkflowCount) == 2
     }
 
+    func testGetWorkflowStaleHitServesCachedValueAndRefreshesInBackground() throws {
+        // Stale-while-revalidate: a stale-but-present entry is served immediately and the cache is
+        // refreshed in the background, mirroring how `OfferingsManager` vends a stale offerings cache.
+        self.mockWorkflowsAPI.shouldStoreGetWorkflowCompletions = true
+        let stale = try Self.workflowDataResult(id: "stale")
+        let refreshed = try Self.workflowDataResult(id: "refreshed")
+
+        // First call populates the cache with the stale value.
+        self.manager.getWorkflow(appUserID: self.appUserID, workflowId: "wf_1", isAppBackgrounded: false) { _ in }
+        self.mockWorkflowsAPI.completeStoredGetWorkflow(workflowId: "wf_1", with: .success(stale))
+        expect(self.workflowsCache.cachedWorkflow(workflowId: "wf_1")) == stale
+
+        // Past the 5-minute foreground TTL: the entry is now stale-but-present.
+        self.dateProvider.advance(by: 6 * 60)
+
+        var served: WorkflowDataResult?
+        self.manager.getWorkflow(appUserID: self.appUserID, workflowId: "wf_1", isAppBackgrounded: false) {
+            served = try? $0.get()
+        }
+
+        // The caller gets the stale cached value immediately, before the background refresh lands.
+        expect(served) == stale
+        // A background refresh was issued (second backend call).
+        expect(self.mockWorkflowsAPI.invokedGetWorkflowCount) == 2
+
+        // When the background refresh completes, it updates the cache to the fresh value.
+        self.mockWorkflowsAPI.completeStoredGetWorkflow(workflowId: "wf_1", with: .success(refreshed))
+        expect(self.workflowsCache.cachedWorkflow(workflowId: "wf_1")) == refreshed
+    }
+
+    func testGetWorkflowStaleHitDoesNotSurfaceFailingBackgroundRefresh() throws {
+        // The caller already has a usable value, so a failing background refresh is logged and
+        // swallowed, never delivered as an error, and the stale value stays cached.
+        self.mockWorkflowsAPI.shouldStoreGetWorkflowCompletions = true
+        let stale = try Self.workflowDataResult(id: "stale")
+
+        self.manager.getWorkflow(appUserID: self.appUserID, workflowId: "wf_1", isAppBackgrounded: false) { _ in }
+        self.mockWorkflowsAPI.completeStoredGetWorkflow(workflowId: "wf_1", with: .success(stale))
+
+        self.dateProvider.advance(by: 6 * 60)
+
+        var served: WorkflowDataResult?
+        var erroredWith: BackendError?
+        self.manager.getWorkflow(appUserID: self.appUserID, workflowId: "wf_1", isAppBackgrounded: false) {
+            switch $0 {
+            case let .success(result): served = result
+            case let .failure(error): erroredWith = error
+            }
+        }
+        expect(served) == stale
+
+        // The background refresh fails: not surfaced to the caller, and the cache keeps the stale value.
+        self.mockWorkflowsAPI.completeStoredGetWorkflow(workflowId: "wf_1", with: .failure(.missingAppUserID()))
+        expect(erroredWith).to(beNil())
+        expect(self.workflowsCache.cachedWorkflow(workflowId: "wf_1")) == stale
+    }
+
+    func testGetWorkflowStaleHitDropsBackgroundWriteWhenCacheClearedBeforeRefreshLands() throws {
+        // The background refresh's write is guarded by the generation captured when the stale value was
+        // served. If an identity change clears the cache before the refresh lands, the write is dropped,
+        // so the previous user's (user-scoped) detail can't repopulate the new user's cache.
+        //
+        // Like the prefetch generation tests, this drives the guard directly: the true sub-statement
+        // race (a clear landing between reading the cached value and capturing the generation) is the
+        // same lock-free read window the workflows cache accepts by design and isn't deterministically
+        // reproducible here.
+        self.mockWorkflowsAPI.shouldStoreGetWorkflowCompletions = true
+        let stale = try Self.workflowDataResult(id: "stale")
+
+        self.manager.getWorkflow(appUserID: self.appUserID, workflowId: "wf_1", isAppBackgrounded: false) { _ in }
+        self.mockWorkflowsAPI.completeStoredGetWorkflow(workflowId: "wf_1", with: .success(stale))
+
+        self.dateProvider.advance(by: 6 * 60)
+
+        // Stale hit: serves the cached value and stores the background refresh (capturing the generation).
+        self.manager.getWorkflow(appUserID: self.appUserID, workflowId: "wf_1", isAppBackgrounded: false) { _ in }
+
+        // Identity change clears the cache (bumping the generation) before the refresh lands.
+        self.workflowsCache.clearCache()
+
+        // The background refresh now returns the previous user's detail: its write must be dropped.
+        self.mockWorkflowsAPI.completeStoredGetWorkflow(workflowId: "wf_1",
+                                                        with: .success(try Self.workflowDataResult(id: "refreshed")))
+        expect(self.workflowsCache.cachedWorkflow(workflowId: "wf_1")).to(beNil())
+    }
+
+    func testGetWorkflowStaleHitInvokesCallerCompletionExactlyOnce() throws {
+        // The caller's completion fires once (with the stale value); the background refresh receives a
+        // separate logging-only closure and never delivers to the caller again.
+        self.mockWorkflowsAPI.shouldStoreGetWorkflowCompletions = true
+        let stale = try Self.workflowDataResult(id: "stale")
+
+        self.manager.getWorkflow(appUserID: self.appUserID, workflowId: "wf_1", isAppBackgrounded: false) { _ in }
+        self.mockWorkflowsAPI.completeStoredGetWorkflow(workflowId: "wf_1", with: .success(stale))
+
+        self.dateProvider.advance(by: 6 * 60)
+
+        var completionCount = 0
+        self.manager.getWorkflow(appUserID: self.appUserID, workflowId: "wf_1", isAppBackgrounded: false) { _ in
+            completionCount += 1
+        }
+        expect(completionCount) == 1
+
+        self.mockWorkflowsAPI.completeStoredGetWorkflow(workflowId: "wf_1",
+                                                        with: .success(try Self.workflowDataResult(id: "refreshed")))
+        expect(completionCount) == 1
+    }
+
+    func testGetWorkflowWithStaleWhileRevalidateDisabledBlocksAndDeliversFreshValue() throws {
+        // With stale-while-revalidate disabled, a stale-but-present entry must not be served: the
+        // caller blocks until the refetch lands and receives the freshly fetched value.
+        self.mockWorkflowsAPI.shouldStoreGetWorkflowCompletions = true
+        let stale = try Self.workflowDataResult(id: "stale")
+        let refreshed = try Self.workflowDataResult(id: "refreshed")
+
+        self.manager.getWorkflow(appUserID: self.appUserID, workflowId: "wf_1", isAppBackgrounded: false,
+                                 staleWhileRevalidate: false) { _ in }
+        self.mockWorkflowsAPI.completeStoredGetWorkflow(workflowId: "wf_1", with: .success(stale))
+
+        self.dateProvider.advance(by: 6 * 60)
+
+        var served: WorkflowDataResult?
+        self.manager.getWorkflow(appUserID: self.appUserID, workflowId: "wf_1", isAppBackgrounded: false,
+                                 staleWhileRevalidate: false) { served = try? $0.get() }
+
+        // Nothing delivered yet: the call blocks on the refetch instead of serving the stale value.
+        expect(served).to(beNil())
+
+        // Once the refetch lands, the caller receives the freshly fetched value.
+        self.mockWorkflowsAPI.completeStoredGetWorkflow(workflowId: "wf_1", with: .success(refreshed))
+        expect(served) == refreshed
+    }
+
     func testGetWorkflowForwardsBackendError() {
         self.mockWorkflowsAPI.stubbedGetWorkflowResult = .failure(.missingAppUserID())
 
@@ -465,6 +598,29 @@ class WorkflowManagerTests: TestCase {
 
         expect(self.mockDeviceCache.cacheWorkflowDetailsCount) >= 1
         expect(self.mockDeviceCache.cachedWorkflowDetailsParameter?.keys).to(contain("wf_prefetch"))
+    }
+
+    func testPrefetchBlocksOnFetchAndPersistsFreshDetailWhenCachedButStale() throws {
+        // Seed the detail cache, then let it go stale.
+        let stale = try Self.workflowDataResult(id: "stale")
+        self.workflowsCache.cache(workflow: stale,
+                                  workflowId: "wf_a",
+                                  ifGeneration: self.workflowsCache.currentCacheGeneration())
+        self.dateProvider.advance(by: 6 * 60)
+
+        // Prefetch the same workflow. Even though it's cached-but-stale, prefetch opts out of
+        // stale-while-revalidate, so it fetches fresh and persists the fresh envelope, never the stale
+        // cached value it would otherwise serve.
+        let fresh = try Self.workflowDataResult(id: "fresh")
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: [
+            .init(id: "wf_a", displayName: "A", offeringId: "off_a", prefetch: true)
+        ]))
+        self.mockWorkflowsAPI.stubbedGetWorkflowResults = ["wf_a": .success(fresh)]
+
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        expect(self.mockDeviceCache.cachedWorkflowDetailsParameter?["wf_a"]) == fresh
+        expect(self.workflowsCache.cachedWorkflow(workflowId: "wf_a")) == fresh
     }
 
     func testOnDemandGetWorkflowDoesNotPersistDetailToDisk() throws {

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -237,6 +237,82 @@ class WorkflowManagerTests: TestCase {
 
     // MARK: - getWorkflowsList
 
+    func testGetWorkflowsListStalePresentServesImmediatelyAndRefreshesInBackground() {
+        // Stale-while-revalidate for the list: when a usable offeringId -> workflowId map is already
+        // cached (stale but present), `onComplete` fires immediately and the list is refreshed in the
+        // background, so a caller (e.g. offerings delivery) isn't blocked on the network.
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: [
+            .init(id: "wf_1", displayName: "A", offeringId: "default", prefetch: false)
+        ]))
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+        expect(self.manager.cachedWorkflowId(forOfferingId: "default")) == "wf_1"
+
+        // Let the list go stale, then control the refresh timing.
+        self.dateProvider.advance(by: 6 * 60)
+        self.mockWorkflowsAPI.shouldStoreGetWorkflowsCompletions = true
+
+        var completed = false
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false) { completed = true }
+
+        // Served immediately, before the background refresh lands, and a refresh was issued.
+        expect(completed) == true
+        expect(self.mockWorkflowsAPI.invokedGetWorkflowsCount) == 2
+        // The stale map keeps resolving in the meantime.
+        expect(self.manager.cachedWorkflowId(forOfferingId: "default")) == "wf_1"
+
+        // When the background refresh lands, the map updates.
+        self.mockWorkflowsAPI.completeStoredGetWorkflows(with: .success(.init(workflows: [
+            .init(id: "wf_2", displayName: "B", offeringId: "default", prefetch: false)
+        ])))
+        expect(self.manager.cachedWorkflowId(forOfferingId: "default")) == "wf_2"
+    }
+
+    func testGetWorkflowsListColdCacheBlocksUntilFetchCompletes() {
+        // With no cached map yet, there's nothing to serve, so `onComplete` must block on the fetch:
+        // callers need a populated offeringId -> workflowId map before `getOfferings` returns.
+        self.mockWorkflowsAPI.shouldStoreGetWorkflowsCompletions = true
+
+        var completed = false
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false) { completed = true }
+
+        expect(completed) == false
+
+        self.mockWorkflowsAPI.completeStoredGetWorkflows(with: .success(.init(workflows: [
+            .init(id: "wf_1", displayName: "A", offeringId: "default", prefetch: false)
+        ])))
+        expect(completed) == true
+        expect(self.manager.cachedWorkflowId(forOfferingId: "default")) == "wf_1"
+    }
+
+    func testGetWorkflowsListStalePresentDropsBackgroundWriteWhenClearedBeforeRefreshLands() throws {
+        // The background list refresh's write is guarded by the generation captured when the stale map
+        // was served. If an identity change clears the cache before the refresh lands, the write is
+        // dropped, so the previous user's offeringId -> workflowId map can't repopulate the new user's
+        // cache. Like the detail drop-after-clear test, this drives the guard directly: the clear is
+        // sequenced after the call, so it passes with or without the capture-before-serve move; the
+        // true sub-statement race is the same lock-free read window the cache accepts by design.
+        self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: [
+            .init(id: "wf_1", displayName: "A", offeringId: "default", prefetch: false)
+        ]))
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+        expect(self.manager.cachedWorkflowId(forOfferingId: "default")) == "wf_1"
+
+        self.dateProvider.advance(by: 6 * 60)
+        self.mockWorkflowsAPI.shouldStoreGetWorkflowsCompletions = true
+
+        // Stale hit: serves the cached map and stores the background refresh (capturing the generation).
+        self.manager.getWorkflowsList(appUserID: self.appUserID, isAppBackgrounded: false)
+
+        // Identity change clears the cache (bumping the generation) before the refresh lands.
+        self.workflowsCache.clearCache()
+
+        // The background refresh returns the previous user's list: its write must be dropped.
+        self.mockWorkflowsAPI.completeStoredGetWorkflows(with: .success(.init(workflows: [
+            .init(id: "wf_2", displayName: "B", offeringId: "default", prefetch: false)
+        ])))
+        expect(self.manager.cachedWorkflowId(forOfferingId: "default")).to(beNil())
+    }
+
     func testGetWorkflowsListCallsBackendAndCachesPayload() {
         self.mockWorkflowsAPI.stubbedGetWorkflowsResult = .success(.init(workflows: [
             .init(id: "wf_1", displayName: "Flow A", offeringId: "default", prefetch: false)


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

Follow-up to #6961 (workflow detail stale-while-revalidate), addressing vegaro's review question: when the workflows list is stale, `getWorkflowsList` blocks the caller on the network. Whoever waits on `onComplete` (offerings delivery on the fresh-offerings path) eats a round-trip even though a usable `offeringId -> workflowId` map is already cached.

> **Stacked on #6961.** Review/merge that first; this branches off it.

### Description

`getWorkflowsList` now uses the same stale-while-revalidate shape as the detail, with one twist: for the list, the case that must block is an **empty** cache, not a stale one. You can serve a stale map (and `cachedWorkflowId(forOfferingId:)` already does, regardless of staleness), but you can't serve a map you've never fetched.

- fresh: `onComplete` immediately (unchanged)
- **stale but present**: serve the cached map (`onComplete` now), refresh + re-prefetch in the background
- **cold / empty**: block on the fetch, since `cachedWorkflowId(forOfferingId:)` must resolve once `onComplete` fires (this is what `deliverEnsuringWorkflowsList` relies on)

```mermaid
flowchart TD
    A([getWorkflowsList]) --> B{list cache stale?}
    B -->|no, fresh| FRESH["onComplete now"]
    B -->|yes| P{map already cached?}
    P -->|"yes (stale but present)"| SWR["capture generation G,<br/>onComplete now,<br/>refresh + re-prefetch in background"]
    P -->|"no (cold / empty)"| COLD["block: fetch, then onComplete<br/>(map must resolve before getOfferings returns)"]
    SWR --> WRITE["guarded list write"]
    COLD --> WRITE
    WRITE --> G{generation still G?}
    G -->|yes| OK["update map + prefetch details"]
    G -->|"no: clearCache on login/logout"| DROP["drop write,<br/>keeps prev user's map out"]
```

No new stale exposure: the in-memory map is already served stale by `cachedWorkflowId(forOfferingId:)` between refreshes today. This just stops blocking `getOfferings` on the refresh. The background list write stays generation-guarded (and the guarding generation is captured before serving), so the #6961 cross-user guarantee holds.

<details>
<summary>AI session context</summary>

## Metadata

- PR: follow-up to #6961, workflows **list** stale-while-revalidate
- Branch: `facu/workflow-list-swr` (stacked on `facu/workflow-detail-swr`)
- Author / human owner: facumenzella
- Agent(s): Claude Code (Opus 4.8, 1M context)
- Generated: 2026-06-09
- Context document version: 1

## Goal

Give the workflows list the same stale-while-revalidate behavior as the detail, so a stale-but-present `offeringId -> workflowId` map is served immediately instead of blocking the caller on the network.

## Initial Prompt

vegaro approved #6961 and asked "We need to do the same for `getWorkflows` right? Otherwise it blocks on a stale cache." After confirming the cache exposes a present-vs-empty distinction (`cachedList.value != nil`), the human asked to open this follow-up.

## Agent Contribution

- Added `WorkflowsCache.hasCachedWorkflowsList` (lock-free, present-regardless-of-staleness).
- Split the list fetch body into `fetchAndCacheWorkflowsList`; `getWorkflowsList` now branches fresh / stale-present (serve + background refresh) / cold (block).
- Captured the background refresh's generation guard before serving (same fix codex flagged on #6961's detail path), with an `ifGeneration:` param mirroring `getWorkflow`.
- Added `shouldStoreGetWorkflowsCompletions` / `completeStoredGetWorkflows` to `MockWorkflowsAPI` to control list-fetch timing.
- TDD: serve-stale-immediately test written first, watched fail (caller blocked) before implementing.

## Human Decisions

- Do the list as a separate follow-up stacked on #6961.
- Block only on the cold/empty cache; serve stale-but-present.

## Files / Symbols Touched

- `Sources/Purchasing/WorkflowManager.swift` - `getWorkflowsList`, new `fetchAndCacheWorkflowsList(... ifGeneration:)`.
- `Sources/Caching/WorkflowsCache.swift` - `hasCachedWorkflowsList`.
- `Tests/UnitTests/Purchasing/WorkflowManagerTests.swift` - 3 new tests.
- `Tests/UnitTests/Mocks/MockWorkflowsAPI.swift` - stored-completion support for `getWorkflows`.

## Validation

- `xcodebuild test` (iPhone 15 sim): `WorkflowManagerTests` (51), `OfferingsManagerTests`, `PurchasesWorkflowTests`, `WorkflowsCacheTests` all green.
- `swiftlint` on changed files: clean.
- Manual verification: Not run.

## Validation Gaps

- The drop-after-clear test drives the generation guard directly; the true sub-statement race (a clear between reading the served map and capturing the generation) is the same lock-free read window the cache accepts by design and isn't deterministically reproducible here.
- `OfferingsManagerTests` pass but were not confirmed to exercise the fresh-offerings + stale-but-present-list path specifically; that path is covered at the `WorkflowManager` level.

## Review Focus

- The block case is empty/cold, not stale (you can't serve a map you don't have); `deliverEnsuringWorkflowsList`'s "map resolves right after getOfferings" invariant still holds.
- Generation captured before `onComplete` on the SWR path; background write dropped on a racing `clearCache()`.

## Non-goals / Out of Scope

- The offerings cache. The detail SWR (its own PR, #6961).

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes offerings-adjacent list delivery and identity-generation guarding on background writes; behavior is well-tested but affects when getOfferings unblocks relative to network refresh.
> 
> **Overview**
> **`getWorkflowsList`** now uses **stale-while-revalidate** for the workflows list, aligned with workflow detail and offerings: when the list is **stale but already in memory**, **`onComplete` runs immediately** and list fetch plus prefetch run in the background, so offerings delivery is not blocked on a network round-trip for a map that was already usable.
> 
> **Only a cold/empty cache** still blocks **`onComplete`** until the fetch (and prefetches) finish, preserving the invariant that **`cachedWorkflowId(forOfferingId:)`** can resolve after **`getOfferings`** when nothing was cached yet.
> 
> **`WorkflowsCache`** adds **`hasCachedWorkflowsList`** to distinguish present-vs-empty. List fetch logic moves into **`fetchAndCacheWorkflowsList`**, with the background refresh’s **cache generation captured before serving** so a late list write is dropped after login/logout. **`MockWorkflowsAPI`** gains deferred **`getWorkflows`** completions; **three unit tests** cover immediate stale serve, cold blocking, and generation-guarded drop on clear.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b57a78c142c4d2c669dbd39856d3c4d6b2c2de68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->