### PR TITLE
fix(workflows): compute intro eligibility for inherited packages on packageless workflow screens

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -2937,6 +2937,7 @@
 		B3F68BC246A0E31CC9F0C5BE /* RulesEngineInternal.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RulesEngineInternal.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3F8418E26F3A93400E560FB /* ErrorCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorCodeTests.swift; sourceTree = "<group>"; };
 		B413E59F2F97B3B900B5F0CA /* CarouselTabSwitchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselTabSwitchTests.swift; sourceTree = "<group>"; };
+		B413E5A02F97B3B900B5F0CA /* PaywallsV2ViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallsV2ViewTests.swift; sourceTree = "<group>"; };
 		B49121C11022272A08D75B4E /* AccessorOperatorsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccessorOperatorsTests.swift; sourceTree = "<group>"; };
 		B72848B4B4D101F1B94E228E /* Value+JSON.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Value+JSON.swift"; sourceTree = "<group>"; };
 		B78483ACCDD62ABD40AF8827 /* Evaluator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Evaluator.swift; sourceTree = "<group>"; };
@@ -3258,6 +3259,7 @@
 				B29E428C04E073334CD13B58 /* CarouselStateTests.swift */,
 				E78770053AB84EF380CC0C1D /* TextComponentViewLoadingTests.swift */,
 				B413E59F2F97B3B900B5F0CA /* CarouselTabSwitchTests.swift */,
+				B413E5A02F97B3B900B5F0CA /* PaywallsV2ViewTests.swift */,
 				DB1FC9592F9A1B74009A95EA /* WorkflowScreenMapperTests.swift */,
 				F468C7BCEB786BEC80277ECA /* WorkflowNavigatorTests.swift */,
 				C07759C930F712D2D53B9333 /* WorkflowStepEventTrackerTests.swift */,

--- a/RevenueCatUI/Purchasing/WorkflowContext.swift
+++ b/RevenueCatUI/Purchasing/WorkflowContext.swift
@@ -119,12 +119,16 @@ struct WorkflowContext {
         }
 
         if let matched = base.packages.first(where: { $0.identifier == preferredPackage.identifier }) {
-            return .init(selectedPackage: matched, packages: base.packages)
+            return .init(selectedPackage: matched,
+                         packages: base.packages,
+                         promoOfferCodesByPackageId: base.promoOfferCodesByPackageId)
         }
 
         if let wfDefault = wfContext?.selectedPackage,
            let matched = base.packages.first(where: { $0.identifier == wfDefault.identifier }) {
-            return .init(selectedPackage: matched, packages: base.packages)
+            return .init(selectedPackage: matched,
+                         packages: base.packages,
+                         promoOfferCodesByPackageId: base.promoOfferCodesByPackageId)
         }
 
         return base
@@ -186,9 +190,16 @@ struct WorkflowContext {
             return nil
         }
 
+        let promoOfferCodes = packages.reduce(into: [String: String]()) { result, entry in
+            if let code = entry.promoOfferCode {
+                result[entry.package.identifier] = code
+            }
+        }
+
         return .init(
             selectedPackage: selectedPackage,
-            packages: packages.map(\.package)
+            packages: packages.map(\.package),
+            promoOfferCodesByPackageId: promoOfferCodes
         )
     }
 
