### PR TITLE
fix(ads): key reward verification poll retries on HTTP status

### DIFF
--- a/Sources/Ads/RewardVerification/Poller.swift
+++ b/Sources/Ads/RewardVerification/Poller.swift
@@ -132,7 +132,7 @@ internal extension RewardVerification {
             case .networkError, .offlineConnectionError:
                 return true
             default:
-                let statusCode = (error as NSError).userInfo[ErrorDetails.statusCodeKey] as? Int
+                let statusCode = (error as NSError).httpStatusCode
                 return statusCode.map { HTTPStatusCode(rawValue: $0).isServerError } ?? false
             }
         }

--- a/Sources/Ads/RewardVerification/Poller.swift
+++ b/Sources/Ads/RewardVerification/Poller.swift
@@ -127,8 +127,6 @@ internal extension RewardVerification {
             return .failed(.timeout)
         }
 
-        /// Retries network/offline transport errors and any HTTP 5xx, keying on the status code
-        /// rather than the mapped `ErrorCode` so empty/unparseable 5xx retry and 4xx fail fast.
         static func isTransientPollingError(_ error: Error) -> Bool {
             switch error as? ErrorCode {
             case .networkError, .offlineConnectionError:

--- a/Sources/Ads/RewardVerification/Poller.swift
+++ b/Sources/Ads/RewardVerification/Poller.swift
@@ -105,9 +105,9 @@ internal extension RewardVerification {
                     case .failed: return .failed(.backendError)
                     case .pending, .unknown: continue
                     }
-                } catch let code as ErrorCode where code.isTransientPolling {
+                } catch where Self.isTransientPollingError(error) {
                     Logger.debug(AdsStrings.poll_transient_error(
-                        error: code,
+                        error: error,
                         transactionID: clientTransactionID
                     ))
                     continue
@@ -125,6 +125,18 @@ internal extension RewardVerification {
                 transactionID: clientTransactionID
             ))
             return .failed(.timeout)
+        }
+
+        /// Retries network/offline transport errors and any HTTP 5xx, keying on the status code
+        /// rather than the mapped `ErrorCode` so empty/unparseable 5xx retry and 4xx fail fast.
+        static func isTransientPollingError(_ error: Error) -> Bool {
+            switch error as? ErrorCode {
+            case .networkError, .offlineConnectionError:
+                return true
+            default:
+                let statusCode = (error as NSError).userInfo[ErrorDetails.statusCodeKey] as? Int
+                return statusCode.map { HTTPStatusCode(rawValue: $0).isServerError } ?? false
+            }
         }
     }
 
@@ -155,22 +167,6 @@ private extension RewardVerificationPollStatus {
         case .pending: return "pending"
         case .failed: return "failed"
         case .unknown: return "unknown"
-        }
-    }
-}
-
-// MARK: - ErrorCode classification
-
-private extension ErrorCode {
-
-    var isTransientPolling: Bool {
-        switch self {
-        case .networkError,
-             .offlineConnectionError,
-             .unknownBackendError:
-            return true
-        default:
-            return false
         }
     }
 }

--- a/Sources/FoundationExtensions/Error+Extensions.swift
+++ b/Sources/FoundationExtensions/Error+Extensions.swift
@@ -20,6 +20,10 @@ extension NSError {
         return self.userInfo[ErrorDetails.attributeErrorsKey] as? [String: String]
     }
 
+    var httpStatusCode: Int? {
+        return self.userInfo[ErrorDetails.statusCodeKey] as? Int
+    }
+
 }
 
 extension Error {

--- a/Tests/UnitTests/Ads/RewardVerification/RewardVerificationPollerTestDoubles.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/RewardVerificationPollerTestDoubles.swift
@@ -146,8 +146,6 @@ func makePoller(
     )
 }
 
