### PR TITLE
Remove unused pollRewardVerificationStatus

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1726,22 +1726,10 @@ extension Purchases {
 
 extension Purchases {
 
-    /// Polls the backend once for reward verification status using `client_transaction_id`.
+    /// Fetches reward-verification status preserving the structured ``BackendError`` so the poller
+    /// can reuse the SDK's retry classification (``BackendError/isTransient``).
     ///
     /// Cancelling the calling `Task` does not cancel the in-flight HTTP request.
-    func pollRewardVerificationStatus(
-        clientTransactionID: String
-    ) async throws -> RewardVerificationPollStatus {
-        do {
-            return try await self.fetchRewardVerificationStatus(clientTransactionID: clientTransactionID)
-        } catch let error as BackendError {
-            throw error.asPublicError
-        }
-    }
-
-    /// Fetches reward-verification status preserving the structured ``BackendError`` so the poller
-    /// can reuse the SDK's retry classification (``BackendError/isTransient``). The public
-    /// ``pollRewardVerificationStatus(clientTransactionID:)`` wraps this and flattens to a public error.
     ///
     /// - Throws: `BackendError`
     internal func fetchRewardVerificationStatus(

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesRewardVerificationTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesRewardVerificationTests.swift
@@ -31,11 +31,11 @@ final class PurchasesRewardVerificationTests: BasePurchasesTests {
         self.setupPurchases()
     }
 
-    func testPollRewardVerificationStatusMapsUnknownStatusToUnknown() async throws {
+    func testFetchRewardVerificationStatusMapsUnknownStatusToUnknown() async throws {
         let transactionID = "AABBCCDD-1111-2222-3333-444455556666"
         try self.mockAdsAPI.stubbedGetRewardVerificationStatusResult = .success(.init(status: .unknown))
 
-        let status = try await self.purchases.pollRewardVerificationStatus(clientTransactionID: transactionID)
+        let status = try await self.purchases.fetchRewardVerificationStatus(clientTransactionID: transactionID)
 
         expect(status) == .unknown
         expect(try self.mockAdsAPI.invokedGetRewardVerificationStatusCount) == 1
@@ -44,56 +44,56 @@ final class PurchasesRewardVerificationTests: BasePurchasesTests {
         expect(try self.mockAdsAPI.invokedGetRewardVerificationStatusParameters?.clientTransactionID) == transactionID
     }
 
-    func testPollRewardVerificationStatusMapsVerifiedStatusWithVirtualCurrencyReward() async throws {
+    func testFetchRewardVerificationStatusMapsVerifiedStatusWithVirtualCurrencyReward() async throws {
         let reward = try XCTUnwrap(VirtualCurrencyReward(code: "coins", amount: 10))
         try self.mockAdsAPI.stubbedGetRewardVerificationStatusResult = .success(
             .init(status: .verified(.virtualCurrency(reward)))
         )
 
-        let status = try await self.purchases.pollRewardVerificationStatus(clientTransactionID: "tx-id")
+        let status = try await self.purchases.fetchRewardVerificationStatus(clientTransactionID: "tx-id")
 
         expect(status) == .verified(.virtualCurrency(reward))
     }
 
-    func testPollRewardVerificationStatusMapsVerifiedStatusWithNoReward() async throws {
+    func testFetchRewardVerificationStatusMapsVerifiedStatusWithNoReward() async throws {
         try self.mockAdsAPI.stubbedGetRewardVerificationStatusResult = .success(
             .init(status: .verified(.noReward))
         )
 
-        let status = try await self.purchases.pollRewardVerificationStatus(clientTransactionID: "tx-id")
+        let status = try await self.purchases.fetchRewardVerificationStatus(clientTransactionID: "tx-id")
 
         expect(status) == .verified(.noReward)
     }
 
-    func testPollRewardVerificationStatusMapsVerifiedStatusWithUnsupportedReward() async throws {
+    func testFetchRewardVerificationStatusMapsVerifiedStatusWithUnsupportedReward() async throws {
         try self.mockAdsAPI.stubbedGetRewardVerificationStatusResult = .success(
             .init(status: .verified(.unsupportedReward))
         )
 
-        let status = try await self.purchases.pollRewardVerificationStatus(clientTransactionID: "tx-id")
+        let status = try await self.purchases.fetchRewardVerificationStatus(clientTransactionID: "tx-id")
 
         expect(status) == .verified(.unsupportedReward)
     }
 
-    func testPollRewardVerificationStatusMapsPendingStatus() async throws {
+    func testFetchRewardVerificationStatusMapsPendingStatus() async throws {
         try self.mockAdsAPI.stubbedGetRewardVerificationStatusResult = .success(.init(status: .pending))
 
-        let status = try await self.purchases.pollRewardVerificationStatus(clientTransactionID: "tx-id")
+        let status = try await self.purchases.fetchRewardVerificationStatus(clientTransactionID: "tx-id")
 
         expect(status) == .pending
     }
 
-    func testPollRewardVerificationStatusMapsFailedStatus() async throws {
+    func testFetchRewardVerificationStatusMapsFailedStatus() async throws {
         try self.mockAdsAPI.stubbedGetRewardVerificationStatusResult = .success(
             .init(status: .failed(.init(reason: nil, message: nil)))
         )
 
-        let status = try await self.purchases.pollRewardVerificationStatus(clientTransactionID: "tx-id")
+        let status = try await self.purchases.fetchRewardVerificationStatus(clientTransactionID: "tx-id")
 
         expect(status) == .failed(reason: nil, message: nil)
     }
 
-    func testPollRewardVerificationStatusForwardsFailureReasonAndMessage() async throws {
+    func testFetchRewardVerificationStatusForwardsFailureReasonAndMessage() async throws {
         try self.mockAdsAPI.stubbedGetRewardVerificationStatusResult = .success(
             .init(status: .failed(.init(
                 reason: "no_access",
@@ -101,7 +101,7 @@ final class PurchasesRewardVerificationTests: BasePurchasesTests {
             )))
         )
 
-        let status = try await self.purchases.pollRewardVerificationStatus(clientTransactionID: "tx-id")
+        let status = try await self.purchases.fetchRewardVerificationStatus(clientTransactionID: "tx-id")
 
         expect(status) == .failed(
             reason: "no_access",
@@ -109,15 +109,15 @@ final class PurchasesRewardVerificationTests: BasePurchasesTests {
         )
     }
 
-    func testPollRewardVerificationStatusForwardsBackendError() async throws {
+    func testFetchRewardVerificationStatusForwardsBackendError() async throws {
         let backendError: BackendError = .networkError(.offlineConnection())
         try self.mockAdsAPI.stubbedGetRewardVerificationStatusResult = .failure(backendError)
 
         do {
-            _ = try await self.purchases.pollRewardVerificationStatus(clientTransactionID: "tx-id")
-            fail("Expected pollRewardVerificationStatus to throw")
+            _ = try await self.purchases.fetchRewardVerificationStatus(clientTransactionID: "tx-id")
+            fail("Expected fetchRewardVerificationStatus to throw")
         } catch {
-            expect(error).to(matchError(backendError.asPurchasesError))
+            expect(error).to(matchError(backendError))
         }
     }
 


### PR DESCRIPTION
### Motivation

I noticed this left-over from a previous refactor.

The method `Purchases.pollRewardVerificationStatus(clientTransactionID:)` is a dead internal wrapper around `fetchRewardVerificationStatus(clientTransactionID:)`. It has no production callers.

The AdMob adapter polls via the `@_spi(Experimental)` full-loop `pollRewardVerification(clientTransactionID:)`, and the internal `RewardVerification.PurchasesStatusPoller` calls `fetchRewardVerificationStatus` directly. Only unit tests referenced it.

### Description

Removed the method and repointed its unit tests to `fetchRewardVerificationStatus`.

No API impact: the method was internal-only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal dead-code removal with test-only call-site updates; no production callers or public API surface affected.
> 
> **Overview**
> Removes the unused internal **`pollRewardVerificationStatus(clientTransactionID:)`** wrapper on **`Purchases`**, which only forwarded to **`fetchRewardVerificationStatus`** and mapped **`BackendError`** to public errors. Production polling already uses **`fetchRewardVerificationStatus`** (via **`RewardVerification.PurchasesStatusPoller`**) so transient-retry behavior is unchanged.
> 
> Unit tests now exercise **`fetchRewardVerificationStatus`** directly and assert thrown **`BackendError`** values instead of flattened purchase errors. No public or SPI API changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5bbfc7f6d2fad42b330f8460550232f43eca6da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->