### PR TITLE
feat(workflows): add workflows_close abandonment event

### DIFF
--- a/RevenueCatUI/Modifiers/EnvironmentValues+Workflow.swift
+++ b/RevenueCatUI/Modifiers/EnvironmentValues+Workflow.swift
@@ -92,6 +92,11 @@ private struct WorkflowExitOfferOfferingBindingKey: EnvironmentKey {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private struct WorkflowCompletedInSessionBindingKey: EnvironmentKey {
+    static let defaultValue: Binding<Bool> = .constant(false)
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension EnvironmentValues {
     /// Called when a button with a component `id` is tapped inside a workflow paywall.
     /// Returns `true` if the workflow consumed the trigger (navigator found a matching step),
@@ -125,6 +130,13 @@ extension EnvironmentValues {
     var workflowExitOfferOfferingBinding: Binding<Offering?> {
         get { self[WorkflowExitOfferOfferingBindingKey.self] }
         set { self[WorkflowExitOfferOfferingBindingKey.self] = newValue }
+    }
+
+    /// A binding injected by the outer presenter so restore-driven dismissal can mark the workflow
+    /// as completed before the embedded workflow view disappears. Regular paywalls do not read this.
+    var workflowCompletedInSessionBinding: Binding<Bool> {
+        get { self[WorkflowCompletedInSessionBindingKey.self] }
+        set { self[WorkflowCompletedInSessionBindingKey.self] = newValue }
     }
 }
 

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -239,8 +239,11 @@ final class PurchaseHandler: ObservableObject {
     /// Resets purchase state for a new paywall session.
     ///
     /// This is called when a paywall appears to ensure we track purchases for the current session only.
-    /// We reset both `sessionPurchaseResult` (used for exit offer logic) and `purchaseResult`
-    /// (used for `onPurchaseCompleted` preference) to avoid stale values triggering handlers.
+    /// We reset `sessionPurchaseResult` (used for exit offer logic), `purchaseResult`
+    /// (used for `onPurchaseCompleted` preference), and `restoredCustomerInfo` (a successful restore is a
+    /// per-session completion signal) to avoid stale values triggering handlers. The handler is held as a
+    /// `@StateObject` by the presenting modifier and reused across present/dismiss cycles, so without this
+    /// a prior session's restore would leak into the next one.
     func resetForNewSession() {
         if let sessionID = self.activePaywallSessionID {
             self.paywallEventTracker.discardSession(sessionID: sessionID)
@@ -248,6 +251,7 @@ final class PurchaseHandler: ObservableObject {
         self.sessionPurchaseResult = nil
         self.consecutiveCancellationRequestID = nil
         self.purchaseResult = nil
+        self.restoredCustomerInfo = nil
         self.activePaywallSessionID = nil
     }
 

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowStepEventCoordinator.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowStepEventCoordinator.swift
@@ -25,6 +25,7 @@ final class WorkflowStepEventCoordinator {
     private let tracker: WorkflowStepEventTracker
     private var hasTrackedInitialStep = false
     private var hasTrackedTerminalCompletion = false
+    private var hasTrackedAbandonment = false
 
     init(workflow: PublishedWorkflow, traceId: String, sink: @escaping (WorkflowEvent) -> Void) {
         self.tracker = WorkflowStepEventTracker(workflow: workflow, traceId: traceId, sink: sink)
@@ -76,6 +77,19 @@ final class WorkflowStepEventCoordinator {
         }
         self.hasTrackedTerminalCompletion = true
         self.tracker.trackStepCompleted(currentStep, toStepId: nil)
+    }
+
+    /// Emits a workflow-level `close` (abandonment) once, only if the workflow was dismissed without
+    /// completing it and a page is currently rendered. Unlike `trackTerminalCompletion`, it is not a
+    /// step-lifecycle signal and is not gated by `screen_type`: abandonment on a non-paywall step still
+    /// fires. A completed purchase or a successful restore is a natural exit, not an abandonment, so
+    /// `hasCompletedInSession` suppresses the event.
+    func trackAbandonment(currentStep: WorkflowStep?, hasRenderedPage: Bool, hasCompletedInSession: Bool) {
+        guard !self.hasTrackedAbandonment, !hasCompletedInSession, hasRenderedPage, let currentStep else {
+            return
+        }
+        self.hasTrackedAbandonment = true
+        self.tracker.trackClose(currentStep)
     }
 
 }

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowStepEventTracker.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowStepEventTracker.swift
@@ -68,6 +68,19 @@ struct WorkflowStepEventTracker {
         )
     }
 
+    /// Emits a `close` for the step the user abandoned the workflow on. Unlike the terminal
+    /// `stepCompleted`, this is a workflow-level abandonment signal and is not gated by `screen_type`,
+    /// so abandonment on a non-paywall step is still captured. The step's position is stamped via
+    /// `isFirstStep`/`isLastStep`; analytics defines "abandonment" from those downstream.
+    func trackClose(_ step: WorkflowStep) {
+        self.sink(
+            .close(
+                .init(),
+                self.data(for: step, fromStepId: nil, toStepId: nil, entryReason: nil)
+            )
+        )
+    }
+
     private func trackStepStarted(_ step: WorkflowStep, fromStepId: String?, entryReason: EntryReason) {
         self.sink(
             .stepStarted(

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -195,6 +195,7 @@ struct WorkflowPaywallView: View {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.workflowExitOfferOfferingBinding) private var exitOfferOfferingBinding
+    @Environment(\.workflowCompletedInSessionBinding) private var workflowCompletedInSessionBinding
 
     enum DismissalAction: Equatable {
         case dismissWorkflow
@@ -231,6 +232,7 @@ struct WorkflowPaywallView: View {
     @State private var stepEventCoordinator: WorkflowStepEventCoordinator
     @State private var transitionState: WorkflowPageTransitionState<RenderedPage>
     @State private var activeTransitionID: UUID?
+    @State private var hasCompletedWorkflowInSession = false
     /// Every step the user has seen, in first-seen order. Each page is kept mounted so its subtree,
     /// and the state it owns (a tab/toggle selection, the `PackageContext` that `PaywallsV2View`
     /// mutates by reference), survives navigating away and back. Also the per-step page cache:
@@ -347,16 +349,17 @@ struct WorkflowPaywallView: View {
         // and programmatic parent dismiss — without firing during inner step transitions (the outer
         // view stays mounted while pages swap).
         .onDisappear {
-            // Workflow abandonment: fires unless the workflow was completed via a purchase or a
-            // successful restore (both auto-dismiss only after their session state is set, so they
-            // reliably suppress it here). Not gated by `screen_type`, so it captures abandonment on
-            // non-paywall steps too.
+            // Workflow abandonment: fires unless the workflow completed naturally before dismissal.
+            // The completion signal is explicit because UIKit can reset PurchaseHandler before this
+            // view disappears, and restore only completes a workflow when the presenter actually
+            // closes it.
             self.stepEventCoordinator.trackAbandonment(
                 currentStep: self.navigator.currentStep,
                 hasRenderedPage: self.transitionState.currentPage != nil,
                 hasCompletedInSession: Self.hasCompletedInSession(
                     hasPurchasedInSession: self.purchaseHandler.hasPurchasedInSession,
-                    didRestoreSuccessfully: self.purchaseHandler.restoredCustomerInfo?.success == true
+                    hasCompletedWorkflowInSession: self.hasCompletedWorkflowInSession ||
+                        self.workflowCompletedInSessionBinding.wrappedValue
                 )
             )
             self.stepEventCoordinator.trackTerminalCompletion(
@@ -516,6 +519,9 @@ struct WorkflowPaywallView: View {
             hasPurchasedInSession: self.purchaseHandler.hasPurchasedInSession
         ) {
         case .dismissWorkflow:
+            if self.purchaseHandler.hasPurchasedInSession {
+                self.markWorkflowCompletedInSession()
+            }
             self.onDismiss()
         case .navigateBack:
             let fromStep = self.navigator.currentStep
@@ -560,23 +566,19 @@ struct WorkflowPaywallView: View {
         return context.exitOfferContext(forStepId: currentStepId)
     }
 
+    private func markWorkflowCompletedInSession() {
+        self.hasCompletedWorkflowInSession = true
+        self.workflowCompletedInSessionBinding.wrappedValue = true
+    }
+
     /// Whether the workflow reached a natural completion (so dismissing it is not an abandonment).
-    /// A purchase or a successful restore both count: each auto-dismisses the workflow, and recording
-    /// `workflows_close` for them would be a false abandonment. Mirrors Android setting
-    /// `_purchaseCompleted` on both a completed purchase and a restore that dismisses the paywall.
-    ///
-    /// Accepted divergence from Android: Android only treats a restore as completion when it actually
-    /// dismisses the paywall (`success && !shouldDisplay`). That `shouldDisplay` check lives in the
-    /// presenter, not this view, so here any successful restore counts. In the rare case where a restore
-    /// succeeds but the paywall's display condition keeps it visible and the user then abandons, this
-    /// under-fires `workflows_close`. That is the safe direction for an ingestion-only analytics event:
-    /// it never records a *false* abandonment. Perfect parity would require recording a completion signal
-    /// at the presenter's restore-dismiss sites (a follow-up).
+    /// Purchase state is kept as a fallback, while restore-driven completion comes from the presenter
+    /// only when restore actually dismisses the workflow.
     static func hasCompletedInSession(
         hasPurchasedInSession: Bool,
-        didRestoreSuccessfully: Bool
+        hasCompletedWorkflowInSession: Bool
     ) -> Bool {
-        return hasPurchasedInSession || didRestoreSuccessfully
+        return hasPurchasedInSession || hasCompletedWorkflowInSession
     }
 
     static func dismissalAction(

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -347,6 +347,18 @@ struct WorkflowPaywallView: View {
         // and programmatic parent dismiss — without firing during inner step transitions (the outer
         // view stays mounted while pages swap).
         .onDisappear {
+            // Workflow abandonment: fires unless the workflow was completed via a purchase or a
+            // successful restore (both auto-dismiss only after their session state is set, so they
+            // reliably suppress it here). Not gated by `screen_type`, so it captures abandonment on
+            // non-paywall steps too.
+            self.stepEventCoordinator.trackAbandonment(
+                currentStep: self.navigator.currentStep,
+                hasRenderedPage: self.transitionState.currentPage != nil,
+                hasCompletedInSession: Self.hasCompletedInSession(
+                    hasPurchasedInSession: self.purchaseHandler.hasPurchasedInSession,
+                    didRestoreSuccessfully: self.purchaseHandler.restoredCustomerInfo?.success == true
+                )
+            )
             self.stepEventCoordinator.trackTerminalCompletion(
                 currentStep: self.navigator.currentStep,
                 hasRenderedPage: self.transitionState.currentPage != nil
@@ -546,6 +558,25 @@ struct WorkflowPaywallView: View {
         currentStepId: String
     ) -> WorkflowExitOfferContext? {
         return context.exitOfferContext(forStepId: currentStepId)
+    }
+
+    /// Whether the workflow reached a natural completion (so dismissing it is not an abandonment).
+    /// A purchase or a successful restore both count: each auto-dismisses the workflow, and recording
+    /// `workflows_close` for them would be a false abandonment. Mirrors Android setting
+    /// `_purchaseCompleted` on both a completed purchase and a restore that dismisses the paywall.
+    ///
+    /// Accepted divergence from Android: Android only treats a restore as completion when it actually
+    /// dismisses the paywall (`success && !shouldDisplay`). That `shouldDisplay` check lives in the
+    /// presenter, not this view, so here any successful restore counts. In the rare case where a restore
+    /// succeeds but the paywall's display condition keeps it visible and the user then abandons, this
+    /// under-fires `workflows_close`. That is the safe direction for an ingestion-only analytics event:
+    /// it never records a *false* abandonment. Perfect parity would require recording a completion signal
+    /// at the presenter's restore-dismiss sites (a follow-up).
+    static func hasCompletedInSession(
+        hasPurchasedInSession: Bool,
+        didRestoreSuccessfully: Bool
+    ) -> Bool {
+        return hasPurchasedInSession || didRestoreSuccessfully
     }
 
     static func dismissalAction(

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -652,6 +652,7 @@ private struct PresentingPaywallModifier: ViewModifier {
             self.purchaseStarted?($0)
         }
         .onPurchaseCompleted { customerInfo in
+            self.markWorkflowCompletedInSession()
             self.purchaseCompleted?(customerInfo)
             // Always close on successful purchase - shouldDisplay drives when to show, not when to close
             self.close()
@@ -703,12 +704,16 @@ private struct PresentingPaywallModifier: ViewModifier {
         self.workflowCompletedInSession = false
     }
 
+    private func markWorkflowCompletedInSession() {
+        self.workflowCompletedInSession = true
+    }
+
     private func handleMainPaywallRestoreResult(_ result: PurchaseHandler.RestoreResult?) {
         guard let result else { return }
 
         // For restore, check shouldDisplay since restore might succeed without granting the expected entitlement.
         if result.success && !self.shouldDisplay(result.customerInfo) {
-            self.workflowCompletedInSession = true
+            self.markWorkflowCompletedInSession()
             self.close()
         }
     }
@@ -718,7 +723,7 @@ private struct PresentingPaywallModifier: ViewModifier {
 
         // For restore, check shouldDisplay since restore might succeed without granting the expected entitlement.
         if result.success && !self.shouldDisplay(result.customerInfo) {
-            self.workflowCompletedInSession = true
+            self.markWorkflowCompletedInSession()
             self.closeExitOffer()
         }
     }
@@ -797,6 +802,7 @@ private struct PresentingPaywallModifier: ViewModifier {
             self.purchaseStarted?($0)
         }
         .onPurchaseCompleted { customerInfo in
+            self.markWorkflowCompletedInSession()
             self.purchaseCompleted?(customerInfo)
             // Always close on successful purchase - shouldDisplay drives when to show, not when to close
             self.closeExitOffer()
@@ -963,6 +969,7 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
             self.purchaseStarted?($0)
         }
         .onPurchaseCompleted { customerInfo in
+            self.markWorkflowCompletedInSession()
             self.purchaseCompleted?(customerInfo)
             // Always close on successful purchase
             self.offering = nil
@@ -1005,6 +1012,7 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
             self.purchaseStarted?($0)
         }
         .onPurchaseCompleted { customerInfo in
+            self.markWorkflowCompletedInSession()
             self.purchaseCompleted?(customerInfo)
             // Always close on successful purchase
             self.presentedExitOffer = nil
@@ -1033,11 +1041,15 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
         self.workflowCompletedInSession = false
     }
 
+    private func markWorkflowCompletedInSession() {
+        self.workflowCompletedInSession = true
+    }
+
     private func handleMainPaywallRestoreResult(_ result: PurchaseHandler.RestoreResult?) {
         guard let result, result.success else { return }
 
         // Close on successful restore.
-        self.workflowCompletedInSession = true
+        self.markWorkflowCompletedInSession()
         self.offering = nil
     }
 
@@ -1045,7 +1057,7 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
         guard let result, result.success else { return }
 
         // Close on successful restore.
-        self.workflowCompletedInSession = true
+        self.markWorkflowCompletedInSession()
         self.presentedExitOffer = nil
         self.exitOfferOffering = nil
     }

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -545,6 +545,11 @@ private struct PresentingPaywallModifier: ViewModifier {
     @State
     private var exitOfferOffering: Offering?
 
+    /// Set when a workflow completes through purchase or restore-driven dismissal.
+    /// Regular paywalls ignore this environment value; only `WorkflowPaywallView` consumes it.
+    @State
+    private var workflowCompletedInSession = false
+
     /// The exit offer currently being presented. Controls the sheet/fullScreenCover.
     /// Set from `exitOfferOffering` when the main paywall dismisses without a purchase.
     @State
@@ -641,6 +646,8 @@ private struct PresentingPaywallModifier: ViewModifier {
             )
         )
         .environment(\.workflowExitOfferOfferingBinding, self.$exitOfferOffering)
+        .environment(\.workflowCompletedInSessionBinding, self.$workflowCompletedInSession)
+        .onAppear(perform: self.resetWorkflowCompletedInSession)
         .onPurchaseStarted {
             self.purchaseStarted?($0)
         }
@@ -658,14 +665,7 @@ private struct PresentingPaywallModifier: ViewModifier {
         .onRestoreCompleted { customerInfo in
             self.restoreCompleted?(customerInfo)
         }
-        .onPreferenceChange(RestoredCustomerInfoPreferenceKey.self) { result in
-            guard let result else { return }
-
-            // For restore, check shouldDisplay since restore might succeed without granting the expected entitlement
-            if result.success && !self.shouldDisplay(result.customerInfo) {
-                self.close()
-            }
-        }
+        .onPreferenceChange(RestoredCustomerInfoPreferenceKey.self, perform: self.handleMainPaywallRestoreResult)
         .onPurchaseFailure {
             self.purchaseFailure?($0)
         }
@@ -697,6 +697,30 @@ private struct PresentingPaywallModifier: ViewModifier {
 
         self.presentedExitOffer = nil
         self.exitOfferOffering = nil
+    }
+
+    private func resetWorkflowCompletedInSession() {
+        self.workflowCompletedInSession = false
+    }
+
+    private func handleMainPaywallRestoreResult(_ result: PurchaseHandler.RestoreResult?) {
+        guard let result else { return }
+
+        // For restore, check shouldDisplay since restore might succeed without granting the expected entitlement.
+        if result.success && !self.shouldDisplay(result.customerInfo) {
+            self.workflowCompletedInSession = true
+            self.close()
+        }
+    }
+
+    private func handleExitOfferRestoreResult(_ result: PurchaseHandler.RestoreResult?) {
+        guard let result else { return }
+
+        // For restore, check shouldDisplay since restore might succeed without granting the expected entitlement.
+        if result.success && !self.shouldDisplay(result.customerInfo) {
+            self.workflowCompletedInSession = true
+            self.closeExitOffer()
+        }
     }
 
     /// Handles dismissal of the main paywall, checking for exit offers.
@@ -768,6 +792,7 @@ private struct PresentingPaywallModifier: ViewModifier {
             )
         )
         .customPaywallVariables(self.customPaywallVariables)
+        .environment(\.workflowCompletedInSessionBinding, self.$workflowCompletedInSession)
         .onPurchaseStarted {
             self.purchaseStarted?($0)
         }
@@ -785,14 +810,7 @@ private struct PresentingPaywallModifier: ViewModifier {
         .onRestoreCompleted { customerInfo in
             self.restoreCompleted?(customerInfo)
         }
-        .onPreferenceChange(RestoredCustomerInfoPreferenceKey.self) { result in
-            guard let result else { return }
-
-            // For restore, check shouldDisplay since restore might succeed without granting the expected entitlement
-            if result.success && !self.shouldDisplay(result.customerInfo) {
-                self.closeExitOffer()
-            }
-        }
+        .onPreferenceChange(RestoredCustomerInfoPreferenceKey.self, perform: self.handleExitOfferRestoreResult)
         .onPurchaseFailure {
             self.purchaseFailure?($0)
         }
@@ -841,6 +859,11 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
     /// Copied to `presentedExitOffer` when ready to show.
     @State
     private var exitOfferOffering: Offering?
+
+    /// Set when a workflow completes through purchase or restore-driven dismissal.
+    /// Regular paywalls ignore this environment value; only `WorkflowPaywallView` consumes it.
+    @State
+    private var workflowCompletedInSession = false
 
     /// The exit offer currently being presented. Controls the sheet/fullScreenCover.
     /// Set from `exitOfferOffering` when the main paywall dismisses without a purchase.
@@ -934,6 +957,8 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
                 promoOfferCache: self.promoOfferCacheOwner.cache
             )
         )
+        .environment(\.workflowCompletedInSessionBinding, self.$workflowCompletedInSession)
+        .onAppear(perform: self.resetWorkflowCompletedInSession)
         .onPurchaseStarted {
             self.purchaseStarted?($0)
         }
@@ -951,11 +976,7 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
         .onRestoreCompleted { customerInfo in
             self.restoreCompleted?(customerInfo)
         }
-        .onPreferenceChange(RestoredCustomerInfoPreferenceKey.self) { result in
-            guard let result, result.success else { return }
-            // Close on successful restore
-            self.offering = nil
-        }
+        .onPreferenceChange(RestoredCustomerInfoPreferenceKey.self, perform: self.handleMainPaywallRestoreResult)
         .onPurchaseFailure {
             self.purchaseFailure?($0)
         }
@@ -979,6 +1000,7 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
             )
         )
         .customPaywallVariables(self.customPaywallVariables)
+        .environment(\.workflowCompletedInSessionBinding, self.$workflowCompletedInSession)
         .onPurchaseStarted {
             self.purchaseStarted?($0)
         }
@@ -997,12 +1019,7 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
         .onRestoreCompleted { customerInfo in
             self.restoreCompleted?(customerInfo)
         }
-        .onPreferenceChange(RestoredCustomerInfoPreferenceKey.self) { result in
-            guard let result, result.success else { return }
-            // Close on successful restore
-            self.presentedExitOffer = nil
-            self.exitOfferOffering = nil
-        }
+        .onPreferenceChange(RestoredCustomerInfoPreferenceKey.self, perform: self.handleExitOfferRestoreResult)
         .onPurchaseFailure {
             self.purchaseFailure?($0)
         }
@@ -1010,6 +1027,27 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
             self.restoreFailure?($0)
         }
         .interactiveDismissDisabled(self.purchaseHandler.actionInProgress)
+    }
+
+    private func resetWorkflowCompletedInSession() {
+        self.workflowCompletedInSession = false
+    }
+
+    private func handleMainPaywallRestoreResult(_ result: PurchaseHandler.RestoreResult?) {
+        guard let result, result.success else { return }
+
+        // Close on successful restore.
+        self.workflowCompletedInSession = true
+        self.offering = nil
+    }
+
+    private func handleExitOfferRestoreResult(_ result: PurchaseHandler.RestoreResult?) {
+        guard let result, result.success else { return }
+
+        // Close on successful restore.
+        self.workflowCompletedInSession = true
+        self.presentedExitOffer = nil
+        self.exitOfferOffering = nil
     }
 
     /// Handles dismissal of the main paywall, checking for exit offers.

--- a/Sources/Events/FeatureEvents/FeatureEvent.swift
+++ b/Sources/Events/FeatureEvents/FeatureEvent.swift
@@ -239,6 +239,7 @@ private extension WorkflowEvent {
             switch self {
             case .stepStarted: return "workflows_step_started"
             case .stepCompleted: return "workflows_step_completed"
+            case .close: return "workflows_close"
             }
         }()
 

--- a/Sources/Events/FeatureEvents/Networking/FeatureEventsRequest+WorkflowEvent.swift
+++ b/Sources/Events/FeatureEvents/Networking/FeatureEventsRequest+WorkflowEvent.swift
@@ -65,30 +65,13 @@ extension FeatureEventsRequest.WorkflowEvent {
 
         do {
             let event = try JSONDecoder.default.decode(StoredWorkflowEvent.self, from: jsonData)
-
-            let eventName: String
-            let fromStepId: String?
-            let toStepId: String?
-            let entryReason: String?
-
-            switch event {
-            case .stepStarted:
-                eventName = Self.stepStartedEventName
-                fromStepId = event.data.fromStepId
-                toStepId = nil
-                entryReason = event.data.entryReason
-            case .stepCompleted:
-                eventName = Self.stepCompletedEventName
-                fromStepId = nil
-                toStepId = event.data.toStepId
-                entryReason = nil
-            }
+            let wire = Self.wireFields(for: event)
 
             self.init(
                 type: Self.typeValue,
                 id: event.creationData.id.uuidString,
                 version: Self.schemaVersion,
-                eventName: eventName,
+                eventName: wire.eventName,
                 timestampMs: event.creationData.date.millisecondsSince1970,
                 appUserID: storedEvent.userID,
                 context: Context(locale: event.data.localeIdentifier),
@@ -96,9 +79,9 @@ extension FeatureEventsRequest.WorkflowEvent {
                     workflowId: event.data.workflowId,
                     stepId: event.data.stepId,
                     traceId: event.data.traceId,
-                    fromStepId: fromStepId,
-                    toStepId: toStepId,
-                    entryReason: entryReason,
+                    fromStepId: wire.fromStepId,
+                    toStepId: wire.toStepId,
+                    entryReason: wire.entryReason,
                     isFirstStep: event.data.isFirstStep,
                     isLastStep: event.data.isLastStep,
                     experimentId: event.data.experimentId,
@@ -112,10 +95,42 @@ extension FeatureEventsRequest.WorkflowEvent {
         }
     }
 
+    /// The event-name and navigation fields that vary per `WorkflowEvent` case. `close` is an
+    /// abandonment signal, not a navigation, so it carries no from/to step or entry reason.
+    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+    private static func wireFields(for event: StoredWorkflowEvent) -> WireFields {
+        switch event {
+        case .stepStarted:
+            return .init(
+                eventName: stepStartedEventName,
+                fromStepId: event.data.fromStepId,
+                toStepId: nil,
+                entryReason: event.data.entryReason
+            )
+        case .stepCompleted:
+            return .init(
+                eventName: stepCompletedEventName,
+                fromStepId: nil,
+                toStepId: event.data.toStepId,
+                entryReason: nil
+            )
+        case .close:
+            return .init(eventName: closeEventName, fromStepId: nil, toStepId: nil, entryReason: nil)
+        }
+    }
+
+    private struct WireFields {
+        let eventName: String
+        let fromStepId: String?
+        let toStepId: String?
+        let entryReason: String?
+    }
+
     private static let schemaVersion = 1
     private static let typeValue = "workflows"
     private static let stepStartedEventName = "workflows_step_started"
     private static let stepCompletedEventName = "workflows_step_completed"
+    private static let closeEventName = "workflows_close"
 
 }
 

--- a/Sources/Paywalls/Events/WorkflowEvent.swift
+++ b/Sources/Paywalls/Events/WorkflowEvent.swift
@@ -21,6 +21,10 @@ import Foundation
 
     case stepStarted(CreationData, Data)
     case stepCompleted(CreationData, Data)
+    /// The user abandoned the workflow before completing it (e.g. dismissed it without purchasing).
+    /// Distinct from a paywall close: it is a workflow-level signal that fires on any step, including
+    /// non-paywall ones, so abandonment that happens before the paywall step is still captured.
+    case close(CreationData, Data)
 
 }
 
@@ -110,6 +114,7 @@ extension WorkflowEvent {
         switch self {
         case let .stepStarted(creationData, _): return creationData
         case let .stepCompleted(creationData, _): return creationData
+        case let .close(creationData, _): return creationData
         }
     }
 
@@ -117,6 +122,7 @@ extension WorkflowEvent {
         switch self {
         case let .stepStarted(_, data): return data
         case let .stepCompleted(_, data): return data
+        case let .close(_, data): return data
         }
     }
 

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
@@ -56,6 +56,34 @@ final class WorkflowPaywallViewTests: TestCase {
         expect(action) == .dismissWorkflow
     }
 
+    func testHasCompletedInSessionTrueAfterPurchase() {
+        expect(WorkflowPaywallView.hasCompletedInSession(
+            hasPurchasedInSession: true,
+            didRestoreSuccessfully: false
+        )) == true
+    }
+
+    func testHasCompletedInSessionTrueAfterSuccessfulRestore() {
+        // A successful restore auto-dismisses the workflow; that is a completion, not an abandonment,
+        // so workflows_close must be suppressed even though no purchase happened. This intentionally also
+        // suppresses the rare case where a restore succeeds but the paywall stays visible and the user
+        // then abandons (the `shouldDisplay` check that distinguishes them lives in the presenter, not
+        // here). Under-firing is the safe direction: it never records a false abandonment. See the
+        // rationale on `WorkflowPaywallView.hasCompletedInSession`.
+        expect(WorkflowPaywallView.hasCompletedInSession(
+            hasPurchasedInSession: false,
+            didRestoreSuccessfully: true
+        )) == true
+    }
+
+    func testHasCompletedInSessionFalseWhenNeitherPurchasedNorRestored() {
+        // Plain dismissal with nothing restored is an abandonment.
+        expect(WorkflowPaywallView.hasCompletedInSession(
+            hasPurchasedInSession: false,
+            didRestoreSuccessfully: false
+        )) == false
+    }
+
     func testTransitionStateStartsWithoutOutgoingPage() {
         let state = WorkflowPageTransitionState(currentPage: "step_1")
 

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
@@ -59,28 +59,31 @@ final class WorkflowPaywallViewTests: TestCase {
     func testHasCompletedInSessionTrueAfterPurchase() {
         expect(WorkflowPaywallView.hasCompletedInSession(
             hasPurchasedInSession: true,
-            didRestoreSuccessfully: false
+            hasCompletedWorkflowInSession: false
         )) == true
     }
 
-    func testHasCompletedInSessionTrueAfterSuccessfulRestore() {
-        // A successful restore auto-dismisses the workflow; that is a completion, not an abandonment,
-        // so workflows_close must be suppressed even though no purchase happened. This intentionally also
-        // suppresses the rare case where a restore succeeds but the paywall stays visible and the user
-        // then abandons (the `shouldDisplay` check that distinguishes them lives in the presenter, not
-        // here). Under-firing is the safe direction: it never records a false abandonment. See the
-        // rationale on `WorkflowPaywallView.hasCompletedInSession`.
+    func testHasCompletedInSessionTrueAfterWorkflowCompletionSignal() {
         expect(WorkflowPaywallView.hasCompletedInSession(
             hasPurchasedInSession: false,
-            didRestoreSuccessfully: true
+            hasCompletedWorkflowInSession: true
         )) == true
+    }
+
+    func testHasCompletedInSessionFalseAfterRestoreWithoutCompletionSignal() {
+        // Raw restore success is not enough to complete a workflow. The presenter marks completion
+        // only when restore actually dismisses the paywall.
+        expect(WorkflowPaywallView.hasCompletedInSession(
+            hasPurchasedInSession: false,
+            hasCompletedWorkflowInSession: false
+        )) == false
     }
 
     func testHasCompletedInSessionFalseWhenNeitherPurchasedNorRestored() {
         // Plain dismissal with nothing restored is an abandonment.
         expect(WorkflowPaywallView.hasCompletedInSession(
             hasPurchasedInSession: false,
-            didRestoreSuccessfully: false
+            hasCompletedWorkflowInSession: false
         )) == false
     }
 

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowStepEventCoordinatorTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowStepEventCoordinatorTests.swift
@@ -161,6 +161,70 @@ final class WorkflowStepEventCoordinatorTests: TestCase {
         expect(self.recorded).to(haveCount(1))
     }
 
+    // MARK: - Abandonment (workflows_close)
+
+    func testAbandonmentEmitsCloseForCurrentStepWhenNotPurchased() throws {
+        let workflow = try Self.makeWorkflow()
+        let coordinator = self.makeCoordinator(workflow: workflow)
+        let step = try XCTUnwrap(workflow.steps["step_1"])
+
+        coordinator.trackAbandonment(currentStep: step, hasRenderedPage: true, hasCompletedInSession: false)
+
+        expect(self.recorded).to(haveCount(1))
+        let data = try XCTUnwrap(Self.closeData(self.recorded[0]))
+        expect(data.stepId) == "step_1"
+        // step_1 navigates to step_2, so it is the first but not the terminal step.
+        expect(data.isFirstStep) == true
+        expect(data.isLastStep) == false
+    }
+
+    func testAbandonmentStampsTerminalStepPosition() throws {
+        // workflows_close is not gated by step position; it just stamps it. On the terminal step
+        // isLastStep is true (analytics decides downstream whether that counts as abandonment).
+        let workflow = try Self.makeWorkflow()
+        let coordinator = self.makeCoordinator(workflow: workflow)
+        let step = try XCTUnwrap(workflow.steps["step_2"])
+
+        coordinator.trackAbandonment(currentStep: step, hasRenderedPage: true, hasCompletedInSession: false)
+
+        let data = try XCTUnwrap(Self.closeData(self.recorded.first))
+        expect(data.stepId) == "step_2"
+        expect(data.isFirstStep) == false
+        expect(data.isLastStep) == true
+    }
+
+    func testAbandonmentDoesNotEmitWhenCompleted() throws {
+        // A completed purchase or successful restore is a natural exit, not an abandonment.
+        let workflow = try Self.makeWorkflow()
+        let coordinator = self.makeCoordinator(workflow: workflow)
+        let step = try XCTUnwrap(workflow.steps["step_1"])
+
+        coordinator.trackAbandonment(currentStep: step, hasRenderedPage: true, hasCompletedInSession: true)
+
+        expect(self.recorded).to(beEmpty())
+    }
+
+    func testAbandonmentDoesNotEmitWhenNoPageRendered() throws {
+        let workflow = try Self.makeWorkflow()
+        let coordinator = self.makeCoordinator(workflow: workflow)
+        let step = try XCTUnwrap(workflow.steps["step_1"])
+
+        coordinator.trackAbandonment(currentStep: step, hasRenderedPage: false, hasCompletedInSession: false)
+
+        expect(self.recorded).to(beEmpty())
+    }
+
+    func testAbandonmentFiresOnlyOnce() throws {
+        let workflow = try Self.makeWorkflow()
+        let coordinator = self.makeCoordinator(workflow: workflow)
+        let step = try XCTUnwrap(workflow.steps["step_1"])
+
+        coordinator.trackAbandonment(currentStep: step, hasRenderedPage: true, hasCompletedInSession: false)
+        coordinator.trackAbandonment(currentStep: step, hasRenderedPage: true, hasCompletedInSession: false)
+
+        expect(self.recorded).to(haveCount(1))
+    }
+
     // MARK: - Trace id continuity
 
     func testFullJourneyEmitsExpectedSequenceSharingOneTraceId() throws {
@@ -291,10 +355,16 @@ private extension WorkflowStepEventCoordinatorTests {
         return data
     }
 
+    static func closeData(_ event: WorkflowEvent?) -> WorkflowEvent.Data? {
+        guard case let .close(_, data) = event else { return nil }
+        return data
+    }
+
     static func kind(_ event: WorkflowEvent) -> String {
         switch event {
         case .stepStarted: return "started"
         case .stepCompleted: return "completed"
+        case .close: return "close"
         }
     }
 

--- a/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
@@ -87,6 +87,20 @@ class PurchaseHandlerTests: TestCase {
         expect(handler.restoreError).to(beNil())
     }
 
+    @MainActor
+    func testResetForNewSessionClearsRestoredCustomerInfo() async throws {
+        // The handler is held as a @StateObject and reused across present/dismiss cycles, so a successful
+        // restore from one session must not leak into the next (it is a per-session completion signal that
+        // gates workflows_close abandonment).
+        let handler: PurchaseHandler = .mock()
+        handler.setRestored(TestData.customerInfo, success: true)
+        expect(handler.restoredCustomerInfo?.success) == true
+
+        handler.resetForNewSession()
+
+        expect(handler.restoredCustomerInfo).to(beNil())
+    }
+
     func testCancelEventContainsProductIdentifierWhenCompletedByRevenueCat() async throws {
         let trackedEvents: Atomic<[PaywallEvent]> = .init([])
 

--- a/Tests/UnitTests/Events/EventsManagerTests.swift
+++ b/Tests/UnitTests/Events/EventsManagerTests.swift
@@ -545,6 +545,38 @@ class EventsManagerTests: TestCase {
         expect(map["from_step_id"]).to(beNil())
     }
 
+    func testWorkflowCloseToMap() {
+        let creationData = WorkflowEvent.CreationData(id: UUID(), date: Date())
+        let event = WorkflowEvent.close(
+            creationData,
+            .init(
+                workflowId: "wfl_abc",
+                stepId: "step-1",
+                localeIdentifier: "en_US",
+                traceId: "trace-xyz",
+                isFirstStep: true,
+                isLastStep: false,
+                isLastVariantStep: true
+            )
+        )
+        let map = (event as FeatureEvent).toMap()
+
+        expect(map["discriminator"] as? String) == "workflows"
+        expect(map["type"] as? String) == "workflows_close"
+        expect(map["id"] as? String) == creationData.id.uuidString
+        expect(map["timestamp"] as? UInt64) == creationData.date.millisecondsSince1970
+        expect(map["workflow_id"] as? String) == "wfl_abc"
+        expect(map["step_id"] as? String) == "step-1"
+        expect(map["locale"] as? String) == "en_US"
+        expect(map["trace_id"] as? String) == "trace-xyz"
+        expect(map["is_first_step"] as? Bool) == true
+        expect(map["is_last_step"] as? Bool) == false
+        expect(map["is_last_variant_step"] as? Bool) == true
+        expect(map["from_step_id"]).to(beNil())
+        expect(map["to_step_id"]).to(beNil())
+        expect(map["entry_reason"]).to(beNil())
+    }
+
     func testWorkflowEventToMapIncludesOptionalFields() {
         let event = WorkflowEvent.stepStarted(
             .init(),

--- a/Tests/UnitTests/Paywalls/Events/WorkflowEventsRequestTests.swift
+++ b/Tests/UnitTests/Paywalls/Events/WorkflowEventsRequestTests.swift
@@ -114,6 +114,54 @@ class WorkflowEventsRequestTests: TestCase {
         expect(request.properties.entryReason).to(beNil())
     }
 
+    // MARK: - Close wire format
+
+    func testCloseEventNameInWireFormat() throws {
+        let event = WorkflowEvent.close(
+            .init(id: id, date: date),
+            .init(workflowId: "wfl_abc", stepId: "step-1", isFirstStep: true, isLastStep: false)
+        )
+        let stored = try XCTUnwrap(storedEvent(from: event))
+        let request = try XCTUnwrap(FeatureEventsRequest.WorkflowEvent(storedEvent: stored))
+
+        expect(request.eventName) == "workflows_close"
+    }
+
+    func testClosePropertiesCarryStepPositionAndOmitNavigationFields() throws {
+        let event = WorkflowEvent.close(
+            .init(id: id, date: date),
+            .init(workflowId: "wfl_abc", stepId: "step-1", isFirstStep: false, isLastStep: true)
+        )
+        let stored = try XCTUnwrap(storedEvent(from: event))
+        let request = try XCTUnwrap(FeatureEventsRequest.WorkflowEvent(storedEvent: stored))
+
+        expect(request.properties.workflowId) == "wfl_abc"
+        expect(request.properties.stepId) == "step-1"
+        expect(request.properties.isFirstStep) == false
+        expect(request.properties.isLastStep) == true
+        // Close is not a navigation event: it has no from/to step and no entry reason.
+        expect(request.properties.fromStepId).to(beNil())
+        expect(request.properties.toStepId).to(beNil())
+        expect(request.properties.entryReason).to(beNil())
+    }
+
+    func testKhepriCompatibleShapeForClose() throws {
+        let event = WorkflowEvent.close(
+            .init(id: id, date: date),
+            .init(workflowId: "wfl_abc", stepId: "step-1", isFirstStep: true, isLastStep: false)
+        )
+        let json = try encodedJSON(from: event)
+
+        expect(json).to(contain("\"event_name\":\"workflows_close\""))
+        expect(json).to(contain("\"workflow_id\":\"wfl_abc\""))
+        expect(json).to(contain("\"step_id\":\"step-1\""))
+        expect(json).to(contain("\"is_first_step\":true"))
+        expect(json).to(contain("\"is_last_step\":false"))
+        expect(json).toNot(contain("from_step_id"))
+        expect(json).toNot(contain("to_step_id"))
+        expect(json).toNot(contain("entry_reason"))
+    }
+
     // MARK: - JSON serialization
 
     func testTypePresentInJSON() throws {


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-android` and hybrids — port of khepri #21505

### Motivation

We can see when a workflow completes, but not when a user abandons one before completing it. This adds a workflow-level `workflows_close` event for that, landing in the `workflows_user_event` stream defined in khepri #21505.

### Description

`workflows_close` fires when a workflow is dismissed without completing it, for whatever step the user is on. It does not replace `paywall_close`, and unlike paywall events it is not gated by `screen_type`, so abandonment on a non-paywall step is captured too. `is_first_step`/`is_last_step` are stamped as metadata; analytics defines abandonment downstream from those.

Natural workflow completion is tracked explicitly. Purchase-driven workflow dismissal is marked before presenter dismissal/reset paths can clear `PurchaseHandler` session state, and restore only counts as completion when the presenter actually dismisses the paywall. A successful restore that leaves the paywall visible no longer suppresses a later `workflows_close` event.

While here, `PurchaseHandler.resetForNewSession()` clears `restoredCustomerInfo`, so a reused `@StateObject` handler does not let a prior presentation's restore leak into a later session.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: 7040
- Branch: `facu/workflows-close-abandonment-event`
- Author / human owner: `facumenzella`
- Agent(s): Codex coding agent
- Session source: current conversation and local branch diff
- Generated: 2026-06-23
- Context document version: 1

## Goal

Review and finish PR #7040 for workflow abandonment analytics, specifically addressing missing behavior around `workflows_close` serialization, purchase dismissal ordering, and restore parity for workflows without changing regular paywall behavior.

## Initial Prompt

Review PR #7040 and identify what is missing. The actionable follow-up was to tackle the missing `workflows_close` map coverage, then fix the two higher-risk workflow-completion issues before pushing the branch.

## Important Follow-up Prompts

- User asked how to tackle issue 2, then asked to tackle issue 4 first.
- User asked how to fix findings 1 and 2; agent proposed an explicit workflow-completion signal instead of inferring completion from raw `PurchaseHandler` restore state.
- User challenged the first draft as too broad; agent trimmed it so shared presenter code remains inert for regular paywalls.
- User specifically asked to ensure the solution makes sense for both paywalls and workflows because the touched presenter code is shared.
- User requested the local changes be pushed to the PR.
- User linked Cursor Bugbot review discussion `discussion_r3460959599`; agent verified the purchase-completion ordering risk and pushed a follow-up fix.

## Agent Contribution

- Reviewed PR #7040 and identified missing or risky areas: UIKit purchase reset ordering, restore parity, missing event map coverage, lifecycle test gaps, PR description AI block placement, and missing scope labels.
- Added `WorkflowEvent.close` map coverage in `EventsManagerTests.testWorkflowCloseToMap`.
- Updated workflow completion logic so `WorkflowPaywallView` no longer treats raw successful restore as completion.
- Added a workflow-only environment binding (`workflowCompletedInSessionBinding`) so SwiftUI presenters can mark restore-driven workflow completion only when the presenter actually closes the paywall.
- Added local `WorkflowPaywallView` state to mark purchase-driven workflow completion before dismissal/reset ordering can clear `PurchaseHandler` session state.
- Addressed Cursor Bugbot's purchase-completion thread by marking workflow completion in presenter purchase-completed branches before invoking the purchase callback and closing.
- Updated focused tests in `WorkflowPaywallViewTests` to cover explicit workflow completion and restore success without completion.
- Committed and pushed local branch updates to PR #7040.
- Refreshed this inline AI session context block and kept it at the end of the PR description.

## Human Decisions

- Human accepted fixing findings 1 and 2 after reviewing the proposed design.
- Human rejected the initial broader implementation direction and asked the agent to be certain shared paywall code still made sense.
- Human requested the changes be pushed.
- Human pointed the agent at the Cursor Bugbot review discussion for the purchase-completion gap.

## Key Implementation Decisions

- Decision: Stop using `restoredCustomerInfo?.success` inside `WorkflowPaywallView.hasCompletedInSession`.
  - Rationale: Restore success is not equivalent to workflow completion; only restore that closes the paywall should suppress abandonment.
  - Rejected: Treat all successful restores as completion. That under-fired `workflows_close` when restore succeeded but the workflow stayed visible.
- Decision: Keep purchase completion state local to `WorkflowPaywallView` and also mark the presenter-owned workflow completion state before presenter purchase-close branches run.
  - Rationale: `PaywallsV2View` defers its own dismissal so purchase preferences propagate first; the outer presenter can close before `WorkflowPaywallView.handleDismiss()` runs.
  - Rejected: Store the completion flag only on `PurchaseHandler`, because `resetForNewSession()` is part of the ordering problem.
- Decision: Add a workflow-only environment binding through shared SwiftUI presenter code.
  - Rationale: The restore and purchase close decisions can happen in the presenter, while `WorkflowPaywallView.onDisappear` owns abandonment emission.
  - Rejected: UIKit presenter wiring for the same binding, because UIKit does not own an equivalent restore-driven close decision in this patch and the workflow view's local purchase flag covers UIKit purchase dismissal.
- Decision: Leave regular paywalls behavior unchanged.
  - Rationale: Regular paywalls do not read `workflowCompletedInSessionBinding`; existing presenter tests were run to guard the shared path.

## Files / Symbols Touched

- `RevenueCatUI/Modifiers/EnvironmentValues+Workflow.swift`
  - Why: Adds workflow-only completion binding.
  - Symbols: `workflowCompletedInSessionBinding`
  - Review relevance: Confirm regular paywalls do not consume this environment value.
- `RevenueCatUI/Templates/V2/WorkflowPaywallView.swift`
  - Why: Marks purchase completion before workflow dismissal and uses explicit completion state in abandonment suppression.
  - Symbols: `hasCompletedInSession`, `markWorkflowCompletedInSession`, `onDisappear`
  - Review relevance: Confirm `workflows_close` is still emitted on true abandonment and suppressed only on natural completion.
- `RevenueCatUI/View+PresentPaywall.swift`
  - Why: Marks workflow completion on purchase and restore branches that already close the paywall.
  - Symbols: `PresentingPaywallModifier`, `PresentingPaywallBindingModifier`, `markWorkflowCompletedInSession`, `handleMainPaywallRestoreResult`, `handleExitOfferRestoreResult`
  - Review relevance: Shared presenter code; verify the environment state is inert for regular paywalls and set before workflow dismissal.
- `Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift`
  - Why: Updates helper tests for explicit completion and restore-without-completion behavior.
  - Symbols: `testHasCompletedInSessionTrueAfterWorkflowCompletionSignal`, `testHasCompletedInSessionFalseAfterRestoreWithoutCompletionSignal`
  - Review relevance: Confirms the intended predicate contract.
- `Tests/UnitTests/Events/EventsManagerTests.swift`
  - Why: Adds `workflows_close` event map coverage.
  - Symbols: `testWorkflowCloseToMap`
  - Review relevance: Confirms backend payload keys and omitted navigation fields.

## Dependencies / Config / Migrations

- None captured. Xcode test commands repeatedly modified `Package.resolved` with package-resolution churn; the agent removed those generated side effects before committing.

## Validation

- Commands run:
  - `rtk xcodebuild test -project RevenueCat.xcodeproj -scheme RevenueCatUITests -destination 'platform=iOS Simulator,id=5A55C411-0B28-48BB-B787-0509F097550E' -only-testing:RevenueCatUITests/WorkflowPaywallViewTests`: passed after the original fix and again after the Bugbot follow-up.
  - `rtk xcodebuild test -project RevenueCat.xcodeproj -scheme RevenueCatUITests -destination 'platform=iOS Simulator,id=5A55C411-0B28-48BB-B787-0509F097550E' -only-testing:RevenueCatUITests/PresentIfNeededTests`: passed after the original fix and again after the Bugbot follow-up.
  - `rtk xcodebuild test -project RevenueCat.xcodeproj -scheme RevenueCat -testPlan CI-RevenueCat -destination 'platform=iOS Simulator,id=5A55C411-0B28-48BB-B787-0509F097550E' -derivedDataPath /private/tmp/rc-events-deriveddata-7040 -only-testing:UnitTests/EventsManagerTests/testWorkflowCloseToMap`: passed.
  - `rtk swiftlint lint RevenueCatUI/Modifiers/EnvironmentValues+Workflow.swift RevenueCatUI/Templates/V2/WorkflowPaywallView.swift RevenueCatUI/View+PresentPaywall.swift Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift Tests/UnitTests/Events/EventsManagerTests.swift`: passed with 0 violations.
  - `rtk swiftlint lint RevenueCatUI/View+PresentPaywall.swift RevenueCatUI/Modifiers/EnvironmentValues+Workflow.swift RevenueCatUI/Templates/V2/WorkflowPaywallView.swift Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift Tests/UnitTests/Events/EventsManagerTests.swift`: passed with 0 violations after the Bugbot follow-up.
  - `rtk git diff --check`: passed.
- Manual verification:
  - Not run.
- CI:
  - Not captured after the latest push.

## Validation Gaps

- No full RevenueCatUI test suite run in this session.
- No manual PaywallsTester verification of workflow purchase, restore-close, and restore-stays-visible event emission.
- No true SwiftUI lifecycle/integration test asserting `WorkflowPaywallView.onDisappear` observes the completion signal after presenter dismissal.

## Review Focus

- Confirm the shared presenter changes remain behaviorally inert for regular paywalls.
- Confirm purchase completion is marked before presenter close branches can cause the workflow view to disappear.
- Confirm restore semantics are correct across `presentPaywallIfNeeded` (`success && !shouldDisplay`) and direct binding presentation (successful restore closes by design).
- Confirm `workflows_close` payload mapping includes required workflow fields and omits navigation-only fields.

## Risks / Reviewer Notes

- Risk: Shared presenter code now carries workflow-only state.
  - Evidence: Search showed only `WorkflowPaywallView` reads `workflowCompletedInSessionBinding`; regular paywall paths ignore it. `PresentIfNeededTests` passed.
  - Mitigation: Keep comments explicit and review future consumers of the environment key.
- Risk: No end-to-end lifecycle test for the exact SwiftUI dismissal timing.
  - Evidence: Current automated coverage validates helper behavior and existing shared presenter behavior, not full lifecycle event emission.
  - Mitigation: Reviewer can manually verify in PaywallsTester or add an integration-style lifecycle test if feasible.
- Risk: First unit-test run failed with broad unrelated RevenueCat linker errors from shared DerivedData.
  - Evidence: Same focused event-map test passed with isolated DerivedData.
  - Mitigation: Reported as build-state issue, not hidden.

## Non-goals / Out of Scope

- No changes to public API.
- No changes to UIKit presenter wiring beyond relying on the workflow view's local purchase-completion signal.
- No changes to labels or CI configuration.

## Omitted Context

Raw transcript, unrelated exploration, sensitive details, repetitive attempts, and chain-of-thought-style content were omitted.

</details>