### PR TITLE
feat(remote-config): add RemoteConfigManager

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -938,8 +938,10 @@
 		A1B2C3D42FE100000000000D /* RCContainerBackwardsCompatibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE100000000000A /* RCContainerBackwardsCompatibilityTests.swift */; };
 		A1B2C3D42FE100000000000E /* RCContainerTestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE100000000000B /* RCContainerTestData.swift */; };
 		A1B2C3D42FE2000000000002 /* RemoteConfigDiskCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE2000000000001 /* RemoteConfigDiskCache.swift */; };
+		A1B2C3D42FE2000000000004 /* RemoteConfigManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE2000000000003 /* RemoteConfigManager.swift */; };
 		A1B2C3D42FE2000000000006 /* RemoteConfigStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE2000000000005 /* RemoteConfigStrings.swift */; };
 		A1B2C3D42FE2000000000009 /* RemoteConfigDiskCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE2000000000008 /* RemoteConfigDiskCacheTests.swift */; };
+		A1B2C3D42FE200000000000B /* RemoteConfigManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE200000000000A /* RemoteConfigManagerTests.swift */; };
 		7648885717DC2DB5009DD01B /* MinMaxOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = C812AE8BAE0546D2F4ACEF35 /* MinMaxOperators.swift */; };
 		7707A94C2CAD93AC006E0313 /* PaywallButtonComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7707A94B2CAD93AC006E0313 /* PaywallButtonComponent.swift */; };
 		7707A94E2CAD94D2006E0313 /* ButtonComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7707A94D2CAD94D2006E0313 /* ButtonComponentViewModel.swift */; };
@@ -2897,8 +2899,10 @@
 		A1B2C3D42FE100000000000C /* README.md */ = {isa = PBXFileReference; lastKnownFileType = text; path = README.md; sourceTree = "<group>"; };
 		A1B2C3D42FE1000000000011 /* RemoteConfigSignatureContextProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigSignatureContextProvider.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE2000000000001 /* RemoteConfigDiskCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigDiskCache.swift; sourceTree = "<group>"; };
+		A1B2C3D42FE2000000000003 /* RemoteConfigManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigManager.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE2000000000005 /* RemoteConfigStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigStrings.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE2000000000008 /* RemoteConfigDiskCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigDiskCacheTests.swift; sourceTree = "<group>"; };
+		A1B2C3D42FE200000000000A /* RemoteConfigManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigManagerTests.swift; sourceTree = "<group>"; };
 		E31E8A264E9F4375A3B29D78 /* RemoteConfigurationDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigurationDecodingTests.swift; sourceTree = "<group>"; };
 		FEDA000000000000000000A1 /* WeightedSourceSelectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightedSourceSelectorTests.swift; sourceTree = "<group>"; };
 		E35BAD07C46D469D8CC7C396 /* RemoteConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfiguration.swift; sourceTree = "<group>"; };
@@ -4540,6 +4544,7 @@
 				F3A2DB969D72432B87F48C5F /* RemoteConfigAPI.swift */,
 				FEDA000000000000000000A2 /* WeightedSourceSelector.swift */,
 				A1B2C3D42FE2000000000001 /* RemoteConfigDiskCache.swift */,
+				A1B2C3D42FE2000000000003 /* RemoteConfigManager.swift */,
 				A1B2C3D42FE1000000000011 /* RemoteConfigSignatureContextProvider.swift */,
 			);
 			path = Networking;
@@ -4585,6 +4590,7 @@
 			isa = PBXGroup;
 			children = (
 				A1B2C3D42FE2000000000008 /* RemoteConfigDiskCacheTests.swift */,
+				A1B2C3D42FE200000000000A /* RemoteConfigManagerTests.swift */,
 			);
 			path = RemoteConfig;
 			sourceTree = "<group>";
@@ -7174,6 +7180,7 @@
 				A1B2C3D42FE1000000000005 /* RCContainer+Element.swift in Sources */,
 				A1B2C3D42FE1000000000007 /* RCContainer+Parser.swift in Sources */,
 				A1B2C3D42FE2000000000002 /* RemoteConfigDiskCache.swift in Sources */,