-/// A `PublicError` carrying `statusCode` in `userInfo`, built through the production
-/// `asBackendError`/`asPublicError` path. Use `.unknownError` to model an unparseable body.
 func makePollingError(statusCode: Int, backendCode: BackendErrorCode) -> NSError {
     ErrorResponse(code: backendCode, originalCode: backendCode.rawValue, message: nil)
         .asBackendError(with: HTTPStatusCode(rawValue: statusCode))

--- a/Tests/UnitTests/Ads/RewardVerification/RewardVerificationPollerTestDoubles.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/RewardVerificationPollerTestDoubles.swift
@@ -145,3 +145,11 @@ func makePoller(
         maxAttempts: maxAttempts
     )
 }
+
+/// A `PublicError` carrying `statusCode` in `userInfo`, built through the production
+/// `asBackendError`/`asPublicError` path. Use `.unknownError` to model an unparseable body.
+func makePollingError(statusCode: Int, backendCode: BackendErrorCode) -> NSError {
+    ErrorResponse(code: backendCode, originalCode: backendCode.rawValue, message: nil)
+        .asBackendError(with: HTTPStatusCode(rawValue: statusCode))
+        .asPublicError
+}

--- a/Tests/UnitTests/Ads/RewardVerification/RewardVerificationPollerTests.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/RewardVerificationPollerTests.swift
@@ -160,7 +160,9 @@ final class RewardVerificationPollerTests: TestCase {
     }
 
     func testEveryAttemptThrowingTransientExhaustsBudgetAndReturnsFailed() async {
-        let statusPoller = ThrowingStatusPoller(error: ErrorCode.unknownBackendError)
+        let statusPoller = ThrowingStatusPoller(
+            error: makePollingError(statusCode: 500, backendCode: .internalServerError)
+        )
         let sleeper = RecordingSleeper()
         let sut = makePoller(statusPoller: statusPoller, sleeper: sleeper, maxAttempts: 5)
 
@@ -197,7 +199,8 @@ final class RewardVerificationPollerTests: TestCase {
     }
 
     func testEachTransientErrorCodeIsRetried() async {
-        let transient: [ErrorCode] = [.networkError, .offlineConnectionError, .unknownBackendError]
+        // Transport-level codes (no HTTP response); `.networkError` also covers URLSession timeouts.
+        let transient: [ErrorCode] = [.networkError, .offlineConnectionError]
         for code in transient {
             let statusPoller = ScriptedStatusPoller(steps: [
                 .throwError(code),
@@ -212,6 +215,75 @@ final class RewardVerificationPollerTests: TestCase {
             }
             XCTAssertEqual(statusPoller.callCount, 2, "Transient code \(code) should have been retried once")
         }
+    }
+
+    // MARK: - HTTP-status-keyed retry (5xx transient, 4xx terminal)
+
+    func testParseableServerErrorIsRetried() async {
+        let statusPoller = ScriptedStatusPoller(steps: [
+            .throwError(makePollingError(statusCode: 500, backendCode: .internalServerError)),
+            .status(.verified(.noReward))
+        ])
+        let sleeper = RecordingSleeper()
+        let sut = makePoller(statusPoller: statusPoller, sleeper: sleeper)
+
+        let outcome = await sut.run(clientTransactionID: "tx-1")
+
+        guard case .verified(.noReward) = outcome else {
+            return XCTFail("Expected .verified(.noReward), got \(outcome)")
+        }
+        XCTAssertEqual(statusPoller.callCount, 2, "A 5xx should be retried")
+    }
+
+    func testUnparseableServerErrorIsRetried() async {
+        // Empty 5xx maps to `.unknownError` (not a transient code) but must still be retried on the 5xx status.
+        let statusPoller = ScriptedStatusPoller(steps: [
+            .throwError(makePollingError(statusCode: 503, backendCode: .unknownError)),
+            .status(.verified(.noReward))
+        ])
+        let sleeper = RecordingSleeper()
+        let sut = makePoller(statusPoller: statusPoller, sleeper: sleeper)
+
+        let outcome = await sut.run(clientTransactionID: "tx-1")
+
+        guard case .verified(.noReward) = outcome else {
+            return XCTFail("Expected .verified(.noReward), got \(outcome)")
+        }
+        XCTAssertEqual(statusPoller.callCount, 2, "An unparseable 5xx should still be retried")
+    }
+
+    func testClientErrorIsNotRetriedAndFailsFastAsBackendError() async {
+        // A 4xx must fail fast as `.backendError`, not be retried to a misleading `.timeout`.
+        let statusPoller = ThrowingStatusPoller(
+            error: makePollingError(statusCode: 400, backendCode: .badRequest)
+        )
+        let sleeper = RecordingSleeper()
+        let sut = makePoller(statusPoller: statusPoller, sleeper: sleeper)
+
+        let outcome = await sut.run(clientTransactionID: "tx-1")
+
+        guard case .failed(.backendError) = outcome else {
+            return XCTFail("Expected .failed(.backendError), got \(outcome)")
+        }
+        XCTAssertEqual(statusPoller.callCount, 1, "A 4xx must not be retried")
+        XCTAssertTrue(sleeper.delays.isEmpty)
+    }
+
+    func testServerErrorAfterPendingIsRetried() async {
+        let statusPoller = ScriptedStatusPoller(steps: [
+            .status(.pending),
+            .throwError(makePollingError(statusCode: 502, backendCode: .unknownError)),
+            .status(.verified(.noReward))
+        ])
+        let sleeper = RecordingSleeper()
+        let sut = makePoller(statusPoller: statusPoller, sleeper: sleeper)
+
+        let outcome = await sut.run(clientTransactionID: "tx-1")
+
+        guard case .verified(.noReward) = outcome else {
+            return XCTFail("Expected .verified(.noReward), got \(outcome)")
+        }
+        XCTAssertEqual(statusPoller.callCount, 3)
     }
 
     // MARK: - Terminal `ErrorCode` path


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

Reward verification polling keyed its retry decision on the mapped `ErrorCode`, so transient infra 5xx with an empty/unparseable body (e.g. a bare load-balancer/Cloudflare 503) mapped to `.unknownError` and failed fast instead of retrying, while permanent 4xx client errors mapped to `.unknownBackendError` and were retried for the full attempt budget, ending in a misleading `.timeout`. Android already keys this on the HTTP status code; this aligns iOS to it.

### Description
- `Poller` now classifies retries via `isTransientPollingError(_:)`, retrying network/offline transport errors (timeouts already map to `.networkError`) and any HTTP 5xx — read from the error's `userInfo` status code. As a result empty/unparseable 5xx responses are retried and 4xx client errors fail fast as `.backendError`.
- Covered by new unit tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ads reward verification outcome timing (retry vs fail-fast) for backend errors; behavior is well covered by new unit tests but affects user-visible reward flows on flaky or misclassified HTTP responses.
> 
> **Overview**
> Reward verification polling now decides whether to retry failed poll attempts from **HTTP status and transport errors**, not from the mapped `ErrorCode` alone.
> 
> `RewardVerification.Poller` uses new `isTransientPollingError(_:)`: it still retries `.networkError` and `.offlineConnectionError`, and for other errors reads `httpStatusCode` from the NSError `userInfo` (via a new `NSError.httpStatusCode` helper) and retries when the status is **5xx**. **4xx** responses fail immediately with `.failed(.backendError)` instead of burning the full attempt budget and ending in `.timeout`. Bare or unparseable **5xx** bodies that map to non-transient codes are retried on status, matching Android.
> 
> The old `ErrorCode.isTransientPolling` path (which treated `.unknownBackendError` as transient) is removed. Unit tests add `makePollingError` and cover 5xx retry, unparseable 5xx retry, 4xx fail-fast, and mixed pending + server-error flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a723c05ec095b6bb58ca75f465fbf77645e6177. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->