### PR TITLE
ci: remove RevenueCat.xcodeproj sync Danger check

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,89 +1,6 @@
 danger.import_dangerfile(github: 'RevenueCat/Dangerfile')
 
-require 'pathname'
-require 'set'
-
-EXCLUDED_SWIFT_PATH_PREFIXES = [
-  'Tests/APITesters/'
-].freeze
-
 COMMENT_MARKER = "<!-- purchases-ios-danger -->"
-
-def normalize_path(path)
-  Pathname(path).cleanpath.to_s.sub(%r{\A\./}, '')
-end
-
-def relevant_swift_file?(path)
-  path = normalize_path(path)
-  return false unless path.end_with?('.swift')
-  return false if EXCLUDED_SWIFT_PATH_PREFIXES.any? { |prefix| path.start_with?(prefix) }
-
-  in_project_sources = path.start_with?('Sources/') || path.start_with?('RevenueCatUI/')
-  in_tests = path.start_with?('Tests/')
-
-  in_project_sources || in_tests
-end
-
-def project_swift_file_paths(project_file)
-  require 'xcodeproj'
-
-  project = Xcodeproj::Project.open(project_file)
-  root = Pathname.pwd
-
-  project.files
-         .map { |file| file.real_path if file.path }
-         .compact
-         .select { |path| path.extname == '.swift' }
-         .map { |path| normalize_path(path.cleanpath.relative_path_from(root).to_s) }
-         .to_set
-rescue LoadError
-  nil
-rescue StandardError
-  nil
-end
-
-def xcodeproj_messages
-  failures = []
-  warnings = []
-
-  project_file = 'RevenueCat.xcodeproj'
-
-  unless File.exist?(project_file)
-    warnings << "RevenueCat.xcodeproj not found"
-    return [failures, warnings]
-  end
-
-  project_swift_files = project_swift_file_paths(project_file)
-  return [failures, warnings] if project_swift_files.nil?
-
-  added_swift_files = git.added_files
-    .select { |file| relevant_swift_file?(file) }
-    .map { |file| normalize_path(file) }
-
-  deleted_swift_files = git.deleted_files
-    .select { |file| relevant_swift_file?(file) }
-    .map { |file| normalize_path(file) }
-
-  missing_files = added_swift_files.reject { |file| project_swift_files.include?(file) }
-  lingering_references = deleted_swift_files.select { |file| project_swift_files.include?(file) }
-
-  return [failures, warnings] if missing_files.empty? && lingering_references.empty?
-
-  message = "**`RevenueCat.xcodeproj` is out of sync.**\n"
-  unless missing_files.empty?
-    message += "\nThe following Swift files were added but are missing from `RevenueCat.xcodeproj`:\n"
-    missing_files.each { |file| message += "• `#{file}`\n" }
-  end
-  unless lingering_references.empty?
-    message += "\nThe following Swift files were deleted but still referenced in `RevenueCat.xcodeproj`:\n"
-    lingering_references.each { |file| message += "• `#{file}`\n" }
-  end
-  message += "\nTo fix: open `RevenueCat.xcodeproj` in Xcode, add/remove the files above in the appropriate target. "
-  message += "Check where similar files in the same directory are assigned if you're unsure which target to use."
-
-  failures << message
-  [failures, warnings]
-end
 
 def public_enum_messages
   swift_files = (git.added_files + git.modified_files)
@@ -125,10 +42,6 @@ submodules = `git submodule status`.strip
 unless submodules.empty?
   all_failures << "This repository should not contain any submodules. When using Swift Package Manager, developers will get a resolution error because SPM cannot access private submodules."
 end
-
-f, w = xcodeproj_messages
-all_failures.concat(f)
-all_warnings.concat(w)
 
 f, w = public_enum_messages
 all_failures.concat(f)


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

Stacked on #6774. As part of retiring the committed `RevenueCat.xcodeproj` in favor of the Tuist-generated workspace, the Danger rule that fails a PR when added/removed Swift files aren't mirrored into `RevenueCat.xcodeproj` no longer matches how the project is built, it just forces manual `.pbxproj` bookkeeping (e.g. it fired on #6978 for a new test file).

### Description

Removes the `xcodeproj_messages` Danger check and its now-unused helpers (`project_swift_file_paths`, `relevant_swift_file?`, `normalize_path`, the `pathname`/`set` requires). The submodule check, public-enum check, and sticky-comment handling are unchanged.
