### PR TITLE
Bump sdks-common-config orb to 4.1.0

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1,7 +1,7 @@
 orbs:
   macos: circleci/macos@2.5.1
   slack: circleci/slack@5.0.0
-  revenuecat: revenuecat/sdks-common-config@4.0.0
+  revenuecat: revenuecat/sdks-common-config@4.1.0
   # Disabled until compatible with M1: codecov: codecov/codecov@3.3.0
   # codecov: codecov/codecov@3.3.0
 


### PR DESCRIPTION
Bump common config orb to 4.1.0 to include error codes reminder

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single orb version pin in CI config; no application or SDK code changes.
> 
> **Overview**
> Updates the shared **`revenuecat/sdks-common-config`** CircleCI orb from **4.0.0** to **4.1.0** in `.circleci/default_config.yml`.
> 
> That version is expected to pick up orb-side behavior around **error codes** (e.g. reminders when error-code maintenance is needed), without changing local job definitions or workflows in this repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddfb1b179e9f5d2e8234ec9348a670632283966f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->