### PR TITLE
test(paywalls): cover video KVO crash fix (#6985)

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerLayerUIView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerLayerUIView.swift
@@ -1,0 +1,172 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  VideoPlayerLayerUIView.swift
+//
+//  Created by RevenueCat.
+
+import AVKit
+@_spi(Internal) import RevenueCat
+import SwiftUI
+
+#if canImport(UIKit) && !os(watchOS)
+import UIKit
+
+// MARK: - PlayerLayerBackedView
+
+/// A `UIView` whose backing layer is an `AVPlayerLayer`.
+///
+/// Using an `AVPlayerLayer` directly (rather than an `AVPlayerViewController`) avoids AVKit's
+/// internal `AVPlayerController`, which observes `currentItem.*` key paths on the player. When the
+/// player is an `AVQueuePlayer` driven by an `AVPlayerLooper`, those observers crash on teardown
+/// because the looper swaps `currentItem` without sending KVO notifications.
+final class PlayerLayerBackedView: UIView {
+
+    override class var layerClass: AnyClass {
+        return AVPlayerLayer.self
+    }
+
+    var playerLayer: AVPlayerLayer {
+        // swiftlint:disable:next force_cast
+        return layer as! AVPlayerLayer
+    }
+
+}
+
+// MARK: - VideoPlayerLayerView
+
+/// Renders a looping/auto-playing video without playback controls via an `AVPlayerLayer`.
+///
+/// This is the no-controls path (used for video backgrounds). It intentionally does not use
+/// `AVPlayerViewController`, so the `AVPlayerLooper`/`AVQueuePlayer` KVO crash cannot occur.
+struct VideoPlayerLayerView: UIViewRepresentable {
+
+    let videoURL: URL
+    let shouldAutoPlay: Bool
+    let contentMode: ContentMode
+    let loopVideo: Bool
+    let muteAudio: Bool
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(
+            videoURL: videoURL,
+            shouldAutoPlay: shouldAutoPlay,
+            loopVideo: loopVideo,
+            muteAudio: muteAudio
+        )
+    }
+
+    func makeUIView(context: Context) -> PlayerLayerBackedView {
+        let view = PlayerLayerBackedView()
+        view.backgroundColor = .clear
+        // No controls: let carousel swipes pass through (parity with the controls-hidden path).
+        view.isUserInteractionEnabled = false
+        view.playerLayer.player = context.coordinator.player
+
+        switch contentMode {
+        case .fit:
+            view.playerLayer.videoGravity = .resizeAspect
+        case .fill:
+            view.playerLayer.videoGravity = .resizeAspectFill
+        }
+
+        return view
+    }
+
+    func updateUIView(_ uiView: PlayerLayerBackedView, context: Context) { }
+
+    static func dismantleUIView(_ uiView: PlayerLayerBackedView, coordinator: Coordinator) {
+        uiView.playerLayer.player = nil
+    }
+
+    class Coordinator {
+
+        let player: AVPlayer
+
+        // Retained for the lifetime of the player so looping keeps working.
+        private let looper: AVPlayerLooper?
+        private let autoplayHandler: VideoAutoplayHandler
+
+        private var previousCategory: AVAudioSession.Category?
+        private var previousMode: AVAudioSession.Mode?
+        private var previousOptions: AVAudioSession.CategoryOptions?
+
+        init(
+            videoURL: URL,
+            shouldAutoPlay: Bool,
+            loopVideo: Bool,
+            muteAudio: Bool
+        ) {
+            let playerItem = AVPlayerItem(url: videoURL)
+
+            let avPlayer: AVPlayer
+            if loopVideo {
+                let aVQueuePlayer = AVQueuePlayer()
+                self.looper = AVPlayerLooper(player: aVQueuePlayer, templateItem: playerItem)
+                avPlayer = aVQueuePlayer
+            } else {
+                avPlayer = AVPlayer(playerItem: playerItem)
+                avPlayer.actionAtItemEnd = .pause
+                self.looper = nil
+            }
+
+            avPlayer.isMuted = muteAudio
+            #if !os(visionOS)
+            avPlayer.preventsDisplaySleepDuringVideoPlayback = false
+            avPlayer.allowsExternalPlayback = false
+            #endif
+
+            self.player = avPlayer
+
+            let audioSession = AVAudioSession.sharedInstance()
+            self.previousCategory = audioSession.category
+            self.previousMode = audioSession.mode
+            self.previousOptions = audioSession.categoryOptions
+            do {
+                try audioSession.setCategory(
+                    .ambient,
+                    mode: .default,
+                    options: [.mixWithOthers]
+                )
+            } catch {
+                Logger.warning(Strings.video_failed_to_set_audio_session_category(error))
+            }
+
+            self.autoplayHandler = VideoAutoplayHandler(
+                playbackController: avPlayer,
+                lifecycleObserver: SystemAppLifecycleObserver()
+            )
+
+            if shouldAutoPlay {
+                avPlayer.play()
+            }
+        }
+
+        deinit {
+            guard let category = previousCategory,
+                  let mode = previousMode,
+                  let options = previousOptions else {
+                return
+            }
+
+            do {
+                try AVAudioSession.sharedInstance().setCategory(
+                    category,
+                    mode: mode,
+                    options: options
+                )
+            } catch {
+                Logger.warning(Strings.video_failed_to_set_audio_session_category(error))
+            }
+        }
+
+    }
+
+}
+#endif

