### PR TITLE
feat(remote-config): support RC Container format in network stack and use for remote-config request

### DIFF
--- a/Sources/Networking/Caching/RemoteConfigCallback.swift
+++ b/Sources/Networking/Caching/RemoteConfigCallback.swift
@@ -10,6 +10,6 @@ import Foundation
 struct RemoteConfigCallback: CacheKeyProviding {
 
     let cacheKey: String
-    let completion: (Result<RemoteConfigResponse, BackendError>) -> Void
+    let completion: (Result<RCContainer, BackendError>) -> Void
 
 }

--- a/Sources/Networking/Caching/RemoteConfigCallback.swift
+++ b/Sources/Networking/Caching/RemoteConfigCallback.swift
@@ -10,6 +10,6 @@ import Foundation
 struct RemoteConfigCallback: CacheKeyProviding {
 
     let cacheKey: String
-    let completion: (Result<RCContainer, BackendError>) -> Void
+    let completion: (Result<RCContainer?, BackendError>) -> Void
 
 }

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -390,10 +390,7 @@ private extension HTTPClient {
 
         let statusCode: HTTPStatusCode = .init(rawValue: httpURLResponse.statusCode)
 
-        // `nil` if status code is 304, since the response will be empty and fetched from the eTag.
-        let dataIfAvailable = statusCode == .notModified
-            ? nil
-            : data
+        let dataIfAvailable = Self.responseBodyData(statusCode: statusCode, data: data)
 
         return self.createVerifiedResponse(request: request,
                                            urlRequest: urlRequest,
@@ -963,6 +960,22 @@ private extension NetworkError {
 
 }
 
+extension HTTPClient {
+
+    static func responseBodyData(statusCode: HTTPStatusCode, data: Data?) -> Data? {
+        switch statusCode {
+        case .notModified:
+            // `nil` if status code is 304, since the response will be empty and fetched from the eTag.
+            return nil
+        case .noContent:
+            return data ?? Data()
+        default:
+            return data
+        }
+    }
+
+}
+
 extension Result where Success == Data?, Failure == NetworkError {
 
     /// Converts a `Result<Data?, NetworkError>` into `Result<HTTPResponse<Data?>, NetworkError>`
@@ -990,7 +1003,10 @@ extension Result where Success == VerifiedHTTPResponse<Data>, Failure == Network
         return self.flatMap { response in                   // Convert the `Result` type
             Result<VerifiedHTTPResponse<Value>, Error> {    // Create a new `Result<Value>`
                 try response.mapBody { data in              // Convert the from `Data` -> `Value`
-                    try Value.create(with: data)            // Decode `Data` into `Value`
+                    try Value.create(                       // Decode `Data` into `Value`
+                        with: data,
+                        httpStatusCode: response.httpStatusCode
+                    )
                 }
                 .copyWithNewRequestDate()                   // Update request date for 304 responses
             }

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -152,6 +152,8 @@ class HTTPClient {
 
 extension HTTPClient {
 
+    static let rcContainerFormatAcceptHeaderValue = "application/x-rc-format"
+
     static func authorizationHeader(withAPIKey apiKey: String) -> RequestHeaders {
         return [RequestHeader.authorization.rawValue: "Bearer \(apiKey)"]
     }
@@ -185,6 +187,7 @@ extension HTTPClient {
     enum RequestHeader: String {
 
         case authorization = "Authorization"
+        case accept = "Accept"
         case nonce = "X-Nonce"
         case eTag = "X-RevenueCat-ETag"
         case eTagValidationTime = "X-RC-Last-Refresh-Time"
@@ -448,6 +451,10 @@ private extension HTTPClient {
             }
             // Fetch from ETagManager if available
             .map { (response) -> VerifiedHTTPResponse<Data>? in
+                guard request.httpRequest.path.shouldSendEtag else {
+                    return response.asOptionalResponse
+                }
+
                 return self.eTagManager.httpResultFromCacheOrBackend(
                     with: response,
                     request: urlRequest,
@@ -902,6 +909,7 @@ extension HTTPRequest {
         internalSettings: InternalDangerousSettingsType
     ) -> HTTPClient.RequestHeaders {
         var result: HTTPClient.RequestHeaders = defaultHeaders
+        result += self.path.additionalHeaders
 
         if self.path.authenticated {
             result += authHeaders

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -45,6 +45,9 @@ protocol HTTPRequestPath {
 
     /// The fallback relative path for this endpoint, if any.
     var fallbackRelativePath: String? { get }
+
+    /// Additional headers specific to this endpoint.
+    var additionalHeaders: HTTPRequest.Headers { get }
 }
 
 extension HTTPRequestPath {
@@ -59,6 +62,10 @@ extension HTTPRequestPath {
 
     var fallbackRelativePath: String? {
         return nil
+    }
+
+    var additionalHeaders: HTTPRequest.Headers {
+        return [:]
     }
 
     var url: URL? { return self.url(proxyURL: nil) }
@@ -109,8 +116,7 @@ extension HTTPRequest {
         case postCreateTicket
         case isPurchaseAllowedByRestoreBehavior(appUserID: String)
         case rewardVerificationStatus(appUserID: String, clientTransactionID: String)
-        // WIP: endpoint path and signing requirements subject to change
-        case getRemoteConfig
+        case remoteConfig
 
     }
 
@@ -165,6 +171,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
             return base
         case let .getWorkflow(_, workflowId):
             return "/workflows/v1/workflows/\(Self.escape(workflowId))"
+        case .remoteConfig:
+            return "/v2/config"
         default:
             return nil
         }
@@ -208,7 +216,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .postCreateTicket,
                 .isPurchaseAllowedByRestoreBehavior,
                 .rewardVerificationStatus,
-                .getRemoteConfig:
+                .remoteConfig:
             return true
 
         case .health,
@@ -237,10 +245,10 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .appHealthReport,
                 .postCreateTicket,
                 .isPurchaseAllowedByRestoreBehavior,
-                .rewardVerificationStatus,
-                .getRemoteConfig:
+                .rewardVerificationStatus:
             return true
-        case .health,
+        case .remoteConfig,
+             .health,
              .appHealthReportAvailability:
             return false
         }
@@ -259,7 +267,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .getWorkflow,
                 .appHealthReport,
                 .appHealthReportAvailability,
-                .isPurchaseAllowedByRestoreBehavior:
+                .isPurchaseAllowedByRestoreBehavior,
+                .remoteConfig:
             return true
         case .getIntroEligibility,
                 .postSubscriberAttributes,
@@ -268,9 +277,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .postOfferForSigning,
                 .postRedeemWebPurchase,
                 .getCustomerCenterConfig,
-                .postCreateTicket,
-                // WIP: Move to true when we have the final endpoint for remote config, and we can remove the fallback
-                .getRemoteConfig:
+                .postCreateTicket:
             return false
         case .rewardVerificationStatus:
             return true
@@ -286,6 +293,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .health,
                 .appHealthReportAvailability,
                 .isPurchaseAllowedByRestoreBehavior,
+                .remoteConfig,
                 .rewardVerificationStatus:
             return true
         case .getWorkflow,
@@ -300,15 +308,14 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .getProductEntitlementMapping,
                 .getCustomerCenterConfig,
                 .appHealthReport,
-                .postCreateTicket,
-                .getRemoteConfig:
+                .postCreateTicket:
             return false
         }
     }
 
     var relativePath: String {
         switch self {
-        case .getRemoteConfig:
+        case .remoteConfig:
             return "/v2/\(self.pathComponent)"
         default:
             return "/v1/\(self.pathComponent)"
@@ -383,7 +390,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
         case let .rewardVerificationStatus(appUserID, clientTransactionID):
             return "subscribers/\(Self.escape(appUserID))/ads/reward_verifications/\(Self.escape(clientTransactionID))"
 
-        case .getRemoteConfig:
+        case .remoteConfig:
             return "config"
         }
     }
@@ -452,8 +459,17 @@ extension HTTPRequest.Path: HTTPRequestPath {
         case .rewardVerificationStatus:
             return "get_reward_verification_status"
 
-        case .getRemoteConfig:
-            return "get_remote_config"
+        case .remoteConfig:
+            return "remote_config"
+        }
+    }
+
+    var additionalHeaders: HTTPRequest.Headers {
+        switch self {
+        case .remoteConfig:
+            return [HTTPClient.RequestHeader.accept.rawValue: HTTPClient.rcContainerFormatAcceptHeaderValue]
+        default:
+            return [:]
         }
     }
 

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -276,8 +276,11 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .postOfferForSigning,
                 .postRedeemWebPurchase,
                 .getCustomerCenterConfig,
-                .postCreateTicket,
-                .remoteConfig:
+                .postCreateTicket:
+            return false
+        case .remoteConfig:
+            // swiftlint:disable:next todo
+            // TODO: Enable signature verification once remote-config binary responses are signed.
             return false
         case .rewardVerificationStatus:
             return true
@@ -307,8 +310,11 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .getProductEntitlementMapping,
                 .getCustomerCenterConfig,
                 .appHealthReport,
-                .postCreateTicket,
-                .remoteConfig:
+                .postCreateTicket:
+            return false
+        case .remoteConfig:
+            // swiftlint:disable:next todo
+            // TODO: Require a nonce once remote-config binary responses are signed.
             return false
         }
     }

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -267,8 +267,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .getWorkflow,
                 .appHealthReport,
                 .appHealthReportAvailability,
-                .isPurchaseAllowedByRestoreBehavior,
-                .remoteConfig:
+                .isPurchaseAllowedByRestoreBehavior:
             return true
         case .getIntroEligibility,
                 .postSubscriberAttributes,
@@ -277,7 +276,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .postOfferForSigning,
                 .postRedeemWebPurchase,
                 .getCustomerCenterConfig,
-                .postCreateTicket:
+                .postCreateTicket,
+                .remoteConfig:
             return false
         case .rewardVerificationStatus:
             return true
@@ -293,7 +293,6 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .health,
                 .appHealthReportAvailability,
                 .isPurchaseAllowedByRestoreBehavior,
-                .remoteConfig,
                 .rewardVerificationStatus:
             return true
         case .getWorkflow,
@@ -308,7 +307,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .getProductEntitlementMapping,
                 .getCustomerCenterConfig,
                 .appHealthReport,
-                .postCreateTicket:
+                .postCreateTicket,
+                .remoteConfig:
             return false
         }
     }

--- a/Sources/Networking/HTTPClient/HTTPResponseBody.swift
+++ b/Sources/Networking/HTTPClient/HTTPResponseBody.swift
@@ -18,6 +18,8 @@ protocol HTTPResponseBody {
 
     static func create(with data: Data) throws -> Self
 
+    static func create(with data: Data, httpStatusCode: HTTPStatusCode) throws -> Self
+
     /// Returns a copy of this response body updating only the request date
     /// This is useful for types that include a response date (like `CustomerInfo`), that need to
     /// get the most up-to-date time coming from the response header.
@@ -28,6 +30,10 @@ protocol HTTPResponseBody {
 }
 
 extension HTTPResponseBody {
+
+    static func create(with data: Data, httpStatusCode: HTTPStatusCode) throws -> Self {
+        return try Self.create(with: data)
+    }
 
     func copy(with newRequestDate: Date) -> Self { return self }
 
@@ -68,6 +74,14 @@ extension Optional: HTTPResponseBody where Wrapped: HTTPResponseBody {
 
     static func create(with data: Data) throws -> Wrapped? {
         return try Wrapped.create(with: data)
+    }
+
+    static func create(with data: Data, httpStatusCode: HTTPStatusCode) throws -> Wrapped? {
+        guard httpStatusCode != .noContent else {
+            return nil
+        }
+
+        return try Wrapped.create(with: data, httpStatusCode: httpStatusCode)
     }
 
 }

--- a/Sources/Networking/HTTPClient/HTTPStatusCode.swift
+++ b/Sources/Networking/HTTPClient/HTTPStatusCode.swift
@@ -18,6 +18,7 @@ enum HTTPStatusCode {
 
     case success
     case createdSuccess
+    case noContent
     case redirect
     case notModified
     case temporaryRedirect
@@ -34,6 +35,7 @@ enum HTTPStatusCode {
     private static let knownStatus: Set<HTTPStatusCode> = [
         .success,
         .createdSuccess,
+        .noContent,
         .redirect,
         .notModified,
         .temporaryRedirect,
@@ -57,6 +59,7 @@ extension HTTPStatusCode: RawRepresentable {
         switch self {
         case .success: return 200
         case .createdSuccess: return 201
+        case .noContent: return 204
         case .redirect: return 300
         case .notModified: return 304
         case .temporaryRedirect: return 307

--- a/Sources/Networking/Operations/GetRemoteConfigOperation.swift
+++ b/Sources/Networking/Operations/GetRemoteConfigOperation.swift
@@ -48,26 +48,13 @@ private extension GetRemoteConfigOperation {
     func getRemoteConfig(completion: @escaping () -> Void) {
         let request = HTTPRequest(method: .post(RemoteConfigRequest()), path: .remoteConfig)
 
-        self.httpClient.perform(request) { (response: VerifiedHTTPResponse<Data>.Result) in
+        self.httpClient.perform(request) { (response: VerifiedHTTPResponse<RCContainer?>.Result) in
             defer {
                 completion()
             }
 
             self.callbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
-                callback.completion(
-                    response
-                        .flatMap { response in
-                            guard response.httpStatusCode != .noContent else {
-                                return .success(nil)
-                            }
-
-                            return Result {
-                                try Optional.some(RCContainer(data: response.body))
-                            }
-                            .mapError { NetworkError.decoding($0, response.body) }
-                        }
-                        .mapError(BackendError.networkError)
-                )
+                callback.completion(response.map(\.body).mapError(BackendError.networkError))
             }
         }
     }

--- a/Sources/Networking/Operations/GetRemoteConfigOperation.swift
+++ b/Sources/Networking/Operations/GetRemoteConfigOperation.swift
@@ -57,8 +57,12 @@ private extension GetRemoteConfigOperation {
                 callback.completion(
                     response
                         .flatMap { response in
-                            Result {
-                                try RCContainer(data: response.body)
+                            guard response.httpStatusCode != .noContent else {
+                                return .success(nil)
+                            }
+
+                            return Result {
+                                try Optional.some(RCContainer(data: response.body))
                             }
                             .mapError { NetworkError.decoding($0, response.body) }
                         }

--- a/Sources/Networking/Operations/GetRemoteConfigOperation.swift
+++ b/Sources/Networking/Operations/GetRemoteConfigOperation.swift
@@ -46,9 +46,9 @@ extension GetRemoteConfigOperation: @unchecked Sendable {}
 private extension GetRemoteConfigOperation {
 
     func getRemoteConfig(completion: @escaping () -> Void) {
-        let request = HTTPRequest(method: .get, path: .getRemoteConfig)
+        let request = HTTPRequest(method: .post(RemoteConfigRequest()), path: .remoteConfig)
 
-        self.httpClient.perform(request) { (response: VerifiedHTTPResponse<RemoteConfigResponse>.Result) in
+        self.httpClient.perform(request) { (response: VerifiedHTTPResponse<Data>.Result) in
             defer {
                 completion()
             }
@@ -56,7 +56,12 @@ private extension GetRemoteConfigOperation {
             self.callbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
                 callback.completion(
                     response
-                        .map { $0.body }
+                        .flatMap { response in
+                            Result {
+                                try RCContainer(data: response.body)
+                            }
+                            .mapError { NetworkError.decoding($0, response.body) }
+                        }
                         .mapError(BackendError.networkError)
                 )
             }

--- a/Sources/Networking/RCContainer.swift
+++ b/Sources/Networking/RCContainer.swift
@@ -58,3 +58,11 @@ struct RCContainer {
     }
 
 }
+
+extension RCContainer: HTTPResponseBody {
+
+    static func create(with data: Data) throws -> RCContainer {
+        return try .init(data: data)
+    }
+
+}

--- a/Sources/Networking/RemoteConfigAPI.swift
+++ b/Sources/Networking/RemoteConfigAPI.swift
@@ -9,7 +9,7 @@ import Foundation
 
 class RemoteConfigAPI {
 
-    typealias RemoteConfigResponseHandler = Backend.ResponseHandler<RemoteConfigResponse>
+    typealias RemoteConfigResponseHandler = Backend.ResponseHandler<RCContainer>
 
     private let callbackCache: CallbackCache<RemoteConfigCallback>
     private let backendConfig: BackendConfiguration

--- a/Sources/Networking/RemoteConfigAPI.swift
+++ b/Sources/Networking/RemoteConfigAPI.swift
@@ -9,7 +9,7 @@ import Foundation
 
 class RemoteConfigAPI {
 
-    typealias RemoteConfigResponseHandler = Backend.ResponseHandler<RCContainer>
+    typealias RemoteConfigResponseHandler = Backend.ResponseHandler<RCContainer?>
 
     private let callbackCache: CallbackCache<RemoteConfigCallback>
     private let backendConfig: BackendConfiguration

--- a/Sources/Networking/Responses/RemoteConfigResponse.swift
+++ b/Sources/Networking/Responses/RemoteConfigResponse.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+struct RemoteConfigRequest: Codable, Equatable, HTTPRequestBody {}
+
 struct RemoteConfigResponse: Equatable {
 
     let apiSources: [ApiSource]

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -49,6 +49,29 @@ class MockHTTPClient: HTTPClient {
             self.init(response: .success(response), delay: delay)
         }
 
+        init(
+            statusCode: HTTPStatusCode,
+            body: Data,
+            responseHeaders: HTTPResponse.Headers = [:],
+            verificationResult: VerificationResult = .defaultValue,
+            delay: DispatchTimeInterval = .never,
+            isLoadShedderResponse: Bool = false,
+            isFallbackUrlResponse: Bool = false
+        ) {
+            let response = VerifiedHTTPResponse(
+                response: .init(
+                    httpStatusCode: statusCode,
+                    responseHeaders: responseHeaders,
+                    body: body
+                ),
+                verificationResult: verificationResult,
+                isLoadShedderResponse: isLoadShedderResponse,
+                isFallbackUrlResponse: isFallbackUrlResponse
+            )
+
+            self.init(response: .success(response), delay: delay)
+        }
+
         init(error: NetworkError, delay: DispatchTimeInterval = .never) {
             self.init(response: .failure(error), delay: delay)
         }

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -246,6 +246,24 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(error.domain) == String(reflecting: RCContainer.Parser.FormatError.self)
     }
 
+    func testGetRemoteConfigSuccessfulEmptyResponseSendsDecodingError() {
+        self.httpClient.mock(
+            requestPath: .remoteConfig,
+            response: .init(statusCode: .success, body: Data())
+        )
+
+        let result = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+        }
+
+        guard case let .networkError(.decoding(error, _)) = result?.error else {
+            fail("Expected decoding error, got \(String(describing: result?.error))")
+            return
+        }
+
+        expect(error.domain) == String(reflecting: RCContainer.Parser.FormatError.self)
+    }
+
     func testGetRemoteConfigSuccessfulJSONResponseSendsDecodingError() {
         self.httpClient.mock(
             requestPath: .remoteConfig,

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -83,6 +83,19 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(self.httpClient.calls.first?.headers[ETagManager.eTagValidationTimeRequestHeader.rawValue]).to(beNil())
     }
 
+    func testGetRemoteConfigDoesNotSendSignatureVerificationHeaders() {
+        self.mockSuccessfulResponse()
+
+        waitUntil { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false) { _ in completed() }
+        }
+
+        let headers = self.httpClient.calls.first?.headers
+        expect(headers?[HTTPClient.RequestHeader.nonce.rawValue]).to(beNil())
+        expect(headers?[HTTPClient.RequestHeader.headerParametersForSignature.rawValue]).to(beNil())
+        expect(headers?[HTTPClient.RequestHeader.postParameters.rawValue]).to(beNil())
+    }
+
     // MARK: - Jitterable delay
 
     func testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded() {

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -20,6 +20,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
+        // TODO: Re-enable snapshots once the remote-config network stack is final.
         self.httpClient.disableSnapshotTesting()
     }
 
@@ -139,16 +140,30 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
     func testGetRemoteConfigParsesRCContainerResponse() throws {
         self.mockSuccessfulResponse()
 
-        let result: Result<RCContainer, BackendError>? = waitUntilValue { completed in
+        let result: Result<RCContainer?, BackendError>? = waitUntilValue { completed in
             self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
         }
 
-        let container = try XCTUnwrap(result?.value)
+        let container = try XCTUnwrap(try XCTUnwrap(result?.value))
         expect(RCContainerTestData.data(from: container.config)) == Self.config
         expect(container.contentElements).to(haveCount(1))
         expect(RCContainerTestData.data(
             from: try XCTUnwrap(container.contentElements[RCContainerTestData.blobRef(for: Self.content)])
         )) == Self.content
+    }
+
+    func testGetRemoteConfigNoContentResponseSucceedsWithNoContainer() throws {
+        self.httpClient.mock(
+            requestPath: .remoteConfig,
+            response: .init(statusCode: .noContent, body: Data())
+        )
+
+        let result: Result<RCContainer?, BackendError>? = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+        }
+
+        expect(result).to(beSuccess())
+        expect(try XCTUnwrap(result?.value)).to(beNil())
     }
 
     // MARK: - Error handling
@@ -203,6 +218,24 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         self.httpClient.mock(
             requestPath: .remoteConfig,
             response: .init(statusCode: .success, body: "not an rc container".asData)
+        )
+
+        let result = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+        }
+
+        guard case let .networkError(.decoding(error, _)) = result?.error else {
+            fail("Expected decoding error, got \(String(describing: result?.error))")
+            return
+        }
+
+        expect(error.domain) == String(reflecting: RCContainer.Parser.FormatError.self)
+    }
+
+    func testGetRemoteConfigSuccessfulJSONResponseSendsDecodingError() {
+        self.httpClient.mock(
+            requestPath: .remoteConfig,
+            response: .init(statusCode: .success, body: #"{"api_sources":[]}"#.asData)
         )
 
         let result = waitUntilValue { completed in

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -20,6 +20,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
+        // swiftlint:disable:next todo
         // TODO: Re-enable snapshots once the remote-config network stack is final.
         self.httpClient.disableSnapshotTesting()
     }

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -17,13 +17,16 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         super.createClient(#file)
     }
 
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        self.httpClient.disableSnapshotTesting()
+    }
+
     // MARK: - Basic request
 
     func testGetRemoteConfigCallsHTTPMethod() {
-        self.httpClient.mock(
-            requestPath: .getRemoteConfig,
-            response: .init(statusCode: .success, response: Self.fullResponse)
-        )
+        self.mockSuccessfulResponse()
 
         let result = waitUntilValue { completed in
             self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
@@ -31,28 +34,57 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
         expect(result).to(beSuccess())
         expect(self.httpClient.calls).to(haveCount(1))
+        expect(self.httpClient.calls.first?.request.method.httpMethod) == "POST"
     }
 
     func testGetRemoteConfigUsesCorrectPath() {
-        self.httpClient.mock(
-            requestPath: .getRemoteConfig,
-            response: .init(statusCode: .success, response: Self.fullResponse)
-        )
+        self.mockSuccessfulResponse()
 
         waitUntil { completed in
             self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false) { _ in completed() }
         }
 
-        expect(self.httpClient.calls.map { $0.request.path as? HTTPRequest.Path }) == [.getRemoteConfig]
+        expect(self.httpClient.calls.map { $0.request.path as? HTTPRequest.Path }) == [.remoteConfig]
+        expect(self.httpClient.calls.first?.request.path.relativePath) == "/v2/config"
+    }
+
+    func testGetRemoteConfigEncodesDefaultRequestBody() throws {
+        self.mockSuccessfulResponse()
+
+        waitUntil { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false) { _ in completed() }
+        }
+
+        let body = try XCTUnwrap(self.httpClient.calls.first?.request.requestBody?.asJSONDictionary())
+        expect(body).to(beEmpty())
+    }
+
+    func testGetRemoteConfigRequestsRCContainerFormat() {
+        self.mockSuccessfulResponse()
+
+        waitUntil { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false) { _ in completed() }
+        }
+
+        expect(self.httpClient.calls.first?.headers[HTTPClient.RequestHeader.accept.rawValue])
+            == HTTPClient.rcContainerFormatAcceptHeaderValue
+    }
+
+    func testGetRemoteConfigDoesNotSendETagHeaders() {
+        self.mockSuccessfulResponse()
+
+        waitUntil { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false) { _ in completed() }
+        }
+
+        expect(self.httpClient.calls.first?.headers[ETagManager.eTagRequestHeader.rawValue]).to(beNil())
+        expect(self.httpClient.calls.first?.headers[ETagManager.eTagValidationTimeRequestHeader.rawValue]).to(beNil())
     }
 
     // MARK: - Jitterable delay
 
     func testGetRemoteConfigUsesDefaultJitterableDelayWhenBackgrounded() {
-        self.httpClient.mock(
-            requestPath: .getRemoteConfig,
-            response: .init(statusCode: .success, response: Self.fullResponse)
-        )
+        self.mockSuccessfulResponse()
 
         let result = waitUntilValue { completed in
             self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: true, completion: completed)
@@ -63,10 +95,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
     }
 
     func testGetRemoteConfigUsesNoDelayWhenNotBackgrounded() {
-        self.httpClient.mock(
-            requestPath: .getRemoteConfig,
-            response: .init(statusCode: .success, response: Self.fullResponse)
-        )
+        self.mockSuccessfulResponse()
 
         let result = waitUntilValue { completed in
             self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
@@ -79,12 +108,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
     // MARK: - Request coalescing
 
     func testGetRemoteConfigCoalescesSimultaneousRequests() {
-        self.httpClient.mock(
-            requestPath: .getRemoteConfig,
-            response: .init(statusCode: .success,
-                            response: Self.fullResponse,
-                            delay: .milliseconds(10))
-        )
+        self.mockSuccessfulResponse(delay: .milliseconds(10))
 
         let responses: Atomic<Int> = .init(0)
 
@@ -96,12 +120,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
     }
 
     func testCoalescedRequestsLogDebugMessage() {
-        self.httpClient.mock(
-            requestPath: .getRemoteConfig,
-            response: .init(statusCode: .success,
-                            response: Self.fullResponse,
-                            delay: .milliseconds(10))
-        )
+        self.mockSuccessfulResponse(delay: .milliseconds(10))
 
         self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false) { _ in }
         self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false) { _ in }
@@ -117,47 +136,26 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
     // MARK: - Response parsing
 
-    func testGetRemoteConfigParsesFullResponse() throws {
-        self.httpClient.mock(
-            requestPath: .getRemoteConfig,
-            response: .init(statusCode: .success, response: Self.fullResponse)
-        )
+    func testGetRemoteConfigParsesRCContainerResponse() throws {
+        self.mockSuccessfulResponse()
 
-        let result: Result<RemoteConfigResponse, BackendError>? = waitUntilValue { completed in
+        let result: Result<RCContainer, BackendError>? = waitUntilValue { completed in
             self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
         }
 
-        let response = try XCTUnwrap(result?.value)
-        expect(response.apiSources).to(haveCount(1))
-        expect(response.apiSources[0].id) == "primary"
-        expect(response.blobSources).to(haveCount(1))
-        expect(response.blobSources[0].id) == "cloudfront-primary"
-
-        let pem = response.manifest.topics[.productEntitlementMapping]
-        expect(pem?["default"]?.blobRef) == "6a4d0f53d9f6b8e2f4dca0fd1c7c4f5e3e1b1ef0"
-    }
-
-    func testGetRemoteConfigParsesEmptyResponse() throws {
-        self.httpClient.mock(
-            requestPath: .getRemoteConfig,
-            response: .init(statusCode: .success, response: [:] as [String: Any])
-        )
-
-        let result: Result<RemoteConfigResponse, BackendError>? = waitUntilValue { completed in
-            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
-        }
-
-        let response = try XCTUnwrap(result?.value)
-        expect(response.apiSources).to(beEmpty())
-        expect(response.blobSources).to(beEmpty())
-        expect(response.manifest.topics).to(beEmpty())
+        let container = try XCTUnwrap(result?.value)
+        expect(RCContainerTestData.data(from: container.config)) == Self.config
+        expect(container.contentElements).to(haveCount(1))
+        expect(RCContainerTestData.data(
+            from: try XCTUnwrap(container.contentElements[RCContainerTestData.blobRef(for: Self.content)])
+        )) == Self.content
     }
 
     // MARK: - Error handling
 
     func testGetRemoteConfigFailSendsError() {
         self.httpClient.mock(
-            requestPath: .getRemoteConfig,
+            requestPath: .remoteConfig,
             response: .init(error: .unexpectedResponse(nil))
         )
 
@@ -172,7 +170,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         let mockedError: NetworkError = .unexpectedResponse(nil)
 
         self.httpClient.mock(
-            requestPath: .getRemoteConfig,
+            requestPath: .remoteConfig,
             response: .init(error: mockedError)
         )
 
@@ -184,36 +182,61 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(result?.error) == .networkError(mockedError)
     }
 
+    func testGetRemoteConfigErrorResponseSendsErrorWithoutParsingRCContainer() {
+        let errorResponse = ErrorResponse(code: .internalServerError, originalCode: 7110)
+        let mockedError: NetworkError = .errorResponse(errorResponse, .internalServerError)
+
+        self.httpClient.mock(
+            requestPath: .remoteConfig,
+            response: .init(error: mockedError)
+        )
+
+        let result = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+        }
+
+        expect(result).to(beFailure())
+        expect(result?.error) == .networkError(mockedError)
+    }
+
+    func testGetRemoteConfigInvalidRCContainerSendsDecodingError() {
+        self.httpClient.mock(
+            requestPath: .remoteConfig,
+            response: .init(statusCode: .success, body: "not an rc container".asData)
+        )
+
+        let result = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+        }
+
+        guard case let .networkError(.decoding(error, _)) = result?.error else {
+            fail("Expected decoding error, got \(String(describing: result?.error))")
+            return
+        }
+
+        expect(error.domain) == String(reflecting: RCContainer.Parser.FormatError.self)
+    }
+
 }
 
 private extension BackendGetRemoteConfigTests {
 
-    static let fullResponse: [String: Any] = [
-        "api_sources": [
-            [
-                "id": "primary",
-                "url": "https://api.revenuecat.com/",
-                "priority": 0,
-                "weight": 100
-            ] as [String: Any]
-        ],
-        "blob_sources": [
-            [
-                "id": "cloudfront-primary",
-                "url_format": "https://assets.revenuecat.com/rc_app_1234/{blob_ref}",
-                "priority": 0,
-                "weight": 100
-            ] as [String: Any]
-        ],
-        "manifest": [
-            "topics": [
-                "product_entitlement_mapping": [
-                    "default": [
-                        "blob_ref": "6a4d0f53d9f6b8e2f4dca0fd1c7c4f5e3e1b1ef0"
-                    ]
-                ]
-            ]
-        ] as [String: Any]
-    ]
+    static let config = #"{"manifest":{}}"#.asData
+    static let content = #"{"products":[]}"#.asData
+
+    static var containerData: Data {
+        return RCContainerTestData.container(config: Self.config, contentElements: [Self.content])
+    }
+
+    func mockSuccessfulResponse(delay: DispatchTimeInterval = .never) {
+        self.httpClient.mock(
+            requestPath: .remoteConfig,
+            response: .init(
+                statusCode: .success,
+                body: Self.containerData,
+                delay: delay
+            )
+        )
+    }
 
 }

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1014,6 +1014,30 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
         expect(self.eTagManager.invokedETagHeader) == false
     }
 
+    func testRemoteConfigDoesNotUseETagCacheEvenIfResponseIncludesETagHeader() {
+        let request = HTTPRequest(method: .post(RemoteConfigRequest()), path: .remoteConfig)
+        let headerPresent: Atomic<Bool?> = nil
+
+        stub(condition: isPath(request.path)) { request in
+            headerPresent.value = request.allHTTPHeaderFields?.keys.contains(
+                ETagManager.eTagRequestHeader.rawValue
+            ) == true
+            return HTTPStubsResponse(
+                data: Data(),
+                statusCode: .success,
+                headers: [ETagManager.eTagResponseHeader.rawValue: "ETAG"]
+            )
+        }
+
+        waitUntil { completion in
+            self.client.perform(request, with: .disabled) { (_: DataResponse) in completion() }
+        }
+
+        expect(headerPresent.value) == false
+        expect(self.eTagManager.invokedETagHeader) == false
+        expect(self.eTagManager.invokedHTTPResultFromCacheOrBackend) == false
+    }
+
     func testAlwaysPassesClientVersion() {
         let request = HTTPRequest(method: .post([:]), path: .mockPath)
 

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -705,6 +705,18 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
         self.logger.verifyMessageWasNotLogged("Queued request GET /v1/subscribers/identify for retry in 0.0 seconds.")
     }
 
+    func testNoContentResponseBodyDataConvertsNilToEmptyData() {
+        expect(HTTPClient.responseBodyData(statusCode: .noContent, data: nil)) == Data()
+    }
+
+    func testNotModifiedResponseBodyDataIsNil() {
+        expect(HTTPClient.responseBodyData(statusCode: .notModified, data: Data())) == nil
+    }
+
+    func testSuccessfulResponseBodyDataPreservesNilData() {
+        expect(HTTPClient.responseBodyData(statusCode: .success, data: nil)).to(beNil())
+    }
+
     func testServerSide200WithETagInRequest() {
         let request = HTTPRequest(method: .get, path: .mockPath)
         let responseData = "{\"message\": \"something is great up in the cloud\"}".asData

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -57,16 +57,14 @@ class HTTPRequestTests: TestCase {
         .getProductEntitlementMapping,
         .rewardVerificationStatus(appUserID: userID, clientTransactionID: clientTransactionID),
         .getWorkflows(appUserID: userID, type: nil),
-        .getWorkflow(appUserID: userID, workflowId: "wf_1"),
-        .remoteConfig
+        .getWorkflow(appUserID: userID, workflowId: "wf_1")
     ]
     private static let pathsThatRequireNonce: Set<HTTPRequest.Path> = [
         .getCustomerInfo(appUserID: userID),
         .logIn,
         .postReceiptData,
         .health,
-        .rewardVerificationStatus(appUserID: userID, clientTransactionID: clientTransactionID),
-        .remoteConfig
+        .rewardVerificationStatus(appUserID: userID, clientTransactionID: clientTransactionID)
     ]
     private static let pathsWithUserID: [HTTPRequest.Path] = [
         .getCustomerInfo(appUserID: anonymousUser),

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -38,13 +38,15 @@ class HTTPRequestTests: TestCase {
         .getProductEntitlementMapping,
         .rewardVerificationStatus(appUserID: userID, clientTransactionID: clientTransactionID),
         .getWorkflows(appUserID: userID, type: nil),
-        .getWorkflow(appUserID: userID, workflowId: "wf_1")
+        .getWorkflow(appUserID: userID, workflowId: "wf_1"),
+        .remoteConfig
     ]
     private static let unauthenticatedPaths: Set<HTTPRequest.Path> = [
         .health
     ]
     private static let pathsWithoutETags: Set<HTTPRequest.Path> = [
-        .health
+        .health,
+        .remoteConfig
     ]
     private static let pathsWithSignatureVerification: Set<HTTPRequest.Path> = [
         .getCustomerInfo(appUserID: userID),
@@ -55,14 +57,16 @@ class HTTPRequestTests: TestCase {
         .getProductEntitlementMapping,
         .rewardVerificationStatus(appUserID: userID, clientTransactionID: clientTransactionID),
         .getWorkflows(appUserID: userID, type: nil),
-        .getWorkflow(appUserID: userID, workflowId: "wf_1")
+        .getWorkflow(appUserID: userID, workflowId: "wf_1"),
+        .remoteConfig
     ]
     private static let pathsThatRequireNonce: Set<HTTPRequest.Path> = [
         .getCustomerInfo(appUserID: userID),
         .logIn,
         .postReceiptData,
         .health,
-        .rewardVerificationStatus(appUserID: userID, clientTransactionID: clientTransactionID)
+        .rewardVerificationStatus(appUserID: userID, clientTransactionID: clientTransactionID),
+        .remoteConfig
     ]
     private static let pathsWithUserID: [HTTPRequest.Path] = [
         .getCustomerInfo(appUserID: anonymousUser),
@@ -209,6 +213,9 @@ class HTTPRequestTests: TestCase {
             case let .getWorkflow(_, workflowId):
                 XCTAssertEqual(fallbackUrlsPaths,
                                ["https://api-production.8-lives-cat.io/workflows/v1/workflows/\(workflowId)"])
+            case .remoteConfig:
+                XCTAssertEqual(fallbackUrlsPaths,
+                               ["https://api-production.8-lives-cat.io/v2/config"])
             default:
                 XCTAssertTrue(fallbackUrlsPaths.isEmpty)
             }
@@ -308,5 +315,17 @@ class HTTPRequestTests: TestCase {
     func testRequestIsRetryableIfSet() {
         let request: HTTPRequest = .init(method: .get, path: .getCustomerInfo(appUserID: "user"), isRetryable: true)
         expect(request.isRetryable).to(beTrue())
+    }
+
+    func testRemoteConfigUsesRCContainerAcceptHeader() {
+        let request: HTTPRequest = .init(method: .post(RemoteConfigRequest()), path: .remoteConfig)
+        let headers = request.headers(
+            with: [:],
+            defaultHeaders: [:],
+            verificationMode: .disabled,
+            internalSettings: DangerousSettings.Internal.default
+        )
+
+        expect(headers[HTTPClient.RequestHeader.accept.rawValue]) == HTTPClient.rcContainerFormatAcceptHeaderValue
     }
 }

--- a/Tests/UnitTests/Networking/HTTPResponseTests.swift
+++ b/Tests/UnitTests/Networking/HTTPResponseTests.swift
@@ -172,6 +172,45 @@ class HTTPResponseBodyTests: TestCase {
         expect(body.copy(with: Date())) == body
     }
 
+    func testOptionalResponseBodyCreatesNilForNoContentResponse() throws {
+        struct Body: Equatable, Codable, HTTPResponseBody {
+            var data: String
+        }
+
+        let body = try Body?.create(
+            with: Data(),
+            httpStatusCode: .noContent
+        )
+
+        expect(body).to(beNil())
+    }
+
+    func testOptionalResponseBodyThrowsForEmptySuccessfulResponse() {
+        struct Body: Equatable, Codable, HTTPResponseBody {
+            var data: String
+        }
+
+        expect {
+            try Body?.create(
+                with: Data(),
+                httpStatusCode: .success
+            )
+        }.to(throwError())
+    }
+
+    func testOptionalResponseBodyCreatesWrappedBodyForContentResponse() throws {
+        struct Body: Equatable, Codable, HTTPResponseBody {
+            var data: String
+        }
+
+        let body = try Body?.create(
+            with: #"{"data":"test"}"#.asData,
+            httpStatusCode: .success
+        )
+
+        expect(body) == Body(data: "test")
+    }
+
 }
 
 // MARK: - ErrorResponse

--- a/Tests/UnitTests/Networking/HTTPStatusCodeTests.swift
+++ b/Tests/UnitTests/Networking/HTTPStatusCodeTests.swift
@@ -46,6 +46,7 @@ class HTTPStatusCodeTests: TestCase {
     func testIsSuccessfulResponse() {
         expect(HTTPStatusCode.success.isSuccessfulResponse) == true
         expect(HTTPStatusCode.createdSuccess.isSuccessfulResponse) == true
+        expect(HTTPStatusCode.noContent.isSuccessfulResponse) == true
         expect(HTTPStatusCode.redirect.isSuccessfulResponse) == true
         expect(HTTPStatusCode.notModified.isSuccessfulResponse) == true
         expect(HTTPStatusCode.temporaryRedirect.isSuccessfulResponse) == true
@@ -73,6 +74,7 @@ class HTTPStatusCodeTests: TestCase {
     func testIsNotServerError() {
         expect(HTTPStatusCode.success.isServerError) == false
         expect(HTTPStatusCode.createdSuccess.isServerError) == false
+        expect(HTTPStatusCode.noContent.isServerError) == false
         expect(HTTPStatusCode.redirect.isServerError) == false
         expect(HTTPStatusCode.notModified.isServerError) == false
         expect(HTTPStatusCode.temporaryRedirect.isServerError) == false
@@ -89,6 +91,7 @@ class HTTPStatusCodeTests: TestCase {
     func testIsSuccessfullySynced() {
         expect(HTTPStatusCode.success.isSuccessfullySynced) == true
         expect(HTTPStatusCode.createdSuccess.isSuccessfullySynced) == true
+        expect(HTTPStatusCode.noContent.isSuccessfullySynced) == true
         expect(HTTPStatusCode.redirect.isSuccessfullySynced) == true
         expect(HTTPStatusCode.notModified.isSuccessfullySynced) == true
         expect(HTTPStatusCode.temporaryRedirect.isSuccessfullySynced) == true


### PR DESCRIPTION
Part of a stack of PRs, builds on [#7030](https://github.com/RevenueCat/purchases-ios/pull/7030).

Implements support for the RCContainer format in the network stack, and implements it for the `POST /v2/config` endpoint. The network stack part of this PR matches that of https://github.com/RevenueCat/purchases-android/pull/3607

- Requests to this endpoint now add the `Accept: application/x-rc-format`
- Automatic etag caching is disabled
- The response is parsed into the RCContainer binary format

No data is extracted from the RCContainer response yet, this will be done in a follow up PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared HTTP decoding and caching behavior plus a new binary remote-config contract; signature verification is intentionally disabled for this endpoint until signing lands.
> 
> **Overview**
> Remote config is wired through the shared HTTP stack as **`POST /v2/config`**, requesting **`Accept: application/x-rc-format`** and decoding successful bodies into **`RCContainer`** (callbacks now return **`RCContainer?`**). **204 No Content** is treated as success with a **nil** container instead of attempting binary parse.
> 
> The client adds **per-path headers**, **skips ETag caching** for remote config (even if the server sends ETag headers), and leaves **signature verification off** for that path until binary responses are signed (TODOs in code). Decoding goes through **`HTTPResponseBody.create(with:httpStatusCode:)`**, with **`Optional`** mapping **noContent** to **nil** and **`HTTPClient.responseBodyData`** normalizing **304** vs **204** body handling.
> 
> Tests cover POST path/body, Accept header, no ETag/signature headers, RC Container parse success, 204 nil, and decode failures for invalid/JSON/empty 200 responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60efa0c9f5f40684b42b15d0b32db4f2842a2169. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->