### PR TITLE
feat(paywalls): add decode-only stateUpdates on interactive components

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -942,6 +942,7 @@
 		77BA1AB32CCBB6EE009BF0EA /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77BA1AB22CCBB6EE009BF0EA /* RootView.swift */; };
 		7DFF88B0441F83F94C8E855F /* VideoAutoplayHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36ECF1E76DAADD986E3D0E5A /* VideoAutoplayHandler.swift */; };
 		7F7F7B1E66E1D8705F06DE51 /* Value+Decodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D92889EDE72E0BC5C030EF03 /* Value+Decodable.swift */; };
+		802593752FE06CDA005AF6DF /* StateUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802593742FE06CDA005AF6DF /* StateUpdate.swift */; };
 		80442DA22FDF0AFA0085069A /* PaywallComponentStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80442DA12FDF0AFA0085069A /* PaywallComponentStateTests.swift */; };
 		80442DA42FDF0B2E0085069A /* StateDeclaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80442DA32FDF0B2E0085069A /* StateDeclaration.swift */; };
 		805B60C97993B311CEC93EAF /* ProductsFetcherSK2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3628C1F100BB3C1782860D24 /* ProductsFetcherSK2.swift */; };
@@ -2471,6 +2472,7 @@
 		7AA86A1D9F5AE92988B20230 /* WorkflowContextTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowContextTests.swift; sourceTree = "<group>"; };
 		7F1B03A2D59CC0822C02186A /* EvaluationError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EvaluationError.swift; sourceTree = "<group>"; };
 		800A129055A298C390AED0B5 /* WorkflowPaywallView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowPaywallView.swift; sourceTree = "<group>"; };
+		802593742FE06CDA005AF6DF /* StateUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateUpdate.swift; sourceTree = "<group>"; };
 		80442DA12FDF0AFA0085069A /* PaywallComponentStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallComponentStateTests.swift; sourceTree = "<group>"; };
 		80442DA32FDF0B2E0085069A /* StateDeclaration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateDeclaration.swift; sourceTree = "<group>"; };
 		806797F92FCD96CD00DF760F /* PaywallScrollEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallScrollEnvironment.swift; sourceTree = "<group>"; };
@@ -3416,6 +3418,7 @@
 				2CC7915E2CC0493600FBE120 /* PaywallComponentLocalization.swift */,
 				2CC7915F2CC0493600FBE120 /* PaywallComponentPropertyTypes.swift */,
 				80442DA32FDF0B2E0085069A /* StateDeclaration.swift */,
+				802593742FE06CDA005AF6DF /* StateUpdate.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -7337,6 +7340,7 @@
 				B37815492857F1E7000A7B93 /* BackendConfiguration.swift in Sources */,
 				57045B3C29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift in Sources */,
 				537BA85B2DBBFAF200C93327 /* SDKHealthError+CustomNSError.swift in Sources */,
+				802593752FE06CDA005AF6DF /* StateUpdate.swift in Sources */,
 				4FBBD4E62A620573001CBA21 /* PaywallColor.swift in Sources */,
 				B35042C626CDD3B100905B95 /* PurchasesDelegate.swift in Sources */,
 				0313FD41268A506400168386 /* DateProvider.swift in Sources */,