@@ -220,12 +231,14 @@ struct WorkflowContext {
     private static func collectPackages(
         in components: [PaywallComponent],
         offering: Offering
-    ) -> [(package: Package, isSelectedByDefault: Bool)] {
+    ) -> [(package: Package, isSelectedByDefault: Bool, promoOfferCode: String?)] {
         return components.reduce(into: []) { result, component in
             switch component {
             case .package(let pkg):
                 if let rcPackage = offering.package(identifier: pkg.packageID) {
-                    result.append((package: rcPackage, isSelectedByDefault: pkg.isSelectedByDefault))
+                    result.append((package: rcPackage,
+                                   isSelectedByDefault: pkg.isSelectedByDefault,
+                                   promoOfferCode: pkg.applePromoOfferProductCode))
                 }
             case .stack(let stack):
                 result += Self.collectPackages(in: stack.components, offering: offering)
@@ -246,6 +259,19 @@ struct WorkflowContext {
 struct WorkflowPackageContext {
     let selectedPackage: Package
     let packages: [Package]
+    /// Apple promo offer product code per package identifier, used to resolve `promo_offer_condition`
+    /// on a workflow step that inherits this package set but hosts no package component of its own.
+    let promoOfferCodesByPackageId: [String: String]
+
+    init(
+        selectedPackage: Package,
+        packages: [Package],
+        promoOfferCodesByPackageId: [String: String] = [:]
+    ) {
+        self.selectedPackage = selectedPackage
+        self.packages = packages
+        self.promoOfferCodesByPackageId = promoOfferCodesByPackageId
+    }
 }
 
 // Temporary launch-argument gate — remove once workflows are fully released.

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -620,12 +620,8 @@ extension PaywallsV2View {
         paywallPackages: [Package],
         workflowPackages: [Package]?
     ) -> [Package] {
-        guard let workflowPackages, !workflowPackages.isEmpty else {
-            return paywallPackages
-        }
-
         var seen = Set<Package>()
-        return (paywallPackages + workflowPackages).filter { seen.insert($0).inserted }
+        return (paywallPackages + (workflowPackages ?? [])).filter { seen.insert($0).inserted }
     }
 
     /// On-screen package infos plus any inherited workflow packages (with their authored promo offer
@@ -636,13 +632,12 @@ extension PaywallsV2View {
         workflowPackages: [Package]?,
         workflowPromoOfferProductCodes: [String: String]?
     ) -> [(package: Package, promotionalOfferProductCode: String?)] {
-        guard let workflowPackages, !workflowPackages.isEmpty else {
-            return paywallPackageInfos
+        var seen = Set<Package>()
+        var result: [(package: Package, promotionalOfferProductCode: String?)] = []
+        for info in paywallPackageInfos where seen.insert(info.package).inserted {
+            result.append(info)
         }
-
-        var seen = Set<Package>(paywallPackageInfos.map(\.package))
-        var result = paywallPackageInfos
-        for package in workflowPackages where seen.insert(package).inserted {
+        for package in workflowPackages ?? [] where seen.insert(package).inserted {
             result.append((package, workflowPromoOfferProductCodes?[package.identifier]))
         }
         return result

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -71,6 +71,7 @@ struct PaywallsV2View: View {
     private let purchaseHandler: PurchaseHandler
     private let workflowDefaultPackage: Package?
     private let workflowPackages: [Package]?
+    private let workflowPromoOfferProductCodes: [String: String]?
     private let showZeroDecimalPlacePrices: Bool
     /// This is a configuration value from PaywallsV1, but it's important to include here just in case the
     /// default paywall is shown. This is not used in the success path
@@ -107,6 +108,7 @@ struct PaywallsV2View: View {
         showZeroDecimalPlacePrices: Bool,
         workflowDefaultPackage: Package? = nil,
         workflowPackages: [Package]? = nil,
+        workflowPromoOfferProductCodes: [String: String]? = nil,
         displayCloseButton: Bool = false,
         onDismiss: @escaping () -> Void,
         closeWorkflowAction: (() -> Void)? = nil,
@@ -129,6 +131,7 @@ struct PaywallsV2View: View {
         self.purchaseHandler = purchaseHandler
         self.workflowDefaultPackage = workflowDefaultPackage
         self.workflowPackages = workflowPackages
+        self.workflowPromoOfferProductCodes = workflowPromoOfferProductCodes
         self.showZeroDecimalPlacePrices = showZeroDecimalPlacePrices
         self.displayCloseButton = displayCloseButton
         self.onDismiss = onDismiss
@@ -313,10 +316,14 @@ struct PaywallsV2View: View {
                         workflowPackages: self.workflowPackages
                     )
                 )
-                // Promo stays on-screen only: the promo offer product code lives on the package
-                // component, which an inherited (packageless-step) package doesn't carry.
                 async let promoCheck: Void = self.paywallPromoOfferCache.computeEligibility(
-                    for: paywallState.packageInfos.map { ($0.package, $0.promotionalOfferProductCode) }
+                    for: Self.promoEligibilityPackageInfos(
+                        paywallPackageInfos: paywallState.packageInfos.map {
+                            ($0.package, $0.promotionalOfferProductCode)
+                        },
+                        workflowPackages: self.workflowPackages,
+                        workflowPromoOfferProductCodes: self.workflowPromoOfferProductCodes
+                    )
                 )
                 _ = await (introCheck, promoCheck)
                 self.didFinishEligibilityCheck = true
@@ -619,6 +626,26 @@ extension PaywallsV2View {
 
         var seen = Set<Package>()
         return (paywallPackages + workflowPackages).filter { seen.insert($0).inserted }
+    }
+
+    /// On-screen package infos plus any inherited workflow packages (with their authored promo offer
+    /// code), so `promo_offer_condition` overrides resolve on a workflow step that has no package
+    /// component of its own.
+    static func promoEligibilityPackageInfos(
+        paywallPackageInfos: [(package: Package, promotionalOfferProductCode: String?)],
+        workflowPackages: [Package]?,
+        workflowPromoOfferProductCodes: [String: String]?
+    ) -> [(package: Package, promotionalOfferProductCode: String?)] {
+        guard let workflowPackages, !workflowPackages.isEmpty else {
+            return paywallPackageInfos
+        }
+
+        var seen = Set<Package>(paywallPackageInfos.map(\.package))
+        var result = paywallPackageInfos
+        for package in workflowPackages where seen.insert(package).inserted {
+            result.append((package, workflowPromoOfferProductCodes?[package.identifier]))
+        }
+        return result
     }
 
     static func chooseLocalization(

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -308,8 +308,13 @@ struct PaywallsV2View: View {
                 }
 
                 async let introCheck: Void = self.introOfferEligibilityContext.computeEligibility(
-                    for: paywallState.packages
+                    for: Self.introEligibilityPackages(
+                        paywallPackages: paywallState.packages,
+                        workflowPackages: self.workflowPackages
+                    )
                 )
+                // Promo stays on-screen only: the promo offer product code lives on the package
+                // component, which an inherited (packageless-step) package doesn't carry.
                 async let promoCheck: Void = self.paywallPromoOfferCache.computeEligibility(
                     for: paywallState.packageInfos.map { ($0.package, $0.promotionalOfferProductCode) }
                 )
@@ -600,6 +605,20 @@ extension PaywallsV2View {
         workflowDefaultPackage: Package?
     ) -> Package? {
         return workflowDefaultPackage ?? pageDefaultPackage
+    }
+
+    /// On-screen packages plus any inherited workflow packages, so `intro_offer_condition` overrides
+    /// resolve on a workflow step that has no package component of its own.
+    static func introEligibilityPackages(
+        paywallPackages: [Package],
+        workflowPackages: [Package]?
+    ) -> [Package] {
+        guard let workflowPackages, !workflowPackages.isEmpty else {
+            return paywallPackages
+        }
+
+        var seen = Set<Package>()
+        return (paywallPackages + workflowPackages).filter { seen.insert($0).inserted }
     }
 
     static func chooseLocalization(

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -421,6 +421,7 @@ struct WorkflowPaywallView: View {
             showZeroDecimalPlacePrices: self.showZeroDecimalPlacePrices,
             workflowDefaultPackage: page.effectiveWorkflowPackageContext?.selectedPackage,
             workflowPackages: page.effectiveWorkflowPackageContext?.packages,
+            workflowPromoOfferProductCodes: page.effectiveWorkflowPackageContext?.promoOfferCodesByPackageId,
             displayCloseButton: page.showCloseButton,
             onDismiss: self.handleDismiss,
             closeWorkflowAction: self.onDismiss,

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallsV2ViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallsV2ViewTests.swift
@@ -65,4 +65,51 @@ final class IntroEligibilityPackagesTests: TestCase {
 
 }
 
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+final class PromoEligibilityPackageInfosTests: TestCase {
+
+    private let annual = TestData.annualPackage
+    private let monthly = TestData.monthlyPackage
+
+    private func pairs(
+        _ infos: [(package: Package, promotionalOfferProductCode: String?)]
+    ) -> [(String, String?)] {
+        infos.map { ($0.package.identifier, $0.promotionalOfferProductCode) }
+    }
+
+    func testReturnsScreenInfosWhenNoWorkflowPackages() {
+        let result = PaywallsV2View.promoEligibilityPackageInfos(
+            paywallPackageInfos: [(annual, "promo_a")],
+            workflowPackages: nil,
+            workflowPromoOfferProductCodes: nil
+        )
+
+        expect(self.pairs(result)).to(equal([("$rc_annual", "promo_a")]))
+    }
+
+    // Mirrors the intro case: a packageless workflow step (empty `paywallPackageInfos`) inherits packages,
+    // and the inherited promo offer code must be carried so `promo_offer_condition` can resolve.
+    func testUsesInheritedPromoCodesWhenScreenHasNoPackageComponents() {
+        let result = PaywallsV2View.promoEligibilityPackageInfos(
+            paywallPackageInfos: [],
+            workflowPackages: [annual, monthly],
+            workflowPromoOfferProductCodes: ["$rc_annual": "promo_a"]
+        )
+
+        expect(self.pairs(result)).to(equal([("$rc_annual", "promo_a"), ("$rc_monthly", nil)]))
+    }
+
+    func testKeepsOnScreenInfoAndAppendsInheritedExtras() {
+        let result = PaywallsV2View.promoEligibilityPackageInfos(
+            paywallPackageInfos: [(annual, "screen_a")],
+            workflowPackages: [annual, monthly],
+            workflowPromoOfferProductCodes: ["$rc_annual": "wf_a", "$rc_monthly": "wf_m"]
+        )
+
+        // On-screen info wins for $rc_annual; only the missing $rc_monthly is appended.
+        expect(self.pairs(result)).to(equal([("$rc_annual", "screen_a"), ("$rc_monthly", "wf_m")]))
+    }
+
+}
+
 #endif

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallsV2ViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallsV2ViewTests.swift
@@ -1,0 +1,68 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PaywallsV2ViewTests.swift
+
+import Nimble
+@_spi(Internal) @testable import RevenueCat
+@_spi(Internal) @testable import RevenueCatUI
+import XCTest
+
+#if !os(tvOS)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+final class IntroEligibilityPackagesTests: TestCase {
+
+    private let annual = TestData.annualPackage
+    private let monthly = TestData.monthlyPackage
+    private let weekly = TestData.weeklyPackage
+
+    func testReturnsScreenPackagesWhenNoWorkflowPackages() {
+        let result = PaywallsV2View.introEligibilityPackages(
+            paywallPackages: [annual, monthly],
+            workflowPackages: nil
+        )
+
+        expect(result) == [annual, monthly]
+    }
+
+    func testReturnsScreenPackagesWhenWorkflowPackagesEmpty() {
+        let result = PaywallsV2View.introEligibilityPackages(
+            paywallPackages: [annual, monthly],
+            workflowPackages: []
+        )
+
+        expect(result) == [annual, monthly]
+    }
+
+    // The bug: a workflow step with no package components (empty `paywallPackages`) inherits a selected
+    // package from another step via `workflowPackages`. Eligibility must be computed for it, otherwise
+    // `intro_offer_condition` overrides on that step never resolve.
+    func testUsesWorkflowPackagesWhenScreenHasNoPackageComponents() {
+        let result = PaywallsV2View.introEligibilityPackages(
+            paywallPackages: [],
+            workflowPackages: [annual, monthly]
+        )
+
+        expect(result) == [annual, monthly]
+    }
+
+    func testMergesAndDeduplicatesScreenAndWorkflowPackages() {
+        let result = PaywallsV2View.introEligibilityPackages(
+            paywallPackages: [annual],
+            workflowPackages: [annual, monthly, weekly]
+        )
+
+        // Screen packages come first, the inherited extras are appended once each.
+        expect(result) == [annual, monthly, weekly]
+    }
+
+}
+
+#endif

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallsV2ViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallsV2ViewTests.swift
@@ -63,6 +63,24 @@ final class IntroEligibilityPackagesTests: TestCase {
         expect(result) == [annual, monthly, weekly]
     }
 
+    func testDeduplicatesDuplicatesWithinWorkflowPackages() {
+        let result = PaywallsV2View.introEligibilityPackages(
+            paywallPackages: [annual],
+            workflowPackages: [monthly, monthly]
+        )
+
+        expect(result) == [annual, monthly]
+    }
+
+    func testDeduplicatesDuplicatesWithinPaywallPackages() {
+        let result = PaywallsV2View.introEligibilityPackages(
+            paywallPackages: [annual, annual],
+            workflowPackages: nil
+        )
+
+        expect(result) == [annual]
+    }
+
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
@@ -108,6 +126,17 @@ final class PromoEligibilityPackageInfosTests: TestCase {
 
         // On-screen info wins for $rc_annual; only the missing $rc_monthly is appended.
         expect(self.pairs(result)).to(equal([("$rc_annual", "screen_a"), ("$rc_monthly", "wf_m")]))
+    }
+
+    func testDeduplicatesDuplicatesWithinPaywallPackageInfos() {
+        let result = PaywallsV2View.promoEligibilityPackageInfos(
+            paywallPackageInfos: [(annual, "promo_a"), (annual, "promo_a2")],
+            workflowPackages: nil,
+            workflowPromoOfferProductCodes: nil
+        )
+
+        // First occurrence wins; the duplicate is dropped.
+        expect(self.pairs(result)).to(equal([("$rc_annual", "promo_a")]))
     }
 
 }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

On Paywalls V2 workflows, `intro_offer_condition` / `promo_offer_condition` overrides on a workflow step that has **no package components** never fire, even when the user is eligible and the step inherits a selected package from another step. Eligibility is computed only over the screen's own package components, which is empty on such a step, so the rules can't resolve.

### Description

Compute eligibility over the inherited workflow package context (`workflowPackages`) in addition to the screen's own packages:

- **Intro:** `introEligibilityPackages(...)` unions the on-screen and inherited packages (order-preserving, deduped).
- **Promo:** the inherited packages' Apple promo offer product codes are carried through the workflow package context (`WorkflowPackageContext.promoOfferCodesByPackageId`, populated from each package component's `applePromoOfferProductCode`) and unioned into the promo eligibility computation, so promos and intros behave the same.

Standalone paywalls are unaffected: `workflowPackages` is `nil` there, so both helpers return the on-screen packages unchanged.

Note: a screen that already hosts its package components (e.g. packages in a sticky footer) was never affected, it always computed eligibility over those packages.

### Verification

A/B in PaywallsTester on the packageless first step, with the user genuinely intro-eligible:

- Without fix: `compute for=[] -> []` → the step's tabs stay visible (rule can't fire).
- With fix: `compute for=[$rc_annual,$rc_monthly] -> true` → tabs hide as intended.

<details>
<summary>AI session context</summary>

Generated with Claude Code. Evidence-first decision log; no secrets included.

**Task.** Investigate a suspected bug on an iOS Paywalls V2 workflow where an intro-eligibility rule didn't take effect, then fix it.

**Investigation (decision log).**
- Pulled the workflow config (`mafdet workflow content`). Found `intro_offer_condition` overrides (hide-when-eligible): a carousel on a screen *with* packages, and tabs on a screen *without* package components. Only `intro_offer_condition` + `selected` conditions exist, so the global `discardRules` trap is not triggered.
- Traced the iOS path: eligibility is computed in `PaywallsV2View.task` over `paywallState.packages`, populated by `PackageValidator`, which only collects package *components* present on the screen (`ViewModelFactory.swift`). A packageless screen => empty list => `isEligible(_:)` always false => override can't fire.
- Confirmed the sticky-footer packages on the carousel screen *are* collected, so that screen was not the bug; corrected an earlier wrong assumption that it was.

**Native A/B (PaywallsTester, instrumented `IntroOfferEligibilityContext` with temporary logs, since reverted), eligibility genuinely true:**
- Without fix: packageless step logs `compute for=[] -> []`; tabs stay visible.
- With fix: packageless step logs `compute for=[$rc_annual,$rc_monthly] -> true`; tabs hide.
- Earlier runs showed `false` only because the StoreKit config lacked a valid intro offer / wasn't applied under `simctl launch`.

**Review follow-up (vegaro).** Asked whether promos should behave the same as intros. They should, and the promo offer product code is reachable (`PackageComponent.applePromoOfferProductCode` in `collectPackages`). Extended the fix to thread it through `WorkflowPackageContext` and union it into the promo eligibility computation; the earlier "promo stays on-screen only" framing was wrong and is gone.

**Honesty caveat.** The originally-reported symptom (carousel not hiding on the screen that *does* have packages) was an eligibility-state issue, not an SDK bug: that screen hides correctly once the user is genuinely eligible, with or without this change. This fix's real effect is the **packageless** workflow step.

**Verification.** `swift build` ok; unit tests for `introEligibilityPackages` + `promoEligibilityPackageInfos` pass; SwiftLint clean; native PaywallsTester A/B as above. Added the new test file to `RevenueCat.xcodeproj` to satisfy the Danger project-sync check.

**Not done / follow-ups.** No end-to-end snapshot test for the full render path (unit tests cover the package-selection decision only).
</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches paywall purchase-path eligibility and workflow package context; behavior change is scoped to workflow steps without local package components, with unit tests covering the merge logic.
> 
> **Overview**
> Fixes **Paywalls V2 workflow** steps that have **no package components** but inherit packages from another step: **`intro_offer_condition`** and **`promo_offer_condition`** overrides could not resolve because eligibility ran only over on-screen packages (empty on those steps).
> 
> **`PaywallsV2View`** now unions inherited **`workflowPackages`** (and their promo codes) into intro and promo eligibility via **`introEligibilityPackages`** and **`promoEligibilityPackageInfos`**, with deduplication and on-screen values winning for promos. **`WorkflowPackageContext`** gains **`promoOfferCodesByPackageId`**, populated from package components’ **`applePromoOfferProductCode`** in **`WorkflowContext.collectPackages`**, and threaded through **`WorkflowPaywallView`**. Standalone paywalls are unchanged when **`workflowPackages`** is nil.
> 
> Adds **`PaywallsV2ViewTests`** for the merge/dedupe helpers and registers the file in the Xcode project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 836e1d0b025aee0635e8bed6fcfc0416364b8852. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->