### PR TITLE
WFL-303 | Add fallback URL for workflows

### DIFF
--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -157,10 +157,14 @@ extension HTTPRequest.Path: HTTPRequestPath {
             return "/v1/offerings"
         case .getProductEntitlementMapping:
             return "/v1/product_entitlement_mapping"
-        case .getWorkflows:
-            return "/workflows/v1/workflows"
+        case let .getWorkflows(_, type):
+            let base = "/workflows/v1/workflows"
+            if let type = type {
+                return "\(base)?type=\(Self.escape(type))"
+            }
+            return base
         case let .getWorkflow(_, workflowId):
-            return "/workflows/v1/workflows/\(workflowId)"
+            return "/workflows/v1/workflows/\(Self.escape(workflowId))"
         default:
             return nil
         }

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -103,8 +103,8 @@ extension HTTPRequest {
         case getProductEntitlementMapping
         case getCustomerCenterConfig(appUserID: String)
         case getVirtualCurrencies(appUserID: String)
-        case getWorkflow(appUserID: String, workflowId: String)
         case getWorkflows(appUserID: String, type: String?)
+        case getWorkflow(appUserID: String, workflowId: String)
         case postRedeemWebPurchase
         case postCreateTicket
         case isPurchaseAllowedByRestoreBehavior(appUserID: String)
@@ -157,6 +157,10 @@ extension HTTPRequest.Path: HTTPRequestPath {
             return "/v1/offerings"
         case .getProductEntitlementMapping:
             return "/v1/product_entitlement_mapping"
+        case .getWorkflows:
+            return "/workflows/v1/workflows"
+        case let .getWorkflow(_, workflowId):
+            return "/workflows/v1/workflows/\(workflowId)"
         default:
             return nil
         }
@@ -183,8 +187,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
         switch self {
         case .getCustomerInfo,
                 .getOfferings,
-                .getWorkflow,
                 .getWorkflows,
+                .getWorkflow,
                 .getIntroEligibility,
                 .logIn,
                 .postAttributionData,
@@ -213,8 +217,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
         switch self {
         case .getCustomerInfo,
                 .getOfferings,
-                .getWorkflow,
                 .getWorkflows,
+                .getWorkflow,
                 .getIntroEligibility,
                 .logIn,
                 .postAttributionData,
@@ -247,8 +251,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .getOfferings,
                 .getProductEntitlementMapping,
                 .getVirtualCurrencies,
-                .getWorkflow,
                 .getWorkflows,
+                .getWorkflow,
                 .appHealthReport,
                 .appHealthReportAvailability,
                 .isPurchaseAllowedByRestoreBehavior:

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -172,7 +172,9 @@ class HTTPRequestTests: TestCase {
 
         expect(staticEndpoints) == [
             .getOfferings(appUserID: Self.userID),
-            .getProductEntitlementMapping
+            .getProductEntitlementMapping,
+            .getWorkflows(appUserID: Self.userID, type: nil),
+            .getWorkflow(appUserID: Self.userID, workflowId: "wf_1")
         ]
     }
 
@@ -199,9 +201,11 @@ class HTTPRequestTests: TestCase {
             case .getOfferings:
                 XCTAssertEqual(fallbackUrlsPaths,
                                ["https://api-production.8-lives-cat.io/v1/offerings"])
-            case .getWorkflows:
-                XCTAssertEqual(fallbackUrlsPaths,
-                               ["https://api-production.8-lives-cat.io/workflows/v1/workflows"])
+            case .getWorkflows(_, let type):
+                let expected = type.map {
+                    "https://api-production.8-lives-cat.io/workflows/v1/workflows?type=\($0)"
+                } ?? "https://api-production.8-lives-cat.io/workflows/v1/workflows"
+                XCTAssertEqual(fallbackUrlsPaths, [expected])
             case let .getWorkflow(_, workflowId):
                 XCTAssertEqual(fallbackUrlsPaths,
                                ["https://api-production.8-lives-cat.io/workflows/v1/workflows/\(workflowId)"])
@@ -209,6 +213,22 @@ class HTTPRequestTests: TestCase {
                 XCTAssertTrue(fallbackUrlsPaths.isEmpty)
             }
         }
+    }
+
+    func testGetWorkflowsFallbackUrlIncludesTypeParam() {
+        let path = HTTPRequest.Path.getWorkflows(appUserID: Self.userID, type: "PAYWALL")
+        XCTAssertEqual(
+            path.fallbackUrls.map { $0.absoluteString },
+            ["https://api-production.8-lives-cat.io/workflows/v1/workflows?type=PAYWALL"]
+        )
+    }
+
+    func testGetWorkflowFallbackUrlEscapesWorkflowId() {
+        let path = HTTPRequest.Path.getWorkflow(appUserID: Self.userID, workflowId: "wf id/with special")
+        XCTAssertEqual(
+            path.fallbackUrls.map { $0.absoluteString },
+            ["https://api-production.8-lives-cat.io/workflows/v1/workflows/wf%20id%2Fwith%20special"]
+        )
     }
 
     func testUserIDEscaping() {

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -36,7 +36,9 @@ class HTTPRequestTests: TestCase {
         .postSubscriberAttributes(appUserID: userID),
         .health,
         .getProductEntitlementMapping,
-        .rewardVerificationStatus(appUserID: userID, clientTransactionID: clientTransactionID)
+        .rewardVerificationStatus(appUserID: userID, clientTransactionID: clientTransactionID),
+        .getWorkflows(appUserID: userID, type: nil),
+        .getWorkflow(appUserID: userID, workflowId: "wf_1")
     ]
     private static let unauthenticatedPaths: Set<HTTPRequest.Path> = [
         .health
@@ -51,7 +53,9 @@ class HTTPRequestTests: TestCase {
         .health,
         .getOfferings(appUserID: userID),
         .getProductEntitlementMapping,
-        .rewardVerificationStatus(appUserID: userID, clientTransactionID: clientTransactionID)
+        .rewardVerificationStatus(appUserID: userID, clientTransactionID: clientTransactionID),
+        .getWorkflows(appUserID: userID, type: nil),
+        .getWorkflow(appUserID: userID, workflowId: "wf_1")
     ]
     private static let pathsThatRequireNonce: Set<HTTPRequest.Path> = [
         .getCustomerInfo(appUserID: userID),
@@ -195,6 +199,12 @@ class HTTPRequestTests: TestCase {
             case .getOfferings:
                 XCTAssertEqual(fallbackUrlsPaths,
                                ["https://api-production.8-lives-cat.io/v1/offerings"])
+            case .getWorkflows:
+                XCTAssertEqual(fallbackUrlsPaths,
+                               ["https://api-production.8-lives-cat.io/workflows/v1/workflows"])
+            case let .getWorkflow(_, workflowId):
+                XCTAssertEqual(fallbackUrlsPaths,
+                               ["https://api-production.8-lives-cat.io/workflows/v1/workflows/\(workflowId)"])
             default:
                 XCTAssertTrue(fallbackUrlsPaths.isEmpty)
             }


### PR DESCRIPTION
### Motivation

Add Fortress fallback URLs for Workflow endpoints 

Android counterpart: https://github.com/RevenueCat/purchases-android/pull/3608


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Networking resilience only: new fallback paths and tests; primary URLs and auth/ETag/signature behavior for workflows are unchanged aside from enum case ordering.
> 
> **Overview**
> Adds **Fortress fallback URLs** for `getWorkflows` and `getWorkflow` so workflow fetches can retry against `api-production.8-lives-cat.io` when the primary API is unavailable, matching offerings and product-entitlement mapping.
> 
> Fallback paths use the **`/workflows/v1/workflows`** shape (list with optional `?type=`, single workflow by ID) rather than the primary subscriber-scoped `/v1/subscribers/.../workflows` routes. Workflow IDs and type values go through the same escaping as other path parameters.
> 
> Unit tests cover fallback URL construction, the `type` query on list, and escaping for workflow IDs with spaces and slashes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 074da843db7651ead2018be0096055ed762eeddd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->