### PR TITLE
feat(remote-config): switch config request to v1 and send app user id

### DIFF
--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -151,7 +151,7 @@ extension HTTPRequest {
         case postCreateTicket
         case isPurchaseAllowedByRestoreBehavior(appUserID: String)
         case rewardVerificationStatus(appUserID: String, clientTransactionID: String)
-        case remoteConfig
+        case remoteConfig(domain: String)
 
     }
 
@@ -206,8 +206,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
             return base
         case let .getWorkflow(_, workflowId):
             return "/workflows/v1/workflows/\(Self.escape(workflowId))"
-        case .remoteConfig:
-            return "/v1/config"
+        case let .remoteConfig(domain):
+            return "/v1/config/\(Self.escape(domain))"
         default:
             return nil
         }
@@ -428,8 +428,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
         case let .rewardVerificationStatus(appUserID, clientTransactionID):
             return "subscribers/\(Self.escape(appUserID))/ads/reward_verifications/\(Self.escape(clientTransactionID))"
 
-        case .remoteConfig:
-            return "config"
+        case let .remoteConfig(domain):
+            return "config/\(Self.escape(domain))"
         }
     }
 

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -207,7 +207,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
         case let .getWorkflow(_, workflowId):
             return "/workflows/v1/workflows/\(Self.escape(workflowId))"
         case .remoteConfig:
-            return "/v2/config"
+            return "/v1/config"
         default:
             return nil
         }
