### PR TITLE
[EXTERNAL] feat: expose revocationDate and revocationReason on StoreTransaction via @mvanhorn

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -157,6 +157,8 @@
 		1EFA95152CDBAB7500CA5951 /* MockWebPurchaseRedemptionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EFA95142CDBAB7500CA5951 /* MockWebPurchaseRedemptionHelper.swift */; };
 		1EFA95162CDBAB7500CA5951 /* MockWebPurchaseRedemptionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EFA95142CDBAB7500CA5951 /* MockWebPurchaseRedemptionHelper.swift */; };
 		2A4BD4BADFA187EA13B7D6CD /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BA50D5AA17E5D4A5D3E99D /* Operators.swift */; };
+		2A5E77D12F10B3B500BC5900 /* RevocationReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5E77D02F10B3B500BC5900 /* RevocationReason.swift */; };
+		2A5E77D22F10B3B500BC5900 /* RevocationReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5E77D02F10B3B500BC5900 /* RevocationReason.swift */; };
 		2B699E6661ECFB93B146A2D9 /* SynchronizedUserDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B0EAB50136613F69FAA3BB /* SynchronizedUserDefaultsTests.swift */; };
 		2C08B2E92CD40DBF0024857B /* ButtonComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C08B2E82CD40DBF0024857B /* ButtonComponentTests.swift */; };
 		2C08B3072CD55D660024857B /* FlexHStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C08B3062CD55D590024857B /* FlexHStack.swift */; };
@@ -2084,6 +2086,7 @@
 		53AAD34E2E09856400605F51 /* PaymentAuthorizationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentAuthorizationProvider.swift; sourceTree = "<group>"; };
 		53E33BBA2E095B8900287158 /* SDKHealthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKHealthManager.swift; sourceTree = "<group>"; };
 		55FCA85B959807F2D3DD175A /* TransactionReason.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TransactionReason.swift; sourceTree = "<group>"; };
+		2A5E77D02F10B3B500BC5900 /* RevocationReason.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RevocationReason.swift; sourceTree = "<group>"; };
 		57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEntitlementMappingDecodingTests.swift; sourceTree = "<group>"; };
 		57045B3929C51751001A5417 /* GetProductEntitlementMappingOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetProductEntitlementMappingOperation.swift; sourceTree = "<group>"; };
 		57045B3B29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEntitlementMappingCallback.swift; sourceTree = "<group>"; };
@@ -3465,6 +3468,7 @@
 				2D1015DD275A57FC0086173F /* SubscriptionPeriod.swift */,
 				4F174F462B07EA7E00FE538E /* StorefrontProvider.swift */,
 				FDC892FD2CD157F1000AEB9F /* WinBackOffer.swift */,
+				2A5E77D02F10B3B500BC5900 /* RevocationReason.swift */,
 				55FCA85B959807F2D3DD175A /* TransactionReason.swift */,
 			);
 			path = StoreKitAbstractions;
@@ -7183,6 +7187,7 @@
 				75ADC06C2E437D4900210ECA /* SimulatedStoreProductsManager.swift in Sources */,
 				FE5151005C0000000000A001 /* SimulatedStoreTransactionFetcher.swift in Sources */,
 				75ADC06D2E437D4900210ECA /* SimulatedStoreTransaction.swift in Sources */,
+				2A5E77D22F10B3B500BC5900 /* RevocationReason.swift in Sources */,
 				9094B41C2E96A9A70094AD5F /* AdEvent.swift in Sources */,
 				AD5000000000000000ADAD04 /* AdRewardEvents.swift in Sources */,
 				9094B41F2E96A9A70094AD5F /* AdHTTPRequestPath.swift in Sources */,
@@ -7394,6 +7399,7 @@
 				03C06FC72D46742D00600693 /* PaywallCarouselComponent.swift in Sources */,
 				DDD45A15A641C0FF0BEF6178 /* PaywallCountdownComponent.swift in Sources */,
 				51978277F6FF8880DDF3028D /* ExitOffer.swift in Sources */,
+				2A5E77D12F10B3B500BC5900 /* RevocationReason.swift in Sources */,
 				909114C714204DFB8C4F3F72 /* TransactionReason.swift in Sources */,
 				461DF6CBD6A73F7081683DC4 /* WorkflowsCache.swift in Sources */,
 			);

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -158,7 +158,6 @@
 		1EFA95162CDBAB7500CA5951 /* MockWebPurchaseRedemptionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EFA95142CDBAB7500CA5951 /* MockWebPurchaseRedemptionHelper.swift */; };
 		2A4BD4BADFA187EA13B7D6CD /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BA50D5AA17E5D4A5D3E99D /* Operators.swift */; };
 		2A5E77D12F10B3B500BC5900 /* RevocationReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5E77D02F10B3B500BC5900 /* RevocationReason.swift */; };
-		2A5E77D22F10B3B500BC5900 /* RevocationReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5E77D02F10B3B500BC5900 /* RevocationReason.swift */; };
 		2B699E6661ECFB93B146A2D9 /* SynchronizedUserDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B0EAB50136613F69FAA3BB /* SynchronizedUserDefaultsTests.swift */; };
 		2C08B2E92CD40DBF0024857B /* ButtonComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C08B2E82CD40DBF0024857B /* ButtonComponentTests.swift */; };
 		2C08B3072CD55D660024857B /* FlexHStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C08B3062CD55D590024857B /* FlexHStack.swift */; };
