### PR TITLE
Support multi-grant reward + moreRewards in reward verification

### DIFF
--- a/Sources/Ads/RewardVerification/AdReward.swift
+++ b/Sources/Ads/RewardVerification/AdReward.swift
@@ -15,7 +15,7 @@ import Foundation
 
 /// Reward payload describing the outcome of a verified rewarded ad.
 ///
-/// Inspect the received reward by checking ``virtualCurrency`` / ``entitlement`` or comparing against
+/// Inspect the reward by checking ``virtualCurrency`` / ``entitlement`` or comparing against
 /// ``noReward`` / ``unsupportedReward``:
 ///
 /// ```swift
@@ -49,7 +49,6 @@ import Foundation
         AdReward(storage: .virtualCurrency(payload))
     }
 
-    /// Reward is a temporary entitlement grant with an identifier and expiration.
     internal static func entitlement(_ payload: EntitlementReward) -> AdReward {
         AdReward(storage: .entitlement(payload))
     }
@@ -66,7 +65,7 @@ import Foundation
         return payload
     }
 
-    /// Non-`nil` when this reward represents an ``EntitlementReward``.
+    /// Entitlement reward payload, if present.
     public var entitlement: EntitlementReward? {
         guard case .entitlement(let payload) = self.storage else { return nil }
         return payload

--- a/Sources/Ads/RewardVerification/EntitlementReward.swift
+++ b/Sources/Ads/RewardVerification/EntitlementReward.swift
@@ -12,22 +12,15 @@
 
 import Foundation
 
-/// An entitlement reward granted by an ad network after a successful reward verification.
-///
-/// The entitlement is surfaced through the standard entitlements API; this payload describes the
-/// grant that was verified for the rewarded ad.
+/// Entitlement reward granted after successful reward verification.
 @_spi(Experimental) public struct EntitlementReward: Sendable, Equatable {
 
-    /// The granted entitlement identifier (the key in the `CustomerInfo` entitlements map).
+    /// Entitlement identifier.
     public let identifier: String
 
-    /// The moment the granted entitlement expires.
+    /// Grant expiration.
     public let expiresAt: Date
 
-    /// Creates an entitlement reward.
-    ///
-    /// Returns `nil` if `identifier` is empty. This is the single source of truth for "what counts as a
-    /// valid entitlement reward" across the SDK.
     internal init?(identifier: String, expiresAt: Date) {
         guard !identifier.isEmpty else { return nil }
         self.identifier = identifier

--- a/Sources/Ads/RewardVerification/Networking/RewardVerificationStatusResponse.swift
+++ b/Sources/Ads/RewardVerification/Networking/RewardVerificationStatusResponse.swift
@@ -19,7 +19,9 @@ struct RewardVerificationStatusResponse: Equatable {
 
     enum Status: Equatable {
 
-        case verified(AdReward)
+        /// Verified by the backend, with the primary `reward` plus any `moreRewards` (additional
+        /// rewards only — `moreRewards` does not repeat `reward`).
+        case verified(reward: AdReward, moreRewards: [AdReward])
         case pending
         case failed(Failure)
         case unknown
@@ -48,6 +50,7 @@ extension RewardVerificationStatusResponse: Decodable {
         case reward
         case failureReason
         case message
+        case moreRewards
     }
 
     private enum RewardCodingKeys: String, CodingKey {
@@ -75,7 +78,10 @@ extension RewardVerificationStatusResponse: Decodable {
     ) -> Status {
         switch rawStatus {
         case "verified":
-            return .verified(Self.decodeVerifiedReward(from: container))
+            return .verified(
+                reward: Self.decodePrimaryReward(from: container),
+                moreRewards: Self.decodeMoreRewards(from: container)
+            )
         case "pending":
             return .pending
         case "failed":
@@ -94,7 +100,7 @@ extension RewardVerificationStatusResponse: Decodable {
         return Failure(reason: reason, message: message)
     }
 
-    private static func decodeVerifiedReward(
+    private static func decodePrimaryReward(
         from container: KeyedDecodingContainer<CodingKeys>
     ) -> AdReward {
         guard container.contains(.reward),
@@ -102,44 +108,78 @@ extension RewardVerificationStatusResponse: Decodable {
             return .noReward
         }
 
-        guard let rewardContainer = try? container.nestedContainer(
-            keyedBy: RewardCodingKeys.self,
-            forKey: .reward
-        ) else {
+        guard let wire = try? container.decode(WireReward.self, forKey: .reward) else {
             Logger.warn(Strings.backendError.unexpected_reward_verification_reward_value)
             return .unsupportedReward
         }
+        return wire.reward
+    }
 
-        let rewardType = (try? rewardContainer.decode(String.self, forKey: .type)) ?? ""
+    private static func decodeMoreRewards(
+        from container: KeyedDecodingContainer<CodingKeys>
+    ) -> [AdReward] {
+        guard container.contains(.moreRewards),
+              (try? container.decodeNil(forKey: .moreRewards)) != true else {
+            return []
+        }
 
-        switch rewardType {
-        case RewardType.virtualCurrency:
-            let code = try? rewardContainer.decode(String.self, forKey: .code)
-            let amount = try? rewardContainer.decode(Int.self, forKey: .amount)
-            guard let code, let amount,
-                  let payload = VirtualCurrencyReward(code: code, amount: amount) else {
+        guard let wire = try? container.decode([WireReward].self, forKey: .moreRewards) else {
+            Logger.warn(Strings.backendError.unexpected_reward_verification_reward_value)
+            return []
+        }
+        return wire.map(\.reward)
+    }
+
+    /// Decodes a single reward object (`{ "type", ... }`) into an ``AdReward``, never throwing:
+    /// malformed or unknown shapes log a warning and fall back to ``AdReward/unsupportedReward`` so a
+    /// single bad entry can't drop the rest of the list.
+    private struct WireReward: Decodable {
+
+        let reward: AdReward
+
+        init(from decoder: Decoder) throws {
+            guard let container = try? decoder.container(keyedBy: RewardCodingKeys.self) else {
+                Logger.warn(Strings.backendError.unexpected_reward_verification_reward_value)
+                self.reward = .unsupportedReward
+                return
+            }
+            self.reward = Self.decodeReward(from: container)
+        }
+
+        private static func decodeReward(
+            from container: KeyedDecodingContainer<RewardCodingKeys>
+        ) -> AdReward {
+            let rewardType = (try? container.decode(String.self, forKey: .type)) ?? ""
+
+            switch rewardType {
+            case RewardType.virtualCurrency:
+                let code = try? container.decode(String.self, forKey: .code)
+                let amount = try? container.decode(Int.self, forKey: .amount)
+                guard let code, let amount,
+                      let payload = VirtualCurrencyReward(code: code, amount: amount) else {
+                    Logger.warn(
+                        Strings.backendError.malformed_reward_verification_reward_payload(type: rewardType)
+                    )
+                    return .unsupportedReward
+                }
+                return .virtualCurrency(payload)
+            case RewardType.entitlement:
+                let identifier = try? container.decode(String.self, forKey: .identifier)
+                let expiresAt = try? container.decode(Date.self, forKey: .expiresAt)
+                guard let identifier, let expiresAt,
+                      let payload = EntitlementReward(identifier: identifier, expiresAt: expiresAt) else {
+                    Logger.warn(
+                        Strings.backendError.malformed_reward_verification_reward_payload(type: rewardType)
+                    )
+                    return .unsupportedReward
+                }
+                return .entitlement(payload)
+            default:
                 Logger.warn(
-                    Strings.backendError.malformed_reward_verification_reward_payload(type: rewardType)
+                    Strings.backendError.unsupported_reward_verification_reward_type(type: rewardType)
                 )
                 return .unsupportedReward
             }
-            return .virtualCurrency(payload)
-        case RewardType.entitlement:
-            let identifier = try? rewardContainer.decode(String.self, forKey: .identifier)
-            let expiresAt = try? rewardContainer.decode(Date.self, forKey: .expiresAt)
-            guard let identifier, let expiresAt,
-                  let payload = EntitlementReward(identifier: identifier, expiresAt: expiresAt) else {
-                Logger.warn(
-                    Strings.backendError.malformed_reward_verification_reward_payload(type: rewardType)
-                )
-                return .unsupportedReward
-            }
-            return .entitlement(payload)
-        default:
-            Logger.warn(
-                Strings.backendError.unsupported_reward_verification_reward_type(type: rewardType)
-            )
-            return .unsupportedReward
         }
     }
 }

--- a/Sources/Ads/RewardVerification/Networking/RewardVerificationStatusResponse.swift
+++ b/Sources/Ads/RewardVerification/Networking/RewardVerificationStatusResponse.swift
@@ -19,8 +19,7 @@ struct RewardVerificationStatusResponse: Equatable {
 
     enum Status: Equatable {
 
-        /// Verified by the backend, with the primary `reward` plus any `moreRewards` (additional
-        /// rewards only — `moreRewards` does not repeat `reward`).
+        /// `moreRewards` contains additional rewards only; it does not repeat `reward`.
         case verified(reward: AdReward, moreRewards: [AdReward])
         case pending
         case failed(Failure)
@@ -130,9 +129,7 @@ extension RewardVerificationStatusResponse: Decodable {
         return wire.map(\.reward)
     }
 
-    /// Decodes a single reward object (`{ "type", ... }`) into an ``AdReward``, never throwing:
-    /// malformed or unknown shapes log a warning and fall back to ``AdReward/unsupportedReward`` so a
-    /// single bad entry can't drop the rest of the list.
+    /// Decodes malformed or unknown reward objects as ``AdReward/unsupportedReward``.
     private struct WireReward: Decodable {
 
         let reward: AdReward

--- a/Sources/Ads/RewardVerification/Networking/RewardVerificationStatusResponse.swift
+++ b/Sources/Ads/RewardVerification/Networking/RewardVerificationStatusResponse.swift
@@ -77,6 +77,8 @@ extension RewardVerificationStatusResponse: Decodable {
     ) -> Status {
         switch rawStatus {
         case "verified":
+            // The backend never sends a null `reward` alongside a non-empty `more_rewards`: the
+            // primary reward is always the first grant, so no promotion/normalization is needed.
             return .verified(
                 reward: Self.decodePrimaryReward(from: container),
                 moreRewards: Self.decodeMoreRewards(from: container)
@@ -107,11 +109,9 @@ extension RewardVerificationStatusResponse: Decodable {
             return .noReward
         }
 
-        guard let wire = try? container.decode(WireReward.self, forKey: .reward) else {
-            Logger.warn(Strings.backendError.unexpected_reward_verification_reward_value)
-            return .unsupportedReward
-        }
-        return wire.reward
+        // `WireReward.init` never throws — it falls back to `.unsupportedReward` internally.
+        let wire = try? container.decode(WireReward.self, forKey: .reward)
+        return wire?.reward ?? .unsupportedReward
     }
 
     private static func decodeMoreRewards(

--- a/Sources/Ads/RewardVerification/Outcome.swift
+++ b/Sources/Ads/RewardVerification/Outcome.swift
@@ -16,7 +16,7 @@ internal extension RewardVerification {
 
     /// Terminal SSV verdict from the polling loop.
     enum Outcome: Sendable {
-        case verified(AdReward)
+        case verified(reward: AdReward, moreRewards: [AdReward])
         case failed(FailureReason)
 
         var logDescription: String {

--- a/Sources/Ads/RewardVerification/Poller.swift
+++ b/Sources/Ads/RewardVerification/Poller.swift
@@ -132,8 +132,8 @@ internal extension RewardVerification {
                     transactionID: clientTransactionID
                 ))
                 switch status {
-                case .verified(let reward):
-                    return .finished(.verified(reward))
+                case let .verified(reward, moreRewards):
+                    return .finished(.verified(reward: reward, moreRewards: moreRewards))
                 case let .failed(reason, message):
                     Logger.warn(AdsStrings.poll_backend_rejected(
                         reason: reason,

--- a/Sources/Ads/RewardVerification/RewardVerificationPollStatus.swift
+++ b/Sources/Ads/RewardVerification/RewardVerificationPollStatus.swift
@@ -16,8 +16,9 @@ import Foundation
 /// Result of a single ad reward verification status poll.
 enum RewardVerificationPollStatus: Sendable, Equatable {
 
-    /// Verified by the backend, with the granted reward payload.
-    case verified(AdReward)
+    /// Verified by the backend, with the primary `reward` plus any `moreRewards` (additional rewards
+    /// only — `moreRewards` does not repeat `reward`).
+    case verified(reward: AdReward, moreRewards: [AdReward])
 
     /// Verification has not yet completed; the caller should keep polling.
     case pending

--- a/Sources/Ads/RewardVerification/RewardVerificationPollStatus.swift
+++ b/Sources/Ads/RewardVerification/RewardVerificationPollStatus.swift
@@ -16,8 +16,7 @@ import Foundation
 /// Result of a single ad reward verification status poll.
 enum RewardVerificationPollStatus: Sendable, Equatable {
 
-    /// Verified by the backend, with the primary `reward` plus any `moreRewards` (additional rewards
-    /// only — `moreRewards` does not repeat `reward`).
+    /// `moreRewards` contains additional rewards only; it does not repeat `reward`.
     case verified(reward: AdReward, moreRewards: [AdReward])
 
     /// Verification has not yet completed; the caller should keep polling.

--- a/Sources/Ads/RewardVerification/RewardVerificationResult.swift
+++ b/Sources/Ads/RewardVerification/RewardVerificationResult.swift
@@ -16,7 +16,7 @@ import Foundation
 @_spi(Experimental) public struct RewardVerificationResult: Sendable, Equatable {
 
     private enum Storage: Equatable, Sendable {
-        case verified(AdReward)
+        case verified(reward: AdReward, moreRewards: [AdReward])
         case failed
     }
 
@@ -27,17 +27,30 @@ import Foundation
     }
 
     /// Server verification succeeded for this ad's transaction.
-    @_spi(Internal) public static func verified(_ reward: AdReward) -> RewardVerificationResult {
-        RewardVerificationResult(storage: .verified(reward))
+    ///
+    /// `moreRewards` carries any *additional* rewards granted alongside the primary `reward`; it does
+    /// not repeat `reward` and is empty in the common single-reward case.
+    @_spi(Internal) public static func verified(
+        _ reward: AdReward,
+        moreRewards: [AdReward] = []
+    ) -> RewardVerificationResult {
+        RewardVerificationResult(storage: .verified(reward: reward, moreRewards: moreRewards))
     }
 
     /// Verification did not complete successfully (rejected, exhausted polling, error, etc.).
     public static let failed = RewardVerificationResult(storage: .failed)
 
-    /// Non-`nil` when verification succeeded.
+    /// Non-`nil` when verification succeeded. The primary reward granted for this ad.
     public var verifiedReward: AdReward? {
-        guard case .verified(let reward) = self.storage else { return nil }
+        guard case .verified(let reward, _) = self.storage else { return nil }
         return reward
+    }
+
+    /// Additional rewards granted alongside ``verifiedReward``. Does not repeat ``verifiedReward``;
+    /// empty when verification failed or only a single reward was granted.
+    public var moreRewards: [AdReward] {
+        guard case .verified(_, let moreRewards) = self.storage else { return [] }
+        return moreRewards
     }
 
     /// `true` when verification did not complete successfully.

--- a/Sources/Ads/RewardVerification/RewardVerificationResult.swift
+++ b/Sources/Ads/RewardVerification/RewardVerificationResult.swift
@@ -28,8 +28,7 @@ import Foundation
 
     /// Server verification succeeded for this ad's transaction.
     ///
-    /// `moreRewards` carries any *additional* rewards granted alongside the primary `reward`; it does
-    /// not repeat `reward` and is empty in the common single-reward case.
+    /// `moreRewards` contains additional rewards only; it does not repeat `reward`.
     @_spi(Internal) public static func verified(
         _ reward: AdReward,
         moreRewards: [AdReward] = []
@@ -40,20 +39,19 @@ import Foundation
     /// Verification did not complete successfully (rejected, exhausted polling, error, etc.).
     public static let failed = RewardVerificationResult(storage: .failed)
 
-    /// Non-`nil` when verification succeeded. The primary reward granted for this ad.
+    /// Primary verified reward, if verification succeeded.
     public var verifiedReward: AdReward? {
         guard case .verified(let reward, _) = self.storage else { return nil }
         return reward
     }
 
-    /// Additional rewards granted alongside ``verifiedReward``. Does not repeat ``verifiedReward``;
-    /// empty when verification failed or only a single reward was granted.
+    /// Additional verified rewards. Empty when verification failed or only one reward was granted.
     public var moreRewards: [AdReward] {
         guard case .verified(_, let moreRewards) = self.storage else { return [] }
         return moreRewards
     }
 
-    /// `true` when verification did not complete successfully.
+    /// Whether verification failed.
     var failed: Bool {
         guard case .failed = self.storage else { return false }
         return true

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1690,9 +1690,7 @@ extension Purchases {
     ///
     /// Call when your ad network's reward callback fires, passing the `clientTransactionID` returned by
     /// ``generateRewardVerificationToken(impressionId:)``.
-    /// On a verified reward, automatically invalidates the relevant cache so the grant is reflected on the
-    /// next access: the virtual currencies cache for a virtual-currency reward, and the `CustomerInfo`
-    /// cache for an entitlement reward.
+    /// Refreshes local reward state before returning verified rewards.
     @_spi(Experimental) public func pollRewardVerification(
         clientTransactionID: String
     ) async -> RewardVerificationResult {
@@ -1715,8 +1713,7 @@ extension Purchases {
         return result
     }
 
-    /// Applies a verified reward's side-effects and returns the result delivered to the caller. A failed
-    /// entitlement `CustomerInfo` refresh downgrades the result to `.failed`.
+    /// Applies local side effects before building the result delivered to the caller.
     private func rewardVerificationResult(
         for outcome: RewardVerification.Outcome,
         clientTransactionID: String
@@ -1733,8 +1730,7 @@ extension Purchases {
             if rewards.contains(where: { $0.entitlement != nil }),
                await self.refreshCustomerInfoAfterEntitlementGrant(clientTransactionID: clientTransactionID)
                 == false {
-                // Couldn't reflect the entitlement(s) locally — report `.failed` so the app doesn't act on
-                // a reward it can't honor yet. The grant persists server-side and syncs on a later fetch.
+                // Do not surface entitlement rewards that could not be reflected locally yet.
                 return .failed
             }
         }
@@ -1748,9 +1744,7 @@ extension Purchases {
     }
 
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-    /// Fetches current `CustomerInfo` so an entitlement reward is reflected locally,
-    /// retrying transient failures since `getCustomerInfo` has no built-in retry. Returns whether it
-    /// succeeded.
+    /// Refreshes `CustomerInfo` after entitlement grants, retrying transient failures.
     private func refreshCustomerInfoAfterEntitlementGrant(clientTransactionID: String) async -> Bool {
         Logger.debug(AdsStrings.reward_verification_entitlement_fetching_customer_info(
             transactionID: clientTransactionID
@@ -1763,7 +1757,6 @@ extension Purchases {
                 )
                 return (shouldRetry: false, info)
             } catch {
-                // Retry only transient failures; a terminal error won't improve on retry.
                 let isTransient = (error as? BackendError)?.isTransient ?? false
                 return (shouldRetry: isTransient, nil)
             }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1722,25 +1722,28 @@ extension Purchases {
         clientTransactionID: String
     ) async -> RewardVerificationResult {
         #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-        if case .verified(let reward) = outcome {
-            if reward.virtualCurrency != nil {
+        if case let .verified(reward, moreRewards) = outcome {
+            let rewards = [reward] + moreRewards
+            if rewards.contains(where: { $0.virtualCurrency != nil }) {
                 Logger.debug(AdsStrings.reward_verification_virtual_currency_invalidating_cache(
                     transactionID: clientTransactionID
                 ))
                 self.invalidateVirtualCurrenciesCache()
             }
-            if reward.entitlement != nil,
+            if rewards.contains(where: { $0.entitlement != nil }),
                await self.refreshCustomerInfoAfterEntitlementGrant(clientTransactionID: clientTransactionID)
                 == false {
-                // Couldn't reflect the entitlement locally — report `.failed` so the app doesn't act on a
-                // reward it can't honor yet. The grant persists server-side and syncs on a later fetch.
+                // Couldn't reflect the entitlement(s) locally — report `.failed` so the app doesn't act on
+                // a reward it can't honor yet. The grant persists server-side and syncs on a later fetch.
                 return .failed
             }
         }
         #endif
         switch outcome {
-        case .verified(let reward): return .verified(reward)
-        case .failed: return .failed
+        case let .verified(reward, moreRewards):
+            return .verified(reward, moreRewards: moreRewards)
+        case .failed:
+            return .failed
         }
     }
 
@@ -1798,8 +1801,8 @@ extension Purchases {
         }
 
         switch response.status {
-        case let .verified(reward):
-            return .verified(reward)
+        case let .verified(reward, moreRewards):
+            return .verified(reward: reward, moreRewards: moreRewards)
         case .pending:
             return .pending
         case let .failed(failure):

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/AdRewardAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/AdRewardAPI.swift
@@ -9,6 +9,7 @@ import Foundation
 var adReward: AdReward!
 var virtualCurrencyReward: VirtualCurrencyReward!
 var entitlementReward: EntitlementReward!
+var rewardVerificationResult: RewardVerificationResult!
 
 func checkAdRewardAPI() {
     let _: VirtualCurrencyReward? = adReward.virtualCurrency
@@ -26,4 +27,10 @@ func checkVirtualCurrencyRewardAPI() {
 func checkEntitlementRewardAPI() {
     let _: String = entitlementReward.identifier
     let _: Date = entitlementReward.expiresAt
+}
+
+func checkRewardVerificationResultAPI() {
+    let _: AdReward? = rewardVerificationResult.verifiedReward
+    let _: [AdReward] = rewardVerificationResult.moreRewards
+    let _: RewardVerificationResult = .failed
 }

--- a/Tests/UnitTests/Ads/RewardVerification/AdReward+TestExtensions.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/AdReward+TestExtensions.swift
@@ -26,8 +26,6 @@ extension AdReward {
         return .virtualCurrency(payload)
     }
 
-    /// Test-only convenience that builds an entitlement reward from an identifier and expiration.
-    /// Falls back to ``unsupportedReward`` when the inputs are rejected.
     static func entitlement(identifier: String, expiresAt: Date) -> AdReward {
         guard let payload = EntitlementReward(identifier: identifier, expiresAt: expiresAt) else {
             return .unsupportedReward

--- a/Tests/UnitTests/Ads/RewardVerification/AdRewardTests.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/AdRewardTests.swift
@@ -84,9 +84,6 @@ final class AdRewardTests: TestCase {
 
     // MARK: - Flat (analytics events) encoding
 
-    /// The analytics-events flat encoding only models a currency `code`/`amount`. Entitlement analytics
-    /// is a deferred non-goal, so an entitlement reward flat-encodes its `type` only and round-trips back
-    /// to ``AdReward/unsupportedReward`` (it cannot be reconstructed without identifier/expiry keys).
     func testEntitlementFlatEncodingEmitsTypeOnlyAndDecodesAsUnsupported() throws {
         let reward = AdReward.entitlement(identifier: "pro", expiresAt: Date())
 
@@ -102,7 +99,6 @@ final class AdRewardTests: TestCase {
 
 }
 
-/// Exercises ``AdReward``'s flat `encode`/`decode` helpers (the analytics-events wire shape).
 private struct FlatRewardWrapper: Codable, Equatable {
 
     enum CodingKeys: String, CodingKey {

--- a/Tests/UnitTests/Ads/RewardVerification/RewardVerificationOutcomeTests.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/RewardVerificationOutcomeTests.swift
@@ -20,18 +20,19 @@ final class RewardVerificationOutcomeTests: TestCase {
         let reward = try XCTUnwrap(VirtualCurrencyReward(code: "coins", amount: 5))
         let outcome = RewardVerification.Outcome.verified(.virtualCurrency(reward))
 
-        guard case .verified(let adReward) = outcome, let captured = adReward.virtualCurrency else {
+        guard case let .verified(adReward, moreRewards) = outcome, let captured = adReward.virtualCurrency else {
             return XCTFail("Expected .verified(.virtualCurrency), got \(outcome)")
         }
         XCTAssertEqual(captured, reward)
         XCTAssertEqual(captured.code, "coins")
         XCTAssertEqual(captured.amount, 5)
+        XCTAssertTrue(moreRewards.isEmpty)
     }
 
     func testVerifiedCarriesNoRewardPayload() {
         let outcome = RewardVerification.Outcome.verified(.noReward)
 
-        guard case .verified(.noReward) = outcome else {
+        guard case .verified(.noReward, _) = outcome else {
             return XCTFail("Expected .verified(.noReward), got \(outcome)")
         }
     }
@@ -39,7 +40,7 @@ final class RewardVerificationOutcomeTests: TestCase {
     func testVerifiedCarriesUnsupportedRewardPayload() {
         let outcome = RewardVerification.Outcome.verified(.unsupportedReward)
 
-        guard case .verified(.unsupportedReward) = outcome else {
+        guard case .verified(.unsupportedReward, _) = outcome else {
             return XCTFail("Expected .verified(.unsupportedReward), got \(outcome)")
         }
     }
@@ -56,5 +57,21 @@ final class RewardVerificationOutcomeTests: TestCase {
         guard case .failed(.terminalError("boom")) = terminal else {
             return XCTFail("Expected .failed(.terminalError(\"boom\")), got \(terminal)")
         }
+    }
+
+    func testVerifiedCarriesPrimaryRewardAndMoreRewards() throws {
+        let primary = try XCTUnwrap(VirtualCurrencyReward(code: "coins", amount: 5))
+        let entitlement = try XCTUnwrap(EntitlementReward(identifier: "pro", expiresAt: Date()))
+        let outcome = RewardVerification.Outcome.verified(
+            reward: .virtualCurrency(primary),
+            moreRewards: [.entitlement(entitlement)]
+        )
+
+        guard case let .verified(adReward, moreRewards) = outcome else {
+            return XCTFail("Expected .verified, got \(outcome)")
+        }
+        XCTAssertEqual(adReward.virtualCurrency, primary)
+        XCTAssertEqual(moreRewards.count, 1)
+        XCTAssertEqual(moreRewards.first?.entitlement, entitlement)
     }
 }

--- a/Tests/UnitTests/Ads/RewardVerification/RewardVerificationPollerTestDoubles.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/RewardVerificationPollerTestDoubles.swift
@@ -12,7 +12,7 @@
 
 import XCTest
 
-@_spi(Internal) @testable import RevenueCat
+@_spi(Internal) @_spi(Experimental) @testable import RevenueCat
 
 final class StubStatusPoller: RewardVerificationStatusPolling, @unchecked Sendable {
 
@@ -193,4 +193,28 @@ func makeConnectivityError() -> BackendError {
 /// A terminal `BackendError` that is not worth retrying (no transient signal).
 func makeTerminalBackendError() -> BackendError {
     .networkError(.signatureVerificationFailed(path: HTTPRequest.Path.health, code: .success))
+}
+
+// MARK: - Single-reward conveniences
+
+// Test-only `verified(_:)` factories mirroring the common single-reward case (no additional rewards),
+// keeping call sites that predate multi-grant terse. They coexist with the
+// `verified(reward:moreRewards:)` enum cases because the argument labels differ.
+
+extension RewardVerificationPollStatus {
+    static func verified(_ reward: AdReward) -> Self {
+        .verified(reward: reward, moreRewards: [])
+    }
+}
+
+extension RewardVerification.Outcome {
+    static func verified(_ reward: AdReward) -> Self {
+        .verified(reward: reward, moreRewards: [])
+    }
+}
+
+extension RewardVerificationStatusResponse.Status {
+    static func verified(_ reward: AdReward) -> Self {
+        .verified(reward: reward, moreRewards: [])
+    }
 }

--- a/Tests/UnitTests/Ads/RewardVerification/RewardVerificationPollerTestDoubles.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/RewardVerificationPollerTestDoubles.swift
@@ -197,10 +197,6 @@ func makeTerminalBackendError() -> BackendError {
 
 // MARK: - Single-reward conveniences
 
-// Test-only `verified(_:)` factories mirroring the common single-reward case (no additional rewards),
-// keeping call sites that predate multi-grant terse. They coexist with the
-// `verified(reward:moreRewards:)` enum cases because the argument labels differ.
-
 extension RewardVerificationPollStatus {
     static func verified(_ reward: AdReward) -> Self {
         .verified(reward: reward, moreRewards: [])

--- a/Tests/UnitTests/Ads/RewardVerification/RewardVerificationPollerTests.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/RewardVerificationPollerTests.swift
@@ -28,7 +28,7 @@ final class RewardVerificationPollerTests: TestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .verified(let adReward) = outcome, let earnedReward = adReward.virtualCurrency else {
+        guard case let .verified(adReward, _) = outcome, let earnedReward = adReward.virtualCurrency else {
             return XCTFail("Expected .verified(.virtualCurrency), got \(outcome)")
         }
         XCTAssertEqual(earnedReward, reward)
@@ -90,7 +90,7 @@ final class RewardVerificationPollerTests: TestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .verified(.noReward) = outcome else {
+        guard case .verified(.noReward, _) = outcome else {
             return XCTFail("Expected .verified(.noReward), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.receivedIDs, ["tx-1", "tx-1", "tx-1"])
@@ -120,7 +120,7 @@ final class RewardVerificationPollerTests: TestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .verified(.noReward) = outcome else {
+        guard case .verified(.noReward, _) = outcome else {
             return XCTFail("Expected .verified(.noReward), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.receivedIDs.count, 10)
@@ -150,7 +150,7 @@ final class RewardVerificationPollerTests: TestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .verified(.noReward) = outcome else {
+        guard case .verified(.noReward, _) = outcome else {
             return XCTFail("Expected .verified(.noReward), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.receivedIDs.count, 3)
@@ -198,7 +198,7 @@ final class RewardVerificationPollerTests: TestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .verified(.noReward) = outcome else {
+        guard case .verified(.noReward, _) = outcome else {
             return XCTFail("Expected .verified(.noReward), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.callCount, 2)
@@ -216,7 +216,7 @@ final class RewardVerificationPollerTests: TestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .verified(.noReward) = outcome else {
+        guard case .verified(.noReward, _) = outcome else {
             return XCTFail("Expected .verified(.noReward), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.callCount, 3)
@@ -279,7 +279,7 @@ final class RewardVerificationPollerTests: TestCase {
 
             let outcome = await sut.run(clientTransactionID: "tx-1")
 
-            guard case .verified(.noReward) = outcome else {
+            guard case .verified(.noReward, _) = outcome else {
                 return XCTFail("Expected .verified for transient error \(error), got \(outcome)")
             }
             XCTAssertEqual(statusPoller.callCount, 2, "Transient error \(error) should have been retried once")
@@ -298,7 +298,7 @@ final class RewardVerificationPollerTests: TestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .verified(.noReward) = outcome else {
+        guard case .verified(.noReward, _) = outcome else {
             return XCTFail("Expected .verified(.noReward), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.callCount, 2, "A 5xx should be retried")
@@ -315,7 +315,7 @@ final class RewardVerificationPollerTests: TestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .verified(.noReward) = outcome else {
+        guard case .verified(.noReward, _) = outcome else {
             return XCTFail("Expected .verified(.noReward), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.callCount, 2, "An unparseable 5xx should still be retried")
@@ -375,7 +375,7 @@ final class RewardVerificationPollerTests: TestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .verified(.noReward) = outcome else {
+        guard case .verified(.noReward, _) = outcome else {
             return XCTFail("Expected .verified(.noReward), got \(outcome)")
         }
         XCTAssertEqual(statusPoller.callCount, 3)
@@ -510,7 +510,7 @@ final class RewardVerificationPollerTests: TestCase {
 
         let outcome = await sut.run(clientTransactionID: "tx-1")
 
-        guard case .verified(.noReward) = outcome else {
+        guard case .verified(.noReward, _) = outcome else {
             return XCTFail("Expected .verified(.noReward) after sleeper failure was swallowed, got \(outcome)")
         }
         XCTAssertEqual(statusPoller.callCount, 2)

--- a/Tests/UnitTests/Ads/RewardVerification/RewardVerificationResultTests.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/RewardVerificationResultTests.swift
@@ -35,4 +35,24 @@ final class RewardVerificationResultTests: TestCase {
         let result = RewardVerificationResult.verified(.unsupportedReward)
         XCTAssertEqual(result.verifiedReward, .unsupportedReward)
     }
+
+    func testSingleRewardHasEmptyMoreRewards() {
+        let result = RewardVerificationResult.verified(.noReward)
+        XCTAssertTrue(result.moreRewards.isEmpty)
+    }
+
+    func testFailedHasEmptyMoreRewards() {
+        XCTAssertTrue(RewardVerificationResult.failed.moreRewards.isEmpty)
+    }
+
+    func testMultiGrantExposesPrimaryAndMoreRewards() throws {
+        let primary = AdReward.virtualCurrency(code: "coins", amount: 10)
+        let entitlement = AdReward.entitlement(identifier: "pro", expiresAt: Date())
+        let result = RewardVerificationResult.verified(primary, moreRewards: [entitlement])
+
+        XCTAssertEqual(result.verifiedReward, primary)
+        XCTAssertEqual(result.moreRewards, [entitlement])
+        // moreRewards must not repeat the primary reward.
+        XCTAssertFalse(result.moreRewards.contains(primary))
+    }
 }

--- a/Tests/UnitTests/Ads/RewardVerification/RewardVerificationResultTests.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/RewardVerificationResultTests.swift
@@ -52,7 +52,6 @@ final class RewardVerificationResultTests: TestCase {
 
         XCTAssertEqual(result.verifiedReward, primary)
         XCTAssertEqual(result.moreRewards, [entitlement])
-        // moreRewards must not repeat the primary reward.
         XCTAssertFalse(result.moreRewards.contains(primary))
     }
 }

--- a/Tests/UnitTests/Ads/RewardVerification/RewardVerificationStatusResponseTests.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/RewardVerificationStatusResponseTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 @_spi(Internal) @_spi(Experimental) @testable import RevenueCat
 
-/// Decoding tests for the reward-verification poll response wire shape.
+/// Decoding tests for the reward-verification poll response wire shape (`reward` + `more_rewards`).
 final class RewardVerificationStatusResponseTests: TestCase {
 
     private static let expiresAtString = "2026-06-16T12:00:00Z"
@@ -41,7 +41,7 @@ final class RewardVerificationStatusResponseTests: TestCase {
         expect(try self.decode(["status": "some_future_state"]).status) == .unknown
     }
 
-    // MARK: - Reward
+    // MARK: - Primary reward
 
     func testDecodesVirtualCurrencyReward() throws {
         let response = try self.decode([
@@ -49,10 +49,11 @@ final class RewardVerificationStatusResponseTests: TestCase {
             "reward": ["type": "virtual_currency", "code": "coins", "amount": 10]
         ])
 
-        guard case let .verified(reward) = response.status else {
+        guard case let .verified(reward, moreRewards) = response.status else {
             return fail("Expected verified, got \(response.status)")
         }
         expect(reward.virtualCurrency) == VirtualCurrencyReward(code: "coins", amount: 10)
+        expect(moreRewards).to(beEmpty())
     }
 
     func testDecodesEntitlementReward() throws {
@@ -61,16 +62,18 @@ final class RewardVerificationStatusResponseTests: TestCase {
             "reward": ["type": "entitlement", "identifier": "pro", "expires_at": Self.expiresAtString]
         ])
 
-        guard case let .verified(reward) = response.status else {
+        guard case let .verified(reward, moreRewards) = response.status else {
             return fail("Expected verified, got \(response.status)")
         }
         let entitlement = try XCTUnwrap(reward.entitlement)
         expect(entitlement.identifier) == "pro"
         expect(entitlement.expiresAt) == Self.expiresAt
+        expect(moreRewards).to(beEmpty())
     }
 
     func testVerifiedWithoutRewardDecodesAsNoReward() throws {
-        expect(try self.decode(["status": "verified"]).status) == .verified(.noReward)
+        let response = try self.decode(["status": "verified"])
+        expect(response.status) == .verified(.noReward)
     }
 
     func testMalformedEntitlementDecodesAsUnsupported() throws {
@@ -110,7 +113,7 @@ final class RewardVerificationStatusResponseTests: TestCase {
         )
     }
 
-    func testUnknownRewardTypeDecodesAsUnsupported() throws {
+    func testUnknownPrimaryRewardTypeDecodesAsUnsupported() throws {
         let response = try self.decode([
             "status": "verified",
             "reward": ["type": "some_future_reward"]
@@ -120,5 +123,73 @@ final class RewardVerificationStatusResponseTests: TestCase {
             Strings.backendError.unsupported_reward_verification_reward_type(type: "some_future_reward"),
             level: .warn
         )
+    }
+
+    // MARK: - moreRewards
+
+    func testMultiGrantDecodesPrimaryAndMoreRewards() throws {
+        let response = try self.decode([
+            "status": "verified",
+            "reward": ["type": "virtual_currency", "code": "coins", "amount": 10],
+            "more_rewards": [
+                ["type": "entitlement", "identifier": "pro", "expires_at": Self.expiresAtString]
+            ]
+        ])
+
+        guard case let .verified(reward, moreRewards) = response.status else {
+            return fail("Expected verified, got \(response.status)")
+        }
+        expect(reward.virtualCurrency) == VirtualCurrencyReward(code: "coins", amount: 10)
+        expect(moreRewards).to(haveCount(1))
+        let entitlement = try XCTUnwrap(moreRewards.first?.entitlement)
+        expect(entitlement.identifier) == "pro"
+        expect(entitlement.expiresAt) == Self.expiresAt
+    }
+
+    func testAbsentMoreRewardsDecodesAsEmpty() throws {
+        let response = try self.decode([
+            "status": "verified",
+            "reward": ["type": "virtual_currency", "code": "coins", "amount": 10]
+        ])
+
+        guard case let .verified(_, moreRewards) = response.status else {
+            return fail("Expected verified, got \(response.status)")
+        }
+        expect(moreRewards).to(beEmpty())
+    }
+
+    func testUnknownTypeInMoreRewardsDecodesAsUnsupportedEntry() throws {
+        let response = try self.decode([
+            "status": "verified",
+            "reward": ["type": "virtual_currency", "code": "coins", "amount": 10],
+            "more_rewards": [["type": "some_future_reward"]]
+        ])
+
+        guard case let .verified(_, moreRewards) = response.status else {
+            return fail("Expected verified, got \(response.status)")
+        }
+        expect(moreRewards) == [.unsupportedReward]
+        self.logger.verifyMessageWasLogged(
+            Strings.backendError.unsupported_reward_verification_reward_type(type: "some_future_reward"),
+            level: .warn
+        )
+    }
+
+    func testMultipleMoreRewardsPreserveOrder() throws {
+        let response = try self.decode([
+            "status": "verified",
+            "reward": ["type": "virtual_currency", "code": "coins", "amount": 10],
+            "more_rewards": [
+                ["type": "entitlement", "identifier": "pro", "expires_at": Self.expiresAtString],
+                ["type": "virtual_currency", "code": "gems", "amount": 5]
+            ]
+        ])
+
+        guard case let .verified(_, moreRewards) = response.status else {
+            return fail("Expected verified, got \(response.status)")
+        }
+        expect(moreRewards).to(haveCount(2))
+        expect(moreRewards[0].entitlement?.identifier) == "pro"
+        expect(moreRewards[1].virtualCurrency) == VirtualCurrencyReward(code: "gems", amount: 5)
     }
 }

--- a/Tests/UnitTests/Ads/RewardVerification/RewardVerificationStatusResponseTests.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/RewardVerificationStatusResponseTests.swift
@@ -173,6 +173,53 @@ final class RewardVerificationStatusResponseTests: TestCase {
         )
     }
 
+    func testNonArrayMoreRewardsDecodesAsEmpty() throws {
+        let response = try self.decode([
+            "status": "verified",
+            "reward": ["type": "virtual_currency", "code": "coins", "amount": 10],
+            "more_rewards": "not-an-array"
+        ])
+
+        guard case let .verified(_, moreRewards) = response.status else {
+            return fail("Expected verified, got \(response.status)")
+        }
+        expect(moreRewards).to(beEmpty())
+        self.logger.verifyMessageWasLogged(
+            Strings.backendError.unexpected_reward_verification_reward_value,
+            level: .warn
+        )
+    }
+
+    func testNullElementInMoreRewardsDecodesAsUnsupportedEntry() throws {
+        let response = try self.decode([
+            "status": "verified",
+            "reward": ["type": "virtual_currency", "code": "coins", "amount": 10],
+            "more_rewards": [NSNull()]
+        ])
+
+        guard case let .verified(_, moreRewards) = response.status else {
+            return fail("Expected verified, got \(response.status)")
+        }
+        expect(moreRewards) == [.unsupportedReward]
+        self.logger.verifyMessageWasLogged(
+            Strings.backendError.unexpected_reward_verification_reward_value,
+            level: .warn
+        )
+    }
+
+    func testExplicitNullMoreRewardsDecodesAsEmpty() throws {
+        let response = try self.decode([
+            "status": "verified",
+            "reward": ["type": "virtual_currency", "code": "coins", "amount": 10],
+            "more_rewards": NSNull()
+        ])
+
+        guard case let .verified(_, moreRewards) = response.status else {
+            return fail("Expected verified, got \(response.status)")
+        }
+        expect(moreRewards).to(beEmpty())
+    }
+
     func testMultipleMoreRewardsPreserveOrder() throws {
         let response = try self.decode([
             "status": "verified",

--- a/Tests/UnitTests/Ads/RewardVerification/RewardVerificationStatusResponseTests.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/RewardVerificationStatusResponseTests.swift
@@ -16,7 +16,6 @@ import XCTest
 
 @_spi(Internal) @_spi(Experimental) @testable import RevenueCat
 
-/// Decoding tests for the reward-verification poll response wire shape (`reward` + `more_rewards`).
 final class RewardVerificationStatusResponseTests: TestCase {
 
     private static let expiresAtString = "2026-06-16T12:00:00Z"
@@ -77,7 +76,6 @@ final class RewardVerificationStatusResponseTests: TestCase {
     }
 
     func testMalformedEntitlementDecodesAsUnsupported() throws {
-        // Entitlement reward missing its `identifier`.
         let response = try self.decode([
             "status": "verified",
             "reward": ["type": "entitlement", "expires_at": Self.expiresAtString]

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesRewardVerificationTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesRewardVerificationTests.swift
@@ -211,7 +211,6 @@ extension PurchasesRewardVerificationTests {
 
     func testPollRewardVerificationFailsWhenEntitlementCustomerInfoRefreshFails() async throws {
         let reward = try XCTUnwrap(EntitlementReward(identifier: "pro", expiresAt: Date()))
-        // Terminal (non-transient) error — should not be retried.
         self.backend.overrideCustomerInfoResult = .failure(makeTerminalBackendError())
         let before = self.backend.getCustomerInfoCallCount
         let poller = self.makeStubPoller(statuses: [.verified(.entitlement(reward))])
@@ -221,7 +220,6 @@ extension PurchasesRewardVerificationTests {
         expect(result) == .failed
         expect(result.verifiedReward).to(beNil())
         expect(self.backend.getCustomerInfoCallCount) == before + 1
-        // The completion log reflects the delivered result, never "verified".
         self.logger.verifyMessageWasLogged(
             AdsStrings.reward_verification_completed(result: .failed, transactionID: "tx-1"),
             level: .info
@@ -234,7 +232,6 @@ extension PurchasesRewardVerificationTests {
     }
 
     func testTransientServerErrorsAreRetriableForEntitlementRefresh() {
-        // Typical transient infra errors (502, 503) must be retried, not treated as terminal.
         for statusCode in [502, 503] {
             let error = makePollingError(statusCode: statusCode, backendCode: .internalServerError)
             expect(error.isTransient).to(beTrue(), description: "status \(statusCode) should be transient")
@@ -261,7 +258,6 @@ extension PurchasesRewardVerificationTests {
 
         let result = await self.purchases.pollRewardVerification(clientTransactionID: "tx-1", poller: poller)
 
-        // VC reward → invalidate the VC cache; entitlement reward → actively refresh CustomerInfo.
         expect(self.mockVirtualCurrencyManager.invalidateVirtualCurrenciesCacheCallCount) == 1
         expect(self.backend.getCustomerInfoCallCount) > before
         expect(result.verifiedReward) == .virtualCurrency(virtualCurrency)
@@ -278,7 +274,6 @@ extension PurchasesRewardVerificationTests {
 
         let result = await self.purchases.pollRewardVerification(clientTransactionID: "tx-1", poller: poller)
 
-        // A failed entitlement refresh fails the whole batch; the VC cache was still invalidated.
         expect(result) == .failed
         expect(self.mockVirtualCurrencyManager.invalidateVirtualCurrenciesCacheCallCount) == 1
     }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesRewardVerificationTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesRewardVerificationTests.swift
@@ -251,6 +251,38 @@ extension PurchasesRewardVerificationTests {
         expect(self.backend.getCustomerInfoCallCount) == before
     }
 
+    func testPollRewardVerificationMultiGrantInvalidatesVCCacheAndFetchesCustomerInfo() async throws {
+        let virtualCurrency = try XCTUnwrap(VirtualCurrencyReward(code: "coins", amount: 5))
+        let entitlement = try XCTUnwrap(EntitlementReward(identifier: "pro", expiresAt: Date()))
+        let before = self.backend.getCustomerInfoCallCount
+        let poller = self.makeStubPoller(statuses: [
+            .verified(reward: .virtualCurrency(virtualCurrency), moreRewards: [.entitlement(entitlement)])
+        ])
+
+        let result = await self.purchases.pollRewardVerification(clientTransactionID: "tx-1", poller: poller)
+
+        // VC reward → invalidate the VC cache; entitlement reward → actively refresh CustomerInfo.
+        expect(self.mockVirtualCurrencyManager.invalidateVirtualCurrenciesCacheCallCount) == 1
+        expect(self.backend.getCustomerInfoCallCount) > before
+        expect(result.verifiedReward) == .virtualCurrency(virtualCurrency)
+        expect(result.moreRewards) == [.entitlement(entitlement)]
+    }
+
+    func testPollRewardVerificationMultiGrantFailsWhenEntitlementRefreshFails() async throws {
+        let virtualCurrency = try XCTUnwrap(VirtualCurrencyReward(code: "coins", amount: 5))
+        let entitlement = try XCTUnwrap(EntitlementReward(identifier: "pro", expiresAt: Date()))
+        self.backend.overrideCustomerInfoResult = .failure(makeTerminalBackendError())
+        let poller = self.makeStubPoller(statuses: [
+            .verified(reward: .virtualCurrency(virtualCurrency), moreRewards: [.entitlement(entitlement)])
+        ])
+
+        let result = await self.purchases.pollRewardVerification(clientTransactionID: "tx-1", poller: poller)
+
+        // A failed entitlement refresh fails the whole batch; the VC cache was still invalidated.
+        expect(result) == .failed
+        expect(self.mockVirtualCurrencyManager.invalidateVirtualCurrenciesCacheCallCount) == 1
+    }
+
 }
 
 // MARK: - generateRewardVerificationToken


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-android`.

### Motivation
A single rewarded ad can grant several rewards at once (a virtual currency and/or one or more entitlements). The verified poll response splits them into the primary `reward` plus a `more_rewards` array of additional rewards.

### Description
Threads `(reward, moreRewards)` through the poll status, outcome, and result; decodes the `more_rewards` array (unknown reward types fall back to `unsupported`); and acts on every granted reward by type — `virtual_currency` invalidates the virtual-currency cache, `entitlement` invalidates the `CustomerInfo` cache and fetches it again. `RewardVerificationResult` gains a `moreRewards` accessor while `verifiedReward` stays the primary reward.

This additively expands our `@_spi(Experimental)` beta API: `RewardVerificationResult` gains a `moreRewards` accessor. The change is source-compatible — no breaking changes to existing call sites. Stacked on #7038.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches experimental reward-verification flow and entitlement CustomerInfo refresh semantics for multi-grant ads; changes are additive and heavily tested but affect when polls return `.failed` vs verified rewards.
> 
> **Overview**
> Adds support for verified poll responses that return a primary **`reward`** plus additional grants in **`more_rewards`**, so one rewarded ad can surface multiple rewards at once.
> 
> The change threads **`(reward, moreRewards)`** through decoding (`RewardVerificationStatusResponse`), polling (`RewardVerificationPollStatus`, `Outcome`, `Poller`), and the public **`RewardVerificationResult`** (new **`moreRewards`** accessor; **`verifiedReward`** stays the primary). Malformed or unknown entries in **`more_rewards`** decode to **`unsupportedReward`** or are dropped with warnings, similar to the primary reward path.
> 
> **`pollRewardVerification`** now applies cache side effects across **all** grants: virtual currency anywhere in the list invalidates the virtual-currency cache; any entitlement triggers **`CustomerInfo`** refresh, and the whole result still fails if that refresh cannot complete locally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7c40d55440fb792ec92807acd135ff1f8a0106d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->