### PR TITLE
feat(paywalls): decode top-level state declaration map

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -19,12 +19,48 @@
       }
     },
     {
+      "identity" : "flyingfox",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swhitty/FlyingFox.git",
+      "state" : {
+        "revision" : "f7829d4aca8cbfecb410a1cce872b1b045224aa1",
+        "version" : "0.16.0"
+      }
+    },
+    {
       "identity" : "nimble",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/quick/nimble",
       "state" : {
         "revision" : "7795df4fff1a9cd231fe4867ae54f4dc5f5734f9",
         "version" : "13.7.1"
+      }
+    },
+    {
+      "identity" : "ohhttpstubs",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/AliSoftware/OHHTTPStubs.git",
+      "state" : {
+        "revision" : "12f19662426d0434d6c330c6974d53e2eb10ecd9",
+        "version" : "9.1.0"
+      }
+    },
+    {
+      "identity" : "simpledebugger",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/EmergeTools/SimpleDebugger.git",
+      "state" : {
+        "revision" : "f065263eb5db95874b690408d136b573c939db9e",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "snapshotpreviews",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/EmergeTools/SnapshotPreviews.git",
+      "state" : {
+        "revision" : "d42446f0439217941a4e3a2ca58a643c1ac328c4",
+        "version" : "0.14.1"
       }
     },
     {

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -942,6 +942,8 @@
 		77BA1AB32CCBB6EE009BF0EA /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77BA1AB22CCBB6EE009BF0EA /* RootView.swift */; };
 		7DFF88B0441F83F94C8E855F /* VideoAutoplayHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36ECF1E76DAADD986E3D0E5A /* VideoAutoplayHandler.swift */; };
 		7F7F7B1E66E1D8705F06DE51 /* Value+Decodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D92889EDE72E0BC5C030EF03 /* Value+Decodable.swift */; };
+		80442DA22FDF0AFA0085069A /* PaywallComponentStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80442DA12FDF0AFA0085069A /* PaywallComponentStateTests.swift */; };
+		80442DA42FDF0B2E0085069A /* StateDeclaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80442DA32FDF0B2E0085069A /* StateDeclaration.swift */; };
 		805B60C97993B311CEC93EAF /* ProductsFetcherSK2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3628C1F100BB3C1782860D24 /* ProductsFetcherSK2.swift */; };
 		806797FB2FCD96CD00DF760F /* PaywallScrollEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806797F92FCD96CD00DF760F /* PaywallScrollEnvironment.swift */; };
 		806797FE2FCD970800DF760F /* PaywallZLayerScrollPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806797FD2FCD970800DF760F /* PaywallZLayerScrollPolicy.swift */; };
@@ -2469,6 +2471,8 @@
 		7AA86A1D9F5AE92988B20230 /* WorkflowContextTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowContextTests.swift; sourceTree = "<group>"; };
 		7F1B03A2D59CC0822C02186A /* EvaluationError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EvaluationError.swift; sourceTree = "<group>"; };
 		800A129055A298C390AED0B5 /* WorkflowPaywallView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowPaywallView.swift; sourceTree = "<group>"; };
+		80442DA12FDF0AFA0085069A /* PaywallComponentStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallComponentStateTests.swift; sourceTree = "<group>"; };
+		80442DA32FDF0B2E0085069A /* StateDeclaration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateDeclaration.swift; sourceTree = "<group>"; };
 		806797F92FCD96CD00DF760F /* PaywallScrollEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallScrollEnvironment.swift; sourceTree = "<group>"; };
 		806797FD2FCD970800DF760F /* PaywallZLayerScrollPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallZLayerScrollPolicy.swift; sourceTree = "<group>"; };
 		80CDB7B52E69C35100D7DB9E /* CustomerCenterStylingUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerCenterStylingUtilities.swift; sourceTree = "<group>"; };
@@ -3368,6 +3372,7 @@
 				16DA8ECC2E4EE33700283940 /* ImageComponentTests.swift */,
 				16DA8EF32E4F7A2500283940 /* VideoComponentTests.swift */,
 				164933232E5808BE00CE43A9 /* PaywallTransitionTest.swift */,
+				80442DA12FDF0AFA0085069A /* PaywallComponentStateTests.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -3410,6 +3415,7 @@
 				2CC7915D2CC0493600FBE120 /* PaywallComponentBase.swift */,
 				2CC7915E2CC0493600FBE120 /* PaywallComponentLocalization.swift */,
 				2CC7915F2CC0493600FBE120 /* PaywallComponentPropertyTypes.swift */,
