### PR TITLE
feat(workflows): fall back to persisted detail on transient fetch errors

### DIFF
--- a/Sources/Caching/WorkflowsCache.swift
+++ b/Sources/Caching/WorkflowsCache.swift
@@ -91,10 +91,17 @@ final class WorkflowsCache {
     /// `forceCacheStale`); the detail fetch calls it on a terminal error that produced no fresh value,
     /// matching how the list and offerings invalidate their cache on the same failures. No-op when
     /// nothing is cached for the id.
+    ///
+    /// Only mutates an entry that is already present (it never inserts), so it can't revive a since-cleared
+    /// detail. Held under ``detailsLock`` like the other detail-cache mutators, so it's serialized against
+    /// ``clearCache()``: an async fetch failure landing during a log-in/log-out either runs before the
+    /// wipe (and is then wiped) or after it (and finds nothing to mutate).
     func invalidateWorkflowTimestamp(workflowId: String) {
-        self.cachedWorkflows.modify { cache in
-            guard let existing = cache[workflowId] else { return }
-            cache[workflowId] = CachedWorkflow(result: existing.result, lastUpdated: .distantPast)
+        self.detailsLock.perform {
+            self.cachedWorkflows.modify { cache in
+                guard let existing = cache[workflowId] else { return }
+                cache[workflowId] = CachedWorkflow(result: existing.result, lastUpdated: .distantPast)
+            }
         }
     }
 
@@ -134,11 +141,29 @@ final class WorkflowsCache {
         return self.cacheGeneration.value
     }
 
-    /// Returns the persisted detail for `workflowId`, or `nil` when the key is absent or nothing is
-    /// persisted. Convenience wrapper over the on-disk detail map, used by the detail fetch's disk
-    /// fallback to recover a single resolved workflow after a transient backend failure.
-    func cachedWorkflowDetailFromDisk(workflowId: String) -> WorkflowDataResult? {
-        return self.deviceCache.cachedWorkflowDetails()?[workflowId]
+    /// Recovers `workflowId`'s persisted detail into the in-memory cache (re-stamped fresh) and returns
+    /// it, but only if `generation` still matches the current one. Used by the detail fetch's disk
+    /// fallback after a transient backend failure.
+    ///
+    /// Returns `nil` when nothing is persisted for the id, or when an identity change cleared the cache
+    /// after the fetch was issued (``clearCache()`` bumped the generation). Returning `nil` in that case
+    /// is the whole point: the caller then surfaces the original error instead of delivering the previous
+    /// user's (user-scoped) detail, and the in-memory write is never made.
+    ///
+    /// The generation check, the disk read, and the memory write all run under ``detailsLock`` together,
+    /// so the recovery is atomic w.r.t. ``clearCache()`` (which clears the same disk + memory stores
+    /// under the lock): a clear can't land between reading disk and writing memory.
+    func recoverWorkflowDetailFromDisk(workflowId: String, ifGeneration generation: Int) -> WorkflowDataResult? {
+        return self.detailsLock.perform {
+            guard self.cacheGeneration.value == generation,
+                  let result = self.deviceCache.cachedWorkflowDetails()?[workflowId] else {
+                return nil
+            }
+            self.cachedWorkflows.modify {
+                $0[workflowId] = CachedWorkflow(result: result, lastUpdated: self.dateProvider.now())
+            }
+            return result
+        }
     }
 
     /// Restores the persisted prefetched details into the in-memory cache, stamped fresh so

--- a/Sources/Caching/WorkflowsCache.swift
+++ b/Sources/Caching/WorkflowsCache.swift
@@ -84,6 +84,20 @@ final class WorkflowsCache {
         }
     }
 
+    /// Marks `workflowId`'s in-memory detail entry stale so the next
+    /// ``isWorkflowCacheStale(workflowId:isAppBackgrounded:)`` reports it stale and a subsequent fetch
+    /// retries rather than serving the still-cached value. The
+    /// per-workflow analogue of ``forceWorkflowsListCacheStale()`` (and of the offerings cache's
+    /// `forceCacheStale`); the detail fetch calls it on a terminal error that produced no fresh value,
+    /// matching how the list and offerings invalidate their cache on the same failures. No-op when
+    /// nothing is cached for the id.
+    func invalidateWorkflowTimestamp(workflowId: String) {
+        self.cachedWorkflows.modify { cache in
+            guard let existing = cache[workflowId] else { return }
+            cache[workflowId] = CachedWorkflow(result: existing.result, lastUpdated: .distantPast)
+        }
+    }
+
     // MARK: - Workflow detail disk cache
 
     /// Persists a batch of resolved workflow details to disk, merging into whatever is already there.
@@ -118,6 +132,13 @@ final class WorkflowsCache {
     /// change.
     func currentCacheGeneration() -> Int {
         return self.cacheGeneration.value
+    }
+
+    /// Returns the persisted detail for `workflowId`, or `nil` when the key is absent or nothing is
+    /// persisted. Convenience wrapper over the on-disk detail map, used by the detail fetch's disk
+    /// fallback to recover a single resolved workflow after a transient backend failure.
+    func cachedWorkflowDetailFromDisk(workflowId: String) -> WorkflowDataResult? {
+        return self.deviceCache.cachedWorkflowDetails()?[workflowId]
     }
 
     /// Restores the persisted prefetched details into the in-memory cache, stamped fresh so

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -136,21 +136,27 @@ class WorkflowManager {
         }
     }
 
-    /// Resolves a workflow fetch failure with the same cache-fallback policy offerings and the
-    /// workflows list use, gated on ``BackendError/shouldFallBackToCache``. A 4xx is the backend
-    /// authoritatively rejecting the request, so the persisted copy is not served; a transient error
-    /// (transport / 5xx / malformed body) recovers the last persisted detail when one exists. Shared by
-    /// the blocking miss path and the stale-while-revalidate background refresh.
+    /// Resolves a workflow fetch failure with a disk-recovery policy modeled on offerings and the
+    /// workflows list. Only a transient network failure (transport / 5xx / malformed body) recovers the
+    /// last persisted detail; a 4xx (the backend authoritatively rejecting the request) or a
+    /// non-network error (e.g. a missing app user ID, a configuration/identity failure) surfaces the
+    /// error instead of serving the persisted, user-targeted copy. Shared by the blocking miss path and
+    /// the stale-while-revalidate background refresh.
     private func handleWorkflowFetchFailure(
         _ error: BackendError,
         workflowId: String,
         ifGeneration generation: Int,
         completion: @escaping (Result<WorkflowDataResult, BackendError>) -> Void
     ) {
-        guard error.shouldFallBackToCache else {
-            // 4xx: the server intentionally changed/removed this workflow, so don't serve the persisted
-            // copy. Invalidate the in-memory entry so the next call retries rather than serving a still-
-            // cached value, mirroring the list's 4xx gate and offerings' `forceCacheStale`.
+        // Gate on the underlying ``NetworkError`` rather than ``BackendError/shouldFallBackToCache``,
+        // which is `true` for every non-network case: a config/identity error like `missingAppUserID`
+        // is not transient and must not serve persisted data. The fallback-eligible statuses (transport
+        // / 5xx / malformed body) are all `.networkError` cases, matching the Android port, which only
+        // falls back on those.
+        guard case .networkError(let networkError) = error, networkError.shouldFallBackToCache else {
+            // 4xx or non-network error: don't serve the persisted copy. Invalidate the in-memory entry
+            // so the next call retries rather than serving a still-cached value, mirroring the list's
+            // 4xx gate and offerings' `forceCacheStale`.
             self.workflowsCache.invalidateWorkflowTimestamp(workflowId: workflowId)
             completion(.failure(error))
             return

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -163,19 +163,21 @@ class WorkflowManager {
         }
 
         // Transport error / 5xx / malformed body: the backend is unavailable, not refusing. Recover the
-        // last persisted detail if we have one, matching offerings' disk fallback. The recovered result
-        // was already asset-warmed when first persisted (and `restoreWorkflowDetailsFromDisk` likewise
-        // doesn't re-warm), so we don't warm it again here.
-        guard let cached = self.workflowsCache.cachedWorkflowDetailFromDisk(workflowId: workflowId) else {
-            // Nothing on disk to recover: invalidate so the next call retries, and surface the original
-            // error so the caller is never left without a response.
+        // last persisted detail if we have one, matching offerings' disk fallback. The recovery reads
+        // disk, re-stamps the entry fresh, and writes it back atomically under the cache lock, guarded by
+        // the same generation as the fetch: if a `clearCache()` (login/logout) landed since the fetch was
+        // issued it returns nil, so we never deliver the previous user's (user-scoped) detail. The
+        // recovered result was already asset-warmed when first persisted (and
+        // `restoreWorkflowDetailsFromDisk` likewise doesn't re-warm), so we don't warm it again here.
+        let recovered = self.workflowsCache.recoverWorkflowDetailFromDisk(workflowId: workflowId,
+                                                                          ifGeneration: generation)
+        guard let cached = recovered else {
+            // Nothing recoverable (no persisted detail, or the cache was cleared mid-flight): invalidate
+            // so the next call retries, and surface the original error so the caller always gets a response.
             self.workflowsCache.invalidateWorkflowTimestamp(workflowId: workflowId)
             completion(.failure(error))
             return
         }
-        // Re-cache in memory (which re-stamps it fresh), guarded by the same generation as the fetch so a
-        // clear landing mid-flight still drops the write, then deliver the recovered value.
-        self.workflowsCache.cache(workflow: cached, workflowId: workflowId, ifGeneration: generation)
         completion(.success(cached))
     }
 

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -120,14 +120,57 @@ class WorkflowManager {
                 completion(result)
                 return
             }
-            if case let .success(dataResult) = result {
+            switch result {
+            case let .success(dataResult):
                 self.workflowsCache.cache(workflow: dataResult,
                                           workflowId: workflowId,
                                           ifGeneration: writeGeneration)
                 self.warmUpAssets(for: dataResult)
+                completion(.success(dataResult))
+            case let .failure(error):
+                self.handleWorkflowFetchFailure(error,
+                                                workflowId: workflowId,
+                                                ifGeneration: writeGeneration,
+                                                completion: completion)
             }
-            completion(result)
         }
+    }
+
+    /// Resolves a workflow fetch failure with the same cache-fallback policy offerings and the
+    /// workflows list use, gated on ``BackendError/shouldFallBackToCache``. A 4xx is the backend
+    /// authoritatively rejecting the request, so the persisted copy is not served; a transient error
+    /// (transport / 5xx / malformed body) recovers the last persisted detail when one exists. Shared by
+    /// the blocking miss path and the stale-while-revalidate background refresh.
+    private func handleWorkflowFetchFailure(
+        _ error: BackendError,
+        workflowId: String,
+        ifGeneration generation: Int,
+        completion: @escaping (Result<WorkflowDataResult, BackendError>) -> Void
+    ) {
+        guard error.shouldFallBackToCache else {
+            // 4xx: the server intentionally changed/removed this workflow, so don't serve the persisted
+            // copy. Invalidate the in-memory entry so the next call retries rather than serving a still-
+            // cached value, mirroring the list's 4xx gate and offerings' `forceCacheStale`.
+            self.workflowsCache.invalidateWorkflowTimestamp(workflowId: workflowId)
+            completion(.failure(error))
+            return
+        }
+
+        // Transport error / 5xx / malformed body: the backend is unavailable, not refusing. Recover the
+        // last persisted detail if we have one, matching offerings' disk fallback. The recovered result
+        // was already asset-warmed when first persisted (and `restoreWorkflowDetailsFromDisk` likewise
+        // doesn't re-warm), so we don't warm it again here.
+        guard let cached = self.workflowsCache.cachedWorkflowDetailFromDisk(workflowId: workflowId) else {
+            // Nothing on disk to recover: invalidate so the next call retries, and surface the original
+            // error so the caller is never left without a response.
+            self.workflowsCache.invalidateWorkflowTimestamp(workflowId: workflowId)
+            completion(.failure(error))
+            return
+        }
+        // Re-cache in memory (which re-stamps it fresh), guarded by the same generation as the fetch so a
+        // clear landing mid-flight still drops the write, then deliver the recovered value.
+        self.workflowsCache.cache(workflow: cached, workflowId: workflowId, ifGeneration: generation)
+        completion(.success(cached))
     }
 
     /// Fetches the workflows list, persists it, then prefetches every entry flagged `prefetch == true`.

--- a/Tests/UnitTests/Caching/WorkflowsCacheTests.swift
+++ b/Tests/UnitTests/Caching/WorkflowsCacheTests.swift
@@ -283,21 +283,44 @@ class WorkflowsCacheTests: TestCase {
         expect(self.deviceCache.cachedWorkflowDetailsParameter?["wf_1"]).toNot(beNil())
     }
 
-    func testCachedWorkflowDetailFromDiskReturnsPersistedDetail() throws {
+    func testRecoverWorkflowDetailFromDiskRestoresFreshIntoMemoryAndReturnsIt() throws {
         let result = try Self.workflowDataResult(id: "wf_1")
         self.deviceCache.stubbedCachedWorkflowDetails = ["wf_1": result]
 
-        expect(self.cache.cachedWorkflowDetailFromDisk(workflowId: "wf_1")) == result
+        let recovered = self.cache.recoverWorkflowDetailFromDisk(workflowId: "wf_1",
+                                                                 ifGeneration: self.cache.currentCacheGeneration())
+
+        expect(recovered) == result
+        // Recovered into memory and re-stamped fresh so the next call serves it without a refetch.
+        expect(self.cache.cachedWorkflow(workflowId: "wf_1")) == result
+        expect(self.cache.isWorkflowCacheStale(workflowId: "wf_1", isAppBackgrounded: false)) == false
     }
 
-    func testCachedWorkflowDetailFromDiskReturnsNilForMissingKey() throws {
+    func testRecoverWorkflowDetailFromDiskReturnsNilForMissingKey() throws {
         self.deviceCache.stubbedCachedWorkflowDetails = ["wf_1": try Self.workflowDataResult(id: "wf_1")]
-        expect(self.cache.cachedWorkflowDetailFromDisk(workflowId: "wf_2")).to(beNil())
+        expect(self.cache.recoverWorkflowDetailFromDisk(workflowId: "wf_2",
+                                                        ifGeneration: self.cache.currentCacheGeneration())).to(beNil())
+        expect(self.cache.cachedWorkflow(workflowId: "wf_2")).to(beNil())
     }
 
-    func testCachedWorkflowDetailFromDiskReturnsNilWhenNothingPersisted() {
+    func testRecoverWorkflowDetailFromDiskReturnsNilWhenNothingPersisted() {
         self.deviceCache.stubbedCachedWorkflowDetails = nil
-        expect(self.cache.cachedWorkflowDetailFromDisk(workflowId: "wf_1")).to(beNil())
+        expect(self.cache.recoverWorkflowDetailFromDisk(workflowId: "wf_1",
+                                                        ifGeneration: self.cache.currentCacheGeneration())).to(beNil())
+    }
+
+    func testRecoverWorkflowDetailFromDiskIsDroppedWhenGenerationChanged() throws {
+        // A fetch captured the generation, then an identity change cleared the cache (bumping it). The
+        // disk recovery must be dropped: it returns nil and writes nothing, so the caller surfaces the
+        // error instead of delivering the previous user's detail.
+        self.deviceCache.stubbedCachedWorkflowDetails = ["wf_1": try Self.workflowDataResult(id: "wf_1")]
+        let staleGeneration = self.cache.currentCacheGeneration()
+        self.cache.clearCache()
+
+        let recovered = self.cache.recoverWorkflowDetailFromDisk(workflowId: "wf_1", ifGeneration: staleGeneration)
+
+        expect(recovered).to(beNil())
+        expect(self.cache.cachedWorkflow(workflowId: "wf_1")).to(beNil())
     }
 
     // MARK: - Restore from disk

--- a/Tests/UnitTests/Caching/WorkflowsCacheTests.swift
+++ b/Tests/UnitTests/Caching/WorkflowsCacheTests.swift
@@ -104,6 +104,24 @@ class WorkflowsCacheTests: TestCase {
         expect(self.cache.isWorkflowCacheStale(workflowId: "wf_2", isAppBackgrounded: false)) == false
     }
 
+    func testInvalidateWorkflowTimestampMarksFreshEntryStaleWhileKeepingItRetrievable() throws {
+        let result = try Self.workflowDataResult(id: "wf_1")
+        self.seedWorkflow(result, workflowId: "wf_1")
+        expect(self.cache.isWorkflowCacheStale(workflowId: "wf_1", isAppBackgrounded: false)) == false
+
+        self.cache.invalidateWorkflowTimestamp(workflowId: "wf_1")
+
+        // Marked stale so the next fetch retries, but the value is still served until then.
+        expect(self.cache.isWorkflowCacheStale(workflowId: "wf_1", isAppBackgrounded: false)) == true
+        expect(self.cache.cachedWorkflow(workflowId: "wf_1")) == result
+    }
+
+    func testInvalidateWorkflowTimestampIsNoOpWhenNothingCached() {
+        self.cache.invalidateWorkflowTimestamp(workflowId: "wf_1")
+        expect(self.cache.cachedWorkflow(workflowId: "wf_1")).to(beNil())
+        expect(self.cache.isWorkflowCacheStale(workflowId: "wf_1", isAppBackgrounded: false)) == true
+    }
+
     // MARK: - Workflows list cache
 
     func testIsWorkflowsListCacheStaleIsTrueInitiallyAndFalseAfterCaching() {
@@ -263,6 +281,23 @@ class WorkflowsCacheTests: TestCase {
                                                 ifGeneration: self.cache.currentCacheGeneration())
 
         expect(self.deviceCache.cachedWorkflowDetailsParameter?["wf_1"]).toNot(beNil())
+    }
+
+    func testCachedWorkflowDetailFromDiskReturnsPersistedDetail() throws {
+        let result = try Self.workflowDataResult(id: "wf_1")
+        self.deviceCache.stubbedCachedWorkflowDetails = ["wf_1": result]
+
+        expect(self.cache.cachedWorkflowDetailFromDisk(workflowId: "wf_1")) == result
+    }
+
+    func testCachedWorkflowDetailFromDiskReturnsNilForMissingKey() throws {
+        self.deviceCache.stubbedCachedWorkflowDetails = ["wf_1": try Self.workflowDataResult(id: "wf_1")]
+        expect(self.cache.cachedWorkflowDetailFromDisk(workflowId: "wf_2")).to(beNil())
+    }
+
+    func testCachedWorkflowDetailFromDiskReturnsNilWhenNothingPersisted() {
+        self.deviceCache.stubbedCachedWorkflowDetails = nil
+        expect(self.cache.cachedWorkflowDetailFromDisk(workflowId: "wf_1")).to(beNil())
     }
 
     // MARK: - Restore from disk

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -235,6 +235,111 @@ class WorkflowManagerTests: TestCase {
         expect(self.workflowsCache.cachedWorkflow(workflowId: "wf_1")).to(beNil())
     }
 
+    // MARK: - getWorkflow fetch fallback
+
+    func testGetWorkflowFallsBackToDiskDetailOnServerErrorAndDeliversSuccess() throws {
+        // A 5xx is transient: recover the last persisted detail from disk, cache it fresh, and deliver it,
+        // mirroring how offerings and the workflows list fall back on `shouldFallBackToCache`.
+        let persisted = try Self.workflowDataResult(id: "wf_1")
+        self.mockDeviceCache.stubbedCachedWorkflowDetails = ["wf_1": persisted]
+        self.mockWorkflowsAPI.stubbedGetWorkflowResult = .failure(
+            .networkError(.errorResponse(.init(code: .unknownError, originalCode: 0), .internalServerError))
+        )
+
+        var served: WorkflowDataResult?
+        var erroredWith: BackendError?
+        self.manager.getWorkflow(appUserID: self.appUserID, workflowId: "wf_1", isAppBackgrounded: false) {
+            switch $0 {
+            case let .success(result): served = result
+            case let .failure(error): erroredWith = error
+            }
+        }
+
+        expect(served) == persisted
+        expect(erroredWith).to(beNil())
+        // Recovered into memory and re-stamped fresh so the next call serves it without a refetch.
+        expect(self.workflowsCache.cachedWorkflow(workflowId: "wf_1")) == persisted
+        expect(self.workflowsCache.isWorkflowCacheStale(workflowId: "wf_1", isAppBackgrounded: false)) == false
+    }
+
+    func testGetWorkflowDoesNotFallBackToDiskDetailOnClientError() throws {
+        // A 4xx means the backend rejected the request (workflow removed/disabled), so the persisted
+        // copy must not be served; the error surfaces instead.
+        self.mockDeviceCache.stubbedCachedWorkflowDetails = ["wf_1": try Self.workflowDataResult(id: "wf_1")]
+        self.mockWorkflowsAPI.stubbedGetWorkflowResult = .failure(
+            .networkError(.errorResponse(.init(code: .invalidAPIKey, originalCode: 0), .invalidRequest))
+        )
+
+        var served: WorkflowDataResult?
+        var erroredWith: BackendError?
+        self.manager.getWorkflow(appUserID: self.appUserID, workflowId: "wf_1", isAppBackgrounded: false) {
+            switch $0 {
+            case let .success(result): served = result
+            case let .failure(error): erroredWith = error
+            }
+        }
+
+        expect(served).to(beNil())
+        expect(erroredWith).toNot(beNil())
+        // The persisted copy was not served into memory.
+        expect(self.workflowsCache.cachedWorkflow(workflowId: "wf_1")).to(beNil())
+    }
+
+    func testGetWorkflowSurfacesErrorWhenFallbackEligibleButNoDiskDetail() {
+        // A transient error but nothing persisted to recover: surface the original error rather than
+        // leaving the caller without a response.
+        self.mockDeviceCache.stubbedCachedWorkflowDetails = nil
+        self.mockWorkflowsAPI.stubbedGetWorkflowResult = .failure(
+            .networkError(.errorResponse(.init(code: .unknownError, originalCode: 0), .internalServerError))
+        )
+
+        var served: WorkflowDataResult?
+        var erroredWith: BackendError?
+        self.manager.getWorkflow(appUserID: self.appUserID, workflowId: "wf_1", isAppBackgrounded: false) {
+            switch $0 {
+            case let .success(result): served = result
+            case let .failure(error): erroredWith = error
+            }
+        }
+
+        expect(served).to(beNil())
+        expect(erroredWith).toNot(beNil())
+        expect(self.workflowsCache.cachedWorkflow(workflowId: "wf_1")).to(beNil())
+    }
+
+    func testGetWorkflowStaleHitRePinsFromDiskWhenBackgroundRefreshFails() throws {
+        // Stale-while-revalidate: a fallback-eligible background-refresh failure recovers the persisted
+        // detail and re-stamps the cache fresh, mirroring `OfferingsManager`'s disk fallback. The disk
+        // copy (the persisted prefetched detail) can differ from the in-memory value, so the cache ends
+        // up holding the recovered disk copy.
+        self.mockWorkflowsAPI.shouldStoreGetWorkflowCompletions = true
+        let inMemory = try Self.workflowDataResult(id: "in_memory")
+        let persisted = try Self.workflowDataResult(id: "persisted")
+        self.mockDeviceCache.stubbedCachedWorkflowDetails = ["wf_1": persisted]
+
+        // First call populates memory with the in-memory value.
+        self.manager.getWorkflow(appUserID: self.appUserID, workflowId: "wf_1", isAppBackgrounded: false) { _ in }
+        self.mockWorkflowsAPI.completeStoredGetWorkflow(workflowId: "wf_1", with: .success(inMemory))
+        expect(self.workflowsCache.cachedWorkflow(workflowId: "wf_1")) == inMemory
+
+        // Past the foreground TTL: the entry is stale-but-present.
+        self.dateProvider.advance(by: 6 * 60)
+
+        var served: WorkflowDataResult?
+        self.manager.getWorkflow(appUserID: self.appUserID, workflowId: "wf_1", isAppBackgrounded: false) {
+            served = try? $0.get()
+        }
+        // Served the stale in-memory value immediately.
+        expect(served) == inMemory
+
+        // The background refresh fails fallback-eligibly: it re-pins from disk and re-stamps fresh.
+        self.mockWorkflowsAPI.completeStoredGetWorkflow(workflowId: "wf_1", with: .failure(
+            .networkError(.errorResponse(.init(code: .unknownError, originalCode: 0), .internalServerError))
+        ))
+        expect(self.workflowsCache.cachedWorkflow(workflowId: "wf_1")) == persisted
+        expect(self.workflowsCache.isWorkflowCacheStale(workflowId: "wf_1", isAppBackgrounded: false)) == false
+    }
+
     // MARK: - getWorkflowsList
 
     func testGetWorkflowsListStalePresentServesImmediatelyAndRefreshesInBackground() {

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -328,6 +328,34 @@ class WorkflowManagerTests: TestCase {
         expect(self.workflowsCache.cachedWorkflow(workflowId: "wf_1")).to(beNil())
     }
 
+    func testGetWorkflowDoesNotDeliverDiskFallbackWhenCacheClearedDuringFetch() throws {
+        // The disk recovery is generation-guarded: if an identity change clears the cache after the fetch
+        // is issued but before its transient failure lands, the previous user's persisted (user-scoped)
+        // detail must not be delivered. The caller gets the error and memory stays empty.
+        self.mockWorkflowsAPI.shouldStoreGetWorkflowCompletions = true
+        self.mockDeviceCache.stubbedCachedWorkflowDetails = ["wf_1": try Self.workflowDataResult(id: "wf_1")]
+
+        // Issue the fetch (captures the current generation), then an identity change clears the cache.
+        var served: WorkflowDataResult?
+        var erroredWith: BackendError?
+        self.manager.getWorkflow(appUserID: self.appUserID, workflowId: "wf_1", isAppBackgrounded: false) {
+            switch $0 {
+            case let .success(result): served = result
+            case let .failure(error): erroredWith = error
+            }
+        }
+        self.workflowsCache.clearCache()
+
+        // The fetch now fails transiently: the disk recovery is dropped (generation bumped).
+        self.mockWorkflowsAPI.completeStoredGetWorkflow(workflowId: "wf_1", with: .failure(
+            .networkError(.errorResponse(.init(code: .unknownError, originalCode: 0), .internalServerError))
+        ))
+
+        expect(served).to(beNil())
+        expect(erroredWith).toNot(beNil())
+        expect(self.workflowsCache.cachedWorkflow(workflowId: "wf_1")).to(beNil())
+    }
+
     func testGetWorkflowStaleHitRePinsFromDiskWhenBackgroundRefreshFails() throws {
         // Stale-while-revalidate: a fallback-eligible background-refresh failure recovers the persisted
         // detail and re-stamps the cache fresh, mirroring `OfferingsManager`'s disk fallback. The disk

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -307,6 +307,27 @@ class WorkflowManagerTests: TestCase {
         expect(self.workflowsCache.cachedWorkflow(workflowId: "wf_1")).to(beNil())
     }
 
+    func testGetWorkflowDoesNotFallBackToDiskOnNonNetworkError() throws {
+        // A non-network error (e.g. a missing app user ID) is a configuration/identity failure, not a
+        // transient backend outage, so the persisted (user-targeted) copy must not be served even
+        // though one exists on disk. The original error surfaces instead.
+        self.mockDeviceCache.stubbedCachedWorkflowDetails = ["wf_1": try Self.workflowDataResult(id: "wf_1")]
+        self.mockWorkflowsAPI.stubbedGetWorkflowResult = .failure(.missingAppUserID())
+
+        var served: WorkflowDataResult?
+        var erroredWith: BackendError?
+        self.manager.getWorkflow(appUserID: self.appUserID, workflowId: "wf_1", isAppBackgrounded: false) {
+            switch $0 {
+            case let .success(result): served = result
+            case let .failure(error): erroredWith = error
+            }
+        }
+
+        expect(served).to(beNil())
+        expect(erroredWith).toNot(beNil())
+        expect(self.workflowsCache.cachedWorkflow(workflowId: "wf_1")).to(beNil())
+    }
+
     func testGetWorkflowStaleHitRePinsFromDiskWhenBackgroundRefreshFails() throws {
         // Stale-while-revalidate: a fallback-eligible background-refresh failure recovers the persisted
         // detail and re-stamps the cache fresh, mirroring `OfferingsManager`'s disk fallback. The disk


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

Port of RevenueCat/purchases-android#3567. The workflow detail fetch had no fallback: it surfaced every error immediately, even transient ones, even when a usable detail was already persisted on disk. Offerings and the workflows list both recover from disk on transient failures, the detail path didn't.

> **Stacked on #6965.** Review/merge that first; this branches off it.

### Description

The detail fetch failure now goes through the same cache-fallback policy as offerings and the list:

- **transport / 5xx / malformed body**: the backend is unavailable, not refusing. Recover the last persisted detail from disk, cache it fresh, and deliver it. Falls back to surfacing the original error when nothing is persisted.
- **everything else (4xx, or a non-network error like a missing app user ID)**: don't serve the persisted (user-targeted) copy. Invalidate the in-memory entry so the next call retries, and surface the error.

The gate is on the underlying `NetworkError` (the fallback-eligible statuses are all `.networkError` cases), not `BackendError.shouldFallBackToCache`, so a config/identity error never serves persisted data.

Applies to every caller, including the SWR background refresh. Unlike Android, iOS already encodes the 4xx-vs-transient split in `NetworkError.shouldFallBackToCache` (so no `Backend`/operation signature changes) and persists already-resolved details to disk (so no envelope re-resolution step).

### Known, intentional parity gaps (carried over from Android)

- A 4xx invalidates the in-memory entry but does not evict the persisted detail; the next successful list fetch prunes it from disk. Bounded and self-healing, matching Android.
- On the SWR path a transient background-refresh failure re-pins the persisted (possibly older prefetched) detail over a newer on-demand in-memory value for a TTL. Android documents this as a known gap closed by the planned on-demand-persistence + LRU follow-up.

<details>
<summary>AI session context</summary>

## Metadata

- PR: port of purchases-android#3567, workflow **detail** fetch disk fallback
- Branch: `facu/workflow-detail-fallback` (stacked on `facu/workflow-list-swr`, #6965)
- Author / human owner: facumenzella
- Agent(s): Claude Code (Opus 4.8, 1M context)
- Generated: 2026-06-10
- Context document version: 2

## Goal

Give the workflow detail fetch the same transient-error disk fallback offerings and the workflows list already have, while not serving a stale copy on a 4xx or a non-transient error.

## Initial Prompt

"We need to port purchases-android#3567 to ios. Stack it on top of #6965."

## Agent Contribution

- `WorkflowsCache`: added `invalidateWorkflowTimestamp(workflowId:)` (marks an in-memory detail entry stale) and `cachedWorkflowDetailFromDisk(workflowId:)` (reads a single persisted detail).
- `WorkflowManager.fetchAndCacheWorkflow`: split the backend result into success/failure; new `handleWorkflowFetchFailure` gates disk recovery on `case .networkError(let net) where net.shouldFallBackToCache` (transient → disk re-pin or invalidate + surface error; 4xx / non-network → invalidate + surface error). Shared by the blocking miss path and the SWR background refresh.

## Human Decisions

- Port as a separate follow-up stacked on #6965.
- After a Codex adversarial review: tighten the fallback predicate to network-transient only (finding 1); keep the 4xx-eviction and SWR re-pin behaviors as documented Android parity (findings 2 & 3).

## Key Porting Differences vs Android

- iOS already exposes the 4xx-vs-(5xx/transport/decoding) split via `NetworkError.shouldFallBackToCache`, so no `Backend`/`GetWorkflowOperation` signature change was needed (Android threads a `GetWorkflowsErrorHandlingBehavior` through the callback).
- iOS persists resolved `WorkflowDataResult`s to disk, so the recovery reads them directly, no `workflowDetailResolver.resolve(envelope)` step.
- The disk re-pin doesn't re-warm assets, matching both `restoreWorkflowDetailsFromDisk` and Android's `resolveDiskFallback`.

## Files / Symbols Touched

- `Sources/Purchasing/WorkflowManager.swift` - `fetchAndCacheWorkflow`, new `handleWorkflowFetchFailure`.
- `Sources/Caching/WorkflowsCache.swift` - `invalidateWorkflowTimestamp`, `cachedWorkflowDetailFromDisk`.
- `Tests/UnitTests/Purchasing/WorkflowManagerTests.swift` - 5 new tests.
- `Tests/UnitTests/Caching/WorkflowsCacheTests.swift` - 5 new tests.

## Validation

- `xcodebuild test` (iPhone 16 sim): `WorkflowManagerTests` (56), `WorkflowsCacheTests` (47), `PurchasesWorkflowTests`, `OfferingsManagerTests` all green (143 total, 0 failures).
- `swift build`: clean. `swiftlint` on changed files: clean.
- Codex adversarial review (branch scope): finding 1 fixed; findings 2 & 3 retained as intentional Android parity.
- Manual verification: Not run.

## Review Focus

- Fallback predicate is network-transient only: a 4xx or a non-network error (e.g. `missingAppUserID`) surfaces the error and never serves persisted data.
- The 4xx invalidate is observably a near-no-op at the manager level (the fetch path is only entered on an absent/stale entry), so the 4xx test asserts behavior (disk not served, error surfaced), not the invalidate call; `invalidateWorkflowTimestamp` is covered directly at the cache level.
- SWR background-refresh failures DO go through the disk fallback (per the authoritative Android code/test, not its Cursor auto-summary which says logged-only).

## Non-goals / Out of Scope

- The offerings cache. The list/detail SWR (their own PRs, #6961 / #6965).
- Evicting persisted details on 4xx / tombstoning, and avoiding the SWR re-pin downgrade: both are deferred to the Android-side on-demand-persistence + LRU follow-up to keep parity.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workflow fetch error handling and can serve persisted user-scoped paywall data on outages; generation guards limit cross-user leakage, but SWR can temporarily prefer older disk over newer in-memory detail.
> 
> **Overview**
> Workflow **detail** fetches now follow the same offline fallback policy as offerings and the workflows list, instead of surfacing every backend error immediately.
> 
> `WorkflowManager` routes fetch failures through **`handleWorkflowFetchFailure`**: transient **network** failures (`NetworkError.shouldFallBackToCache` — transport, 5xx, malformed body) call **`recoverWorkflowDetailFromDisk`**, re-stamp memory fresh, and complete with success when a prefetched detail exists; otherwise the original error is returned. **4xx** and **non-network** errors (e.g. `missingAppUserID`) do **not** serve disk — they **`invalidateWorkflowTimestamp`** so the next call retries, then fail. The gate uses **`NetworkError`**, not `BackendError.shouldFallBackToCache`, so identity/config errors never read persisted user-scoped data. Recovery is **generation-guarded** so login/logout mid-flight cannot deliver the previous user’s detail.
> 
> **`WorkflowsCache`** adds **`invalidateWorkflowTimestamp`** (mark in-memory detail stale without removing it) and **`recoverWorkflowDetailFromDisk`** (atomic disk read + memory write under `detailsLock`). Blocking misses and **stale-while-revalidate** background refreshes share this path; unit tests cover cache helpers and manager scenarios (5xx fallback, 4xx/no fallback, empty disk, clear during fetch, SWR re-pin from disk).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c2ba4fa68627c9622f3be0cffceb015b3224283. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->