@@ -357,12 +357,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
     }
 
     var relativePath: String {
-        switch self {
-        case .remoteConfig:
-            return "/v2/\(self.pathComponent)"
-        default:
-            return "/v1/\(self.pathComponent)"
-        }
+        return "/v1/\(self.pathComponent)"
     }
 
     var pathComponent: String {

--- a/Sources/Networking/Operations/GetRemoteConfigOperation.swift
+++ b/Sources/Networking/Operations/GetRemoteConfigOperation.swift
@@ -53,7 +53,6 @@ struct RemoteConfigRequest: Codable, Equatable, HTTPRequestBody {
     let prefetchedBlobs: [String]
 
     private enum CodingKeys: String, CodingKey {
-        // JSONDecoder.default converts `app_user_id` to `appUserId` before matching CodingKeys.
         case appUserID = "appUserId"
         case manifest
         case prefetchedBlobs

--- a/Sources/Networking/Operations/GetRemoteConfigOperation.swift
+++ b/Sources/Networking/Operations/GetRemoteConfigOperation.swift
@@ -55,7 +55,6 @@ struct RemoteConfigRequest: Codable, Equatable, HTTPRequestBody {
     private enum CodingKeys: String, CodingKey {
         // JSONDecoder.default converts `app_user_id` to `appUserId` before matching CodingKeys.
         case appUserID = "appUserId"
-        case domain
         case manifest
         case prefetchedBlobs
     }
@@ -84,7 +83,6 @@ struct RemoteConfigRequest: Codable, Equatable, HTTPRequestBody {
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(self.appUserID, forKey: .appUserID)
-        try container.encode(self.domain, forKey: .domain)
         try container.encodeIfPresent(self.manifest, forKey: .manifest)
         if !self.prefetchedBlobs.isEmpty {
             try container.encode(self.prefetchedBlobs, forKey: .prefetchedBlobs)
@@ -95,7 +93,7 @@ struct RemoteConfigRequest: Codable, Equatable, HTTPRequestBody {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         self.appUserID = try container.decode(String.self, forKey: .appUserID)
-        self.domain = try container.decode(String.self, forKey: .domain)
+        self.domain = RemoteConfiguration.defaultDomain
         self.manifest = try container.decodeIfPresent(String.self, forKey: .manifest)
         self.prefetchedBlobs = try container.decodeIfPresent([String].self, forKey: .prefetchedBlobs) ?? []
     }
@@ -108,7 +106,7 @@ extension GetRemoteConfigOperation: @unchecked Sendable {}
 private extension GetRemoteConfigOperation {
 
     func getRemoteConfig(completion: @escaping () -> Void) {
-        let request = HTTPRequest(method: .post(self.request), path: .remoteConfig)
+        let request = HTTPRequest(method: .post(self.request), path: .remoteConfig(domain: self.request.domain))
 
         self.httpClient.perform(request) { (response: VerifiedHTTPResponse<RemoteConfigContainer?>.Result) in
             defer {

--- a/Sources/Networking/Operations/GetRemoteConfigOperation.swift
+++ b/Sources/Networking/Operations/GetRemoteConfigOperation.swift
@@ -84,9 +84,7 @@ struct RemoteConfigRequest: Codable, Equatable, HTTPRequestBody {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(self.appUserID, forKey: .appUserID)
         try container.encodeIfPresent(self.manifest, forKey: .manifest)
-        if !self.prefetchedBlobs.isEmpty {
-            try container.encode(self.prefetchedBlobs, forKey: .prefetchedBlobs)
-        }
+        try container.encode(self.prefetchedBlobs, forKey: .prefetchedBlobs)
     }
 
     init(from decoder: Decoder) throws {

--- a/Sources/Networking/Operations/GetRemoteConfigOperation.swift
+++ b/Sources/Networking/Operations/GetRemoteConfigOperation.swift
@@ -47,21 +47,26 @@ final class GetRemoteConfigOperation: CacheableNetworkOperation {
 
 struct RemoteConfigRequest: Codable, Equatable, HTTPRequestBody {
 
+    let appUserID: String
     let domain: String
     let manifest: String?
     let prefetchedBlobs: [String]
 
     private enum CodingKeys: String, CodingKey {
+        // JSONDecoder.default converts `app_user_id` to `appUserId` before matching CodingKeys.
+        case appUserID = "appUserId"
         case domain
         case manifest
         case prefetchedBlobs
     }
 
     init(
+        appUserID: String,
         domain: String = RemoteConfiguration.defaultDomain,
         manifest: String? = nil,
         prefetchedBlobs: [String] = []
     ) {
+        self.appUserID = appUserID
         self.domain = domain
         self.manifest = manifest
         self.prefetchedBlobs = prefetchedBlobs
@@ -69,6 +74,7 @@ struct RemoteConfigRequest: Codable, Equatable, HTTPRequestBody {
 
     var cacheKey: String {
         [
+            "app_user_id=\(self.appUserID)",
             "domain=\(self.domain)",
             "manifest=\(self.manifest ?? "")",
             "prefetched_blobs=\(self.prefetchedBlobs.sorted().joined(separator: ","))"
@@ -77,11 +83,21 @@ struct RemoteConfigRequest: Codable, Equatable, HTTPRequestBody {
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.appUserID, forKey: .appUserID)
         try container.encode(self.domain, forKey: .domain)
         try container.encodeIfPresent(self.manifest, forKey: .manifest)
         if !self.prefetchedBlobs.isEmpty {
             try container.encode(self.prefetchedBlobs, forKey: .prefetchedBlobs)
         }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.appUserID = try container.decode(String.self, forKey: .appUserID)
+        self.domain = try container.decode(String.self, forKey: .domain)
+        self.manifest = try container.decodeIfPresent(String.self, forKey: .manifest)
+        self.prefetchedBlobs = try container.decodeIfPresent([String].self, forKey: .prefetchedBlobs) ?? []
     }
 
 }

--- a/Sources/Networking/RemoteConfigAPI.swift
+++ b/Sources/Networking/RemoteConfigAPI.swift
@@ -32,7 +32,7 @@ class RemoteConfigAPI: RemoteConfigAPIType {
     }
 
     func getRemoteConfig(
-        request: RemoteConfigRequest = .init(),
+        request: RemoteConfigRequest,
         isAppBackgrounded: Bool,
         completion: @escaping RemoteConfigResponseHandler
     ) {

--- a/Sources/Networking/RemoteConfigAPI.swift
+++ b/Sources/Networking/RemoteConfigAPI.swift
@@ -73,7 +73,7 @@ struct RemoteConfigContainer {
     /// Underlying generic RC Container parsed from the remote config response.
     let rcContainer: RCContainer
 
-    /// The first RC Container element, interpreted as the remote config payload for `/v1/config`.
+    /// The first RC Container element, interpreted as the remote config payload for `/v1/config/<domain>`.
     let configElement: RCContainer.Element
 
     /// Inline blob elements delivered with the remote config response, keyed by stored checksum.

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -27,16 +27,19 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     private let dateProvider: DateProvider
     private let isRefreshing: Atomic<Bool> = false
     private let blobStore: RemoteConfigBlobStoreType
+    private let currentUserProvider: CurrentUserProvider
 
     init(
         remoteConfigAPI: RemoteConfigAPIType,
         diskCache: RemoteConfigDiskCacheType,
         blobStore: RemoteConfigBlobStoreType,
+        currentUserProvider: CurrentUserProvider,
         dateProvider: DateProvider = DateProvider()
     ) {
         self.remoteConfigAPI = remoteConfigAPI
         self.diskCache = diskCache
         self.blobStore = blobStore
+        self.currentUserProvider = currentUserProvider
         self.dateProvider = dateProvider
     }
 
@@ -45,6 +48,7 @@ final class RemoteConfigManager: RemoteConfigManagerType {
 
         let persisted = self.diskCache.read()
         let request = RemoteConfigRequest(
+            appUserID: self.currentUserProvider.currentAppUserID,
             domain: persisted?.domain ?? Self.defaultDomain,
             manifest: persisted?.manifest,
             prefetchedBlobs: self.cachedPrefetchedBlobRefs(from: persisted)

--- a/Sources/Networking/Responses/RemoteConfiguration.swift
+++ b/Sources/Networking/Responses/RemoteConfiguration.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-/// The `/v2/config` configuration object.
+/// The `/v1/config` configuration object.
 ///
 /// This is returned by the remote config API either as the config JSON inside an `RCContainer`
 /// response or as the plain JSON HTTP response body.

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -31,7 +31,11 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         self.mockSuccessfulResponse()
 
         let result = waitUntilValue { completed in
-            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+            self.remoteConfigAPI.getRemoteConfig(
+                request: Self.defaultRequest,
+                isAppBackgrounded: false,
+                completion: completed
+            )
         }
 
         expect(result).to(beSuccess())
@@ -43,22 +47,29 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         self.mockSuccessfulResponse()
 
         waitUntil { completed in
-            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false) { _ in completed() }
+            self.remoteConfigAPI.getRemoteConfig(
+                request: Self.defaultRequest,
+                isAppBackgrounded: false
+            ) { _ in completed() }
         }
 
         expect(self.httpClient.calls.map { $0.request.path as? HTTPRequest.Path }) == [.remoteConfig]
         expect(self.httpClient.calls.first?.request.path.relativePath) == "/v1/config"
     }
 
-    func testGetRemoteConfigEncodesDefaultManifestRequestBody() throws {
+    func testGetRemoteConfigEncodesAppUserIDInRequestBody() throws {
         self.mockSuccessfulResponse()
 
         waitUntil { completed in
-            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false) { _ in completed() }
+            self.remoteConfigAPI.getRemoteConfig(
+                request: Self.defaultRequest,
+                isAppBackgrounded: false
+            ) { _ in completed() }
         }
 
         let body = try XCTUnwrap(self.httpClient.calls.first?.request.requestBody?.asJSONDictionary())
 
+        expect(body["app_user_id"] as? String) == Self.appUserID
         expect(body["domain"] as? String) == "app"
         expect(body["manifest"]).to(beNil())
         expect(body["prefetched_blobs"]).to(beNil())
@@ -68,6 +79,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         self.mockSuccessfulResponse()
 
         let request = RemoteConfigRequest(
+            appUserID: Self.appUserID,
             domain: "project",
             manifest: "v1.123.paywalls:etag-paywalls,product_entitlement_mapping:etag-pem",
             prefetchedBlobs: ["blob-b"]
@@ -82,6 +94,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
         let body = try XCTUnwrap(self.httpClient.calls.first?.request.requestBody?.asJSONDictionary())
 
+        expect(body["app_user_id"] as? String) == Self.appUserID
         expect(body["domain"] as? String) == "project"
         expect(body["manifest"] as? String) == "v1.123.paywalls:etag-paywalls,product_entitlement_mapping:etag-pem"
         expect(body["prefetched_blobs"] as? [String]) == ["blob-b"]
@@ -91,7 +104,10 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         self.mockSuccessfulResponse()
 
         waitUntil { completed in
-            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false) { _ in completed() }
+            self.remoteConfigAPI.getRemoteConfig(
+                request: Self.defaultRequest,
+                isAppBackgrounded: false
+            ) { _ in completed() }
         }
 
         expect(self.httpClient.calls.first?.headers[HTTPClient.RequestHeader.accept.rawValue])
@@ -102,7 +118,10 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         self.mockSuccessfulResponse()
 
         waitUntil { completed in
-            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false) { _ in completed() }
+            self.remoteConfigAPI.getRemoteConfig(
+                request: Self.defaultRequest,
+                isAppBackgrounded: false
+            ) { _ in completed() }
         }
 
         expect(self.httpClient.calls.first?.headers[ETagManager.eTagRequestHeader.rawValue]).to(beNil())
@@ -113,7 +132,10 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         self.mockSuccessfulResponse()
 
         waitUntil { completed in
-            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false) { _ in completed() }
+            self.remoteConfigAPI.getRemoteConfig(
+                request: Self.defaultRequest,
+                isAppBackgrounded: false
+            ) { _ in completed() }
         }
 
         let headers = self.httpClient.calls.first?.headers
@@ -128,7 +150,11 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         self.mockSuccessfulResponse()
 
         let result = waitUntilValue { completed in
-            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: true, completion: completed)
+            self.remoteConfigAPI.getRemoteConfig(
+                request: Self.defaultRequest,
+                isAppBackgrounded: true,
+                completion: completed
+            )
         }
 
         expect(result).to(beSuccess())
@@ -139,7 +165,11 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         self.mockSuccessfulResponse()
 
         let result = waitUntilValue { completed in
-            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+            self.remoteConfigAPI.getRemoteConfig(
+                request: Self.defaultRequest,
+                isAppBackgrounded: false,
+                completion: completed
+            )
         }
 
         expect(result).to(beSuccess())
@@ -153,6 +183,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
         let responses: Atomic<Int> = .init(0)
         let request = RemoteConfigRequest(
+            appUserID: Self.appUserID,
             manifest: "v1.10.paywalls:etag-a",
             prefetchedBlobs: ["blob-b", "blob-a"]
         )
@@ -170,12 +201,12 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         let responses: Atomic<Int> = .init(0)
 
         self.remoteConfigAPI.getRemoteConfig(
-            request: .init(manifest: "v1.10.paywalls:etag-a"),
+            request: .init(appUserID: Self.appUserID, manifest: "v1.10.paywalls:etag-a"),
             isAppBackgrounded: false
         ) { _ in responses.value += 1 }
 
         self.remoteConfigAPI.getRemoteConfig(
-            request: .init(manifest: "v1.10.paywalls:etag-b"),
+            request: .init(appUserID: Self.appUserID, manifest: "v1.10.paywalls:etag-b"),
             isAppBackgrounded: false
         ) { _ in responses.value += 1 }
 
@@ -189,12 +220,31 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         let responses: Atomic<Int> = .init(0)
 
         self.remoteConfigAPI.getRemoteConfig(
-            request: .init(domain: "app", manifest: "v1.10.paywalls:etag-a"),
+            request: .init(appUserID: Self.appUserID, domain: "app", manifest: "v1.10.paywalls:etag-a"),
             isAppBackgrounded: false
         ) { _ in responses.value += 1 }
 
         self.remoteConfigAPI.getRemoteConfig(
-            request: .init(domain: "app_workflows", manifest: "v1.10.paywalls:etag-a"),
+            request: .init(appUserID: Self.appUserID, domain: "app_workflows", manifest: "v1.10.paywalls:etag-a"),
+            isAppBackgrounded: false
+        ) { _ in responses.value += 1 }
+
+        expect(responses.value).toEventually(equal(2))
+        expect(self.httpClient.calls).to(haveCount(2))
+    }
+
+    func testGetRemoteConfigDoesNotCoalesceSimultaneousRequestsWithDifferentAppUserIDs() {
+        self.mockSuccessfulResponse(delay: .milliseconds(10))
+
+        let responses: Atomic<Int> = .init(0)
+
+        self.remoteConfigAPI.getRemoteConfig(
+            request: .init(appUserID: "app-user-a", manifest: "v1.10.paywalls:etag-a"),
+            isAppBackgrounded: false
+        ) { _ in responses.value += 1 }
+
+        self.remoteConfigAPI.getRemoteConfig(
+            request: .init(appUserID: "app-user-b", manifest: "v1.10.paywalls:etag-a"),
             isAppBackgrounded: false
         ) { _ in responses.value += 1 }
 
@@ -208,12 +258,12 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         let responses: Atomic<Int> = .init(0)
 
         self.remoteConfigAPI.getRemoteConfig(
-            request: .init(manifest: "v1.10.paywalls:etag-a", prefetchedBlobs: ["blob-a"]),
+            request: .init(appUserID: Self.appUserID, manifest: "v1.10.paywalls:etag-a", prefetchedBlobs: ["blob-a"]),
             isAppBackgrounded: false
         ) { _ in responses.value += 1 }
 
         self.remoteConfigAPI.getRemoteConfig(
-            request: .init(manifest: "v1.10.paywalls:etag-a", prefetchedBlobs: ["blob-b"]),
+            request: .init(appUserID: Self.appUserID, manifest: "v1.10.paywalls:etag-a", prefetchedBlobs: ["blob-b"]),
             isAppBackgrounded: false
         ) { _ in responses.value += 1 }
 
@@ -224,8 +274,8 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
     func testCoalescedRequestsLogDebugMessage() {
         self.mockSuccessfulResponse(delay: .milliseconds(10))
 
-        self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false) { _ in }
-        self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false) { _ in }
+        self.remoteConfigAPI.getRemoteConfig(request: Self.defaultRequest, isAppBackgrounded: false) { _ in }
+        self.remoteConfigAPI.getRemoteConfig(request: Self.defaultRequest, isAppBackgrounded: false) { _ in }
 
         expect(self.httpClient.calls).toEventually(haveCount(1))
         expect(self.httpClient.calls).toNever(haveCount(2))
@@ -242,7 +292,11 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         self.mockSuccessfulResponse()
 
         let result: Result<RemoteConfigFetchResult, BackendError>? = waitUntilValue { completed in
-            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+            self.remoteConfigAPI.getRemoteConfig(
+                request: Self.defaultRequest,
+                isAppBackgrounded: false,
+                completion: completed
+            )
         }
 
         let fetchResult = try XCTUnwrap(result?.value)
@@ -262,7 +316,11 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         self.mockSuccessfulResponse(verificationResult: .verified)
 
         let result: Result<RemoteConfigFetchResult, BackendError>? = waitUntilValue { completed in
-            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+            self.remoteConfigAPI.getRemoteConfig(
+                request: Self.defaultRequest,
+                isAppBackgrounded: false,
+                completion: completed
+            )
         }
 
         let fetchResult = try XCTUnwrap(result?.value)
@@ -287,7 +345,11 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         )
 
         let result: Result<RemoteConfigFetchResult, BackendError>? = waitUntilValue { completed in
-            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+            self.remoteConfigAPI.getRemoteConfig(
+                request: Self.defaultRequest,
+                isAppBackgrounded: false,
+                completion: completed
+            )
         }
 
         let fetchResult = try XCTUnwrap(result?.value)
@@ -310,7 +372,11 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         )
 
         let result: Result<RemoteConfigFetchResult, BackendError>? = waitUntilValue { completed in
-            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+            self.remoteConfigAPI.getRemoteConfig(
+                request: Self.defaultRequest,
+                isAppBackgrounded: false,
+                completion: completed
+            )
         }
 
         let fetchResult = try XCTUnwrap(result?.value)
@@ -323,7 +389,11 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         self.mockSuccessfulResponse(verificationResult: .failed)
 
         let result: Result<RemoteConfigFetchResult, BackendError>? = waitUntilValue { completed in
-            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+            self.remoteConfigAPI.getRemoteConfig(
+                request: Self.defaultRequest,
+                isAppBackgrounded: false,
+                completion: completed
+            )
         }
 
         let fetchResult = try XCTUnwrap(result?.value)
@@ -339,7 +409,11 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         )
 
         let result: Result<RemoteConfigFetchResult, BackendError>? = waitUntilValue { completed in
-            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+            self.remoteConfigAPI.getRemoteConfig(
+                request: Self.defaultRequest,
+                isAppBackgrounded: false,
+                completion: completed
+            )
         }
 
         expect(result).to(beSuccess())
@@ -358,7 +432,11 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         )
 
         let result = waitUntilValue { completed in
-            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+            self.remoteConfigAPI.getRemoteConfig(
+                request: Self.defaultRequest,
+                isAppBackgrounded: false,
+                completion: completed
+            )
         }
 
         expect(result).to(beFailure())
@@ -373,7 +451,11 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         )
 
         let result = waitUntilValue { completed in
-            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+            self.remoteConfigAPI.getRemoteConfig(
+                request: Self.defaultRequest,
+                isAppBackgrounded: false,
+                completion: completed
+            )
         }
 
         expect(result).to(beFailure())
@@ -390,7 +472,11 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         )
 
         let result = waitUntilValue { completed in
-            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+            self.remoteConfigAPI.getRemoteConfig(
+                request: Self.defaultRequest,
+                isAppBackgrounded: false,
+                completion: completed
+            )
         }
 
         expect(result).to(beFailure())
@@ -404,7 +490,11 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         )
 
         let result = waitUntilValue { completed in
-            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+            self.remoteConfigAPI.getRemoteConfig(
+                request: Self.defaultRequest,
+                isAppBackgrounded: false,
+                completion: completed
+            )
         }
 
         guard case let .networkError(.decoding(error, _)) = result?.error else {
@@ -422,7 +512,11 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         )
 
         let result = waitUntilValue { completed in
-            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+            self.remoteConfigAPI.getRemoteConfig(
+                request: Self.defaultRequest,
+                isAppBackgrounded: false,
+                completion: completed
+            )
         }
 
         guard case let .networkError(.decoding(error, _)) = result?.error else {
@@ -440,7 +534,11 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         )
 
         let result = waitUntilValue { completed in
-            self.remoteConfigAPI.getRemoteConfig(isAppBackgrounded: false, completion: completed)
+            self.remoteConfigAPI.getRemoteConfig(
+                request: Self.defaultRequest,
+                isAppBackgrounded: false,
+                completion: completed
+            )
         }
 
         guard case let .networkError(.decoding(error, _)) = result?.error else {
@@ -457,6 +555,11 @@ private extension BackendGetRemoteConfigTests {
 
     static let config = #"{"manifest":{}}"#.asData
     static let content = #"{"products":[]}"#.asData
+    static let appUserID = "app-user-id"
+
+    static var defaultRequest: RemoteConfigRequest {
+        return .init(appUserID: Self.appUserID)
+    }
 
     static var containerData: Data {
         return RCContainerTestData.container(config: Self.config, contentElements: [Self.content])

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -72,7 +72,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(body["app_user_id"] as? String) == Self.appUserID
         expect(body["domain"]).to(beNil())
         expect(body["manifest"]).to(beNil())
-        expect(body["prefetched_blobs"]).to(beNil())
+        expect(body["prefetched_blobs"] as? [String]).to(beEmpty())
     }
 
     func testGetRemoteConfigEncodesCustomManifestRequestBody() throws {

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -53,8 +53,8 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
             ) { _ in completed() }
         }
 
-        expect(self.httpClient.calls.map { $0.request.path as? HTTPRequest.Path }) == [.remoteConfig]
-        expect(self.httpClient.calls.first?.request.path.relativePath) == "/v1/config"
+        expect(self.httpClient.calls.map { $0.request.path as? HTTPRequest.Path }) == [.remoteConfig(domain: "app")]
+        expect(self.httpClient.calls.first?.request.path.relativePath) == "/v1/config/app"
     }
 
     func testGetRemoteConfigEncodesAppUserIDInRequestBody() throws {
@@ -70,13 +70,13 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         let body = try XCTUnwrap(self.httpClient.calls.first?.request.requestBody?.asJSONDictionary())
 
         expect(body["app_user_id"] as? String) == Self.appUserID
-        expect(body["domain"] as? String) == "app"
+        expect(body["domain"]).to(beNil())
         expect(body["manifest"]).to(beNil())
         expect(body["prefetched_blobs"]).to(beNil())
     }
 
     func testGetRemoteConfigEncodesCustomManifestRequestBody() throws {
-        self.mockSuccessfulResponse()
+        self.mockSuccessfulResponse(domain: "project")
 
         let request = RemoteConfigRequest(
             appUserID: Self.appUserID,
@@ -94,8 +94,9 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
         let body = try XCTUnwrap(self.httpClient.calls.first?.request.requestBody?.asJSONDictionary())
 
+        expect(self.httpClient.calls.first?.request.path.relativePath) == "/v1/config/project"
         expect(body["app_user_id"] as? String) == Self.appUserID
-        expect(body["domain"] as? String) == "project"
+        expect(body["domain"]).to(beNil())
         expect(body["manifest"] as? String) == "v1.123.paywalls:etag-paywalls,product_entitlement_mapping:etag-pem"
         expect(body["prefetched_blobs"] as? [String]) == ["blob-b"]
     }
@@ -216,6 +217,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
     func testGetRemoteConfigDoesNotCoalesceSimultaneousRequestsWithDifferentDomains() {
         self.mockSuccessfulResponse(delay: .milliseconds(10))
+        self.mockSuccessfulResponse(domain: "app_workflows", delay: .milliseconds(10))
 
         let responses: Atomic<Int> = .init(0)
 
@@ -231,6 +233,8 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
         expect(responses.value).toEventually(equal(2))
         expect(self.httpClient.calls).to(haveCount(2))
+        expect(self.httpClient.calls.map { $0.request.path.relativePath })
+            .to(contain("/v1/config/app", "/v1/config/app_workflows"))
     }
 
     func testGetRemoteConfigDoesNotCoalesceSimultaneousRequestsWithDifferentAppUserIDs() {
@@ -340,7 +344,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
             }
         )
         self.httpClient.mock(
-            requestPath: .remoteConfig,
+            requestPath: .remoteConfig(domain: "app"),
             response: .init(statusCode: .success, body: data)
         )
 
@@ -367,7 +371,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
             checksumOverride: { _, _ in Array(repeating: 0, count: RCContainerTestData.checksumSize) }
         )
         self.httpClient.mock(
-            requestPath: .remoteConfig,
+            requestPath: .remoteConfig(domain: "app"),
             response: .init(statusCode: .success, body: data)
         )
 
@@ -404,7 +408,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
     func testGetRemoteConfigNoContentResponseSucceedsWithNoContainer() throws {
         self.httpClient.mock(
-            requestPath: .remoteConfig,
+            requestPath: .remoteConfig(domain: "app"),
             response: .init(statusCode: .noContent, body: Data(), verificationResult: .verified)
         )
 
@@ -427,7 +431,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
     func testGetRemoteConfigFailSendsError() {
         self.httpClient.mock(
-            requestPath: .remoteConfig,
+            requestPath: .remoteConfig(domain: "app"),
             response: .init(error: .unexpectedResponse(nil))
         )
 
@@ -446,7 +450,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         let mockedError: NetworkError = .unexpectedResponse(nil)
 
         self.httpClient.mock(
-            requestPath: .remoteConfig,
+            requestPath: .remoteConfig(domain: "app"),
             response: .init(error: mockedError)
         )
 
@@ -467,7 +471,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         let mockedError: NetworkError = .errorResponse(errorResponse, .internalServerError)
 
         self.httpClient.mock(
-            requestPath: .remoteConfig,
+            requestPath: .remoteConfig(domain: "app"),
             response: .init(error: mockedError)
         )
 
@@ -485,7 +489,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
     func testGetRemoteConfigInvalidRCContainerSendsDecodingError() {
         self.httpClient.mock(
-            requestPath: .remoteConfig,
+            requestPath: .remoteConfig(domain: "app"),
             response: .init(statusCode: .success, body: "not an rc container".asData)
         )
 
@@ -507,7 +511,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
     func testGetRemoteConfigSuccessfulEmptyResponseSendsDecodingError() {
         self.httpClient.mock(
-            requestPath: .remoteConfig,
+            requestPath: .remoteConfig(domain: "app"),
             response: .init(statusCode: .success, body: Data())
         )
 
@@ -529,7 +533,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
     func testGetRemoteConfigSuccessfulJSONResponseSendsDecodingError() {
         self.httpClient.mock(
-            requestPath: .remoteConfig,
+            requestPath: .remoteConfig(domain: "app"),
             response: .init(statusCode: .success, body: #"{"api_sources":[]}"#.asData)
         )
 
@@ -566,11 +570,12 @@ private extension BackendGetRemoteConfigTests {
     }
 
     func mockSuccessfulResponse(
+        domain: String = "app",
         verificationResult: VerificationResult = .defaultValue,
         delay: DispatchTimeInterval = .never
     ) {
         self.httpClient.mock(
-            requestPath: .remoteConfig,
+            requestPath: .remoteConfig(domain: domain),
             response: .init(
                 statusCode: .success,
                 body: Self.containerData,

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -47,7 +47,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         }
 
         expect(self.httpClient.calls.map { $0.request.path as? HTTPRequest.Path }) == [.remoteConfig]
-        expect(self.httpClient.calls.first?.request.path.relativePath) == "/v2/config"
+        expect(self.httpClient.calls.first?.request.path.relativePath) == "/v1/config"
     }
 
     func testGetRemoteConfigEncodesDefaultManifestRequestBody() throws {

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1027,7 +1027,10 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
     }
 
     func testRemoteConfigDoesNotUseETagCacheEvenIfResponseIncludesETagHeader() {
-        let request = HTTPRequest(method: .post(RemoteConfigRequest()), path: .remoteConfig)
+        let request = HTTPRequest(
+            method: .post(RemoteConfigRequest(appUserID: "app-user-id")),
+            path: .remoteConfig
+        )
         let headerPresent: Atomic<Bool?> = nil
 
         stub(condition: isPath(request.path)) { request in

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1029,7 +1029,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
     func testRemoteConfigDoesNotUseETagCacheEvenIfResponseIncludesETagHeader() {
         let request = HTTPRequest(
             method: .post(RemoteConfigRequest(appUserID: "app-user-id")),
-            path: .remoteConfig
+            path: .remoteConfig(domain: "app")
         )
         let headerPresent: Atomic<Bool?> = nil
 

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -39,14 +39,14 @@ class HTTPRequestTests: TestCase {
         .rewardVerificationStatus(appUserID: userID, clientTransactionID: clientTransactionID),
         .getWorkflows(appUserID: userID, type: nil),
         .getWorkflow(appUserID: userID, workflowId: "wf_1"),
-        .remoteConfig
+        .remoteConfig(domain: "app")
     ]
     private static let unauthenticatedPaths: Set<HTTPRequest.Path> = [
         .health
     ]
     private static let pathsWithoutETags: Set<HTTPRequest.Path> = [
         .health,
-        .remoteConfig
+        .remoteConfig(domain: "app")
     ]
     private static let pathsWithSignatureVerification: Set<HTTPRequest.Path> = [
         .getCustomerInfo(appUserID: userID),
@@ -58,7 +58,7 @@ class HTTPRequestTests: TestCase {
         .rewardVerificationStatus(appUserID: userID, clientTransactionID: clientTransactionID),
         .getWorkflows(appUserID: userID, type: nil),
         .getWorkflow(appUserID: userID, workflowId: "wf_1"),
-        .remoteConfig
+        .remoteConfig(domain: "app")
     ]
     private static let pathsThatRequireNonce: Set<HTTPRequest.Path> = [
         .getCustomerInfo(appUserID: userID),
@@ -215,7 +215,7 @@ class HTTPRequestTests: TestCase {
                                ["https://api-production.8-lives-cat.io/workflows/v1/workflows/\(workflowId)"])
             case .remoteConfig:
                 XCTAssertEqual(fallbackUrlsPaths,
-                               ["https://api-production.8-lives-cat.io/v1/config"])
+                               ["https://api-production.8-lives-cat.io/v1/config/app"])
             default:
                 XCTAssertTrue(fallbackUrlsPaths.isEmpty)
             }
@@ -228,6 +228,14 @@ class HTTPRequestTests: TestCase {
             path.fallbackUrls.map { $0.absoluteString },
             ["https://api-production.8-lives-cat.io/workflows/v1/workflows?type=PAYWALL"]
         )
+    }
+
+    func testRemoteConfigPathEscapesDomain() {
+        let path = HTTPRequest.Path.remoteConfig(domain: "app workflows/project")
+
+        expect(path.relativePath) == "/v1/config/app%20workflows%2Fproject"
+        expect(path.fallbackUrls.map { $0.absoluteString })
+            == ["https://api-production.8-lives-cat.io/v1/config/app%20workflows%2Fproject"]
     }
 
     func testGetWorkflowFallbackUrlEscapesWorkflowId() {
@@ -320,7 +328,7 @@ class HTTPRequestTests: TestCase {
     func testRemoteConfigUsesRCContainerAcceptHeader() {
         let request: HTTPRequest = .init(
             method: .post(RemoteConfigRequest(appUserID: "app-user-id")),
-            path: .remoteConfig
+            path: .remoteConfig(domain: "app")
         )
         let headers = request.headers(
             with: [:],

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -65,7 +65,7 @@ class HTTPRequestTests: TestCase {
         .logIn,
         .postReceiptData,
         .health,
-        .remoteConfig,
+        .remoteConfig(domain: "app"),
         .rewardVerificationStatus(appUserID: userID, clientTransactionID: clientTransactionID)
     ]
     private static let pathsWithUserID: [HTTPRequest.Path] = [

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -318,7 +318,10 @@ class HTTPRequestTests: TestCase {
     }
 
     func testRemoteConfigUsesRCContainerAcceptHeader() {
-        let request: HTTPRequest = .init(method: .post(RemoteConfigRequest()), path: .remoteConfig)
+        let request: HTTPRequest = .init(
+            method: .post(RemoteConfigRequest(appUserID: "app-user-id")),
+            path: .remoteConfig
+        )
         let headers = request.headers(
             with: [:],
             defaultHeaders: [:],

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -215,7 +215,7 @@ class HTTPRequestTests: TestCase {
                                ["https://api-production.8-lives-cat.io/workflows/v1/workflows/\(workflowId)"])
             case .remoteConfig:
                 XCTAssertEqual(fallbackUrlsPaths,
-                               ["https://api-production.8-lives-cat.io/v2/config"])
+                               ["https://api-production.8-lives-cat.io/v1/config"])
             default:
                 XCTAssertTrue(fallbackUrlsPaths.isEmpty)
             }

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -13,11 +13,13 @@ import XCTest
 final class RemoteConfigManagerTests: TestCase {
 
     private static let lastRefreshAt = Date(timeIntervalSince1970: 1_710_000_100)
+    private static let appUserID = "app-user-id"
 
     private var remoteConfigAPI: MockRemoteConfigAPI!
     private var diskCache: MockRemoteConfigDiskCache!
     private var dateProvider: MockDateProvider!
     private var blobStore: MockRemoteConfigBlobStore!
+    private var currentUserProvider: MockCurrentUserProvider!
     private var manager: RemoteConfigManager!
 
     override func setUpWithError() throws {
@@ -27,10 +29,12 @@ final class RemoteConfigManagerTests: TestCase {
         self.diskCache = MockRemoteConfigDiskCache()
         self.dateProvider = MockDateProvider(stubbedNow: Self.lastRefreshAt)
         self.blobStore = MockRemoteConfigBlobStore()
+        self.currentUserProvider = MockCurrentUserProvider(mockAppUserID: Self.appUserID)
         self.manager = RemoteConfigManager(
             remoteConfigAPI: self.remoteConfigAPI,
             diskCache: self.diskCache,
             blobStore: self.blobStore,
+            currentUserProvider: self.currentUserProvider,
             dateProvider: self.dateProvider
         )
     }
@@ -39,6 +43,7 @@ final class RemoteConfigManagerTests: TestCase {
         self.manager = nil
         self.dateProvider = nil
         self.blobStore = nil
+        self.currentUserProvider = nil
         self.diskCache = nil
         self.remoteConfigAPI = nil
 
@@ -51,6 +56,7 @@ final class RemoteConfigManagerTests: TestCase {
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.appUserID) == Self.appUserID
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.manifest).to(beNil())
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.prefetchedBlobs).to(beEmpty())
     }
@@ -67,6 +73,7 @@ final class RemoteConfigManagerTests: TestCase {
 
         self.manager.refreshRemoteConfig(isAppBackgrounded: true)
 
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.appUserID) == Self.appUserID
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.domain) == "custom"
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.manifest) == persistedManifest
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.prefetchedBlobs) == ["prefetchedBlob"]

--- a/Tests/UnitTests/Networking/Responses/RemoteConfigurationDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/RemoteConfigurationDecodingTests.swift
@@ -310,14 +310,17 @@ final class RemoteConfigurationDecodingTests: TestCase {
 
     func testRequestEncodeRoundTripPreservesShape() throws {
         let request = RemoteConfigRequest(
+            appUserID: "app-user-id",
             domain: "app",
             manifest: "v1.123.sources:sources-etag",
             prefetchedBlobs: ["blob-b", "blob-a"]
         )
 
         let data = try JSONEncoder.default.encode(request)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
         let decoded = try JSONDecoder.default.decode(RemoteConfigRequest.self, from: data)
 
+        expect(json["app_user_id"] as? String) == "app-user-id"
         expect(decoded) == request
     }
 

--- a/Tests/UnitTests/Networking/Responses/RemoteConfigurationDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/RemoteConfigurationDecodingTests.swift
@@ -308,20 +308,21 @@ final class RemoteConfigurationDecodingTests: TestCase {
         expect(json["prefetch"]).to(beNil())
     }
 
-    func testRequestEncodeRoundTripPreservesShape() throws {
+    func testRequestEncodingOmitsDomain() throws {
         let request = RemoteConfigRequest(
             appUserID: "app-user-id",
-            domain: "app",
+            domain: "project",
             manifest: "v1.123.sources:sources-etag",
             prefetchedBlobs: ["blob-b", "blob-a"]
         )
 
         let data = try JSONEncoder.default.encode(request)
         let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
-        let decoded = try JSONDecoder.default.decode(RemoteConfigRequest.self, from: data)
 
         expect(json["app_user_id"] as? String) == "app-user-id"
-        expect(decoded) == request
+        expect(json["domain"]).to(beNil())
+        expect(json["manifest"] as? String) == "v1.123.sources:sources-etag"
+        expect(json["prefetched_blobs"] as? [String]) == ["blob-b", "blob-a"]
     }
 
 }

--- a/Tests/UnitTests/Networking/Responses/RemoteConfigurationDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/RemoteConfigurationDecodingTests.swift
@@ -325,6 +325,18 @@ final class RemoteConfigurationDecodingTests: TestCase {
         expect(json["prefetched_blobs"] as? [String]) == ["blob-b", "blob-a"]
     }
 
+    func testFirstRunRequestEncodingIncludesEmptyPrefetchedBlobs() throws {
+        let request = RemoteConfigRequest(appUserID: "app-user-id")
+
+        let data = try JSONEncoder.default.encode(request)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        expect(json["app_user_id"] as? String) == "app-user-id"
+        expect(json["domain"]).to(beNil())
+        expect(json["manifest"]).to(beNil())
+        expect(json["prefetched_blobs"] as? [String]).to(beEmpty())
+    }
+
 }
 
 private extension RemoteConfigurationDecodingTests {

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -1175,7 +1175,10 @@ final class EnforcedSignatureVerificationHTTPClientTests: BaseSignatureVerificat
 private extension BaseSignatureVerificationHTTPClientTests {
 
     static var remoteConfigRequest: HTTPRequest {
-        return .init(method: .post(RemoteConfigRequest()), path: HTTPRequest.Path.remoteConfig)
+        return .init(
+            method: .post(RemoteConfigRequest(appUserID: "app-user-id")),
+            path: HTTPRequest.Path.remoteConfig
+        )
     }
 
     static func rcContainer(

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -348,7 +348,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
     func testValidRemoteConfigSignatureUsesConfigPayloadAsSignedMessage() throws {
         let config = "config".asData
         let body = Self.rcContainer(config: config, contentElements: ["content".asData])
-        self.mockResponse(path: HTTPRequest.Path.remoteConfig,
+        self.mockResponse(path: HTTPRequest.Path.remoteConfig(domain: "app"),
                           signature: Self.sampleSignature,
                           requestDate: Self.date2,
                           body: body)
@@ -373,7 +373,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
     }
 
     func testRemoteConfigSignatureIncludesETagIfBackendSendsIt() throws {
-        self.mockResponse(path: HTTPRequest.Path.remoteConfig,
+        self.mockResponse(path: HTTPRequest.Path.remoteConfig(domain: "app"),
                           signature: Self.sampleSignature,
                           requestDate: Self.date2,
                           eTag: Self.eTag,
@@ -389,7 +389,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
     }
 
     func testRemoteConfigNoContentResponseVerifiesRequestContextWithEmptyResponseMessage() throws {
-        self.mockResponse(path: HTTPRequest.Path.remoteConfig,
+        self.mockResponse(path: HTTPRequest.Path.remoteConfig(domain: "app"),
                           signature: Self.sampleSignature,
                           requestDate: Self.date2,
                           body: "not an RC Container".asData,
@@ -411,7 +411,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
 
     func testRemoteConfigNoContentResponseWithDisabledVerificationIsNotRequested() throws {
         self.changeClient(.disabled)
-        self.mockResponse(path: HTTPRequest.Path.remoteConfig,
+        self.mockResponse(path: HTTPRequest.Path.remoteConfig(domain: "app"),
                           signature: nil,
                           requestDate: nil,
                           body: Data(),
@@ -428,7 +428,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
     }
 
     func testRemoteConfigNoContentResponseMissingSignatureReturnsFailedVerification() throws {
-        self.mockResponse(path: HTTPRequest.Path.remoteConfig,
+        self.mockResponse(path: HTTPRequest.Path.remoteConfig(domain: "app"),
                           signature: nil,
                           requestDate: Self.date2,
                           body: Data(),
@@ -446,7 +446,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
 
     func testRemoteConfigNoContentResponseMissingSignatureFailsInEnforcedMode() throws {
         self.changeClientToEnforced()
-        self.mockResponse(path: HTTPRequest.Path.remoteConfig,
+        self.mockResponse(path: HTTPRequest.Path.remoteConfig(domain: "app"),
                           signature: nil,
                           requestDate: Self.date2,
                           body: Data(),
@@ -459,14 +459,14 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
         expect(response).to(beFailure())
         expect(response?.error)
             .to(matchError(NetworkError.signatureVerificationFailed(
-                path: HTTPRequest.Path.remoteConfig,
+                path: HTTPRequest.Path.remoteConfig(domain: "app"),
                 code: .noContent
             )))
         expect(self.signing.requests).to(beEmpty())
     }
 
     func testRemoteConfigNoContentResponseInvalidSignatureReturnsFailedVerification() throws {
-        self.mockResponse(path: HTTPRequest.Path.remoteConfig,
+        self.mockResponse(path: HTTPRequest.Path.remoteConfig(domain: "app"),
                           signature: Self.sampleSignature,
                           requestDate: Self.date2,
                           body: Data(),
@@ -487,7 +487,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
 
     func testRemoteConfigNoContentResponseInvalidSignatureFailsInEnforcedMode() throws {
         self.changeClientToEnforced()
-        self.mockResponse(path: HTTPRequest.Path.remoteConfig,
+        self.mockResponse(path: HTTPRequest.Path.remoteConfig(domain: "app"),
                           signature: Self.sampleSignature,
                           requestDate: Self.date2,
                           body: Data(),
@@ -501,7 +501,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
         expect(response).to(beFailure())
         expect(response?.error)
             .to(matchError(NetworkError.signatureVerificationFailed(
-                path: HTTPRequest.Path.remoteConfig,
+                path: HTTPRequest.Path.remoteConfig(domain: "app"),
                 code: .noContent
             )))
         expect(self.signing.requests).to(haveCount(1))
@@ -518,7 +518,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
     }
 
     func testRemoteConfigMissingSignatureReturnsFailedVerification() throws {
-        self.mockResponse(path: HTTPRequest.Path.remoteConfig,
+        self.mockResponse(path: HTTPRequest.Path.remoteConfig(domain: "app"),
                           signature: nil,
                           requestDate: Self.date2,
                           body: Self.rcContainer())
@@ -535,7 +535,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
 
     func testRemoteConfigMissingSignatureFailsInEnforcedMode() throws {
         self.changeClientToEnforced()
-        self.mockResponse(path: HTTPRequest.Path.remoteConfig,
+        self.mockResponse(path: HTTPRequest.Path.remoteConfig(domain: "app"),
                           signature: nil,
                           requestDate: Self.date2,
                           body: Self.rcContainer())
@@ -548,14 +548,14 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
         expect(response).to(beFailure())
         expect(response?.error)
             .to(matchError(NetworkError.signatureVerificationFailed(
-                path: HTTPRequest.Path.remoteConfig,
+                path: HTTPRequest.Path.remoteConfig(domain: "app"),
                 code: .success
             )))
         expect(self.signing.requests).to(beEmpty())
     }
 
     func testRemoteConfigInvalidSignatureReturnsFailedVerification() throws {
-        self.mockResponse(path: HTTPRequest.Path.remoteConfig,
+        self.mockResponse(path: HTTPRequest.Path.remoteConfig(domain: "app"),
                           signature: Self.sampleSignature,
                           requestDate: Self.date2,
                           body: Self.rcContainer())
@@ -572,7 +572,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
 
     func testRemoteConfigInvalidSignatureFailsInEnforcedMode() throws {
         self.changeClientToEnforced()
-        self.mockResponse(path: HTTPRequest.Path.remoteConfig,
+        self.mockResponse(path: HTTPRequest.Path.remoteConfig(domain: "app"),
                           signature: Self.sampleSignature,
                           requestDate: Self.date2,
                           body: Self.rcContainer())
@@ -585,7 +585,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
         expect(response).to(beFailure())
         expect(response?.error)
             .to(matchError(NetworkError.signatureVerificationFailed(
-                path: HTTPRequest.Path.remoteConfig,
+                path: HTTPRequest.Path.remoteConfig(domain: "app"),
                 code: .success
             )))
         expect(self.signing.requests).to(haveCount(1))
@@ -600,7 +600,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
                 return index == 0 ? Array(checksum.reversed()) : checksum
             }
         )
-        self.mockResponse(path: HTTPRequest.Path.remoteConfig,
+        self.mockResponse(path: HTTPRequest.Path.remoteConfig(domain: "app"),
                           signature: Self.sampleSignature,
                           requestDate: Self.date2,
                           body: body)
@@ -622,7 +622,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
         let content = "content".asData
         var body = Self.rcContainer(config: config, contentElements: [content])
         body[Self.contentPayloadOffset(config: config)] = UInt8(ascii: "x")
-        self.mockResponse(path: HTTPRequest.Path.remoteConfig,
+        self.mockResponse(path: HTTPRequest.Path.remoteConfig(domain: "app"),
                           signature: Self.sampleSignature,
                           requestDate: Self.date2,
                           body: body)
@@ -1137,7 +1137,7 @@ final class EnforcedSignatureVerificationHTTPClientTests: BaseSignatureVerificat
                 return index == 0 ? Array(checksum.reversed()) : checksum
             }
         )
-        self.mockResponse(path: HTTPRequest.Path.remoteConfig,
+        self.mockResponse(path: HTTPRequest.Path.remoteConfig(domain: "app"),
                           signature: Self.sampleSignature,
                           requestDate: Self.date2,
                           body: body)
@@ -1177,7 +1177,7 @@ private extension BaseSignatureVerificationHTTPClientTests {
     static var remoteConfigRequest: HTTPRequest {
         return .init(
             method: .post(RemoteConfigRequest(appUserID: "app-user-id")),
-            path: HTTPRequest.Path.remoteConfig
+            path: HTTPRequest.Path.remoteConfig(domain: "app")
         )
     }
 


### PR DESCRIPTION
Some small API request updates

- Switches the API endpoint from `/v2/config` to `/v1/config`
- Includes the current app user ID in the POST body of the request, as `app_user_id: "something"`
- Removes the `domain` from the request/response models and sends it in the URL instead as `/v1/config/:domain`
- Always encodes `prefetched_blobs` in the body as empty array instead of omitting (consistent with Android now).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking API contract change for remote config (URL and body shape); misalignment with the backend would break config sync for all clients on this SDK version.
> 
> **Overview**
> Remote config fetch is retargeted from **`POST /v2/config`** to **`POST /v1/config/:domain`**, with the config **domain** moved out of the JSON body and into the path (escaped). **`HTTPRequest.Path.remoteConfig`** is now **`remoteConfig(domain:)`**, and all paths use the standard **`/v1/`** prefix instead of a special v2 case.
> 
> The POST body now sends **`app_user_id`** (from **`CurrentUserProvider`** in **`RemoteConfigManager`**), plus **`manifest`** and always **`prefetched_blobs`** (including an empty array on first run). **`domain` is no longer encoded** in the body. **`RemoteConfigAPI.getRemoteConfig`** requires an explicit **`RemoteConfigRequest`**, and request coalescing keys include app user id, domain, manifest, and prefetched blobs.
> 
> Tests are updated for the new URL shape, body fields, domain escaping, and coalescing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e80150d2d84f4964cf9c84789f31eeb0eb26bb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->