+				80442DA32FDF0B2E0085069A /* StateDeclaration.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -7265,6 +7271,7 @@
 				2DDF41A224F6F331005BC22D /* ProductsManager.swift in Sources */,
 				2DDF41A424F6F331005BC22D /* InstallmentsInfoFactory.swift in Sources */,
 				57CCC6EC2984496D001CE9B6 /* Box.swift in Sources */,
+				80442DA42FDF0B2E0085069A /* StateDeclaration.swift in Sources */,
 				4F6ABC7E2A81700900250E63 /* PaywallsStrings.swift in Sources */,
 				75B6DFFD2E30ECB8009F0A99 /* WebOfferingProductsResponse.swift in Sources */,
 				575137CF27F50D2F0064AB2C /* HTTPResponseBody.swift in Sources */,
@@ -7491,6 +7498,7 @@
 				5766AAC5283E843300FA6091 /* PurchasesConfiguringTests.swift in Sources */,
 				351B514D26D44A8600BD2BD7 /* MockHTTPClient.swift in Sources */,
 				4FBBD4E42A620539001CBA21 /* PaywallColorTests.swift in Sources */,
+				80442DA22FDF0AFA0085069A /* PaywallComponentStateTests.swift in Sources */,
 				5733B1AA27FFBCF900EC2045 /* BaseErrorTests.swift in Sources */,
 				FD25F3782F33D502007C1A91 /* BackendIsPurchaseAllowedByRestoreBehaviorTests.swift in Sources */,
 				578FB10E27ADDA8000F70709 /* AvailabilityChecks.swift in Sources */,

--- a/Sources/Networking/Responses/RevenueCatUI/PaywallComponentsData.swift
+++ b/Sources/Networking/Responses/RevenueCatUI/PaywallComponentsData.swift
@@ -112,6 +112,11 @@ import Foundation
     /// Exit offers configuration for this paywall.
     public var exitOffers: ExitOffers?
 
+    /// Declared paywall state keys (key → type + default), used to seed the presentation-session
+    /// state store. Declared at the root of the presentation unit; `nil` when the paywall declares
+    /// no state, which behaves identically to an empty declaration.
+    public private(set) var state: [String: PaywallComponent.StateDeclaration]?
+
     /// When `false`, paywall text will not respect Dynamic Type and would use fixed sizing. Otherwise it will scale.
     public var automaticallyScaleFontSize: Bool
 
@@ -131,6 +136,7 @@ import Foundation
         case zeroDecimalPlaceCountries
         case exitOffers
         case automaticallyScaleFontSize
+        case state
     }
 
     public init(id: String? = nil,
@@ -142,7 +148,8 @@ import Foundation
                 defaultLocaleIdentifier: String,
                 zeroDecimalPlaceCountries: [String] = [],
                 exitOffers: ExitOffers? = nil,
-                automaticallyScaleFontSize: Bool = true) {
+                automaticallyScaleFontSize: Bool = true,
+                state: [String: PaywallComponent.StateDeclaration]? = nil) {
         self.id = id
         self.templateName = templateName
         self.assetBaseURL = assetBaseURL
@@ -153,6 +160,7 @@ import Foundation
         self.zeroDecimalPlaceCountries = zeroDecimalPlaceCountries
         self.exitOffers = exitOffers
         self.automaticallyScaleFontSize = automaticallyScaleFontSize
+        self.state = state
     }
 
 }
@@ -218,6 +226,17 @@ import Foundation
 
         exitOffers = try container.decodeIfPresent(ExitOffers.self, forKey: .exitOffers)
 
+        // Resilient state decoding: malformed entries are dropped individually and a malformed
+        // map is ignored entirely, so a bad declaration can never fail the whole paywall.
+        //
+        // An empty result is normalized to `nil` so that a missing key, an empty `{}` object, and
+        // a map whose entries all fail to decode are all represented identically.
+        let decodedState = ((try? container.decodeIfPresent(
+            [String: FailableStateDeclaration].self,
+            forKey: .state
+        )) ?? nil)?.compactMapValues(\.declaration)
+        state = (decodedState?.isEmpty == false) ? decodedState : nil
+
         let shouldScale = try container.decodeIfPresent(Bool.self, forKey: .automaticallyScaleFontSize)
         // default behavior should respect the dynamic type settings unless explicitly disabled
         automaticallyScaleFontSize = shouldScale ?? true
