### PR TITLE
Expose `autoResumeDate` and `productPlanIdentifier` on `SubscriptionInfo`

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1803,6 +1803,7 @@
 		2DD500CE2C519EB4009C19B7 /* ProxyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyView.swift; sourceTree = "<group>"; };
 		2DD500CF2C519EB4009C19B7 /* ProxyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyViewModel.swift; sourceTree = "<group>"; };
 		2DD500D12C519EB4009C19B7 /* CustomerInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoView.swift; sourceTree = "<group>"; };
+		2DD5DA7E00000000F0010001 /* SubscriptionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionsView.swift; sourceTree = "<group>"; };
 		2DD500D22C519EB4009C19B7 /* CustomerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerView.swift; sourceTree = "<group>"; };
 		2DD500D32C519EB4009C19B7 /* EntitlementsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntitlementsView.swift; sourceTree = "<group>"; };
 		2DD500D42C519EB4009C19B7 /* SubscriberAttributesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriberAttributesView.swift; sourceTree = "<group>"; };
@@ -3898,6 +3899,7 @@
 			isa = PBXGroup;
 			children = (
 				2DD500D12C519EB4009C19B7 /* CustomerInfoView.swift */,
+				2DD5DA7E00000000F0010001 /* SubscriptionsView.swift */,
 				2DD500D22C519EB4009C19B7 /* CustomerView.swift */,
 				2DD500D32C519EB4009C19B7 /* EntitlementsView.swift */,
 				2DD500D42C519EB4009C19B7 /* SubscriberAttributesView.swift */,

--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -285,6 +285,7 @@ public typealias ProductIdentifier = String
                 periodType: subscriptionData.periodType,
                 refundedAt: subscriptionData.refundedAt,
                 storeTransactionId: subscriptionData.storeTransactionId,
+                autoResumeDate: subscriptionData.autoResumeDate,
                 requestDate: response.requestDate,
                 price: subscriptionData.price.map { ProductPaidPrice(currency: $0.currency, amount: $0.amount) },
                 managementURL: subscriptionData.managementUrl,

--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -289,7 +289,8 @@ public typealias ProductIdentifier = String
                 requestDate: response.requestDate,
                 price: subscriptionData.price.map { ProductPaidPrice(currency: $0.currency, amount: $0.amount) },
                 managementURL: subscriptionData.managementUrl,
-                displayName: subscriptionData.displayName
+                displayName: subscriptionData.displayName,
+                productPlanIdentifier: subscriptionData.productPlanIdentifier
             ))
         })
 

--- a/Sources/Identity/SubscriptionInfo.swift
+++ b/Sources/Identity/SubscriptionInfo.swift
@@ -85,6 +85,10 @@ import Foundation
     /// Management purchase URL
     @objc public let managementURL: URL?
 
+    /// The base plan identifier that unlocked this subscription (Google Play base plans
+    /// and Apple purchases with non-upfront billing plans).
+    @objc public let productPlanIdentifier: String?
+
     init(productIdentifier: String,
          purchaseDate: Date,
          originalPurchaseDate: Date?,
@@ -102,7 +106,8 @@ import Foundation
          requestDate: Date,
          price: ProductPaidPrice?,
          managementURL: URL?,
-         displayName: String?) {
+         displayName: String?,
+         productPlanIdentifier: String?) {
         self.productIdentifier = productIdentifier
         self.purchaseDate = purchaseDate
         self.originalPurchaseDate = originalPurchaseDate
@@ -126,6 +131,7 @@ import Foundation
         self.price = price
         self.managementURL = managementURL
         self.displayName = displayName
+        self.productPlanIdentifier = productPlanIdentifier
 
         super.init()
     }
@@ -149,7 +155,8 @@ import Foundation
             isActive: \(isActive),
             willRenew: \(willRenew),
             managementURL: \(String(describing: managementURL)),