+				A1B2C3D42FE2000000000004 /* RemoteConfigManager.swift in Sources */,
 				A1B2C3D42FE2000000000006 /* RemoteConfigStrings.swift in Sources */,
 				A1B2C3D42FE1000000000010 /* RemoteConfigSignatureContextProvider.swift in Sources */,
 				DB3395DD2F840A790079250C /* WorkflowResponseAction.swift in Sources */,
@@ -7733,6 +7740,7 @@
 				A1B2C3D42FE100000000000D /* RCContainerBackwardsCompatibilityTests.swift in Sources */,
 				A1B2C3D42FE100000000000E /* RCContainerTestData.swift in Sources */,
 				A1B2C3D42FE2000000000009 /* RemoteConfigDiskCacheTests.swift in Sources */,
+				A1B2C3D42FE200000000000B /* RemoteConfigManagerTests.swift in Sources */,
 				DB7EA7772F964CA200BCC082 /* WorkflowDetailProcessorTests.swift in Sources */,
 				FDC4B60B2FCE1122001E5F96 /* InstallmentsInfoTests.swift in Sources */,
 				4F8DDB692AAA9189000188F2 /* OperationDispatcherTests.swift in Sources */,

--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -11,6 +11,8 @@ enum RemoteConfigStrings {
 
     case failedToReadCache(Error)
     case failedToWriteCache
+    case failedToParseResponse(Error)
+    case refreshFailed(BackendError)
 
 }
 
@@ -22,6 +24,11 @@ extension RemoteConfigStrings: LogMessage {
             return "Failed to read remote config cache from disk: \(error.localizedDescription)"
         case .failedToWriteCache:
             return "Failed to write remote config cache to disk."
+        case let .failedToParseResponse(error):
+            return "Failed to parse remote config response. Keeping cached configuration. Error: " +
+            "\(error.localizedDescription)"
+        case let .refreshFailed(error):
+            return "Remote config refresh failed. Keeping cached configuration. Error: \(error)"
         }
     }
 

--- a/Sources/Networking/RemoteConfigAPI.swift
+++ b/Sources/Networking/RemoteConfigAPI.swift
@@ -7,7 +7,19 @@
 
 import Foundation
 
