### PR TITLE
Use a snapshot-env-free macOS executor for update-error-codes

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -59,6 +59,25 @@ executors:
       CIRCLECI_TESTS_GENERATE_REVENUECAT_UI_SNAPSHOTS: << pipeline.parameters.generate_revenuecatui_snapshots >>
     working_directory: ~/purchases-ios
     shell: /bin/bash --login -o pipefail
+  # A macOS executor safe to pass into orb jobs (e.g. revenuecat/update-error-codes).
+  # The standard macos-executor embeds pipeline.parameters.* in its environment, which
+  # don't resolve when an executor is evaluated outside this config's own pipeline-parameter
+  # scope (such as inside an orb), causing an "Unknown variable(s)" config error. This
+  # variant hardcodes those values so it carries no such references.
+  macos-executor-external:
+    parameters:
+      xcode_version:
+        type: string
+        default: "16.4"
+    macos:
+      # circleci-lint: disable=unknown-xcode-version
+      xcode: << parameters.xcode_version >>
+    resource_class: m4pro.medium
+    environment:
+      CIRCLECI_TESTS_GENERATE_SNAPSHOTS: "false"
+      CIRCLECI_TESTS_GENERATE_REVENUECAT_UI_SNAPSHOTS: "false"
+    working_directory: ~/purchases-ios
+    shell: /bin/bash --login -o pipefail
   macos-executor-large:
     parameters:
       xcode_version:
@@ -2573,7 +2592,7 @@ workflows:
           output: Sources/Generated/ErrorCode.swift
           commit_paths: "Sources/Generated/ErrorCode.swift,api"
           executor:
-            name: macos-executor
+            name: macos-executor-external
             xcode_version: *swiftinterface-xcode-version
           update_api_steps:
             - install-dependencies


### PR DESCRIPTION
The default `macos-executor` has two pipeline parameters for snapshots as environment variables. When passed to an external orb, it can't resolve them, causing an [error](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/39292)

To work around this, I've defined a separate executor for external use that just hardcodes the envs to false.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI configuration only; no application or SDK code changes, and snapshot env behavior for the error-codes job is intentionally fixed to false.
> 
> **Overview**
> Fixes CircleCI **Unknown variable(s)** failures when the `revenuecat/update-error-codes` orb job receives the default **`macos-executor`**, whose environment still references `<< pipeline.parameters.generate_snapshots >>` and related snapshot flags that do not resolve inside the orb’s config scope.
> 
> Adds **`macos-executor-external`**, mirroring the standard macOS executor but hardcoding `CIRCLECI_TESTS_GENERATE_SNAPSHOTS` and `CIRCLECI_TESTS_GENERATE_REVENUECAT_UI_SNAPSHOTS` to `"false"`, and wires the **`update-error-codes`** workflow to use it instead of **`macos-executor`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e846fc1fc037720f9f82f971d790f8dfcc051c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->