--- a/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerView.swift
@@ -67,15 +67,29 @@ struct VideoPlayerView: View {
         )
         .allowsHitTesting(showControls)
 #elseif canImport(UIKit)
-        VideoPlayerUIView(
-            videoURL: videoURL,
-            shouldAutoPlay: shouldAutoPlay && !reduceMotion,
-            contentMode: contentMode,
-            loopVideo: loopVideo,
-            showControls: showControls,
-            muteAudio: muteAudio
-        )
-        .allowsHitTesting(showControls)
+        if showControls {
+            // Controls require AVPlayerViewController for the playback UI.
+            VideoPlayerUIView(
+                videoURL: videoURL,
+                shouldAutoPlay: shouldAutoPlay && !reduceMotion,
+                contentMode: contentMode,
+                loopVideo: loopVideo,
+                showControls: showControls,
+                muteAudio: muteAudio
+            )
+            .allowsHitTesting(true)
+        } else {
+            // No controls (e.g. backgrounds): render via AVPlayerLayer to avoid AVKit's internal
+            // AVPlayerController, whose KVO observers crash when fed an AVPlayerLooper-driven queue player.
+            VideoPlayerLayerView(
+                videoURL: videoURL,
+                shouldAutoPlay: shouldAutoPlay && !reduceMotion,
+                contentMode: contentMode,
+                loopVideo: loopVideo,
+                muteAudio: muteAudio
+            )
+            .allowsHitTesting(false)
+        }
 #endif
     }
 

