### PR TITLE
Fix tvOS/visionOS build: import AVFoundation in VideoPlayerViewUIView

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerViewUIView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerViewUIView.swift
@@ -11,6 +11,7 @@
 //
 //  Created by Jacob Zivan Rakidzich on 8/18/25.
 
+import AVFoundation
 import AVKit
 @_spi(Internal) import RevenueCat
 import SwiftUI


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

Follow-up to #6987 / #6997: the tvOS and visionOS CI builds fail with `type 'AVPlayerItem' has no member 'didPlayToEndTimeNotification'`.

### Description

`AVPlayerItem.didPlayToEndTimeNotification` is declared in **AVFoundation**, but the controls-path file imported only `AVKit`. AVKit re-exposes the symbol on iOS and Mac Catalyst (so those builds passed) but not on tvOS/visionOS. Importing `AVFoundation` explicitly fixes it — the same pattern the existing watchOS code in `VideoPlayerView.swift` already uses for this symbol. No deployment-target or behavior changes.

Verified by building `RevenueCatUI` on iOS, tvOS, visionOS, watchOS, macOS, and Mac Catalyst.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single import-line change with no logic or deployment-target changes; only restores compile-time access to an API already used in the file.
> 
> **Overview**
> Adds an explicit **`import AVFoundation`** to `VideoPlayerViewUIView.swift` so the controls-path video player can reference **`AVPlayerItem.didPlayToEndTimeNotification`** when setting up manual loop observers.
> 
> That notification lives in AVFoundation; importing only AVKit was enough on iOS and Mac Catalyst but **breaks compilation on tvOS and visionOS**, where CI reported the symbol missing. Runtime behavior is unchanged—this only fixes cross-platform builds, matching the watchOS pattern in `VideoPlayerView.swift`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77020b48c009d3f7ee01f4105a36c4a28dd51f7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->