### PR TITLE
Revert #7032 and #7043

### DIFF
--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -84,7 +84,6 @@ enum PurchaseStrings {
                                                  placementID: String?,
                                                  paywallSessionID: UUID?)
     case caching_presented_offering_identifier(offeringID: String, productID: String)
-    case cache_purchase_data_offering_mismatch(existingOfferingID: String, newOfferingID: String, productID: String)
     case payment_queue_wrapper_delegate_call_sk1_enabled
     case restorepurchases_called_with_allow_sharing_appstore_account_false
     case sk2_observer_mode_error_processing_transaction(Error)
@@ -348,12 +347,6 @@ extension PurchaseStrings: LogMessage {
 
         case let .caching_presented_offering_identifier(offeringID, productID):
             return "Caching presented offering identifier '\(offeringID)' for product '\(productID)'"
-
-        case let .cache_purchase_data_offering_mismatch(existingOfferingID, newOfferingID, productID):
-            return "Caching purchase data for product '\(productID)' with offering '\(newOfferingID)', but a " +
-            "different offering '\(existingOfferingID)' was already cached for it. This usually means a purchase " +
-            "was started for a different package than the one presented. Keeping the latest offering and " +
-            "discarding the previously cached data for this product."
 
         case .payment_queue_wrapper_delegate_call_sk1_enabled:
             return "Unexpectedly received PaymentQueueWrapperDelegate call with SK1 enabled"

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -603,8 +603,7 @@ final class PurchasesOrchestrator {
         self.cachePurchaseData(
             presentedOfferingContext: package?.presentedOfferingContext,
             paywallEvent: paywallEvent,
-            productIdentifier: productIdentifier,
-            originatedFromPurchase: true
+            productIdentifier: productIdentifier
         )
 
         self.productsManager.cache(StoreProduct(sk1Product: sk1Product))
@@ -816,18 +815,6 @@ final class PurchasesOrchestrator {
 
             let presentedOfferingContext = package?.presentedOfferingContext
 
-            // We cache the context here, before starting the purchase, even though this SK2 purchase
-            // path never reads it back: the transaction can be delivered (and its receipt posted) by
-            // the `Transaction.updates` queue listener before `purchase(sk2Product:)` returns. The
-            // listener's `.queue` post is what reads this cache, so the attribution isn't lost to
-            // that race. See `consumeCachedPurchaseContext(for:initiationSource:)`.
-            self.cachePurchaseData(
-                presentedOfferingContext: presentedOfferingContext,
-                paywallEvent: paywallEvent,
-                productIdentifier: sk2Product.id,
-                originatedFromPurchase: true
-            )
-
             result = try await self.purchase(sk2Product, options)
 
             // The `purchase(sk2Product)` call can throw a `StoreKitError.userCancelled` error.
@@ -842,7 +829,6 @@ final class PurchasesOrchestrator {
             case .userCancelled:
                 userCancelled = true
                 transaction = nil
-                self.clearCachedPurchaseData(productIdentifier: sk2Product.id)
                 if self.systemInfo.dangerousSettings.customEntitlementComputation {
                     throw ErrorUtils.purchaseCancelledError()
                 }
@@ -905,8 +891,6 @@ final class PurchasesOrchestrator {
         promotionalOfferId: String?,
         winBackOfferApplied: Bool
     ) async throws -> PurchaseResultData {
-        self.clearCachedPurchaseData(productIdentifier: productId)
-
         if case StoreKitError.userCancelled = error {
             guard !self.systemInfo.dangerousSettings.customEntitlementComputation else {
                 throw ErrorUtils.purchaseCancelledError()
@@ -982,17 +966,11 @@ final class PurchasesOrchestrator {
 
     /// Caches purchase context (offering + optional paywall event) for a product.
     /// Both the `.myApp` external purchase path and `PaywallExtensions` call this through
-    /// the `@_spi(Internal)` API. The SK1 and SK2 purchase paths call this internally passing
-    /// `originatedFromPurchase: true`.
-    ///
-    /// - Parameter originatedFromPurchase: whether the context was cached at the intent of a
-    ///   RevenueCat `purchase()` call. This governs how the entry is evicted on retrieval, see
-    ///   `consumeCachedPurchaseContext(for:initiationSource:)`.
+    /// the `@_spi(Internal)` API. The SK1 purchase path also calls this internally.
     func cachePurchaseData(
         presentedOfferingContext: PresentedOfferingContext?,
         paywallEvent: PaywallEvent?,
-        productIdentifier: String,
-        originatedFromPurchase: Bool = false
+        productIdentifier: String
     ) {
         guard presentedOfferingContext != nil || paywallEvent != nil else { return }
 
@@ -1006,39 +984,12 @@ final class PurchasesOrchestrator {
             Logger.verbose(Strings.paywalls.caching_purchase_initiated_paywall)
         }
 
-        self.cachedPurchaseContextByProductID.modify { cache in
-            let existing = cache[productIdentifier]
-
-            let existingOfferingID = existing?.offeringContext?.offeringIdentifier
-                ?? existing?.paywallEvent?.data.offeringIdentifier
-            let newOfferingID = presentedOfferingContext?.offeringIdentifier
-                ?? paywallEvent?.data.offeringIdentifier
-
-            if let existingOfferingID, let newOfferingID, existingOfferingID != newOfferingID {
-                // A different offering was already cached for this same product.
-                // So we attribute the purchase that's actually happening (new data).
-                Logger.warn(Strings.purchase.cache_purchase_data_offering_mismatch(
-                    existingOfferingID: existingOfferingID,
-                    newOfferingID: newOfferingID,
-                    productID: productIdentifier
-                ))
-                cache[productIdentifier] = CachedPurchaseContext(
-                    offeringContext: presentedOfferingContext,
-                    paywallEvent: paywallEvent,
-                    cacheDate: self.dateProvider.now(),
-                    originatedFromPurchase: originatedFromPurchase
-                )
-            } else {
-                // Same offering (or one side absent): merge. This preserves a paywall event an
-                // earlier call cached when a later same-product call omits it.
-                cache[productIdentifier] = CachedPurchaseContext(
-                    offeringContext: presentedOfferingContext ?? existing?.offeringContext,
-                    paywallEvent: paywallEvent ?? existing?.paywallEvent,
-                    cacheDate: self.dateProvider.now(),
-                    originatedFromPurchase: originatedFromPurchase || (existing?.originatedFromPurchase ?? false)
-                )
-            }
-        }
+        let cached = CachedPurchaseContext(
+            offeringContext: presentedOfferingContext,
+            paywallEvent: paywallEvent,
+            cacheDate: self.dateProvider.now()
+        )
+        self.cachedPurchaseContextByProductID.modify { $0[productIdentifier] = cached }
     }
 
     func clearCachedPurchaseData(productIdentifier: String) {
@@ -1551,13 +1502,11 @@ extension PurchasesOrchestrator: StoreKit2TransactionListenerDelegate {
     ) async throws {
         // Only attribute offering context and paywall data for transactions that are not known
         // to be renewals. When the reason is `nil` (i.e. iOS < 17), we still attempt
-        // attribution because the product-ID and date matching in `consumeCachedPurchaseContext`
+        // attribution because the product-ID and date matching in `getAndRemoveCachedPurchaseContext`
         // will safely return nil for non-matching transactions, making the misattribution case
         // extremely unlikely.
         let isKnownRenewal = transaction.reason == .renewal
-        let cached = isKnownRenewal
-            ? nil
-            : self.consumeCachedPurchaseContext(for: transaction, initiationSource: .queue)
+        let cached = isKnownRenewal ? nil : self.getAndRemoveCachedPurchaseContext(for: transaction)
         let offeringContext = cached?.offeringContext
         let paywall = cached?.paywallEvent
 
@@ -1975,13 +1924,8 @@ private extension PurchasesOrchestrator {
     func handleSK1PurchasedTransaction(_ purchasedTransaction: StoreTransaction,
                                        storefront: StorefrontType?,
                                        restored: Bool) {
-        let purchaseSource = self.purchaseSource(for: purchasedTransaction.productIdentifier,
-                                                 restored: restored)
         // Don't attribute offering context or paywall data for restored transactions
-        let cached = restored
-            ? nil
-            : self.consumeCachedPurchaseContext(for: purchasedTransaction,
-                                                initiationSource: purchaseSource.initiationSource)
+        let cached = restored ? nil : self.getAndRemoveCachedPurchaseContext(for: purchasedTransaction)
         let offeringContext = cached?.offeringContext
         let paywall = cached?.paywallEvent
         let unsyncedAttributes = self.refreshATTStatusAndGetUnsyncedAttributes()
@@ -1993,6 +1937,8 @@ private extension PurchasesOrchestrator {
                 aadAttributionToken: adServicesToken,
                 storeCountry: storefront?.countryCode
             )
+            let purchaseSource = self.purchaseSource(for: purchasedTransaction.productIdentifier,
+                                                     restored: restored)
 
             self.transactionPoster.handlePurchasedTransaction(
                 purchasedTransaction,
@@ -2037,45 +1983,29 @@ private extension PurchasesOrchestrator {
 
     /// Cached purchase context containing both offering and optional paywall event data,
     /// keyed by product identifier. The `cacheDate` is used to verify that the cached
-    /// context corresponds to a specific transaction (not an older/newer one). `originatedFromPurchase`
-    /// records whether the entry was cached at the intent of a RevenueCat `purchase()` call.
+    /// context corresponds to a specific transaction (not an older/newer one).
     struct CachedPurchaseContext {
         let offeringContext: PresentedOfferingContext?
         let paywallEvent: PaywallEvent?
         let cacheDate: Date
-        let originatedFromPurchase: Bool
     }
 
-    /// Returns the cached purchase context for a `transaction`, **potentially evicting it from the
-    /// cache** (see eviction rule below), applying the product-ID and date-compatibility check: the
-    /// cache date must be at or before the transaction's purchase date, otherwise the cache is for a
-    /// later purchase and `nil` is returned. Also returns `nil` when there is no cached context for
-    /// the product.
-    ///
-    /// Whether the entry is *consumed* (removed) or only *peeked* (left in place) depends on its
-    /// origin, not on the caller:
-    /// - Entries cached at the intent of a RevenueCat `purchase()` call (`originatedFromPurchase`)
-    ///   are consumed only by their purchase-initiated post. Queue-initiated reads peek, so a queue
-    ///   transaction racing ahead of `purchase()` returning and the later purchase post are both
-    ///   attributed.
-    /// - Externally-cached entries (SwiftUI StoreKit paywalls, custom purchase logic via the
-    ///   `@_spi(Internal)` `cachePurchaseData`) have no purchase-initiated post to follow, so the
-    ///   first read (a queue post) consumes them, preventing the entry from leaking indefinitely.
-    func consumeCachedPurchaseContext(
-        for transaction: StoreTransactionType,
-        initiationSource: PostReceiptSource.InitiationSource
+    /// Atomically retrieves and removes the cached purchase context for a transaction.
+    /// Returns `nil` if no cached context exists for the product, or if the cache date
+    /// is after the transaction's purchase date (meaning the cache is for a later purchase).
+    func getAndRemoveCachedPurchaseContext(
+        for transaction: StoreTransactionType
     ) -> CachedPurchaseContext? {
         return self.cachedPurchaseContextByProductID.modify { cache in
-            guard let cached = cache[transaction.productIdentifier],
-                  cached.cacheDate <= transaction.purchaseDate else {
+            guard let cached = cache[transaction.productIdentifier] else {
                 return nil
             }
 
-            let shouldRemove = !cached.originatedFromPurchase || initiationSource == .purchase
-            if shouldRemove {
-                cache.removeValue(forKey: transaction.productIdentifier)
+            guard cached.cacheDate <= transaction.purchaseDate else {
+                return nil
             }
 
+            cache.removeValue(forKey: transaction.productIdentifier)
             return cached
         }
     }
@@ -2351,7 +2281,7 @@ extension PurchasesOrchestrator {
         presentedOfferingContext: PresentedOfferingContext? = nil,
         presentedPaywall: PaywallEvent? = nil
     ) async throws -> CustomerInfo {
-        let cached = self.consumeCachedPurchaseContext(for: transaction, initiationSource: initiationSource)
+        let cached = self.getAndRemoveCachedPurchaseContext(for: transaction)
         let offeringContext = presentedOfferingContext ?? cached?.offeringContext
         let paywall = presentedPaywall ?? cached?.paywallEvent
         let unsyncedAttributes = self.refreshATTStatusAndGetUnsyncedAttributes()

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorSK1Tests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorSK1Tests.swift
@@ -893,7 +893,7 @@ class PurchasesOrchestratorSK1Tests: BasePurchasesOrchestratorTests, PurchasesOr
         let product = try await self.fetchSk1Product()
         let payment = self.storeKit1Wrapper.payment(with: product)
 
-        // Simulate a hybrid SDK caching the context via the @_spi(Internal) API (external entry).
+        // Simulate a hybrid SDK caching the context via the @_spi(Internal) API
         self.orchestrator.cachePurchaseData(
             presentedOfferingContext: PresentedOfferingContext(offeringIdentifier: "hybrid_offering"),
             paywallEvent: nil,
@@ -933,8 +933,6 @@ class PurchasesOrchestratorSK1Tests: BasePurchasesOrchestratorTests, PurchasesOr
             }
         }
 
-        // A cancelled/failed purchase clears the cached context regardless of where it came from,
-        // so the subsequent successful purchase of the same product has no offering context.
         expect(
             self.backend.invokedPostReceiptDataParameters?.transactionData.presentedOfferingContext
         ).to(beNil())
@@ -1126,107 +1124,6 @@ class PurchasesOrchestratorSK1Tests: BasePurchasesOrchestratorTests, PurchasesOr
         // The paywall data should NOT be included because the product ID doesn't match
         expect(
             self.backend.invokedPostReceiptDataParameters?.transactionData.presentedPaywall
-        ).to(beNil())
-    }
-
-    // MARK: - Cached purchase context peek vs remove
-
-    func testSK1QueueTransactionPeeksCachedPurchaseContext() async throws {
-        self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
-
-        let product = try await self.fetchSk1Product()
-        let mockPayment = self.storeKit1Wrapper.payment(with: product)
-
-        let cacheDate = self.mockDateProvider.now()
-        // A purchase-originated entry is only consumed by its purchase-initiated post, so queue
-        // reads peek and leave it in place.
-        self.orchestrator.cachePurchaseData(
-            presentedOfferingContext: PresentedOfferingContext(offeringIdentifier: "test_offering"),
-            paywallEvent: nil,
-            productIdentifier: Self.testProductId,
-            originatedFromPurchase: true
-        )
-
-        let queueTransaction = MockTransaction()
-        queueTransaction.mockPayment = mockPayment
-        queueTransaction.mockState = .purchased
-        queueTransaction.mockTransactionDate = cacheDate.addingTimeInterval(1)
-
-        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(
-            self.storeKit1Wrapper,
-            updatedTransaction: queueTransaction
-        )
-
-        await expect(self.backend.invokedPostReceiptData).toEventually(beTrue())
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData
-                .presentedOfferingContext?.offeringIdentifier
-        ) == "test_offering"
-        expect(self.backend.invokedPostReceiptDataParameters?.postReceiptSource.initiationSource) == .queue
-
-        self.backend.invokedPostReceiptData = false
-        self.backend.invokedPostReceiptDataParameters = nil
-
-        let secondQueueTransaction = MockTransaction()
-        secondQueueTransaction.mockPayment = mockPayment
-        secondQueueTransaction.mockState = .purchased
-        secondQueueTransaction.mockTransactionDate = cacheDate.addingTimeInterval(2)
-
-        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(
-            self.storeKit1Wrapper,
-            updatedTransaction: secondQueueTransaction
-        )
-
-        await expect(self.backend.invokedPostReceiptData).toEventually(beTrue())
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData
-                .presentedOfferingContext?.offeringIdentifier
-        ) == "test_offering"
-    }
-
-    func testSK1PurchaseTransactionRemovesCachedPurchaseContext() async throws {
-        self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
-
-        let product = try await self.fetchSk1Product()
-        let payment = self.storeKit1Wrapper.payment(with: product)
-
-        self.orchestrator.cachePurchaseData(
-            presentedOfferingContext: PresentedOfferingContext(offeringIdentifier: "test_offering"),
-            paywallEvent: nil,
-            productIdentifier: Self.testProductId
-        )
-
-        _ = await withCheckedContinuation { continuation in
-            self.orchestrator.purchase(
-                sk1Product: product,
-                payment: payment,
-                package: nil,
-                wrapper: self.storeKit1Wrapper
-            ) { transaction, customerInfo, error, userCancelled in
-                continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
-            }
-        }
-
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData
-                .presentedOfferingContext?.offeringIdentifier
-        ) == "test_offering"
-
-        self.backend.invokedPostReceiptData = false
-
-        let queueTransaction = MockTransaction()
-        queueTransaction.mockPayment = payment
-        queueTransaction.mockState = .purchased
-        queueTransaction.mockTransactionDate = self.mockDateProvider.now().addingTimeInterval(1)
-
-        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(
-            self.storeKit1Wrapper,
-            updatedTransaction: queueTransaction
-        )
-
-        await expect(self.backend.invokedPostReceiptData).toEventually(beTrue())
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData.presentedOfferingContext
         ).to(beNil())
     }
 

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorSK2Tests.swift
@@ -1244,49 +1244,6 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
         ) == "test_offering"
     }
 
-    func testSK2TransactionListenerDelegateIncludesCachedOfferingAndPaywall() async throws {
-        self.setUpStoreKit2Listener()
-
-        self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
-        self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
-
-        let offeringContext = PresentedOfferingContext(offeringIdentifier: "test_offering")
-        let paywallEvent = PaywallEvent.purchaseInitiated(
-            Self.paywallEventCreationData,
-            Self.paywallEventWithPurchaseInfo
-        )
-
-        let cacheDate = self.mockDateProvider.now()
-        self.orchestrator.cachePurchaseData(
-            presentedOfferingContext: offeringContext,
-            paywallEvent: paywallEvent,
-            productIdentifier: Self.testProductId
-        )
-
-        let transaction = MockStoreTransaction(
-            productIdentifier: Self.testProductId,
-            purchaseDate: cacheDate.addingTimeInterval(1)
-        )
-
-        try await self.orchestrator.storeKit2TransactionListener(
-            self.mockStoreKit2TransactionListener!,
-            updatedTransaction: transaction
-        )
-
-        expect(self.backend.invokedPostReceiptData) == true
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData
-                .presentedOfferingContext?.offeringIdentifier
-        ) == "test_offering"
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData.presentedPaywall?.creationData
-        ) == Self.paywallEventCreationData
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData.presentedPaywall?.data
-        ) == Self.paywallEventWithPurchaseInfo
-        expect(self.backend.invokedPostReceiptDataParameters?.postReceiptSource.initiationSource) == .queue
-    }
-
     func testSK2PurchaseWithPackageThenCancelledThenPurchaseWithProductDoesNotIncludeOfferingContext() async throws {
         self.setUpStoreKit2Listener()
 
@@ -1382,7 +1339,7 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
         ).to(beNil())
     }
 
-    func testSK2CancelledPurchaseClearsCachedPresentedOfferingContext() async throws {
+    func testSK2CancelledPurchaseDoesNotClearExternallyCachedPresentedOfferingContext() async throws {
         self.setUpStoreKit2Listener()
 
         self.customerInfoManager.stubbedCustomerInfoResult = .success(self.mockCustomerInfo)
@@ -1412,7 +1369,8 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
         )
         expect(cancelled) == true
 
-        // The SK2 purchase path clears cached context on cancel.
+        // The SK2 purchase path does not clear externally cached context.
+        // A subsequent transaction via the listener should still pick it up.
         let transaction = MockStoreTransaction(productIdentifier: product.id)
 
         try await self.orchestrator.storeKit2TransactionListener(
@@ -1422,11 +1380,12 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
 
         expect(self.backend.invokedPostReceiptData) == true
         expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData.presentedOfferingContext
-        ).to(beNil())
+            self.backend.invokedPostReceiptDataParameters?.transactionData
+                .presentedOfferingContext?.offeringIdentifier
+        ) == "test_offering"
     }
 
-    func testSK2FailedPurchaseClearsCachedPresentedOfferingContext() async throws {
+    func testSK2FailedPurchaseDoesNotClearExternallyCachedPresentedOfferingContext() async throws {
         self.setUpStoreKit2Listener()
 
         self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
@@ -1461,7 +1420,8 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
 
         self.testSession.failTransactionsEnabled = false
 
-        // The SK2 purchase path clears cached context on failure.
+        // The SK2 purchase path does not clear externally cached context.
+        // A subsequent transaction via the listener should still pick it up.
         let transaction = MockStoreTransaction(productIdentifier: product.id)
 
         try await self.orchestrator.storeKit2TransactionListener(
@@ -1471,11 +1431,12 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
 
         expect(self.backend.invokedPostReceiptData) == true
         expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData.presentedOfferingContext
-        ).to(beNil())
+            self.backend.invokedPostReceiptDataParameters?.transactionData
+                .presentedOfferingContext?.offeringIdentifier
+        ) == "test_offering"
     }
 
-    func testSK2CancelledPurchaseClearsCachedContextWithCustomEntitlementComputation() async throws {
+    func testSK2CancelledPurchaseDoesNotClearExternallyCachedContextWithCustomEntitlementComputation() async throws {
         self.setUpSystemInfo(finishTransactions: true, customEntitlementComputation: true)
         self.setUpOrchestrator()
         self.setUpStoreKit2Listener()
@@ -1509,7 +1470,8 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
             expect(error).to(matchError(ErrorCode.purchaseCancelledError))
         }
 
-        // The SK2 purchase path clears cached context on cancel.
+        // The SK2 purchase path does not clear externally cached context.
+        // A subsequent transaction via the listener should still pick it up.
         let transaction = MockStoreTransaction(productIdentifier: product.id)
 
         try await self.orchestrator.storeKit2TransactionListener(
@@ -1519,8 +1481,9 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
 
         expect(self.backend.invokedPostReceiptData) == true
         expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData.presentedOfferingContext
-        ).to(beNil())
+            self.backend.invokedPostReceiptDataParameters?.transactionData
+                .presentedOfferingContext?.offeringIdentifier
+        ) == "test_offering"
     }
 
     func testSK2FailedPurchaseForProductADoesNotAffectProductBContext() async throws {
@@ -1574,7 +1537,7 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
         ) == "offering_b"
     }
 
-    func testSK2ExternallyCachedContextIsClearedOnFailure() async throws {
+    func testSK2ExternallyCachedContextIsNotClearedOnFailure() async throws {
         self.setUpStoreKit2Listener()
 
         self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
@@ -1609,8 +1572,8 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
 
         self.testSession.failTransactionsEnabled = false
 
-        // A cancelled/failed purchase clears the cached context regardless of where it came from,
-        // so a subsequent transaction via the listener has no offering context to attach.
+        // The SK2 purchase path does not clear externally cached context.
+        // A subsequent transaction via the listener should still pick it up.
         let transaction = MockStoreTransaction(productIdentifier: product.id)
 
         try await self.orchestrator.storeKit2TransactionListener(
@@ -1620,8 +1583,9 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
 
         expect(self.backend.invokedPostReceiptData) == true
         expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData.presentedOfferingContext
-        ).to(beNil())
+            self.backend.invokedPostReceiptDataParameters?.transactionData
+                .presentedOfferingContext?.offeringIdentifier
+        ) == "hybrid_offering"
     }
 
     func testSK2PurchasePackageCancelThenPurchasePackageAgainIncludesOfferingContext() async throws {
@@ -1756,147 +1720,6 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
         ) == "test_offering"
     }
 
-    func testSK2QueueListenerPeeksPurchaseOriginatedContextWithoutRemoving() async throws {
-        self.setUpStoreKit2Listener()
-
-        self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
-        self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
-
-        // A purchase-originated entry is only consumed by its purchase-initiated post, so queue
-        // reads peek and leave it in place (handling the race where a queue transaction arrives
-        // before `purchase()` returns).
-        self.orchestrator.cachePurchaseData(
-            presentedOfferingContext: PresentedOfferingContext(offeringIdentifier: "test_offering"),
-            paywallEvent: nil,
-            productIdentifier: Self.testProductId,
-            originatedFromPurchase: true
-        )
-
-        let transaction = MockStoreTransaction(productIdentifier: Self.testProductId)
-
-        try await self.orchestrator.storeKit2TransactionListener(
-            self.mockStoreKit2TransactionListener!,
-            updatedTransaction: transaction
-        )
-
-        expect(self.backend.invokedPostReceiptData) == true
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData
-                .presentedOfferingContext?.offeringIdentifier
-        ) == "test_offering"
-        expect(self.backend.invokedPostReceiptDataParameters?.postReceiptSource.initiationSource) == .queue
-
-        self.backend.invokedPostReceiptData = false
-        self.backend.invokedPostReceiptDataParameters = nil
-
-        let secondTransaction = MockStoreTransaction(productIdentifier: Self.testProductId)
-
-        try await self.orchestrator.storeKit2TransactionListener(
-            self.mockStoreKit2TransactionListener!,
-            updatedTransaction: secondTransaction
-        )
-
-        expect(self.backend.invokedPostReceiptData) == true
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData
-                .presentedOfferingContext?.offeringIdentifier
-        ) == "test_offering"
-    }
-
-    func testSK2QueueListenerRemovesExternallyCachedPurchaseContext() async throws {
-        self.setUpStoreKit2Listener()
-
-        self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
-        self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
-
-        // An externally-cached entry (the default, e.g. SwiftUI StoreKit paywalls) has no
-        // purchase-initiated post to follow, so the first queue read consumes it.
-        self.orchestrator.cachePurchaseData(
-            presentedOfferingContext: PresentedOfferingContext(offeringIdentifier: "test_offering"),
-            paywallEvent: nil,
-            productIdentifier: Self.testProductId
-        )
-
-        let transaction = MockStoreTransaction(productIdentifier: Self.testProductId)
-
-        try await self.orchestrator.storeKit2TransactionListener(
-            self.mockStoreKit2TransactionListener!,
-            updatedTransaction: transaction
-        )
-
-        expect(self.backend.invokedPostReceiptData) == true
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData
-                .presentedOfferingContext?.offeringIdentifier
-        ) == "test_offering"
-        expect(self.backend.invokedPostReceiptDataParameters?.postReceiptSource.initiationSource) == .queue
-
-        self.backend.invokedPostReceiptData = false
-
-        // The entry was consumed by the first queue read, so a subsequent same-product queue
-        // transaction gets no attribution, preventing the externally-cached context from leaking.
-        let secondTransaction = MockStoreTransaction(productIdentifier: Self.testProductId)
-
-        try await self.orchestrator.storeKit2TransactionListener(
-            self.mockStoreKit2TransactionListener!,
-            updatedTransaction: secondTransaction
-        )
-
-        expect(self.backend.invokedPostReceiptData) == true
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData.presentedOfferingContext
-        ).to(beNil())
-    }
-
-    func testSK2PurchaseRemovesCachedPurchaseContext() async throws {
-        self.setUpStoreKit2Listener()
-
-        self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
-        self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
-
-        self.orchestrator.cachePurchaseData(
-            presentedOfferingContext: PresentedOfferingContext(offeringIdentifier: "test_offering"),
-            paywallEvent: nil,
-            productIdentifier: Self.testProductId
-        )
-
-        let mockListener = try XCTUnwrap(
-            self.orchestrator.storeKit2TransactionListener as? MockStoreKit2TransactionListener
-        )
-        mockListener.mockTransaction = .init(try await self.simulateAnyPurchase())
-
-        let product = try await self.fetchSk2Product()
-
-        _ = try await self.orchestrator.purchase(
-            sk2Product: product,
-            package: nil,
-            promotionalOffer: nil,
-            winBackOffer: nil,
-            introductoryOfferEligibilityJWS: nil,
-            billingPlanType: nil,
-            promotionalOfferOptions: nil
-        )
-
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData
-                .presentedOfferingContext?.offeringIdentifier
-        ) == "test_offering"
-
-        self.backend.invokedPostReceiptData = false
-
-        let queueTransaction = MockStoreTransaction(productIdentifier: Self.testProductId)
-
-        try await self.orchestrator.storeKit2TransactionListener(
-            self.mockStoreKit2TransactionListener!,
-            updatedTransaction: queueTransaction
-        )
-
-        expect(self.backend.invokedPostReceiptData) == true
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData.presentedOfferingContext
-        ).to(beNil())
-    }
-
     func testSK2TransactionListenerDoesNotAttributeCachedDataWhenPurchaseDateIsBeforeCacheDate() async throws {
         self.setUpStoreKit2Listener()
 
@@ -1930,327 +1753,6 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
         // transaction's purchase date is before the cache date
         expect(self.backend.invokedPostReceiptDataParameters?.transactionData.presentedOfferingContext).to(beNil())
         expect(self.backend.invokedPostReceiptDataParameters?.transactionData.presentedPaywall).to(beNil())
-    }
-
-    func testSK2TransactionListenerAttributesStaleCachedContextToLaterSameProductTransaction() async throws {
-        self.setUpStoreKit2Listener()
-
-        self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
-        self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
-
-        let cacheDate = self.mockDateProvider.now()
-        self.orchestrator.cachePurchaseData(
-            presentedOfferingContext: PresentedOfferingContext(offeringIdentifier: "test_offering"),
-            paywallEvent: .purchaseInitiated(
-                Self.paywallEventCreationData,
-                Self.paywallEventWithPurchaseInfo
-            ),
-            productIdentifier: Self.testProductId,
-            originatedFromPurchase: true
-        )
-
-        // A later transaction for the same product arrives via the queue, well after the cached
-        // purchase intent. Because a purchase-originated entry is only peeked (never evicted) by
-        // queue reads and the transaction's purchase date is at/after the cache date, the cached
-        // context is intentionally reused. This is the flip side of
-        // `testSK2TransactionListenerDoesNotAttributeCachedDataWhenPurchaseDateIsBeforeCacheDate`
-        // and pins down the accepted trade-off of peeking purchase-originated entries on the queue.
-        let laterTransaction = MockStoreTransaction(
-            productIdentifier: Self.testProductId,
-            purchaseDate: cacheDate.addingTimeInterval(60 * 60)
-        )
-
-        try await self.orchestrator.storeKit2TransactionListener(
-            self.mockStoreKit2TransactionListener!,
-            updatedTransaction: laterTransaction
-        )
-
-        expect(self.backend.invokedPostReceiptData) == true
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData
-                .presentedOfferingContext?.offeringIdentifier
-        ) == "test_offering"
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData.presentedPaywall?.creationData
-        ) == Self.paywallEventCreationData
-        expect(self.backend.invokedPostReceiptDataParameters?.postReceiptSource.initiationSource) == .queue
-    }
-
-    func testCachePurchaseDataMergePreservesCachedPaywallWhenLaterWriteOmitsIt() async throws {
-        self.setUpStoreKit2Listener()
-
-        self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
-        self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
-
-        // A first write caches the paywall (e.g. an external `cachePurchaseData` call) and a later
-        // same-product write omits it (e.g. the SDK's purchase path caching only the offering). The
-        // merge must keep the previously cached paywall rather than clobber it with nil.
-        self.orchestrator.cachePurchaseData(
-            presentedOfferingContext: PresentedOfferingContext(offeringIdentifier: "offering"),
-            paywallEvent: .purchaseInitiated(
-                Self.paywallEventCreationData,
-                Self.paywallEventWithPurchaseInfo
-            ),
-            productIdentifier: Self.testProductId
-        )
-        self.orchestrator.cachePurchaseData(
-            presentedOfferingContext: PresentedOfferingContext(offeringIdentifier: "offering"),
-            paywallEvent: nil,
-            productIdentifier: Self.testProductId,
-            originatedFromPurchase: true
-        )
-
-        try await self.orchestrator.storeKit2TransactionListener(
-            self.mockStoreKit2TransactionListener!,
-            updatedTransaction: MockStoreTransaction(productIdentifier: Self.testProductId)
-        )
-
-        expect(self.backend.invokedPostReceiptData) == true
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData
-                .presentedOfferingContext?.offeringIdentifier
-        ) == "offering"
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData.presentedPaywall?.creationData
-        ) == Self.paywallEventCreationData
-    }
-
-    func testCachePurchaseDataMergePreservesCachedOfferingWhenLaterWriteOmitsIt() async throws {
-        self.setUpStoreKit2Listener()
-
-        self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
-        self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
-
-        // Symmetric to the paywall case: a first write caches the offering and a later same-product
-        // write carries only the paywall (whose offering matches). The merge must keep the previously
-        // cached offering.
-        self.orchestrator.cachePurchaseData(
-            presentedOfferingContext: PresentedOfferingContext(offeringIdentifier: "offering"),
-            paywallEvent: nil,
-            productIdentifier: Self.testProductId
-        )
-        self.orchestrator.cachePurchaseData(
-            presentedOfferingContext: nil,
-            paywallEvent: .purchaseInitiated(
-                Self.paywallEventCreationData,
-                Self.paywallEventWithPurchaseInfo
-            ),
-            productIdentifier: Self.testProductId,
-            originatedFromPurchase: true
-        )
-
-        try await self.orchestrator.storeKit2TransactionListener(
-            self.mockStoreKit2TransactionListener!,
-            updatedTransaction: MockStoreTransaction(productIdentifier: Self.testProductId)
-        )
-
-        expect(self.backend.invokedPostReceiptData) == true
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData
-                .presentedOfferingContext?.offeringIdentifier
-        ) == "offering"
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData.presentedPaywall?.creationData
-        ) == Self.paywallEventCreationData
-    }
-
-    func testCachePurchaseDataMergeKeepsPurchaseOriginatedFlagAcrossWrites() async throws {
-        self.setUpStoreKit2Listener()
-
-        self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
-        self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
-
-        // A purchase-originated write is followed by a later external (default) write. The merged
-        // entry must stay purchase-originated, so queue reads peek (never evict) it. Otherwise the
-        // entry would be consumed by the first queue read and lost before `purchase()` returns.
-        self.orchestrator.cachePurchaseData(
-            presentedOfferingContext: PresentedOfferingContext(offeringIdentifier: "offering"),
-            paywallEvent: nil,
-            productIdentifier: Self.testProductId,
-            originatedFromPurchase: true
-        )
-        self.orchestrator.cachePurchaseData(
-            presentedOfferingContext: PresentedOfferingContext(offeringIdentifier: "offering"),
-            paywallEvent: nil,
-            productIdentifier: Self.testProductId
-        )
-
-        try await self.orchestrator.storeKit2TransactionListener(
-            self.mockStoreKit2TransactionListener!,
-            updatedTransaction: MockStoreTransaction(productIdentifier: Self.testProductId)
-        )
-
-        expect(self.backend.invokedPostReceiptData) == true
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData
-                .presentedOfferingContext?.offeringIdentifier
-        ) == "offering"
-
-        self.backend.invokedPostReceiptData = false
-        self.backend.invokedPostReceiptDataParameters = nil
-
-        // A second queue read still sees the entry: the purchase-originated flag survived the merge.
-        try await self.orchestrator.storeKit2TransactionListener(
-            self.mockStoreKit2TransactionListener!,
-            updatedTransaction: MockStoreTransaction(productIdentifier: Self.testProductId)
-        )
-
-        expect(self.backend.invokedPostReceiptData) == true
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData
-                .presentedOfferingContext?.offeringIdentifier
-        ) == "offering"
-    }
-
-    func testCachePurchaseDataKeepsLatestAndDropsPreviousWhenOfferingDiffersForSameProduct() async throws {
-        self.setUpStoreKit2Listener()
-
-        self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
-        self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
-
-        // A paywall caches an offering + paywall event for the product, then the developer starts a
-        // purchase for a *different* offering's package (same product id). The offerings disagree, so
-        // the latest write wins and the previously cached paywall event is dropped rather than merged.
-        self.orchestrator.cachePurchaseData(
-            presentedOfferingContext: PresentedOfferingContext(offeringIdentifier: "offering"),
-            paywallEvent: .purchaseInitiated(
-                Self.paywallEventCreationData,
-                Self.paywallEventWithPurchaseInfo
-            ),
-            productIdentifier: Self.testProductId
-        )
-        self.orchestrator.cachePurchaseData(
-            presentedOfferingContext: PresentedOfferingContext(offeringIdentifier: "offering_b"),
-            paywallEvent: nil,
-            productIdentifier: Self.testProductId,
-            originatedFromPurchase: true
-        )
-
-        try await self.orchestrator.storeKit2TransactionListener(
-            self.mockStoreKit2TransactionListener!,
-            updatedTransaction: MockStoreTransaction(productIdentifier: Self.testProductId)
-        )
-
-        expect(self.backend.invokedPostReceiptData) == true
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData
-                .presentedOfferingContext?.offeringIdentifier
-        ) == "offering_b"
-        expect(self.backend.invokedPostReceiptDataParameters?.transactionData.presentedPaywall).to(beNil())
-    }
-
-    func testCachePurchaseDataDetectsOfferingMismatchUsingCachedPaywallOffering() async throws {
-        self.setUpStoreKit2Listener()
-
-        self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
-        self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
-
-        // The cached entry has no offering context, only a paywall event, so its offering is read from
-        // the paywall (`"offering"`). A later purchase for a different offering ("offering_b") must
-        // still be detected as a mismatch and keep only the latest data.
-        self.orchestrator.cachePurchaseData(
-            presentedOfferingContext: nil,
-            paywallEvent: .purchaseInitiated(
-                Self.paywallEventCreationData,
-                Self.paywallEventWithPurchaseInfo
-            ),
-            productIdentifier: Self.testProductId
-        )
-        self.orchestrator.cachePurchaseData(
-            presentedOfferingContext: PresentedOfferingContext(offeringIdentifier: "offering_b"),
-            paywallEvent: nil,
-            productIdentifier: Self.testProductId,
-            originatedFromPurchase: true
-        )
-
-        try await self.orchestrator.storeKit2TransactionListener(
-            self.mockStoreKit2TransactionListener!,
-            updatedTransaction: MockStoreTransaction(productIdentifier: Self.testProductId)
-        )
-
-        expect(self.backend.invokedPostReceiptData) == true
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData
-                .presentedOfferingContext?.offeringIdentifier
-        ) == "offering_b"
-        expect(self.backend.invokedPostReceiptDataParameters?.transactionData.presentedPaywall).to(beNil())
-    }
-
-    func testSK2QueueTransactionArrivingDuringPurchaseIsAttributedAndPurchaseStillConsumesCache() async throws {
-        self.setUpStoreKit2Listener()
-
-        self.customerInfoManager.stubbedCustomerInfoResult = .success(self.mockCustomerInfo)
-        self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
-        self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
-
-        let product = try await self.fetchSk2Product()
-        let package = Package(
-            identifier: "package",
-            packageType: .monthly,
-            storeProduct: StoreProduct(sk2Product: product),
-            offeringIdentifier: "test_offering",
-            webCheckoutUrl: nil
-        )
-
-        let mockListener = try XCTUnwrap(
-            self.orchestrator.storeKit2TransactionListener as? MockStoreKit2TransactionListener
-        )
-        mockListener.mockTransaction = .init(try await self.simulateAnyPurchase())
-
-        // Reproduce the race we're fixing: while `purchase()` is in flight (the purchase intent
-        // has been cached, but the purchase-initiated POST hasn't happened yet), a queue
-        // transaction for the same product arrives. The `onHandle` hook fires from within the
-        // listener's `handle(purchaseResult:)`, which the purchase flow awaits after caching the
-        // intent and before posting.
-        var queuePostInitiationSource: PostReceiptSource.InitiationSource?
-        var queuePostOfferingIdentifier: String??
-        mockListener.onHandle = {
-            let queueTransaction = MockStoreTransaction(productIdentifier: product.id)
-            try await self.orchestrator.storeKit2TransactionListener(
-                self.mockStoreKit2TransactionListener!,
-                updatedTransaction: queueTransaction
-            )
-            queuePostInitiationSource =
-                self.backend.invokedPostReceiptDataParameters?.postReceiptSource.initiationSource
-            queuePostOfferingIdentifier =
-                self.backend.invokedPostReceiptDataParameters?.transactionData
-                    .presentedOfferingContext?.offeringIdentifier
-        }
-
-        _ = try await self.orchestrator.purchase(
-            sk2Product: product,
-            package: package,
-            promotionalOffer: nil,
-            winBackOffer: nil,
-            introductoryOfferEligibilityJWS: nil,
-            billingPlanType: nil,
-            promotionalOfferOptions: nil
-        )
-
-        // The queue transaction that arrived mid-purchase was attributed from the cached intent.
-        expect(queuePostInitiationSource) == .queue
-        expect(queuePostOfferingIdentifier) == "test_offering"
-
-        // The purchase-initiated POST is also attributed (offering passed directly + cached intent).
-        expect(self.backend.invokedPostReceiptDataParameters?.postReceiptSource.initiationSource) == .purchase
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData
-                .presentedOfferingContext?.offeringIdentifier
-        ) == "test_offering"
-
-        // After the purchase consumed the cache, a later queue transaction for the same product
-        // no longer gets attribution.
-        self.backend.invokedPostReceiptData = false
-        let trailingTransaction = MockStoreTransaction(productIdentifier: product.id)
-        try await self.orchestrator.storeKit2TransactionListener(
-            self.mockStoreKit2TransactionListener!,
-            updatedTransaction: trailingTransaction
-        )
-
-        expect(self.backend.invokedPostReceiptData) == true
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData.presentedOfferingContext
-        ).to(beNil())
     }
 
     func testSK2TransactionListenerDelegateIncludesAttributionForPurchaseReason() async throws {
@@ -2379,70 +1881,6 @@ class PurchasesOrchestratorSK2Tests: BasePurchasesOrchestratorTests, PurchasesOr
             self.backend.invokedPostReceiptDataParameters?.transactionData.presentedPaywall?.data
         ) == Self.paywallEventWithPurchaseInfo
         expect(self.backend.invokedPostReceiptDataParameters?.postReceiptSource.initiationSource) == .queue
