### PR TITLE
Add update-error-codes workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,8 @@ parameters:
         run-manual-docs-deploy,
         update_paywall_templates,
         record_paywall_screenshots,
-        deploy_rct_tester
+        deploy_rct_tester,
+        update_error_codes
       ]
     default: default
   generate_snapshots:

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -2571,6 +2571,7 @@ workflows:
       - revenuecat/update-error-codes:
           platform: ios
           output: Sources/Generated/ErrorCode.swift
+          commit_paths: "Sources/Generated/ErrorCode.swift,api"
           executor:
             name: macos-executor
             xcode_version: *swiftinterface-xcode-version

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1,7 +1,7 @@
 orbs:
   macos: circleci/macos@2.5.1
   slack: circleci/slack@5.0.0
-  revenuecat: revenuecat/sdks-common-config@3.20.0
+  revenuecat: revenuecat/sdks-common-config@3.21.0
   # Disabled until compatible with M1: codecov: codecov/codecov@3.3.0
   # codecov: codecov/codecov@3.3.0
 
@@ -2564,6 +2564,22 @@ workflows:
     jobs:
       - update-paywall-preview-resources-commit
 
+  update-error-codes:
+    when:
+      equal: [update_error_codes, << pipeline.parameters.action >>]
+    jobs:
+      - revenuecat/update-error-codes:
+          platform: ios
+          output: Sources/Generated/ErrorCode.swift
+          executor:
+            name: macos-executor
+            xcode_version: *swiftinterface-xcode-version
+          update_api_steps:
+            - install-dependencies
+            - run:
+                name: Update swiftinterface baselines
+                command: bundle exec fastlane ios update_swiftinterface_baselines scheme:RevenueCat
+
   manual-trigger-docs-deploy:
     when:
       equal: [run-manual-docs-deploy, << pipeline.parameters.action >>]
@@ -2586,6 +2602,8 @@ workflows:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
         - not:
             equal: [bump, << pipeline.parameters.action >>]
+        - not:
+            equal: [update_error_codes, << pipeline.parameters.action >>]
         - not: << pipeline.parameters.generate_snapshots >>
         - not: << pipeline.parameters.generate_revenuecatui_snapshots >>
         - not: << pipeline.parameters.generate_swiftinterface >>

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GIT
 
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: ce6a7efb479db6a99fe95e7bb6dd48cc1bf63b8e
+  revision: d911a06677d2926dd61beb80400b5b5e69fbc1df
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
       nokogiri


### PR DESCRIPTION
Adds the `update-error-codes` workflow (gated on `action=update_error_codes`) that runs `revenuecat/update-error-codes@3.21.0` on `macos-executor`: copies the generated `Sources/Generated/ErrorCode.swift` from purchases-error-codes, refreshes the swiftinterface baselines, and opens/updates the PR. Bumps the orb to 3.21.0.

Merge after the orb is published and the plugin pin is bumped (`bundle update fastlane-plugin-revenuecat_internal`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and dependency pin changes only; no runtime SDK logic. Merge timing depends on orb 3.21.0 being published as noted in the PR description.
> 
> **Overview**
> Adds a **manual CircleCI pipeline action** `update_error_codes` so CI can sync generated error codes and open/update a PR without running the full `release-or-main` suite on that trigger.
> 
> The new **`update-error-codes` workflow** runs when `action=update_error_codes`, invoking **`revenuecat/update-error-codes`** from **`revenuecat/sdks-common-config@3.21.0`** (orb bumped from 3.20.0). It targets iOS, writes **`Sources/Generated/ErrorCode.swift`**, commits **`Sources/Generated/ErrorCode.swift`** and **`api`**, uses **`macos-executor`** with the swiftinterface Xcode version, and runs **`update_swiftinterface_baselines`** for the RevenueCat scheme after **`install-dependencies`**.
> 
> **`release-or-main`** now skips when `action` is `update_error_codes` (same pattern as `bump`). **`Gemfile.lock`** pins a newer **`fastlane-plugin-revenuecat_internal`** revision for the orb/plugin stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98d9caa591cd5dd4633bac49e2d7a127acc29b76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->