### PR TITLE
feat(RevenueCatUI): evaluate state conditions in the override resolver

### DIFF
--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
@@ -50,15 +50,25 @@ struct ConditionContext {
     /// Custom variables for condition evaluation (developer-provided merged with dashboard defaults).
     let customVariables: [String: CustomVariableValue]
 
+    /// Snapshot of the presentation session's state store (current values of declared state keys).
+    let stateValues: [String: PaywallComponent.ConditionValue]
+
+    /// Declared defaults for state keys, used when a key has no value in the store snapshot.
+    let stateDefaults: [String: PaywallComponent.ConditionValue]
+
     /// Creates a context with the given parameters.
     /// Developer-provided `customVariables` take priority over `defaultCustomVariables` from the dashboard.
     init(
         selectedPackageId: String? = nil,
         customVariables: [String: CustomVariableValue] = [:],
-        defaultCustomVariables: [String: CustomVariableValue] = [:]
+        defaultCustomVariables: [String: CustomVariableValue] = [:],
+        stateValues: [String: PaywallComponent.ConditionValue] = [:],
+        stateDefaults: [String: PaywallComponent.ConditionValue] = [:]
     ) {
         self.selectedPackageId = selectedPackageId
         self.customVariables = defaultCustomVariables.merging(customVariables) { _, developer in developer }
+        self.stateValues = stateValues
+        self.stateDefaults = stateDefaults
     }
 
 }
@@ -187,9 +197,15 @@ extension PresentedPartial {
                 selectedPackageId: conditionContext.selectedPackageId
             )
 
-        // State condition — evaluation deferred to a future PR
-        case .state:
-            return false
+        // Paywall component state condition
+        case .state(let conditionOperator, let name, let value):
+            return evaluateStateCondition(
+                name: name,
+                expectedValue: value,
+                operator: conditionOperator,
+                stateValues: conditionContext.stateValues,
+                stateDefaults: conditionContext.stateDefaults
+            )
 
         // Unknown/unsupported conditions never match
         case .unsupported:
@@ -246,6 +262,60 @@ extension PresentedPartial {
             return matches
         case .notEquals:
             return !matches
+        }
+    }
+
+    /// Evaluates a `state` condition against the state-store snapshot.
+    ///
+    /// A key with no value in the store falls back to its declared default. A key that is neither
+    /// in the store nor declared evaluates to `false` regardless of operator, so the containing
+    /// override is never applied. This deliberately differs from `evaluateVariableCondition`'s
+    /// missing-variable rule (`!=` matches a missing variable): state keys are editor-managed,
+    /// so an undeclared reference is a consistency error rather than a legitimately absent value.
+    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+    private static func evaluateStateCondition(
+        name: String,
+        expectedValue: PaywallComponent.ConditionValue,
+        operator conditionOperator: PaywallComponent.EqualityOperator,
+        stateValues: [String: PaywallComponent.ConditionValue],
+        stateDefaults: [String: PaywallComponent.ConditionValue]
+    ) -> Bool {
+        guard let actualValue = stateValues[name] ?? stateDefaults[name] else {
+            return false
+        }
+
+        let matches = matchesConditionValue(actualValue: actualValue, expectedValue: expectedValue)
+
+        switch conditionOperator {
+        case .equals:
+            return matches
+        case .notEquals:
+            return !matches
+        }
+    }
+
+    /// Type-strict comparison of two `ConditionValue`s: string matches only string, boolean only
+    /// boolean, and numbers (int or double) match numbers; any other type mismatch is "not equal".
+    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+    private static func matchesConditionValue(
+        actualValue: PaywallComponent.ConditionValue,
+        expectedValue: PaywallComponent.ConditionValue
+    ) -> Bool {
+        switch (actualValue, expectedValue) {
+        case (.string(let actual), .string(let expected)):
+            return actual == expected
+        case (.bool(let actual), .bool(let expected)):
+            return actual == expected
+        case (.int(let actual), .int(let expected)):
+            return actual == expected
+        case (.int(let actual), .double(let expected)):
+            return doublesMatch(Double(actual), expected)
+        case (.double(let actual), .int(let expected)):
+            return doublesMatch(actual, Double(expected))
+        case (.double(let actual), .double(let expected)):
+            return doublesMatch(actual, expected)
+        default:
+            return false
         }
     }
 

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
@@ -72,14 +72,21 @@ final class UIConfigProvider {
     }
 
     /// Creates a `ConditionContext` by merging developer-provided custom variables with dashboard defaults.