--- a/Sources/Paywalls/Components/Common/StateUpdate.swift
+++ b/Sources/Paywalls/Components/Common/StateUpdate.swift
@@ -1,0 +1,96 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  StateUpdate.swift
+//
+// swiftlint:disable missing_docs nesting
+
+import Foundation
+
+@_spi(Internal) public extension PaywallComponent {
+
+    /// A declarative state-store mutation applied when an interactive component's primary event fires.
+    ///
+    /// JSON shape (current operations):
+    /// ```
+    /// { "set": "<state key>", "to": <literal value | "$value"> }
+    /// ```
+    ///
+    /// The `"$value"` token instructs the runtime to substitute the interaction's payload
+    /// (e.g. selected tab id, carousel destination page index).
+    /// Unknown shapes decode as `.unsupported` so newer JSON remains safe on older SDKs.
+    /// Decode-only in Phase 0: components carry these updates but do not apply them yet.
+    enum StateUpdate: Codable, Sendable, Hashable, Equatable {
+
+        case set(key: String, value: StateUpdateValue)
+
+        /// Fallback for state-update shapes this SDK version does not understand
+        /// (e.g. future `toggle` / `increment` operations).
+        case unsupported
+
+        private enum CodingKeys: String, CodingKey {
+            case set
+            case toValue = "to"
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let key = (try? container.decodeIfPresent(String.self, forKey: .set)) ?? nil
+            if let key, let value = try? container.decode(StateUpdateValue.self, forKey: .toValue) {
+                self = .set(key: key, value: value)
+                return
+            }
+            self = .unsupported
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            switch self {
+            case .set(let key, let value):
+                try container.encode(key, forKey: .set)
+                try container.encode(value, forKey: .toValue)
+            case .unsupported:
+                break
+            }
+        }
+
+    }
+
+    /// The value of a `StateUpdate.set` operation. Either a literal `ConditionValue` or a reference
+    /// to the firing component's interaction payload (`"$value"` in JSON).
+    enum StateUpdateValue: Codable, Sendable, Hashable, Equatable {
+
+        case literal(ConditionValue)
+        case payloadReference
+
+        /// The reserved JSON string indicating the value should be taken from the interaction's payload.
+        public static let payloadReferenceToken: String = "$value"
+
+        public init(from decoder: Decoder) throws {
+            let conditionValue = try ConditionValue(from: decoder)
+            if case .string(let str) = conditionValue, str == StateUpdateValue.payloadReferenceToken {
+                self = .payloadReference
+            } else {
+                self = .literal(conditionValue)
+            }
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            switch self {
+            case .literal(let value):
+                try container.encode(value)
+            case .payloadReference:
+                try container.encode(StateUpdateValue.payloadReferenceToken)
+            }
+        }
+
+    }
+
+}

--- a/Sources/Paywalls/Components/Common/StateUpdate.swift
+++ b/Sources/Paywalls/Components/Common/StateUpdate.swift
@@ -40,7 +40,10 @@ import Foundation
         }
 
         public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
+            guard let container = try? decoder.container(keyedBy: CodingKeys.self) else {
+                self = .unsupported
+                return
+            }
             let key = (try? container.decodeIfPresent(String.self, forKey: .set)) ?? nil
             if let key, let value = try? container.decode(StateUpdateValue.self, forKey: .toValue) {
                 self = .set(key: key, value: value)

--- a/Sources/Paywalls/Components/PaywallButtonComponent.swift
+++ b/Sources/Paywalls/Components/PaywallButtonComponent.swift
@@ -27,6 +27,8 @@ import Foundation
         public let stack: PaywallComponent.StackComponent
         public let transition: PaywallComponent.Transition?
         public let overrides: ComponentOverrides<PartialButtonComponent>?
+        /// State updates applied when the button's action fires. Decode-only in Phase 0.
+        public let stateUpdates: [StateUpdate]?
         /// Preserves the backend-only `close_workflow` action without growing the public enum surface.
         @_spi(Internal) public let isCloseWorkflowAction: Bool
 
@@ -37,7 +39,8 @@ import Foundation
             action: Action,
             stack: PaywallComponent.StackComponent,
             transition: PaywallComponent.Transition? = nil,
-            overrides: ComponentOverrides<PartialButtonComponent>? = nil
+            overrides: ComponentOverrides<PartialButtonComponent>? = nil,
+            stateUpdates: [StateUpdate]? = nil
         ) {
             self.type = .button
             self.name = name
@@ -47,6 +50,7 @@ import Foundation
             self.stack = stack
             self.transition = transition
             self.overrides = overrides
+            self.stateUpdates = stateUpdates
             self.isCloseWorkflowAction = false
         }
 
@@ -59,6 +63,7 @@ import Foundation
             case stack
             case transition
             case overrides
+            case stateUpdates
         }
 
         private enum ActionCodingKeys: String, CodingKey {
@@ -86,6 +91,7 @@ import Foundation
                 ComponentOverrides<PartialButtonComponent>.self,
                 forKey: .overrides
             )
