### PR TITLE
Danger: block manual edits to generated error codes

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1,7 +1,7 @@
 orbs:
   macos: circleci/macos@2.5.1
   slack: circleci/slack@5.0.0
-  revenuecat: revenuecat/sdks-common-config@3.21.0
+  revenuecat: revenuecat/sdks-common-config@3.21.1
   # Disabled until compatible with M1: codecov: codecov/codecov@3.3.0
   # codecov: codecov/codecov@3.3.0
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -161,3 +161,5 @@ else
 
   fail("Purchases iOS checks failed — see the comment above for details.") unless all_failures.empty?
 end
+
+fail_on_generated_edits(["Sources/Generated/"])


### PR DESCRIPTION
- Adds a Danger check to prevent modification of autogenerated files from [purchases-error-codes](https://github.com/RevenueCat/purchases-error-codes). Calls a function defined in [RevenueCat/Dangerfile](https://github.com/RevenueCat/Dangerfile/pull/16)
- Bumps the [shared orb](https://github.com/RevenueCat/sdks-circleci-orb/pull/68) to get the proper labels on the generated PRs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and Danger policy only; no runtime SDK or app behavior changes.
> 
> **Overview**
> Adds a **Danger** guard so PRs that touch **`Sources/Generated/`** fail CI, steering error-code updates through the **`purchases-error-codes`** / **`update-error-codes`** automation instead of hand edits (via shared **`fail_on_generated_edits`** from **RevenueCat/Dangerfile**).
> 
> Bumps the CircleCI **`revenuecat/sdks-common-config`** orb **3.21.0 → 3.21.1** so automated error-code PRs get the expected labels from the shared orb.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a153497cc036c3dc5c83e663eba72fc13ced3b8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->