### PR TITLE
test: cover user ID escaping for workflow paths

### DIFF
--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -65,7 +65,9 @@ class HTTPRequestTests: TestCase {
         .getOfferings(appUserID: anonymousUser),
         .getIntroEligibility(appUserID: anonymousUser),
         .postAttributionData(appUserID: anonymousUser),
-        .postSubscriberAttributes(appUserID: anonymousUser)
+        .postSubscriberAttributes(appUserID: anonymousUser),
+        .getWorkflows(appUserID: anonymousUser, type: nil),
+        .getWorkflow(appUserID: anonymousUser, workflowId: "wf_1")
     ]
 
     func testPathsDontHaveLeadingSlash() {


### PR DESCRIPTION
### Description

`getWorkflows`/`getWorkflow` were missing from `pathsWithUserID`, so `testPathsEscapeUserID` never checked that the primary workflow paths escape the app user ID, unlike every other user-scoped endpoint. This adds them.

Test-only, no behavior change. Noticed while reviewing #7008 (workflow Fortress fallback); the fallback path intentionally drops the user ID, but the primary path escapes it and that path was untested.