### PR TITLE
Make LargeItemCache writes atomic

### DIFF
--- a/Sources/Caching/LargeItemCacheType.swift
+++ b/Sources/Caching/LargeItemCacheType.swift
@@ -74,7 +74,7 @@ extension FileManager: LargeItemCacheType {
     func saveData(_ data: Data, to url: URL) throws {
         let directoryURL = url.deletingLastPathComponent()
         try createDirectory(at: directoryURL, withIntermediateDirectories: true, attributes: nil)
-        try data.write(to: url)
+        try data.write(to: url, options: .atomic)
     }
 
     /// Store data to a url and validate that the file is correct before saving


### PR DESCRIPTION
Additional context can be found in [this](https://github.com/RevenueCat/purchases-ios/pull/7076#discussion_r3474073957) comment. But basically we wanted to have the additional safety of atomic writes when integrating the `LargeItemCache` for the `RemoteConfiguration` manifest cache.

Since `LargeItemCache` is already used throughout the SDK we wanted to extract this into it's own (tiny) PR for proper review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes signature verification and signed-payload derivation for remote config (security-sensitive), though behavior is heavily covered by tests; atomic file writes are a low-risk infrastructure tweak.
> 
> **Overview**
> Adds **remote config** persistence via `RemoteConfigDiskCache` (`remote_config.json` manifest/topic blob refs) on top of `SynchronizedLargeItemCache`, with read/write error logging.
> 
> Enables **response signature verification** for `.remoteConfig` (and keeps it for reward verification): a pluggable `ResponseSignatureContextProvider` lets verification use endpoint-specific signed bytes and request-body inputs. Remote config signs the **first RC Container element’s stored checksum** (not the full body), omits the POST body from signature params, and treats **204** as a nil response message. `RCContainer.ElementParser` supports parsing only that first element before full decode. Failures to build the signed payload are logged and counted as verification failures.
> 
> `getRemoteConfig` now returns **`RemoteConfigFetchResult`** (optional `RCContainer` + `VerificationResult`) instead of a bare container. Shared **`FileManager.saveData`** sync writes use **`.atomic`** for safer overwrites (relevant to manifest cache).
> 
> Tests cover disk cache, atomic overwrite, HTTP path flags, backend fetch results, and extensive remote-config signature scenarios (including 204 and enforced mode).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad2dff381abf524fd3f69ac7d5024dccda6f9bc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->