+    /// `stateValues` / `stateDefaults` carry the presentation session's state-store snapshot for
+    /// `state` condition evaluation; they default to empty for call sites without a store (wired
+    /// per component in later state-driven-paywalls phases).
     func conditionContext(
         selectedPackageId: String?,
-        customVariables: [String: CustomVariableValue]
+        customVariables: [String: CustomVariableValue],
+        stateValues: [String: PaywallComponent.ConditionValue] = [:],
+        stateDefaults: [String: PaywallComponent.ConditionValue] = [:]
     ) -> ConditionContext {
         ConditionContext(
             selectedPackageId: selectedPackageId,
             customVariables: customVariables,
-            defaultCustomVariables: self.defaultCustomVariables
+            defaultCustomVariables: self.defaultCustomVariables,
+            stateValues: stateValues,
+            stateDefaults: stateDefaults
         )
     }
 

--- a/Tests/RevenueCatUITests/PaywallsV2/PresentedPartialsTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PresentedPartialsTests.swift
@@ -984,6 +984,310 @@ class PresentedPartialsTests: TestCase {
         expect(result).to(beNil())
     }
 
+    // MARK: - State Condition Tests
+
+    func testStateCondition_BoolEquals_Matches() throws {
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .state(operator: .equals, name: "planComparisonOpen", value: .bool(true))
+        ]
+
+        let context = ConditionContext(stateValues: ["planComparisonOpen": .bool(true)])
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: context,
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).toNot(beNil())
+    }
+
+    func testStateCondition_BoolEquals_DoesNotMatchDifferentValue() throws {
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .state(operator: .equals, name: "planComparisonOpen", value: .bool(true))
+        ]
+
+        let context = ConditionContext(stateValues: ["planComparisonOpen": .bool(false)])
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: context,
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).to(beNil())
+    }
+
+    func testStateCondition_StringNotEquals_Matches() throws {
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .state(operator: .notEquals, name: "selectedFeatureTab", value: .string("billing"))
+        ]
+
+        let context = ConditionContext(stateValues: ["selectedFeatureTab": .string("usage")])
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: context,
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).toNot(beNil())
+    }
+
+    func testStateCondition_IntEquals_Matches() throws {
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .state(operator: .equals, name: "activeSlide", value: .int(2))
+        ]
+
+        let context = ConditionContext(stateValues: ["activeSlide": .int(2)])
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: context,
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).toNot(beNil())
+    }
+
+    func testStateCondition_DoubleEquals_MatchesWithinEpsilon() throws {
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .state(operator: .equals, name: "discountMultiplier", value: .double(0.3))
+        ]
+
+        let context = ConditionContext(stateValues: ["discountMultiplier": .double(0.1 + 0.2)])
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: context,
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).toNot(beNil())
+    }
+
+    func testStateCondition_IntValueMatchesDoubleState() throws {
+        // Numbers match numbers across int/double representations.
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .state(operator: .equals, name: "discountMultiplier", value: .int(2))
+        ]
+
+        let context = ConditionContext(stateValues: ["discountMultiplier": .double(2.0)])
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: context,
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).toNot(beNil())
+    }
+
+    func testStateCondition_TypeMismatch_EqualsDoesNotMatch() throws {
+        // Condition expects int(2), state holds string("2") — types do not match.
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .state(operator: .equals, name: "activeSlide", value: .int(2))
+        ]
+
+        let context = ConditionContext(stateValues: ["activeSlide": .string("2")])
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: context,
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).to(beNil())
+    }
+
+    func testStateCondition_TypeMismatch_NotEqualsMatches() throws {
+        // Type mismatch is treated as "not equal", so != matches for a declared key.
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .state(operator: .notEquals, name: "activeSlide", value: .int(2))
+        ]
+
+        let context = ConditionContext(stateValues: ["activeSlide": .string("2")])
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: context,
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).toNot(beNil())
+    }
+
+    func testStateCondition_MissingValueFallsBackToDeclaredDefault() throws {
+        // Declared with a default, no value in the store snapshot yet.
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .state(operator: .equals, name: "planComparisonOpen", value: .bool(false))
+        ]
+
+        let context = ConditionContext(stateDefaults: ["planComparisonOpen": .bool(false)])
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: context,
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).toNot(beNil())
+    }
+
+    func testStateCondition_StoreValueWinsOverDeclaredDefault() throws {
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .state(operator: .equals, name: "planComparisonOpen", value: .bool(true))
+        ]
+
+        let context = ConditionContext(
+            stateValues: ["planComparisonOpen": .bool(true)],
+            stateDefaults: ["planComparisonOpen": .bool(false)]
+        )
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: context,
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).toNot(beNil())
+    }
+
+    func testStateCondition_UndeclaredKeyWithEquals_DoesNotMatch() throws {
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .state(operator: .equals, name: "undeclared", value: .bool(true))
+        ]
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: ConditionContext(),
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).to(beNil())
+    }
+
+    func testStateCondition_UndeclaredKeyWithNotEquals_DoesNotMatch() throws {
+        // Unlike variable_condition, an undeclared state key never matches — for BOTH operators —
+        // so the containing override is never applied.
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .state(operator: .notEquals, name: "undeclared", value: .bool(true))
+        ]
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: ConditionContext(),
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).to(beNil())
+    }
+
+    func testStateCondition_CombinedWithSelectedPackageCondition_AllMustMatch() throws {
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .selectedPackage(operator: .in, packages: ["annual"]),
+            .state(operator: .equals, name: "planComparisonOpen", value: .bool(true))
+        ]
+
+        let matchingContext = ConditionContext(
+            selectedPackageId: "annual",
+            stateValues: ["planComparisonOpen": .bool(true)]
+        )
+        let failingContext = ConditionContext(
+            selectedPackageId: "annual",
+            stateValues: ["planComparisonOpen": .bool(false)]
+        )
+
+        let overrides = [PresentedOverride(conditions: conditions, properties: TestPartial())]
+
+        let matching = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: matchingContext,
+            with: overrides
+        )
+        let failing = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: failingContext,
+            with: overrides
+        )
+
+        expect(matching).toNot(beNil())
+        expect(failing).to(beNil())
+    }
+
+    func testStateCondition_VisibilityDrivenByState_LastMatchingOverrideWins() throws {
+        let overrides: PresentedOverrides<VisibilityPartial> = [
+            PresentedOverride(
+                conditions: [.state(operator: .equals, name: "planComparisonOpen", value: .bool(true))],
+                properties: VisibilityPartial(visible: true)
+            ),
+            PresentedOverride(
+                conditions: [.state(operator: .equals, name: "selectedFeatureTab", value: .string("usage"))],
+                properties: VisibilityPartial(visible: false)
+            )
+        ]
+
+        let context = ConditionContext(
+            stateValues: [
+                "planComparisonOpen": .bool(true),
+                "selectedFeatureTab": .string("usage")
+            ]
+        )
+
+        let result = VisibilityPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: context,
+            with: overrides
+        )
+
+        expect(result?.visible).to(equal(false))
+    }
+
     // MARK: - Unsupported Condition Tests
 
     func testUnsupportedCondition_DoesNotMatch() throws {


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->
<!-- AI agents: fill in this template, and also follow the "Pull Requests" section in AGENTS.md. -->

### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Final PR in the Phase 0 stack ([PWENG-56](https://linear.app/revenuecat/issue/PWENG-56/ios-foundation-state-store-resolver-hook-forward-compat)). Wires `state` condition evaluation into the override resolver so state-driven overrides can be resolved.
Spec: https://github.com/RevenueCat/sdk-specs/tree/main/openspec/changes/add-paywall-component-state

### Description
Replaces the PR3 stub with real `state` evaluation: type-aware comparison, missing key -> declared default, undeclared key -> false regardless of operator (per spec, deliberately unlike `variable_condition`). Extends `ConditionContext` with the store snapshot + defaults.

Note: the per-component resolver call sites aren't yet passing the store snapshot into `conditionContext(...)`, so state conditions don't affect rendering at runtime yet, that threading is the open half of task 3.6. Flagging for review on whether it belongs here or a follow-up.

Stack: 5/5 → base `pw-state/4-store`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall override/visibility resolution semantics for a new condition type; behavior is well-tested but incorrect wiring later could silently leave state-driven overrides inert until snapshots are passed.
> 
> **Overview**
> Implements real **`state`** extended-condition evaluation for Paywalls V2 component overrides, replacing the previous stub that always failed.
> 
> **`ConditionContext`** now carries a presentation-session snapshot (`stateValues`) plus declared **`stateDefaults`**. **`UIConfigProvider.conditionContext`** forwards those fields (defaulting to empty) so callers can supply store data when available.
> 
> Override resolution compares expected `ConditionValue`s with type-strict rules (string/bool/int/double, numeric cross-type with epsilon). Missing store values use declared defaults; keys absent from both store and defaults **never match** (including `notEquals`), unlike missing custom variables.
> 
> Extensive **`PresentedPartialsTests`** cover equality, defaults, undeclared keys, AND with other conditions, and visibility override precedence.
> 
> **Note:** Component resolver call sites still invoke `conditionContext` without the store snapshot, so **`state` conditions do not affect live rendering until that wiring lands** (called out in PR description).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5de26ff1ab5bb28c1053066f34b1c3044e2aa4fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->