--- a/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerViewUIView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerViewUIView.swift
@@ -30,71 +30,24 @@ extension AVPlayer: VideoPlaybackController {
 
 struct VideoPlayerUIView: UIViewControllerRepresentable {
     let videoURL: URL
+    let shouldAutoPlay: Bool
     let contentMode: ContentMode
+    let loopVideo: Bool
     let showControls: Bool
-    let player: AVPlayer
-    let looper: AVPlayerLooper?
-
-    init(
-        videoURL: URL,
-        shouldAutoPlay: Bool,
-        contentMode: ContentMode,
-        loopVideo: Bool,
-        showControls: Bool,
-        muteAudio: Bool
-    ) {
-        self.videoURL = videoURL
-        self.contentMode = contentMode
-        self.showControls = showControls
-
-        let playerItem = AVPlayerItem(url: videoURL)
-
-        let avPlayer: AVPlayer
-        if loopVideo {
-            let aVQueuePlayer = AVQueuePlayer()
-            self.looper = AVPlayerLooper(player: aVQueuePlayer, templateItem: playerItem)
-            avPlayer = aVQueuePlayer
-        } else {
-            avPlayer = AVPlayer(playerItem: playerItem)
-            avPlayer.actionAtItemEnd = .pause
-            self.looper = nil
-        }
-
-        avPlayer.isMuted = muteAudio
-        #if !os(visionOS)
-        avPlayer.preventsDisplaySleepDuringVideoPlayback = false
-        avPlayer.allowsExternalPlayback = false
-        #endif
-
-        self.player = avPlayer
-
-        if shouldAutoPlay {
-            avPlayer.play()
-        }
-    }
+    let muteAudio: Bool
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(player: player)
+        Coordinator(
+            videoURL: videoURL,
+            shouldAutoPlay: shouldAutoPlay,
+            loopVideo: loopVideo,
+            muteAudio: muteAudio
+        )
     }
 
     func makeUIViewController(context: Context) -> AVPlayerViewController {
-        let audioSession = AVAudioSession.sharedInstance()
-        context.coordinator.previousCategory = audioSession.category
-        context.coordinator.previousMode = audioSession.mode
-        context.coordinator.previousOptions = audioSession.categoryOptions
-
-        do {
-            try audioSession.setCategory(
-                .ambient,
-                mode: .default,
-                options: [.mixWithOthers]
-            )
-        } catch {
-            Logger.warning(Strings.video_failed_to_set_audio_session_category(error))
-        }
-
         let controller = AVPlayerViewController()
-        controller.player = player
+        controller.player = context.coordinator.player
         controller.view.backgroundColor = .clear
         controller.showsPlaybackControls = showControls
         // When controls are hidden, disable user interaction to allow carousel swipes to pass through.
@@ -107,6 +60,13 @@ struct VideoPlayerUIView: UIViewControllerRepresentable {
         if #available(tvOS 14.0, *) {
             controller.allowsPictureInPicturePlayback = false
         }
+        // Defense-in-depth: disabling video-frame-analysis removes one family of `currentItem.*`
+        // observers that AVKit's internal AVPlayerController registers and that can crash on teardown.
+        #if os(iOS)
+        if #available(iOS 16.0, *) {
+            controller.allowsVideoFrameAnalysis = false
+        }
+        #endif
 
         DispatchQueue.main.async {
             switch contentMode {
@@ -121,22 +81,93 @@ struct VideoPlayerUIView: UIViewControllerRepresentable {
 
     func updateUIViewController(_ uiViewController: AVPlayerViewController, context: Context) { }
 
+    static func dismantleUIViewController(_ uiViewController: AVPlayerViewController, coordinator: Coordinator) {
+        // Deterministically tear the player down before the controller deallocates.
+        uiViewController.player?.pause()
+        uiViewController.player = nil
+        coordinator.tearDown()
+    }
+
     class Coordinator {
 
-        var previousCategory: AVAudioSession.Category?
-        var previousMode: AVAudioSession.Mode?
-        var previousOptions: AVAudioSession.CategoryOptions?
+        let player: AVPlayer
+
+        private var previousCategory: AVAudioSession.Category?
+        private var previousMode: AVAudioSession.Mode?
+        private var previousOptions: AVAudioSession.CategoryOptions?
 
         private let autoplayHandler: VideoAutoplayHandler
+        private var loopObserver: NSObjectProtocol?
 
-        init(player: AVPlayer) {
+        init(
+            videoURL: URL,
+            shouldAutoPlay: Bool,
+            loopVideo: Bool,
+            muteAudio: Bool
+        ) {
+            let playerItem = AVPlayerItem(url: videoURL)
+            let avPlayer = AVPlayer(playerItem: playerItem)
+            // Loop manually instead of via AVPlayerLooper/AVQueuePlayer. AVPlayerLooper swaps the
+            // queue player's currentItem without sending KVO notifications, which crashes
+            // AVPlayerViewController's internal observers (e.g. on `currentItem.status`) on teardown.
+            avPlayer.actionAtItemEnd = loopVideo ? .none : .pause
+
+            avPlayer.isMuted = muteAudio
+            #if !os(visionOS)
+            avPlayer.preventsDisplaySleepDuringVideoPlayback = false
+            avPlayer.allowsExternalPlayback = false
+            #endif
+
+            self.player = avPlayer
+
+            let audioSession = AVAudioSession.sharedInstance()
+            self.previousCategory = audioSession.category
+            self.previousMode = audioSession.mode
+            self.previousOptions = audioSession.categoryOptions
+            do {
+                try audioSession.setCategory(
+                    .ambient,
+                    mode: .default,
+                    options: [.mixWithOthers]
+                )
+            } catch {
+                Logger.warning(Strings.video_failed_to_set_audio_session_category(error))
+            }
+
             self.autoplayHandler = VideoAutoplayHandler(
-                playbackController: player,
+                playbackController: avPlayer,
                 lifecycleObserver: SystemAppLifecycleObserver()
             )
+
+            if loopVideo {
+                self.loopObserver = NotificationCenter.default.addObserver(
+                    forName: AVPlayerItem.didPlayToEndTimeNotification,
+                    object: playerItem,
+                    queue: .main
+                ) { [weak avPlayer] _ in
+                    avPlayer?.seek(to: .zero)
+                    avPlayer?.play()
+                }
+            }
+
+            if shouldAutoPlay {
+                avPlayer.play()
+            }
+        }
+
+        func tearDown() {
+            player.pause()
+            if let loopObserver = self.loopObserver {
+                NotificationCenter.default.removeObserver(loopObserver)
+                self.loopObserver = nil
+            }
         }
 
         deinit {
+            if let loopObserver = self.loopObserver {
+                NotificationCenter.default.removeObserver(loopObserver)
+            }
+
             guard let category = previousCategory,
                   let mode = previousMode,
                   let options = previousOptions else {

--- a/Tests/RevenueCatUITests/PaywallsV2/VideoPlayerViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/VideoPlayerViewTests.swift
@@ -1,0 +1,113 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  VideoPlayerViewTests.swift
+//
+//  Created by RevenueCat.
+//
+
+import AVFoundation
+@_spi(Internal) import RevenueCat
+@testable import RevenueCatUI
+import SwiftUI
+import XCTest
+
+#if os(iOS)
+import UIKit
+
+@available(iOS 15.0, *)
+@MainActor
+final class VideoPlayerViewTests: TestCase {
+
+    private static let videoURL = URL(string: "https://assets.revenuecat.com/video.mp4")!
+
+    // MARK: - Controls path (AVPlayerViewController)
+
+    // The controls path renders with AVPlayerViewController. Handing it an AVPlayerLooper-driven
+    // AVQueuePlayer is what crashes on teardown (NSInternalInconsistencyException on
+    // currentItem.status, issue #6985), so a looping controls video must loop via a single-item
+    // AVPlayer + seek and must never build an AVQueuePlayer.
+    func testControlsLoopingVideoDoesNotUseQueuePlayer() {
+        let view = VideoPlayerUIView(
+            videoURL: Self.videoURL,
+            shouldAutoPlay: false,
+            contentMode: .fill,
+            loopVideo: true,
+            showControls: true,
+            muteAudio: true
+        )
+
+        let coordinator = view.makeCoordinator()
+
+        XCTAssertFalse(coordinator.player is AVQueuePlayer)
+    }
+
+    func testControlsNonLoopingVideoDoesNotUseQueuePlayer() {
+        let view = VideoPlayerUIView(
+            videoURL: Self.videoURL,
+            shouldAutoPlay: false,
+            contentMode: .fill,
+            loopVideo: false,
+            showControls: true,
+            muteAudio: true
+        )
+
+        let coordinator = view.makeCoordinator()
+
+        XCTAssertFalse(coordinator.player is AVQueuePlayer)
+    }
+
+    // MARK: - No-controls path (AVPlayerLayer)
+
+    // The no-controls path renders via an AVPlayerLayer-backed view, which has no internal
+    // AVPlayerController and therefore never registers the observers that crash. It can safely
+    // drive looping with an AVQueuePlayer + AVPlayerLooper.
+    func testNoControlsLoopingVideoUsesQueuePlayer() {
+        let view = VideoPlayerLayerView(
+            videoURL: Self.videoURL,
+            shouldAutoPlay: false,
+            contentMode: .fill,
+            loopVideo: true,
+            muteAudio: true
+        )
+
+        let coordinator = view.makeCoordinator()
+
+        XCTAssertTrue(coordinator.player is AVQueuePlayer)
+    }
+
+    func testNoControlsNonLoopingVideoUsesSingleItemPlayer() {
+        let view = VideoPlayerLayerView(
+            videoURL: Self.videoURL,
+            shouldAutoPlay: false,
+            contentMode: .fill,
+            loopVideo: false,
+            muteAudio: true
+        )
+
+        let coordinator = view.makeCoordinator()
+
+        XCTAssertFalse(coordinator.player is AVQueuePlayer)
+    }
+
+    // MARK: - Layer backing
+
+    // The no-controls view must be backed by an AVPlayerLayer (not an AVPlayerViewController), so
+    // AVKit's internal AVPlayerController and its crashing currentItem.* observers never exist.
+    func testPlayerLayerBackedViewIsBackedByAVPlayerLayer() {
+        XCTAssertTrue(PlayerLayerBackedView.layerClass is AVPlayerLayer.Type)
+
+        let view = PlayerLayerBackedView()
+        XCTAssertTrue(view.layer is AVPlayerLayer)
+        XCTAssertTrue(view.playerLayer === view.layer)
+    }
+
+}
+
+#endif


### PR DESCRIPTION
Stacked on top of #6987 (targets `alex/fix-avfoundation-kvo-crash`, not `main`).

#6987 fixes the looping-video KVO teardown crash but ships without automated coverage, and the core invariant is cheap to pin. This adds structural tests so the fix can't silently regress:

- `testControlsLoopingVideoDoesNotUseQueuePlayer` is the actual root cause: the `AVPlayerViewController` path must never build an `AVQueuePlayer` (an `AVPlayerLooper`-driven queue player handed to AVKit's internal `AVPlayerController` is what crashes on teardown, #6985).
- `testNoControlsLoopingVideoUsesQueuePlayer` + `testPlayerLayerBackedViewIsBackedByAVPlayerLayer` guard the no-controls path: it renders via `AVPlayerLayer` (no `AVPlayerController`), where the queue player + looper are safe.
- Two non-looping companions document the other branch of each path.

They assert through `makeCoordinator()`, so they also cover the player-ownership seam #6987 introduced.

Verified locally on `iPhone 16 Pro (18.4)` via the `RevenueCatUITests` scheme: 5 tests, 0 failures.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: this PR (tests), stacked on #6987; resolves coverage gap for #6985
- Branch: `facu/paywall-video-kvo-crash-tests` (base `alex/fix-avfoundation-kvo-crash`)
- Author / human owner: facumenzella
- Agent(s): Claude Code (Opus 4.8)
- Session source: current conversation
- Generated: 2026-06-12
- Context document version: 1

## Goal

Add automated coverage for the looping-video crash fix in #6987 so the fix is regression-proof. No production code changed; tests only.

## Initial Prompt

Review issue #6985 (looping Paywalls V2 video crashes with `NSInternalInconsistencyException`), then compare an independently-built fix against the official PR #6987, and push for test coverage on #6987 by drafting the missing tests. (Opened as "check this out https://.../issues/6985".)

## Important Follow-up Prompts

- "check our solution against #6987" then "Drop ours, defer to #6987".
- "let's review it" (review of #6987).
- "Let's push for tests, can you draft them?"
- Deliver as a draft PR against #6987, mentioned in alex's PR.

## Agent Contribution

- Drafted `VideoPlayerViewTests.swift` (5 tests) targeting #6987's API (`VideoPlayerUIView`, `VideoPlayerLayerView`, `PlayerLayerBackedView`, `Coordinator.player`).
- Checked out `alex/fix-avfoundation-kvo-crash`, regenerated the Tuist workspace, ran the tests.

## Human Decisions

- Decided to defer to #6987 over the independently-built fix.
- Chose to deliver coverage as a stacked draft PR plus a mention on #6987.

## Key Implementation Decisions

- Decision: assert through `makeCoordinator()` and check `player is AVQueuePlayer` / layer backing.
  - Rationale: the dealloc race is not directly unit-testable, but the structural invariant (no `AVQueuePlayer` to `AVPlayerViewController`; no-controls uses `AVPlayerLayer`) is, and it sits on the ownership seam #6987 added.
  - Rejected: a full SwiftUI lifecycle/teardown test (impractical in a unit test, high flakiness).

## Files / Symbols Touched

- `Tests/RevenueCatUITests/PaywallsV2/VideoPlayerViewTests.swift`
  - Why: new test coverage.
  - Symbols: `VideoPlayerUIView`, `VideoPlayerLayerView`, `PlayerLayerBackedView`, `Coordinator.player`.
  - Review relevance: confirm the assertions match the intended invariant and the API stays stable.

## Dependencies / Config / Migrations

- None.

## Validation

- Commands run:
  - `tuist generate --no-open`: success
  - `xcodebuild test ... -only-testing:RevenueCatUITests/VideoPlayerViewTests`: 5 tests, 0 failures
  - `swiftlint lint`: clean
- Manual verification: confirmed each test maps to a pre-fix failure mode (controls path built an `AVQueuePlayer`; the layer types did not exist).
- CI: Not captured.

## Validation Gaps

- Tests assert player/looper construction, not the actual AVKit teardown sequence (not unit-testable).
- Run on a single simulator (`iPhone 16 Pro`, iOS 18.4); not exercised across the SDK's full OS matrix locally.

## Review Focus

- Are the asserted invariants the ones the maintainer wants pinned long-term?
- Should the controls+loop manual-seek behavior (non-gapless) get its own coverage/expectation?

## Risks / Reviewer Notes

- Risk: tests couple to internal types (`Coordinator.player`).
  - Evidence: `@testable import` makes this intentional and stable; it's the genuine owner of the player.
  - Mitigation: assertions are behavioral (player type / layer class), not implementation trivia.

## Non-goals / Out of Scope

- No changes to the fix in #6987.
- Audio-session save/restore and teardown-symmetry observations raised in review are out of scope here.

## Omitted Context

- Raw transcript, the dropped independent implementation, and exploratory steps were omitted.

</details>
