### PR TITLE
Removes stale paywall template screenshots if necessary

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -265,7 +265,6 @@ platform :ios do
       )
     end
 
-    # Remove screenshots for paywalls we no longer render, so stale or renamed entries don't linger.
     remove_stale_template_screenshots(
       target_repository_path: target_repository_path,
       produced_offering_ids_by_platform: produced_offering_ids_by_platform
@@ -312,21 +311,20 @@ platform :ios do
        "--repo-name", "RevenueCat/purchases-ios",
        "#{output_dir}/images")
 
-    # Return the offering IDs produced for this platform, so the caller can prune stale screenshots.
+    # Return the offering IDs produced for this platform.
     produced_offering_ids
   end
 
-  # Removes screenshots (and now-empty directories) for paywalls that were not rendered in this run, so stale or
-  # renamed entries don't linger in the target repository. Only the platform files produced by this lane are pruned
-  # (ios.png and the mac-*.png variants), each against the offering IDs produced for that platform, so screenshots
-  # owned by other platforms (e.g. android.png) are never affected.
+  # Removes screenshots (and now-empty directories) for paywalls that were not rendered in this run. Only the
+  # platform files produced by this lane are pruned (ios.png and the mac-*.png variants), each against the
+  # offering IDs produced for that platform, so screenshots owned by other platforms (e.g. android.png) are
+  # never affected.
   private_lane :remove_stale_template_screenshots do |options|
     target_repository_path = options[:target_repository_path] || UI.user_error!("No target_repository_path provided")
     produced_offering_ids_by_platform = options[:produced_offering_ids_by_platform] || UI.user_error!("No produced_offering_ids_by_platform provided")
 
     templates_dir = "#{target_repository_path}/screenshots/templates"
     produced_offering_ids_by_platform.each do |platform, produced_offering_ids|
-      # Safety: never prune a platform if it produced nothing (e.g. a failed render), to avoid wiping its screenshots.
       if produced_offering_ids.empty?
         UI.important("No #{platform} screenshots were produced; skipping stale cleanup for it.")
         next
@@ -340,7 +338,7 @@ platform :ios do
       end
     end
 
-    # Remove any template directories that no longer contain any files (e.g. once every platform dropped a paywall).
+    # Remove any empty directories.
     Dir.glob("#{templates_dir}/*").each do |dir|
       next unless File.directory?(dir)
       Dir.rmdir(dir) if Dir.empty?(dir)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -250,6 +250,7 @@ platform :ios do
                  "mac-catalyst-scaled-to-match-ipad",
                  "mac-native"]
 
+    produced_offering_ids_by_platform = {}
     platforms.each do |platform|
       UI.message("Generating screenshots for platform: #{platform}")
 
@@ -257,12 +258,18 @@ platform :ios do
       UI.message("Output directory for #{platform}: #{output_dir}")
 
       # Process the screenshots from the output directory
-      process_paywall_screenshots(
+      produced_offering_ids_by_platform[platform] = process_paywall_screenshots(
         output_dir: output_dir,
         target_repository_path: target_repository_path,
         platform: platform
       )
     end
+
+    # Remove screenshots for paywalls we no longer render, so stale or renamed entries don't linger.
+    remove_stale_template_screenshots(
+      target_repository_path: target_repository_path,
+      produced_offering_ids_by_platform: produced_offering_ids_by_platform
+    )
 
     # Commit, push, and create a PR in the target repository
     Dir.chdir(target_repository_path) do
@@ -283,8 +290,10 @@ platform :ios do
     target_repository_path = options[:target_repository_path] || UI.user_error!("No target_repository_path provided")
     platform = options[:platform] || UI.user_error!("No platform provided")
 
+    produced_offering_ids = []
     Dir.glob("#{output_dir}/images/*.png").each do |file_path|
       offering_id = File.basename(file_path, File.extname(file_path))
+      produced_offering_ids << offering_id
       target_dir = "#{target_repository_path}/screenshots/templates/#{offering_id}"
 
       target_path = "#{target_dir}/#{platform}.png"
@@ -302,6 +311,40 @@ platform :ios do
        "--id", "com.revenuecat.paywall-rendering-validation.#{platform}",
        "--repo-name", "RevenueCat/purchases-ios",
        "#{output_dir}/images")
+
+    # Return the offering IDs produced for this platform, so the caller can prune stale screenshots.
+    produced_offering_ids
+  end
+
+  # Removes screenshots (and now-empty directories) for paywalls that were not rendered in this run, so stale or
+  # renamed entries don't linger in the target repository. Only the platform files produced by this lane are pruned
+  # (ios.png and the mac-*.png variants), each against the offering IDs produced for that platform, so screenshots
+  # owned by other platforms (e.g. android.png) are never affected.
+  private_lane :remove_stale_template_screenshots do |options|
+    target_repository_path = options[:target_repository_path] || UI.user_error!("No target_repository_path provided")
+    produced_offering_ids_by_platform = options[:produced_offering_ids_by_platform] || UI.user_error!("No produced_offering_ids_by_platform provided")
+
+    templates_dir = "#{target_repository_path}/screenshots/templates"
+    produced_offering_ids_by_platform.each do |platform, produced_offering_ids|
+      # Safety: never prune a platform if it produced nothing (e.g. a failed render), to avoid wiping its screenshots.
+      if produced_offering_ids.empty?
+        UI.important("No #{platform} screenshots were produced; skipping stale cleanup for it.")
+        next
+      end
+
+      Dir.glob("#{templates_dir}/*/#{platform}.png").each do |existing|
+        offering_id = File.basename(File.dirname(existing))
+        next if produced_offering_ids.include?(offering_id)
+        UI.message("Removing stale #{platform} screenshot: #{existing}")
+        FileUtils.rm(existing)
+      end
+    end
+
+    # Remove any template directories that no longer contain any files (e.g. once every platform dropped a paywall).
+    Dir.glob("#{templates_dir}/*").each do |dir|
+      next unless File.directory?(dir)
+      Dir.rmdir(dir) if Dir.empty?(dir)
+    end
   end
 
   private_lane :commit_push_and_create_pr_if_necessary do |options|


### PR DESCRIPTION
## Description
We would only ever add new paywall screenshots to paywall-rendering-validation, never remove ones that we deleted from paywall-preview-resources. This PR implements just that.

Android equivalent: https://github.com/RevenueCat/purchases-android/pull/3595

<div><a href="https://cursor.com/agents/bc-916e35d0-71c1-49cb-ab37-f644d0757727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-916e35d0-71c1-49cb-ab37-f644d0757727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The lane deletes files in the target validation repo; safeguards (per-platform scope, skip on empty output) limit blast radius but a bad CI run could still remove expected screenshots if offerings fail to render yet the run is non-empty.
> 
> **Overview**
> Keeps **paywall-rendering-validation** in sync when templates disappear from **paywall-preview-resources** by pruning stale assets during `record_and_push_paywall_template_screenshots`, not only copying new screenshots.
> 
> `process_paywall_screenshots` now **returns the offering IDs** produced for each platform; the lane aggregates them and runs new **`remove_stale_template_screenshots`** before commit/PR. Cleanup deletes `screenshots/templates/<offering>/<platform>.png` when that offering was not rendered for that platform in the current run, then **removes empty offering directories**. Only Apple lane filenames (`ios.png`, `mac-*.png`) are touched—**`android.png` and other platforms are never deleted**. If a platform run produces **no** screenshots, stale cleanup for that platform is **skipped** to avoid mass deletion on a failed/partial run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ba2b2dc2454bd3c02d9da3e27b0a7bdc4527465. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->