### PR TITLE
fix: report sdkOriginated on queue-first SDK purchases

### DIFF
--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -459,6 +459,7 @@ private extension CustomerInfoManager {
                         transactionToPost,
                         data: transactionData,
                         postReceiptSource: Self.sourceForUnfinishedTransaction,
+                        forceSdkOriginated: false,
                         currentUserID: appUserID
                     )
                     switch result {
@@ -573,6 +574,7 @@ private extension CustomerInfoManager {
                         transaction,
                         data: data,
                         postReceiptSource: postReceiptSource,
+                        forceSdkOriginated: false,
                         currentUserID: appUserID
                     )
                 }

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -1581,7 +1581,7 @@ extension PurchasesOrchestrator: StoreKit2TransactionListenerDelegate {
             transaction,
             data: transactionData,
             postReceiptSource: purchaseSource,
-            originatedFromPurchase: cached?.originatedFromPurchase ?? false,
+            forceSdkOriginated: cached?.originatedFromPurchase ?? false,
             currentUserID: self.appUserID
         )
 
@@ -1999,7 +1999,7 @@ private extension PurchasesOrchestrator {
                 purchasedTransaction,
                 data: transactionData,
                 postReceiptSource: purchaseSource,
-                originatedFromPurchase: cached?.originatedFromPurchase ?? false,
+                forceSdkOriginated: cached?.originatedFromPurchase ?? false,
                 currentUserID: self.appUserID
             ) { result in
 
@@ -2373,7 +2373,7 @@ extension PurchasesOrchestrator {
             transaction,
             data: transactionData,
             postReceiptSource: purchaseSource,
-            originatedFromPurchase: cached?.originatedFromPurchase ?? false,
+            forceSdkOriginated: cached?.originatedFromPurchase ?? false,
             currentUserID: self.appUserID
         )
 

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -1581,6 +1581,7 @@ extension PurchasesOrchestrator: StoreKit2TransactionListenerDelegate {
             transaction,
             data: transactionData,
             postReceiptSource: purchaseSource,
+            originatedFromPurchase: cached?.originatedFromPurchase ?? false,
             currentUserID: self.appUserID
         )
 
@@ -1998,6 +1999,7 @@ private extension PurchasesOrchestrator {
                 purchasedTransaction,
                 data: transactionData,
                 postReceiptSource: purchaseSource,
+                originatedFromPurchase: cached?.originatedFromPurchase ?? false,
                 currentUserID: self.appUserID
             ) { result in
 
@@ -2371,6 +2373,7 @@ extension PurchasesOrchestrator {
             transaction,
             data: transactionData,
             postReceiptSource: purchaseSource,
+            originatedFromPurchase: cached?.originatedFromPurchase ?? false,
             currentUserID: self.appUserID
         )
 

--- a/Sources/Purchasing/Purchases/TransactionPoster.swift
+++ b/Sources/Purchasing/Purchases/TransactionPoster.swift
@@ -60,15 +60,16 @@ typealias CachedTransactionMetadataPostResult = (
 protocol TransactionPosterType: AnyObject, Sendable {
 
     /// Starts a `PostReceiptDataOperation` for the transaction.
-    /// - Parameter originatedFromPurchase: whether the transaction originated from a RevenueCat
-    /// `purchase()` call, even if this particular post is queue-initiated (a queue transaction can
-    /// race ahead of `purchase()` returning). Drives `sdkOriginated` for those queue-initiated posts.
+    /// - Parameter forceSdkOriginated: when `true`, report this post as `sdkOriginated` even if it
+    /// is queue-initiated. Used when a queue transaction races ahead of `purchase()` returning so
+    /// it's still attributed to the SDK. When `false`, `sdkOriginated` is derived normally (from the
+    /// initiation source / stored metadata), so `false` does not imply the post is not SDK-originated.
     // swiftlint:disable:next function_parameter_count
     func handlePurchasedTransaction(
         _ transaction: StoreTransactionType,
         data: PurchasedTransactionData,
         postReceiptSource: PostReceiptSource,
-        originatedFromPurchase: Bool,
+        forceSdkOriginated: Bool,
         currentUserID: String,
         completion: @escaping CustomerAPI.CustomerInfoResponseHandler
     )
@@ -142,7 +143,7 @@ final class TransactionPoster: TransactionPosterType {
     func handlePurchasedTransaction(_ transaction: StoreTransactionType,
                                     data: PurchasedTransactionData,
                                     postReceiptSource: PostReceiptSource,
-                                    originatedFromPurchase: Bool,
+                                    forceSdkOriginated: Bool,
                                     currentUserID: String,
                                     completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
         Logger.debug(Strings.purchase.transaction_poster_handling_transaction(
@@ -169,7 +170,7 @@ final class TransactionPoster: TransactionPosterType {
                         self.postReceipt(transaction: transaction,
                                          purchasedTransactionData: data,
                                          postReceiptSource: postReceiptSource,
-                                         originatedFromPurchase: originatedFromPurchase,
+                                         forceSdkOriginated: forceSdkOriginated,
                                          receipt: encodedReceipt,
                                          product: product,
                                          appTransaction: appTransaction,
@@ -203,7 +204,7 @@ final class TransactionPoster: TransactionPosterType {
                              purchasedTransactionData: data,
                              postReceiptSource: postReceiptSource,
                              // Synced SK2 transactions are detected outside an SDK `purchase()` call.
-                             originatedFromPurchase: false,
+                             forceSdkOriginated: false,
                              receipt: receipt,
                              product: product,
                              appTransaction: appTransactionJWS,
@@ -304,7 +305,7 @@ extension TransactionPosterType {
         _ transaction: StoreTransaction,
         data: PurchasedTransactionData,
         postReceiptSource: PostReceiptSource,
-        originatedFromPurchase: Bool = false,
+        forceSdkOriginated: Bool,
         currentUserID: String
     ) async -> Result<CustomerInfo, BackendError> {
         await Async.call { completion in
@@ -312,7 +313,7 @@ extension TransactionPosterType {
                 transaction,
                 data: data,
                 postReceiptSource: postReceiptSource,
-                originatedFromPurchase: originatedFromPurchase,
+                forceSdkOriginated: forceSdkOriginated,
                 currentUserID: currentUserID,
                 completion: completion
             )
@@ -372,7 +373,7 @@ extension TransactionPoster {
     private func postReceipt(transaction: StoreTransactionType,
                              purchasedTransactionData: PurchasedTransactionData,
                              postReceiptSource: PostReceiptSource,
-                             originatedFromPurchase: Bool,
+                             forceSdkOriginated: Bool,
                              receipt: EncodedAppleReceipt,
                              product: StoreProduct?,
                              appTransaction: String?,
@@ -398,11 +399,11 @@ extension TransactionPoster {
 
         // sdkOriginated indicates whether this purchase was initiated by the SDK (stored metadata takes precedence):
         // - true when the purchase was initiated via SDK's purchase() methods (initiationSource == .purchase)
-        // - true when a queue-initiated post carries context cached at the intent of a purchase() call
-        //   (a queue transaction can race ahead of purchase() returning, see `originatedFromPurchase`)
+        // - true when `forceSdkOriginated` is set, i.e. a queue-initiated post carries context cached at
+        //   the intent of a purchase() call (a queue transaction can race ahead of purchase() returning)
         // - false when the purchase was detected in the queue but triggered outside the SDK
         let sdkOriginated = storedTransactionMetadata?.sdkOriginated ??
-            (postReceiptSource.initiationSource == .purchase || originatedFromPurchase)
+            (postReceiptSource.initiationSource == .purchase || forceSdkOriginated)
 
         if shouldStoreMetadata {
             let metadataToStore = LocalTransactionMetadata(

--- a/Sources/Purchasing/Purchases/TransactionPoster.swift
+++ b/Sources/Purchasing/Purchases/TransactionPoster.swift
@@ -60,10 +60,15 @@ typealias CachedTransactionMetadataPostResult = (
 protocol TransactionPosterType: AnyObject, Sendable {
 
     /// Starts a `PostReceiptDataOperation` for the transaction.
+    /// - Parameter originatedFromPurchase: whether the transaction originated from a RevenueCat
+    /// `purchase()` call, even if this particular post is queue-initiated (a queue transaction can
+    /// race ahead of `purchase()` returning). Drives `sdkOriginated` for those queue-initiated posts.
+    // swiftlint:disable:next function_parameter_count
     func handlePurchasedTransaction(
         _ transaction: StoreTransactionType,
         data: PurchasedTransactionData,
         postReceiptSource: PostReceiptSource,
+        originatedFromPurchase: Bool,
         currentUserID: String,
         completion: @escaping CustomerAPI.CustomerInfoResponseHandler
     )
@@ -137,6 +142,7 @@ final class TransactionPoster: TransactionPosterType {
     func handlePurchasedTransaction(_ transaction: StoreTransactionType,
                                     data: PurchasedTransactionData,
                                     postReceiptSource: PostReceiptSource,
+                                    originatedFromPurchase: Bool,
                                     currentUserID: String,
                                     completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
         Logger.debug(Strings.purchase.transaction_poster_handling_transaction(
@@ -163,6 +169,7 @@ final class TransactionPoster: TransactionPosterType {
                         self.postReceipt(transaction: transaction,
                                          purchasedTransactionData: data,
                                          postReceiptSource: postReceiptSource,
+                                         originatedFromPurchase: originatedFromPurchase,
                                          receipt: encodedReceipt,
                                          product: product,
                                          appTransaction: appTransaction,
@@ -195,6 +202,8 @@ final class TransactionPoster: TransactionPosterType {
             self.postReceipt(transaction: transaction,
                              purchasedTransactionData: data,
                              postReceiptSource: postReceiptSource,
+                             // Synced SK2 transactions are detected outside an SDK `purchase()` call.
+                             originatedFromPurchase: false,
                              receipt: receipt,
                              product: product,
                              appTransaction: appTransactionJWS,
@@ -295,6 +304,7 @@ extension TransactionPosterType {
         _ transaction: StoreTransaction,
         data: PurchasedTransactionData,
         postReceiptSource: PostReceiptSource,
+        originatedFromPurchase: Bool = false,
         currentUserID: String
     ) async -> Result<CustomerInfo, BackendError> {
         await Async.call { completion in
@@ -302,6 +312,7 @@ extension TransactionPosterType {
                 transaction,
                 data: data,
                 postReceiptSource: postReceiptSource,
+                originatedFromPurchase: originatedFromPurchase,
                 currentUserID: currentUserID,
                 completion: completion
             )
@@ -361,6 +372,7 @@ extension TransactionPoster {
     private func postReceipt(transaction: StoreTransactionType,
                              purchasedTransactionData: PurchasedTransactionData,
                              postReceiptSource: PostReceiptSource,
+                             originatedFromPurchase: Bool,
                              receipt: EncodedAppleReceipt,
                              product: StoreProduct?,
                              appTransaction: String?,
@@ -386,9 +398,11 @@ extension TransactionPoster {
 
         // sdkOriginated indicates whether this purchase was initiated by the SDK (stored metadata takes precedence):
         // - true when the purchase was initiated via SDK's purchase() methods (initiationSource == .purchase)
+        // - true when a queue-initiated post carries context cached at the intent of a purchase() call
+        //   (a queue transaction can race ahead of purchase() returning, see `originatedFromPurchase`)
         // - false when the purchase was detected in the queue but triggered outside the SDK
         let sdkOriginated = storedTransactionMetadata?.sdkOriginated ??
-            (postReceiptSource.initiationSource == .purchase)
+            (postReceiptSource.initiationSource == .purchase || originatedFromPurchase)
 
         if shouldStoreMetadata {
             let metadataToStore = LocalTransactionMetadata(

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
@@ -1785,6 +1785,9 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
                 .presentedOfferingContext?.offeringIdentifier
         ) == "test_offering"
         expect(self.backend.invokedPostReceiptDataParameters?.postReceiptSource.initiationSource) == .queue
+        // Even though the post is queue-initiated, the context originated from a `purchase()` call,
+        // so this must be reported as SDK-originated (the queue transaction raced ahead of `purchase()`).
+        expect(self.backend.invokedPostReceiptDataParameters?.sdkOriginated) == true
 
         self.backend.invokedPostReceiptData = false
         self.backend.invokedPostReceiptDataParameters = nil
@@ -1801,6 +1804,7 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
             self.backend.invokedPostReceiptDataParameters?.transactionData
                 .presentedOfferingContext?.offeringIdentifier
         ) == "test_offering"
+        expect(self.backend.invokedPostReceiptDataParameters?.sdkOriginated) == true
     }
 
     func testSK2QueueListenerRemovesExternallyCachedPurchaseContext() async throws {
@@ -1830,6 +1834,9 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
                 .presentedOfferingContext?.offeringIdentifier
         ) == "test_offering"
         expect(self.backend.invokedPostReceiptDataParameters?.postReceiptSource.initiationSource) == .queue
+        // The context was cached externally (not from a `purchase()` call), so a queue-initiated
+        // post must not be reported as SDK-originated.
+        expect(self.backend.invokedPostReceiptDataParameters?.sdkOriginated) == false
 
         self.backend.invokedPostReceiptData = false
 

--- a/Tests/UnitTests/Mocks/MockTransactionPoster.swift
+++ b/Tests/UnitTests/Mocks/MockTransactionPoster.swift
@@ -29,6 +29,7 @@ final class MockTransactionPoster: TransactionPosterType {
                                                              data: PurchasedTransactionData,
                                                              postReceiptSource: PostReceiptSource,
                                                              currentUserID: String)?> = nil
+    let invokedHandlePurchasedTransactionOriginatedFromPurchase: Atomic<Bool?> = nil
     let invokedHandlePurchasedTransactionParameterList: Atomic<[(transaction: StoreTransactionType,
                                                                  data: PurchasedTransactionData,
                                                                  postReceiptSource: PostReceiptSource)]> = .init([])
@@ -42,10 +43,12 @@ final class MockTransactionPoster: TransactionPosterType {
         )
     }
 
+    // swiftlint:disable:next function_parameter_count
     func handlePurchasedTransaction(
         _ transaction: StoreTransactionType,
         data: PurchasedTransactionData,
         postReceiptSource: PostReceiptSource,
+        originatedFromPurchase: Bool,
         currentUserID: String,
         completion: @escaping CustomerAPI.CustomerInfoResponseHandler
     ) {
@@ -58,7 +61,11 @@ final class MockTransactionPoster: TransactionPosterType {
 
         self.invokedHandlePurchasedTransaction.value = true
         self.invokedHandlePurchasedTransactionCount.modify { $0 += 1 }
-        self.invokedHandlePurchasedTransactionParameters.value = (transaction, data, postReceiptSource, currentUserID)
+        self.invokedHandlePurchasedTransactionParameters.value = (transaction,
+                                                                  data,
+                                                                  postReceiptSource,
+                                                                  currentUserID)
+        self.invokedHandlePurchasedTransactionOriginatedFromPurchase.value = originatedFromPurchase
         self.invokedHandlePurchasedTransactionParameterList.modify {
             $0.append((transaction, data, postReceiptSource))
         }

--- a/Tests/UnitTests/Mocks/MockTransactionPoster.swift
+++ b/Tests/UnitTests/Mocks/MockTransactionPoster.swift
@@ -29,7 +29,7 @@ final class MockTransactionPoster: TransactionPosterType {
                                                              data: PurchasedTransactionData,
                                                              postReceiptSource: PostReceiptSource,
                                                              currentUserID: String)?> = nil
-    let invokedHandlePurchasedTransactionOriginatedFromPurchase: Atomic<Bool?> = nil
+    let invokedHandlePurchasedTransactionForceSdkOriginated: Atomic<Bool?> = nil
     let invokedHandlePurchasedTransactionParameterList: Atomic<[(transaction: StoreTransactionType,
                                                                  data: PurchasedTransactionData,
                                                                  postReceiptSource: PostReceiptSource)]> = .init([])
@@ -48,7 +48,7 @@ final class MockTransactionPoster: TransactionPosterType {
         _ transaction: StoreTransactionType,
         data: PurchasedTransactionData,
         postReceiptSource: PostReceiptSource,
-        originatedFromPurchase: Bool,
+        forceSdkOriginated: Bool,
         currentUserID: String,
         completion: @escaping CustomerAPI.CustomerInfoResponseHandler
     ) {
@@ -65,7 +65,7 @@ final class MockTransactionPoster: TransactionPosterType {
                                                                   data,
                                                                   postReceiptSource,
                                                                   currentUserID)
-        self.invokedHandlePurchasedTransactionOriginatedFromPurchase.value = originatedFromPurchase
+        self.invokedHandlePurchasedTransactionForceSdkOriginated.value = forceSdkOriginated
         self.invokedHandlePurchasedTransactionParameterList.modify {
             $0.append((transaction, data, postReceiptSource))
         }

--- a/Tests/UnitTests/Purchasing/Purchases/TransactionPosterTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/TransactionPosterTests.swift
@@ -1493,14 +1493,14 @@ private extension TransactionPosterTests {
     func handleTransaction(
         _ data: PurchasedTransactionData,
         postReceiptSource: PostReceiptSource = .init(isRestore: false, initiationSource: .queue),
-        originatedFromPurchase: Bool = false
+        forceSdkOriginated: Bool = false
     ) throws -> Result<CustomerInfo, BackendError> {
         let result = waitUntilValue { completion in
             self.poster.handlePurchasedTransaction(
                 self.mockTransaction,
                 data: data,
                 postReceiptSource: postReceiptSource,
-                originatedFromPurchase: originatedFromPurchase,
+                forceSdkOriginated: forceSdkOriginated,
                 currentUserID: "user"
             ) {
                 completion($0)

--- a/Tests/UnitTests/Purchasing/Purchases/TransactionPosterTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/TransactionPosterTests.swift
@@ -1492,13 +1492,15 @@ private extension TransactionPosterTests {
 
     func handleTransaction(
         _ data: PurchasedTransactionData,
-        postReceiptSource: PostReceiptSource = .init(isRestore: false, initiationSource: .queue)
+        postReceiptSource: PostReceiptSource = .init(isRestore: false, initiationSource: .queue),
+        originatedFromPurchase: Bool = false
     ) throws -> Result<CustomerInfo, BackendError> {
         let result = waitUntilValue { completion in
             self.poster.handlePurchasedTransaction(
                 self.mockTransaction,
                 data: data,
                 postReceiptSource: postReceiptSource,
+                originatedFromPurchase: originatedFromPurchase,
                 currentUserID: "user"
             ) {
                 completion($0)


### PR DESCRIPTION
### Checklist
- [x] Unit tests
- [ ] Follow-up for `purchases-android` and hybrids

### Motivation
Follow-up to #7032. A StoreKit transaction can reach the queue before the SDK's `purchase()` call returns; that queue-initiated `POST /receipts` (and the metadata it caches) reported `sdk_originated: false` even though the purchase was SDK-initiated.

### Description
- The queue-initiated post now carries the cached context's `originatedFromPurchase` flag so it reports `sdk_originated` correctly.