@@ -254,6 +273,23 @@ import Foundation
         )
         try container.encodeIfPresent(exitOffers, forKey: .exitOffers)
         try container.encode(automaticallyScaleFontSize, forKey: .automaticallyScaleFontSize)
+        try container.encodeIfPresent(state, forKey: .state)
+    }
+
+}
+
+private extension PaywallComponentsData {
+
+    /// Wrapper that swallows per-entry decoding failures so one malformed state declaration
+    /// does not discard the rest of the map.
+    struct FailableStateDeclaration: Decodable {
+
+        let declaration: PaywallComponent.StateDeclaration?
+
+        init(from decoder: Decoder) throws {
+            self.declaration = try? PaywallComponent.StateDeclaration(from: decoder)
+        }
+
     }
 
 }

--- a/Sources/Networking/Responses/RevenueCatUI/PaywallComponentsData.swift
+++ b/Sources/Networking/Responses/RevenueCatUI/PaywallComponentsData.swift
@@ -115,7 +115,7 @@ import Foundation
     /// Declared paywall state keys (key → type + default), used to seed the presentation-session
     /// state store. Declared at the root of the presentation unit; `nil` when the paywall declares
     /// no state, which behaves identically to an empty declaration.
-    public private(set) var state: [String: PaywallComponent.StateDeclaration]?
+    public private(set) var stateDeclarations: [String: PaywallComponent.StateDeclaration]?
 
     /// When `false`, paywall text will not respect Dynamic Type and would use fixed sizing. Otherwise it will scale.
     public var automaticallyScaleFontSize: Bool
@@ -136,7 +136,7 @@ import Foundation
         case zeroDecimalPlaceCountries
         case exitOffers
         case automaticallyScaleFontSize
-        case state
+        case stateDeclarations = "state"
     }
 
     public init(id: String? = nil,
@@ -149,7 +149,7 @@ import Foundation
                 zeroDecimalPlaceCountries: [String] = [],
                 exitOffers: ExitOffers? = nil,
                 automaticallyScaleFontSize: Bool = true,
-                state: [String: PaywallComponent.StateDeclaration]? = nil) {
+                stateDeclarations: [String: PaywallComponent.StateDeclaration]? = nil) {
         self.id = id
         self.templateName = templateName
         self.assetBaseURL = assetBaseURL
@@ -160,7 +160,7 @@ import Foundation
         self.zeroDecimalPlaceCountries = zeroDecimalPlaceCountries
         self.exitOffers = exitOffers
         self.automaticallyScaleFontSize = automaticallyScaleFontSize
-        self.state = state
+        self.stateDeclarations = stateDeclarations
     }
 
 }
@@ -233,9 +233,9 @@ import Foundation
         // a map whose entries all fail to decode are all represented identically.
         let decodedState = ((try? container.decodeIfPresent(
             [String: FailableStateDeclaration].self,
-            forKey: .state
+            forKey: .stateDeclarations
         )) ?? nil)?.compactMapValues(\.declaration)
-        state = (decodedState?.isEmpty == false) ? decodedState : nil
+        stateDeclarations = (decodedState?.isEmpty == false) ? decodedState : nil
 
         let shouldScale = try container.decodeIfPresent(Bool.self, forKey: .automaticallyScaleFontSize)
         // default behavior should respect the dynamic type settings unless explicitly disabled
@@ -273,7 +273,7 @@ import Foundation
         )
         try container.encodeIfPresent(exitOffers, forKey: .exitOffers)
         try container.encode(automaticallyScaleFontSize, forKey: .automaticallyScaleFontSize)
-        try container.encodeIfPresent(state, forKey: .state)
+        try container.encodeIfPresent(stateDeclarations, forKey: .stateDeclarations)
     }
 
 }

