### PR TITLE
Makes `run_plugin_action_in_current_directory` resilient to missing subdirectories

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,10 +23,7 @@ end
 # Hack to work around a Fastlane quirk where plugin actions are run from the parent of the current working directory.
 # We switch to the first subdirectory, then run the action. The action will run from the parent of the subdirectory, which is
 # our actual current working directory.
-# This is only needed when our current working directory is not the ./fastlane directory. When it is the ./fastlane
-# directory, Fastlane already runs plugin actions from its parent (the repository root), which is what we want, so we
-# run the action directly. We also fall back to running directly when there are no subdirectories to switch into,
-# which otherwise raised "undefined method `chomp' for nil:NilClass".
+# This is only needed when our current working directory is not the ./fastlane directory.
 # https://docs.fastlane.tools/advanced/fastlane/#directory-behavior
 def run_plugin_action_in_current_directory(&block)
   first_subdirectory = Dir["*/"].first

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,12 +22,19 @@ end
 
 # Hack to work around a Fastlane quirk where plugin actions are run from the parent of the current working directory.
 # We switch to the first subdirectory, then run the action. The action will run from the parent of the subdirectory, which is
-# our actual current working directory. The obvious limitation is that this doesn't work if the current working directory
-# does not have any subdirectories.
-# This is only needed when our current working directory is not the ./fastlane directory.
+# our actual current working directory.
+# This is only needed when our current working directory is not the ./fastlane directory. When it is the ./fastlane
+# directory, Fastlane already runs plugin actions from its parent (the repository root), which is what we want, so we
+# run the action directly. We also fall back to running directly when there are no subdirectories to switch into,
+# which otherwise raised "undefined method `chomp' for nil:NilClass".
 # https://docs.fastlane.tools/advanced/fastlane/#directory-behavior
 def run_plugin_action_in_current_directory(&block)
-  Dir.chdir(Dir["*/"].first.chomp("/"), &block)
+  first_subdirectory = Dir["*/"].first
+  if first_subdirectory.nil?
+    block.call
+  else
+    Dir.chdir(first_subdirectory.chomp("/"), &block)
+  end
 end
 
 


### PR DESCRIPTION
## Description
iOS equivalent of https://github.com/RevenueCat/purchases-android/pull/3585. The bug currently doesn't surface in iOS because its `./fastlane` directory contains an `actions/` subdirectory, but the bug does exist.

<div><a href="https://cursor.com/agents/bc-916e35d0-71c1-49cb-ab37-f644d0757727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-916e35d0-71c1-49cb-ab37-f644d0757727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Fastlane-only change with no SDK or runtime impact; only affects CI lanes that use this helper when cwd lacks subdirectories.
> 
> **Overview**
> Updates **`run_plugin_action_in_current_directory`** in `fastlane/Fastfile` so Fastlane plugin actions still run when the current directory has **no subfolders**.
> 
> Previously the helper always `chdir`'d into `Dir["*/"].first`, which **crashes** if that glob is empty. It now **runs the block in place** when there is no first subdirectory, and only uses the subdirectory trick when one exists (same Fastlane directory quirk as before).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 427d5227d6af46de0ed1f4352f686f6a05454353. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->