-            displayName: \(String(describing: displayName))
+            displayName: \(String(describing: displayName)),
+            productPlanIdentifier: \(String(describing: productPlanIdentifier))
         }
         """
     }

--- a/Sources/Identity/SubscriptionInfo.swift
+++ b/Sources/Identity/SubscriptionInfo.swift
@@ -49,6 +49,10 @@ import Foundation
     /// nil if the customer has never been in a grace period.
     @objc public let gracePeriodExpiresDate: Date?
 
+    /// Date when a paused subscription is expected to automatically resume.
+    /// Only set for Google Play subscriptions that have been paused; nil otherwise.
+    @objc public let autoResumeDate: Date?
+
     /// How the Customer received access to this subscription:
     /// - ``PurchaseOwnershipType/purchased``: The customer bought the subscription.
     /// - ``PurchaseOwnershipType/familyShared``: The Customer has access to the product via their family.
@@ -94,6 +98,7 @@ import Foundation
          periodType: PeriodType,
          refundedAt: Date?,
          storeTransactionId: String?,
+         autoResumeDate: Date?,
          requestDate: Date,
          price: ProductPaidPrice?,
          managementURL: URL?,
@@ -107,6 +112,7 @@ import Foundation
         self.unsubscribeDetectedAt = unsubscribeDetectedAt
         self.billingIssuesDetectedAt = billingIssuesDetectedAt
         self.gracePeriodExpiresDate = gracePeriodExpiresDate
+        self.autoResumeDate = autoResumeDate
         self.ownershipType = ownershipType
         self.periodType = periodType
         self.refundedAt = refundedAt
@@ -135,6 +141,7 @@ import Foundation
             unsubscribeDetectedAt: \(String(describing: unsubscribeDetectedAt)),
             billingIssuesDetectedAt: \(String(describing: billingIssuesDetectedAt)),
             gracePeriodExpiresDate: \(String(describing: gracePeriodExpiresDate)),
+            autoResumeDate: \(String(describing: autoResumeDate)),
             ownershipType: \(ownershipType),
             periodType: \(String(describing: periodType)),
             refundedAt: \(String(describing: refundedAt)),

--- a/Sources/Networking/Responses/CustomerInfoResponse.swift
+++ b/Sources/Networking/Responses/CustomerInfoResponse.swift
@@ -65,6 +65,7 @@ extension CustomerInfoResponse {
         var gracePeriodExpiresDate: Date?
         var refundedAt: Date?
         var storeTransactionId: String?
+        var autoResumeDate: Date?
 
         var displayName: String?
 

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCSubscriptionInfoAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCSubscriptionInfoAPI.m
@@ -32,6 +32,7 @@
     BOOL willRenew __unused = subscription.willRenew;
     NSString *displayName __unused = subscription.displayName;
     NSURL *managementURL __unused = subscription.managementURL;
+    NSString *productPlanIdentifier __unused = subscription.productPlanIdentifier;
 }
 
 @end

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCSubscriptionInfoAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCSubscriptionInfoAPI.m
@@ -23,6 +23,7 @@
     NSDate *unsubscribeDetectedAt __unused = subscription.unsubscribeDetectedAt;
     NSDate *billingIssuesDetectedAt __unused = subscription.billingIssuesDetectedAt;
     NSDate *gracePeriodExpiresDate __unused = subscription.gracePeriodExpiresDate;
+    NSDate *autoResumeDate __unused = subscription.autoResumeDate;
     RCPurchaseOwnershipType ownershipType __unused = subscription.ownershipType;
     RCPeriodType periodType __unused = subscription.periodType;
     NSDate *refundedAt __unused = subscription.refundedAt;

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/SubscriptionInfoAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/SubscriptionInfoAPI.swift
@@ -26,6 +26,7 @@ func checkSubscriptionInfoAPI() {
     let uda: Date? = subscription.unsubscribeDetectedAt
     let bida: Date? = subscription.billingIssuesDetectedAt
     let gped: Date? = subscription.gracePeriodExpiresDate
+    let ard: Date? = subscription.autoResumeDate
     let oType: PurchaseOwnershipType = subscription.ownershipType
     let pType: PeriodType = subscription.periodType
     let rAt: Date? = subscription.refundedAt

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/SubscriptionInfoAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/SubscriptionInfoAPI.swift
@@ -36,4 +36,5 @@ func checkSubscriptionInfoAPI() {
     let displayName: String? = subscription.displayName
     let managementURL: URL? = subscription.managementURL
     let price: ProductPaidPrice? = subscription.price
+    let productPlanIdentifier: String? = subscription.productPlanIdentifier
 }

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		2C10F19127AC31610078444D /* TransactionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C10F19027AC31610078444D /* TransactionsView.swift */; };
 		2C10F19427AC319A0078444D /* EntitlementsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C10F19327AC319A0078444D /* EntitlementsView.swift */; };
 		2C10F19727AC31B80078444D /* CustomerInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C10F19627AC31B80078444D /* CustomerInfoView.swift */; };
+		2CAB4369000000000000F002 /* SubscriptionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAB4369000000000000F001 /* SubscriptionsView.swift */; };
 		2C10F19A27AC32840078444D /* SubscriberAttributesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C10F19927AC32840078444D /* SubscriberAttributesView.swift */; };
 		2CD2C516278C9B02005D1CC2 /* PurchaseTesterApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD2C4EE278C9B01005D1CC2 /* PurchaseTesterApp.swift */; };
 		2CD2C518278C9B02005D1CC2 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD2C4EF278C9B01005D1CC2 /* ContentView.swift */; };
@@ -127,6 +128,7 @@
 		2C10F19027AC31610078444D /* TransactionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionsView.swift; sourceTree = "<group>"; };
 		2C10F19327AC319A0078444D /* EntitlementsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntitlementsView.swift; sourceTree = "<group>"; };
 		2C10F19627AC31B80078444D /* CustomerInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoView.swift; sourceTree = "<group>"; };
+		2CAB4369000000000000F001 /* SubscriptionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionsView.swift; sourceTree = "<group>"; };
 		2C10F19927AC32840078444D /* SubscriberAttributesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriberAttributesView.swift; sourceTree = "<group>"; };
 		2C8C610D27CEBEF200F86F21 /* PurchaseTester-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "PurchaseTester-Info.plist"; sourceTree = "<group>"; };
 		2CCAF2AB286232EB0004E2CA /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
@@ -229,6 +231,7 @@
 			children = (
 				2C10F18A27A997570078444D /* CustomerView.swift */,
 				2C10F19627AC31B80078444D /* CustomerInfoView.swift */,
+				2CAB4369000000000000F001 /* SubscriptionsView.swift */,
 				2C10F19327AC319A0078444D /* EntitlementsView.swift */,
 				2C10F19027AC31610078444D /* TransactionsView.swift */,
 				2C10F19927AC32840078444D /* SubscriberAttributesView.swift */,
@@ -527,6 +530,7 @@
 				575642A6290C7D3100719219 /* Windows.swift in Sources */,
 				57B5795729536B8C003EAA40 /* ProductFetcherSK1.swift in Sources */,
 				2C10F19727AC31B80078444D /* CustomerInfoView.swift in Sources */,
+				2CAB4369000000000000F002 /* SubscriptionsView.swift in Sources */,
 				57ED6A86290893B6009580C6 /* Extensions.swift in Sources */,
 				57ED6A8229089111009580C6 /* Identifiable.swift in Sources */,
 				4F1F5E9B2A18124C00C4EB88 /* ProxyViewModel.swift in Sources */,

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Customer/CustomerInfoView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Customer/CustomerInfoView.swift
@@ -24,8 +24,9 @@ struct CustomerInfoView: View {
                     }
                 }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(.horizontal, 20)
+        .padding(.horizontal)
     }
 
 }

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Customer/CustomerView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Customer/CustomerView.swift
@@ -42,15 +42,20 @@ struct CustomerView: View {
                     Image(systemName: "2.square.fill")
                     Text("Entitlements")
                 }
-            TransactionsView(customerInfo: self.customerInfo)
+            SubscriptionsView(customerInfo: self.customerInfo)
                 .tabItem {
                     Image(systemName: "3.square.fill")
+                    Text("Subscriptions")
+                }
+            TransactionsView(customerInfo: self.customerInfo)
+                .tabItem {
+                    Image(systemName: "4.square.fill")
                     Text("Transactions")
                 }
             SubscriberAttributesView(customerInfo: self.customerInfo)
                 .tabItem {
-                    Image(systemName: "4.square.fill")
-                    Text("Subscriber Atts")
+                    Image(systemName: "5.square.fill")
+                    Text("Attributes")
                 }
         }
         .navigationTitle("Customer Info")

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Customer/SubscriptionsView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Customer/SubscriptionsView.swift
@@ -47,46 +47,19 @@ private extension SubscriptionsView {
 
     func rows(for subscription: SubscriptionInfo) -> [(name: String, value: String)] {
         return [
-            ("Store", self.storeName(subscription.store)),
+            ("Store", "\(subscription.store)"),
             ("Is Active", "\(subscription.isActive)"),
             ("Will Renew", "\(subscription.willRenew)"),
-            ("Period Type", self.periodTypeName(subscription.periodType)),
+            ("Period Type", "\(subscription.periodType)"),
             ("Expires Date", self.date(subscription.expiresDate) ?? "-"),
             ("Grace Period Expires", self.date(subscription.gracePeriodExpiresDate) ?? "-"),
             ("Auto Resume Date", self.date(subscription.autoResumeDate) ?? "-"),
+            ("Product Plan Identifier", subscription.productPlanIdentifier ?? "-"),
         ]
     }
 
     func date(_ date: Date?) -> String? {
         return date.map { $0.formatted() }
-    }
-
-    func storeName(_ store: Store) -> String {
-        switch store {
-        case .appStore: return "App Store"
-        case .macAppStore: return "Mac App Store"
-        case .playStore: return "Play Store"
-        case .stripe: return "Stripe"
-        case .promotional: return "Promotional"
-        case .unknownStore: return "Unknown"
-        case .amazon: return "Amazon"
-        case .rcBilling: return "RevenueCat Billing"
-        case .external: return "External"
-        case .paddle: return "Paddle"
-        case .testStore: return "Test Store"
-        case .galaxy: return "Galaxy Store"
-        @unknown default: return "Unknown"
-        }
-    }
-
-    func periodTypeName(_ periodType: PeriodType) -> String {
-        switch periodType {
-        case .normal: return "Normal"
-        case .intro: return "Intro"
-        case .trial: return "Trial"
-        case .prepaid: return "Prepaid"
-        @unknown default: return "Unknown"
-        }
     }
 
 }

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Customer/SubscriptionsView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Customer/SubscriptionsView.swift
@@ -1,0 +1,92 @@
+//
+//  SubscriptionsView.swift
+//  PurchaseTester
+//
+//  Created by Álvaro Brey.
+//
+
+import Foundation
+import SwiftUI
+import RevenueCat
+
+struct SubscriptionsView: View {
+
+    let customerInfo: CustomerInfo
+
+    var subscriptions: [SubscriptionInfo] {
+        return self.customerInfo.subscriptionsByProductIdentifier
+            .values
+            .sorted { $0.productIdentifier < $1.productIdentifier }
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 10) {
+                if self.subscriptions.isEmpty {
+                    Text("No subscriptions")
+                } else {
+                    ForEach(self.subscriptions, id: \.productIdentifier) { subscription in
+                        VStack(alignment: .leading, spacing: 0) {
+                            Text(subscription.productIdentifier)
+                                .bold()
+                            ForEach(self.rows(for: subscription), id: \.name) { row in
+                                Text("\(row.name): \(row.value)")
+                                    .font(.caption)
+                            }
+                        }
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }.padding(.horizontal)
+    }
+
+}
+
+private extension SubscriptionsView {
+
+    func rows(for subscription: SubscriptionInfo) -> [(name: String, value: String)] {
+        return [
+            ("Store", self.storeName(subscription.store)),
+            ("Is Active", "\(subscription.isActive)"),
+            ("Will Renew", "\(subscription.willRenew)"),
+            ("Period Type", self.periodTypeName(subscription.periodType)),
+            ("Expires Date", self.date(subscription.expiresDate) ?? "-"),
+            ("Grace Period Expires", self.date(subscription.gracePeriodExpiresDate) ?? "-"),
+            ("Auto Resume Date", self.date(subscription.autoResumeDate) ?? "-"),
+        ]
+    }
+
+    func date(_ date: Date?) -> String? {
+        return date.map { $0.formatted() }
+    }
+
+    func storeName(_ store: Store) -> String {
+        switch store {
+        case .appStore: return "App Store"
+        case .macAppStore: return "Mac App Store"
+        case .playStore: return "Play Store"
+        case .stripe: return "Stripe"
+        case .promotional: return "Promotional"
+        case .unknownStore: return "Unknown"
+        case .amazon: return "Amazon"
+        case .rcBilling: return "RevenueCat Billing"
+        case .external: return "External"
+        case .paddle: return "Paddle"
+        case .testStore: return "Test Store"
+        case .galaxy: return "Galaxy Store"
+        @unknown default: return "Unknown"
+        }
+    }
+
+    func periodTypeName(_ periodType: PeriodType) -> String {
+        switch periodType {
+        case .normal: return "Normal"
+        case .intro: return "Intro"
+        case .trial: return "Trial"
+        case .prepaid: return "Prepaid"
+        @unknown default: return "Unknown"
+        }
+    }
+
+}

--- a/Tests/UnitTests/Networking/Responses/CustomerInfoDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/CustomerInfoDecodingTests.swift
@@ -212,6 +212,20 @@ class CustomerInfoVersion2DecodingTests: BaseHTTPResponseTest {
         )
         expect(pausedSubscription.store) == .playStore
         expect(pausedSubscription.autoResumeDate) == dateFormatter.date(from: "2023-02-01T00:00:00Z")
+        expect(pausedSubscription.productPlanIdentifier) == "annual-plan"
+    }
+
+    func testSubscriptionsByProductIdentifierExposesAutoResumeDateAndProductPlan() throws {
+        let subscriptions = self.customerInfo.subscriptionsByProductIdentifier
+
+        let pausedSubscription = try XCTUnwrap(subscriptions["com.revenuecat.annual_39.99.2_week_intro"])
+        expect(pausedSubscription.store) == .playStore
+        expect(pausedSubscription.autoResumeDate) == dateFormatter.date(from: "2023-02-01T00:00:00Z")
+        expect(pausedSubscription.productPlanIdentifier) == "annual-plan"
+
+        let activeSubscription = try XCTUnwrap(subscriptions["com.revenuecat.monthly_4.99.1_week_intro"])
+        expect(activeSubscription.autoResumeDate).to(beNil())
+        expect(activeSubscription.productPlanIdentifier).to(beNil())
     }
 
     func testEntitlements() throws {

--- a/Tests/UnitTests/Networking/Responses/CustomerInfoDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/CustomerInfoDecodingTests.swift
@@ -205,6 +205,13 @@ class CustomerInfoVersion2DecodingTests: BaseHTTPResponseTest {
         expect(subscription.purchaseDate) == dateFormatter.date(from: "2023-01-12T20:29:44Z")
         expect(subscription.store) == .appStore
         expect(subscription.unsubscribeDetectedAt).to(beNil())
+        expect(subscription.autoResumeDate).to(beNil())
+
+        let pausedSubscription = try XCTUnwrap(
+            subscriber.subscriptions["com.revenuecat.annual_39.99.2_week_intro"]
+        )
+        expect(pausedSubscription.store) == .playStore
+        expect(pausedSubscription.autoResumeDate) == dateFormatter.date(from: "2023-02-01T00:00:00Z")
     }
 
     func testEntitlements() throws {

--- a/Tests/UnitTests/Networking/Responses/Fixtures/CustomerInfo-v2.json
+++ b/Tests/UnitTests/Networking/Responses/Fixtures/CustomerInfo-v2.json
@@ -47,7 +47,8 @@
                 "billing_issues_detected_at": null,
                 "ownership_type": "PURCHASED",
                 "store": "play_store",
-                "auto_resume_date": "2023-02-01T00:00:00Z"
+                "auto_resume_date": "2023-02-01T00:00:00Z",
+                "product_plan_identifier": "annual-plan"
             },
             "com.revenuecat.intro_test.monthly.1_week_intro": {
                 "original_purchase_date": "2022-12-21T18:14:53Z",

--- a/Tests/UnitTests/Networking/Responses/Fixtures/CustomerInfo-v2.json
+++ b/Tests/UnitTests/Networking/Responses/Fixtures/CustomerInfo-v2.json
@@ -46,8 +46,8 @@
                 "purchase_date": "2022-12-20T08:34:35Z",
                 "billing_issues_detected_at": null,
                 "ownership_type": "PURCHASED",
-                "store": "app_store",
-                "auto_resume_date": null
+                "store": "play_store",
+                "auto_resume_date": "2023-02-01T00:00:00Z"
             },
             "com.revenuecat.intro_test.monthly.1_week_intro": {
                 "original_purchase_date": "2022-12-21T18:14:53Z",

--- a/api/revenuecat-api-ios-simulator.swiftinterface
+++ b/api/revenuecat-api-ios-simulator.swiftinterface
@@ -260,6 +260,7 @@ extension RevenueCat.CustomerInfo : Swift.Identifiable {
   @objc final public let displayName: Swift.String?
   @objc final public let price: RevenueCat.ProductPaidPrice?
   @objc final public let managementURL: Foundation.URL?
+  @objc final public let productPlanIdentifier: Swift.String?
   @objc override final public var description: Swift.String {
     @objc get
   }

--- a/api/revenuecat-api-ios-simulator.swiftinterface
+++ b/api/revenuecat-api-ios-simulator.swiftinterface
@@ -250,6 +250,7 @@ extension RevenueCat.CustomerInfo : Swift.Identifiable {
   @objc final public let unsubscribeDetectedAt: Foundation.Date?
   @objc final public let billingIssuesDetectedAt: Foundation.Date?
   @objc final public let gracePeriodExpiresDate: Foundation.Date?
+  @objc final public let autoResumeDate: Foundation.Date?
   @objc final public let ownershipType: RevenueCat.PurchaseOwnershipType
   @objc final public let periodType: RevenueCat.PeriodType
   @objc final public let refundedAt: Foundation.Date?

--- a/api/revenuecat-api-ios.swiftinterface
+++ b/api/revenuecat-api-ios.swiftinterface
@@ -260,6 +260,7 @@ extension RevenueCat.CustomerInfo : Swift.Identifiable {
   @objc final public let displayName: Swift.String?
   @objc final public let price: RevenueCat.ProductPaidPrice?
   @objc final public let managementURL: Foundation.URL?
+  @objc final public let productPlanIdentifier: Swift.String?
   @objc override final public var description: Swift.String {
     @objc get
   }

--- a/api/revenuecat-api-ios.swiftinterface
+++ b/api/revenuecat-api-ios.swiftinterface
@@ -250,6 +250,7 @@ extension RevenueCat.CustomerInfo : Swift.Identifiable {
   @objc final public let unsubscribeDetectedAt: Foundation.Date?
   @objc final public let billingIssuesDetectedAt: Foundation.Date?
   @objc final public let gracePeriodExpiresDate: Foundation.Date?
+  @objc final public let autoResumeDate: Foundation.Date?
   @objc final public let ownershipType: RevenueCat.PurchaseOwnershipType
   @objc final public let periodType: RevenueCat.PeriodType
   @objc final public let refundedAt: Foundation.Date?

--- a/api/revenuecat-api-macos.swiftinterface
+++ b/api/revenuecat-api-macos.swiftinterface
@@ -261,6 +261,7 @@ extension RevenueCat.CustomerInfo : Swift.Identifiable {
   @objc final public let displayName: Swift.String?
   @objc final public let price: RevenueCat.ProductPaidPrice?
   @objc final public let managementURL: Foundation.URL?
+  @objc final public let productPlanIdentifier: Swift.String?
   @objc override final public var description: Swift.String {
     @objc get
   }

--- a/api/revenuecat-api-macos.swiftinterface
+++ b/api/revenuecat-api-macos.swiftinterface
@@ -251,6 +251,7 @@ extension RevenueCat.CustomerInfo : Swift.Identifiable {
   @objc final public let unsubscribeDetectedAt: Foundation.Date?
   @objc final public let billingIssuesDetectedAt: Foundation.Date?
   @objc final public let gracePeriodExpiresDate: Foundation.Date?
+  @objc final public let autoResumeDate: Foundation.Date?
   @objc final public let ownershipType: RevenueCat.PurchaseOwnershipType
   @objc final public let periodType: RevenueCat.PeriodType
   @objc final public let refundedAt: Foundation.Date?

--- a/api/revenuecat-api-tvos-simulator.swiftinterface
+++ b/api/revenuecat-api-tvos-simulator.swiftinterface
@@ -259,6 +259,7 @@ extension RevenueCat.CustomerInfo : Swift.Identifiable {
   @objc final public let displayName: Swift.String?
   @objc final public let price: RevenueCat.ProductPaidPrice?
   @objc final public let managementURL: Foundation.URL?
+  @objc final public let productPlanIdentifier: Swift.String?
   @objc override final public var description: Swift.String {
     @objc get
   }

--- a/api/revenuecat-api-tvos-simulator.swiftinterface
+++ b/api/revenuecat-api-tvos-simulator.swiftinterface
@@ -249,6 +249,7 @@ extension RevenueCat.CustomerInfo : Swift.Identifiable {
   @objc final public let unsubscribeDetectedAt: Foundation.Date?
   @objc final public let billingIssuesDetectedAt: Foundation.Date?
   @objc final public let gracePeriodExpiresDate: Foundation.Date?
+  @objc final public let autoResumeDate: Foundation.Date?
   @objc final public let ownershipType: RevenueCat.PurchaseOwnershipType
   @objc final public let periodType: RevenueCat.PeriodType
   @objc final public let refundedAt: Foundation.Date?

--- a/api/revenuecat-api-tvos.swiftinterface
+++ b/api/revenuecat-api-tvos.swiftinterface
@@ -259,6 +259,7 @@ extension RevenueCat.CustomerInfo : Swift.Identifiable {
   @objc final public let displayName: Swift.String?
   @objc final public let price: RevenueCat.ProductPaidPrice?
   @objc final public let managementURL: Foundation.URL?
+  @objc final public let productPlanIdentifier: Swift.String?
   @objc override final public var description: Swift.String {
     @objc get
   }

--- a/api/revenuecat-api-tvos.swiftinterface
+++ b/api/revenuecat-api-tvos.swiftinterface
@@ -249,6 +249,7 @@ extension RevenueCat.CustomerInfo : Swift.Identifiable {
   @objc final public let unsubscribeDetectedAt: Foundation.Date?
   @objc final public let billingIssuesDetectedAt: Foundation.Date?
   @objc final public let gracePeriodExpiresDate: Foundation.Date?
+  @objc final public let autoResumeDate: Foundation.Date?
   @objc final public let ownershipType: RevenueCat.PurchaseOwnershipType
   @objc final public let periodType: RevenueCat.PeriodType
   @objc final public let refundedAt: Foundation.Date?

--- a/api/revenuecat-api-visionos-simulator.swiftinterface
+++ b/api/revenuecat-api-visionos-simulator.swiftinterface
@@ -260,6 +260,7 @@ extension RevenueCat.CustomerInfo : Swift.Identifiable {
   @objc final public let displayName: Swift.String?
   @objc final public let price: RevenueCat.ProductPaidPrice?
   @objc final public let managementURL: Foundation.URL?
+  @objc final public let productPlanIdentifier: Swift.String?
   @objc override final public var description: Swift.String {
     @objc get
   }

--- a/api/revenuecat-api-visionos-simulator.swiftinterface
+++ b/api/revenuecat-api-visionos-simulator.swiftinterface
@@ -250,6 +250,7 @@ extension RevenueCat.CustomerInfo : Swift.Identifiable {
   @objc final public let unsubscribeDetectedAt: Foundation.Date?
   @objc final public let billingIssuesDetectedAt: Foundation.Date?
   @objc final public let gracePeriodExpiresDate: Foundation.Date?
+  @objc final public let autoResumeDate: Foundation.Date?
   @objc final public let ownershipType: RevenueCat.PurchaseOwnershipType
   @objc final public let periodType: RevenueCat.PeriodType
   @objc final public let refundedAt: Foundation.Date?

--- a/api/revenuecat-api-visionos.swiftinterface
+++ b/api/revenuecat-api-visionos.swiftinterface
@@ -260,6 +260,7 @@ extension RevenueCat.CustomerInfo : Swift.Identifiable {
   @objc final public let displayName: Swift.String?
   @objc final public let price: RevenueCat.ProductPaidPrice?
   @objc final public let managementURL: Foundation.URL?
+  @objc final public let productPlanIdentifier: Swift.String?
   @objc override final public var description: Swift.String {
     @objc get
   }

--- a/api/revenuecat-api-visionos.swiftinterface
+++ b/api/revenuecat-api-visionos.swiftinterface
@@ -250,6 +250,7 @@ extension RevenueCat.CustomerInfo : Swift.Identifiable {
   @objc final public let unsubscribeDetectedAt: Foundation.Date?
   @objc final public let billingIssuesDetectedAt: Foundation.Date?
   @objc final public let gracePeriodExpiresDate: Foundation.Date?
+  @objc final public let autoResumeDate: Foundation.Date?
   @objc final public let ownershipType: RevenueCat.PurchaseOwnershipType
   @objc final public let periodType: RevenueCat.PeriodType
   @objc final public let refundedAt: Foundation.Date?

--- a/api/revenuecat-api-watchos-simulator.swiftinterface
+++ b/api/revenuecat-api-watchos-simulator.swiftinterface
@@ -260,6 +260,7 @@ extension RevenueCat.CustomerInfo : Swift.Identifiable {
   @objc final public let displayName: Swift.String?
   @objc final public let price: RevenueCat.ProductPaidPrice?
   @objc final public let managementURL: Foundation.URL?
+  @objc final public let productPlanIdentifier: Swift.String?
   @objc override final public var description: Swift.String {
     @objc get
   }

--- a/api/revenuecat-api-watchos-simulator.swiftinterface
+++ b/api/revenuecat-api-watchos-simulator.swiftinterface
@@ -250,6 +250,7 @@ extension RevenueCat.CustomerInfo : Swift.Identifiable {
   @objc final public let unsubscribeDetectedAt: Foundation.Date?
   @objc final public let billingIssuesDetectedAt: Foundation.Date?
   @objc final public let gracePeriodExpiresDate: Foundation.Date?
+  @objc final public let autoResumeDate: Foundation.Date?
   @objc final public let ownershipType: RevenueCat.PurchaseOwnershipType
   @objc final public let periodType: RevenueCat.PeriodType
   @objc final public let refundedAt: Foundation.Date?

--- a/api/revenuecat-api-watchos.swiftinterface
+++ b/api/revenuecat-api-watchos.swiftinterface
@@ -260,6 +260,7 @@ extension RevenueCat.CustomerInfo : Swift.Identifiable {
   @objc final public let displayName: Swift.String?
   @objc final public let price: RevenueCat.ProductPaidPrice?
   @objc final public let managementURL: Foundation.URL?
+  @objc final public let productPlanIdentifier: Swift.String?
   @objc override final public var description: Swift.String {
     @objc get
   }

--- a/api/revenuecat-api-watchos.swiftinterface
+++ b/api/revenuecat-api-watchos.swiftinterface
@@ -250,6 +250,7 @@ extension RevenueCat.CustomerInfo : Swift.Identifiable {
   @objc final public let unsubscribeDetectedAt: Foundation.Date?
   @objc final public let billingIssuesDetectedAt: Foundation.Date?
   @objc final public let gracePeriodExpiresDate: Foundation.Date?
+  @objc final public let autoResumeDate: Foundation.Date?
   @objc final public let ownershipType: RevenueCat.PurchaseOwnershipType
   @objc final public let periodType: RevenueCat.PeriodType
   @objc final public let refundedAt: Foundation.Date?


### PR DESCRIPTION
Part of [SDK-4369: \[purchases-flutter\] Expose SubscriptionInfo / autoResumeDate on CustomerInfo](https://linear.app/revenuecat/issue/SDK-4369/purchases-flutter-expose-subscriptioninfo-autoresumedate-on)

* Exposes the previously unparsed `auto_resume_date` for subscriptions
* Adds a new tab to Customer Info in `PurchasesTester` to visualize subscription info:

<img width="500"  alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-19 at 15 59 20" src="https://github.com/user-attachments/assets/3d60e8ef-b6e4-4d77-ac72-7dfcf3da7dd6" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Additive public API on subscription/customer-info mapping could affect downstream SDKs and apps that depend on stable SubscriptionInfo shape, though behavior is read-only decoding.
> 
> **Overview**
> **`SubscriptionInfo`** now surfaces **`autoResumeDate`** (decoded from backend `auto_resume_date`, mainly for paused Google Play subs) and **`productPlanIdentifier`** (plan/base plan id), wired from **`CustomerInfoResponse.Subscription`** through **`CustomerInfo.subscriptionsByProductIdentifier`**.
> 
> Public API snapshots, Swift/ObjC API testers, and decoding tests (including **`CustomerInfo-v2.json`**) cover the new fields. **PurchaseTester** adds a **Subscriptions** tab that lists subscription details including auto-resume and plan id, with small layout tweaks on customer info screens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32d7633d580262323a227ddfe1fb9393be268ef7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Closes SDK-4381
