### PR TITLE
Add macCatalyst availability check

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerViewUIView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerViewUIView.swift
@@ -61,7 +61,7 @@ struct VideoPlayerUIView: UIViewControllerRepresentable {
         // Defense-in-depth: disabling video-frame-analysis removes one family of `currentItem.*`
         // observers that AVKit's internal AVPlayerController registers and that can crash on teardown.
         #if os(iOS)
-        if #available(iOS 16.0, *) {
+        if #available(iOS 16.0, macCatalyst 18.0, *) {
             controller.allowsVideoFrameAnalysis = false
         }
         #endif


### PR DESCRIPTION
Extend the availability condition to include macCatalyst 18.0 when disabling allowsVideoFrameAnalysis. This ensures the defense-in-depth change (disabling AVKit video-frame-analysis to avoid AVPlayerController observer-related teardown crashes) is also applied for macCatalyst builds.

### Checklist
- [ ] ~~If applicable, unit tests~~ 
- [ ] ~~If applicable, create follow-up issues for `purchases-android` and hybrids~~ 

### Motivation
Resolves current CI build issues

### Description
n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line availability fix with no behavior change on iOS; only aligns Mac Catalyst with an existing defensive AVKit setting.
> 
> **Overview**
> Extends the `#available` check around `allowsVideoFrameAnalysis = false` in `VideoPlayerUIView` so it also applies on **macCatalyst 18.0**, not only **iOS 16.0**.
> 
> That keeps the existing teardown crash mitigation (turning off AVKit video-frame-analysis observers) active for Mac Catalyst builds and addresses the CI compile issue tied to the narrower availability condition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5515d2ceb52ba25648b3d3715e7f11f82f2426f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->