### PR TITLE
Add Danger check to discourage large PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,7 @@ For snapshot testing, sample applications, pre-commit hooks, and release process
 
 ### Size & Structure
 
-- **Prefer smaller, self-contained stacked PRs** when possible. "Self-contained" means the PR compiles, passes tests, and is reviewable on its own. As a rule of thumb, aim to keep the diff under ~500 lines of hand-written source — excluding generated, serialized, or non-reviewed files (e.g. JSON, snapshots, lockfiles, `api/*.swiftinterface`). For larger tasks, plan the PR breakdown up front and stack interdependent changes instead of bundling everything into one large PR.
+- **Prefer smaller, self-contained stacked PRs** when possible. "Self-contained" means the PR compiles, passes tests, and is reviewable on its own. As a rule of thumb, aim to keep the diff under ~300 lines of hand-written source — excluding generated, serialized, or non-reviewed files (e.g. JSON, snapshots, lockfiles, `api/*.swiftinterface`) and test or example app files. For larger tasks, plan the PR breakdown up front and stack interdependent changes instead of bundling everything into one large PR.
 
 ### Description
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -32,7 +32,8 @@ def production_swift_file?(path)
   return false unless path.end_with?('.swift')
   return false if path.start_with?('Sources/Generated/')
 
-  path.start_with?('Sources/') || path.start_with?('RevenueCatUI/')
+  path.start_with?('Sources/') || path.start_with?('RevenueCatUI/') ||
+    path.start_with?('RulesEngineInternal/')
 end
 
 def project_swift_file_paths(project_file)

--- a/Dangerfile
+++ b/Dangerfile
@@ -9,6 +9,9 @@ EXCLUDED_SWIFT_PATH_PREFIXES = [
 
 COMMENT_MARKER = "<!-- purchases-ios-danger -->"
 
+PROD_LINES_LIMIT = 300
+SKIP_SIZE_LABEL = "skip-pr-lines-changed-check"
+
 def normalize_path(path)
   Pathname(path).cleanpath.to_s.sub(%r{\A\./}, '')
 end
@@ -22,6 +25,14 @@ def relevant_swift_file?(path)
   in_tests = path.start_with?('Tests/')
 
   in_project_sources || in_tests
+end
+
+def production_swift_file?(path)
+  path = normalize_path(path)
+  return false unless path.end_with?('.swift')
+  return false if path.start_with?('Sources/Generated/')
+
+  path.start_with?('Sources/') || path.start_with?('RevenueCatUI/')
 end
 
 def project_swift_file_paths(project_file)
@@ -117,6 +128,29 @@ def public_enum_messages
   [[], [message]]
 end
 
+# Fail PRs that change too many lines of production Swift code.
+# Large PRs are hard to review well, so we cap the churn (insertions + deletions)
+# across real .swift files, excluding tests, example apps, and generated output.
+# Authors who legitimately need a large PR can add the bypass label.
+def pr_size_messages
+  prod_files = (git.modified_files + git.added_files).uniq.select { |f| production_swift_file?(f) }
+
+  total_changed = prod_files.sum do |f|
+    info = git.info_for_file(f)
+    info ? info[:insertions] + info[:deletions] : 0
+  end
+
+  return [[], []] if total_changed <= PROD_LINES_LIMIT
+
+  if github.pr_labels.include?(SKIP_SIZE_LABEL)
+    [[], ["This PR changes #{total_changed} lines of production Swift (limit #{PROD_LINES_LIMIT}); " \
+          "skipped via `#{SKIP_SIZE_LABEL}` label."]]
+  else
+    [["This PR changes #{total_changed} lines of production Swift code, over the #{PROD_LINES_LIMIT}-line " \
+      "limit. Split it into smaller PRs, or add the `#{SKIP_SIZE_LABEL}` label to bypass."], []]
+  end
+end
+
 # Collect all issues
 all_failures = []
 all_warnings = []
@@ -131,6 +165,10 @@ all_failures.concat(f)
 all_warnings.concat(w)
 
 f, w = public_enum_messages
+all_failures.concat(f)
+all_warnings.concat(w)
+
+f, w = pr_size_messages
 all_failures.concat(f)
 all_warnings.concat(w)
 


### PR DESCRIPTION
## Why

Large PRs are slow and error-prone to review, and problems are more likely to slip through. This adds a Danger check that nudges us toward smaller, more focused PRs.

## What

Fails the Danger check when a PR changes more than 300 lines of production Swift code (insertions + deletions). Test sources, example apps, and generated output are excluded so only "real" code counts.

When a large PR is genuinely necessary, add the `skip-pr-lines-changed-check` label to bypass the failure.

Mirrors the equivalent Android check: https://github.com/RevenueCat/purchases-android/pull/3543

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/documentation only; no SDK runtime or public API behavior changes.
> 
> **Overview**
> Adds a **Danger gate** that **fails** when a PR’s **production Swift** churn (insertions + deletions) exceeds **300 lines**, counting only `Sources/`, `RevenueCatUI/`, and `RulesEngineInternal/` while **excluding** tests, example apps, and `Sources/Generated/`.
> 
> Authors can bypass with the **`skip-pr-lines-changed-check`** label (warns instead of failing). **`AGENTS.md`** is updated to match the **~300-line** guideline and to call out test/example exclusions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08d4474e7bdc7b5156f1bfb1429ce99d0abfe9ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->