### PR TITLE
fix: re-warm intro eligibility cache on CustomerInfo change

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -2463,8 +2463,14 @@ private extension Purchases {
 
             if #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *),
                let cache = self.paywallCache {
+                // Re-warm from cached offerings (no fetch) so the just-cleared eligibility
+                // cache isn't left cold for the next paywall.
+                let cachedOfferings = self.offeringsManager.cachedOfferings
                 self.operationDispatcher.dispatchOnWorkerThread {
                     await cache.clearEligibilityCache()
+                    if let cachedOfferings {
+                        await cache.warmUpEligibilityCache(offerings: cachedOfferings)
+                    }
                 }
             }
         }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
@@ -307,6 +307,56 @@ class ExistingUserPurchasesLogInTests: BasePurchasesLogInTests {
         expect(self.paywallCache.invokedClearEligibilityCacheCount).toEventually(equal(2))
     }
 
+    func testCustomerInfoChangeRewarmsEligibilityCacheFromCachedOfferings() throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        let offerings = try XCTUnwrap(
+            self.offeringsFactory.createOfferings(from: [:],
+                                                  contents: .mockContents,
+                                                  loadedFromDiskCache: false)
+        )
+        self.mockOfferingsManager.stubbedOfferingsCompletionResult = .success(offerings)
+
+        self.awaitInitialClearAndResetEligibilityWarmTracking()
+
+        let offeringsFetchCountBefore = self.mockOfferingsManager.invokedOfferingsCount
+        let updateOfferingsCacheCountBefore = self.mockOfferingsManager.invokedUpdateOfferingsCacheCount
+
+        self.customerInfoManager.cache(customerInfo: Self.mockLoggedInInfo, appUserID: Self.appUserID)
+
+        // The change clears the eligibility cache and then re-warms it from cached offerings.
+        expect(self.paywallCache.invokedClearEligibilityCacheCount).toEventually(equal(2))
+        expect(self.paywallCache.invokedWarmUpEligibilityCache).toEventually(beTrue())
+        expect(self.paywallCache.invokedWarmUpEligibilityCacheOfferings) === offerings
+
+        // Re-warming reads already-cached offerings only; it must not trigger an offerings fetch.
+        expect(self.mockOfferingsManager.invokedOfferingsCount) == offeringsFetchCountBefore
+        expect(self.mockOfferingsManager.invokedUpdateOfferingsCacheCount) == updateOfferingsCacheCountBefore
+    }
+
+    func testCustomerInfoChangeDoesNotWarmEligibilityCacheWithoutCachedOfferings() throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        // No cached offerings: the default stubbed offerings result is a failure, so
+        // `cachedOfferings` is nil and there is nothing to re-warm.
+        self.awaitInitialClearAndResetEligibilityWarmTracking()
+
+        self.customerInfoManager.cache(customerInfo: Self.mockLoggedInInfo, appUserID: Self.appUserID)
+
+        // The change still clears the eligibility cache...
+        expect(self.paywallCache.invokedClearEligibilityCacheCount).toEventually(equal(2))
+        // ...but without cached offerings there is nothing to re-warm.
+        expect(self.paywallCache.invokedWarmUpEligibilityCache) == false
+    }
+
+    /// Waits for the initial setup-triggered eligibility-cache clear to settle, then resets
+    /// warm-up tracking so a subsequent `CustomerInfo` change can be observed in isolation.
+    private func awaitInitialClearAndResetEligibilityWarmTracking() {
+        expect(self.paywallCache.invokedClearEligibilityCacheCount).toEventually(equal(1))
+        self.paywallCache.invokedWarmUpEligibilityCache = false
+        self.paywallCache.invokedWarmUpEligibilityCacheOfferings = nil
+    }
+
 }
 
 // MARK: -


### PR DESCRIPTION
### Checklist
- [x] Unit tests
- [ ] Follow-up issues for `purchases-android` and hybrids

### Motivation

Intro eligibility is cleared on every `CustomerInfo` change but never re-warmed. A mid-session change (e.g. a background `CustomerInfo` refresh) leaves the intro-eligibility cache cold, so the next paywall renders the non-trial variant and then visibly flips to the trial variant once eligibility resolves. This is the "standard paywall, then free-trial view appears a few seconds later" behavior.

### Description

After clearing the eligibility cache in `handleCustomerInfoChanged`, re-warm it from already-cached offerings (`offeringsManager.cachedOfferings`, an in-memory read, no network fetch), guarded on cached offerings being present. If nothing is cached yet, the normal post-`getOfferings` warm-up still handles it.