+            self.stateUpdates = try container.decodeIfPresent([StateUpdate].self, forKey: .stateUpdates)
         }
 
         public func encode(to encoder: Encoder) throws {
@@ -103,6 +109,7 @@ import Foundation
             try container.encode(stack, forKey: .stack)
             try container.encodeIfPresent(transition, forKey: .transition)
             try container.encodeIfPresent(overrides, forKey: .overrides)
+            try container.encodeIfPresent(stateUpdates, forKey: .stateUpdates)
         }
 
         public func hash(into hasher: inout Hasher) {
@@ -115,6 +122,7 @@ import Foundation
             hasher.combine(stack)
             hasher.combine(transition)
             hasher.combine(overrides)
+            hasher.combine(stateUpdates)
         }
 
         public static func == (lhs: ButtonComponent, rhs: ButtonComponent) -> Bool {
@@ -126,7 +134,8 @@ import Foundation
                    lhs.isCloseWorkflowAction == rhs.isCloseWorkflowAction &&
                    lhs.stack == rhs.stack &&
                    lhs.transition == rhs.transition &&
-                   lhs.overrides == rhs.overrides
+                   lhs.overrides == rhs.overrides &&
+                   lhs.stateUpdates == rhs.stateUpdates
 
         }
 

--- a/Sources/Paywalls/Components/PaywallCarouselComponent.swift
+++ b/Sources/Paywalls/Components/PaywallCarouselComponent.swift
@@ -135,6 +135,8 @@ import Foundation
         public let pageControl: PageControl?
 
         public let overrides: ComponentOverrides<PartialCarouselComponent>?
+        /// State updates applied when the carousel's page changes. Decode-only in Phase 0.
+        public let stateUpdates: [StateUpdate]?
 
         public init(
             name: String? = nil,
@@ -154,7 +156,8 @@ import Foundation
             loop: Bool = false,
             autoAdvance: PaywallComponent.CarouselComponent.AutoAdvanceSlides? = nil,
             pageControl: PageControl? = nil,
-            overrides: ComponentOverrides<PartialCarouselComponent>? = nil
+            overrides: ComponentOverrides<PartialCarouselComponent>? = nil,
+            stateUpdates: [StateUpdate]? = nil
         ) {
             self.type = .carousel
 
@@ -176,6 +179,7 @@ import Foundation
             self.autoAdvance = autoAdvance
             self.pageControl = pageControl
             self.overrides = overrides
+            self.stateUpdates = stateUpdates
         }
 
         public static func == (lhs: CarouselComponent, rhs: CarouselComponent) -> Bool {
@@ -197,7 +201,8 @@ import Foundation
                 lhs.loop == rhs.loop &&
                 lhs.autoAdvance == rhs.autoAdvance &&
                 lhs.pageControl == rhs.pageControl &&
-                lhs.overrides == rhs.overrides
+                lhs.overrides == rhs.overrides &&
+                lhs.stateUpdates == rhs.stateUpdates
         }
 
         // MARK: - Hashable
@@ -221,6 +226,7 @@ import Foundation
             hasher.combine(autoAdvance)
             hasher.combine(pageControl)
             hasher.combine(overrides)
+            hasher.combine(stateUpdates)
         }
 
     }

--- a/Sources/Paywalls/Components/PaywallTabsComponent.swift
+++ b/Sources/Paywalls/Components/PaywallTabsComponent.swift
@@ -173,6 +173,8 @@ import Foundation
         public let defaultTabId: String?
 
         public let overrides: ComponentOverrides<PartialTabsComponent>?
