### PR TITLE
feat(paywalls): add dedicated state condition to component overrides

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -19,48 +19,12 @@
       }
     },
     {
-      "identity" : "flyingfox",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swhitty/FlyingFox.git",
-      "state" : {
-        "revision" : "f7829d4aca8cbfecb410a1cce872b1b045224aa1",
-        "version" : "0.16.0"
-      }
-    },
-    {
       "identity" : "nimble",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/quick/nimble",
       "state" : {
         "revision" : "7795df4fff1a9cd231fe4867ae54f4dc5f5734f9",
         "version" : "13.7.1"
-      }
-    },
-    {
-      "identity" : "ohhttpstubs",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/AliSoftware/OHHTTPStubs.git",
-      "state" : {
-        "revision" : "12f19662426d0434d6c330c6974d53e2eb10ecd9",
-        "version" : "9.1.0"
-      }
-    },
-    {
-      "identity" : "simpledebugger",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/EmergeTools/SimpleDebugger.git",
-      "state" : {
-        "revision" : "f065263eb5db95874b690408d136b573c939db9e",
-        "version" : "1.0.0"
-      }
-    },
-    {
-      "identity" : "snapshotpreviews",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/EmergeTools/SnapshotPreviews.git",
-      "state" : {
-        "revision" : "d42446f0439217941a4e3a2ca58a643c1ac328c4",
-        "version" : "0.14.1"
       }
     },
     {

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
@@ -128,7 +128,7 @@ extension PresentedPartial {
     }
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    // swiftlint:disable:next function_parameter_count
+    // swiftlint:disable:next function_parameter_count cyclomatic_complexity
     private static func evaluateCondition(
         _ condition: PaywallComponent.ExtendedCondition,
         state: ComponentViewState,
@@ -186,6 +186,10 @@ extension PresentedPartial {
                 operator: conditionOperator,
                 selectedPackageId: conditionContext.selectedPackageId
             )
+
+        // State condition — evaluation deferred to a future PR
+        case .state:
+            return false
 
         // Unknown/unsupported conditions never match
         case .unsupported:

--- a/Sources/Paywalls/Components/Common/ComponentOverrides.swift
+++ b/Sources/Paywalls/Components/Common/ComponentOverrides.swift
@@ -183,6 +183,9 @@ extension PaywallComponent {
         case variable(operator: EqualityOperator, variable: String, value: ConditionValue)
         case selectedPackage(operator: ArrayOperator, packages: [String])
 
+        // MARK: - Paywall component state (state-driven paywalls)
+        case state(operator: EqualityOperator, name: String, value: ConditionValue)
+
         // MARK: - Fallback for unknown conditions
         case unsupported
 
@@ -197,7 +200,7 @@ extension PaywallComponent {
             case .compact, .medium, .expanded, .selected, .introOffer, .promoOffer,
                  .multipleIntroOffers, .unsupported:
                 return false
-            case .introOfferCondition, .promoOfferCondition, .variable, .selectedPackage:
+            case .introOfferCondition, .promoOfferCondition, .variable, .selectedPackage, .state:
                 return true
             }
         }
@@ -212,7 +215,7 @@ extension PaywallComponent {
             case .selected: return .selected
             case .introOffer, .introOfferCondition: return .introOffer
             case .promoOffer, .promoOfferCondition: return .promoOffer
-            case .multipleIntroOffers, .variable, .selectedPackage, .unsupported: return .unsupported
+            case .multipleIntroOffers, .variable, .selectedPackage, .state, .unsupported: return .unsupported
             }
         }
 
@@ -266,61 +269,74 @@ extension PaywallComponent {
                 try container.encode(ConditionType.selectedPackageCondition.rawValue, forKey: .type)
                 try container.encode(condOp, forKey: .operator)
                 try container.encode(packages, forKey: .packages)
+            case .state(let condOp, let name, let value):
+                try container.encode(ConditionType.stateCondition.rawValue, forKey: .type)
+                try container.encode(condOp, forKey: .operator)
+                try container.encode(name, forKey: .name)
+                try container.encode(value, forKey: .value)
             case .unsupported:
                 try container.encode("unsupported", forKey: .type)
             }
         }
 