--- a/Sources/Paywalls/Components/Common/StateDeclaration.swift
+++ b/Sources/Paywalls/Components/Common/StateDeclaration.swift
@@ -1,0 +1,65 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  StateDeclaration.swift
+//
+// swiftlint:disable missing_docs nesting
+
+import Foundation
+
+@_spi(Internal) public extension PaywallComponent {
+
+    /// Declares a named paywall state key: its value type and the default the state store is seeded with.
+    ///
+    /// JSON shape (an entry of the top-level `state` map):
+    /// ```
+    /// "<key>": { "type": "boolean" | "integer" | "double" | "string", "default": <value> }
+    /// ```
+    ///
+    /// The `type` is kept as an opaque string so future types decode without failing;
+    /// keys themselves are opaque, editor-generated identifiers the SDK never derives or transforms.
+    struct StateDeclaration: Codable, Sendable, Hashable, Equatable {
+
+        /// Known wire values for ``type``. Caseless namespace: forward-compatible with future types.
+        @_spi(Internal) public enum ValueType {
+            public static let boolean = "boolean"
+            public static let integer = "integer"
+            public static let double = "double"
+            public static let string = "string"
+        }
+
+        /// The declared value type. One of `boolean`, `integer`, `double`, or `string`;
+        /// unknown values are preserved as-is for forward compatibility.
+        public let type: String
+
+        /// The value the state store holds for this key until a state update writes to it.
+        public let defaultValue: ConditionValue
+
+        /// The declared default, coerced to the declared `type` where the JSON literal is ambiguous
+        /// (e.g. a `double`-typed key whose default was authored as `0` decodes as an int literal).
+        public var normalizedDefaultValue: ConditionValue {
+            if self.type == ValueType.double, case .int(let intValue) = self.defaultValue {
+                return .double(Double(intValue))
+            }
+            return self.defaultValue
+        }
+
+        public init(type: String, defaultValue: ConditionValue) {
+            self.type = type
+            self.defaultValue = defaultValue
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case type
+            case defaultValue = "default"
+        }
+
+    }
+
+}

