### PR TITLE
Fix applyMediaWidth to respect aspect ratio when width=fit and height=fixed

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -230,7 +230,7 @@ struct ImageComponentView: View {
         with style: ImageComponentStyle
     ) -> some View {
         content
-            .applyMediaWidth(size: style.size)
+            .applyMediaWidth(size: style.size, aspectRatio: self.aspectRatio(style: style))
             .applyMediaHeight(size: style.size, aspectRatio: self.aspectRatio(style: style))
             .applyIfLet(style.colorOverlay, apply: { view, colorOverlay in
                 view.overlay(

--- a/RevenueCatUI/Templates/V2/Components/Video/VideoComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoComponentView.swift
@@ -173,7 +173,7 @@ struct VideoComponentView: View {
                             )
                         }
                     }
-                    .applyMediaWidth(size: style.size)
+                    .applyMediaWidth(size: style.size, aspectRatio: self.aspectRatio(style: style))
                     .applyMediaHeight(size: style.size, aspectRatio: self.aspectRatio(style: style))
                     .applyIfLet(style.colorOverlay, apply: { view, colorOverlay in
                         view.overlay(

--- a/RevenueCatUI/Templates/V2/ViewHelpers/ApplySizing.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/ApplySizing.swift
@@ -18,10 +18,18 @@ import SwiftUI
 extension View {
 
     @ViewBuilder
-    func applyMediaWidth(size: PaywallComponent.Size) -> some View {
+    func applyMediaWidth(size: PaywallComponent.Size, aspectRatio: Double) -> some View {
         switch size.width {
         case .fit:
-            self
+            switch size.height {
+            case .fixed(let value):
+                // Mirror the inverse of applyMediaHeight's height=fit + width=fixed case.
+                // When the image has width=fit and a fixed height, set a fixed width derived
+                // from the aspect ratio so the image is not stretched horizontally.
+                self.frame(width: Double(value) * aspectRatio)
+            default:
+                self
+            }
         case .fill:
             self.frame(maxWidth: .infinity)
         case .fixed(let value):


### PR DESCRIPTION
Fixes #6404

## What's wrong

`applyMediaWidth` had no special handling for the case where `width=fit` and `height=fixed`. It fell through to `self` (no-op), leaving the view free to stretch horizontally to fill available space. The result is that images and videos with this size combination render using fill-like behavior on iOS, even though the Paywall Builder and Android both display them correctly.

`applyMediaHeight` already handles the inverse case (`height=fit`, `width=fixed`) by computing a fixed height from the aspect ratio:

```swift
self.frame(height: Double(value) / aspectRatio)
```

The width function just needs the symmetric treatment.

## Fix

Add the missing case to `applyMediaWidth`: when `width=fit` and `height=fixed`, set a fixed width derived from the aspect ratio (`height * aspectRatio`). This mirrors the existing logic in `applyMediaHeight` and matches the behavior Android implements via `adjustDimension()`.

`applyMediaWidth` now takes an `aspectRatio` parameter (same as `applyMediaHeight`). Both call sites in `ImageComponentView` and `VideoComponentView` pass `self.aspectRatio(style:)`, which was already being computed for the height call.

## Changes

- `ApplySizing.swift` — add `aspectRatio` parameter to `applyMediaWidth`; handle `width=fit + height=fixed` by computing `frame(width: height * aspectRatio)`
- `ImageComponentView.swift` — pass `aspectRatio` to `applyMediaWidth`
- `VideoComponentView.swift` — pass `aspectRatio` to `applyMediaWidth`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, symmetric layout fix in Paywalls V2 media sizing helpers with no auth, data, or payment logic changes.
> 
> **Overview**
> Fixes horizontal stretching for Paywalls V2 **images and videos** when layout uses **width=fit** with a **fixed height** on iOS.
> 
> `applyMediaWidth` now takes an **`aspectRatio`** argument (like `applyMediaHeight`) and, for that size combo, applies **`frame(width: fixedHeight * aspectRatio)`** instead of leaving width unconstrained. **`ImageComponentView`** and **`VideoComponentView`** pass the same `aspectRatio(style:)` already used for height sizing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0395c741141cffb1f695dddb579be65a28127cdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->