-        // swiftlint:disable:next cyclomatic_complexity
         public init(from decoder: Decoder) throws {
             do {
-                let container = try decoder.container(keyedBy: CodingKeys.self)
-                let rawValue = try container.decode(String.self, forKey: .type)
-
-                guard let conditionType = ConditionType(rawValue: rawValue) else {
-                    Logger.warn(Strings.paywalls.unrecognized_condition_type(rawValue))
-                    self = .unsupported
-                    return
-                }
-
-                switch conditionType {
-                case .compact:
-                    self = .compact
-                case .medium:
-                    self = .medium
-                case .expanded:
-                    self = .expanded
-                case .selected:
-                    self = .selected
-                case .introOffer:
-                    self = .introOffer
-                case .introOfferCondition:
-                    let condOp = try container.decode(EqualityOperator.self, forKey: .operator)
-                    let value = try container.decode(Bool.self, forKey: .value)
-                    self = .introOfferCondition(operator: condOp, value: value)
-                case .promoOffer:
-                    self = .promoOffer
-                case .promoOfferCondition:
-                    let condOp = try container.decode(EqualityOperator.self, forKey: .operator)
-                    let value = try container.decode(Bool.self, forKey: .value)
-                    self = .promoOfferCondition(operator: condOp, value: value)
-                case .multipleIntroOffers:
-                    self = .multipleIntroOffers
-                case .variableCondition:
-                    let condOp = try container.decode(EqualityOperator.self, forKey: .operator)
-                    let variable = try container.decode(String.self, forKey: .variable)
-                    let value = try container.decode(ConditionValue.self, forKey: .value)
-                    self = .variable(operator: condOp, variable: variable, value: value)
-                case .selectedPackageCondition:
-                    let condOp = try container.decode(ArrayOperator.self, forKey: .operator)
-                    let packages = try container.decode([String].self, forKey: .packages)
-                    self = .selectedPackage(operator: condOp, packages: packages)
-                }
+                self = try Self.decodeCondition(from: decoder)
             } catch {
                 let rawType = (try? decoder.container(keyedBy: CodingKeys.self)
                     .decode(String.self, forKey: .type)) ?? "unknown"
                 Logger.warn(Strings.paywalls.malformed_condition(rawType, error))
                 self = .unsupported
+            }
+        }
+
+        // swiftlint:disable:next cyclomatic_complexity
+        private static func decodeCondition(from decoder: Decoder) throws -> Self {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let rawValue = try container.decode(String.self, forKey: .type)
+
+            guard let conditionType = ConditionType(rawValue: rawValue) else {
+                Logger.warn(Strings.paywalls.unrecognized_condition_type(rawValue))
+                return .unsupported
+            }
+
+            switch conditionType {
+            case .compact:
+                return .compact
+            case .medium:
+                return .medium
+            case .expanded:
+                return .expanded
+            case .selected:
+                return .selected
+            case .introOffer:
+                return .introOffer
+            case .introOfferCondition:
+                let condOp = try container.decode(EqualityOperator.self, forKey: .operator)
+                let value = try container.decode(Bool.self, forKey: .value)
+                return .introOfferCondition(operator: condOp, value: value)
+            case .promoOffer:
+                return .promoOffer
+            case .promoOfferCondition:
+                let condOp = try container.decode(EqualityOperator.self, forKey: .operator)
+                let value = try container.decode(Bool.self, forKey: .value)
+                return .promoOfferCondition(operator: condOp, value: value)
+            case .multipleIntroOffers:
+                return .multipleIntroOffers
+            case .variableCondition:
+                let condOp = try container.decode(EqualityOperator.self, forKey: .operator)
+                let variable = try container.decode(String.self, forKey: .variable)
+                let value = try container.decode(ConditionValue.self, forKey: .value)
+                return .variable(operator: condOp, variable: variable, value: value)
+            case .selectedPackageCondition:
+                let condOp = try container.decode(ArrayOperator.self, forKey: .operator)
+                let packages = try container.decode([String].self, forKey: .packages)
+                return .selectedPackage(operator: condOp, packages: packages)
+            case .stateCondition:
+                let condOp = try container.decode(EqualityOperator.self, forKey: .operator)
+                let name = try container.decode(String.self, forKey: .name)
+                let value = try container.decode(ConditionValue.self, forKey: .value)
+                return .state(operator: condOp, name: name, value: value)
             }
         }
 