--- a/Tests/UnitTests/Paywalls/Components/PaywallComponentStateTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/PaywallComponentStateTests.swift
@@ -1,0 +1,204 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PaywallComponentStateTests.swift
+//
+
+import Nimble
+@_spi(Internal) @testable import RevenueCat
+import XCTest
+
+#if !os(tvOS) // For Paywalls V2
+
+private let minimalStackJSON = """
+{
+    "type": "stack",
+    "dimension": {
+        "type": "vertical",
+        "alignment": "center",
+        "distribution": "start"
+    },
+    "size": {
+        "width": { "type": "fill" },
+        "height": { "type": "fill" }
+    },
+    "padding": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 },
+    "margin": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 },
+    "components": []
+}
+"""
+
+// MARK: - StateDeclaration and top-level state map decoding
+
+final class StateDeclarationDecodingTests: TestCase {
+
+    func testDecodeBooleanStateDeclaration() throws {
+        let declaration = try decodeDeclaration("""
+        {"type": "boolean", "default": false}
+        """)
+        expect(declaration.type).to(equal(PaywallComponent.StateDeclaration.ValueType.boolean))
+        expect(declaration.defaultValue).to(equal(.bool(false)))
+    }
+
+    func testDecodeIntegerStateDeclaration() throws {
+        let declaration = try decodeDeclaration("""
+        {"type": "integer", "default": 0}
+        """)
+        expect(declaration.type).to(equal(PaywallComponent.StateDeclaration.ValueType.integer))
+        expect(declaration.defaultValue).to(equal(.int(0)))
+    }
+
+    func testDecodeDoubleStateDeclaration() throws {
+        let declaration = try decodeDeclaration("""
+        {"type": "double", "default": 0.5}
+        """)
+        expect(declaration.type).to(equal(PaywallComponent.StateDeclaration.ValueType.double))
+        expect(declaration.defaultValue).to(equal(.double(0.5)))
+    }
+
+    func testDecodeStringStateDeclaration() throws {
+        let declaration = try decodeDeclaration("""
+        {"type": "string", "default": "billing"}
+        """)
+        expect(declaration.type).to(equal(PaywallComponent.StateDeclaration.ValueType.string))
+        expect(declaration.defaultValue).to(equal(.string("billing")))
+    }
+
+    func testDecodeStateDeclarationIgnoresUnknownFields() throws {
+        let declaration = try decodeDeclaration("""
+        {"type": "string", "default": "billing", "future_field": 1}
+        """)
+        expect(declaration.defaultValue).to(equal(.string("billing")))
+    }
+
+    func testDoubleTypedDeclarationNormalizesIntegralDefault() throws {
+        // A double-typed key whose default was authored as `0` decodes as an int literal.
+        let declaration = try decodeDeclaration("""
+        {"type": "double", "default": 1}
+        """)
+        expect(declaration.defaultValue).to(equal(.int(1)))
+        expect(declaration.normalizedDefaultValue).to(equal(.double(1)))
+    }
+
+    // MARK: Top-level state map on PaywallComponentsData
+
+    func testDecodePaywallComponentsDataWithStateMap() throws {
+        let data = try decodeComponentsData(state: """
+        {
+            "planComparisonOpen": {"type": "boolean", "default": false},
+            "activeSlide": {"type": "integer", "default": 0},
+            "discountMultiplier": {"type": "double", "default": 0.5},
+            "selectedFeatureTab": {"type": "string", "default": "billing"}
+        }
+        """)
+
+        let state = try XCTUnwrap(data.state)
+        expect(state).to(haveCount(4))
+        expect(state["planComparisonOpen"]?.defaultValue).to(equal(.bool(false)))
+        expect(state["activeSlide"]?.defaultValue).to(equal(.int(0)))
+        expect(state["discountMultiplier"]?.defaultValue).to(equal(.double(0.5)))
+        expect(state["selectedFeatureTab"]?.defaultValue).to(equal(.string("billing")))
+    }
+
+    func testDecodePaywallComponentsDataWithoutStateMap() throws {
+        let data = try decodeComponentsData(state: nil)
+
+        expect(data.state).to(beNil())
+        expect(data.errorInfo).to(beNil())
+    }
+
+    func testMalformedStateEntryIsDroppedWithoutFailingThePaywall() throws {
+        let data = try decodeComponentsData(state: """
+        {
+            "valid": {"type": "boolean", "default": true},
+            "missingDefault": {"type": "boolean"},
+            "invalidDefault": {"type": "string", "default": [1, 2]}
+        }
+        """)
+
+        let state = try XCTUnwrap(data.state)
+        expect(state).to(haveCount(1))
+        expect(state["valid"]?.defaultValue).to(equal(.bool(true)))
+        expect(data.errorInfo).to(beNil())
+    }
+
+    func testMalformedStateMapIsIgnoredWithoutFailingThePaywall() throws {
+        let data = try decodeComponentsData(state: """
+        "not_an_object"
+        """)
+
+        expect(data.state).to(beNil())
+        expect(data.errorInfo).to(beNil())
+    }
+
+    func testEmptyStateMapIsNormalizedToNil() throws {
+        let data = try decodeComponentsData(state: "{}")
+
+        expect(data.state).to(beNil())
+        expect(data.errorInfo).to(beNil())
+    }
+
+    func testStateMapWhoseEntriesAllFailIsNormalizedToNil() throws {
+        let data = try decodeComponentsData(state: """
+        {
+            "missingDefault": {"type": "boolean"},
+            "invalidDefault": {"type": "string", "default": [1, 2]}
+        }
+        """)
+
+        expect(data.state).to(beNil())
+        expect(data.errorInfo).to(beNil())
+    }
+
+    func testPaywallComponentsDataStateRoundTrip() throws {
+        let original = try decodeComponentsData(state: """
+        {"selectedFeatureTab": {"type": "string", "default": "billing"}}
+        """)
+
+        let encoded = try JSONEncoder.default.encode(original)
+        let decoded = try JSONDecoder.default.decode(PaywallComponentsData.self, from: encoded)
+
+        expect(decoded.state).to(equal(original.state))
+    }
+
+    // MARK: Helpers
+
+    private func decodeDeclaration(_ json: String) throws -> PaywallComponent.StateDeclaration {
+        return try JSONDecoder.default.decode(
+            PaywallComponent.StateDeclaration.self,
+            from: json.data(using: .utf8)!
+        )
+    }
+
+    private func decodeComponentsData(state: String?) throws -> PaywallComponentsData {
+        let stateField = state.map { ",\n\"state\": \($0)" } ?? ""
+        let json = """
+        {
+            "template_name": "components",
+            "asset_base_url": "https://assets.revenuecat.com",
+            "components_config": {
+                "base": {
+                    "stack": \(minimalStackJSON),
+                    "background": {
+                        "type": "color",
+                        "value": { "light": { "type": "hex", "value": "#ffffff" } }
+                    }
+                }
+            },
+            "components_localizations": { "en_US": {} },
+            "default_locale": "en_US",
+            "revision": 1\(stateField)
+        }
+        """
+        return try JSONDecoder.default.decode(PaywallComponentsData.self, from: json.data(using: .utf8)!)
+    }
+
+}
+
+#endif

