### PR TITLE
Model entitlement reward variant in reward verification

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1102,6 +1102,7 @@
 		900D27082F96950000D32EDF /* MockAdsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900D27022F96929800D32EDF /* MockAdsAPI.swift */; };
 		900D270A2F96A00000D32EDF /* VirtualCurrencyReward.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900D27092F96A00000D32EDF /* VirtualCurrencyReward.swift */; };
 		900D270C2F96A00000D32EDF /* AdReward.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900D270B2F96A00000D32EDF /* AdReward.swift */; };
+		AAE17E010000000000000001 /* EntitlementReward.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE17E010000000000000002 /* EntitlementReward.swift */; };
 		900D270E2F96A00000D32EDF /* PurchasesRewardVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900D270D2F96A00000D32EDF /* PurchasesRewardVerificationTests.swift */; };
 		901DE80E2EA0E097007EAA86 /* AdTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901DE80D2EA0E096007EAA86 /* AdTracker.swift */; };
 		9025C53D2EA66E2500845BCE /* PostFeatureEventsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9025C53C2EA66E2500845BCE /* PostFeatureEventsOperation.swift */; };
@@ -1241,6 +1242,7 @@
 		C53CDAA4FC3E6B51CC70D724 /* WorkflowPaywallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800A129055A298C390AED0B5 /* WorkflowPaywallView.swift */; };
 		C808D299537245E695865C31 /* CapturingLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = E51CFC7D19BE49D2BA1A79CC /* CapturingLogger.swift */; };
 		D012440C2FD02DC90043B43B /* RewardVerificationResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D012440B2FD02DC90043B43B /* RewardVerificationResultTests.swift */; };
+		AAE17E010000000000000003 /* RewardVerificationStatusResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE17E010000000000000004 /* RewardVerificationStatusResponseTests.swift */; };
 		D012440D2FD02DC90043B43B /* RewardVerificationOutcomeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01244082FD02DC90043B43B /* RewardVerificationOutcomeTests.swift */; };
 		D012440E2FD02DC90043B43B /* RewardVerificationPollerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D012440A2FD02DC90043B43B /* RewardVerificationPollerTests.swift */; };
 		D012440F2FD02DC90043B43B /* RewardVerificationPollerTestDoubles.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01244092FD02DC90043B43B /* RewardVerificationPollerTestDoubles.swift */; };
@@ -2682,6 +2684,7 @@
 		900D27062F96943200D32EDF /* BackendGetRewardVerificationStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendGetRewardVerificationStatusTests.swift; sourceTree = "<group>"; };
 		900D27092F96A00000D32EDF /* VirtualCurrencyReward.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VirtualCurrencyReward.swift; sourceTree = "<group>"; };
 		900D270B2F96A00000D32EDF /* AdReward.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdReward.swift; sourceTree = "<group>"; };
+		AAE17E010000000000000002 /* EntitlementReward.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntitlementReward.swift; sourceTree = "<group>"; };
 		900D270D2F96A00000D32EDF /* PurchasesRewardVerificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesRewardVerificationTests.swift; sourceTree = "<group>"; };
 		901DE80D2EA0E096007EAA86 /* AdTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdTracker.swift; sourceTree = "<group>"; };
 		9025C53C2EA66E2500845BCE /* PostFeatureEventsOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostFeatureEventsOperation.swift; sourceTree = "<group>"; };
@@ -2836,6 +2839,7 @@
 		D01244092FD02DC90043B43B /* RewardVerificationPollerTestDoubles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardVerificationPollerTestDoubles.swift; sourceTree = "<group>"; };
 		D012440A2FD02DC90043B43B /* RewardVerificationPollerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardVerificationPollerTests.swift; sourceTree = "<group>"; };
 		D012440B2FD02DC90043B43B /* RewardVerificationResultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardVerificationResultTests.swift; sourceTree = "<group>"; };
+		AAE17E010000000000000004 /* RewardVerificationStatusResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardVerificationStatusResponseTests.swift; sourceTree = "<group>"; };
 		D01244152FD02FC30043B43B /* Outcome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Outcome.swift; sourceTree = "<group>"; };
 		D01244162FD02FC30043B43B /* Poller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Poller.swift; sourceTree = "<group>"; };
 		D01244172FD02FC30043B43B /* RewardVerification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardVerification.swift; sourceTree = "<group>"; };
@@ -5905,6 +5909,7 @@
 				900D26F42F96927E00D32EDF /* Networking */,
 				900D26F52F96927E00D32EDF /* RewardVerificationPollStatus.swift */,
 				900D270B2F96A00000D32EDF /* AdReward.swift */,
+				AAE17E010000000000000002 /* EntitlementReward.swift */,
 				900D27092F96A00000D32EDF /* VirtualCurrencyReward.swift */,
 			);
 			path = RewardVerification;
@@ -6022,6 +6027,7 @@
 				D01244092FD02DC90043B43B /* RewardVerificationPollerTestDoubles.swift */,
 				D012440A2FD02DC90043B43B /* RewardVerificationPollerTests.swift */,
 				D012440B2FD02DC90043B43B /* RewardVerificationResultTests.swift */,
+				AAE17E010000000000000004 /* RewardVerificationStatusResponseTests.swift */,
 				90A1B2C42F96927E00D32EDF /* VirtualCurrencyRewardTests.swift */,
 				90A1B2C62F96927E00D32EDF /* AdRewardTests.swift */,
 				AD5000000000000000ADAD05 /* AdReward+TestExtensions.swift */,
