### PR TITLE
Align iOS paywall preview mocks with web/dashboard catalog

### DIFF
--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallPreviewResourcesLoader.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallPreviewResourcesLoader.swift
@@ -173,19 +173,20 @@ class PaywallPreviewResourcesLoader {
 
     private static func subscriptionProduct(
         productIdentifier: String,
-        title: String,
+        description: String,
         price: Decimal,
         localizedPriceString: String,
         subscriptionPeriod: SubscriptionPeriod
     ) -> StoreProduct {
         return TestStoreProduct(
-            localizedTitle: title,
+            // Matches the web/dashboard `product.store_product_name` ("Pro Access").
+            localizedTitle: "Pro Access",
             price: price,
             currencyCode: "USD",
             localizedPriceString: localizedPriceString,
             productIdentifier: productIdentifier,
             productType: .autoRenewableSubscription,
-            localizedDescription: title,
+            localizedDescription: description,
             subscriptionPeriod: subscriptionPeriod,
             introductoryDiscount: introductoryOffer(),
             locale: previewLocale
@@ -197,7 +198,7 @@ class PaywallPreviewResourcesLoader {
     /// specifies a billing plan identifier.
     private static func previewStoreProductsByID() -> [String: StoreProduct] {
         let lifetime = TestStoreProduct(
-            localizedTitle: "Lifetime",
+            localizedTitle: "Pro Access",
             price: 119.99,
             currencyCode: "USD",
             localizedPriceString: "$119.99",
@@ -209,42 +210,42 @@ class PaywallPreviewResourcesLoader {
 
         let weekly = subscriptionProduct(
             productIdentifier: "com.revenuecat.weekly_product",
-            title: "Weekly",
+            description: "Weekly",
             price: 2.99,
             localizedPriceString: "$2.99",
             subscriptionPeriod: .init(value: 1, unit: .week)
         )
         let monthly = subscriptionProduct(
             productIdentifier: "com.revenuecat.monthly_product",
-            title: "Monthly",
+            description: "Monthly",
             price: 9.99,
             localizedPriceString: "$9.99",
             subscriptionPeriod: .init(value: 1, unit: .month)
         )
         let bimonthly = subscriptionProduct(
             productIdentifier: "com.revenuecat.bimonthly_product",
-            title: "2 Months",
+            description: "2 Months",
             price: 17.99,
             localizedPriceString: "$17.99",
             subscriptionPeriod: .init(value: 2, unit: .month)
         )
         let quarterly = subscriptionProduct(
             productIdentifier: "com.revenuecat.quarterly_product",
-            title: "3 Months",
+            description: "3 Months",
             price: 24.99,
             localizedPriceString: "$24.99",
             subscriptionPeriod: .init(value: 3, unit: .month)
         )
         let semester = subscriptionProduct(
             productIdentifier: "com.revenuecat.semester_product",
-            title: "6 Months",
+            description: "6 Months",
             price: 39.99,
             localizedPriceString: "$39.99",
             subscriptionPeriod: .init(value: 6, unit: .month)
         )
         let annual = subscriptionProduct(
             productIdentifier: "com.revenuecat.annual_product",
-            title: "Annual",
+            description: "Annual",
             price: 69.99,
             localizedPriceString: "$69.99",
             subscriptionPeriod: .init(value: 1, unit: .year)

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallPreviewResourcesLoader.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallPreviewResourcesLoader.swift
@@ -133,50 +133,138 @@ class PaywallPreviewResourcesLoader {
                 apiKey: "preview_api_key",
                 preferredLocalesProvider: .init(preferredLocaleOverride: nil)
             )
-            let offerings = OfferingsFactory(systemInfo: systemInfo).createOfferings(from: [
-                "com.revenuecat.lifetime_product": .init(sk1Product: PreviewMock.Product(
-                    price: 1.99,
-                    unit: .week,
-                    localizedTitle: "Lifeime"
-                )),
-                "com.revenuecat.annual_product": .init(sk1Product: PreviewMock.Product(
-                    price: 1.99,
-                    unit: .year,
-                    localizedTitle: "Annual"
-                )),
-                "com.revenuecat.semester_product": .init(sk1Product: PreviewMock.Product(
-                    price: 1.99,
-                    unit: .month,
-                    localizedTitle: "6 Month"
-                )),
-                "com.revenuecat.quarterly_product": .init(sk1Product: PreviewMock.Product(
-                    price: 1.99,
-                    unit: .week,
-                    localizedTitle: "3 Month"
-                )),
-                "com.revenuecat.bimonthly_product": .init(sk1Product: PreviewMock.Product(
-                    price: 1.99,
-                    unit: .week,
-                    localizedTitle: "2 Month"
-                )),
-                "com.revenuecat.monthly_product": .init(sk1Product: PreviewMock.Product(
-                    price: 1.99,
-                    unit: .month,
-                    localizedTitle: "Monthly"
-                )),
-                "com.revenuecat.weekly_product": .init(sk1Product: PreviewMock.Product(
-                    price: 1.99,
-                    unit: .week,
-                    localizedTitle: "Weekly"
-                ))
-            ], contents: Offerings.Contents(response: offeringsResponseWithPackages,
-                                            httpResponseOriginalSource: .mainServer),
-                                                               loadedFromDiskCache: false)
+            // Mock products for the preview offerings. Prices, subscription periods, and
+            // the single introductory offer ($1.99 for 1 week) are kept in sync with the
+            // web/dashboard preview tables so the rendering-validation screenshots show the
+            // same products, prices, and offers across platforms.
+            let storeProductsByID = Self.previewStoreProductsByID()
+
+            let offerings = OfferingsFactory(systemInfo: systemInfo).createOfferings(
+                from: storeProductsByID,
+                contents: Offerings.Contents(response: offeringsResponseWithPackages,
+                                             httpResponseOriginalSource: .mainServer),
+                loadedFromDiskCache: false
+            )
 
             result.merge(offerings!.all)
         }
 
         return result
+    }
+
+    // MARK: - Preview products
+
+    private static let previewLocale = Locale(identifier: "en_US")
+
+    /// A single introductory offer ($1.99 for 1 week) attached to every subscription.
+    /// Matches the offer values in the web/dashboard preview variable tables and makes
+    /// the products intro-offer eligible so offer-gated UI renders.
+    private static func introductoryOffer() -> TestStoreProductDiscount {
+        return TestStoreProductDiscount(
+            identifier: "intro_offer",
+            price: 1.99,
+            localizedPriceString: "$1.99",
+            paymentMode: .payUpFront,
+            subscriptionPeriod: .init(value: 1, unit: .week),
+            numberOfPeriods: 1,
+            type: .introductory
+        )
+    }
+
+    private static func subscriptionProduct(
+        productIdentifier: String,
+        title: String,
+        price: Decimal,
+        localizedPriceString: String,
+        subscriptionPeriod: SubscriptionPeriod
+    ) -> StoreProduct {
+        return TestStoreProduct(
+            localizedTitle: title,
+            price: price,
+            currencyCode: "USD",
+            localizedPriceString: localizedPriceString,
+            productIdentifier: productIdentifier,
+            productType: .autoRenewableSubscription,
+            localizedDescription: title,
+            subscriptionPeriod: subscriptionPeriod,
+            introductoryDiscount: introductoryOffer(),
+            locale: previewLocale
+        ).toStoreProduct()
+    }
+
+    /// Mock products keyed by both the base product identifier and the compound
+    /// "product:plan" identifier, so packages resolve whether or not packages.json
+    /// specifies a billing plan identifier.
+    private static func previewStoreProductsByID() -> [String: StoreProduct] {
+        let lifetime = TestStoreProduct(
+            localizedTitle: "Lifetime",
+            price: 119.99,
+            currencyCode: "USD",
+            localizedPriceString: "$119.99",
+            productIdentifier: "com.revenuecat.lifetime_product",
+            productType: .nonConsumable,
+            localizedDescription: "Lifetime",
+            locale: previewLocale
+        ).toStoreProduct()
+
+        let weekly = subscriptionProduct(
+            productIdentifier: "com.revenuecat.weekly_product",
+            title: "Weekly",
+            price: 2.99,
+            localizedPriceString: "$2.99",
+            subscriptionPeriod: .init(value: 1, unit: .week)
+        )
+        let monthly = subscriptionProduct(
+            productIdentifier: "com.revenuecat.monthly_product",
+            title: "Monthly",
+            price: 9.99,
+            localizedPriceString: "$9.99",
+            subscriptionPeriod: .init(value: 1, unit: .month)
+        )
+        let bimonthly = subscriptionProduct(
+            productIdentifier: "com.revenuecat.bimonthly_product",
+            title: "2 Months",
+            price: 17.99,
+            localizedPriceString: "$17.99",
+            subscriptionPeriod: .init(value: 2, unit: .month)
+        )
+        let quarterly = subscriptionProduct(
+            productIdentifier: "com.revenuecat.quarterly_product",
+            title: "3 Months",
+            price: 24.99,
+            localizedPriceString: "$24.99",
+            subscriptionPeriod: .init(value: 3, unit: .month)
+        )
+        let semester = subscriptionProduct(
+            productIdentifier: "com.revenuecat.semester_product",
+            title: "6 Months",
+            price: 39.99,
+            localizedPriceString: "$39.99",
+            subscriptionPeriod: .init(value: 6, unit: .month)
+        )
+        let annual = subscriptionProduct(
+            productIdentifier: "com.revenuecat.annual_product",
+            title: "Annual",
+            price: 69.99,
+            localizedPriceString: "$69.99",
+            subscriptionPeriod: .init(value: 1, unit: .year)
+        )
+
+        return [
+            "com.revenuecat.lifetime_product": lifetime,
+            "com.revenuecat.weekly_product": weekly,
+            "com.revenuecat.weekly_product:p1w": weekly,
+            "com.revenuecat.monthly_product": monthly,
+            "com.revenuecat.monthly_product:p1m": monthly,
+            "com.revenuecat.bimonthly_product": bimonthly,
+            "com.revenuecat.bimonthly_product:p2m": bimonthly,
+            "com.revenuecat.quarterly_product": quarterly,
+            "com.revenuecat.quarterly_product:p3m": quarterly,
+            "com.revenuecat.semester_product": semester,
+            "com.revenuecat.semester_product:p6m": semester,
+            "com.revenuecat.annual_product": annual,
+            "com.revenuecat.annual_product:p1y": annual
+        ]
     }
 
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Motivation

One of four coordinated PRs (iOS, Android, web SDK, dashboard) to reconcile the products/prices/offers shown on the cross-platform paywall rendering-validation screenshots. The screenshots diverge because each platform mocks the missing product data (the shared `offerings.json`/`packages.json` contain no prices or offers) from its own hard-coded table. iOS was the biggest outlier: every product was mocked at a flat **$1.99** with **no intro offers**.

Additionally, the loader keyed products only by base identifier, while `OfferingsFactory` looks them up by *compound* `product:plan` identifier (e.g. `com.revenuecat.annual_product:p1y`, since `packages.json` carries billing plan identifiers). That mismatch can silently drop subscription packages.

### Description

Reworks `PaywallPreviewResourcesLoader` (test-only) to build the preview products with `TestStoreProduct`:

- Canonical prices/periods matching the web + dashboard preview tables (which are identical and treated as the source of truth): weekly $2.99, monthly $9.99, 2-month $17.99, 3-month $24.99, 6-month $39.99, annual $69.99, lifetime $119.99.
- A single `$1.99` / 1-week **introductory offer** on each subscription, so products are intro-offer eligible and offer text/UI render (matching the web/dashboard "intro offer present" state and the Android trial/intro phases).
- `"Pro Access"` as the localized product title, matching the web/dashboard `product.store_product_name` and the Android preview parser.
- The products map is keyed by **both** base and compound (`product:plan`) identifiers so packages resolve regardless of billing plan ids.

Only the test-only loader under `Tests/RevenueCatUITests/` is changed; no SDK source is touched.

Known residual: the `relative_discount` badge is a hard-coded "19%" string on web/dashboard but computed from prices on iOS/Android, so that percentage may still differ across platforms.

### Testing

I could not build/run the screenshot tests in this environment (no Xcode/SwiftLint available). The screenshots are regenerated by the `record_paywall_screenshots` lane in CI; please verify the recorded iOS screenshots there.

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73d3a58b-e36d-4085-8e65-48900f62e89f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73d3a58b-e36d-4085-8e65-48900f62e89f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

