### PR TITLE
ci: add AVFoundation to RevenueCatUI API baselines

### DIFF
--- a/api/revenuecatui-api-ios-simulator.swiftinterface
+++ b/api/revenuecatui-api-ios-simulator.swiftinterface
@@ -2,6 +2,7 @@
 // swift-compiler-version: Apple Swift version 6.3.2 effective-5.10 (swiftlang-6.3.2.1.108 clang-2100.1.1.101)
 // swift-module-flags: -target arm64-apple-ios13.0-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -O -enable-experimental-feature DebugDescriptionMacro -module-name RevenueCatUI -package-name purchases_ios
 // swift-module-flags-ignorable:  -formal-cxx-interoperability-mode=off -interface-compiler-version 6.3.2
+import AVFoundation
 import AVKit
 import Combine
 import DeveloperToolsSupport

--- a/api/revenuecatui-api-ios.swiftinterface
+++ b/api/revenuecatui-api-ios.swiftinterface
@@ -2,6 +2,7 @@
 // swift-compiler-version: Apple Swift version 6.3.2 effective-5.10 (swiftlang-6.3.2.1.108 clang-2100.1.1.101)
 // swift-module-flags: -target arm64-apple-ios13.0 -enable-objc-interop -enable-library-evolution -swift-version 5 -O -enable-experimental-feature DebugDescriptionMacro -module-name RevenueCatUI -package-name purchases_ios
 // swift-module-flags-ignorable:  -formal-cxx-interoperability-mode=off -interface-compiler-version 6.3.2
+import AVFoundation
 import AVKit
 import Combine
 import DeveloperToolsSupport

--- a/api/revenuecatui-api-macos.swiftinterface
+++ b/api/revenuecatui-api-macos.swiftinterface
@@ -2,6 +2,7 @@
 // swift-compiler-version: Apple Swift version 6.3.2 effective-5.10 (swiftlang-6.3.2.1.108 clang-2100.1.1.101)
 // swift-module-flags: -target arm64-apple-macos10.15 -enable-objc-interop -enable-library-evolution -swift-version 5 -O -enable-experimental-feature DebugDescriptionMacro -module-name RevenueCatUI -package-name purchases_ios
 // swift-module-flags-ignorable:  -formal-cxx-interoperability-mode=off -interface-compiler-version 6.3.2
+import AVFoundation
 import AVKit
 import AppKit
 import Combine

--- a/api/revenuecatui-api-tvos-simulator.swiftinterface
+++ b/api/revenuecatui-api-tvos-simulator.swiftinterface
@@ -2,6 +2,7 @@
 // swift-compiler-version: Apple Swift version 6.3.2 effective-5.10 (swiftlang-6.3.2.1.108 clang-2100.1.1.101)
 // swift-module-flags: -target arm64-apple-tvos13.0-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -O -enable-experimental-feature DebugDescriptionMacro -module-name RevenueCatUI -package-name purchases_ios
 // swift-module-flags-ignorable:  -formal-cxx-interoperability-mode=off -interface-compiler-version 6.3.2
+import AVFoundation
 import AVKit
 import Combine
 import DeveloperToolsSupport

--- a/api/revenuecatui-api-tvos.swiftinterface
+++ b/api/revenuecatui-api-tvos.swiftinterface
@@ -2,6 +2,7 @@
 // swift-compiler-version: Apple Swift version 6.3.2 effective-5.10 (swiftlang-6.3.2.1.108 clang-2100.1.1.101)
 // swift-module-flags: -target arm64-apple-tvos13.0 -enable-objc-interop -enable-library-evolution -swift-version 5 -O -enable-experimental-feature DebugDescriptionMacro -module-name RevenueCatUI -package-name purchases_ios
 // swift-module-flags-ignorable:  -formal-cxx-interoperability-mode=off -interface-compiler-version 6.3.2
+import AVFoundation
 import AVKit
 import Combine
 import DeveloperToolsSupport

--- a/api/revenuecatui-api-visionos-simulator.swiftinterface
+++ b/api/revenuecatui-api-visionos-simulator.swiftinterface
@@ -2,6 +2,7 @@
 // swift-compiler-version: Apple Swift version 6.3.2 effective-5.10 (swiftlang-6.3.2.1.108 clang-2100.1.1.101)
 // swift-module-flags: -target arm64-apple-xros1.0-simulator -enable-objc-interop -enable-library-evolution -swift-version 5 -O -enable-experimental-feature DebugDescriptionMacro -module-name RevenueCatUI -package-name purchases_ios
 // swift-module-flags-ignorable:  -formal-cxx-interoperability-mode=off -interface-compiler-version 6.3.2
+import AVFoundation
 import AVKit
 import Combine
 import DeveloperToolsSupport

--- a/api/revenuecatui-api-visionos.swiftinterface
+++ b/api/revenuecatui-api-visionos.swiftinterface
@@ -2,6 +2,7 @@
 // swift-compiler-version: Apple Swift version 6.3.2 effective-5.10 (swiftlang-6.3.2.1.108 clang-2100.1.1.101)
 // swift-module-flags: -target arm64-apple-xros1.0 -enable-objc-interop -enable-library-evolution -swift-version 5 -O -enable-experimental-feature DebugDescriptionMacro -module-name RevenueCatUI -package-name purchases_ios
 // swift-module-flags-ignorable:  -formal-cxx-interoperability-mode=off -interface-compiler-version 6.3.2
+import AVFoundation
 import AVKit
 import Combine
 import DeveloperToolsSupport


### PR DESCRIPTION
### Motivation

`check-api-changes-revenuecatui` is failing on every open PR. #7000 added `import AVFoundation` to `VideoPlayerViewUIView.swift` (UIKit-gated) to fix the tvOS/visionOS build, but the generated RevenueCatUI swiftinterface baselines were never updated, so the generated interface no longer matches `api/revenuecatui-api-*.swiftinterface`.

### Description

Adds `import AVFoundation` to the affected platform baselines (iOS/macOS/tvOS/visionOS + simulators). watchOS already carried it. Each file is the verbatim CI-generated interface, so the diff is exactly one `import AVFoundation` line per file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Baseline-only CI fix with no runtime or public API changes beyond an import line in generated interfaces.
> 
> **Overview**
> Updates the checked-in **RevenueCatUI** `api/revenuecatui-api-*.swiftinterface` baselines so they match the module interface CI now generates after `VideoPlayerViewUIView.swift` began importing **AVFoundation**.
> 
> Seven platform variants (iOS, iOS simulator, macOS, tvOS, tvOS simulator, visionOS, visionOS simulator) each gain a single `import AVFoundation` line before `import AVKit`. No public API signatures change—only the import list. This unblocks `check-api-changes-revenuecatui`, which was failing because the baselines lagged the prior source change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 520aa7bc4e6ad68b4a706333358160ae107df982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->