@@ -7059,6 +7065,7 @@
 				900D26FC2F96927E00D32EDF /* RewardVerificationStatusCallback.swift in Sources */,
 				900D270A2F96A00000D32EDF /* VirtualCurrencyReward.swift in Sources */,
 				900D270C2F96A00000D32EDF /* AdReward.swift in Sources */,
+				AAE17E010000000000000001 /* EntitlementReward.swift in Sources */,
 				9A65E03B25918B0900DE00B0 /* CustomerInfoStrings.swift in Sources */,
 				5721360F28B4602C006C46BE /* Purchases+nonasync.swift in Sources */,
 				57DE806D28074976008D6C6F /* Storefront.swift in Sources */,
@@ -7556,6 +7563,7 @@
 				57E9CF11290B2ADC00EE12D1 /* CachingTrialOrIntroPriceEligibilityCheckerTests.swift in Sources */,
 				5757EDF82DEE092900AC4BE1 /* ClockTests.swift in Sources */,
 				D012440C2FD02DC90043B43B /* RewardVerificationResultTests.swift in Sources */,
+				AAE17E010000000000000003 /* RewardVerificationStatusResponseTests.swift in Sources */,
 				D012440D2FD02DC90043B43B /* RewardVerificationOutcomeTests.swift in Sources */,
 				D012440E2FD02DC90043B43B /* RewardVerificationPollerTests.swift in Sources */,
 				D012440F2FD02DC90043B43B /* RewardVerificationPollerTestDoubles.swift in Sources */,

--- a/Sources/Ads/RewardVerification/AdReward.swift
+++ b/Sources/Ads/RewardVerification/AdReward.swift
@@ -15,12 +15,14 @@ import Foundation
 
 /// Reward payload describing the outcome of a verified rewarded ad.
 ///
-/// Inspect the received reward by checking ``virtualCurrency`` or comparing against
+/// Inspect the received reward by checking ``virtualCurrency`` / ``entitlement`` or comparing against
 /// ``noReward`` / ``unsupportedReward``:
 ///
 /// ```swift
 /// if let virtualCurrency = adReward.virtualCurrency {
 ///     // Reward is a virtual-currency line item.
+/// } else if let entitlement = adReward.entitlement {
+///     // Reward is a temporary entitlement grant.
 /// } else if adReward == .noReward {
 ///     // Verification succeeded but no reward was granted.
 /// } else if adReward == .unsupportedReward {
@@ -31,6 +33,7 @@ import Foundation
 
     private enum Storage: Sendable, Equatable {
         case virtualCurrency(VirtualCurrencyReward)
+        case entitlement(EntitlementReward)
         case noReward
         case unsupportedReward
     }
@@ -46,6 +49,11 @@ import Foundation
         AdReward(storage: .virtualCurrency(payload))
     }
 
+    /// Reward is a temporary entitlement grant with an identifier and expiration.
+    internal static func entitlement(_ payload: EntitlementReward) -> AdReward {
+        AdReward(storage: .entitlement(payload))
+    }
+
     /// Verification succeeded but no reward was granted.
     public static let noReward = AdReward(storage: .noReward)
 
@@ -58,10 +66,17 @@ import Foundation
         return payload
     }
 
+    /// Non-`nil` when this reward represents an ``EntitlementReward``.
+    public var entitlement: EntitlementReward? {
+        guard case .entitlement(let payload) = self.storage else { return nil }
+        return payload
+    }
+
     /// Stable raw value used for wire encoding and ObjC interop.
     internal var kindRawValue: String {
         switch self.storage {
         case .virtualCurrency: return Self.Kind.virtualCurrency
+        case .entitlement: return Self.Kind.entitlement
         case .noReward: return Self.Kind.noReward
         case .unsupportedReward: return Self.Kind.unsupportedReward
         }
@@ -69,6 +84,7 @@ import Foundation
 
     internal enum Kind {
         static let virtualCurrency = "virtual_currency"
+        static let entitlement = "entitlement"
         static let noReward = "no_reward"
         static let unsupportedReward = "unsupported_reward"
     }

--- a/Sources/Ads/RewardVerification/EntitlementReward.swift
+++ b/Sources/Ads/RewardVerification/EntitlementReward.swift
@@ -1,0 +1,36 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  EntitlementReward.swift
+//
+
+import Foundation
+
+/// An entitlement reward granted by an ad network after a successful reward verification.
+///
+/// The entitlement is surfaced through the standard entitlements API; this payload describes the
+/// grant that was verified for the rewarded ad.
+@_spi(Experimental) public struct EntitlementReward: Sendable, Equatable {
+
+    /// The granted entitlement identifier (the key in the `CustomerInfo` entitlements map).
+    public let identifier: String
+
+    /// The moment the granted entitlement expires.
+    public let expiresAt: Date
+
+    /// Creates an entitlement reward.
+    ///
+    /// Returns `nil` if `identifier` is empty. This is the single source of truth for "what counts as a
+    /// valid entitlement reward" across the SDK.
+    internal init?(identifier: String, expiresAt: Date) {
+        guard !identifier.isEmpty else { return nil }
+        self.identifier = identifier
+        self.expiresAt = expiresAt
+    }
+}

--- a/Sources/Ads/RewardVerification/Networking/RewardVerificationStatusResponse.swift
+++ b/Sources/Ads/RewardVerification/Networking/RewardVerificationStatusResponse.swift
@@ -54,10 +54,13 @@ extension RewardVerificationStatusResponse: Decodable {
         case type
         case code
         case amount
+        case identifier
+        case expiresAt
     }
 
     private enum RewardType {
         static let virtualCurrency = "virtual_currency"
+        static let entitlement = "entitlement"
     }
 
     init(from decoder: Decoder) throws {
@@ -121,6 +124,17 @@ extension RewardVerificationStatusResponse: Decodable {
                 return .unsupportedReward
             }
             return .virtualCurrency(payload)
+        case RewardType.entitlement:
+            let identifier = try? rewardContainer.decode(String.self, forKey: .identifier)
+            let expiresAt = try? rewardContainer.decode(Date.self, forKey: .expiresAt)
+            guard let identifier, let expiresAt,
+                  let payload = EntitlementReward(identifier: identifier, expiresAt: expiresAt) else {
+                Logger.warn(
+                    Strings.backendError.malformed_reward_verification_reward_payload(type: rewardType)
+                )
+                return .unsupportedReward
+            }
+            return .entitlement(payload)
         default:
             Logger.warn(
                 Strings.backendError.unsupported_reward_verification_reward_type(type: rewardType)

--- a/Sources/Ads/RewardVerification/RewardVerificationResult.swift
+++ b/Sources/Ads/RewardVerification/RewardVerificationResult.swift
@@ -39,4 +39,10 @@ import Foundation
         guard case .verified(let reward) = self.storage else { return nil }
         return reward
     }
+
+    /// `true` when verification did not complete successfully.
+    public var failed: Bool {
+        guard case .failed = self.storage else { return false }
+        return true
+    }
 }

--- a/Sources/Ads/RewardVerification/RewardVerificationResult.swift
+++ b/Sources/Ads/RewardVerification/RewardVerificationResult.swift
@@ -41,7 +41,7 @@ import Foundation
     }
 
     /// `true` when verification did not complete successfully.