-    }
-
-    func testHandleRecordPurchaseRemovesExternallyCachedPurchaseContext() async throws {
-        self.setUpSystemInfo(finishTransactions: false) // Observer mode (required by recordPurchase)
-        self.setUpOrchestrator()
-        self.setUpStoreKit2Listener()
-
-        self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
-        self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
-
-        self.orchestrator.cachePurchaseData(
-            presentedOfferingContext: PresentedOfferingContext(offeringIdentifier: "test_offering"),
-            paywallEvent: .purchaseInitiated(
-                Self.paywallEventCreationData,
-                Self.paywallEventWithPurchaseInfo
-            ),
-            productIdentifier: Self.testProductId
-        )
-
-        let product = try await self.fetchSk2Product()
-        let purchaseResult = try await product.purchase()
-
-        guard case let .success(verificationResult) = purchaseResult,
-              case let .verified(sk2Transaction) = verificationResult else {
-            fail("Expected verified transaction")
-            return
-        }
-
-        let mockListener = try XCTUnwrap(
-            self.orchestrator.storeKit2TransactionListener as? MockStoreKit2TransactionListener
-        )
-        mockListener.mockTransaction = .init(sk2Transaction)
-        mockListener.mockJWSToken = verificationResult.jwsRepresentation
-
-        let transaction = try await self.orchestrator.handleRecordPurchase(purchaseResult)
-
-        expect(transaction).toNot(beNil())
-        expect(self.backend.invokedPostReceiptData) == true
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData.presentedPaywall?.creationData
-        ) == Self.paywallEventCreationData
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData
-                .presentedOfferingContext?.offeringIdentifier
-        ) == "test_offering"
-        expect(self.backend.invokedPostReceiptDataParameters?.postReceiptSource.initiationSource) == .queue
-
-        self.backend.invokedPostReceiptData = false
-
-        // The cached context was externally cached (no purchase-initiated post follows), so the
-        // `recordPurchase` queue post consumed it: a subsequent same-product queue transaction is
-        // no longer attributed.
-        let secondTransaction = MockStoreTransaction(productIdentifier: Self.testProductId)
-
-        try await self.orchestrator.storeKit2TransactionListener(
-            mockListener,
-            updatedTransaction: secondTransaction
-        )
-
-        expect(self.backend.invokedPostReceiptData) == true
-        expect(self.backend.invokedPostReceiptDataParameters?.transactionData.presentedPaywall).to(beNil())
-        expect(
-            self.backend.invokedPostReceiptDataParameters?.transactionData.presentedOfferingContext
-        ).to(beNil())
     }
 
     func testHandleRecordPurchaseWithoutPaywall() async throws {

--- a/Tests/UnitTests/Mocks/MockStoreKit2TransactionListener.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKit2TransactionListener.swift
@@ -55,11 +55,6 @@ final class MockStoreKit2TransactionListener: StoreKit2TransactionListenerType {
     var invokedHandleParameters: (purchaseResult: Box<StoreKit.Product.PurchaseResult>, Void)?
     var invokedHandleParametersList = [(purchaseResult: Box<StoreKit.Product.PurchaseResult>, Void)]()
 
-    /// Optional hook invoked from within `handle(purchaseResult:)`, before it returns. Lets tests
-    /// reproduce the race where a queue transaction arrives while a `purchase()` call is still
-    /// in flight (i.e. after the purchase intent has been cached but before the purchase posts).
-    var onHandle: (() async throws -> Void)?
-
     func handle(
         purchaseResult: StoreKit.Product.PurchaseResult,
         fromTransactionUpdate: Bool = false
@@ -68,8 +63,6 @@ final class MockStoreKit2TransactionListener: StoreKit2TransactionListenerType {
         self.invokedHandleCount += 1
         self.invokedHandleParameters = (.init(purchaseResult), ())
         self.invokedHandleParametersList.append((.init(purchaseResult), ()))
-
-        try await self.onHandle?()
 
         if self.mockCancelled {
             return .userCancelled


### PR DESCRIPTION
### Motivation
Reverting the queue-initiated receipt post attribution changes from #7032 and its follow-up #7043. We'll take a different approach to solve SDK-4373

### Description
- #7043 was stacked onto #7032's branch, so both landed on `main` as the single squash commit `0dc32c9`. This reverts that commit, undoing both PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how offering and paywall data attach to receipt posts (SK1/SK2 queue vs purchase timing), which can mis-attribute or lose attribution compared to the reverted behavior.
> 
> **Overview**
> Reverts the **queue-initiated receipt post attribution** work from #7032/#7043, restoring the prior **purchase-context cache** model in `PurchasesOrchestrator`.
> 
> **Cache read/write:** `consumeCachedPurchaseContext(for:initiationSource:)` becomes **`getAndRemoveCachedPurchaseContext(for:)`**, which **always removes** the entry when it matches (product id + `cacheDate <= purchaseDate`). The **`originatedFromPurchase`** flag, **merge** of offering/paywall across writes, **offering-mismatch** handling, and the **`cache_purchase_data_offering_mismatch`** log are removed; **`cachePurchaseData`** now **overwrites** per product id only.
> 
> **SK2 purchase path:** Stops **pre-caching** context before `purchase(sk2Product:)` and stops **clearing** cached context on **cancel/failure** (externally cached context can still be picked up by the transaction listener). SK1 still caches at purchase start and clears on failed/cancelled purchase callbacks.
> 
> **Tests/mocks:** Drops peek-vs-consume, mid-purchase queue race, merge, and mismatch coverage; updates expectations (e.g. SK2 cancel/failure no longer clears external cache). Removes **`MockStoreKit2TransactionListener.onHandle`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a970c46ed9682cf5645286f50a2ef77fa35617a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->