This complements the existing redaction-while-pending behavior, it just keeps the cache from going cold between offerings fetches so there's less to wait on (or flip) on the next paywall.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: draft (this PR)
- Branch: `facu/rewarm-eligibility-on-customerinfo-change`
- Author / human owner: facumenzella
- Agent(s): Claude Code (Opus 4.8, 1M context); Codex (read-only review pass)
- Session source: current conversation
- Generated: 2026-06-10
- Context document version: 1

## Goal

Stop V2 paywalls from rendering non-trial content and then visibly flipping to the trial variant when a free trial is available, in the case where the intro-eligibility cache has gone cold mid-session.

## Initial Prompt

Investigation started from "are we prewarming promo offers / free trials / introductory offers? we show a loading state but maybe aren't prewarming", then a customer report (GlobalRadio, on SDK 5.67.2, video attached) of the paywall showing the standard variant then switching to the free-trial variant. After diagnosis, the actionable instruction was: implement the "re-warm eligibility cache on CustomerInfo change" improvement, send it to Codex for review, address what's addressable, run /simplify, and open a draft PR.

## Important Follow-up Prompts

- Confirm V1 vs V2 from the customer video before recommending a fix (resolved: V2).
- Scope the work to improvement option #2 (re-warm on CustomerInfo change) specifically.

## Agent Contribution

- Diagnosed the flip: intro eligibility resolves after the paywall is on screen; the robust fixes (#6775 redact-while-pending in 5.78.0, #6839 warm-all in 5.75.0) postdate the customer's 5.67.2.
- Implemented the re-warm in `handleCustomerInfoChanged`.
- Wrote two unit tests (TDD: watched the positive one fail before implementing).
- Ran the Codex review pass and strengthened the positive test per its (low) finding.
- Ran /simplify (4 agents); applied the test-helper extraction, skipped the production-helper extraction.

## Human Decisions

- Chose improvement #2 over the other candidates (redaction coverage, promo prewarm, V1, diagnosability).

## Key Implementation Decisions

- Decision: re-warm from `offeringsManager.cachedOfferings` (in-memory) only if present.
  - Rationale: no network fetch; if uncached, the post-`getOfferings` warm-up covers it.
  - Rejected: extracting a dedicated `clearAndReWarmEligibilityCache` helper (single caller; inline closure is clearer, per 2 of 4 /simplify agents).

## Files / Symbols Touched

- `Sources/Purchasing/Purchases/Purchases.swift`
  - Why: re-warm after clear on CustomerInfo change.
  - Symbols: `Purchases.handleCustomerInfoChanged(from:to:)`
  - Review relevance: ordering (clear before warm, same worker closure); `cachedOfferings` read placement.
- `Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift`
  - Why: cover the new branch (warm with cached offerings; no warm without).
  - Symbols: `ExistingUserPurchasesLogInTests` + `awaitInitialClearAndResetEligibilityWarmTracking()`

## Dependencies / Config / Migrations

- None.

## Validation

- Commands run:
  - `xcodebuild test ... -scheme UnitTests -only-testing:.../testCustomerInfoChangeRewarms... -only-testing:.../testCustomerInfoChangeDoesNotWarm...`: RED before impl (positive failed for the right reason), GREEN after.
  - Regression: full `ExistingUserPurchasesLogInTests` + `PurchasesGetOfferingsTests/testGetOfferingsWarmsUpEligibilityCache`: all passed.
  - `swiftlint lint` on both files: no violations.
- Manual verification: Not run (behavioral "no flip" is timing/UI; not unit-testable).
- CI: Not captured (draft).

## Validation Gaps

- The "no visible flip" end-to-end outcome is not unit-tested; tests assert the wiring (clear + re-warm with cached offerings, no fetch triggered).
- Tests use `MockOfferingsManager.cachedOfferings`, not the real `DeviceCache`/`InMemoryCachedObject` path.

## Review Focus

- Is re-warming on every `CustomerInfo` change acceptable? It adds an eager StoreKit intro-eligibility request per change when offerings are cached. The pre-existing code already invalidates the eligibility cache on every change, so this moves cost from lazy to eager rather than adding invalidation churn.
- Under bursty `CustomerInfo` changes, worker dispatch uses detached tasks, so a later clear can interleave with an earlier warm (dedupe is per-task, not global). No correctness break observed; flagged by Codex as low.

## Risks / Reviewer Notes

- Risk: excessive eager eligibility requests on frequent CustomerInfo updates.
  - Evidence: guarded on `cachedOfferings != nil`; only fires on a real change (`old != nil`).
  - Mitigation (optional follow-up): skip re-warm if the product set is unchanged, or move to app-foreground.

## Non-goals / Out of Scope

- Redaction coverage beyond text components; promo-offer prewarming; V1 paywalls; added diagnostics. These were identified as separate improvements.

## Omitted Context

- Raw transcript, version archaeology details, and exploratory tool logs were omitted.

</details>