+        /// State updates applied when a tab is selected. Decode-only in Phase 0.
+        public let stateUpdates: [StateUpdate]?
 
         public init(
             name: String? = nil,
@@ -189,7 +191,8 @@ import Foundation
             tabs: [Tab],
             defaultTabId: String? = nil,
 
-            overrides: ComponentOverrides<PartialTabsComponent>? = nil
+            overrides: ComponentOverrides<PartialTabsComponent>? = nil,
+            stateUpdates: [StateUpdate]? = nil
         ) {
             self.type = .stack
             self.name = name
@@ -207,6 +210,7 @@ import Foundation
             self.defaultTabId = defaultTabId
 
             self.overrides = overrides
+            self.stateUpdates = stateUpdates
         }
 
         public func hash(into hasher: inout Hasher) {
@@ -224,6 +228,7 @@ import Foundation
             hasher.combine(tabs)
             hasher.combine(defaultTabId)
             hasher.combine(overrides)
+            hasher.combine(stateUpdates)
         }
 
         public static func == (lhs: TabsComponent, rhs: TabsComponent) -> Bool {
@@ -240,7 +245,8 @@ import Foundation
                    lhs.control == rhs.control &&
                    lhs.tabs == rhs.tabs &&
                    lhs.defaultTabId == rhs.defaultTabId &&
-                   lhs.overrides == rhs.overrides
+                   lhs.overrides == rhs.overrides &&
+                   lhs.stateUpdates == rhs.stateUpdates
         }
     }
 

--- a/Tests/UnitTests/Paywalls/Components/PaywallComponentStateTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/PaywallComponentStateTests.swift
@@ -201,4 +201,131 @@ final class StateDeclarationDecodingTests: TestCase {
 
 }
 
+// MARK: - StateUpdate decoding
+
+final class StateUpdateDecodingTests: TestCase {
+
+    typealias StateUpdate = PaywallComponent.StateUpdate
+
+    // MARK: set operation
+
+    func testDecodeSetWithStringLiteral() throws {
+        let update = try decodeStateUpdate("""
+        {"set": "selectedFeatureTab", "to": "billing"}
+        """)
+        expect(update).to(equal(.set(key: "selectedFeatureTab", value: .literal(.string("billing")))))
+    }
+
+    func testDecodeSetWithIntegerLiteral() throws {
+        let update = try decodeStateUpdate("""
+        {"set": "activeSlide", "to": 2}
+        """)
+        expect(update).to(equal(.set(key: "activeSlide", value: .literal(.int(2)))))
+    }
+
+    func testDecodeSetWithDoubleLiteral() throws {
+        let update = try decodeStateUpdate("""
+        {"set": "discountMultiplier", "to": 0.5}
+        """)
+        expect(update).to(equal(.set(key: "discountMultiplier", value: .literal(.double(0.5)))))
+    }
+
+    func testDecodeSetWithBooleanLiteral() throws {
+        let update = try decodeStateUpdate("""
+        {"set": "planComparisonOpen", "to": true}
+        """)
+        expect(update).to(equal(.set(key: "planComparisonOpen", value: .literal(.bool(true)))))
+    }
+
+    func testDecodeSetWithPayloadReference() throws {
+        let update = try decodeStateUpdate("""
+        {"set": "activeSlide", "to": "$value"}
+        """)
+        expect(update).to(equal(.set(key: "activeSlide", value: .payloadReference)))
+    }
+
+    func testDecodeIgnoresUnknownFields() throws {
+        let update = try decodeStateUpdate("""
+        {"set": "planComparisonOpen", "to": true, "future_field": 1}
+        """)
+        expect(update).to(equal(.set(key: "planComparisonOpen", value: .literal(.bool(true)))))
+    }
+
+    // MARK: unsupported / resilience
+
+    func testDecodeUnknownOperationIsUnsupported() throws {
+        // A future operation (e.g. `toggle`) carries no `set`/`to` keys.
+        let update = try decodeStateUpdate("""
+        {"toggle": "planComparisonOpen"}
+        """)
+        expect(update).to(equal(.unsupported))
+    }
+
+    func testDecodeSetWithoutValueIsUnsupported() throws {
+        let update = try decodeStateUpdate("""
+        {"set": "planComparisonOpen"}
+        """)
+        expect(update).to(equal(.unsupported))
+    }
+
+    func testDecodeNonObjectEntryIsUnsupported() throws {
+        // Regression: a non-object entry has no keyed container and must degrade to `.unsupported`
+        // rather than throwing and failing the enclosing component's decode.
+        expect(try self.decodeStateUpdate("\"not_an_object\"")).to(equal(.unsupported))
+        expect(try self.decodeStateUpdate("42")).to(equal(.unsupported))
+        expect(try self.decodeStateUpdate("true")).to(equal(.unsupported))
+        expect(try self.decodeStateUpdate("[1, 2]")).to(equal(.unsupported))
+        expect(try self.decodeStateUpdate("null")).to(equal(.unsupported))
+    }
+
+    func testDecodeArrayDegradesBadEntriesWithoutFailing() throws {
+        // The reviewer's case: a malformed entry must not fail the whole `stateUpdates` array
+        // (and therefore the whole button/carousel/tabs component) decode.
+        let updates = try decodeStateUpdates("""
+        [
+            {"set": "selectedFeatureTab", "to": "billing"},
+            "not_an_object",
+            {"set": "activeSlide", "to": "$value"}
+        ]
+        """)
+        expect(updates).to(haveCount(3))
+        expect(updates[0]).to(equal(.set(key: "selectedFeatureTab", value: .literal(.string("billing")))))
+        expect(updates[1]).to(equal(.unsupported))
+        expect(updates[2]).to(equal(.set(key: "activeSlide", value: .payloadReference)))
+    }
+
+    // MARK: round-trip
+
+    func testSetRoundTrips() throws {
+        let original = StateUpdate.set(key: "activeSlide", value: .literal(.int(3)))
+        let decoded = try JSONDecoder.default.decode(
+            StateUpdate.self,
+            from: JSONEncoder.default.encode(original)
+        )
+        expect(decoded).to(equal(original))
+    }
+
+    func testPayloadReferenceRoundTrips() throws {
+        let original = StateUpdate.set(key: "activeSlide", value: .payloadReference)
+        let decoded = try JSONDecoder.default.decode(
+            StateUpdate.self,
+            from: JSONEncoder.default.encode(original)
+        )
+        expect(decoded).to(equal(original))
+    }
+
+    // MARK: Helpers
+
+    /// Decodes a single update by wrapping it in a one-element array, mirroring how `stateUpdates`
+    /// is always decoded (`[StateUpdate]`) and keeping every fixture a valid top-level JSON document.
+    private func decodeStateUpdate(_ json: String) throws -> StateUpdate {
+        return try XCTUnwrap(decodeStateUpdates("[\(json)]").first)
+    }
+
+    private func decodeStateUpdates(_ json: String) throws -> [StateUpdate] {
+        return try JSONDecoder.default.decode([StateUpdate].self, from: json.data(using: .utf8)!)
+    }
+
+}
+
 #endif


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->
<!-- AI agents: fill in this template, and also follow the "Pull Requests" section in AGENTS.md. -->

### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Phase 0 stack ([PWENG-56](https://linear.app/revenuecat/issue/PWENG-56/ios-foundation-state-store-resolver-hook-forward-compat)). Adds the `stateUpdates` wire format on interactive components so the SDK can carry the mutations a component will apply when its interaction fires. Decode-only this phase, nothing writes to the store yet.
Spec: https://github.com/RevenueCat/sdk-specs/tree/main/openspec/changes/add-paywall-component-state

### Description
Adds `StateUpdate` / `StateUpdateValue` (the `set` op and the `$value` payload token) and an optional `stateUpdates` field on Button, Carousel, and Tabs. 
Unknown update shapes decode as `.unsupported` for forward-compat. `@_spi(Internal)`.

Stack: 2/5 → base `pw-state/1-declaration`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal SPI models and JSON decoding only; no paywall runtime or purchase behavior changes in this phase.
> 
> **Overview**
> Introduces **`StateUpdate`** / **`StateUpdateValue`** so paywall JSON can describe declarative store mutations (`{ "set": "<key>", "to": … }`), including the **`"$value"`** payload token for interaction-driven values. Unknown operation shapes decode as **`.unsupported`** instead of failing the paywall.
> 
> Adds optional **`stateUpdates`** on **Button**, **Carousel**, and **Tabs** (wired through init, equality, and Button’s explicit Codable). **Phase 0 is decode-only**—nothing applies these updates at runtime yet. Types are **`@_spi(Internal)`**.
> 
> Unit tests cover literals, **`$value`**, forward-compat, malformed array entries, and encode round-trips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39543e185e4158a897be794913b526bf6db32877. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->