### PR TITLE
Thread customerInfo through PaywallView initializers

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -73,6 +73,10 @@ public struct PaywallView: View {
     ///
     /// - Parameter fonts: An optional ``PaywallFontProvider``.
     /// - Parameter displayCloseButton: Set this to `true` to automatically include a close button.
+    /// - Parameter customerInfo: Optional pre-loaded ``CustomerInfo``. Pass the cached value from
+    /// ``Purchases/customerInfo()`` to skip the skeleton loading state on the first paywall presentation.
+    /// When `nil`, the SDK falls back to the cached value if available and otherwise fetches asynchronously,
+    /// which can briefly surface ``LoadingPaywallView``.
     ///
     /// - Note: If loading the current `Offering` fails (if the user is offline, for example),
     /// an error will be displayed.
@@ -81,12 +85,14 @@ public struct PaywallView: View {
     public init(
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         displayCloseButton: Bool = false,
+        customerInfo: CustomerInfo? = nil,
         performPurchase: PerformPurchase? = nil,
         performRestore: PerformRestore? = nil
     ) {
         let purchaseHandler = PurchaseHandler.default(performPurchase: performPurchase, performRestore: performRestore)
         self.init(
             configuration: .init(
+                customerInfo: customerInfo,
                 fonts: fonts,
                 displayCloseButton: displayCloseButton,
                 purchaseHandler: purchaseHandler
@@ -99,6 +105,8 @@ public struct PaywallView: View {
     /// - Parameter offering: The `Offering` containing the desired paywall to display.
     /// - Parameter fonts: An optional `PaywallFontProvider`.
     /// - Parameter displayCloseButton: Set this to `true` to automatically include a close button.
+    /// - Parameter customerInfo: Optional pre-loaded ``CustomerInfo``. Pass the cached value from
+    /// ``Purchases/customerInfo()`` to skip the skeleton loading state on the first paywall presentation.
     ///
     /// - Note: if `offering` does not have a current paywall (`hasPaywall == false`), or it fails to load
     /// due to invalid data, a default paywall will be displayed.
@@ -108,6 +116,7 @@ public struct PaywallView: View {
         offering: Offering,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         displayCloseButton: Bool = false,
+        customerInfo: CustomerInfo? = nil,
         performPurchase: PerformPurchase? = nil,
         performRestore: PerformRestore? = nil
     ) {
@@ -116,6 +125,7 @@ public struct PaywallView: View {
             fonts: fonts,
             displayCloseButton: displayCloseButton,
             useDraftPaywall: false,
+            customerInfo: customerInfo,
             performPurchase: performPurchase,
             performRestore: performRestore
             )
@@ -128,6 +138,7 @@ public struct PaywallView: View {
         displayCloseButton: Bool = false,
         useDraftPaywall: Bool,
         introEligibility: TrialOrIntroEligibilityChecker? = nil,
+        customerInfo: CustomerInfo? = nil,
         performPurchase: PerformPurchase? = nil,
         performRestore: PerformRestore? = nil
     ) {
@@ -136,6 +147,7 @@ public struct PaywallView: View {
         self.init(
             configuration: .init(
                 offering: offering,
+                customerInfo: customerInfo,
                 fonts: fonts,
                 displayCloseButton: displayCloseButton,
                 useDraftPaywall: useDraftPaywall,

--- a/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/PaywallViewAPI.swift
+++ b/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/PaywallViewAPI.swift
@@ -32,6 +32,7 @@ struct App: View {
     #endif
     private var paywallDismissed: () -> Void = {}
     private var requestedDismissal: () -> Void = {}
+    private var preloadedCustomerInfo: CustomerInfo? = nil
 
     var body: some View {
         self.content
@@ -45,10 +46,19 @@ struct App: View {
         PaywallView(displayCloseButton: true)
         PaywallView(fonts: self.fonts)
         PaywallView(fonts: self.fonts, displayCloseButton: true)
+        PaywallView(customerInfo: self.preloadedCustomerInfo)
+        PaywallView(fonts: self.fonts, displayCloseButton: true, customerInfo: self.preloadedCustomerInfo)
         PaywallView(offering: self.offering)
         PaywallView(offering: self.offering, displayCloseButton: true)
         PaywallView(offering: self.offering, fonts: self.fonts)
         PaywallView(offering: self.offering, fonts: self.fonts, displayCloseButton: true)
+        PaywallView(offering: self.offering, customerInfo: self.preloadedCustomerInfo)
+        PaywallView(
+            offering: self.offering,
+            fonts: self.fonts,
+            displayCloseButton: true,
+            customerInfo: self.preloadedCustomerInfo
+        )
     }
 
     @ViewBuilder


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [x] If applicable, create follow-up issues for \`purchases-android\` and hybrids

### Motivation
Resolves #6389

\`PaywallView\`'s public initializers built a \`PaywallViewConfiguration\` without ever passing the caller's \`CustomerInfo\`, so the configuration always fell back to \`loadCachedCustomerInfoIfPossible()\`. On the first paywall presentation in a session the cache is empty, \`LoadingPaywallView\` flashes, and only then does the async \`Purchases.shared.customerInfo()\` resolve — exactly what the issue reporter walked through line-by-line.

### Description
Adds an optional \`customerInfo: CustomerInfo? = nil\` parameter to the three \`PaywallView\` inits and forwards it into \`PaywallViewConfiguration\`, which already accepts \`customerInfo\`. Apps that already hold a fresh \`CustomerInfo\` (from \`Purchases.shared.customerInfo()\`) can now hand it to \`PaywallView\` directly and skip the skeleton state.

Source-compatible: the parameter has a default, so every existing call site compiles unchanged.

No unit test added — \`PaywallView\` \`@State\` init wiring isn't unit-testable per the existing comment at [PaywallView.swift:166-168](https://github.com/RevenueCat/purchases-ios/blob/main/RevenueCatUI/PaywallView.swift#L166). I extended \`RevenueCatUISwiftAPITester/PaywallViewAPI.swift\` so the new parameter is pinned by the API tester (caught by \`run_api_tests\` in CI).

Follow-up: a matching change in \`purchases-android\` is worth filing if the parallel \`PaywallView\` composable has the same gap — happy to do that as a separate issue once this lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Source-compatible API addition with default nil; only affects initial paywall state seeding, not purchase or entitlement logic.
> 
> **Overview**
> Adds an optional **`customerInfo`** argument to the public **`PaywallView`** initializers (default/current offering, explicit offering, and internal SPI offering init) and passes it into **`PaywallViewConfiguration`**, which already knew how to seed **`@State`**. Apps that already have **`CustomerInfo`** from **`Purchases.shared.customerInfo()`** can supply it at construction time so the paywall can render with subscription state immediately instead of briefly showing the redacted **`LoadingPaywallView`** while **`customerInfo`** is fetched on a cold cache.
> 
> Doc comments explain the intended use (pre-load to skip skeleton) and that **`nil`** keeps the existing cache-then-async-fetch behavior. **`RevenueCatUISwiftAPITester/PaywallViewAPI.swift`** is extended so CI API tests cover the new overloads; existing call sites stay unchanged thanks to the default parameter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b869aa54b536bea17841abd9da35320cc5d1111f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->