### PR TITLE
Fix RevenueCatUI build on older Xcode: use legacy AVPlayerItemDidPlayToEndTime

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerView.swift
@@ -136,12 +136,25 @@ struct VideoPlayerView: View {
             }
         }
 
+        #if os(watchOS)
+        // Prefer the modern class-scoped notification name, but fall back to the legacy constant on
+        // older compilers/SDKs (pre-Swift 5.9 / Xcode 15) where
+        // `AVPlayerItem.didPlayToEndTimeNotification` doesn't exist.
+        private var didPlayToEndTimeNotification: NSNotification.Name {
+            #if compiler(>=5.9)
+            return AVPlayerItem.didPlayToEndTimeNotification
+            #else
+            return NSNotification.Name.AVPlayerItemDidPlayToEndTime
+            #endif
+        }
+        #endif
+
         var body: some View {
             VideoPlayer(player: player)
             #if os(watchOS)
                 // This is less reliable than using the AVPlayerLooper.
                 // Unfortunately, that is not available on watchOS
-                .onReceive(notificationCenter.publisher(for: NSNotification.Name.AVPlayerItemDidPlayToEndTime)) { _ in
+                .onReceive(notificationCenter.publisher(for: didPlayToEndTimeNotification)) { _ in
                     if loopVideo {
                         player.seek(to: .zero)
                         player.play()

--- a/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerView.swift
@@ -141,7 +141,7 @@ struct VideoPlayerView: View {
             #if os(watchOS)
                 // This is less reliable than using the AVPlayerLooper.
                 // Unfortunately, that is not available on watchOS
-                .onReceive(notificationCenter.publisher(for: AVPlayerItem.didPlayToEndTimeNotification)) { _ in
+                .onReceive(notificationCenter.publisher(for: NSNotification.Name.AVPlayerItemDidPlayToEndTime)) { _ in
                     if loopVideo {
                         player.seek(to: .zero)
                         player.play()

--- a/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerViewUIView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerViewUIView.swift
@@ -141,7 +141,9 @@ struct VideoPlayerUIView: UIViewControllerRepresentable {
 
             if loopVideo {
                 self.loopObserver = NotificationCenter.default.addObserver(
-                    forName: AVPlayerItem.didPlayToEndTimeNotification,
+                    // Use the legacy constant (not `AVPlayerItem.didPlayToEndTimeNotification`):
+                    // the class-property form doesn't exist on older SDKs the CI matrix builds against.
+                    forName: NSNotification.Name.AVPlayerItemDidPlayToEndTime,
                     object: playerItem,
                     queue: .main
                 ) { [weak self] _ in

--- a/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerViewUIView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerViewUIView.swift
@@ -140,10 +140,19 @@ struct VideoPlayerUIView: UIViewControllerRepresentable {
             )
 
             if loopVideo {
+                // Prefer the modern class-scoped notification name, but fall back to the legacy
+                // constant on older compilers/SDKs (pre-Swift 5.9 / Xcode 15) where
+                // `AVPlayerItem.didPlayToEndTimeNotification` doesn't exist. The CI compatibility
+                // matrix builds RevenueCatUI on those older toolchains.
+                let endOfItemNotification: NSNotification.Name
+                #if compiler(>=5.9)
+                endOfItemNotification = AVPlayerItem.didPlayToEndTimeNotification
+                #else
+                endOfItemNotification = NSNotification.Name.AVPlayerItemDidPlayToEndTime
+                #endif
+
                 self.loopObserver = NotificationCenter.default.addObserver(
-                    // Use the legacy constant (not `AVPlayerItem.didPlayToEndTimeNotification`):
-                    // the class-property form doesn't exist on older SDKs the CI matrix builds against.
-                    forName: NSNotification.Name.AVPlayerItemDidPlayToEndTime,
+                    forName: endOfItemNotification,
                     object: playerItem,
                     queue: .main
                 ) { [weak self] _ in


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

The `test_revenuecatui` CI lane (RevenueCatUI on an older Xcode — iOS 15.5 simulator, pre-visionOS toolchain) fails to compile with `type 'AVPlayerItem' has no member 'didPlayToEndTimeNotification'`. This persisted after the earlier `import AVFoundation` fix (#7000).

### Description

The Swift class-property form `AVPlayerItem.didPlayToEndTimeNotification` doesn't exist in the older AVFoundation SDK that lane builds against — it only resolves on newer Xcode, which is why local builds passed. Both usages now use the original `NSNotification.Name.AVPlayerItemDidPlayToEndTime` constant, available on every SDK since iOS 4. Same behavior, no deployment-target changes.

The watchOS-only sibling in `VideoPlayerView.swift` is updated too, to prevent the identical latent failure there.

Note: local Xcode can't reproduce the older-toolchain failure, so the real confirmation is the `test_revenuecatui` lane re-running green in CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time API selection only; loop logic and runtime behavior stay the same on both code paths.
> 
> **Overview**
> Fixes **RevenueCatUI** compile failures on older CI Xcode (pre–Swift 5.9 / Xcode 15) where `AVPlayerItem.didPlayToEndTimeNotification` is unavailable.
> 
> Video loop handling now picks the notification name at **compile time**: the modern `AVPlayerItem.didPlayToEndTimeNotification` when `compiler(>=5.9)`, otherwise `NSNotification.Name.AVPlayerItemDidPlayToEndTime`. Applied in **watchOS** `VideoPlayerView` (`.onReceive` for manual loop) and **UIKit** `VideoPlayerViewUIView` (loop `NotificationCenter` observer). Playback and loop behavior are unchanged on supported SDKs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94823cc9629dbdf6e9f132cfec70d8ea863b7184. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->