-    public var failed: Bool {
+    var failed: Bool {
         guard case .failed = self.storage else { return false }
         return true
     }

--- a/Sources/Logging/Strings/AdsStrings.swift
+++ b/Sources/Logging/Strings/AdsStrings.swift
@@ -35,7 +35,8 @@ enum AdsStrings {
     case poll_cancelled(transactionID: String)
     case reward_verification_completed(outcome: String, transactionID: String)
     case reward_verification_virtual_currency_invalidating_cache(transactionID: String)
-    case reward_verification_entitlement_invalidating_customer_info(transactionID: String)
+    case reward_verification_entitlement_fetching_customer_info(transactionID: String)
+    case reward_verification_entitlement_customer_info_refresh_failed(transactionID: String)
 
 }
 
@@ -93,8 +94,12 @@ extension AdsStrings: LogMessage {
         case let .reward_verification_virtual_currency_invalidating_cache(transactionID):
             return "Reward verification granted a virtual currency; invalidating virtual currencies cache " +
                 "transactionID=\(transactionID)"
-        case let .reward_verification_entitlement_invalidating_customer_info(transactionID):
-            return "Reward verification granted an entitlement; invalidating CustomerInfo cache " +
+        case let .reward_verification_entitlement_fetching_customer_info(transactionID):
+            return "Reward verification granted an entitlement; fetching updated CustomerInfo " +
+                "transactionID=\(transactionID)"
+        case let .reward_verification_entitlement_customer_info_refresh_failed(transactionID):
+            return "Reward verification granted an entitlement but refreshing CustomerInfo failed; " +
+                "reporting the reward as failed (the grant persists server-side and will sync later). " +
                 "transactionID=\(transactionID)"
         }
     }

--- a/Sources/Logging/Strings/AdsStrings.swift
+++ b/Sources/Logging/Strings/AdsStrings.swift
@@ -34,6 +34,8 @@ enum AdsStrings {
     case poll_terminal_error(error: Error, transactionID: String)
     case poll_cancelled(transactionID: String)
     case reward_verification_completed(outcome: String, transactionID: String)
+    case reward_verification_virtual_currency_invalidating_cache(transactionID: String)
+    case reward_verification_entitlement_invalidating_customer_info(transactionID: String)
 
 }
 
@@ -88,6 +90,12 @@ extension AdsStrings: LogMessage {
             return "Reward verification was cancelled before completion. transactionID=\(transactionID)"
         case let .reward_verification_completed(outcome, transactionID):
             return "Reward verification completed outcome=\(outcome) transactionID=\(transactionID)"
+        case let .reward_verification_virtual_currency_invalidating_cache(transactionID):
+            return "Reward verification granted a virtual currency; invalidating virtual currencies cache " +
+                "transactionID=\(transactionID)"
+        case let .reward_verification_entitlement_invalidating_customer_info(transactionID):
+            return "Reward verification granted an entitlement; invalidating CustomerInfo cache " +
+                "transactionID=\(transactionID)"
         }
     }
 

