### PR TITLE
Migrate update_error_codes to the outputs parameter

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1,7 +1,7 @@
 orbs:
   macos: circleci/macos@2.5.1
   slack: circleci/slack@5.0.0
-  revenuecat: revenuecat/sdks-common-config@3.21.2
+  revenuecat: revenuecat/sdks-common-config@4.0.0
   # Disabled until compatible with M1: codecov: codecov/codecov@3.3.0
   # codecov: codecov/codecov@3.3.0
 
@@ -2591,7 +2591,7 @@ workflows:
     jobs:
       - revenuecat/update-error-codes:
           platform: ios
-          output: Sources/Generated/ErrorCode.swift
+          outputs: "ErrorCode.swift:Sources/Generated/ErrorCode.swift"
           commit_paths: "Sources/Generated/ErrorCode.swift,api"
           executor:
             name: macos-executor-external


### PR DESCRIPTION
Migrates the `update_error_codes` job to the orb's `outputs` parameter, required by sdks-circleci-orb v4.0.0 (which removes the `output` parameter).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI configuration only; no application runtime changes, with the same generated file path and commit scope as before.
> 
> **Overview**
> Upgrades the **`revenuecat/sdks-common-config`** CircleCI orb from **3.21.2** to **4.0.0** and updates the **`update-error-codes`** workflow so it matches the orb’s new API.
> 
> The orb job no longer accepts **`output`**; it now uses **`outputs`** with a source-to-destination mapping: `ErrorCode.swift:Sources/Generated/ErrorCode.swift` (replacing a single `output: Sources/Generated/ErrorCode.swift`). **`commit_paths`**, the external macOS executor, and the swiftinterface baseline fastlane step are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 528782e810192ab92dc57576fd9d7747a6b06355. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->