### PR TITLE
refactor(remote-config): make rc container validation domain-specific

### DIFF
--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -327,6 +327,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .health,
                 .appHealthReportAvailability,
                 .isPurchaseAllowedByRestoreBehavior,
+                .remoteConfig,
                 .rewardVerificationStatus:
             return true
         case .getWorkflow,
@@ -342,8 +343,6 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .getCustomerCenterConfig,
                 .appHealthReport,
                 .postCreateTicket:
-            return false
-        case .remoteConfig:
             return false
         }
     }

--- a/Sources/Networking/Operations/GetRemoteConfigOperation.swift
+++ b/Sources/Networking/Operations/GetRemoteConfigOperation.swift
@@ -94,7 +94,7 @@ private extension GetRemoteConfigOperation {
     func getRemoteConfig(completion: @escaping () -> Void) {
         let request = HTTPRequest(method: .post(self.request), path: .remoteConfig)
 
-        self.httpClient.perform(request) { (response: VerifiedHTTPResponse<Data?>.Result) in
+        self.httpClient.perform(request) { (response: VerifiedHTTPResponse<RemoteConfigContainer?>.Result) in
             defer {
                 completion()
             }
@@ -102,12 +102,7 @@ private extension GetRemoteConfigOperation {
             self.callbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
                 callback.completion(
                     response
-                        .flatMap { response in
-                            Result {
-                                try RemoteConfigFetchResult(response: response)
-                            }
-                            .mapError { NetworkError.decoding($0, response.body ?? Data()) }
-                        }
+                        .map(RemoteConfigFetchResult.init(response:))
                         .mapError(BackendError.networkError)
                 )
             }

--- a/Sources/Networking/Operations/GetRemoteConfigOperation.swift
+++ b/Sources/Networking/Operations/GetRemoteConfigOperation.swift
@@ -94,7 +94,7 @@ private extension GetRemoteConfigOperation {
     func getRemoteConfig(completion: @escaping () -> Void) {
         let request = HTTPRequest(method: .post(self.request), path: .remoteConfig)
 
-        self.httpClient.perform(request) { (response: VerifiedHTTPResponse<RCContainer?>.Result) in
+        self.httpClient.perform(request) { (response: VerifiedHTTPResponse<Data?>.Result) in
             defer {
                 completion()
             }
@@ -102,7 +102,12 @@ private extension GetRemoteConfigOperation {
             self.callbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
                 callback.completion(
                     response
-                        .map { RemoteConfigFetchResult(response: $0) }
+                        .flatMap { response in
+                            Result {
+                                try RemoteConfigFetchResult(response: response)
+                            }
+                            .mapError { NetworkError.decoding($0, response.body ?? Data()) }
+                        }
                         .mapError(BackendError.networkError)
                 )
             }

--- a/Sources/Networking/RCContainer+Element.swift
+++ b/Sources/Networking/RCContainer+Element.swift
@@ -5,6 +5,7 @@
 //  Created by RevenueCat.
 //  Copyright © 2026 RevenueCat, Inc. All rights reserved.
 
+import CryptoKit
 import Foundation
 
 extension RCContainer {
@@ -58,6 +59,31 @@ extension RCContainer {
             return try self.withBytes(in: self.checksumRange, body)
         }
 
+        /// Returns whether the payload bytes match the element's stored checksum.
+        func isChecksumValid() -> Bool {
+            return self.checksum == self.payloadChecksum
+        }
+
+        /// Validates the payload bytes against the element's stored checksum.
+        func validateChecksum() throws {
+            let actual = self.payloadChecksum
+            guard self.checksum == actual else {
+                throw Parser.FormatError.checksumMismatch(
+                    expected: self.checksum,
+                    actual: actual
+                )
+            }
+        }
+
+        private var payloadChecksum: String {
+            var hash = SHA256()
+            self.withPayloadBytes { bytes in
+                hash.update(bufferPointer: bytes)
+            }
+
+            return Self.base64URLString(from: Array(hash.finalize().prefix(Self.checksumSize)))
+        }
+
         private func withBytes<T>(
             in range: Range<Data.Index>,
             _ body: (UnsafeRawBufferPointer) throws -> T
@@ -71,6 +97,20 @@ extension RCContainer {
             }
         }
 
+    }
+
+}
+
+private extension RCContainer.Element {
+
+    static let checksumSize = 24
+
+    static func base64URLString(from bytes: [UInt8]) -> String {
+        return Data(bytes)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
     }
 
 }

--- a/Sources/Networking/RCContainer+Parser.swift
+++ b/Sources/Networking/RCContainer+Parser.swift
@@ -121,8 +121,10 @@ extension RCContainer {
 
         /// Parses one element and returns an `Element` that points into the original container bytes.
         ///
-        /// The parser reads the stored checksum and payload range, but intentionally does not validate
-        /// payload bytes against the checksum. Callers validate elements according to their domain rules.
+        /// This parser validates only the container structure needed to safely find element boundaries.
+        /// It records the stored checksum and payload range without deciding whether that checksum is a
+        /// trust boundary. Element blob checksums should be validated before the blob is used or written
+        /// to disk; request/response signature verification should be used to verify authenticity.
         mutating func parseElement(index: Int) throws -> Element {
             guard self.hasBytes(Self.elementHeaderSize) else {
                 throw Parser.FormatError.truncatedElementHeader(index: index)

--- a/Sources/Networking/RCContainer+Parser.swift
+++ b/Sources/Networking/RCContainer+Parser.swift
@@ -5,15 +5,15 @@
 //  Created by RevenueCat.
 //  Copyright © 2026 RevenueCat, Inc. All rights reserved.
 
-import CryptoKit
 import Foundation
 
 extension RCContainer {
 
-    /// Validates and indexes the RC Container binary format.
+    /// Validates and indexes the RC Container binary structure.
     ///
-    /// The parser walks the container with a byte offset cursor, validates each field before advancing
-    /// past it, and records `Data.Index` ranges that point at the retained backing `Data`.
+    /// The parser walks the container with a byte offset cursor, validates structural fields before
+    /// advancing past them, and records `Data.Index` ranges that point at the retained backing `Data`.
+    /// Payload checksum validation is handled by `Element` according to each caller's domain rules.
     struct Parser {
 
         // swiftlint:disable nesting
@@ -27,8 +27,8 @@ extension RCContainer {
             case truncatedElementHeader(index: Int)
             case truncatedElement(index: Int)
             case nonZeroPadding(index: Int)
-            case checksumMismatch(index: Int, expected: String, actual: String)
-            case missingConfigElement
+            case checksumMismatch(expected: String, actual: String)
+            case missingElement(index: Int)
 
         }
         // swiftlint:enable nesting
@@ -121,9 +121,8 @@ extension RCContainer {
 
         /// Parses one element and returns an `Element` that points into the original container bytes.
         ///
-        /// The stored checksum is read before the cursor moves into the payload. The payload checksum
-        /// is then recomputed from the payload range so checksum validation does not depend on mutable
-        /// cursor state after parsing continues.
+        /// The parser reads the stored checksum and payload range, but intentionally does not validate
+        /// payload bytes against the checksum. Callers validate elements according to their domain rules.
         mutating func parseElement(index: Int) throws -> Element {
             guard self.hasBytes(Self.elementHeaderSize) else {
                 throw Parser.FormatError.truncatedElementHeader(index: index)
@@ -147,14 +146,6 @@ extension RCContainer {
 
             let payloadStartOffset = self.offset
             let payloadRange = self.dataRange(offset: payloadStartOffset, count: elementSize)
-            let actualChecksum = self.checksumString(in: payloadStartOffset..<payloadStartOffset + elementSize)
-            guard checksum == actualChecksum else {
-                throw Parser.FormatError.checksumMismatch(
-                    index: index,
-                    expected: checksum,
-                    actual: actualChecksum
-                )
-            }
 
             self.offset += elementSize
             try self.consumePadding(forElementSize: elementSize, elementIndex: index)
@@ -192,19 +183,6 @@ extension RCContainer {
             }
         }
 
-        /// Computes the blob-ref string for a payload range.
-        ///
-        /// Blob refs are the first 24 bytes of the SHA-256 digest encoded as unpadded base64url,
-        /// producing a stable 32-character string that can be used as a content lookup key.
-        private func checksumString(in range: Range<Int>) -> String {
-            var hash = SHA256()
-            self.withUnsafeBytes(in: range) { bytes in
-                hash.update(bufferPointer: bytes)
-            }
-
-            return Self.base64URLString(from: Array(hash.finalize().prefix(Self.checksumSize)))
-        }
-
         /// Encodes bytes already present in the container as an unpadded base64url string.
         private func base64URLString(in range: Range<Int>) -> String {
             var bytes: [UInt8] = []
@@ -223,13 +201,6 @@ extension RCContainer {
                 .replacingOccurrences(of: "+", with: "-")
                 .replacingOccurrences(of: "/", with: "_")
                 .replacingOccurrences(of: "=", with: "")
-        }
-
-        /// Re-bases an integer byte range into the `Data` storage for temporary zero-copy access.
-        private func withUnsafeBytes<T>(in range: Range<Int>, _ body: (UnsafeRawBufferPointer) -> T) -> T {
-            return self.data.withUnsafeBytes { bytes in
-                return body(UnsafeRawBufferPointer(rebasing: bytes[range]))
-            }
         }
 
         /// Reads the wire-format little-endian `UInt32` used for payload sizes and reserved metadata.

--- a/Sources/Networking/RCContainer.swift
+++ b/Sources/Networking/RCContainer.swift
@@ -14,13 +14,12 @@ import Foundation
 /// Header (8 bytes): magic byte[2]="RC" | version u8 | flags u8 | reserved byte[4]
 /// Element:          checksum byte[24]  | element_size u32 | reserved u32 | element[element_size] | pad -> 8
 /// ```
-/// Elements repeat until the backing data is exhausted (the format stores no count). Element 0 is
-/// always `config`; the remaining elements are content-addressed by checksum. The final element may
-/// omit trailing padding, but any padding bytes present in the container must be zero.
+/// Elements repeat until the backing data is exhausted (the format stores no count). The final
+/// element may omit trailing padding, but any padding bytes present in the container must be zero.
 ///
-/// Content elements are keyed by their checksum encoded as a 32-character URL-safe base64 string
-/// with no padding. `config` and each `Element` expose closure-based byte access backed by the
-/// original container data, so parsing does not create per-element `Data` copies.
+/// Elements are stored in wire order and are keyed by their checksum encoded as a 32-character
+/// URL-safe base64 string with no padding. `Element` exposes closure-based byte access backed by
+/// the original container data, so parsing does not create per-element `Data` copies.
 struct RCContainer {
 
     /// Format flags from the container header.
@@ -28,33 +27,36 @@ struct RCContainer {
     /// The parser preserves these bits for future use. Version 1 does not currently interpret them.
     let flags: UInt8
 
-    /// The first element in the container. This contains the remote config payload.
-    let config: Element
+    /// Elements in the order they appear in the container.
+    let elements: [Element]
 
-    /// Remaining elements, keyed by their externally-referenced blob ref string.
+    /// Elements keyed by their externally-referenced blob ref string.
     ///
-    /// If the container contains duplicate content checksums, the last element wins to match the
+    /// If the container contains duplicate checksums, the last element wins to match the
     /// content lookup behavior used by the backend and Android parser.
-    let contentElements: [String: Element]
+    let elementsByChecksum: [String: Element]
 
-    /// Parses and validates an RC Container while retaining the original `Data` backing storage.
+    init(
+        flags: UInt8,
+        elements: [Element]
+    ) {
+        self.flags = flags
+        self.elements = elements
+        self.elementsByChecksum = Dictionary(
+            elements.map { ($0.checksum, $0) },
+            uniquingKeysWith: { _, last in last }
+        )
+    }
+
+    /// Parses and structurally validates an RC Container while retaining the original `Data` backing storage.
     ///
     /// Element payloads are exposed through closure-based byte access on `Element`, so constructing the
     /// container does not create per-element `Data` copies.
     init(data: Data) throws {
         var parser = Parser(data: data)
         let parsed = try parser.parse()
-        let elements = parsed.elements
-        guard let config = elements.first else {
-            throw Parser.FormatError.missingConfigElement
-        }
 
-        self.flags = parsed.flags
-        self.config = config
-        self.contentElements = Dictionary(
-            elements.dropFirst().map { ($0.checksum, $0) },
-            uniquingKeysWith: { _, last in last }
-        )
+        self.init(flags: parsed.flags, elements: parsed.elements)
     }
 
 }

--- a/Sources/Networking/RCContainer.swift
+++ b/Sources/Networking/RCContainer.swift
@@ -60,11 +60,3 @@ struct RCContainer {
     }
 
 }
-
-extension RCContainer: HTTPResponseBody {
-
-    static func create(with data: Data) throws -> RCContainer {
-        return try .init(data: data)
-    }
-
-}

--- a/Sources/Networking/RemoteConfigAPI.swift
+++ b/Sources/Networking/RemoteConfigAPI.swift
@@ -110,10 +110,7 @@ struct RemoteConfigContainer {
     }
 
     init(rcContainer container: RCContainer) throws {
-        guard let configElement = container.elements.first else {
-            throw RCContainer.Parser.FormatError.missingElement(index: 0)
-        }
-        try configElement.validateChecksum()
+        let configElement = try Self.validatedConfigElement(in: container)
 
         self.rcContainer = container
         self.configElement = configElement
@@ -121,6 +118,37 @@ struct RemoteConfigContainer {
             container.elements.dropFirst().map { ($0.checksum, $0) },
             uniquingKeysWith: { _, last in last }
         )
+    }
+
+}
+
+extension RemoteConfigContainer {
+
+    /// Parses only the first RC Container element, which remote config defines as the config element.
+    ///
+    /// This avoids parsing the whole container when signature verification only needs the config
+    /// checksum.
+    static func validatedConfigElement(from data: Data) throws -> RCContainer.Element {
+        var parser = RCContainer.ElementParser(data: data)
+        try parser.moveToFirstElement()
+        guard parser.hasRemainingBytes else {
+            throw RCContainer.Parser.FormatError.missingElement(index: 0)
+        }
+
+        return try self.validatedConfigElement(parser.parseElement(index: 0))
+    }
+
+    static func validatedConfigElement(in container: RCContainer) throws -> RCContainer.Element {
+        guard let configElement = container.elements.first else {
+            throw RCContainer.Parser.FormatError.missingElement(index: 0)
+        }
+
+        return try self.validatedConfigElement(configElement)
+    }
+
+    private static func validatedConfigElement(_ element: RCContainer.Element) throws -> RCContainer.Element {
+        try element.validateChecksum()
+        return element
     }
 
 }

--- a/Sources/Networking/RemoteConfigAPI.swift
+++ b/Sources/Networking/RemoteConfigAPI.swift
@@ -54,37 +54,16 @@ class RemoteConfigAPI: RemoteConfigAPIType {
 
 }
 
-enum RemoteConfigFetchResult {
+struct RemoteConfigFetchResult {
 
-    case container(RemoteConfigContainer, verificationResult: VerificationResult)
-    case noContent(verificationResult: VerificationResult)
-
-    var container: RemoteConfigContainer? {
-        switch self {
-        case let .container(container, _):
-            return container
-        case .noContent:
-            return nil
-        }
-    }
-
-    var verificationResult: VerificationResult {
-        switch self {
-        case let .container(_, verificationResult),
-             let .noContent(verificationResult):
-            return verificationResult
-        }
-    }
+    /// `nil` represents a successful `204 No Content` response. Malformed or undecodable
+    /// container bytes should fail before this result is created.
+    let container: RemoteConfigContainer?
+    let verificationResult: VerificationResult
 
     init(response: VerifiedHTTPResponse<RemoteConfigContainer?>) {
-        if let container = response.body {
-            self = .container(
-                container,
-                verificationResult: response.verificationResult
-            )
-        } else {
-            self = .noContent(verificationResult: response.verificationResult)
-        }
+        self.container = response.body
+        self.verificationResult = response.verificationResult
     }
 
 }

--- a/Sources/Networking/RemoteConfigAPI.swift
+++ b/Sources/Networking/RemoteConfigAPI.swift
@@ -76,10 +76,10 @@ enum RemoteConfigFetchResult {
         }
     }
 
-    init(response: VerifiedHTTPResponse<Data?>) throws {
-        if let body = response.body {
-            self = try .container(
-                RemoteConfigContainer(data: body),
+    init(response: VerifiedHTTPResponse<RemoteConfigContainer?>) {
+        if let container = response.body {
+            self = .container(
+                container,
                 verificationResult: response.verificationResult
             )
         } else {
@@ -118,6 +118,14 @@ struct RemoteConfigContainer {
             container.elements.dropFirst().map { ($0.checksum, $0) },
             uniquingKeysWith: { _, last in last }
         )
+    }
+
+}
+
+extension RemoteConfigContainer: HTTPResponseBody {
+
+    static func create(with data: Data) throws -> RemoteConfigContainer {
+        return try .init(data: data)
     }
 
 }

--- a/Sources/Networking/RemoteConfigAPI.swift
+++ b/Sources/Networking/RemoteConfigAPI.swift
@@ -73,7 +73,7 @@ struct RemoteConfigContainer {
     /// Underlying generic RC Container parsed from the remote config response.
     let rcContainer: RCContainer
 
-    /// The first RC Container element, interpreted as the remote config payload for `/v2/config`.
+    /// The first RC Container element, interpreted as the remote config payload for `/v1/config`.
     let configElement: RCContainer.Element
 
     /// Inline blob elements delivered with the remote config response, keyed by stored checksum.

--- a/Sources/Networking/RemoteConfigAPI.swift
+++ b/Sources/Networking/RemoteConfigAPI.swift
@@ -79,17 +79,18 @@ struct RemoteConfigContainer {
     /// Inline blob elements delivered with the remote config response, keyed by stored checksum.
     let inlineContentElements: [String: RCContainer.Element]
 
-    /// Parses a remote config response container and validates the required config element.
+    /// Parses a remote config response container and extracts the required config element.
     ///
-    /// Inline content elements are opportunistic cache entries and are validated only when they are
-    /// written to the blob store.
+    /// The config element is authenticated by response signature verification over its payload bytes.
+    /// Inline content elements are opportunistic cache entries and are validated only when they are written
+    /// to the blob store.
     init(data: Data) throws {
         let container = try RCContainer(data: data)
         try self.init(rcContainer: container)
     }
 
     init(rcContainer container: RCContainer) throws {
-        let configElement = try Self.validatedConfigElement(in: container)
+        let configElement = try Self.configElement(in: container)
 
         self.rcContainer = container
         self.configElement = configElement
@@ -114,28 +115,23 @@ extension RemoteConfigContainer {
     /// Parses only the first RC Container element, which remote config defines as the config element.
     ///
     /// This avoids parsing the whole container when signature verification only needs the config
-    /// checksum.
-    static func validatedConfigElement(from data: Data) throws -> RCContainer.Element {
+    /// payload.
+    static func configElement(from data: Data) throws -> RCContainer.Element {
         var parser = RCContainer.ElementParser(data: data)
         try parser.moveToFirstElement()
         guard parser.hasRemainingBytes else {
             throw RCContainer.Parser.FormatError.missingElement(index: 0)
         }
 
-        return try self.validatedConfigElement(parser.parseElement(index: 0))
+        return try parser.parseElement(index: 0)
     }
 
-    static func validatedConfigElement(in container: RCContainer) throws -> RCContainer.Element {
+    static func configElement(in container: RCContainer) throws -> RCContainer.Element {
         guard let configElement = container.elements.first else {
             throw RCContainer.Parser.FormatError.missingElement(index: 0)
         }
 
-        return try self.validatedConfigElement(configElement)
-    }
-
-    private static func validatedConfigElement(_ element: RCContainer.Element) throws -> RCContainer.Element {
-        try element.validateChecksum()
-        return element
+        return configElement
     }
 
 }

--- a/Sources/Networking/RemoteConfigAPI.swift
+++ b/Sources/Networking/RemoteConfigAPI.swift
@@ -54,16 +54,73 @@ class RemoteConfigAPI: RemoteConfigAPIType {
 
 }
 
-struct RemoteConfigFetchResult {
+enum RemoteConfigFetchResult {
 
-    /// `nil` represents a successful `204 No Content` response. Malformed or undecodable
-    /// container bytes should fail before this result is created.
-    let container: RCContainer?
-    let verificationResult: VerificationResult
+    case container(RemoteConfigContainer, verificationResult: VerificationResult)
+    case noContent(verificationResult: VerificationResult)
 
-    init(response: VerifiedHTTPResponse<RCContainer?>) {
-        self.container = response.body
-        self.verificationResult = response.verificationResult
+    var container: RemoteConfigContainer? {
+        switch self {
+        case let .container(container, _):
+            return container
+        case .noContent:
+            return nil
+        }
+    }
+
+    var verificationResult: VerificationResult {
+        switch self {
+        case let .container(_, verificationResult),
+             let .noContent(verificationResult):
+            return verificationResult
+        }
+    }
+
+    init(response: VerifiedHTTPResponse<Data?>) throws {
+        if let body = response.body {
+            self = try .container(
+                RemoteConfigContainer(data: body),
+                verificationResult: response.verificationResult
+            )
+        } else {
+            self = .noContent(verificationResult: response.verificationResult)
+        }
+    }
+
+}
+
+struct RemoteConfigContainer {
+
+    /// Underlying generic RC Container parsed from the remote config response.
+    let rcContainer: RCContainer
+
+    /// The first RC Container element, interpreted as the remote config payload for `/v2/config`.
+    let configElement: RCContainer.Element
+
+    /// Inline blob elements delivered with the remote config response, keyed by stored checksum.
+    let inlineContentElements: [String: RCContainer.Element]
+
+    /// Parses a remote config response container and validates the required config element.
+    ///
+    /// Inline content elements are opportunistic cache entries and are validated only when they are
+    /// written to the blob store.
+    init(data: Data) throws {
+        let container = try RCContainer(data: data)
+        try self.init(rcContainer: container)
+    }
+
+    init(rcContainer container: RCContainer) throws {
+        guard let configElement = container.elements.first else {
+            throw RCContainer.Parser.FormatError.missingElement(index: 0)
+        }
+        try configElement.validateChecksum()
+
+        self.rcContainer = container
+        self.configElement = configElement
+        self.inlineContentElements = Dictionary(
+            container.elements.dropFirst().map { ($0.checksum, $0) },
+            uniquingKeysWith: { _, last in last }
+        )
     }
 
 }

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -80,7 +80,7 @@ private extension RemoteConfigManager {
     }
 
     func persist(
-        container: RCContainer?,
+        container: RemoteConfigContainer?,
         previous: PersistedRemoteConfiguration?
     ) {
         guard let container else {
@@ -89,7 +89,7 @@ private extension RemoteConfigManager {
         }
 
         do {
-            let response = try container.config.withPayloadBytes { bytes in
+            let response = try container.configElement.withPayloadBytes { bytes in
                 try JSONDecoder.default.decode(
                     RemoteConfiguration.self,
                     from: Data(bytes)

--- a/Sources/Networking/RemoteConfigSignatureContextProvider.swift
+++ b/Sources/Networking/RemoteConfigSignatureContextProvider.swift
@@ -39,14 +39,7 @@ private extension RemoteConfigSignatureContextProvider {
             throw RCContainer.Parser.FormatError.missingBody
         }
 
-        var parser = RCContainer.ElementParser(data: data)
-        try parser.moveToFirstElement()
-        guard parser.hasRemainingBytes else {
-            throw RCContainer.Parser.FormatError.missingElement(index: 0)
-        }
-
-        let configElement = try parser.parseElement(index: 0)
-        try configElement.validateChecksum()
+        let configElement = try RemoteConfigContainer.validatedConfigElement(from: data)
 
         return configElement.withChecksumBytes { bytes in
             Data(bytes)

--- a/Sources/Networking/RemoteConfigSignatureContextProvider.swift
+++ b/Sources/Networking/RemoteConfigSignatureContextProvider.swift
@@ -9,16 +9,16 @@ import Foundation
 
 /// Provides the signature inputs for remote config RC Container responses.
 ///
-/// The response signature covers the config element's stored 24-byte checksum. A `204 No Content`
-/// response has no response payload, but still verifies the request context.
+/// The response signature covers the config element's payload bytes exactly as received. A `204 No Content`
+/// response verifies the request context with an empty payload.
 struct RemoteConfigSignatureContextProvider: ResponseSignatureContextProvider {
 
     func responsePayloadForSignature(from body: Data?, statusCode: HTTPStatusCode) throws -> Data? {
         guard statusCode != .noContent else {
-            return nil
+            return Data()
         }
 
-        return try Self.configChecksum(from: body)
+        return try Self.configPayload(from: body)
     }
 
     func requestBodyForSignature(for request: HTTPRequest) -> HTTPRequestBody? {
@@ -32,16 +32,16 @@ private extension RemoteConfigSignatureContextProvider {
     /// Extracts the signed payload from a remote config RC Container response.
     ///
     /// Remote config defines the first RC Container element as the config element. The backend signs
-    /// that element's stored checksum, not the full container body. This intentionally parses only
-    /// the first element so verification can fail before the full response is decoded later.
-    static func configChecksum(from data: Data?) throws -> Data {
+    /// that element's payload bytes, not the full container body or stored checksum. This intentionally
+    /// parses only the first element so verification can fail before the full response is decoded later.
+    static func configPayload(from data: Data?) throws -> Data {
         guard let data = data else {
             throw RCContainer.Parser.FormatError.missingBody
         }
 
-        let configElement = try RemoteConfigContainer.validatedConfigElement(from: data)
+        let configElement = try RemoteConfigContainer.configElement(from: data)
 
-        return configElement.withChecksumBytes { bytes in
+        return configElement.withPayloadBytes { bytes in
             Data(bytes)
         }
     }

--- a/Sources/Networking/RemoteConfigSignatureContextProvider.swift
+++ b/Sources/Networking/RemoteConfigSignatureContextProvider.swift
@@ -42,10 +42,12 @@ private extension RemoteConfigSignatureContextProvider {
         var parser = RCContainer.ElementParser(data: data)
         try parser.moveToFirstElement()
         guard parser.hasRemainingBytes else {
-            throw RCContainer.Parser.FormatError.missingConfigElement
+            throw RCContainer.Parser.FormatError.missingElement(index: 0)
         }
 
         let configElement = try parser.parseElement(index: 0)
+        try configElement.validateChecksum()
+
         return configElement.withChecksumBytes { bytes in
             Data(bytes)
         }

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -291,9 +291,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         }
 
         let fetchResult = try XCTUnwrap(result?.value)
-        guard case let .container(container, _) = fetchResult else {
-            return XCTFail("Expected remote config container result")
-        }
+        let container = try XCTUnwrap(fetchResult.container)
 
         let contentElementsByChecksum = container.inlineContentElements
 

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -248,10 +248,12 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         let fetchResult = try XCTUnwrap(result?.value)
         let container = try XCTUnwrap(fetchResult.container)
 
-        expect(RCContainerTestData.data(from: container.config)) == Self.config
-        expect(container.contentElements).to(haveCount(1))
+        let contentElementsByChecksum = container.inlineContentElements
+
+        expect(RCContainerTestData.data(from: container.configElement)) == Self.config
+        expect(contentElementsByChecksum).to(haveCount(1))
         expect(RCContainerTestData.data(
-            from: try XCTUnwrap(container.contentElements[RCContainerTestData.blobRef(for: Self.content)])
+            from: try XCTUnwrap(contentElementsByChecksum[RCContainerTestData.blobRef(for: Self.content)])
         )) == Self.content
         expect(fetchResult.verificationResult) == .notRequested
     }
@@ -267,6 +269,58 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
         expect(fetchResult.container).toNot(beNil())
         expect(fetchResult.verificationResult) == .verified
+    }
+
+    func testGetRemoteConfigKeepsContentElementsWithChecksumMismatch() throws {
+        let data = RCContainerTestData.container(
+            config: Self.config,
+            contentElements: [Self.content],
+            checksumOverride: { index, payload in
+                return index == 1
+                    ? Array(repeating: 0, count: RCContainerTestData.checksumSize)
+                    : RCContainerTestData.checksum(for: payload)
+            }
+        )
+        self.httpClient.mock(
+            requestPath: .remoteConfig,
+            response: .init(statusCode: .success, body: data)
+        )
+
+        let result: Result<RemoteConfigFetchResult, BackendError>? = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+        }
+
+        let fetchResult = try XCTUnwrap(result?.value)
+        guard case let .container(container, _) = fetchResult else {
+            return XCTFail("Expected remote config container result")
+        }
+
+        let contentElementsByChecksum = container.inlineContentElements
+
+        expect(RCContainerTestData.data(from: container.configElement)) == Self.config
+        expect(contentElementsByChecksum).to(haveCount(1))
+    }
+
+    func testGetRemoteConfigFailsWhenConfigChecksumMismatches() {
+        let data = RCContainerTestData.container(
+            config: Self.config,
+            checksumOverride: { _, _ in Array(repeating: 0, count: RCContainerTestData.checksumSize) }
+        )
+        self.httpClient.mock(
+            requestPath: .remoteConfig,
+            response: .init(statusCode: .success, body: data)
+        )
+
+        let result: Result<RemoteConfigFetchResult, BackendError>? = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+        }
+
+        guard case let .networkError(.decoding(error, _)) = result?.error else {
+            fail("Expected decoding error, got \(String(describing: result?.error))")
+            return
+        }
+
+        expect(error.domain) == String(reflecting: RCContainer.Parser.FormatError.self)
     }
 
     func testGetRemoteConfigReturnsFailedVerificationResultFromHTTPClient() throws {

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -299,7 +299,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(contentElementsByChecksum).to(haveCount(1))
     }
 
-    func testGetRemoteConfigFailsWhenConfigChecksumMismatches() {
+    func testGetRemoteConfigParsesResponseWhenConfigChecksumMismatches() throws {
         let data = RCContainerTestData.container(
             config: Self.config,
             checksumOverride: { _, _ in Array(repeating: 0, count: RCContainerTestData.checksumSize) }
@@ -313,12 +313,10 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
             self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
         }
 
-        guard case let .networkError(.decoding(error, _)) = result?.error else {
-            fail("Expected decoding error, got \(String(describing: result?.error))")
-            return
-        }
+        let fetchResult = try XCTUnwrap(result?.value)
+        let container = try XCTUnwrap(fetchResult.container)
 
-        expect(error.domain) == String(reflecting: RCContainer.Parser.FormatError.self)
+        expect(RCContainerTestData.data(from: container.configElement)) == Self.config
     }
 
     func testGetRemoteConfigReturnsFailedVerificationResultFromHTTPClient() throws {

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -65,6 +65,7 @@ class HTTPRequestTests: TestCase {
         .logIn,
         .postReceiptData,
         .health,
+        .remoteConfig,
         .rewardVerificationStatus(appUserID: userID, clientTransactionID: clientTransactionID)
     ]
     private static let pathsWithUserID: [HTTPRequest.Path] = [
@@ -177,8 +178,7 @@ class HTTPRequestTests: TestCase {
             .getOfferings(appUserID: Self.userID),
             .getProductEntitlementMapping,
             .getWorkflows(appUserID: Self.userID, type: nil),
-            .getWorkflow(appUserID: Self.userID, workflowId: "wf_1"),
-            .remoteConfig
+            .getWorkflow(appUserID: Self.userID, workflowId: "wf_1")
         ]
     }
 

--- a/Tests/UnitTests/Networking/RCContainer/RCContainerBackwardsCompatibilityTests.swift
+++ b/Tests/UnitTests/Networking/RCContainer/RCContainerBackwardsCompatibilityTests.swift
@@ -14,21 +14,24 @@ final class RCContainerBackwardsCompatibilityTests: TestCase {
 
     func testConfigOnlyFixtureParses() throws {
         let container = try Self.parseFixture("v1_config_only")
+        let configElement = try RCContainerTestData.firstElement(in: container)
 
         expect(container.flags) == 0
-        expect(RCContainerTestData.data(from: container.config)) == RCContainerTestData.configJSON
-        expect(container.config.checksum) == RCContainerTestData.blobRef(for: RCContainerTestData.configJSON)
-        expect(container.config.withChecksumBytes { $0.count }) == RCContainerTestData.checksumSize
-        expect(container.contentElements).to(beEmpty())
+        expect(RCContainerTestData.data(from: configElement)) == RCContainerTestData.configJSON
+        expect(configElement.checksum) == RCContainerTestData.blobRef(for: RCContainerTestData.configJSON)
+        expect(configElement.withChecksumBytes { $0.count }) == RCContainerTestData.checksumSize
+        expect(RCContainerTestData.contentElements(in: container)).to(beEmpty())
     }
 
     func testSingleElementFixtureParses() throws {
         let container = try Self.parseFixture("v1_single_element")
         let blob = RCContainerTestData.entitlementMappingBlob
-        let element = try XCTUnwrap(container.contentElements[RCContainerTestData.blobRef(for: blob)])
+        let contentElementsByChecksum = RCContainerTestData.contentElements(in: container)
+        let element = try XCTUnwrap(contentElementsByChecksum[RCContainerTestData.blobRef(for: blob)])
 
-        expect(RCContainerTestData.data(from: container.config)) == RCContainerTestData.configJSON
-        expect(container.contentElements).to(haveCount(1))
+        expect(RCContainerTestData.data(from: try RCContainerTestData.firstElement(in: container))) ==
+        RCContainerTestData.configJSON
+        expect(contentElementsByChecksum).to(haveCount(1))
         expect(RCContainerTestData.data(from: element)) == blob
         expect(element.checksum) == RCContainerTestData.blobRef(for: blob)
     }
@@ -41,17 +44,19 @@ final class RCContainerBackwardsCompatibilityTests: TestCase {
             RCContainerTestData.entitlementMappingBlob,
             RCContainerTestData.largeBlob
         ]
+        let contentElementsByChecksum = RCContainerTestData.contentElements(in: container)
 
-        expect(RCContainerTestData.data(from: container.config)) == RCContainerTestData.configJSON
-        expect(container.contentElements).to(haveCount(expected.count))
+        expect(RCContainerTestData.data(from: try RCContainerTestData.firstElement(in: container))) ==
+        RCContainerTestData.configJSON
+        expect(contentElementsByChecksum).to(haveCount(expected.count))
 
         for blob in expected {
-            let element = try XCTUnwrap(container.contentElements[RCContainerTestData.blobRef(for: blob)])
+            let element = try XCTUnwrap(contentElementsByChecksum[RCContainerTestData.blobRef(for: blob)])
             expect(RCContainerTestData.data(from: element)) == blob
         }
 
         let largeElement = try XCTUnwrap(
-            container.contentElements[RCContainerTestData.blobRef(for: RCContainerTestData.largeBlob)]
+            contentElementsByChecksum[RCContainerTestData.blobRef(for: RCContainerTestData.largeBlob)]
         )
         expect(largeElement.size) == 300
     }
@@ -59,12 +64,13 @@ final class RCContainerBackwardsCompatibilityTests: TestCase {
     func testEmptyConfigFixtureParses() throws {
         let container = try Self.parseFixture("v1_empty_config")
         let blob = RCContainerTestData.entitlementMappingBlob
+        let contentElementsByChecksum = RCContainerTestData.contentElements(in: container)
 
-        expect(container.config.size) == 0
-        expect(RCContainerTestData.data(from: container.config)).to(beEmpty())
-        expect(container.contentElements).to(haveCount(1))
+        expect(try RCContainerTestData.firstElement(in: container).size) == 0
+        expect(RCContainerTestData.data(from: try RCContainerTestData.firstElement(in: container))).to(beEmpty())
+        expect(contentElementsByChecksum).to(haveCount(1))
         expect(RCContainerTestData.data(
-            from: try XCTUnwrap(container.contentElements[RCContainerTestData.blobRef(for: blob)])
+            from: try XCTUnwrap(contentElementsByChecksum[RCContainerTestData.blobRef(for: blob)])
         )) == blob
     }
 
@@ -72,15 +78,18 @@ final class RCContainerBackwardsCompatibilityTests: TestCase {
         let container = try Self.parseFixture("v1_flags_set")
 
         expect(container.flags) == 0x07
-        expect(RCContainerTestData.data(from: container.config)) == RCContainerTestData.configJSON
+        expect(RCContainerTestData.data(
+            from: try RCContainerTestData.firstElement(in: container)
+        )) == RCContainerTestData.configJSON
     }
 
     func testDuplicateElementsFixtureCollapsesInContentAddressedMap() throws {
         let container = try Self.parseFixture("v1_duplicate_elements")
+        let contentElementsByChecksum = RCContainerTestData.contentElements(in: container)
 
-        expect(container.contentElements).to(haveCount(1))
+        expect(contentElementsByChecksum).to(haveCount(1))
         expect(RCContainerTestData.data(
-            from: try XCTUnwrap(container.contentElements[
+            from: try XCTUnwrap(contentElementsByChecksum[
                 RCContainerTestData.blobRef(for: RCContainerTestData.entitlementMappingBlob)
             ])
         )) == RCContainerTestData.entitlementMappingBlob

--- a/Tests/UnitTests/Networking/RCContainer/RCContainerTestData.swift
+++ b/Tests/UnitTests/Networking/RCContainer/RCContainerTestData.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2026 RevenueCat, Inc. All rights reserved.
 
 import Foundation
+import XCTest
+
 @testable import RevenueCat
 
 enum RCContainerTestData {
@@ -106,6 +108,17 @@ enum RCContainerTestData {
 
     static func data(from element: RCContainer.Element) -> Data {
         return element.withPayloadBytes { Data($0) }
+    }
+
+    static func firstElement(in container: RCContainer) throws -> RCContainer.Element {
+        return try XCTUnwrap(container.elements.first)
+    }
+
+    static func contentElements(in container: RCContainer) -> [String: RCContainer.Element] {
+        return Dictionary(
+            container.elements.dropFirst().map { ($0.checksum, $0) },
+            uniquingKeysWith: { _, last in last }
+        )
     }
 
     static func blobRef(for data: Data) -> String {

--- a/Tests/UnitTests/Networking/RCContainer/RCContainerTests.swift
+++ b/Tests/UnitTests/Networking/RCContainer/RCContainerTests.swift
@@ -21,16 +21,17 @@ final class RCContainerTests: TestCase {
             productMapping,
             paywall
         ]))
+        let contentElementsByChecksum = RCContainerTestData.contentElements(in: container)
 
-        expect(RCContainerTestData.data(from: container.config)) == config
+        expect(RCContainerTestData.data(from: try RCContainerTestData.firstElement(in: container))) == config
         expect(container.flags) == 0
-        expect(container.config.size) == config.count
-        expect(container.contentElements).to(haveCount(2))
+        expect(try RCContainerTestData.firstElement(in: container).size) == config.count
+        expect(contentElementsByChecksum).to(haveCount(2))
         expect(RCContainerTestData.data(
-            from: try XCTUnwrap(container.contentElements[RCContainerTestData.blobRef(for: productMapping)])
+            from: try XCTUnwrap(contentElementsByChecksum[RCContainerTestData.blobRef(for: productMapping)])
         )) == productMapping
         expect(RCContainerTestData.data(
-            from: try XCTUnwrap(container.contentElements[RCContainerTestData.blobRef(for: paywall)])
+            from: try XCTUnwrap(contentElementsByChecksum[RCContainerTestData.blobRef(for: paywall)])
         )) == paywall
     }
 
@@ -41,11 +42,12 @@ final class RCContainerTests: TestCase {
             config: Data(),
             contentElements: [content]
         ))
+        let contentElementsByChecksum = RCContainerTestData.contentElements(in: container)
 
-        expect(container.config.size) == 0
-        expect(RCContainerTestData.data(from: container.config)).to(beEmpty())
+        expect(try RCContainerTestData.firstElement(in: container).size) == 0
+        expect(RCContainerTestData.data(from: try RCContainerTestData.firstElement(in: container))).to(beEmpty())
         expect(RCContainerTestData.data(
-            from: try XCTUnwrap(container.contentElements[RCContainerTestData.blobRef(for: content)])
+            from: try XCTUnwrap(contentElementsByChecksum[RCContainerTestData.blobRef(for: content)])
         )) == content
     }
 
@@ -61,11 +63,12 @@ final class RCContainerTests: TestCase {
             config: "config".asData,
             contentElements: contentElements
         ))
+        let contentElementsByChecksum = RCContainerTestData.contentElements(in: container)
 
-        expect(container.contentElements).to(haveCount(contentElements.count))
+        expect(contentElementsByChecksum).to(haveCount(contentElements.count))
         for contentElement in contentElements {
             expect(RCContainerTestData.data(
-                from: try XCTUnwrap(container.contentElements[RCContainerTestData.blobRef(for: contentElement)])
+                from: try XCTUnwrap(contentElementsByChecksum[RCContainerTestData.blobRef(for: contentElement)])
             )) == contentElement
         }
     }
@@ -76,7 +79,7 @@ final class RCContainerTests: TestCase {
 
         let container = try RCContainer(data: RCContainerTestData.container(config: config, contentElements: [content]))
         let ref = RCContainerTestData.blobRef(for: content)
-        let element = try XCTUnwrap(container.contentElements[ref])
+        let element = try XCTUnwrap(RCContainerTestData.contentElements(in: container)[ref])
 
         expect(ref).to(haveCount(32))
         expect(ref).toNot(contain("="))
@@ -92,10 +95,11 @@ final class RCContainerTests: TestCase {
             content,
             content
         ]))
+        let contentElementsByChecksum = RCContainerTestData.contentElements(in: container)
 
-        expect(container.contentElements).to(haveCount(1))
+        expect(contentElementsByChecksum).to(haveCount(1))
         expect(RCContainerTestData.data(
-            from: try XCTUnwrap(container.contentElements[RCContainerTestData.blobRef(for: content)])
+            from: try XCTUnwrap(contentElementsByChecksum[RCContainerTestData.blobRef(for: content)])
         )) == content
     }
 
@@ -104,15 +108,15 @@ final class RCContainerTests: TestCase {
 
         let container = try RCContainer(data: RCContainerTestData.container(config: config))
 
-        expect(container.config.size) == 257
-        expect(RCContainerTestData.data(from: container.config)) == config
+        expect(try RCContainerTestData.firstElement(in: container).size) == 257
+        expect(RCContainerTestData.data(from: try RCContainerTestData.firstElement(in: container))) == config
     }
 
     func testParsesNonZeroFlags() throws {
         let container = try RCContainer(data: RCContainerTestData.container(config: "config".asData, flags: 0x07))
 
         expect(container.flags) == 0x07
-        expect(RCContainerTestData.data(from: container.config)) == "config".asData
+        expect(RCContainerTestData.data(from: try RCContainerTestData.firstElement(in: container))) == "config".asData
     }
 
     func testIgnoresReservedFields() throws {
@@ -122,8 +126,8 @@ final class RCContainerTests: TestCase {
             elementReserved: 0x01020304
         ))
 
-        expect(RCContainerTestData.data(from: container.config)) == "config".asData
-        expect(container.config.reserved) == 0x01020304
+        expect(RCContainerTestData.data(from: try RCContainerTestData.firstElement(in: container))) == "config".asData
+        expect(try RCContainerTestData.firstElement(in: container).reserved) == 0x01020304
     }
 
     func testAcceptsOmittedFinalPadding() throws {
@@ -134,7 +138,7 @@ final class RCContainerTests: TestCase {
             omitFinalPadding: true
         ))
 
-        expect(RCContainerTestData.data(from: container.config)) == config
+        expect(RCContainerTestData.data(from: try RCContainerTestData.firstElement(in: container))) == config
     }
 
     func testAcceptsPartiallyOmittedFinalPadding() throws {
@@ -143,7 +147,7 @@ final class RCContainerTests: TestCase {
 
         let container = try RCContainer(data: data)
 
-        expect(RCContainerTestData.data(from: container.config)) == "abc".asData
+        expect(RCContainerTestData.data(from: try RCContainerTestData.firstElement(in: container))) == "abc".asData
     }
 
     func testParsesDataSliceWithNonZeroStartIndex() throws {
@@ -153,10 +157,11 @@ final class RCContainerTests: TestCase {
         let slicedData = prefixedData[prefix.count..<prefixedData.endIndex]
 
         let container = try RCContainer(data: slicedData)
+        let contentElementsByChecksum = RCContainerTestData.contentElements(in: container)
 
-        expect(RCContainerTestData.data(from: container.config)) == "config".asData
+        expect(RCContainerTestData.data(from: try RCContainerTestData.firstElement(in: container))) == "config".asData
         expect(RCContainerTestData.data(
-            from: try XCTUnwrap(container.contentElements[RCContainerTestData.blobRef(for: "blob".asData)])
+            from: try XCTUnwrap(contentElementsByChecksum[RCContainerTestData.blobRef(for: "blob".asData)])
         )) == "blob".asData
     }
 
@@ -176,7 +181,6 @@ final class RCContainerTests: TestCase {
 
     func testRejectsTruncatedContainers() {
         Self.expectParsing(Data([UInt8(ascii: "R")]), throws: .truncatedHeader)
-        Self.expectParsing(RCContainerTestData.header(), throws: .missingConfigElement)
         Self.expectParsing(
             RCContainerTestData.header() + Data([0]),
             throws: .truncatedElementHeader(index: 0)
@@ -190,6 +194,13 @@ final class RCContainerTests: TestCase {
         Self.expectParsing(truncatedElement, throws: .truncatedElement(index: 0))
     }
 
+    func testParsesStructurallyValidEmptyContainer() throws {
+        let container = try RCContainer(data: RCContainerTestData.header())
+
+        expect(container.elements).to(beEmpty())
+        expect(container.elementsByChecksum).to(beEmpty())
+    }
+
     func testRejectsNonZeroPadding() {
         var data = RCContainerTestData.container(config: "abc".asData)
         let lastIndex = data.index(before: data.endIndex)
@@ -198,23 +209,54 @@ final class RCContainerTests: TestCase {
         Self.expectParsing(data, throws: .nonZeroPadding(index: 0))
     }
 
-    func testRejectsChecksumMismatch() {
+    func testParsesStructurallyValidContainerWithConfigChecksumMismatch() throws {
         var data = RCContainerTestData.container(config: "config".asData)
         data[data.index(data.startIndex, offsetBy: RCContainerTestData.firstPayloadOffset)] = UInt8(ascii: "x")
 
+        let container = try RCContainer(data: data)
+
+        expect(try RCContainerTestData.firstElement(in: container).isChecksumValid()) == false
+        expect(RCContainerTestData.data(from: try RCContainerTestData.firstElement(in: container))) == "xonfig".asData
+    }
+
+    func testParsesStructurallyValidContainerWithContentChecksumMismatch() throws {
+        let content = "content".asData
+        let data = RCContainerTestData.container(
+            config: "config".asData,
+            contentElements: [content],
+            checksumOverride: { index, payload in
+                return index == 1
+                    ? Array(repeating: 0, count: RCContainerTestData.checksumSize)
+                    : RCContainerTestData.checksum(for: payload)
+            }
+        )
+
+        let container = try RCContainer(data: data)
+        let contentElementsByChecksum = RCContainerTestData.contentElements(in: container)
+        let element = try XCTUnwrap(contentElementsByChecksum["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"])
+
+        expect(element.isChecksumValid()) == false
+        expect(RCContainerTestData.data(from: element)) == content
+    }
+
+    func testElementValidateChecksumThrowsChecksumMismatch() throws {
+        let data = RCContainerTestData.container(
+            config: "config".asData,
+            checksumOverride: { _, _ in Array(repeating: 0, count: RCContainerTestData.checksumSize) }
+        )
+        let container = try RCContainer(data: data)
+
         do {
-            _ = try RCContainer(data: data)
+            try RCContainerTestData.firstElement(in: container).validateChecksum()
             fail("Expected checksum mismatch")
         } catch let error as RCContainer.Parser.FormatError {
-            guard case let .checksumMismatch(index, expected, actual) = error else {
+            guard case let .checksumMismatch(expected, actual) = error else {
                 fail("Expected checksum mismatch, got \(error)")
                 return
             }
 
-            expect(index) == 0
-            expect(expected).to(haveCount(32))
-            expect(actual).to(haveCount(32))
-            expect(expected) != actual
+            expect(expected) == "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+            expect(actual) == RCContainerTestData.blobRef(for: "config".asData)
         } catch {
             fail("Expected RCContainer.Parser.FormatError, got \(error)")
         }
@@ -224,10 +266,10 @@ final class RCContainerTests: TestCase {
         let payload = "borrowed bytes".asData
         let container = try RCContainer(data: RCContainerTestData.container(config: payload))
 
-        let size = container.config.withPayloadBytes { bytes in
+        let size = try RCContainerTestData.firstElement(in: container).withPayloadBytes { bytes in
             return bytes.count
         }
-        let bytes = container.config.withPayloadBytes { bytes in
+        let bytes = try RCContainerTestData.firstElement(in: container).withPayloadBytes { bytes in
             return Array(bytes)
         }
 
@@ -243,7 +285,7 @@ final class RCContainerTests: TestCase {
         try data.withUnsafeBytes { containerBytes in
             let containerBaseAddress = UInt(bitPattern: try XCTUnwrap(containerBytes.baseAddress))
 
-            try container.config.withPayloadBytes { payloadBytes in
+            try RCContainerTestData.firstElement(in: container).withPayloadBytes { payloadBytes in
                 let payloadBaseAddress = UInt(bitPattern: try XCTUnwrap(payloadBytes.baseAddress))
 
                 expect(payloadBaseAddress) == containerBaseAddress + UInt(RCContainerTestData.firstPayloadOffset)

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -303,8 +303,8 @@ private extension RemoteConfigManagerTests {
     static func container(
         config: String,
         contentElements: [Data] = []
-    ) throws -> RCContainer {
-        return try RCContainer(data: RCContainerTestData.container(
+    ) throws -> RemoteConfigContainer {
+        return try RemoteConfigContainer(data: RCContainerTestData.container(
             config: config.asData,
             contentElements: contentElements
         ))

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -317,7 +317,7 @@ private extension RemoteConfigFetchResult {
     /// Builds a fetch result through the production initializer. A `nil` container
     /// represents a `204 No Content` response.
     static func test(
-        container: RCContainer?,
+        container: RemoteConfigContainer?,
         verificationResult: VerificationResult = .verified
     ) -> RemoteConfigFetchResult {
         return RemoteConfigFetchResult(response: .init(

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -454,7 +454,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
                           body: Data(),
                           statusCode: .noContent)
 
-        let response: VerifiedHTTPResponse<RCContainer?>.Result? = waitUntilValue { completion in
+        let response: VerifiedHTTPResponse<Data?>.Result? = waitUntilValue { completion in
             self.client.perform(Self.remoteConfigRequest, completionHandler: completion)
         }
 
@@ -475,7 +475,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
                           statusCode: .noContent)
         self.signing.stubbedVerificationResult = false
 
-        let response: VerifiedHTTPResponse<RCContainer?>.Result? = waitUntilValue { completion in
+        let response: VerifiedHTTPResponse<Data?>.Result? = waitUntilValue { completion in
             self.client.perform(Self.remoteConfigRequest, completionHandler: completion)
         }
 
@@ -495,7 +495,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
                           statusCode: .noContent)
         self.signing.stubbedVerificationResult = false
 
-        let response: VerifiedHTTPResponse<RCContainer?>.Result? = waitUntilValue { completion in
+        let response: VerifiedHTTPResponse<Data?>.Result? = waitUntilValue { completion in
             self.client.perform(Self.remoteConfigRequest, completionHandler: completion)
         }
 
@@ -1147,7 +1147,7 @@ final class EnforcedSignatureVerificationHTTPClientTests: BaseSignatureVerificat
                           body: body)
         self.signing.stubbedVerificationResult = true
 
-        let response: VerifiedHTTPResponse<RCContainer?>.Result? = waitUntilValue { completion in
+        let response: VerifiedHTTPResponse<Data?>.Result? = waitUntilValue { completion in
             self.client.perform(Self.remoteConfigRequest, completionHandler: completion)
         }
 

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -356,7 +356,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
 
         let request = Self.remoteConfigRequest
 
-        let response: VerifiedHTTPResponse<RCContainer?>.Result? = waitUntilValue { completion in
+        let response: VerifiedHTTPResponse<Data?>.Result? = waitUntilValue { completion in
             self.client.perform(request, completionHandler: completion)
         }
 
@@ -382,7 +382,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
                           body: Self.rcContainer())
         self.signing.stubbedVerificationResult = true
 
-        let response: VerifiedHTTPResponse<RCContainer?>.Result? = waitUntilValue { completion in
+        let response: VerifiedHTTPResponse<Data?>.Result? = waitUntilValue { completion in
             self.client.perform(Self.remoteConfigRequest, completionHandler: completion)
         }
 
@@ -398,7 +398,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
                           statusCode: .noContent)
         self.signing.stubbedVerificationResult = true
 
-        let response: VerifiedHTTPResponse<RCContainer?>.Result? = waitUntilValue { completion in
+        let response: VerifiedHTTPResponse<Data?>.Result? = waitUntilValue { completion in
             self.client.perform(Self.remoteConfigRequest, completionHandler: completion)
         }
 
@@ -419,7 +419,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
                           body: Data(),
                           statusCode: .noContent)
 
-        let response: VerifiedHTTPResponse<RCContainer?>.Result? = waitUntilValue { completion in
+        let response: VerifiedHTTPResponse<Data?>.Result? = waitUntilValue { completion in
             self.client.perform(Self.remoteConfigRequest, completionHandler: completion)
         }
 
@@ -436,7 +436,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
                           body: Data(),
                           statusCode: .noContent)
 
-        let response: VerifiedHTTPResponse<RCContainer?>.Result? = waitUntilValue { completion in
+        let response: VerifiedHTTPResponse<Data?>.Result? = waitUntilValue { completion in
             self.client.perform(Self.remoteConfigRequest, completionHandler: completion)
         }
 
@@ -524,7 +524,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
                           body: Self.rcContainer())
         self.signing.stubbedVerificationResult = true
 
-        let response: VerifiedHTTPResponse<RCContainer?>.Result? = waitUntilValue { completion in
+        let response: VerifiedHTTPResponse<Data?>.Result? = waitUntilValue { completion in
             self.client.perform(Self.remoteConfigRequest, completionHandler: completion)
         }
 
@@ -541,7 +541,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
                           body: Self.rcContainer())
         self.signing.stubbedVerificationResult = true
 
-        let response: VerifiedHTTPResponse<RCContainer?>.Result? = waitUntilValue { completion in
+        let response: VerifiedHTTPResponse<Data?>.Result? = waitUntilValue { completion in
             self.client.perform(Self.remoteConfigRequest, completionHandler: completion)
         }
 
@@ -561,7 +561,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
                           body: Self.rcContainer())
         self.signing.stubbedVerificationResult = false
 
-        let response: VerifiedHTTPResponse<RCContainer?>.Result? = waitUntilValue { completion in
+        let response: VerifiedHTTPResponse<Data?>.Result? = waitUntilValue { completion in
             self.client.perform(Self.remoteConfigRequest, completionHandler: completion)
         }
 
@@ -578,7 +578,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
                           body: Self.rcContainer())
         self.signing.stubbedVerificationResult = false
 
-        let response: VerifiedHTTPResponse<RCContainer?>.Result? = waitUntilValue { completion in
+        let response: VerifiedHTTPResponse<Data?>.Result? = waitUntilValue { completion in
             self.client.perform(Self.remoteConfigRequest, completionHandler: completion)
         }
 
@@ -604,7 +604,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
                           body: body)
         self.signing.stubbedVerificationResult = true
 
-        let response: VerifiedHTTPResponse<RCContainer?>.Result? = waitUntilValue { completion in
+        let response: VerifiedHTTPResponse<Data?>.Result? = waitUntilValue { completion in
             self.client.perform(Self.remoteConfigRequest, completionHandler: completion)
         }
 
@@ -632,7 +632,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
                           body: body)
         self.signing.stubbedVerificationResult = true
 
-        let response: VerifiedHTTPResponse<RCContainer?>.Result? = waitUntilValue { completion in
+        let response: VerifiedHTTPResponse<Data?>.Result? = waitUntilValue { completion in
             self.client.perform(Self.remoteConfigRequest, completionHandler: completion)
         }
 

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -345,7 +345,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
         expect(signingRequest.publicKey).toNot(beNil())
     }
 
-    func testValidRemoteConfigSignatureUsesConfigChecksumAsSignedMessage() throws {
+    func testValidRemoteConfigSignatureUsesConfigPayloadAsSignedMessage() throws {
         let config = "config".asData
         let body = Self.rcContainer(config: config, contentElements: ["content".asData])
         self.mockResponse(path: HTTPRequest.Path.remoteConfig,
@@ -354,10 +354,8 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
                           body: body)
         self.signing.stubbedVerificationResult = true
 
-        let request = Self.remoteConfigRequest
-
         let response: VerifiedHTTPResponse<Data?>.Result? = waitUntilValue { completion in
-            self.client.perform(request, completionHandler: completion)
+            self.client.perform(Self.remoteConfigRequest, completionHandler: completion)
         }
 
         expect(response).to(beSuccess())
@@ -367,8 +365,8 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
         expect(self.signing.requests).to(haveCount(1))
         let signingRequest = try XCTUnwrap(self.signing.requests.onlyElement)
 
-        expect(signingRequest.parameters.message) == Data(RCContainerTestData.checksum(for: config))
-        expect(signingRequest.parameters.nonce).to(beNil())
+        expect(signingRequest.parameters.message) == config
+        expect(signingRequest.parameters.nonce).toNot(beNil())
         expect(signingRequest.parameters.requestBody).to(beNil())
         expect(signingRequest.parameters.requestDate) == Self.date2.millisecondsSince1970
         expect(signingRequest.signature) == Self.sampleSignature
@@ -406,8 +404,8 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
         expect(response?.value?.body).to(beNil())
         expect(response?.value?.verificationResult) == .verified
         expect(self.signing.requests).to(haveCount(1))
-        expect(self.signing.requests.onlyElement?.parameters.message).to(beNil())
-        expect(self.signing.requests.onlyElement?.parameters.nonce).to(beNil())
+        expect(self.signing.requests.onlyElement?.parameters.message) == Data()
+        expect(self.signing.requests.onlyElement?.parameters.nonce).toNot(beNil())
         expect(self.signing.requests.onlyElement?.parameters.requestBody).to(beNil())
     }
 
@@ -483,7 +481,8 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
         expect(response?.value?.body).to(beNil())
         expect(response?.value?.verificationResult) == .failed
         expect(self.signing.requests).to(haveCount(1))
-        expect(self.signing.requests.onlyElement?.parameters.message).to(beNil())
+        expect(self.signing.requests.onlyElement?.parameters.message) == Data()
+        expect(self.signing.requests.onlyElement?.parameters.nonce).toNot(beNil())
     }
 
     func testRemoteConfigNoContentResponseInvalidSignatureFailsInEnforcedMode() throws {
@@ -506,7 +505,8 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
                 code: .noContent
             )))
         expect(self.signing.requests).to(haveCount(1))
-        expect(self.signing.requests.onlyElement?.parameters.message).to(beNil())
+        expect(self.signing.requests.onlyElement?.parameters.message) == Data()
+        expect(self.signing.requests.onlyElement?.parameters.nonce).toNot(beNil())
     }
 
     func testRemoteConfigSignaturePayloadMissingBodyThrowsMissingBodyError() {
@@ -591,8 +591,10 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
         expect(self.signing.requests).to(haveCount(1))
     }
 
-    func testRemoteConfigConfigChecksumMismatchFailsDecodingBeforeCallingSigner() throws {
+    func testRemoteConfigConfigChecksumMismatchStillVerifiesConfigPayload() throws {
+        let config = "config".asData
         let body = Self.rcContainer(
+            config: config,
             checksumOverride: { index, data in
                 let checksum = RCContainerTestData.checksum(for: data)
                 return index == 0 ? Array(checksum.reversed()) : checksum
@@ -608,17 +610,11 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
             self.client.perform(Self.remoteConfigRequest, completionHandler: completion)
         }
 
-        // A config checksum mismatch is both a signature-payload failure and an invalid
-        // RC Container. Informational mode does not fail the request for verification alone,
-        // but typed response parsing still fails because there is no valid container to return.
-        expect(response).to(beFailure())
-        switch try XCTUnwrap(response?.error) {
-        case .decoding:
-            break
-        default:
-            fail("Expected decoding error")
-        }
-        expect(self.signing.requests).to(beEmpty())
+        expect(response).to(beSuccess())
+        expect(response?.value?.verificationResult) == .verified
+        expect(self.signing.requests).to(haveCount(1))
+        expect(self.signing.requests.onlyElement?.parameters.message) == config
+        expect(self.signing.requests.onlyElement?.parameters.nonce).toNot(beNil())
     }
 
     func testRemoteConfigCorruptedContentElementDoesNotAffectSignedMessage() throws {
@@ -638,9 +634,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
 
         expect(response).to(beSuccess())
         expect(self.signing.requests).to(haveCount(1))
-        expect(self.signing.requests.onlyElement?.parameters.message) == Data(
-            RCContainerTestData.checksum(for: config)
-        )
+        expect(self.signing.requests.onlyElement?.parameters.message) == config
     }
 
     func testPerformRequestOverridesVerificationMode() throws {
@@ -1134,8 +1128,10 @@ final class EnforcedSignatureVerificationHTTPClientTests: BaseSignatureVerificat
         expect(response?.value?.verificationResult) == .failed
     }
 
-    func testRemoteConfigConfigChecksumMismatchFailsRequestBeforeCallingSigner() throws {
+    func testRemoteConfigConfigChecksumMismatchVerifiesConfigPayload() throws {
+        let config = "config".asData
         let body = Self.rcContainer(
+            config: config,
             checksumOverride: { index, data in
                 let checksum = RCContainerTestData.checksum(for: data)
                 return index == 0 ? Array(checksum.reversed()) : checksum
@@ -1151,15 +1147,11 @@ final class EnforcedSignatureVerificationHTTPClientTests: BaseSignatureVerificat
             self.client.perform(Self.remoteConfigRequest, completionHandler: completion)
         }
 
-        // Enforced mode turns the failed verification result into a transport failure before
-        // typed RC Container parsing can report the checksum mismatch as a decoding error.
-        expect(response).to(beFailure())
-        expect(response?.error)
-            .to(matchError(NetworkError.signatureVerificationFailed(
-                path: HTTPRequest.Path.remoteConfig,
-                code: .success
-            )))
-        expect(self.signing.requests).to(beEmpty())
+        expect(response).to(beSuccess())
+        expect(response?.value?.verificationResult) == .verified
+        expect(self.signing.requests).to(haveCount(1))
+        expect(self.signing.requests.onlyElement?.parameters.message) == config
+        expect(self.signing.requests.onlyElement?.parameters.nonce).toNot(beNil())
     }
 
     func testFakeSignatureFailuresWithDisabledVerification() {

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -636,7 +636,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
             self.client.perform(Self.remoteConfigRequest, completionHandler: completion)
         }
 
-        expect(response).to(beFailure())
+        expect(response).to(beSuccess())
         expect(self.signing.requests).to(haveCount(1))
         expect(self.signing.requests.onlyElement?.parameters.message) == Data(
             RCContainerTestData.checksum(for: config)


### PR DESCRIPTION
Part of a stack of PRs, builds on https://github.com/RevenueCat/purchases-ios/pull/7067 and aligned with Android PR https://github.com/RevenueCat/purchases-android/pull/3615.

## Architecture

Refactors part of the `RCContainer(Element)Parser`, `RemoteConfigAPI` and `RCContainer` itself to extract it's domain specific logic about the config API into external implementations.

- Introduces the `RemoteConfigContainer` wrapper type, which has the domain knowledge about the config element  at index 0
- Moves element checksum validation to the element itself
- `RCContainer` validation now no longer validates the element checksums, but only validates it's structure
  - This also allows potentially corrupt blobs to be ignored while still storing valid blobs to disk (storing itself done in a future PR)
- Remote config endpoint validation now works with the `RemoteConfigContainer` directly in deciding on Request Signature Validation

## Technically
Updates the request signing behavior to;
- Send `nonce` with requests
- Use the full config blob's `Data` as the signature input, not just the checksum anymore


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication inputs and nonce behavior for `/v2/config` response verification; misalignment with backend would break verified fetches or weaken trust assumptions.
> 
> **Overview**
> Refactors **RC Container** parsing so **`RCContainer`** only checks wire structure; element checksums are optional via **`Element.isChecksumValid()` / `validateChecksum()`**, allowing structurally valid containers (including bad inline blobs) to parse without failing upfront.
> 
> Introduces **`RemoteConfigContainer`** as the remote-config HTTP body type: first element is **`configElement`**, later elements are **`inlineContentElements`** (checksum validation deferred until blob store writes). **`RemoteConfigManager`** and fetch results use this wrapper instead of **`RCContainer`** directly.
> 
> **Remote config signature verification** changes: **`.remoteConfig`** now requires a **nonce**; the signed message is the **config element payload bytes** (not the 24-byte checksum); **204 No Content** uses an **empty `Data()`** payload for verification. Parsing can succeed even when stored checksums do not match payloads, as long as structure and signature inputs are consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 804e8b83f00a46d64671b524bb3e0e947b060fca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->