### PR TITLE
feat(RevenueCatUI): add presentation-session PaywallStateStore

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -943,6 +943,7 @@
 		7DFF88B0441F83F94C8E855F /* VideoAutoplayHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36ECF1E76DAADD986E3D0E5A /* VideoAutoplayHandler.swift */; };
 		7F7F7B1E66E1D8705F06DE51 /* Value+Decodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D92889EDE72E0BC5C030EF03 /* Value+Decodable.swift */; };
 		802593752FE06CDA005AF6DF /* StateUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802593742FE06CDA005AF6DF /* StateUpdate.swift */; };
+		8025937E2FE06FA1005AF6DF /* PaywallStateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8025937D2FE06FA1005AF6DF /* PaywallStateStore.swift */; };
 		80442DA22FDF0AFA0085069A /* PaywallComponentStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80442DA12FDF0AFA0085069A /* PaywallComponentStateTests.swift */; };
 		80442DA42FDF0B2E0085069A /* StateDeclaration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80442DA32FDF0B2E0085069A /* StateDeclaration.swift */; };
 		805B60C97993B311CEC93EAF /* ProductsFetcherSK2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3628C1F100BB3C1782860D24 /* ProductsFetcherSK2.swift */; };
@@ -2473,6 +2474,8 @@
 		7F1B03A2D59CC0822C02186A /* EvaluationError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EvaluationError.swift; sourceTree = "<group>"; };
 		800A129055A298C390AED0B5 /* WorkflowPaywallView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowPaywallView.swift; sourceTree = "<group>"; };
 		802593742FE06CDA005AF6DF /* StateUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateUpdate.swift; sourceTree = "<group>"; };
+		8025937D2FE06FA1005AF6DF /* PaywallStateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallStateStore.swift; sourceTree = "<group>"; };
+		802593842FE07057005AF6DF /* PaywallStateStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallStateStoreTests.swift; sourceTree = "<group>"; };
 		80442DA12FDF0AFA0085069A /* PaywallComponentStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallComponentStateTests.swift; sourceTree = "<group>"; };
 		80442DA32FDF0B2E0085069A /* StateDeclaration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateDeclaration.swift; sourceTree = "<group>"; };
 		806797F92FCD96CD00DF760F /* PaywallScrollEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallScrollEnvironment.swift; sourceTree = "<group>"; };
@@ -3069,6 +3072,7 @@
 		030890822D2B77DD0069677B /* PaywallsV2 */ = {
 			isa = PBXGroup;
 			children = (
+				802593842FE07057005AF6DF /* PaywallStateStoreTests.swift */,
 				16A9F7B62FAA22D0008E8A4D /* VideoComponentViewTests.swift */,
 				A9D45E4EAFAD4C0385BEDFB3 /* VideoPlayerViewTests.swift */,
 				FACD00012F61A1230073D2DE /* TextComponentLocalizationTests.swift */,
@@ -3354,6 +3358,7 @@
 				1D76F2592F921CA100863AF8 /* PlanSelectionDefaultPackage.swift */,
 				19B7F3F7BB1256FB17221052 /* CarouselState.swift */,
 				CFE7B86606D743B4929124FD /* PaywallLoadingKey.swift */,
+				8025937D2FE06FA1005AF6DF /* PaywallStateStore.swift */,
 			);
 			path = EnvironmentObjects;
 			sourceTree = "<group>";
@@ -8119,6 +8124,7 @@
 				DBE7C6552F02D48900A28663 /* StoreProductDiscount+CustomerCenter.swift in Sources */,
 				5798C96B2DF1985700F44400 /* View+PresentCustomerCenter.swift in Sources */,
 				5798C96C2DF1985700F44400 /* ScrollViewSection.swift in Sources */,
+				8025937E2FE06FA1005AF6DF /* PaywallStateStore.swift in Sources */,
 				1699BC362EEB4EAE002001FB /* DefaultPaywallView.swift in Sources */,
 				5798C96D2DF1985700F44400 /* ContactSupportUtilities.swift in Sources */,
 				5798C96E2DF1985700F44400 /* CompatibilityContentUnavailableView.swift in Sources */,

--- a/RevenueCatUI/Templates/V2/EnvironmentObjects/PaywallStateStore.swift
+++ b/RevenueCatUI/Templates/V2/EnvironmentObjects/PaywallStateStore.swift
@@ -93,10 +93,8 @@ final class PaywallStateStore: ObservableObject {
 
         let changed = self.withLock {
             var didChange = false
-            for update in updates {
-                if self.apply(update, payload: payload) {
-                    didChange = true
-                }
+            for update in updates where self.apply(update, payload: payload) {
+                didChange = true
             }
             return didChange
         }

--- a/RevenueCatUI/Templates/V2/EnvironmentObjects/PaywallStateStore.swift
+++ b/RevenueCatUI/Templates/V2/EnvironmentObjects/PaywallStateStore.swift
@@ -1,0 +1,227 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PaywallStateStore.swift
+
+import Foundation
+@_spi(Internal) import RevenueCat
+import SwiftUI
+
+#if !os(tvOS) // For Paywalls V2
+
+/// Presentation-session-scoped paywall state store.
+///
+/// Holds the current values of declared paywall state keys for a single presentation session —
+/// the workflow when the paywall is part of one (injected at `WorkflowPaywallView` level so values
+/// survive screen navigation), the single paywall otherwise (injected at `PaywallsV2View` level).
+/// The store is seeded from the declared defaults and resets when the presentation ends, because
+/// its owning view (and therefore the `@StateObject`) is torn down; nothing persists across
+/// presentations or app launches.
+///
+/// Reads feed `ConditionContext` so the override resolver can evaluate `state` conditions;
+/// writes come from component `stateUpdates` (wired in later phases).
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+final class PaywallStateStore: ObservableObject {
+
+    private let lock = NSLock()
+    private var declaredDefaults: [String: PaywallComponent.ConditionValue]
+    private var currentValues: [String: PaywallComponent.ConditionValue]
+    private var declaredTypes: [String: String]
+
+    /// Creates a store seeded from the given state declarations: each declared key starts out
+    /// holding its declared default value.
+    init(declarations: [String: PaywallComponent.StateDeclaration] = [:]) {
+        let defaults = declarations.mapValues { $0.normalizedDefaultValue }
+        self.declaredDefaults = defaults
+        self.currentValues = defaults
+        self.declaredTypes = declarations.mapValues { $0.type }
+    }
+
+    /// The current value of every state key (declared defaults overlaid with any applied updates).
+    var values: [String: PaywallComponent.ConditionValue] {
+        self.withLock { self.currentValues }
+    }
+
+    /// The declared default value of every state key.
+    var defaults: [String: PaywallComponent.ConditionValue] {
+        self.withLock { self.declaredDefaults }
+    }
+
+    /// Registers additional declarations without overwriting keys that are already declared or
+    /// hold a value. Lets presentation units whose declarations arrive incrementally (e.g. workflow
+    /// screens) contribute their keys to a shared session store.
+    func registerDeclarations(_ declarations: [String: PaywallComponent.StateDeclaration]) {
+        guard !declarations.isEmpty else { return }
+
+        let changed = self.withLock {
+            var didChange = false
+            for (key, declaration) in declarations where self.declaredDefaults[key] == nil {
+                self.declaredDefaults[key] = declaration.normalizedDefaultValue
+                self.declaredTypes[key] = declaration.type
+                if self.currentValues[key] == nil {
+                    self.currentValues[key] = declaration.normalizedDefaultValue
+                    didChange = true
+                }
+            }
+            return didChange
+        }
+
+        if changed {
+            self.notifyChange()
+        }
+    }
+
+    /// Applies a batch of declarative state updates declared on an interactive component, in array order.
+    /// - Parameters:
+    ///   - updates: The updates parsed from the component's JSON `stateUpdates` field.
+    ///   - payload: The interaction's payload value, substituted for `"$value"` references.
+    ///              Pass `nil` for interactions without a payload (e.g. button taps).
+    ///
+    /// Writes to undeclared keys and writes whose value type does not match the key's declared
+    /// type are ignored — the key keeps its current value, per the component-state spec.
+    func apply(
+        _ updates: [PaywallComponent.StateUpdate],
+        payload: PaywallComponent.ConditionValue? = nil
+    ) {
+        guard !updates.isEmpty else { return }
+
+        let changed = self.withLock {
+            var didChange = false
+            for update in updates {
+                if self.apply(update, payload: payload) {
+                    didChange = true
+                }
+            }
+            return didChange
+        }
+
+        if changed {
+            self.notifyChange()
+        }
+    }
+
+    /// Resets every key back to its declared default, as when a presentation starts fresh.
+    func reset() {
+        let changed = self.withLock {
+            guard self.currentValues != self.declaredDefaults else { return false }
+            self.currentValues = self.declaredDefaults
+            return true
+        }
+
+        if changed {
+            self.notifyChange()
+        }
+    }
+
+    // MARK: - Private
+
+    /// Applies a single update to `currentValues`. Must be called while holding `lock`.
+    /// Returns whether a value changed.
+    private func apply(
+        _ update: PaywallComponent.StateUpdate,
+        payload: PaywallComponent.ConditionValue?
+    ) -> Bool {
+        switch update {
+        case .set(let key, let value):
+            let resolvedValue: PaywallComponent.ConditionValue?
+            switch value {
+            case .literal(let literal):
+                resolvedValue = literal
+            case .payloadReference:
+                // No payload available → skip silently. Defensive: the JSON should only
+                // reference "$value" on components whose interaction provides one.
+                resolvedValue = payload
+            }
+
+            guard let resolvedValue,
+                  let newValue = self.normalizedValue(resolvedValue, forKey: key),
+                  self.currentValues[key] != newValue else {
+                return false
+            }
+
+            self.currentValues[key] = newValue
+            return true
+
+        case .unsupported:
+            return false
+        }
+    }
+
+    /// Validates a write against the key's declaration. Must be called while holding `lock`.
+    /// Returns the value to store (coerced to the declared type where the runtime representation
+    /// is ambiguous, e.g. an integral number written to a `double` key), or `nil` when the write
+    /// must be ignored (undeclared key or type mismatch).
+    private func normalizedValue(
+        _ value: PaywallComponent.ConditionValue,
+        forKey key: String
+    ) -> PaywallComponent.ConditionValue? {
+        guard let declaredType = self.declaredTypes[key] else {
+            // Undeclared key (e.g. a dangling reference cascade-delete should have cleaned).
+            return nil
+        }
+
+        typealias ValueType = PaywallComponent.StateDeclaration.ValueType
+
+        switch (declaredType, value) {
+        case (ValueType.string, .string),
+             (ValueType.boolean, .bool),
+             (ValueType.integer, .int),
+             (ValueType.double, .double):
+            return value
+        case (ValueType.double, .int(let intValue)):
+            return .double(Double(intValue))
+        case (ValueType.integer, .double(let doubleValue)):
+            guard let intValue = Int(exactly: doubleValue) else { return nil }
+            return .int(intValue)
+        default:
+            return nil
+        }
+    }
+
+    private func withLock<T>(_ work: () -> T) -> T {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return work()
+    }
+
+    /// Notifies SwiftUI observers on the main thread.
+    private func notifyChange() {
+        if Thread.isMainThread {
+            self.objectWillChange.send()
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.objectWillChange.send()
+            }
+        }
+    }
+
+}
+
+// MARK: - Environment integration
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private struct PaywallStateStoreKey: EnvironmentKey {
+
+    /// `nil` by default: the presentation root (`WorkflowPaywallView` for workflows,
+    /// `PaywallsV2View` for standalone paywalls) injects the session's store.
+    static let defaultValue: PaywallStateStore? = nil
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension EnvironmentValues {
+
+    var paywallStateStore: PaywallStateStore? {
+        get { self[PaywallStateStoreKey.self] }
+        set { self[PaywallStateStoreKey.self] = newValue }
+    }
+
+}
+
+#endif

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -51,6 +51,11 @@ struct PaywallsV2View: View {
     @Environment(\.workflowPackageContext)
     private var workflowPackageContext
 
+    /// Non-`nil` when an ancestor (i.e. `WorkflowPaywallView`) already injected the presentation
+    /// session's state store; in that case this view must not shadow it with its own.
+    @Environment(\.paywallStateStore)
+    private var inheritedStateStore
+
     #if DEBUG
     @Environment(\.paywallLoadingOverride)
     private var paywallLoadingOverride: Bool?
@@ -58,6 +63,11 @@ struct PaywallsV2View: View {
 
     @StateObject
     private var introOfferEligibilityContext: IntroOfferEligibilityContext
+
+    /// Paywall-level state store, used only when this paywall is presented standalone
+    /// (no workflow-level store injected from above). Seeded from the paywall's declared state.
+    @StateObject
+    private var ownStateStore: PaywallStateStore
 
     @StateObject
     private var paywallStateManager: PaywallStateManager
@@ -143,6 +153,9 @@ struct PaywallsV2View: View {
         self._introOfferEligibilityContext = .init(
             wrappedValue: introEligibilityContext ?? .init(introEligibilityChecker: introEligibilityChecker)
         )
+        self._ownStateStore = .init(
+            wrappedValue: PaywallStateStore(declarations: paywallComponents.data.state ?? [:])
+        )
 
         // Step 0: Decide which ComponentsConfig to use (base is default)
         let componentsConfig = paywallComponentsData.componentsConfig.base
@@ -208,6 +221,9 @@ struct PaywallsV2View: View {
                 }
             }
         )
+        // Standalone paywalls own their presentation session's state store; inside a workflow the
+        // store injected by WorkflowPaywallView wins so state survives screen navigation.
+        .environment(\.paywallStateStore, self.inheritedStateStore ?? self.ownStateStore)
     }
 
     private func loadedPaywallView(paywallState: PaywallState) -> some View {

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -154,7 +154,7 @@ struct PaywallsV2View: View {
             wrappedValue: introEligibilityContext ?? .init(introEligibilityChecker: introEligibilityChecker)
         )
         self._ownStateStore = .init(
-            wrappedValue: PaywallStateStore(declarations: paywallComponents.data.state ?? [:])
+            wrappedValue: PaywallStateStore(declarations: paywallComponents.data.stateDeclarations ?? [:])
         )
 
         // Step 0: Decide which ComponentsConfig to use (base is default)

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -214,6 +214,11 @@ struct WorkflowPaywallView: View {
     private let onDismiss: () -> Void
 
     @StateObject private var navigator: WorkflowNavigator
+    /// One paywall state store per workflow presentation: all screens read and write the same
+    /// store, so values survive screen navigation and reset only when the presentation ends
+    /// (this view, and with it the `@StateObject`, is torn down). Seeded empty for now —
+    /// workflow-root `state` declarations arrive with the workflow wire-format follow-up.
+    @StateObject private var stateStore = PaywallStateStore()
     // Held via PromoOfferCacheOwner so this view owns one cache shared across all workflow pages
     // without subscribing to its @Published changes: body only forwards the cache to children.
     // Observing it directly would re-render the whole page ForEach + header overlay on each update.
@@ -350,6 +355,10 @@ struct WorkflowPaywallView: View {
         .onChangeOf(self.navigator.currentStepId) { _ in
             self.syncExitOfferBinding()
         }
+        // Workflow-level injection: every page (current, outgoing, and hidden-but-mounted) shares
+        // this presentation session's state store. PaywallsV2View only creates its own store when
+        // no store was injected from above (i.e. standalone presentation).
+        .environment(\.paywallStateStore, self.stateStore)
     }
 
     // MARK: - Helpers

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallStateStoreTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallStateStoreTests.swift
@@ -1,0 +1,235 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PaywallStateStoreTests.swift
+//
+
+import Combine
+import Nimble
+@_spi(Internal) import RevenueCat
+@testable import RevenueCatUI
+import XCTest
+
+#if !os(tvOS) // For Paywalls V2
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+class PaywallStateStoreTests: TestCase {
+
+    private static let declarations: [String: PaywallComponent.StateDeclaration] = [
+        "planComparisonOpen": .init(type: "boolean", defaultValue: .bool(false)),
+        "activeSlide": .init(type: "integer", defaultValue: .int(0)),
+        "discountMultiplier": .init(type: "double", defaultValue: .double(0.5)),
+        "selectedFeatureTab": .init(type: "string", defaultValue: .string("billing"))
+    ]
+
+    // MARK: - Seeding
+
+    func testStoreSeededFromDeclaredDefaults() {
+        let store = PaywallStateStore(declarations: Self.declarations)
+
+        expect(store.values["planComparisonOpen"]).to(equal(.bool(false)))
+        expect(store.values["activeSlide"]).to(equal(.int(0)))
+        expect(store.values["discountMultiplier"]).to(equal(.double(0.5)))
+        expect(store.values["selectedFeatureTab"]).to(equal(.string("billing")))
+    }
+
+    func testEmptyStoreHasNoValues() {
+        let store = PaywallStateStore()
+
+        expect(store.values).to(beEmpty())
+        expect(store.defaults).to(beEmpty())
+    }
+
+    func testSeedingNormalizesDoubleTypedIntegralDefault() {
+        let store = PaywallStateStore(declarations: [
+            "multiplier": .init(type: "double", defaultValue: .int(1))
+        ])
+
+        expect(store.values["multiplier"]).to(equal(.double(1)))
+    }
+
+    // MARK: - Updates
+
+    func testSetUpdateWritesLiteralValue() {
+        let store = PaywallStateStore(declarations: Self.declarations)
+
+        store.apply([.set(key: "planComparisonOpen", value: .literal(.bool(true)))])
+
+        expect(store.values["planComparisonOpen"]).to(equal(.bool(true)))
+    }
+
+    func testSetUpdateSubstitutesPayloadForPayloadReference() {
+        let store = PaywallStateStore(declarations: Self.declarations)
+
+        store.apply([.set(key: "activeSlide", value: .payloadReference)], payload: .int(3))
+
+        expect(store.values["activeSlide"]).to(equal(.int(3)))
+    }
+
+    func testPayloadReferenceWithoutPayloadIsIgnored() {
+        let store = PaywallStateStore(declarations: Self.declarations)
+
+        store.apply([.set(key: "activeSlide", value: .payloadReference)], payload: nil)
+
+        expect(store.values["activeSlide"]).to(equal(.int(0)))
+    }
+
+    func testUpdatesAppliedInDeclaredOrder() {
+        let store = PaywallStateStore(declarations: Self.declarations)
+
+        store.apply([
+            .set(key: "selectedFeatureTab", value: .literal(.string("usage"))),
+            .set(key: "selectedFeatureTab", value: .literal(.string("support")))
+        ])
+
+        expect(store.values["selectedFeatureTab"]).to(equal(.string("support")))
+    }
+
+    func testWriteToUndeclaredKeyIsIgnored() {
+        let store = PaywallStateStore(declarations: Self.declarations)
+
+        store.apply([.set(key: "undeclared", value: .literal(.bool(true)))])
+
+        expect(store.values["undeclared"]).to(beNil())
+    }
+
+    func testTypeMismatchedWriteIsIgnored() {
+        let store = PaywallStateStore(declarations: Self.declarations)
+
+        // String written to a boolean key keeps the current value.
+        store.apply([.set(key: "planComparisonOpen", value: .literal(.string("true")))])
+
+        expect(store.values["planComparisonOpen"]).to(equal(.bool(false)))
+    }
+
+    func testIntegralWriteToDoubleKeyIsCoerced() {
+        let store = PaywallStateStore(declarations: Self.declarations)
+
+        store.apply([.set(key: "discountMultiplier", value: .literal(.int(2)))])
+
+        expect(store.values["discountMultiplier"]).to(equal(.double(2)))
+    }
+
+    func testIntegralDoubleWriteToIntegerKeyIsCoerced() {
+        let store = PaywallStateStore(declarations: Self.declarations)
+
+        store.apply([.set(key: "activeSlide", value: .literal(.double(4)))])
+
+        expect(store.values["activeSlide"]).to(equal(.int(4)))
+    }
+
+    func testNonIntegralDoubleWriteToIntegerKeyIsIgnored() {
+        let store = PaywallStateStore(declarations: Self.declarations)
+
+        store.apply([.set(key: "activeSlide", value: .literal(.double(1.5)))])
+
+        expect(store.values["activeSlide"]).to(equal(.int(0)))
+    }
+
+    func testUnsupportedUpdateIsIgnored() {
+        let store = PaywallStateStore(declarations: Self.declarations)
+
+        store.apply([.unsupported])
+
+        expect(store.values).to(equal(store.defaults))
+    }
+
+    // MARK: - Reset
+
+    func testResetRestoresDeclaredDefaults() {
+        let store = PaywallStateStore(declarations: Self.declarations)
+        store.apply([
+            .set(key: "planComparisonOpen", value: .literal(.bool(true))),
+            .set(key: "activeSlide", value: .literal(.int(5)))
+        ])
+
+        store.reset()
+
+        expect(store.values["planComparisonOpen"]).to(equal(.bool(false)))
+        expect(store.values["activeSlide"]).to(equal(.int(0)))
+    }
+
+    // MARK: - Incremental declarations
+
+    func testRegisterDeclarationsAddsNewKeys() {
+        let store = PaywallStateStore()
+
+        store.registerDeclarations(["newKey": .init(type: "boolean", defaultValue: .bool(true))])
+
+        expect(store.values["newKey"]).to(equal(.bool(true)))
+        expect(store.defaults["newKey"]).to(equal(.bool(true)))
+    }
+
+    func testRegisterDeclarationsDoesNotOverwriteExistingKeys() {
+        let store = PaywallStateStore(declarations: Self.declarations)
+        store.apply([.set(key: "planComparisonOpen", value: .literal(.bool(true)))])
+
+        store.registerDeclarations([
+            "planComparisonOpen": .init(type: "boolean", defaultValue: .bool(false))
+        ])
+
+        // Mutated value and original default are both preserved.
+        expect(store.values["planComparisonOpen"]).to(equal(.bool(true)))
+        expect(store.defaults["planComparisonOpen"]).to(equal(.bool(false)))
+    }
+
+    // MARK: - Change notifications
+
+    func testApplyNotifiesObserversOnChange() {
+        let store = PaywallStateStore(declarations: Self.declarations)
+        var changeCount = 0
+        let cancellable = store.objectWillChange.sink { changeCount += 1 }
+        defer { cancellable.cancel() }
+
+        // Applied from the main thread, so the notification is delivered synchronously.
+        store.apply([.set(key: "planComparisonOpen", value: .literal(.bool(true)))])
+
+        expect(changeCount).to(equal(1))
+    }
+
+    func testNoOpApplyDoesNotNotifyObservers() {
+        let store = PaywallStateStore(declarations: Self.declarations)
+        var changeCount = 0
+        let cancellable = store.objectWillChange.sink { changeCount += 1 }
+        defer { cancellable.cancel() }
+
+        // Writing the value the key already holds is a no-op.
+        store.apply([.set(key: "planComparisonOpen", value: .literal(.bool(false)))])
+
+        expect(changeCount).to(equal(0))
+    }
+
+    // MARK: - Thread safety
+
+    func testConcurrentReadsAndWritesDoNotCrashAndLandOnAValidValue() {
+        let store = PaywallStateStore(declarations: Self.declarations)
+        let iterations = 500
+
+        DispatchQueue.concurrentPerform(iterations: iterations) { index in
+            store.apply([.set(key: "activeSlide", value: .literal(.int(index)))])
+            _ = store.values
+            _ = store.defaults
+            if index.isMultiple(of: 7) {
+                store.registerDeclarations([
+                    "key\(index)": .init(type: "integer", defaultValue: .int(index))
+                ])
+            }
+        }
+
+        guard case .int(let finalValue)? = store.values["activeSlide"] else {
+            fail("Expected an int value for activeSlide")
+            return
+        }
+        expect(finalValue).to(beGreaterThanOrEqualTo(0))
+        expect(finalValue).to(beLessThan(iterations))
+    }
+
+}
+
+#endif


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->
<!-- AI agents: fill in this template, and also follow the "Pull Requests" section in AGENTS.md. -->

### Motivation
Phase 0 stack ([PWENG-56](https://linear.app/revenuecat/issue/PWENG-56/ios-foundation-state-store-resolver-hook-forward-compat)). Adds the presentation-session state store that holds current state-key values — scoped to the workflow when present, the single paywall otherwise — seeded from declared defaults and reset when the presentation ends.
Spec: https://github.com/RevenueCat/sdk-specs/tree/main/openspec/changes/add-paywall-component-state

### Description
Adds the thread-safe `PaywallStateStore` and injects it into the environment at `WorkflowPaywallView` (shared across screens so state survives navigation) and `PaywallsV2View` (own store when presented standalone). Writes from `stateUpdates` and component wiring come in later phases.

Stack: 4/5 → base `pw-state/3-condition`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Foundation-only change: store and environment injection with no purchase/auth paths touched; behavior is gated behind later wiring of reads/writes.
> 
> **Overview**
> Introduces **`PaywallStateStore`**, a thread-safe, presentation-scoped holder for declared paywall **state** keys (defaults, typed writes from `stateUpdates`, `$value` payload substitution, `reset`, and incremental `registerDeclarations`). It publishes SwiftUI changes via `ObservableObject` and is exposed as **`\.paywallStateStore`** in the environment.
> 
> **`WorkflowPaywallView`** owns one shared `@StateObject` store for the whole workflow (empty seed for now) and injects it so state can survive step navigation. **`PaywallsV2View`** seeds a local store from `stateDeclarations` when standalone, but reuses an inherited store when embedded in a workflow so it does not replace the workflow session store.
> 
> Unit tests cover seeding, apply/validation/coercion rules, reset, registration, observer notifications, and concurrent access. Wiring **`stateUpdates`** and feeding state into **`ConditionContext`** are explicitly deferred to later stack items.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3289b77b9b1e4bf0f55046c585d2126b79f7ba0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->