--- a/Tests/UnitTests/Paywalls/Components/PaywallComponentStateTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/PaywallComponentStateTests.swift
@@ -98,7 +98,7 @@ final class StateDeclarationDecodingTests: TestCase {
         }
         """)
 
-        let state = try XCTUnwrap(data.state)
+        let state = try XCTUnwrap(data.stateDeclarations)
         expect(state).to(haveCount(4))
         expect(state["planComparisonOpen"]?.defaultValue).to(equal(.bool(false)))
         expect(state["activeSlide"]?.defaultValue).to(equal(.int(0)))
@@ -109,7 +109,7 @@ final class StateDeclarationDecodingTests: TestCase {
     func testDecodePaywallComponentsDataWithoutStateMap() throws {
         let data = try decodeComponentsData(state: nil)
 
-        expect(data.state).to(beNil())
+        expect(data.stateDeclarations).to(beNil())
         expect(data.errorInfo).to(beNil())
     }
 
@@ -122,7 +122,7 @@ final class StateDeclarationDecodingTests: TestCase {
         }
         """)
 
-        let state = try XCTUnwrap(data.state)
+        let state = try XCTUnwrap(data.stateDeclarations)
         expect(state).to(haveCount(1))
         expect(state["valid"]?.defaultValue).to(equal(.bool(true)))
         expect(data.errorInfo).to(beNil())
@@ -133,14 +133,14 @@ final class StateDeclarationDecodingTests: TestCase {
         "not_an_object"
         """)
 
-        expect(data.state).to(beNil())
+        expect(data.stateDeclarations).to(beNil())
         expect(data.errorInfo).to(beNil())
     }
 
     func testEmptyStateMapIsNormalizedToNil() throws {
         let data = try decodeComponentsData(state: "{}")
 
-        expect(data.state).to(beNil())
+        expect(data.stateDeclarations).to(beNil())
         expect(data.errorInfo).to(beNil())
     }
 
@@ -152,7 +152,7 @@ final class StateDeclarationDecodingTests: TestCase {
         }
         """)
 
-        expect(data.state).to(beNil())
+        expect(data.stateDeclarations).to(beNil())
         expect(data.errorInfo).to(beNil())
     }
 
@@ -164,7 +164,7 @@ final class StateDeclarationDecodingTests: TestCase {
         let encoded = try JSONEncoder.default.encode(original)
         let decoded = try JSONDecoder.default.decode(PaywallComponentsData.self, from: encoded)
 
-        expect(decoded.state).to(equal(original.state))
+        expect(decoded.stateDeclarations).to(equal(original.stateDeclarations))
     }
 
     // MARK: Helpers


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->
<!-- AI agents: fill in this template, and also follow the "Pull Requests" section in AGENTS.md. -->

### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
First PR in the state-driven paywalls Phase 0 stack (iOS, [PWENG-56](https://linear.app/revenuecat/issue/PWENG-56/ios-foundation-state-store-resolver-hook-forward-compat)). Adds the top-level `state` map so the SDK can decode declared state keys (type + default) that seed the presentation-session store in later PRs. Strictly additive and decode-only. 
Spec: https://github.com/RevenueCat/sdk-specs/tree/main/openspec/changes/add-paywall-component-state


### Description
Decodes the optional top-level `state` declaration on `PaywallComponentsData` into `StateDeclaration` values. Decoding is resilient: a malformed entry is dropped individually and a malformed map is ignored, so it can never fail the whole paywall. All types are `@_spi(Internal)`.

Stack: 1/5 → base `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, internal SPI decoding with no runtime state-store or UI behavior yet; malformed state is dropped without failing paywall loads.
> 
> **Overview**
> Adds **decode-only** support for the optional top-level `state` map on paywall component JSON, as the first step toward state-driven paywalls.
> 
> Introduces `PaywallComponent.StateDeclaration` (wire `type` + `default` as existing `ConditionValue`, plus `normalizedDefaultValue` for double keys with integral JSON literals). `PaywallComponentsData` gains `stateDeclarations`, mapped from JSON key `state`, with resilient decoding: malformed entries are skipped, a bad map is ignored, and empty/missing/all-failed maps become `nil` so paywall decode never fails on state. Encoding round-trips the map. New unit tests cover declarations and `PaywallComponentsData` edge cases. `Package.resolved` also picks up additional SPM pins (e.g. snapshot/preview tooling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6977334987bdc8301690c57ab93f1f241222c9b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->