@@ -7187,7 +7186,6 @@
 				75ADC06C2E437D4900210ECA /* SimulatedStoreProductsManager.swift in Sources */,
 				FE5151005C0000000000A001 /* SimulatedStoreTransactionFetcher.swift in Sources */,
 				75ADC06D2E437D4900210ECA /* SimulatedStoreTransaction.swift in Sources */,
-				2A5E77D22F10B3B500BC5900 /* RevocationReason.swift in Sources */,
 				9094B41C2E96A9A70094AD5F /* AdEvent.swift in Sources */,
 				AD5000000000000000ADAD04 /* AdRewardEvents.swift in Sources */,
 				9094B41F2E96A9A70094AD5F /* AdHTTPRequestPath.swift in Sources */,

--- a/Sources/Logging/Strings/StoreKitStrings.swift
+++ b/Sources/Logging/Strings/StoreKitStrings.swift
@@ -77,6 +77,8 @@ enum StoreKitStrings {
 
     case sk2_unknown_transaction_reason(String)
 
+    case sk2_unknown_revocation_reason(String)
+
     case sk2_error_encoding_receipt(Error)
 
     case sk2_error_fetching_app_transaction(Error)
@@ -233,6 +235,9 @@ extension StoreKitStrings: LogMessage {
 
         case let .sk2_unknown_transaction_reason(reason):
             return "Unrecognized StoreKit Transaction Reason: \(reason)"
+
+        case let .sk2_unknown_revocation_reason(reason):
+            return "Unrecognized StoreKit Transaction Revocation Reason: \(reason)"
 
         case let .sk2_error_encoding_receipt(error):
             return "Error encoding SK2 receipt: '\(error)'"

--- a/Sources/Misc/Deprecations.swift
+++ b/Sources/Misc/Deprecations.swift
@@ -315,6 +315,8 @@ extension CustomerInfo {
         internal var jwsRepresentation: String? { return nil }
         internal var environment: StoreEnvironment? { return nil }
         var reason: TransactionReason? { return nil }
+        var revocationDate: Date? { return nil }
+        var revocationReason: RevocationReason? { return nil }
 
         var hasKnownPurchaseDate: Bool { true }
         var hasKnownTransactionIdentifier: Bool { return true }

--- a/Sources/Purchasing/SimulatedStore/SimulatedStoreTransaction.swift
+++ b/Sources/Purchasing/SimulatedStore/SimulatedStoreTransaction.swift
@@ -24,6 +24,8 @@ struct SimulatedStoreTransaction: StoreTransactionType, Equatable {
 
     let environment: StoreEnvironment? = nil
     let reason: TransactionReason? = nil
+    let revocationDate: Date? = nil
+    let revocationReason: RevocationReason? = nil
 
     func finish(_ wrapper: any PaymentQueueWrapperType, completion: @escaping @Sendable () -> Void) {
         // no-op

--- a/Sources/Purchasing/StoreKitAbstractions/RevocationReason.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/RevocationReason.swift
@@ -20,16 +20,42 @@ import StoreKit
 /// When the revocation reason cannot be determined, the property is `nil`. This happens for:
 /// - All StoreKit 1 transactions (SK1 does not expose revocation metadata).
 /// - StoreKit 2 transactions that were not revoked.
-public struct RevocationReason: RawRepresentable, Equatable, Sendable {
+@objc(RCRevocationReason)
+public final class RevocationReason: NSObject, RawRepresentable, Sendable {
 
-    public let rawValue: String
+    /// String representation of the revocation reason.
+    @objc public let rawValue: String
 
-    public init(rawValue: String) {
+    /// Creates a revocation reason with the specified raw value.
+    @objc public init(rawValue: String) {
         self.rawValue = rawValue
+        super.init()
     }
 
-    public static let developerIssue = RevocationReason(rawValue: "developer_issue")
-    public static let other = RevocationReason(rawValue: "other")
+    /// The transaction was revoked because of an issue with the app.
+    @objc(RCDeveloperIssue) public static let developerIssue = RevocationReason(rawValue: "developer_issue")
+
+    /// The transaction was revoked for another reason.
+    @objc(RCOther) public static let other = RevocationReason(rawValue: "other")
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? RevocationReason else { return false }
+
+        if self === other {
+            return true
+        }
+
+        return self.rawValue == other.rawValue
+    }
+
+    public override var hash: Int {
+        return self.rawValue.hashValue
+    }
+
+    /// Pattern matching operator.
+    public static func ~= (lhs: RevocationReason, rhs: RevocationReason) -> Bool {
+        lhs.rawValue == rhs.rawValue
+    }
 
 }
 
@@ -42,12 +68,12 @@ extension RevocationReason {
     /// Creates a ``RevocationReason`` from a StoreKit 2 `Transaction.RevocationReason`.
     ///
     /// Returns `nil` for unrecognized reasons.
-    init?(sk2RevocationReason reason: SK2Transaction.RevocationReason) {
+    convenience init?(sk2RevocationReason reason: SK2Transaction.RevocationReason) {
         switch reason {
         case .developerIssue:
-            self = .developerIssue
+            self.init(rawValue: Self.developerIssue.rawValue)
         case .other:
-            self = .other
+            self.init(rawValue: Self.other.rawValue)
         default:
             Logger.appleWarning(
                 Strings.storeKit.sk2_unknown_revocation_reason(String(describing: reason))

--- a/Sources/Purchasing/StoreKitAbstractions/RevocationReason.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/RevocationReason.swift
@@ -1,0 +1,60 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  RevocationReason.swift
+
+import Foundation
+import StoreKit
+
+/// Indicates the reason for a transaction revocation.
+///
+/// This mirrors StoreKit 2's `Transaction.RevocationReason` (available on iOS 15+, macOS 12+,
+/// tvOS 15+, watchOS 8+).
+///
+/// When the revocation reason cannot be determined, the property is `nil`. This happens for:
+/// - All StoreKit 1 transactions (SK1 does not expose revocation metadata).
+/// - StoreKit 2 transactions that were not revoked.
+public struct RevocationReason: RawRepresentable, Equatable, Sendable {
+
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public static let developerIssue = RevocationReason(rawValue: "developer_issue")
+    public static let other = RevocationReason(rawValue: "other")
+
+}
+
+// MARK: - StoreKit 2
+
+#if swift(>=5.9)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevocationReason {
+
+    /// Creates a ``RevocationReason`` from a StoreKit 2 `Transaction.RevocationReason`.
+    ///
+    /// Returns `nil` for unrecognized reasons.
+    init?(sk2RevocationReason reason: SK2Transaction.RevocationReason) {
+        switch reason {
+        case .developerIssue:
+            self = .developerIssue
+        case .other:
+            self = .other
+        default:
+            Logger.appleWarning(
+                Strings.storeKit.sk2_unknown_revocation_reason(String(describing: reason))
+            )
+            return nil
+        }
+    }
+
+}
+#endif

--- a/Sources/Purchasing/StoreKitAbstractions/RevocationReason.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/RevocationReason.swift
@@ -68,11 +68,19 @@ extension RevocationReason {
     ///
     /// Returns `nil` for unrecognized reasons.
     convenience init?(sk2RevocationReason reason: SK2Transaction.RevocationReason) {
+        guard let revocationReason = Self.from(sk2RevocationReason: reason) else {
+            return nil
+        }
+
+        self.init(rawValue: revocationReason.rawValue)
+    }
+
+    static func from(sk2RevocationReason reason: SK2Transaction.RevocationReason) -> RevocationReason? {
         switch reason {
         case .developerIssue:
-            self.init(rawValue: Self.developerIssue.rawValue)
+            return Self.developerIssue
         case .other:
-            self.init(rawValue: Self.other.rawValue)
+            return Self.other
         default:
             Logger.appleWarning(
                 Strings.storeKit.sk2_unknown_revocation_reason(String(describing: reason))

--- a/Sources/Purchasing/StoreKitAbstractions/RevocationReason.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/RevocationReason.swift
@@ -61,7 +61,6 @@ public final class RevocationReason: NSObject, RawRepresentable, Sendable {
 
 // MARK: - StoreKit 2
 
-#if swift(>=5.9)
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension RevocationReason {
 
@@ -83,4 +82,3 @@ extension RevocationReason {
     }
 
 }
-#endif

--- a/Sources/Purchasing/StoreKitAbstractions/SK1StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK1StoreTransaction.swift
@@ -51,6 +51,16 @@ internal struct SK1StoreTransaction: StoreTransactionType {
         return nil
     }
 
+    var revocationDate: Date? {
+        // StoreKit 1 does not expose revocation metadata.
+        return nil
+    }
+
+    var revocationReason: RevocationReason? {
+        // StoreKit 1 does not expose revocation metadata.
+        return nil
+    }
+
     var hasKnownPurchaseDate: Bool {
         return self.underlyingSK1Transaction.transactionDate != nil
     }

--- a/Sources/Purchasing/StoreKitAbstractions/SK2StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK2StoreTransaction.swift
@@ -30,7 +30,8 @@ internal struct SK2StoreTransaction: StoreTransactionType {
         self.jwsRepresentation = jwsRepresentation
         self.environment = environmentOverride ?? .init(sk2Transaction: sk2Transaction)
         self.revocationDate = sk2Transaction.revocationDate
-        self.revocationReason = sk2Transaction.revocationReason.flatMap { RevocationReason(sk2RevocationReason: $0) }
+        self.revocationReason = sk2Transaction.revocationReason
+            .flatMap { RevocationReason.from(sk2RevocationReason: $0) }
 
         #if swift(>=5.9)
         if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {

--- a/Sources/Purchasing/StoreKitAbstractions/SK2StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK2StoreTransaction.swift
@@ -29,6 +29,8 @@ internal struct SK2StoreTransaction: StoreTransactionType {
         self.quantity = sk2Transaction.purchasedQuantity
         self.jwsRepresentation = jwsRepresentation
         self.environment = environmentOverride ?? .init(sk2Transaction: sk2Transaction)
+        self.revocationDate = sk2Transaction.revocationDate
+        self.revocationReason = sk2Transaction.revocationReason.flatMap { RevocationReason(sk2RevocationReason: $0) }
 
         #if swift(>=5.9)
         if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
@@ -54,6 +56,8 @@ internal struct SK2StoreTransaction: StoreTransactionType {
     let jwsRepresentation: String?
     var environment: StoreEnvironment?
     let reason: TransactionReason?
+    let revocationDate: Date?
+    let revocationReason: RevocationReason?
 
     var hasKnownPurchaseDate: Bool { return true }
     var hasKnownTransactionIdentifier: Bool { return true }

--- a/Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift
@@ -46,8 +46,7 @@ public typealias SK2Transaction = StoreKit.Transaction
     internal var environment: StoreEnvironment? { self.transaction.environment }
     internal var reason: TransactionReason? { self.transaction.reason }
     @objc public var revocationDate: Date? { self.transaction.revocationDate }
-    // Not exposed to Objective-C: `RevocationReason` is a Swift struct and cannot be represented as `@objc`.
-    public var revocationReason: RevocationReason? { self.transaction.revocationReason }
+    @objc public var revocationReason: RevocationReason? { self.transaction.revocationReason }
 
     var hasKnownPurchaseDate: Bool { return self.transaction.hasKnownPurchaseDate }
     var hasKnownTransactionIdentifier: Bool { self.transaction.hasKnownTransactionIdentifier }

--- a/Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift
@@ -45,6 +45,9 @@ public typealias SK2Transaction = StoreKit.Transaction
     @objc internal var jwsRepresentation: String? { self.transaction.jwsRepresentation }
     internal var environment: StoreEnvironment? { self.transaction.environment }
     internal var reason: TransactionReason? { self.transaction.reason }
+    @objc public var revocationDate: Date? { self.transaction.revocationDate }
+    // Not exposed to Objective-C: `RevocationReason` is a Swift struct and cannot be represented as `@objc`.
+    public var revocationReason: RevocationReason? { self.transaction.revocationReason }
 
     var hasKnownPurchaseDate: Bool { return self.transaction.hasKnownPurchaseDate }
     var hasKnownTransactionIdentifier: Bool { self.transaction.hasKnownTransactionIdentifier }
@@ -126,6 +129,14 @@ internal protocol StoreTransactionType: Sendable {
     /// The reason for the transaction, if known.
     /// - Note: this is only available for StoreKit 2 transactions starting with iOS 17.
     var reason: TransactionReason? { get }
+
+    /// The date the App Store refunded or revoked the transaction, if it was revoked; `nil` otherwise.
+    /// - Note: this is only available for StoreKit 2 transactions.
+    var revocationDate: Date? { get }
+
+    /// The reason the transaction was revoked, if it was revoked; `nil` otherwise.
+    /// - Note: this is only available for StoreKit 2 transactions.
+    var revocationReason: RevocationReason? { get }
 
     /// Indicates to the App Store that the app delivered the purchased content
     /// or enabled the service to finish the transaction.

--- a/Sources/Purchasing/StoreKitAbstractions/TestStoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/TestStoreTransaction.swift
@@ -23,6 +23,8 @@ struct TestStoreTransaction: StoreTransactionType {
     let jwsRepresentation: String? = nil
     let environment: StoreEnvironment? = nil
     let reason: TransactionReason? = nil
+    let revocationDate: Date? = nil
+    let revocationReason: RevocationReason? = nil
 
     func finish(_ wrapper: any PaymentQueueWrapperType, completion: @escaping @Sendable () -> Void) {
         // no-op

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCStoreTransactionAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCStoreTransactionAPI.m
@@ -20,6 +20,7 @@
     NSString *transactionIdentifier __unused = transaction.transactionIdentifier;
     NSInteger quantity __unused = transaction.quantity;
     RCStorefront *__nullable storefront __unused = transaction.storefront;
+    NSDate *__nullable revocationDate __unused = transaction.revocationDate;
 
     SKPaymentTransaction *sk1 __unused = transaction.sk1Transaction;
 }

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCStoreTransactionAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCStoreTransactionAPI.m
@@ -21,6 +21,10 @@
     NSInteger quantity __unused = transaction.quantity;
     RCStorefront *__nullable storefront __unused = transaction.storefront;
     NSDate *__nullable revocationDate __unused = transaction.revocationDate;
+    RCRevocationReason *__nullable revocationReason __unused = transaction.revocationReason;
+    RCRevocationReason *developerIssue __unused = [RCRevocationReason RCDeveloperIssue];
+    RCRevocationReason *other __unused = [RCRevocationReason RCOther];
+    NSString *revocationReasonRawValue __unused = [RCRevocationReason RCOther].rawValue;
 
     SKPaymentTransaction *sk1 __unused = transaction.sk1Transaction;
 }

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/StoreTransactionAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/StoreTransactionAPI.swift
@@ -17,6 +17,12 @@ func checkStoreTransactionAPI(storefront: RevenueCat.Storefront?) {
     let _: String = transaction.transactionIdentifier
     let _: Int = transaction.quantity
     let _: RevenueCat.Storefront? = transaction.storefront
+    let _: Date? = transaction.revocationDate
+    let _: RevocationReason? = transaction.revocationReason
+    let _: RevocationReason = .developerIssue
+    let _: RevocationReason = .other
+    let _: RevocationReason = RevocationReason(rawValue: "x")
+    let _: String = RevocationReason.other.rawValue
 
     let _: SKPaymentTransaction? = transaction.sk1Transaction
 

--- a/Tests/RevenueCatUITests/Purchasing/MockStoreTransaction.swift
+++ b/Tests/RevenueCatUITests/Purchasing/MockStoreTransaction.swift
@@ -29,6 +29,8 @@ final class MockStoreTransaction: StoreTransactionType {
     let jwsRepresentation: String?
     let environment: StoreEnvironment?
     let reason: TransactionReason?
+    let revocationDate: Date? = nil
+    let revocationReason: RevocationReason? = nil
 
     init(jwsRepresentation: String? = nil, environment: StoreEnvironment = .sandbox) {
         self.productIdentifier = UUID().uuidString

--- a/Tests/StoreKitUnitTests/StoreTransactionTests.swift
+++ b/Tests/StoreKitUnitTests/StoreTransactionTests.swift
@@ -43,6 +43,22 @@ class StoreTransactionTests: StoreKitConfigTestCase {
         expect(transaction.environment).to(beNil())
     }
 
+    func testSK1TransactionReturnsNilRevocationFields() async throws {
+        let product = MockSK1Product(mockProductIdentifier: Self.productID)
+        let payment = SKPayment(product: product)
+
+        let sk1Transaction = MockTransaction()
+        sk1Transaction.mockPayment = payment
+        sk1Transaction.mockTransactionDate = Date()
+        sk1Transaction.mockTransactionIdentifier = UUID().uuidString
+        sk1Transaction.mockState = .purchased
+
+        let transaction = StoreTransaction(sk1Transaction: sk1Transaction)
+
+        expect(transaction.revocationDate).to(beNil())
+        expect(transaction.revocationReason).to(beNil())
+    }
+
     func testSK1TransactionWithMissingDate() async throws {
         let product = MockSK1Product(mockProductIdentifier: Self.productID)
         let payment = SKPayment(product: product)
@@ -97,6 +113,12 @@ class StoreTransactionTests: StoreKitConfigTestCase {
         } else {
             expect(transaction.storefront).to(beNil())
         }
+    }
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func testRevocationReasonMapsKnownSK2Reasons() throws {
+        expect(RevocationReason(sk2RevocationReason: .developerIssue)).to(equal(.developerIssue))
+        expect(RevocationReason(sk2RevocationReason: .other)).to(equal(.other))
     }
 
     func testSk1TransactionDateBecomesAnInvalidDateIfNoDate() {

--- a/Tests/StoreKitUnitTests/StoreTransactionTests.swift
+++ b/Tests/StoreKitUnitTests/StoreTransactionTests.swift
@@ -119,11 +119,15 @@ class StoreTransactionTests: StoreKitConfigTestCase {
     func testRevocationReasonMapsKnownSK2Reasons() throws {
         expect(RevocationReason(sk2RevocationReason: .developerIssue)).to(equal(.developerIssue))
         expect(RevocationReason(sk2RevocationReason: .other)).to(equal(.other))
+
+        expect(RevocationReason.from(sk2RevocationReason: .developerIssue)) === .developerIssue
+        expect(RevocationReason.from(sk2RevocationReason: .other)) === .other
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testRevocationReasonReturnsNilForUnknownSK2Reason() throws {
         expect(RevocationReason(sk2RevocationReason: .init(rawValue: 12345))).to(beNil())
+        expect(RevocationReason.from(sk2RevocationReason: .init(rawValue: 12345))).to(beNil())
     }
 
     func testRevocationReasonValues() {

--- a/Tests/StoreKitUnitTests/StoreTransactionTests.swift
+++ b/Tests/StoreKitUnitTests/StoreTransactionTests.swift
@@ -121,6 +121,54 @@ class StoreTransactionTests: StoreKitConfigTestCase {
         expect(RevocationReason(sk2RevocationReason: .other)).to(equal(.other))
     }
 
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func testRevocationReasonReturnsNilForUnknownSK2Reason() throws {
+        expect(RevocationReason(sk2RevocationReason: .init(rawValue: 12345))).to(beNil())
+    }
+
+    func testRevocationReasonValues() {
+        expect(RevocationReason.developerIssue.rawValue) == "developer_issue"
+        expect(RevocationReason.other.rawValue) == "other"
+    }
+
+    func testRevocationReasonRawValueInitializer() {
+        expect(RevocationReason(rawValue: "developer_issue")) == .developerIssue
+        expect(RevocationReason(rawValue: "other")) == .other
+
+        let custom = RevocationReason(rawValue: "custom")
+
+        expect(custom.rawValue) == "custom"
+        expect(custom).toNot(equal(.developerIssue))
+        expect(custom).toNot(equal(.other))
+    }
+
+    func testRevocationReasonHash() {
+        expect(RevocationReason.developerIssue.hash) == RevocationReason.developerIssue.rawValue.hashValue
+        expect(RevocationReason.other.hash) == RevocationReason.other.rawValue.hashValue
+    }
+
+    func testRevocationReasonPatternMatchingOperator() {
+        expect(RevocationReason.developerIssue ~= RevocationReason(rawValue: "developer_issue")).to(beTrue())
+        expect(RevocationReason.other ~= RevocationReason(rawValue: "other")).to(beTrue())
+
+        expect(RevocationReason.developerIssue ~= RevocationReason.other).to(beFalse())
+    }
+
+    func testRevocationReasonSwitchStatementWorks() {
+        let reason = RevocationReason(rawValue: "developer_issue")
+
+        switch reason {
+        case .developerIssue:
+            return
+        case .other:
+            fail("Switch should go through developerIssue case")
+        default:
+            fail("Switch should go through developerIssue case")
+        }
+
+        fail("Switch should go through developerIssue case")
+    }
+
     func testSk1TransactionDateBecomesAnInvalidDateIfNoDate() {
         let sk1Transaction = MockTransaction()
         sk1Transaction.mockTransactionDate = nil

--- a/Tests/StoreKitUnitTests/StoreTransactionTests.swift
+++ b/Tests/StoreKitUnitTests/StoreTransactionTests.swift
@@ -120,8 +120,8 @@ class StoreTransactionTests: StoreKitConfigTestCase {
         expect(RevocationReason(sk2RevocationReason: .developerIssue)).to(equal(.developerIssue))
         expect(RevocationReason(sk2RevocationReason: .other)).to(equal(.other))
 
-        expect(RevocationReason.from(sk2RevocationReason: .developerIssue)) === .developerIssue
-        expect(RevocationReason.from(sk2RevocationReason: .other)) === .other
+        expect(RevocationReason.from(sk2RevocationReason: .developerIssue)) === RevocationReason.developerIssue
+        expect(RevocationReason.from(sk2RevocationReason: .other)) === RevocationReason.other
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)

--- a/Tests/UnitTests/Mocks/MockStoreTransaction.swift
+++ b/Tests/UnitTests/Mocks/MockStoreTransaction.swift
@@ -29,6 +29,8 @@ final class MockStoreTransaction: StoreTransactionType {
     let jwsRepresentation: String?
     let environment: StoreEnvironment?
     let reason: TransactionReason?
+    let revocationDate: Date? = nil
+    let revocationReason: RevocationReason? = nil
 
     init(
         productIdentifier: String = UUID().uuidString,

--- a/api/revenuecat-api-ios-simulator.swiftinterface
+++ b/api/revenuecat-api-ios-simulator.swiftinterface
@@ -2569,6 +2569,19 @@ extension RevenueCat.PromotionalOffer : Swift.Sendable {
 }
 extension RevenueCat.PromotionalOffer.SignedData : Swift.Sendable {
 }
+@objc(RCRevocationReason) final public class RevocationReason : ObjectiveC.NSObject, Swift.RawRepresentable, Swift.Sendable {
+  @objc final public let rawValue: Swift.String
+  @objc public init(rawValue: Swift.String)
+  @objc(RCDeveloperIssue) public static let developerIssue: RevenueCat.RevocationReason
+  @objc(RCOther) public static let other: RevenueCat.RevocationReason
+  @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
+  @objc override final public var hash: Swift.Int {
+    @objc get
+  }
+  public static func ~= (lhs: RevenueCat.RevocationReason, rhs: RevenueCat.RevocationReason) -> Swift.Bool
+  public typealias RawValue = Swift.String
+  @objc deinit
+}
 public typealias SK1Product = StoreKit.SKProduct
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 public typealias SK2Product = StoreKit.Product
@@ -2832,6 +2845,12 @@ public typealias SK2Transaction = StoreKit.Transaction
     @objc get
   }
   @objc final public var storefront: RevenueCat.Storefront? {
+    @objc get
+  }
+  @objc final public var revocationDate: Foundation.Date? {
+    @objc get
+  }
+  @objc final public var revocationReason: RevenueCat.RevocationReason? {
     @objc get
   }
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool

--- a/api/revenuecat-api-ios.swiftinterface
+++ b/api/revenuecat-api-ios.swiftinterface
@@ -2569,6 +2569,19 @@ extension RevenueCat.PromotionalOffer : Swift.Sendable {
 }
 extension RevenueCat.PromotionalOffer.SignedData : Swift.Sendable {
 }
+@objc(RCRevocationReason) final public class RevocationReason : ObjectiveC.NSObject, Swift.RawRepresentable, Swift.Sendable {
+  @objc final public let rawValue: Swift.String
+  @objc public init(rawValue: Swift.String)
+  @objc(RCDeveloperIssue) public static let developerIssue: RevenueCat.RevocationReason
+  @objc(RCOther) public static let other: RevenueCat.RevocationReason
+  @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
+  @objc override final public var hash: Swift.Int {
+    @objc get
+  }
+  public static func ~= (lhs: RevenueCat.RevocationReason, rhs: RevenueCat.RevocationReason) -> Swift.Bool
+  public typealias RawValue = Swift.String
+  @objc deinit
+}
 public typealias SK1Product = StoreKit.SKProduct
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 public typealias SK2Product = StoreKit.Product
@@ -2832,6 +2845,12 @@ public typealias SK2Transaction = StoreKit.Transaction
     @objc get
   }
   @objc final public var storefront: RevenueCat.Storefront? {
+    @objc get
+  }
+  @objc final public var revocationDate: Foundation.Date? {
+    @objc get
+  }
+  @objc final public var revocationReason: RevenueCat.RevocationReason? {
     @objc get
   }
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool

--- a/api/revenuecat-api-macos.swiftinterface
+++ b/api/revenuecat-api-macos.swiftinterface
@@ -2471,6 +2471,19 @@ extension RevenueCat.PromotionalOffer : Swift.Sendable {
 }
 extension RevenueCat.PromotionalOffer.SignedData : Swift.Sendable {
 }
+@objc(RCRevocationReason) final public class RevocationReason : ObjectiveC.NSObject, Swift.RawRepresentable, Swift.Sendable {
+  @objc final public let rawValue: Swift.String
+  @objc public init(rawValue: Swift.String)
+  @objc(RCDeveloperIssue) public static let developerIssue: RevenueCat.RevocationReason
+  @objc(RCOther) public static let other: RevenueCat.RevocationReason
+  @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
+  @objc override final public var hash: Swift.Int {
+    @objc get
+  }
+  public static func ~= (lhs: RevenueCat.RevocationReason, rhs: RevenueCat.RevocationReason) -> Swift.Bool
+  public typealias RawValue = Swift.String
+  @objc deinit
+}
 public typealias SK1Product = StoreKit.SKProduct
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 public typealias SK2Product = StoreKit.Product
@@ -2734,6 +2747,12 @@ public typealias SK2Transaction = StoreKit.Transaction
     @objc get
   }
   @objc final public var storefront: RevenueCat.Storefront? {
+    @objc get
+  }
+  @objc final public var revocationDate: Foundation.Date? {
+    @objc get
+  }
+  @objc final public var revocationReason: RevenueCat.RevocationReason? {
     @objc get
   }
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool

--- a/api/revenuecat-api-tvos-simulator.swiftinterface
+++ b/api/revenuecat-api-tvos-simulator.swiftinterface
@@ -2455,6 +2455,19 @@ extension RevenueCat.PromotionalOffer : Swift.Sendable {
 }
 extension RevenueCat.PromotionalOffer.SignedData : Swift.Sendable {
 }
+@objc(RCRevocationReason) final public class RevocationReason : ObjectiveC.NSObject, Swift.RawRepresentable, Swift.Sendable {
+  @objc final public let rawValue: Swift.String
+  @objc public init(rawValue: Swift.String)
+  @objc(RCDeveloperIssue) public static let developerIssue: RevenueCat.RevocationReason
+  @objc(RCOther) public static let other: RevenueCat.RevocationReason
+  @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
+  @objc override final public var hash: Swift.Int {
+    @objc get
+  }
+  public static func ~= (lhs: RevenueCat.RevocationReason, rhs: RevenueCat.RevocationReason) -> Swift.Bool
+  public typealias RawValue = Swift.String
+  @objc deinit
+}
 public typealias SK1Product = StoreKit.SKProduct
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 public typealias SK2Product = StoreKit.Product
@@ -2718,6 +2731,12 @@ public typealias SK2Transaction = StoreKit.Transaction
     @objc get
   }
   @objc final public var storefront: RevenueCat.Storefront? {
+    @objc get
+  }
+  @objc final public var revocationDate: Foundation.Date? {
+    @objc get
+  }
+  @objc final public var revocationReason: RevenueCat.RevocationReason? {
     @objc get
   }
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool

--- a/api/revenuecat-api-tvos.swiftinterface
+++ b/api/revenuecat-api-tvos.swiftinterface
@@ -2455,6 +2455,19 @@ extension RevenueCat.PromotionalOffer : Swift.Sendable {
 }
 extension RevenueCat.PromotionalOffer.SignedData : Swift.Sendable {
 }
+@objc(RCRevocationReason) final public class RevocationReason : ObjectiveC.NSObject, Swift.RawRepresentable, Swift.Sendable {
+  @objc final public let rawValue: Swift.String
+  @objc public init(rawValue: Swift.String)
+  @objc(RCDeveloperIssue) public static let developerIssue: RevenueCat.RevocationReason
+  @objc(RCOther) public static let other: RevenueCat.RevocationReason
+  @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
+  @objc override final public var hash: Swift.Int {
+    @objc get
+  }
+  public static func ~= (lhs: RevenueCat.RevocationReason, rhs: RevenueCat.RevocationReason) -> Swift.Bool
+  public typealias RawValue = Swift.String
+  @objc deinit
+}
 public typealias SK1Product = StoreKit.SKProduct
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 public typealias SK2Product = StoreKit.Product
@@ -2718,6 +2731,12 @@ public typealias SK2Transaction = StoreKit.Transaction
     @objc get
   }
   @objc final public var storefront: RevenueCat.Storefront? {
+    @objc get
+  }
+  @objc final public var revocationDate: Foundation.Date? {
+    @objc get
+  }
+  @objc final public var revocationReason: RevenueCat.RevocationReason? {
     @objc get
   }
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool

--- a/api/revenuecat-api-visionos-simulator.swiftinterface
+++ b/api/revenuecat-api-visionos-simulator.swiftinterface
@@ -2569,6 +2569,19 @@ extension RevenueCat.PromotionalOffer : Swift.Sendable {
 }
 extension RevenueCat.PromotionalOffer.SignedData : Swift.Sendable {
 }
+@objc(RCRevocationReason) final public class RevocationReason : ObjectiveC.NSObject, Swift.RawRepresentable, Swift.Sendable {
+  @objc final public let rawValue: Swift.String
+  @objc public init(rawValue: Swift.String)
+  @objc(RCDeveloperIssue) public static let developerIssue: RevenueCat.RevocationReason
+  @objc(RCOther) public static let other: RevenueCat.RevocationReason
+  @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
+  @objc override final public var hash: Swift.Int {
+    @objc get
+  }
+  public static func ~= (lhs: RevenueCat.RevocationReason, rhs: RevenueCat.RevocationReason) -> Swift.Bool
+  public typealias RawValue = Swift.String
+  @objc deinit
+}
 public typealias SK1Product = StoreKit.SKProduct
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 public typealias SK2Product = StoreKit.Product
@@ -2832,6 +2845,12 @@ public typealias SK2Transaction = StoreKit.Transaction
     @objc get
   }
   @objc final public var storefront: RevenueCat.Storefront? {
+    @objc get
+  }
+  @objc final public var revocationDate: Foundation.Date? {
+    @objc get
+  }
+  @objc final public var revocationReason: RevenueCat.RevocationReason? {
     @objc get
   }
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool

--- a/api/revenuecat-api-visionos.swiftinterface
+++ b/api/revenuecat-api-visionos.swiftinterface
@@ -2569,6 +2569,19 @@ extension RevenueCat.PromotionalOffer : Swift.Sendable {
 }
 extension RevenueCat.PromotionalOffer.SignedData : Swift.Sendable {
 }
+@objc(RCRevocationReason) final public class RevocationReason : ObjectiveC.NSObject, Swift.RawRepresentable, Swift.Sendable {
+  @objc final public let rawValue: Swift.String
+  @objc public init(rawValue: Swift.String)
+  @objc(RCDeveloperIssue) public static let developerIssue: RevenueCat.RevocationReason
+  @objc(RCOther) public static let other: RevenueCat.RevocationReason
+  @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
+  @objc override final public var hash: Swift.Int {
+    @objc get
+  }
+  public static func ~= (lhs: RevenueCat.RevocationReason, rhs: RevenueCat.RevocationReason) -> Swift.Bool
+  public typealias RawValue = Swift.String
+  @objc deinit
+}
 public typealias SK1Product = StoreKit.SKProduct
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 public typealias SK2Product = StoreKit.Product
@@ -2832,6 +2845,12 @@ public typealias SK2Transaction = StoreKit.Transaction
     @objc get
   }
   @objc final public var storefront: RevenueCat.Storefront? {
+    @objc get
+  }
+  @objc final public var revocationDate: Foundation.Date? {
+    @objc get
+  }
+  @objc final public var revocationReason: RevenueCat.RevocationReason? {
     @objc get
   }
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool

--- a/api/revenuecat-api-watchos-simulator.swiftinterface
+++ b/api/revenuecat-api-watchos-simulator.swiftinterface
@@ -2456,6 +2456,19 @@ extension RevenueCat.PromotionalOffer : Swift.Sendable {
 }
 extension RevenueCat.PromotionalOffer.SignedData : Swift.Sendable {
 }
+@objc(RCRevocationReason) final public class RevocationReason : ObjectiveC.NSObject, Swift.RawRepresentable, Swift.Sendable {
+  @objc final public let rawValue: Swift.String
+  @objc public init(rawValue: Swift.String)
+  @objc(RCDeveloperIssue) public static let developerIssue: RevenueCat.RevocationReason
+  @objc(RCOther) public static let other: RevenueCat.RevocationReason
+  @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
+  @objc override final public var hash: Swift.Int {
+    @objc get
+  }
+  public static func ~= (lhs: RevenueCat.RevocationReason, rhs: RevenueCat.RevocationReason) -> Swift.Bool
+  public typealias RawValue = Swift.String
+  @objc deinit
+}
 public typealias SK1Product = StoreKit.SKProduct
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 public typealias SK2Product = StoreKit.Product
@@ -2719,6 +2732,12 @@ public typealias SK2Transaction = StoreKit.Transaction
     @objc get
   }
   @objc final public var storefront: RevenueCat.Storefront? {
+    @objc get
+  }
+  @objc final public var revocationDate: Foundation.Date? {
+    @objc get
+  }
+  @objc final public var revocationReason: RevenueCat.RevocationReason? {
     @objc get
   }
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool

--- a/api/revenuecat-api-watchos.swiftinterface
+++ b/api/revenuecat-api-watchos.swiftinterface
@@ -2456,6 +2456,19 @@ extension RevenueCat.PromotionalOffer : Swift.Sendable {
 }
 extension RevenueCat.PromotionalOffer.SignedData : Swift.Sendable {
 }
+@objc(RCRevocationReason) final public class RevocationReason : ObjectiveC.NSObject, Swift.RawRepresentable, Swift.Sendable {
+  @objc final public let rawValue: Swift.String
+  @objc public init(rawValue: Swift.String)
+  @objc(RCDeveloperIssue) public static let developerIssue: RevenueCat.RevocationReason
+  @objc(RCOther) public static let other: RevenueCat.RevocationReason
+  @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
+  @objc override final public var hash: Swift.Int {
+    @objc get
+  }
+  public static func ~= (lhs: RevenueCat.RevocationReason, rhs: RevenueCat.RevocationReason) -> Swift.Bool
+  public typealias RawValue = Swift.String
+  @objc deinit
+}
 public typealias SK1Product = StoreKit.SKProduct
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 public typealias SK2Product = StoreKit.Product
@@ -2719,6 +2732,12 @@ public typealias SK2Transaction = StoreKit.Transaction
     @objc get
   }
   @objc final public var storefront: RevenueCat.Storefront? {
+    @objc get
+  }
+  @objc final public var revocationDate: Foundation.Date? {
+    @objc get
+  }
+  @objc final public var revocationReason: RevenueCat.RevocationReason? {
     @objc get
   }
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool


### PR DESCRIPTION
Contains the original changes made by @mvanhorn in https://github.com/RevenueCat/purchases-ios/pull/6962 + added Objc compatibility

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public API on transaction wrappers with SK1 and mocks unchanged (nil); no purchase or entitlement logic changes.
> 
> **Overview**
> Adds public **refund/revocation metadata** on `StoreTransaction`, aligned with StoreKit 2’s `Transaction.revocationDate` and `Transaction.RevocationReason`.
> 
> Introduces **`RevocationReason`** (`developer_issue`, `other`, raw-value + ObjC `RCRevocationReason`) and wires **SK2** transactions to copy `revocationDate` and map revocation reasons; unknown SK2 values log a warning and surface as `nil` on the reason. **SK1**, simulated, test, and backend-parsed transaction types return `nil` for both fields.
> 
> `StoreTransaction` exposes **`revocationDate`** and **`revocationReason`** on the public API (Swift and ObjC), with updated swiftinterfaces and API testers. Unit tests cover SK1 nil behavior, SK2 reason mapping, and `RevocationReason` equality/switching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3efd1a8e458bc3237749d9867d08495e02e42d37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->