### PR TITLE
feat(workflows): gate all paywall events by step screen_type

### DIFF
--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -86,6 +86,10 @@ struct PaywallsV2View: View {
     /// The workflow step's `screen_type` classification, used to gate impression reporting. `nil` for
     /// standalone paywalls and for workflow steps the backend did not tag (see `stepScreenType`).
     private let workflowScreenType: [String]?
+    /// Whether this workflow step is the workflow's `singleStepFallbackId`. Only consulted for untagged
+    /// steps (`nil` `screen_type`), where it restores the structural rule of reporting on the fallback
+    /// step alone. Irrelevant for standalone paywalls and tagged steps.
+    private let isWorkflowSingleStepFallback: Bool
     @State
     private var didFinishEligibilityCheck: Bool = {
         #if DEBUG
@@ -121,7 +125,8 @@ struct PaywallsV2View: View {
         introEligibilityContext: IntroOfferEligibilityContext? = nil,
         selectedPackageContextOverride: PackageContext? = nil,
         isActiveWorkflowPage: Bool? = nil,
-        workflowScreenType: [String]? = nil
+        workflowScreenType: [String]? = nil,
+        isWorkflowSingleStepFallback: Bool = false
     ) {
         let uiConfigProvider = UIConfigProvider(
             uiConfig: paywallComponents.uiConfig,
@@ -142,6 +147,7 @@ struct PaywallsV2View: View {
         self.closeWorkflowAction = closeWorkflowAction
         self.isActiveWorkflowPage = isActiveWorkflowPage
         self.workflowScreenType = workflowScreenType
+        self.isWorkflowSingleStepFallback = isWorkflowSingleStepFallback
         self._paywallPromoOfferCache = .init(wrappedValue: promoOfferCache ?? PaywallPromoOfferCache(
             subscriptionHistoryTracker: purchaseHandler.subscriptionHistoryTracker
         ))
@@ -360,7 +366,12 @@ struct PaywallsV2View: View {
             }
             .environment(
                 \.componentInteractionLogger,
-                self.purchaseHandler.componentInteractionLogger(sessionID: self.paywallSessionID)
+                // A non-paywall workflow step reports no paywall events, so install a no-op logger there
+                // instead of one bound to this page's session. Otherwise component interactions would be
+                // the one paywall event still emitted on a non-paywall step.
+                Self.componentInteractionLogger(tracksPaywallEvents: self.tracksPaywallEvents) {
+                    self.purchaseHandler.componentInteractionLogger(sessionID: self.paywallSessionID)
+                }
             )
             .onChangeOf(self.purchaseHandler.hasPurchasedInSession) { hasPurchased in
                 guard hasPurchased else { return }
@@ -379,26 +390,46 @@ struct PaywallsV2View: View {
 
     }
 
-    static func shouldReportPaywallImpression(
+    /// Whether the current step reports paywall events (impression, close, purchase, cancel, exit offer,
+    /// component interaction). Driven by the backend `screen_type` tag:
+    /// - classified as a `paywall` → reports;
+    /// - tagged without `paywall` (including an empty list) → suppressed;
+    /// - untagged (legacy/pre-rollout payloads with no `screen_type`) → falls back to the structural rule,
+    ///   reporting only on the workflow's `singleStepFallbackId` step. When the workflow has no
+    ///   `singleStepFallbackId` either, no step is the fallback, so no paywall events are reported on any
+    ///   step (only workflow events) — intended, not a regression.
+    /// Standalone paywalls (no workflow) always report.
+    static func shouldTrackPaywallEvents(
         isActiveWorkflowPage: Bool?,
-        workflowScreenType: [String]?
+        workflowScreenType: [String]?,
+        isSingleStepFallback: Bool
     ) -> Bool {
         guard isActiveWorkflowPage != nil else { return true }
-        guard let screenType = workflowScreenType else { return true }
+        guard let screenType = workflowScreenType else { return isSingleStepFallback }
         return screenType.contains(WorkflowScreenType.paywall)
     }
 
-    private var reportsPaywallImpression: Bool {
-        Self.shouldReportPaywallImpression(
+    private var tracksPaywallEvents: Bool {
+        Self.shouldTrackPaywallEvents(
             isActiveWorkflowPage: self.isActiveWorkflowPage,
-            workflowScreenType: self.workflowScreenType
+            workflowScreenType: self.workflowScreenType,
+            isSingleStepFallback: self.isWorkflowSingleStepFallback
         )
+    }
+
+    /// The component interaction logger for the current step: the real session-bound logger when the step
+    /// tracks paywall events, otherwise a no-op so non-paywall steps emit no `component_interaction` event.
+    static func componentInteractionLogger(
+        tracksPaywallEvents: Bool,
+        makeLogger: () -> ComponentInteractionLogger
+    ) -> ComponentInteractionLogger {
+        tracksPaywallEvents ? makeLogger() : ComponentInteractionLogger()
     }
 
     private func firePaywallImpression(sessionID: PaywallEvent.SessionID? = nil) {
         // A workflow step the backend did not classify as a paywall reports no paywall events. Clear
         // any active session so a purchase here is unattributed, not charged to the prior paywall step.
-        guard self.reportsPaywallImpression else {
+        guard self.tracksPaywallEvents else {
             self.purchaseHandler.clearActivePaywallSession()
             return
         }
@@ -420,7 +451,7 @@ struct PaywallsV2View: View {
     }
 
     private func firePaywallClose() {
-        guard self.reportsPaywallImpression else { return }
+        guard self.tracksPaywallEvents else { return }
 
         if self.isActiveWorkflowPage == nil {
             // Standalone paywall: close whichever session is active (unchanged behavior).

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -432,8 +432,10 @@ struct WorkflowPaywallView: View {
             selectedPackageContextOverride: page.packageContext,
             // Drives per-visit paywall_viewed / paywall_close: this page is the current workflow step.
             isActiveWorkflowPage: isActive,
-            // Gates impression reporting: only steps tagged as paywalls report a paywall impression.
-            workflowScreenType: page.screenType
+            // Gates paywall events: steps tagged as paywalls report; untagged steps fall back to the
+            // single-step-fallback rule below.
+            workflowScreenType: page.screenType,
+            isWorkflowSingleStepFallback: page.isSingleStepFallback
         )
         .environment(\.workflowPackageContext, page.effectiveWorkflowPackageContext)
         .environment(\.workflowTriggerAction, { componentId in
@@ -659,6 +661,7 @@ struct WorkflowPaywallView: View {
             stepId: stepId,
             content: .init(paywallComponents: paywallComponents, offering: offering),
             screenType: step.stepScreenType,
+            isSingleStepFallback: stepId == context.workflow.singleStepFallbackId,
             headerComponent: screen.componentsConfig.base.header,
             showCloseButton: showCloseButton,
             introOfferEligibilityContext: .init(introEligibilityChecker: introEligibilityChecker),
@@ -760,8 +763,11 @@ private struct RenderedPage: Identifiable {
     let stepId: String
     let content: CurrentStepContent
     /// The step's `screen_type` classification (`nil` when the backend did not tag it). Drives whether
-    /// this page reports a paywall impression. See `PaywallsV2View.shouldReportPaywallImpression`.
+    /// this page reports paywall events. See `PaywallsV2View.shouldTrackPaywallEvents`.
     let screenType: [String]?
+    /// Whether this step is the workflow's `singleStepFallbackId`. Only used to gate paywall events on
+    /// untagged steps (`nil` `screenType`), restoring the structural fallback-step-only rule.
+    let isSingleStepFallback: Bool
     let headerComponent: PaywallComponent.HeaderComponent?
     let showCloseButton: Bool
     /// Page-scoped so late async eligibility checks cannot overwrite another workflow step.

--- a/Sources/Networking/Responses/WorkflowsResponse.swift
+++ b/Sources/Networking/Responses/WorkflowsResponse.swift
@@ -88,8 +88,9 @@ import Foundation
     let metadata: [String: AnyDecodable]?
 
     /// The step's `screen_type` from the backend (`metadata.screen_type`). `nil` = untagged (older
-    /// workflows), `[]` = tagged with no known type; the distinction drives impression gating. Key is
-    /// literal snake_case: `convertFromSnakeCase` skips keys inside `[String: AnyDecodable]`.
+    /// workflows), `[]` = tagged with no known type; the distinction drives paywall-event gating (see
+    /// `PaywallsV2View.shouldTrackPaywallEvents`). Key is literal snake_case: `convertFromSnakeCase` skips
+    /// keys inside `[String: AnyDecodable]`.
     public var stepScreenType: [String]? {
         guard case let .array(values)? = self.metadata?[WorkflowScreenType.metadataKey] else {
             return nil

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallsV2ViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallsV2ViewTests.swift
@@ -142,57 +142,136 @@ final class PromoEligibilityPackageInfosTests: TestCase {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-final class ShouldReportPaywallImpressionTests: TestCase {
+final class ShouldTrackPaywallEventsTests: TestCase {
 
     func testStandalonePaywallAlwaysReports() {
         // Standalone paywalls have no workflow screen_type and must keep reporting impressions.
-        expect(PaywallsV2View.shouldReportPaywallImpression(
+        expect(PaywallsV2View.shouldTrackPaywallEvents(
             isActiveWorkflowPage: nil,
-            workflowScreenType: nil
+            workflowScreenType: nil,
+            isSingleStepFallback: false
         )) == true
-        expect(PaywallsV2View.shouldReportPaywallImpression(
+        expect(PaywallsV2View.shouldTrackPaywallEvents(
             isActiveWorkflowPage: nil,
-            workflowScreenType: ["survey"]
+            workflowScreenType: ["survey"],
+            isSingleStepFallback: false
         )) == true
     }
 
     func testWorkflowPaywallStepReports() {
-        expect(PaywallsV2View.shouldReportPaywallImpression(
+        // A step tagged as a paywall reports regardless of whether it is the fallback step.
+        expect(PaywallsV2View.shouldTrackPaywallEvents(
             isActiveWorkflowPage: true,
-            workflowScreenType: [WorkflowScreenType.paywall]
+            workflowScreenType: [WorkflowScreenType.paywall],
+            isSingleStepFallback: false
         )) == true
     }
 
-    func testWorkflowUntaggedStepReportsToPreserveBehavior() {
-        // Older/untagged workflows (nil screen_type) must keep firing impressions so a backend that
-        // has not rolled out screen analytics is not silently muted.
-        expect(PaywallsV2View.shouldReportPaywallImpression(
+    func testWorkflowUntaggedStepFallsBackToSingleStepFallback() {
+        // Untagged workflows (nil screen_type, e.g. a backend that has not rolled out screen analytics)
+        // fall back to the structural rule: only the singleStepFallbackId step reports.
+        expect(PaywallsV2View.shouldTrackPaywallEvents(
             isActiveWorkflowPage: true,
-            workflowScreenType: nil
+            workflowScreenType: nil,
+            isSingleStepFallback: true
         )) == true
+        // Untagged and not the fallback step → suppressed. This also covers the owner-confirmed case of a
+        // workflow with no `singleStepFallbackId` at all: `WorkflowPaywallView` derives `isSingleStepFallback`
+        // as `stepId == singleStepFallbackId`, which is `false` for every step when the optional fallback id
+        // is absent, so no paywall events fire on any step (only workflow events).
+        expect(PaywallsV2View.shouldTrackPaywallEvents(
+            isActiveWorkflowPage: true,
+            workflowScreenType: nil,
+            isSingleStepFallback: false
+        )) == false
     }
 
     func testWorkflowStepTaggedNonPaywallDoesNotReport() {
-        expect(PaywallsV2View.shouldReportPaywallImpression(
+        // A tagged step without `paywall` is suppressed even when it is the fallback step.
+        expect(PaywallsV2View.shouldTrackPaywallEvents(
             isActiveWorkflowPage: true,
-            workflowScreenType: []
+            workflowScreenType: [],
+            isSingleStepFallback: true
         )) == false
-        expect(PaywallsV2View.shouldReportPaywallImpression(
+        expect(PaywallsV2View.shouldTrackPaywallEvents(
             isActiveWorkflowPage: true,
-            workflowScreenType: ["survey"]
+            workflowScreenType: ["survey"],
+            isSingleStepFallback: false
         )) == false
     }
 
     func testInactiveWorkflowPageGatedBySameRule() {
         // `isActiveWorkflowPage == false` is still a workflow page; the screen_type rule applies.
-        expect(PaywallsV2View.shouldReportPaywallImpression(
+        expect(PaywallsV2View.shouldTrackPaywallEvents(
             isActiveWorkflowPage: false,
-            workflowScreenType: [WorkflowScreenType.paywall]
+            workflowScreenType: [WorkflowScreenType.paywall],
+            isSingleStepFallback: false
         )) == true
-        expect(PaywallsV2View.shouldReportPaywallImpression(
+        expect(PaywallsV2View.shouldTrackPaywallEvents(
             isActiveWorkflowPage: false,
-            workflowScreenType: ["survey"]
+            workflowScreenType: ["survey"],
+            isSingleStepFallback: false
         )) == false
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@MainActor
+final class WorkflowComponentInteractionLoggerTests: TestCase {
+
+    private static let interactionData = PaywallEvent.ComponentInteractionData(
+        componentType: .text,
+        componentName: "link_copy",
+        componentValue: "navigate_to_url"
+    )
+
+    func testNonPaywallStepGetsNoOpLogger() {
+        var factoryInvoked = false
+        let logger = PaywallsV2View.componentInteractionLogger(tracksPaywallEvents: false) {
+            factoryInvoked = true
+            return ComponentInteractionLogger { _ in true }
+        }
+
+        // A non-paywall step must emit no component_interaction: the real logger is never built and the
+        // installed no-op reports nothing.
+        expect(factoryInvoked) == false
+        expect(logger(Self.interactionData)) == false
+    }
+
+    func testPaywallStepGetsRealLogger() async throws {
+        let tracker = PaywallEventTracker(
+            purchases: MockPurchases(
+                purchase: { _, _, _ in
+                    (transaction: nil, customerInfo: TestData.customerInfo, userCancelled: false)
+                },
+                restorePurchases: { TestData.customerInfo },
+                trackEvent: { _ in },
+                customerInfo: { TestData.customerInfo }
+            ),
+            eventDispatcher: PaywallEventTrackerTestDispatcher.value
+        )
+        let eventData: PaywallEvent.Data = .init(
+            offering: TestData.offeringWithIntroOffer,
+            paywall: TestData.paywallWithIntroOffer,
+            sessionID: .init(),
+            displayMode: .fullScreen,
+            locale: .init(identifier: "en_US"),
+            darkMode: false,
+            source: nil
+        )
+        tracker.trackPaywallImpression(eventData)
+
+        let logger = PaywallsV2View.componentInteractionLogger(tracksPaywallEvents: true) {
+            tracker.componentInteractionLogger(sessionID: eventData.sessionIdentifier)
+        }
+
+        // A paywall step uses the real session-bound logger, which reports the interaction.
+        expect(logger(Self.interactionData)) == true
+
+        await Task(priority: .low) {
+            await Task.yield()
+        }.value
     }
 
 }

--- a/Tests/UnitTests/Networking/Workflows/WorkflowResponseTests.swift
+++ b/Tests/UnitTests/Networking/Workflows/WorkflowResponseTests.swift
@@ -357,7 +357,8 @@ class WorkflowResponseTests: TestCase {
     }
 
     func testDecodeWorkflowStepScreenTypeNilWhenKeyAbsent() throws {
-        // Older workflows omit `screen_type`. `nil` (not `[]`) preserves the always-report behavior.
+        // Older workflows omit `screen_type`. `nil` (not `[]`) drives the untagged fallback in the UI
+        // layer (report only on `singleStepFallbackId`); see `PaywallsV2View.shouldTrackPaywallEvents`.
         let json = """
         {
           "id": "step_1",


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-android` and hybrids — port of purchases-android #3620

### Motivation

On non-paywall workflow steps we were only suppressing the impression (and close). `component_interaction` kept firing because its logger is wired to the page session, not the `screen_type` gate, so non-paywall steps still leaked interaction events. This brings iOS in line with purchases-android #3620.

### Description

Every paywall event (impression, close, purchase, cancel, exit offer, component interaction) now honors the step's `screen_type`. Untagged steps fall back to the structural rule and report only on the workflow's `singleStepFallbackId`; a workflow with neither `screen_type` nor `singleStepFallbackId` reports no paywall events, only workflow events.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: this PR
- Branch: `facu/workflow-gate-paywall-events-screen-type` (base `facu/workflows-remove-runtime-flag`)
- Author / human owner: facumenzella
- Agent(s): Claude Code (Opus 4.8, 1M context); review via Codex `/codex:review` + `/codex:adversarial-review`
- Session source: current conversation
- Generated: 2026-06-17
- Context document version: 1

## Goal

Make iOS match purchases-android #3620: gate **all** existing paywall events by a workflow step's `screen_type`, not just the impression.

## Initial Prompt

"Check purchases-android #3620 — it has the real implementation of events for workflows; ours is not correct." Resolved to the concrete task: iOS (shipped in #7021) only gated the impression/close by `screen_type`; bring every paywall event under the same gate so non-paywall workflow steps emit only workflow events.

## Important Follow-up Prompts

- "paywall events (existing ones) should only fire on screenType paywalls. We're currently gating only the impression event." → scoped the fix to all paywall events; identified `component_interaction` as the leak.
- "Let's match android" + run the codex review/fix loop.
- "Just updated android's PR. If there are no screentypes, we fallback to singleStepId and track only on that one." → changed untagged behavior from always-report to a `singleStepFallbackId` fallback.
- "if screen_type absent and singleStepFallbackId == null then we don't track any paywall events, only workflows." → edge case to honor.

## Agent Contribution

- Traced every paywall event path; found `component_interaction` was the only ungated one (wired to the per-page `paywallSessionID` via the environment logger).
- Renamed the gate `reportsPaywallImpression`/`shouldReportPaywallImpression` → `tracksPaywallEvents`/`shouldTrackPaywallEvents`; gated the component-interaction logger (no-op on non-paywall steps) via a testable static selector.
- Added the untagged→`singleStepFallbackId` fallback, threading `isWorkflowSingleStepFallback` from `WorkflowPaywallView` into `PaywallsV2View`.
- Added/updated unit tests; fixed two now-stale doc comments about untagged "always-report".
- Ran the codex review/fix loop to convergence.

## Human Decisions

- Match Android exactly: suppress all paywall events (incl. purchase-family) on non-paywall steps, rather than keeping purchases attributed.
- Untagged steps fall back to `singleStepFallbackId` (overriding an earlier "always-report" interim).
- Untagged **and** no `singleStepFallbackId` ⇒ no paywall events on any step (only workflow events). Owner-confirmed; Codex adversarial review flagged this "no-ship" but it is the intended behavior.

## Key Implementation Decisions

- Decision: gate `component_interaction` by installing the default no-op `ComponentInteractionLogger()` when the step does not track paywall events.
  - Rationale: puts component_interaction on the same `tracksPaywallEvents` flag as impression/close; localized and testable.
  - Rejected: re-routing component_interaction off the per-page session onto the global `activePaywallSessionID` (breaks the per-page workflow session model; out of scope).
- Decision: untagged → report only when `stepId == singleStepFallbackId`.
  - Rationale: matches the updated Android rule; `nil` fallback id yields `false` for every step, so no paywall events fire (only workflow events).
- Decision: keep the pre-existing `clearActivePaywallSession()` to suppress purchase-family events on non-paywall steps.

## Files / Symbols Touched

- `RevenueCatUI/Templates/V2/PaywallsV2View.swift`
  - Symbols: `shouldTrackPaywallEvents(...)`, `tracksPaywallEvents`, `componentInteractionLogger(tracksPaywallEvents:makeLogger:)`, `isWorkflowSingleStepFallback`, `firePaywallImpression`, `firePaywallClose`
  - Review relevance: the gate logic and the no-op logger swap in `.environment`.
- `RevenueCatUI/Templates/V2/WorkflowPaywallView.swift`
  - Symbols: `RenderedPage.isSingleStepFallback`, `renderedPage(...)`, `pageView(for:isActive:)`
  - Review relevance: `stepId == context.workflow.singleStepFallbackId` derivation and threading.
- `Sources/Networking/Responses/WorkflowsResponse.swift` — doc only (`stepScreenType`).
- `Tests/RevenueCatUITests/PaywallsV2/PaywallsV2ViewTests.swift` — gate + logger tests.
- `Tests/UnitTests/Networking/Workflows/WorkflowResponseTests.swift` — doc only.

## Dependencies / Config / Migrations

- None. No public API change.

## Validation

- Commands run:
  - `swift build --target RevenueCatUI`: success.
  - `swiftlint` on changed files: no violations.
  - `xcodebuild test` (RevenueCatUITests, iPhone 16 Pro) for `ShouldTrackPaywallEventsTests` + `WorkflowComponentInteractionLoggerTests`: **7 tests, 0 failures**.
  - Codex `/codex:review` (2 passes): no actionable bugs. `/codex:adversarial-review`: sole finding is the owner-approved untagged+no-fallback behavior.
- Manual verification: Not run (no on-device run).
- CI: Not captured.

## Validation Gaps

- `UnitTests/WorkflowResponseTests` not executed (the change there is comment-only).
- No on-device verification of navigating onto a `[]`-tagged step and interacting/purchasing.

## Review Focus

- Confirm untagged + missing `singleStepFallbackId` ⇒ no paywall events is acceptable (intended; pinned by `testWorkflowUntaggedStepFallsBackToSingleStepFallback`).
- Confirm the no-op logger swap is the right altitude vs a single session-level gate.

## Risks / Reviewer Notes

- Risk: legacy untagged workflows with no `singleStepFallbackId` emit no paywall events.
  - Evidence: deliberate, matches Android #3620 and owner instruction; documented in `shouldTrackPaywallEvents` and tested.
  - Mitigation: regression test; behavior is gated to workflow pages only (standalone paywalls always report).

## Non-goals / Out of Scope

- Re-architecting per-event gating into a single authoritative session lever.
- Changing standalone-paywall event behavior.

## Omitted Context

- Raw transcript, unrelated exploration, and repetitive review iterations were omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes analytics behavior for legacy untagged workflows and non-paywall steps; mistaken gating would mute or mis-attribute revenue events, though standalone paywalls are unaffected.
> 
> **Overview**
> Aligns iOS workflow paywall analytics with Android by gating **all** paywall events—not only impression/close—on each step’s `screen_type`.
> 
> **`shouldTrackPaywallEvents`** (renamed from impression-only gating) decides whether a workflow page reports paywall events: tagged `paywall` steps report; explicitly non-paywall tags (including `[]`) suppress; **untagged** legacy steps report only when the step is the workflow’s **`singleStepFallbackId`** (no fallback id ⇒ no paywall events on any step). Standalone paywalls are unchanged.
> 
> **`component_interaction`** is fixed by installing a **no-op** `ComponentInteractionLogger` when tracking is off, so non-paywall steps no longer leak interaction events. **`WorkflowPaywallView`** passes `isWorkflowSingleStepFallback` into **`PaywallsV2View`**. Tests cover the gate matrix and the logger behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d44d69d744079a3385d6098720b96ac0b96833e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<details>
<summary>Post-merge review follow-up (vegaro)</summary>

Both observations from the review were investigated against a live PaywallsTester run of workflow `wfdfd1d372810545e6` (iOS 26 simulator, StoreKit config, instrumented build capturing the event log):

1. `shouldTrackPaywallEvents` firing ~10x per transition is normal SwiftUI `body` re-evaluation. It is a pure function read from the view body (via the `componentInteractionLogger` environment), with no side effects.
2. `Attempted to track paywall close but eventData is nil` is a harmless redundant close on dismiss. Two layers close the same session: `View+PresentPaywall` calls `trackPaywallClose()` then `resetForNewSession()` (which emits the real close and discards the session), then `PaywallsV2View.onDisappear` calls `firePaywallClose(sessionID:)` for the same, now discarded, session. Exactly one `close` event reaches the backend; the second attempt only logs at debug. Follow-up to quiet the log: #7075.

</details>