--- a/Sources/Logging/Strings/AdsStrings.swift
+++ b/Sources/Logging/Strings/AdsStrings.swift
@@ -33,7 +33,7 @@ enum AdsStrings {
     case poll_unexpected_response(transactionID: String)
     case poll_terminal_error(error: Error, transactionID: String)
     case poll_cancelled(transactionID: String)
-    case reward_verification_completed(outcome: String, transactionID: String)
+    case reward_verification_completed(result: RewardVerificationResult, transactionID: String)
     case reward_verification_virtual_currency_invalidating_cache(transactionID: String)
     case reward_verification_entitlement_fetching_customer_info(transactionID: String)
     case reward_verification_entitlement_customer_info_refresh_failed(transactionID: String)
@@ -89,7 +89,8 @@ extension AdsStrings: LogMessage {
                 "transactionID=\(transactionID)"
         case let .poll_cancelled(transactionID):
             return "Reward verification was cancelled before completion. transactionID=\(transactionID)"
-        case let .reward_verification_completed(outcome, transactionID):
+        case let .reward_verification_completed(result, transactionID):
+            let outcome = result.failed ? "failed" : "verified"
             return "Reward verification completed outcome=\(outcome) transactionID=\(transactionID)"
         case let .reward_verification_virtual_currency_invalidating_cache(transactionID):
             return "Reward verification granted a virtual currency; invalidating virtual currencies cache " +

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1710,8 +1710,19 @@ extension Purchases {
             transactionID: clientTransactionID
         ))
         #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-        if case .verified(let reward) = outcome, reward.virtualCurrency != nil {
-            self.invalidateVirtualCurrenciesCache()
+        if case .verified(let reward) = outcome {
+            if reward.virtualCurrency != nil {
+                Logger.debug(AdsStrings.reward_verification_virtual_currency_invalidating_cache(
+                    transactionID: clientTransactionID
+                ))
+                self.invalidateVirtualCurrenciesCache()
+            }
+            if reward.entitlement != nil {
+                Logger.debug(AdsStrings.reward_verification_entitlement_invalidating_customer_info(
+                    transactionID: clientTransactionID
+                ))
+                self.invalidateCustomerInfoCache()
+            }
         }
         #endif
         switch outcome {

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1690,7 +1690,9 @@ extension Purchases {
     ///
     /// Call when your ad network's reward callback fires, passing the `clientTransactionID` returned by
     /// ``generateRewardVerificationToken(impressionId:)``.
-    /// Invalidates the virtual currencies cache automatically on a verified virtual-currency reward.
+    /// On a verified reward, automatically invalidates the relevant cache so the grant is reflected on the
+    /// next access: the virtual currencies cache for a virtual-currency reward, and the `CustomerInfo`
+    /// cache for an entitlement reward.
     @_spi(Experimental) public func pollRewardVerification(
         clientTransactionID: String
     ) async -> RewardVerificationResult {

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1708,19 +1708,8 @@ extension Purchases {
     ) async -> RewardVerificationResult {
         let outcome = await poller.run(clientTransactionID: clientTransactionID)
         let result = await self.rewardVerificationResult(for: outcome, clientTransactionID: clientTransactionID)
-
-        // Log the *delivered* result, not the raw poll outcome — an entitlement-refresh failure downgrades
-        // a verified poll to `.failed`, so the completion log must match what the caller receives.
-        let resultDescription: String
-        if result.verifiedReward != nil {
-            resultDescription = "verified"
-        } else if case .failed = outcome {
-            resultDescription = outcome.logDescription
-        } else {
-            resultDescription = "failed(entitlementRefreshFailed)"
-        }
         Logger.info(AdsStrings.reward_verification_completed(
-            outcome: resultDescription,
+            result: result,
             transactionID: clientTransactionID
         ))
         return result

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1707,10 +1707,31 @@ extension Purchases {
         poller: RewardVerification.Poller
     ) async -> RewardVerificationResult {
         let outcome = await poller.run(clientTransactionID: clientTransactionID)
+        let result = await self.rewardVerificationResult(for: outcome, clientTransactionID: clientTransactionID)
+
+        // Log the *delivered* result, not the raw poll outcome — an entitlement-refresh failure downgrades
+        // a verified poll to `.failed`, so the completion log must match what the caller receives.
+        let resultDescription: String
+        if result.verifiedReward != nil {
+            resultDescription = "verified"
+        } else if case .failed = outcome {
+            resultDescription = outcome.logDescription
+        } else {
+            resultDescription = "failed(entitlementRefreshFailed)"
+        }
         Logger.info(AdsStrings.reward_verification_completed(
-            outcome: outcome.logDescription,
+            outcome: resultDescription,
             transactionID: clientTransactionID
         ))
+        return result
+    }
+
+    /// Applies a verified reward's side-effects and returns the result delivered to the caller. A failed
+    /// entitlement `CustomerInfo` refresh downgrades the result to `.failed`.
+    private func rewardVerificationResult(
+        for outcome: RewardVerification.Outcome,
+        clientTransactionID: String
+    ) async -> RewardVerificationResult {
         #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
         if case .verified(let reward) = outcome {
             if reward.virtualCurrency != nil {
@@ -1719,11 +1740,12 @@ extension Purchases {
                 ))
                 self.invalidateVirtualCurrenciesCache()
             }
-            if reward.entitlement != nil {
-                Logger.debug(AdsStrings.reward_verification_entitlement_invalidating_customer_info(
-                    transactionID: clientTransactionID
-                ))
-                self.invalidateCustomerInfoCache()
+            if reward.entitlement != nil,
+               await self.refreshCustomerInfoAfterEntitlementGrant(clientTransactionID: clientTransactionID)
+                == false {
+                // Couldn't reflect the entitlement locally — report `.failed` so the app doesn't act on a
+                // reward it can't honor yet. The grant persists server-side and syncs on a later fetch.
+                return .failed
             }
         }
         #endif
@@ -1732,6 +1754,36 @@ extension Purchases {
         case .failed: return .failed
         }
     }
+
+    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+    /// Refreshes `CustomerInfo` (bypassing the cache) so an entitlement reward is reflected locally,
+    /// retrying transient failures since `getCustomerInfo` has no built-in retry. Returns whether it
+    /// succeeded.
+    private func refreshCustomerInfoAfterEntitlementGrant(clientTransactionID: String) async -> Bool {
+        Logger.debug(AdsStrings.reward_verification_entitlement_fetching_customer_info(
+            transactionID: clientTransactionID
+        ))
+        let refreshed: CustomerInfo? = await Async.retry(maximumRetries: 3) {
+            do {
+                let info = try await self.customerInfoManager.customerInfo(
+                    appUserID: self.appUserID,
+                    fetchPolicy: .fetchCurrent
+                )
+                return (shouldRetry: false, info)
+            } catch {
+                // Retry only transient failures; a terminal error won't improve on retry.
+                let isTransient = (error as? BackendError)?.isTransient ?? false
+                return (shouldRetry: isTransient, nil)
+            }
+        }
+        if refreshed == nil {
+            Logger.warn(AdsStrings.reward_verification_entitlement_customer_info_refresh_failed(
+                transactionID: clientTransactionID
+            ))
+        }
+        return refreshed != nil
+    }
+    #endif
 
 }
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1745,7 +1745,7 @@ extension Purchases {
     }
 
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-    /// Refreshes `CustomerInfo` (bypassing the cache) so an entitlement reward is reflected locally,
+    /// Fetches current `CustomerInfo` so an entitlement reward is reflected locally,
     /// retrying transient failures since `getCustomerInfo` has no built-in retry. Returns whether it
     /// succeeded.
     private func refreshCustomerInfoAfterEntitlementGrant(clientTransactionID: String) async -> Bool {

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/AdRewardAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/AdRewardAPI.swift
@@ -6,20 +6,24 @@
 import Foundation
 @_spi(Experimental) import RevenueCat
 
-func checkAdRewardAPI(reward: AdReward) {
-    let _: VirtualCurrencyReward? = reward.virtualCurrency
-    let _: EntitlementReward? = reward.entitlement
+var adReward: AdReward!
+var virtualCurrencyReward: VirtualCurrencyReward!
+var entitlementReward: EntitlementReward!
+
+func checkAdRewardAPI() {
+    let _: VirtualCurrencyReward? = adReward.virtualCurrency
+    let _: EntitlementReward? = adReward.entitlement
     let _: AdReward = .noReward
     let _: AdReward = .unsupportedReward
-    let _: Bool = reward == .noReward
+    let _: Bool = adReward == .noReward
 }
 
-func checkVirtualCurrencyRewardAPI(reward: VirtualCurrencyReward) {
-    let _: String = reward.code
-    let _: Int = reward.amount
+func checkVirtualCurrencyRewardAPI() {
+    let _: String = virtualCurrencyReward.code
+    let _: Int = virtualCurrencyReward.amount
 }
 
-func checkEntitlementRewardAPI(reward: EntitlementReward) {
-    let _: String = reward.identifier
-    let _: Date = reward.expiresAt
+func checkEntitlementRewardAPI() {
+    let _: String = entitlementReward.identifier
+    let _: Date = entitlementReward.expiresAt
 }

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/AdRewardAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/AdRewardAPI.swift
@@ -1,0 +1,25 @@
+//
+//  AdRewardAPI.swift
+//  SwiftAPITester
+//
+
+import Foundation
+@_spi(Experimental) import RevenueCat
+
+func checkAdRewardAPI(reward: AdReward) {
+    let _: VirtualCurrencyReward? = reward.virtualCurrency
+    let _: EntitlementReward? = reward.entitlement
+    let _: AdReward = .noReward
+    let _: AdReward = .unsupportedReward
+    let _: Bool = reward == .noReward
+}
+
+func checkVirtualCurrencyRewardAPI(reward: VirtualCurrencyReward) {
+    let _: String = reward.code
+    let _: Int = reward.amount
+}
+
+func checkEntitlementRewardAPI(reward: EntitlementReward) {
+    let _: String = reward.identifier
+    let _: Date = reward.expiresAt
+}

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/main.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/main.swift
@@ -72,5 +72,9 @@ func main() -> Int {
 
     checkDangerousSettingsAPI()
 
+    checkAdRewardAPI()
+    checkVirtualCurrencyRewardAPI()
+    checkEntitlementRewardAPI()
+
     return 0
 }

--- a/Tests/UnitTests/Ads/RewardVerification/AdReward+TestExtensions.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/AdReward+TestExtensions.swift
@@ -26,4 +26,13 @@ extension AdReward {
         return .virtualCurrency(payload)
     }
 
+    /// Test-only convenience that builds an entitlement reward from an identifier and expiration.
+    /// Falls back to ``unsupportedReward`` when the inputs are rejected.
+    static func entitlement(identifier: String, expiresAt: Date) -> AdReward {
+        guard let payload = EntitlementReward(identifier: identifier, expiresAt: expiresAt) else {
+            return .unsupportedReward
+        }
+        return .entitlement(payload)
+    }
+
 }

--- a/Tests/UnitTests/Ads/RewardVerification/AdRewardTests.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/AdRewardTests.swift
@@ -51,8 +51,79 @@ final class AdRewardTests: TestCase {
 
     func testKindRawValuesAreStable() {
         expect(AdReward.virtualCurrency(code: "x", amount: 1).kindRawValue) == "virtual_currency"
+        expect(AdReward.entitlement(identifier: "pro", expiresAt: Date()).kindRawValue) == "entitlement"
         expect(AdReward.noReward.kindRawValue) == "no_reward"
         expect(AdReward.unsupportedReward.kindRawValue) == "unsupported_reward"
     }
 
+    // MARK: - Entitlement
+
+    func testEntitlementCarriesAssociatedPayload() throws {
+        let expiresAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let payload = try XCTUnwrap(EntitlementReward(identifier: "pro", expiresAt: expiresAt))
+        let reward = AdReward.entitlement(payload)
+        expect(reward.entitlement) == payload
+        expect(reward.entitlement?.identifier) == "pro"
+        expect(reward.entitlement?.expiresAt) == expiresAt
+        expect(reward.virtualCurrency).to(beNil())
+    }
+
+    func testEntitlementRewardRequiresNonEmptyIdentifier() {
+        expect(EntitlementReward(identifier: "", expiresAt: Date())).to(beNil())
+    }
+
+    func testEqualityDistinguishesEntitlementFromOtherKinds() throws {
+        let expiresAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let one = try XCTUnwrap(EntitlementReward(identifier: "pro", expiresAt: expiresAt))
+        let differentID = try XCTUnwrap(EntitlementReward(identifier: "plus", expiresAt: expiresAt))
+        expect(AdReward.entitlement(one)) == AdReward.entitlement(one)
+        expect(AdReward.entitlement(one)) != AdReward.entitlement(differentID)
+        expect(AdReward.entitlement(one)) != AdReward.noReward
+        expect(AdReward.entitlement(one)) != AdReward.virtualCurrency(code: "coins", amount: 1)
+    }
+
+    // MARK: - Flat (analytics events) encoding
+
+    /// The analytics-events flat encoding only models a currency `code`/`amount`. Entitlement analytics
+    /// is a deferred non-goal, so an entitlement reward flat-encodes its `type` only and round-trips back
+    /// to ``AdReward/unsupportedReward`` (it cannot be reconstructed without identifier/expiry keys).
+    func testEntitlementFlatEncodingEmitsTypeOnlyAndDecodesAsUnsupported() throws {
+        let reward = AdReward.entitlement(identifier: "pro", expiresAt: Date())
+
+        let data = try JSONEncoder().encode(FlatRewardWrapper(reward: reward))
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        expect(json["type"] as? String) == "entitlement"
+        expect(json.keys).toNot(contain("code"))
+        expect(json.keys).toNot(contain("amount"))
+
+        let decoded = try JSONDecoder().decode(FlatRewardWrapper.self, from: data)
+        expect(decoded.reward) == .unsupportedReward
+    }
+
+}
+
+/// Exercises ``AdReward``'s flat `encode`/`decode` helpers (the analytics-events wire shape).
+private struct FlatRewardWrapper: Codable, Equatable {
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case code
+        case amount
+    }
+
+    let reward: AdReward
+
+    init(reward: AdReward) {
+        self.reward = reward
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try self.reward.encode(into: &container, typeKey: .type, codeKey: .code, amountKey: .amount)
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.reward = try AdReward.decode(from: container, typeKey: .type, codeKey: .code, amountKey: .amount)
+    }
 }

--- a/Tests/UnitTests/Ads/RewardVerification/RewardVerificationStatusResponseTests.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/RewardVerificationStatusResponseTests.swift
@@ -34,7 +34,7 @@ final class RewardVerificationStatusResponseTests: TestCase {
     }
 
     func testDecodesFailedStatus() throws {
-        expect(try self.decode(["status": "failed"]).status) == .failed
+        expect(try self.decode(["status": "failed"]).status) == .failed(.init(reason: nil, message: nil))
     }
 
     func testDecodesUnknownStatus() throws {

--- a/Tests/UnitTests/Ads/RewardVerification/RewardVerificationStatusResponseTests.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/RewardVerificationStatusResponseTests.swift
@@ -86,6 +86,30 @@ final class RewardVerificationStatusResponseTests: TestCase {
         )
     }
 
+    func testEntitlementMissingExpiresAtDecodesAsUnsupported() throws {
+        let response = try self.decode([
+            "status": "verified",
+            "reward": ["type": "entitlement", "identifier": "pro"]
+        ])
+        expect(response.status) == .verified(.unsupportedReward)
+        self.logger.verifyMessageWasLogged(
+            Strings.backendError.malformed_reward_verification_reward_payload(type: "entitlement"),
+            level: .warn
+        )
+    }
+
+    func testEntitlementInvalidExpiresAtDecodesAsUnsupported() throws {
+        let response = try self.decode([
+            "status": "verified",
+            "reward": ["type": "entitlement", "identifier": "pro", "expires_at": "not-a-date"]
+        ])
+        expect(response.status) == .verified(.unsupportedReward)
+        self.logger.verifyMessageWasLogged(
+            Strings.backendError.malformed_reward_verification_reward_payload(type: "entitlement"),
+            level: .warn
+        )
+    }
+
     func testUnknownRewardTypeDecodesAsUnsupported() throws {
         let response = try self.decode([
             "status": "verified",

--- a/Tests/UnitTests/Ads/RewardVerification/RewardVerificationStatusResponseTests.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/RewardVerificationStatusResponseTests.swift
@@ -1,0 +1,100 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  RewardVerificationStatusResponseTests.swift
+//
+
+import Foundation
+import Nimble
+import XCTest
+
+@_spi(Internal) @_spi(Experimental) @testable import RevenueCat
+
+/// Decoding tests for the reward-verification poll response wire shape.
+final class RewardVerificationStatusResponseTests: TestCase {
+
+    private static let expiresAtString = "2026-06-16T12:00:00Z"
+    private static let expiresAt = ISO8601DateFormatter().date(from: expiresAtString)!
+
+    private func decode(_ json: [String: Any]) throws -> RewardVerificationStatusResponse {
+        let data = try JSONSerialization.data(withJSONObject: json)
+        return try RewardVerificationStatusResponse.create(with: data)
+    }
+
+    // MARK: - Status
+
+    func testDecodesPendingStatus() throws {
+        expect(try self.decode(["status": "pending"]).status) == .pending
+    }
+
+    func testDecodesFailedStatus() throws {
+        expect(try self.decode(["status": "failed"]).status) == .failed
+    }
+
+    func testDecodesUnknownStatus() throws {
+        expect(try self.decode(["status": "some_future_state"]).status) == .unknown
+    }
+
+    // MARK: - Reward
+
+    func testDecodesVirtualCurrencyReward() throws {
+        let response = try self.decode([
+            "status": "verified",
+            "reward": ["type": "virtual_currency", "code": "coins", "amount": 10]
+        ])
+
+        guard case let .verified(reward) = response.status else {
+            return fail("Expected verified, got \(response.status)")
+        }
+        expect(reward.virtualCurrency) == VirtualCurrencyReward(code: "coins", amount: 10)
+    }
+
+    func testDecodesEntitlementReward() throws {
+        let response = try self.decode([
+            "status": "verified",
+            "reward": ["type": "entitlement", "identifier": "pro", "expires_at": Self.expiresAtString]
+        ])
+
+        guard case let .verified(reward) = response.status else {
+            return fail("Expected verified, got \(response.status)")
+        }
+        let entitlement = try XCTUnwrap(reward.entitlement)
+        expect(entitlement.identifier) == "pro"
+        expect(entitlement.expiresAt) == Self.expiresAt
+    }
+
+    func testVerifiedWithoutRewardDecodesAsNoReward() throws {
+        expect(try self.decode(["status": "verified"]).status) == .verified(.noReward)
+    }
+
+    func testMalformedEntitlementDecodesAsUnsupported() throws {
+        // Entitlement reward missing its `identifier`.
+        let response = try self.decode([
+            "status": "verified",
+            "reward": ["type": "entitlement", "expires_at": Self.expiresAtString]
+        ])
+        expect(response.status) == .verified(.unsupportedReward)
+        self.logger.verifyMessageWasLogged(
+            Strings.backendError.malformed_reward_verification_reward_payload(type: "entitlement"),
+            level: .warn
+        )
+    }
+
+    func testUnknownRewardTypeDecodesAsUnsupported() throws {
+        let response = try self.decode([
+            "status": "verified",
+            "reward": ["type": "some_future_reward"]
+        ])
+        expect(response.status) == .verified(.unsupportedReward)
+        self.logger.verifyMessageWasLogged(
+            Strings.backendError.unsupported_reward_verification_reward_type(type: "some_future_reward"),
+            level: .warn
+        )
+    }
+}

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesRewardVerificationTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesRewardVerificationTests.swift
@@ -223,13 +223,13 @@ extension PurchasesRewardVerificationTests {
         expect(self.backend.getCustomerInfoCallCount) == before + 1
         // The completion log reflects the delivered result, never "verified".
         self.logger.verifyMessageWasLogged(
-            AdsStrings.reward_verification_completed(
-                outcome: "failed(entitlementRefreshFailed)", transactionID: "tx-1"
-            ),
+            AdsStrings.reward_verification_completed(result: .failed, transactionID: "tx-1"),
             level: .info
         )
         self.logger.verifyMessageWasNotLogged(
-            AdsStrings.reward_verification_completed(outcome: "verified", transactionID: "tx-1")
+            AdsStrings.reward_verification_completed(
+                result: .verified(.entitlement(reward)), transactionID: "tx-1"
+            )
         )
     }
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesRewardVerificationTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesRewardVerificationTests.swift
@@ -197,6 +197,28 @@ extension PurchasesRewardVerificationTests {
         expect(self.mockVirtualCurrencyManager.invalidateVirtualCurrenciesCacheCallCount) == 0
     }
 
+    func testPollRewardVerificationInvalidatesCustomerInfoCacheOnEntitlementReward() async throws {
+        let reward = try XCTUnwrap(EntitlementReward(identifier: "pro", expiresAt: Date()))
+        let before = self.deviceCache.invokedClearCustomerInfoCacheCount
+        let poller = self.makeStubPoller(statuses: [.verified(.entitlement(reward))])
+
+        let result = await self.purchases.pollRewardVerification(clientTransactionID: "tx-1", poller: poller)
+
+        expect(result.verifiedReward) == .entitlement(reward)
+        expect(self.deviceCache.invokedClearCustomerInfoCacheCount) == before + 1
+        expect(self.mockVirtualCurrencyManager.invalidateVirtualCurrenciesCacheCallCount) == 0
+    }
+
+    func testPollRewardVerificationDoesNotInvalidateCustomerInfoCacheOnVirtualCurrencyReward() async throws {
+        let reward = try XCTUnwrap(VirtualCurrencyReward(code: "coins", amount: 4))
+        let before = self.deviceCache.invokedClearCustomerInfoCacheCount
+        let poller = self.makeStubPoller(statuses: [.verified(.virtualCurrency(reward))])
+
+        _ = await self.purchases.pollRewardVerification(clientTransactionID: "tx-1", poller: poller)
+
+        expect(self.deviceCache.invokedClearCustomerInfoCacheCount) == before
+    }
+
 }
 
 // MARK: - generateRewardVerificationToken

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesRewardVerificationTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesRewardVerificationTests.swift
@@ -197,26 +197,58 @@ extension PurchasesRewardVerificationTests {
         expect(self.mockVirtualCurrencyManager.invalidateVirtualCurrenciesCacheCallCount) == 0
     }
 
-    func testPollRewardVerificationInvalidatesCustomerInfoCacheOnEntitlementReward() async throws {
+    func testPollRewardVerificationFetchesCustomerInfoOnEntitlementReward() async throws {
         let reward = try XCTUnwrap(EntitlementReward(identifier: "pro", expiresAt: Date()))
-        let before = self.deviceCache.invokedClearCustomerInfoCacheCount
+        let before = self.backend.getCustomerInfoCallCount
         let poller = self.makeStubPoller(statuses: [.verified(.entitlement(reward))])
 
         let result = await self.purchases.pollRewardVerification(clientTransactionID: "tx-1", poller: poller)
 
         expect(result.verifiedReward) == .entitlement(reward)
-        expect(self.deviceCache.invokedClearCustomerInfoCacheCount) == before + 1
+        expect(self.backend.getCustomerInfoCallCount) > before
         expect(self.mockVirtualCurrencyManager.invalidateVirtualCurrenciesCacheCallCount) == 0
     }
 
-    func testPollRewardVerificationDoesNotInvalidateCustomerInfoCacheOnVirtualCurrencyReward() async throws {
+    func testPollRewardVerificationFailsWhenEntitlementCustomerInfoRefreshFails() async throws {
+        let reward = try XCTUnwrap(EntitlementReward(identifier: "pro", expiresAt: Date()))
+        // Terminal (non-transient) error — should not be retried.
+        self.backend.overrideCustomerInfoResult = .failure(makeTerminalBackendError())
+        let before = self.backend.getCustomerInfoCallCount
+        let poller = self.makeStubPoller(statuses: [.verified(.entitlement(reward))])
+
+        let result = await self.purchases.pollRewardVerification(clientTransactionID: "tx-1", poller: poller)
+
+        expect(result) == .failed
+        expect(result.verifiedReward).to(beNil())
+        expect(self.backend.getCustomerInfoCallCount) == before + 1
+        // The completion log reflects the delivered result, never "verified".
+        self.logger.verifyMessageWasLogged(
+            AdsStrings.reward_verification_completed(
+                outcome: "failed(entitlementRefreshFailed)", transactionID: "tx-1"
+            ),
+            level: .info
+        )
+        self.logger.verifyMessageWasNotLogged(
+            AdsStrings.reward_verification_completed(outcome: "verified", transactionID: "tx-1")
+        )
+    }
+
+    func testTransientServerErrorsAreRetriableForEntitlementRefresh() {
+        // Typical transient infra errors (502, 503) must be retried, not treated as terminal.
+        for statusCode in [502, 503] {
+            let error = makePollingError(statusCode: statusCode, backendCode: .internalServerError)
+            expect(error.isTransient).to(beTrue(), description: "status \(statusCode) should be transient")
+        }
+    }
+
+    func testPollRewardVerificationDoesNotFetchCustomerInfoOnVirtualCurrencyReward() async throws {
         let reward = try XCTUnwrap(VirtualCurrencyReward(code: "coins", amount: 4))
-        let before = self.deviceCache.invokedClearCustomerInfoCacheCount
+        let before = self.backend.getCustomerInfoCallCount
         let poller = self.makeStubPoller(statuses: [.verified(.virtualCurrency(reward))])
 
         _ = await self.purchases.pollRewardVerification(clientTransactionID: "tx-1", poller: poller)
 
-        expect(self.deviceCache.invokedClearCustomerInfoCacheCount) == before
+        expect(self.backend.getCustomerInfoCallCount) == before
     }
 
 }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-android`.

### Motivation
Rewarded ads can now grant a temporary entitlement, not just a virtual currency. This teaches the SDK's reward-verification poll to recognize the new `entitlement` reward variant and surface the grant.

### Description
Adds an `EntitlementReward` payload and an `entitlement` case + accessor on `AdReward`, decodes the `entitlement` variant from the verified poll response, and invalidates the `CustomerInfo` cache on a verified entitlement reward so the ad-granted entitlement is picked up on the next `CustomerInfo` access.

This additively expands our `@_spi(Experimental)` beta API: the new `EntitlementReward` type and `AdReward.entitlement` accessor. The change is source-compatible — `AdReward` is a struct (not an enum), so new reward variants don't break existing call sites.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes entitlement-related post-verification behavior (`CustomerInfo` fetch and surfacing `.failed` when refresh fails), which affects how apps react to ad-granted entitlements even though the SPI remains experimental.
> 
> **Overview**
> Adds support for **temporary entitlement grants** from rewarded-ad verification, alongside existing virtual-currency rewards.
> 
> Introduces `EntitlementReward` (`identifier`, `expiresAt`) and extends `AdReward` with an `entitlement` case and accessor. The reward-verification poll response decoder now handles `type: "entitlement"` with `identifier` and `expires_at`.
> 
> After a verified entitlement reward, `pollRewardVerification` fetches current `CustomerInfo` (with retries on transient backend errors) so the grant is visible locally; if that refresh fails, the API returns **`.failed`** even though the server grant still stands. Virtual-currency rewards still only invalidate the virtual currencies cache.
> 
> Completion logging now takes the final `RewardVerificationResult` (so downgraded failures log as failed). Tests and Swift API testers cover decoding, `AdReward` behavior, and entitlement refresh paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f977ed82ea847d40da52478d29a71dc4a73ec70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->