### PR TITLE
Add Cursor Cloud Agent environment config

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,6 @@
+# Cloud Agent environment for purchases-ios.
+#
+# NOTE: iOS/Swift code cannot be compiled in this Linux container (no Xcode or
+# Apple toolchain). This image only provides the Ruby toolchain so agents can
+# run fastlane lanes that don't require building Swift code.
+FROM cimg/ruby:3.2.0

--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -4,3 +4,11 @@
 # Apple toolchain). This image only provides the Ruby toolchain so agents can
 # run fastlane lanes that don't require building Swift code.
 FROM cimg/ruby:3.2.0
+
+# The agent runtime injects a bundled `/exec-daemon/ssh-keygen` (used to sign git
+# commits) ahead of the system binaries on PATH, but that bundled binary requires
+# a newer glibc than this image provides, so commit signing fails. We can't move
+# /exec-daemon off the front of PATH from here (the runtime prepends it after the
+# image is built), but $HOME/bin is placed *before* /exec-daemon on PATH, so we
+# shadow the broken binary with the image's working OpenSSH ssh-keygen.
+RUN mkdir -p "$HOME/bin" && ln -sf /usr/bin/ssh-keygen "$HOME/bin/ssh-keygen"

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -3,5 +3,5 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
-  "install": "bundle install"
+  "install": "bundle install --frozen"
 }

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -3,5 +3,5 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
-  "install": "bundle install --frozen"
+  "install": "bundle config set frozen true && bundle install"
 }

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,7 @@
+{
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "install": "bundle install"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Motivation
Cloud agents need a configured environment to run fastlane lanes. iOS/Swift code can't be compiled in a Linux container (no Xcode/Apple toolchain), but a Ruby-based image is enough to run fastlane lanes that don't require building Swift.

### Description
Adds `.cursor/environment.json` and `.cursor/Dockerfile` following the [manual Dockerfile setup](https://cursor.com/docs/cloud-agent/setup#manual-setup-with-dockerfile-advanced). The Dockerfile is based on CircleCI's `cimg/ruby:3.2.0` image (matching the Ruby version already used in `.circleci`), and the install step runs `bundle install` to set up the fastlane/Ruby dependencies from the `Gemfile`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76289e31-c835-45b3-ad1f-1fa70fe566fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76289e31-c835-45b3-ad1f-1fa70fe566fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

