### PR TITLE
chore: Add 3-day Dependabot cooldown, excluding fastlane plugin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 3
+      exclude:
+        - "fastlane-plugin-revenuecat_internal"


### PR DESCRIPTION
Adds a 3-day cooldown to Dependabot so we don't pick up dependency versions that were released less than 3 days ago. Our own `fastlane-plugin-revenuecat_internal` is excluded from the cooldown so it continues to update immediately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes Dependabot scheduling behavior; no application runtime, auth, or data paths are affected.
> 
> **Overview**
> Dependabot’s **bundler** update entry now includes a **`cooldown`** block with **`default-days: 3`**, so daily PRs won’t target gem versions published in the last three days.
> 
> **`fastlane-plugin-revenuecat_internal`** is listed under **`cooldown.exclude`**, so that dependency can still be bumped as soon as Dependabot sees a new release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a4e8ae9c9b1715aef75edf845a27df0bf40e216. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->