-class RemoteConfigAPI {
+protocol RemoteConfigAPIType: AnyObject {
+
+    typealias RemoteConfigResponseHandler = Backend.ResponseHandler<RemoteConfigFetchResult>
+
+    func getRemoteConfig(
+        request: RemoteConfigRequest,
+        isAppBackgrounded: Bool,
+        completion: @escaping RemoteConfigResponseHandler
+    )
+
+}
+
+class RemoteConfigAPI: RemoteConfigAPIType {
 
     typealias RemoteConfigResponseHandler = Backend.ResponseHandler<RemoteConfigFetchResult>
 

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -1,0 +1,123 @@
+//
+//  RemoteConfigManager.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+
+protocol RemoteConfigManagerType: AnyObject {
+
+    func refreshRemoteConfig(isAppBackgrounded: Bool)
+
+}
+
+/// Coordinates a single remote config refresh.
+///
+/// This manager currently owns only manifest replay and config-state persistence.
+// swiftlint:disable:next todo
+/// TODO: Remove this interim scope once blob extraction, topic handler dispatch, and SDK lifecycle wiring land.
+final class RemoteConfigManager: RemoteConfigManagerType {
+
+    private static let defaultDomain = "app"
+
+    private let remoteConfigAPI: RemoteConfigAPIType
+    private let diskCache: RemoteConfigDiskCacheType
+    private let dateProvider: DateProvider
+    private let isRefreshing: Atomic<Bool> = false
+
+    init(
+        remoteConfigAPI: RemoteConfigAPIType,
+        diskCache: RemoteConfigDiskCacheType,
+        dateProvider: DateProvider = DateProvider()
+    ) {
+        self.remoteConfigAPI = remoteConfigAPI
+        self.diskCache = diskCache
+        self.dateProvider = dateProvider
+    }
+
+    func refreshRemoteConfig(isAppBackgrounded: Bool) {
+        guard self.beginRefreshIfNeeded() else { return }
+
+        let persisted = self.diskCache.read()
+        let request = RemoteConfigRequest(
+            domain: persisted?.domain ?? Self.defaultDomain,
+            manifest: persisted?.manifest,
+            prefetchedBlobs: persisted?.prefetchBlobs ?? []
+        )
+
+        self.remoteConfigAPI.getRemoteConfig(
+            request: request,
+            isAppBackgrounded: isAppBackgrounded
+        ) { [weak self] result in
+            guard let self else { return }
+            defer { self.endRefresh() }
+
+            switch result {
+            case let .success(.container(container, _)):
+                self.persist(container: container, previous: persisted)
+            case .success(.noContent):
+                break
+            case let .failure(error):
+                Logger.error(Strings.remoteConfig.refreshFailed(error))
+            }
+        }
+    }
+
+}
+
+private extension RemoteConfigManager {
+
+    func beginRefreshIfNeeded() -> Bool {
+        return self.isRefreshing.modify { isRefreshing in
+            guard !isRefreshing else { return false }
+            isRefreshing = true
+            return true
+        }
+    }
+
+    func endRefresh() {
+        self.isRefreshing.value = false
+    }
+
+    func persist(
+        container: RCContainer,
+        previous: PersistedRemoteConfiguration?
+    ) {
+        do {
+            let response = try container.config.withPayloadBytes { bytes in
+                try JSONDecoder.default.decode(
+                    RemoteConfiguration.self,
+                    from: Data(bytes)
+                )
+            }
+
+            let topicBlobRefs = self.mergedTopicBlobRefs(
+                previous: previous?.topicBlobRefs ?? [:],
+                response: response
+            )
+
+            self.diskCache.write(PersistedRemoteConfiguration(
+                domain: response.domain,
+                manifest: response.manifest,
+                activeTopics: response.activeTopics,
+                prefetchBlobs: response.prefetchBlobs,
+                topicBlobRefs: topicBlobRefs,
+                lastRefreshAt: self.dateProvider.now()
+            ))
+        } catch {
+            Logger.error(Strings.remoteConfig.failedToParseResponse(error))
+        }
+    }
+
+    func mergedTopicBlobRefs(
+        previous: [String: [String]],
+        response: RemoteConfiguration
+    ) -> [String: [String]] {
+        return previous
+            .merging(response.topics.topicBlobRefs) { _, changed in changed }
+            .filter { topic, _ in response.activeTopics.contains(topic) }
+    }
+
+}

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -55,10 +55,10 @@ final class RemoteConfigManager: RemoteConfigManagerType {
             defer { self.endRefresh() }
 
             switch result {
-            case let .success(.container(container, _)):
-                self.persist(container: container, previous: persisted)
-            case .success(.noContent):
-                break
+            case let .success(fetchResult):
+                if let container = fetchResult.container {
+                    self.persist(container: container, previous: persisted)
+                }
             case let .failure(error):
                 Logger.error(Strings.remoteConfig.refreshFailed(error))
             }
@@ -118,6 +118,17 @@ private extension RemoteConfigManager {
         return previous
             .merging(response.topics.topicBlobRefs) { _, changed in changed }
             .filter { topic, _ in response.activeTopics.contains(topic) }
+    }
+
+}
+
+fileprivate extension RemoteConfiguration.Topics {
+
+    /// The blob refs each changed topic's items reference, keyed by topic name.
+    var topicBlobRefs: [String: [String]] {
+        return self.entries.mapValues { topic in
+            topic.values.compactMap(\.blobRef).sorted()
+        }
     }
 
 }

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -56,9 +56,7 @@ final class RemoteConfigManager: RemoteConfigManagerType {
 
             switch result {
             case let .success(fetchResult):
-                if let container = fetchResult.container {
-                    self.persist(container: container, previous: persisted)
-                }
+                self.persist(container: fetchResult.container, previous: persisted)
             case let .failure(error):
                 Logger.error(Strings.remoteConfig.refreshFailed(error))
             }
@@ -82,9 +80,14 @@ private extension RemoteConfigManager {
     }
 
     func persist(
-        container: RCContainer,
+        container: RCContainer?,
         previous: PersistedRemoteConfiguration?
     ) {
+        guard let container else {
+            self.persistLastRefreshAt(previous: previous)
+            return
+        }
+
         do {
             let response = try container.config.withPayloadBytes { bytes in
                 try JSONDecoder.default.decode(
@@ -109,6 +112,19 @@ private extension RemoteConfigManager {
         } catch {
             Logger.error(Strings.remoteConfig.failedToParseResponse(error))
         }
+    }
+
+    func persistLastRefreshAt(previous: PersistedRemoteConfiguration?) {
+        guard let previous else { return }
+
+        self.diskCache.write(PersistedRemoteConfiguration(
+            domain: previous.domain,
+            manifest: previous.manifest,
+            activeTopics: previous.activeTopics,
+            prefetchBlobs: previous.prefetchBlobs,
+            topicBlobRefs: previous.topicBlobRefs,
+            lastRefreshAt: self.dateProvider.now()
+        ))
     }
 
     func mergedTopicBlobRefs(

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -1,0 +1,335 @@
+//
+//  RemoteConfigManagerTests.swift
+//  UnitTests
+//
+//  Created by Rick van der Linden.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+import Nimble
+@testable import RevenueCat
+import XCTest
+
+final class RemoteConfigManagerTests: TestCase {
+
+    private static let lastRefreshAt = Date(timeIntervalSince1970: 1_710_000_100)
+
+    private var remoteConfigAPI: MockRemoteConfigAPI!
+    private var diskCache: MockRemoteConfigDiskCache!
+    private var dateProvider: MockDateProvider!
+    private var manager: RemoteConfigManager!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        self.remoteConfigAPI = MockRemoteConfigAPI()
+        self.diskCache = MockRemoteConfigDiskCache()
+        self.dateProvider = MockDateProvider(stubbedNow: Self.lastRefreshAt)
+        self.manager = RemoteConfigManager(
+            remoteConfigAPI: self.remoteConfigAPI,
+            diskCache: self.diskCache,
+            dateProvider: self.dateProvider
+        )
+    }
+
+    override func tearDownWithError() throws {
+        self.manager = nil
+        self.dateProvider = nil
+        self.diskCache = nil
+        self.remoteConfigAPI = nil
+
+        try super.tearDownWithError()
+    }
+
+    func testFirstRunSendsDefaultAppDomainManifest() throws {
+        self.diskCache.stubbedRead = nil
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.manifest).to(beNil())
+    }
+
+    func testSubsequentRunReplaysPersistedManifest() throws {
+        let persistedManifest = "v1.1710000100.sources:etag1"
+        self.diskCache.stubbedRead = Self.persisted(
+            domain: "custom",
+            manifest: persistedManifest,
+            prefetchBlobs: ["alreadyCachedBlob"]
+        )
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.domain) == "custom"
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.manifest) == persistedManifest
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.prefetchedBlobs) == ["alreadyCachedBlob"]
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.isAppBackgrounded) == true
+    }
+
+    func testOverlappingRefreshesAreIgnoredUntilInFlightRefreshCompletes() {
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+
+        self.remoteConfigAPI.complete(with: .success(.noContent(verificationResult: .verified)))
+        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.isAppBackgrounded) == true
+    }
+
+    func testContainerResponsePersistsServerManifestAndChangedTopicBlobRefs() throws {
+        self.diskCache.stubbedRead = nil
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.sources:etag2",
+          "active_topics": ["sources"],
+          "prefetch_blobs": ["newBlob"],
+          "topics": {
+            "sources": {
+              "default": { "blob_ref": "newBlob" }
+            }
+          }
+        }
+        """
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(
+            with: .success(.container(try Self.container(config: response), verificationResult: .verified))
+        )
+
+        expect(self.diskCache.invokedWriteCount) == 1
+        expect(self.diskCache.invokedWriteParameter?.domain) == "app"
+        expect(self.diskCache.invokedWriteParameter?.manifest)
+            == "v1.1710000100.sources:etag2"
+        expect(self.diskCache.invokedWriteParameter?.activeTopics) == ["sources"]
+        expect(self.diskCache.invokedWriteParameter?.prefetchBlobs) == ["newBlob"]
+        expect(self.diskCache.invokedWriteParameter?.topicBlobRefs) == ["sources": ["newBlob"]]
+        expect(self.diskCache.invokedWriteParameter?.lastRefreshAt) == Self.lastRefreshAt
+    }
+
+    func testContainerResponseMergesUnchangedTopicRefsAndPrunesDroppedTopics() throws {
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.product_entitlement_mapping:pemEtag1,sources:etag1",
+            topicBlobRefs: [
+                "sources": ["oldSources"],
+                "product_entitlement_mapping": ["pemBlob"]
+            ]
+        )
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.sources:etag2",
+          "active_topics": ["sources"],
+          "topics": {
+            "sources": {
+              "default": { "blob_ref": "newSources" }
+            }
+          }
+        }
+        """
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(
+            with: .success(.container(try Self.container(config: response), verificationResult: .verified))
+        )
+
+        expect(self.diskCache.invokedWriteParameter?.topicBlobRefs) == ["sources": ["newSources"]]
+    }
+
+    func testContainerResponseKeepsPreviousRefsForUnchangedTopicsStillActive() throws {
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.product_entitlement_mapping:pemEtag1,sources:etag1",
+            topicBlobRefs: [
+                "sources": ["oldSources"],
+                "product_entitlement_mapping": ["pemBlob"]
+            ]
+        )
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.product_entitlement_mapping:pemEtag1,sources:etag2",
+          "active_topics": ["sources", "product_entitlement_mapping"],
+          "topics": {
+            "sources": {
+              "default": { "blob_ref": "newSources" }
+            }
+          }
+        }
+        """
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(
+            with: .success(.container(try Self.container(config: response), verificationResult: .verified))
+        )
+
+        expect(self.diskCache.invokedWriteParameter?.topicBlobRefs) == [
+            "sources": ["newSources"],
+            "product_entitlement_mapping": ["pemBlob"]
+        ]
+    }
+
+    func testContainerResponsePersistsEmptyBlobRefListForInlineOnlyChangedTopics() throws {
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.sources:etag2",
+          "active_topics": ["sources"],
+          "topics": {
+            "sources": {
+              "api": {
+                "url": "https://api.revenuecat.com",
+                "priority": 100
+              }
+            }
+          }
+        }
+        """
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(
+            with: .success(.container(try Self.container(config: response), verificationResult: .verified))
+        )
+
+        expect(self.diskCache.invokedWriteParameter?.topicBlobRefs) == ["sources": []]
+    }
+
+    func testNoContentResponseLeavesCacheUntouched() {
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.sources:etag1"
+        )
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .success(.noContent(verificationResult: .verified)))
+
+        expect(self.diskCache.invokedWriteCount) == 0
+    }
+
+    func testBackendErrorLeavesCacheUntouched() {
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.sources:etag1"
+        )
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(
+            with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1))))
+        )
+
+        expect(self.diskCache.invokedWriteCount) == 0
+    }
+
+    func testMalformedConfigPayloadLeavesCacheUntouched() throws {
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(
+            with: .success(.container(try Self.container(config: "{ not valid json"), verificationResult: .verified))
+        )
+
+        expect(self.diskCache.invokedWriteCount) == 0
+    }
+
+    func testConfigDecodingUsesOnlyContainerConfigElement() throws {
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.sources:etag2",
+          "active_topics": ["sources"],
+          "topics": {
+            "sources": {
+              "default": { "blob_ref": "newBlob" }
+            }
+          }
+        }
+        """
+        let invalidContentElement = "{ invalid content element json".asData
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(
+            with: .success(.container(
+                try Self.container(config: response, contentElements: [invalidContentElement]),
+                verificationResult: .verified
+            ))
+        )
+
+        expect(self.diskCache.invokedWriteCount) == 1
+        expect(self.diskCache.invokedWriteParameter?.topicBlobRefs) == ["sources": ["newBlob"]]
+    }
+
+}
+
+private extension RemoteConfigManagerTests {
+
+    static func persisted(
+        domain: String = RemoteConfiguration.defaultDomain,
+        manifest: String,
+        activeTopics: [String] = [],
+        prefetchBlobs: [String] = [],
+        topicBlobRefs: [String: [String]] = [:],
+        lastRefreshAt: Date? = nil
+    ) -> PersistedRemoteConfiguration {
+        return PersistedRemoteConfiguration(
+            domain: domain,
+            manifest: manifest,
+            activeTopics: activeTopics,
+            prefetchBlobs: prefetchBlobs,
+            topicBlobRefs: topicBlobRefs,
+            lastRefreshAt: lastRefreshAt
+        )
+    }
+
+    static func container(
+        config: String,
+        contentElements: [Data] = []
+    ) throws -> RCContainer {
+        return try RCContainer(data: RCContainerTestData.container(
+            config: config.asData,
+            contentElements: contentElements
+        ))
+    }
+
+}
+
+private final class MockRemoteConfigAPI: RemoteConfigAPIType {
+
+    private(set) var invokedGetRemoteConfigCount = 0
+    private(set) var invokedGetRemoteConfigParameters: (
+        request: RemoteConfigRequest,
+        isAppBackgrounded: Bool
+    )?
+
+    private var completion: Backend.ResponseHandler<RemoteConfigFetchResult>?
+
+    func getRemoteConfig(
+        request: RemoteConfigRequest,
+        isAppBackgrounded: Bool,
+        completion: @escaping Backend.ResponseHandler<RemoteConfigFetchResult>
+    ) {
+        self.invokedGetRemoteConfigCount += 1
+        self.invokedGetRemoteConfigParameters = (request, isAppBackgrounded)
+        self.completion = completion
+    }
+
+    func complete(with result: Result<RemoteConfigFetchResult, BackendError>) {
+        self.completion?(result)
+    }
+
+}
+
+private final class MockRemoteConfigDiskCache: RemoteConfigDiskCacheType {
+
+    var stubbedRead: PersistedRemoteConfiguration?
+
+    private(set) var invokedWriteCount = 0
+    private(set) var invokedWriteParameter: PersistedRemoteConfiguration?
+
+    func read() -> PersistedRemoteConfiguration? {
+        return self.stubbedRead
+    }
+
+    func write(_ configuration: PersistedRemoteConfiguration) {
+        self.invokedWriteCount += 1
+        self.invokedWriteParameter = configuration
+    }
+
+}

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -196,10 +196,33 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.diskCache.invokedWriteParameter?.topicBlobRefs) == ["sources": []]
     }
 
-    func testNoContentResponseLeavesCacheUntouched() {
-        self.diskCache.stubbedRead = Self.persisted(
-            manifest: "v1.1710000100.sources:etag1"
+    func testNoContentResponseUpdatesLastRefreshAtForPersistedCache() {
+        let previous = Self.persisted(
+            domain: "app",
+            manifest: "v1.1710000100.sources:etag1",
+            activeTopics: ["sources"],
+            prefetchBlobs: ["prefetchBlob"],
+            topicBlobRefs: ["sources": ["sourceBlob"]],
+            lastRefreshAt: Date(timeIntervalSince1970: 1)
         )
+        self.diskCache.stubbedRead = previous
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
+
+        expect(self.diskCache.invokedWriteCount) == 1
+        expect(self.diskCache.invokedWriteParameter) == PersistedRemoteConfiguration(
+            domain: previous.domain,
+            manifest: previous.manifest,
+            activeTopics: previous.activeTopics,
+            prefetchBlobs: previous.prefetchBlobs,
+            topicBlobRefs: previous.topicBlobRefs,
+            lastRefreshAt: Self.lastRefreshAt
+        )
+    }
+
+    func testNoContentResponseWithNoPersistedCacheLeavesCacheUntouched() {
+        self.diskCache.stubbedRead = nil
 
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .success(.test(container: nil)))

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -72,7 +72,7 @@ final class RemoteConfigManagerTests: TestCase {
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
 
-        self.remoteConfigAPI.complete(with: .success(.noContent(verificationResult: .verified)))
+        self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
         self.manager.refreshRemoteConfig(isAppBackgrounded: true)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
@@ -97,7 +97,7 @@ final class RemoteConfigManagerTests: TestCase {
 
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
-            with: .success(.container(try Self.container(config: response), verificationResult: .verified))
+            with: .success(.test(container: try Self.container(config: response)))
         )
 
         expect(self.diskCache.invokedWriteCount) == 1
@@ -133,7 +133,7 @@ final class RemoteConfigManagerTests: TestCase {
 
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
-            with: .success(.container(try Self.container(config: response), verificationResult: .verified))
+            with: .success(.test(container: try Self.container(config: response)))
         )
 
         expect(self.diskCache.invokedWriteParameter?.topicBlobRefs) == ["sources": ["newSources"]]
@@ -162,7 +162,7 @@ final class RemoteConfigManagerTests: TestCase {
 
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
-            with: .success(.container(try Self.container(config: response), verificationResult: .verified))
+            with: .success(.test(container: try Self.container(config: response)))
         )
 
         expect(self.diskCache.invokedWriteParameter?.topicBlobRefs) == [
@@ -190,7 +190,7 @@ final class RemoteConfigManagerTests: TestCase {
 
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
-            with: .success(.container(try Self.container(config: response), verificationResult: .verified))
+            with: .success(.test(container: try Self.container(config: response)))
         )
 
         expect(self.diskCache.invokedWriteParameter?.topicBlobRefs) == ["sources": []]
@@ -202,7 +202,7 @@ final class RemoteConfigManagerTests: TestCase {
         )
 
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
-        self.remoteConfigAPI.complete(with: .success(.noContent(verificationResult: .verified)))
+        self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
 
         expect(self.diskCache.invokedWriteCount) == 0
     }
@@ -223,7 +223,7 @@ final class RemoteConfigManagerTests: TestCase {
     func testMalformedConfigPayloadLeavesCacheUntouched() throws {
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
-            with: .success(.container(try Self.container(config: "{ not valid json"), verificationResult: .verified))
+            with: .success(.test(container: try Self.container(config: "{ not valid json")))
         )
 
         expect(self.diskCache.invokedWriteCount) == 0
@@ -246,9 +246,8 @@ final class RemoteConfigManagerTests: TestCase {
 
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
-            with: .success(.container(
-                try Self.container(config: response, contentElements: [invalidContentElement]),
-                verificationResult: .verified
+            with: .success(.test(
+                container: try Self.container(config: response, contentElements: [invalidContentElement])
             ))
         )
 
@@ -285,6 +284,26 @@ private extension RemoteConfigManagerTests {
         return try RCContainer(data: RCContainerTestData.container(
             config: config.asData,
             contentElements: contentElements
+        ))
+    }
+
+}
+
+private extension RemoteConfigFetchResult {
+
+    /// Builds a fetch result through the production initializer. A `nil` container
+    /// represents a `204 No Content` response.
+    static func test(
+        container: RCContainer?,
+        verificationResult: VerificationResult = .verified
+    ) -> RemoteConfigFetchResult {
+        return RemoteConfigFetchResult(response: .init(
+            httpStatusCode: container == nil ? .noContent : .success,
+            responseHeaders: [:],
+            body: container,
+            verificationResult: verificationResult,
+            isLoadShedderResponse: false,
+            isFallbackUrlResponse: false
         ))
     }
 


### PR DESCRIPTION
Part of a stack of PRs, builds on https://github.com/RevenueCat/purchases-ios/pull/7076 and should be aligned with the Android equivalent in https://github.com/RevenueCat/purchases-android/pull/3612.

## Description
- Introduces the `RemoteConfigManager`, which is responsible for refreshing the latest config using the `RemoteConfigAPI`.
- Will use the persistence layer for storing the latest `PersistedRemoteConfiguration`
- This data will be included with subsequent requests to the remote config API, allowing the backend to return just the diff of what to sync

Downloading / storing the topics payloads itself will be done in a follow up PR.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New coordination layer for remote config persistence and incremental sync state; behavior is defensive on errors but will affect future SDK config flows once wired.
> 
> **Overview**
> Adds **`RemoteConfigManager`** to own remote config refresh: it reads **`PersistedRemoteConfiguration`** from the disk cache, builds a **`RemoteConfigRequest`** (domain, manifest, prefetched blobs), calls **`RemoteConfigAPI`**, and writes updated manifest/topics state back—or only bumps **`lastRefreshAt`** on **204 No Content**. Overlapping refreshes are deduped with an atomic in-flight flag; network, parse, and malformed-config failures log and leave the cache unchanged.
> 
> **`RemoteConfigAPI`** is split behind **`RemoteConfigAPIType`** for injection/mocking. **`RemoteConfigStrings`** gains messages for refresh and parse failures. Unit tests cover first-run vs replay, concurrency, topic/blob ref merge/prune, and error paths. Topic blob download and SDK wiring are explicitly deferred (TODO).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fbb1ebde1ac362fab46e88518ec39ac1200295e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->