@@ -332,6 +348,7 @@ extension PaywallComponent {
             case value
             case variable
             case packages
+            case name
 
         }
 
@@ -349,6 +366,7 @@ extension PaywallComponent {
             case selected
             case variableCondition = "variable_condition"
             case selectedPackageCondition = "selected_package_condition"
+            case stateCondition = "state_condition"
 
         }
 

--- a/Tests/RevenueCatUITests/PaywallsV2/ConditionDeserializationTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/ConditionDeserializationTests.swift
@@ -338,6 +338,90 @@ class ConditionDeserializationTests: TestCase {
         expect(condition).to(equal(.unsupported))
     }
 
+    // MARK: - State Condition Tests
+
+    func testDecodeStateConditionWithBooleanValue() throws {
+        let json = """
+        {"type": "state_condition", "operator": "=", "name": "planComparisonOpen", "value": true}
+        """
+        let condition = try decode(json)
+        expect(condition).to(equal(.state(operator: .equals, name: "planComparisonOpen", value: .bool(true))))
+    }
+
+    func testDecodeStateConditionWithIntegerValue() throws {
+        let json = """
+        {"type": "state_condition", "operator": "=", "name": "activeSlide", "value": 2}
+        """
+        let condition = try decode(json)
+        expect(condition).to(equal(.state(operator: .equals, name: "activeSlide", value: .int(2))))
+    }
+
+    func testDecodeStateConditionWithDoubleValue() throws {
+        let json = """
+        {"type": "state_condition", "operator": "=", "name": "discountMultiplier", "value": 0.5}
+        """
+        let condition = try decode(json)
+        expect(condition).to(equal(.state(operator: .equals, name: "discountMultiplier", value: .double(0.5))))
+    }
+
+    func testDecodeStateConditionWithStringValueAndNotEquals() throws {
+        let json = """
+        {"type": "state_condition", "operator": "!=", "name": "selectedFeatureTab", "value": "billing"}
+        """
+        let condition = try decode(json)
+        expect(condition).to(equal(
+            .state(operator: .notEquals, name: "selectedFeatureTab", value: .string("billing"))
+        ))
+    }
+
+    func testDecodeStateConditionIgnoresUnknownFields() throws {
+        let json = """
+        {"type": "state_condition", "operator": "=", "name": "key", "value": "v", "future_field": 1}
+        """
+        let condition = try decode(json)
+        expect(condition).to(equal(.state(operator: .equals, name: "key", value: .string("v"))))
+    }
+
+    func testDecodeStateConditionMissingName_FallsBackToUnsupported() throws {
+        let json = """
+        {"type": "state_condition", "operator": "=", "value": true}
+        """
+        let condition = try decode(json)
+        expect(condition).to(equal(.unsupported))
+    }
+
+    func testDecodeStateConditionMissingValue_FallsBackToUnsupported() throws {
+        let json = """
+        {"type": "state_condition", "operator": "=", "name": "key"}
+        """
+        let condition = try decode(json)
+        expect(condition).to(equal(.unsupported))
+    }
+
+    func testDecodeStateConditionWithUnknownOperator_FallsBackToUnsupported() throws {
+        let json = """
+        {"type": "state_condition", "operator": ">", "name": "activeSlide", "value": 2}
+        """
+        let condition = try decode(json)
+        expect(condition).to(equal(.unsupported))
+    }
+
+    func testDecodeStateConditionWithArrayValue_FallsBackToUnsupported() throws {
+        let json = """
+        {"type": "state_condition", "operator": "=", "name": "key", "value": [1, 2]}
+        """
+        let condition = try decode(json)
+        expect(condition).to(equal(.unsupported))
+    }
+
+    func testDecodeStateConditionWithObjectValue_FallsBackToUnsupported() throws {
+        let json = """
+        {"type": "state_condition", "operator": "=", "name": "key", "value": {"nested": true}}
+        """
+        let condition = try decode(json)
+        expect(condition).to(equal(.unsupported))
+    }
+
     // MARK: - Encoding Tests
 
     func testEncodeVariableCondition() throws {
@@ -358,6 +442,20 @@ class ConditionDeserializationTests: TestCase {
         let condition = PaywallComponent.ExtendedCondition.selectedPackage(
             operator: .in,
             packages: ["monthly", "annual"]
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(condition)
+        let decoded = try decode(String(data: data, encoding: .utf8)!)
+
+        expect(decoded).to(equal(condition))
+    }
+
+    func testEncodeStateCondition() throws {
+        let condition = PaywallComponent.ExtendedCondition.state(
+            operator: .notEquals,
+            name: "selectedFeatureTab",
+            value: .string("billing")
         )
 
         let encoder = JSONEncoder()
@@ -411,6 +509,13 @@ class ConditionDeserializationTests: TestCase {
             packages: ["monthly"]
         )
         expect(packageCondition.toCondition()).to(equal(.unsupported))
+
+        let stateCondition = PaywallComponent.ExtendedCondition.state(
+            operator: .equals,
+            name: "planComparisonOpen",
+            value: .bool(true)
+        )
+        expect(stateCondition.toCondition()).to(equal(.unsupported))
     }
 
     // MARK: - Helpers

--- a/Tests/RevenueCatUITests/PaywallsV2/ToPresentedOverridesTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/ToPresentedOverridesTests.swift
@@ -623,6 +623,87 @@ class ToPresentedOverridesTests: TestCase {
         expect(result.count).to(equal(3))
     }
 
+    // MARK: - State Condition Rule Behavior
+
+    func testStateConditionIsARule() throws {
+        let condition = PaywallComponent.ExtendedCondition.state(
+            operator: .equals,
+            name: "planComparisonOpen",
+            value: .bool(true)
+        )
+
+        expect(condition.isRule).to(beTrue())
+    }
+
+    func testHasUnsupportedCondition_WithStateCondition_ReturnsFalse() throws {
+        // A recognized state condition is supported on this SDK version.
+        let overrides: PaywallComponent.ComponentOverrides<PaywallComponent.PartialStackComponent> = [
+            .init(extendedConditions: [
+                .state(operator: .equals, name: "planComparisonOpen", value: .bool(true))
+            ], properties: .init())
+        ]
+
+        expect(overrides.hasUnsupportedCondition()).to(beFalse())
+    }
+
+    func testToPresentedOverrides_WithDiscardRulesTrue_DiscardsStateOverrides() throws {
+        // When an unsupported condition is found anywhere in the paywall, all rule-based overrides
+        // (state included) are discarded so the default paywall renders with legacy overrides only.
+        let overrides: PaywallComponent.ComponentOverrides<PaywallComponent.PartialStackComponent> = [
+            .init(extendedConditions: [.compact], properties: .init()),
+            .init(extendedConditions: [
+                .state(operator: .equals, name: "planComparisonOpen", value: .bool(true))
+            ], properties: .init()),
+            .init(extendedConditions: [.medium], properties: .init())
+        ]
+
+        let result = overrides.toPresentedOverrides(discardRules: true) { $0 }
+        expect(result.count).to(equal(2))
+        expect(result[0].conditions).to(equal([PaywallComponent.ExtendedCondition.compact]))
+        expect(result[1].conditions).to(equal([PaywallComponent.ExtendedCondition.medium]))
+    }
+
+    func testToPresentedOverrides_WithDiscardRulesFalse_KeepsStateOverrides() throws {
+        let stateCondition = PaywallComponent.ExtendedCondition.state(
+            operator: .equals,
+            name: "planComparisonOpen",
+            value: .bool(true)
+        )
+        let overrides: PaywallComponent.ComponentOverrides<PaywallComponent.PartialStackComponent> = [
+            .init(extendedConditions: [stateCondition], properties: .init())
+        ]
+
+        let result = overrides.toPresentedOverrides(discardRules: false) { $0 }
+        expect(result.count).to(equal(1))
+        expect(result[0].conditions).to(equal([stateCondition]))
+    }
+
+    // MARK: - Forward Compatibility (older-SDK degradation path)
+
+    func testMalformedStateConditionDecodesAsUnsupportedAndTriggersDefaultPaywall() throws {
+        // A state condition this SDK cannot parse behaves exactly like an unknown condition type:
+        // it decodes as .unsupported, which flags the paywall for default-paywall degradation.
+        let json = """
+        {
+            "conditions": [
+                {"type": "state_condition", "operator": "=", "name": "planComparisonOpen", "value": [1, 2]}
+            ],
+            "properties": {}
+        }
+        """
+        let override = try JSONDecoder().decode(
+            PaywallComponent.ComponentOverride<PaywallComponent.PartialStackComponent>.self,
+            from: json.data(using: .utf8)!
+        )
+
+        expect(override.extendedConditions).to(equal([.unsupported]))
+        expect([override].hasUnsupportedCondition()).to(beTrue())
+
+        // The degradation path then discards all rule-based overrides globally.
+        let result = [override].toPresentedOverrides(discardRules: true) { $0 }
+        expect(result).to(beEmpty())
+    }
+
 }
 
 #endif


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->
<!-- AI agents: fill in this template, and also follow the "Pull Requests" section in AGENTS.md. -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Phase 0 stack ([PWENG-56](https://linear.app/revenuecat/issue/PWENG-56/ios-foundation-state-store-resolver-hook-forward-compat)). Introduces the dedicated `state` condition type in component overrides, joining the existing condition types. A dedicated type (rather than overloading `variable_condition`) gives clean forward-compat: older SDKs decode it as unsupported and fall back to the default paywall. 
Spec: https://github.com/RevenueCat/sdk-specs/tree/main/openspec/changes/add-paywall-component-state

### Description
Adds the `state` case to `ExtendedCondition` (`toCondition()` → `.unsupported`, `isRule` true) and the `state_condition` wire type. The resolver switch handles it as non-matching for now (`case .state: return false`); real evaluation lands in the resolver PR. `@_spi(Internal)`; no public API change.

Stack: 3/5 → base `pw-state/2-updates`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal SPI-only paywall condition plumbing with evaluation disabled (`false`); behavior change is limited until the resolver PR lands.
> 
> **Overview**
> Introduces a **`state`** extended override condition (`state_condition` on the wire: `name`, `operator`, `value`) for state-driven paywalls, separate from `variable_condition` so older SDKs can treat unknown types as unsupported and degrade safely.
> 
> **`ExtendedCondition`** gains encode/decode, **`isRule`**, and **`toCondition()` → `.unsupported`**; decoding is refactored into **`decodeCondition`**. Paywalls V2 **`evaluateCondition`** handles **`.state`** by always returning **`false`** until a follow-up PR implements real resolution. **`Package.resolved`** drops several test-only SPM pins (e.g. FlyingFox, OHHTTPStubs).
> 
> Tests cover JSON round-trips, malformed payloads → **`.unsupported`**, rule discard under **`discardRules`**, and forward-compat degradation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 812ed31c3788dc09d101c10ba9a0e4ee2030dc80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->