### PR TITLE
feat: web_view content-blocking isolation

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1138,6 +1138,7 @@
 		9A65E07B2591977500DE00B0 /* NetworkStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A65E07A2591977500DE00B0 /* NetworkStrings.swift */; };
 		9A65E0A02591A23200DE00B0 /* OfferingStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A65E09F2591A23200DE00B0 /* OfferingStrings.swift */; };
 		9A65E0A52591A23500DE00B0 /* PurchaseStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A65E0A42591A23500DE00B0 /* PurchaseStrings.swift */; };
+		9EA7410B386848B365F44AED /* WebViewCapabilitiesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECBCE280B1AB66FD155FA74 /* WebViewCapabilitiesConfiguration.swift */; };
 		A153288D312E5729B0305553 /* RulesEngineEvaluateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 645D8E14F3E2F79FAC1C2FA0 /* RulesEngineEvaluateTests.swift */; };
 		A1B2C3D42FE1000000000002 /* RCContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE1000000000001 /* RCContainer.swift */; };
 		A1B2C3D42FE1000000000004 /* RCContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE1000000000003 /* RCContainerTests.swift */; };
@@ -2869,6 +2870,8 @@
 		B7BA50D5AA17E5D4A5D3E99D /* Operators.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Operators.swift; sourceTree = "<group>"; };
 		B807748D6D88B7836EC273ED /* EqualityOperators.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EqualityOperators.swift; sourceTree = "<group>"; };
 		B8BCBA1A622A35B377B35254 /* ValueTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ValueTests.swift; sourceTree = "<group>"; };
+		BC6D9D5964DA2EA53FAEB2F5 /* WebViewCapabilitiesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewCapabilitiesTests.swift; sourceTree = "<group>"; };
+		BECBCE280B1AB66FD155FA74 /* WebViewCapabilitiesConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewCapabilitiesConfiguration.swift; sourceTree = "<group>"; };
 		BF0DA22F713FAE8939275417 /* RulesEngineEvaluate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RulesEngineEvaluate.swift; sourceTree = "<group>"; };
 		C07759C930F712D2D53B9333 /* WorkflowStepEventTrackerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowStepEventTrackerTests.swift; sourceTree = "<group>"; };
 		C41FD75CE31F51BBE614F9B0 /* WorkflowsCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowsCache.swift; sourceTree = "<group>"; };
@@ -3188,6 +3191,7 @@
 				1D76F25F2F921DB800863AF8 /* ButtonComponentViewModelInteractionTests.swift */,
 				808963A62FE168FD008E858C /* TabsComponentStateTests.swift */,
 				8BAF5880071599951932A6A1 /* ImageComponentViewTests.swift */,
+				BC6D9D5964DA2EA53FAEB2F5 /* WebViewCapabilitiesTests.swift */,
 			);
 			path = PaywallsV2;
 			sourceTree = "<group>";
@@ -3383,6 +3387,7 @@
 				88B1BADC2C813A3C001B7EE5 /* Text */,
 				778360772CCA85D1000785B8 /* StickyFooter */,
 				778360742CCA84FA000785B8 /* Root */,
+				44BC398E1A1A1376EEAB0973 /* WebView */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -4736,6 +4741,15 @@
 				2DDF41AA24F6F37C005BC22D /* InAppPurchase.swift */,
 			);
 			path = BasicTypes;
+			sourceTree = "<group>";
+		};
+		44BC398E1A1A1376EEAB0973 /* WebView */ = {
+			isa = PBXGroup;
+			children = (
+				BECBCE280B1AB66FD155FA74 /* WebViewCapabilitiesConfiguration.swift */,
+			);
+			name = WebView;
+			path = WebView;
 			sourceTree = "<group>";
 		};
 		4D3BA5B12D47AB4400668AFC /* Timeline */ = {
@@ -8348,6 +8362,7 @@
 				150BEBF14F59182317CDA8DA /* WorkflowContext.swift in Sources */,
 				C53CDAA4FC3E6B51CC70D724 /* WorkflowPaywallView.swift in Sources */,
 				C1311C20A12B3813D86A2EDF /* WorkflowPreview.swift in Sources */,
+				9EA7410B386848B365F44AED /* WebViewCapabilitiesConfiguration.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -109,6 +109,9 @@ enum Strings {
     case video_failed_to_set_audio_session_category(Error)
     case video_failed_to_cache(URL, Error)
 
+    // Web View
+    case paywall_web_view_content_rules_failed(Error)
+
     // Exit Offers
     case errorFetchingOfferings(Error)
     case exitOfferNotFound(String)
@@ -362,6 +365,10 @@ extension Strings: CustomStringConvertible {
             return "Failed to set audio session category: \(error)"
         case .video_failed_to_cache(let url, let error):
             return "Failed to cache video at \(url): \(error)"
+
+        case .paywall_web_view_content_rules_failed(let error):
+            return "Failed to compile content-blocking rules for a web_view component; the page " +
+            "remains isolated to its uploaded bundle: \(error)"
 
         case .errorFetchingOfferings(let error):
             return "Error fetching offerings: \(error)"

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewCapabilitiesConfiguration.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewCapabilitiesConfiguration.swift
@@ -1,0 +1,127 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WebViewCapabilitiesConfiguration.swift
+
+import Foundation
+@_spi(Internal) import RevenueCat
+#if canImport(WebKit)
+import WebKit
+#endif
+
+#if !os(tvOS) && canImport(WebKit) // For Paywalls V2
+
+/// WebKit-free content-blocking policy for `web_view` components. Kept separate from the WKWebView
+/// rendering code so it can be unit-tested without instantiating a web view.
+///
+/// For the initial version every `web_view` is isolated from external sources: customers must
+/// upload everything in a single bundle. The fixed policy blocks remote (third-party) images,
+/// scripts and fonts while allowing same-origin assets, blocks `data:` images and fonts, and
+/// blocks XHR (`raw`) loads entirely.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+enum WebViewCapabilitiesConfiguration {
+
+    /// Stable identifier used to cache the compiled `WKContentRuleList` for the fixed isolation
+    /// policy. The policy never varies, so a single identifier is enough.
+    static let contentRuleListIdentifier = "rc-webview-v1-isolation"
+
+    /// The fixed content-blocking rules (as a JSON string) enforcing full isolation from external
+    /// sources. `raw` is used for XHR (rather than the newer `fetch`/`websocket` resource types) so
+    /// the list compiles on older OS versions; an unknown resource-type would fail the whole list
+    /// closed.
+    static var contentBlockingRules: String? {
+        let rules: [[String: Any]] = [
+            // Block remote (third-party) images, scripts and fonts; same-origin assets still load.
+            [
+                "trigger": [
+                    "url-filter": ".*",
+                    "resource-type": ["image", "script", "font"],
+                    "load-type": ["third-party"]
+                ],
+                "action": ["type": "block"]
+            ],
+            // Block inline `data:` images and fonts.
+            [
+                "trigger": [
+                    "url-filter": "^data:",
+                    "resource-type": ["image", "font"]
+                ],
+                "action": ["type": "block"]
+            ],
+            // Block XHR.
+            [
+                "trigger": [
+                    "url-filter": ".*",
+                    "resource-type": ["raw"]
+                ],
+                "action": ["type": "block"]
+            ]
+        ]
+
+        guard let data = try? JSONSerialization.data(withJSONObject: rules),
+              let json = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        return json
+    }
+
+}
+
+/// Caches compiled `WKContentRuleList`s keyed by identifier so the fixed isolation policy is
+/// compiled at most once per session.
+///
+/// Compilation is asynchronous; a web view attaches the rule list once
+/// ``ruleList(forIdentifier:json:completion:)`` finishes compiling it.
+///
+/// Accessed on the main thread only (`compileContentRuleList`'s completion handler is invoked there).
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+final class WebViewContentRuleListStore {
+
+    static let shared = WebViewContentRuleListStore()
+
+    private var cache: [String: WKContentRuleList] = [:]
+
+    private init() {}
+
+    /// Returns the compiled rule list for `identifier`, compiling `json` if it isn't cached yet.
+    /// Completes on the main thread; `nil` indicates compilation failed (the caller should fail
+    /// closed by blocking all requests).
+    func ruleList(
+        forIdentifier identifier: String,
+        json: String,
+        completion: @escaping (WKContentRuleList?) -> Void
+    ) {
+        if let cached = self.cache[identifier] {
+            completion(cached)
+            return
+        }
+
+        guard let store = WKContentRuleListStore.default() else {
+            completion(nil)
+            return
+        }
+
+        store.compileContentRuleList(
+            forIdentifier: identifier,
+            encodedContentRuleList: json
+        ) { [weak self] ruleList, error in
+            if let error {
+                Logger.debug(Strings.paywall_web_view_content_rules_failed(error))
+            }
+            if let ruleList {
+                self?.cache[identifier] = ruleList
+            }
+            completion(ruleList)
+        }
+    }
+
+}
+
+#endif

--- a/Tests/RevenueCatUITests/PaywallsV2/WebViewCapabilitiesTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WebViewCapabilitiesTests.swift
@@ -1,0 +1,85 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WebViewCapabilitiesTests.swift
+
+@_spi(Internal) @testable import RevenueCat
+@testable import RevenueCatUI
+import XCTest
+
+#if !os(tvOS) && canImport(WebKit)
+
+import WebKit
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+final class WebViewCapabilitiesTests: TestCase {
+
+    // MARK: - Content-blocking rules
+
+    func testContentRuleListIdentifierIsStableConstant() {
+        XCTAssertEqual(WebViewCapabilitiesConfiguration.contentRuleListIdentifier, "rc-webview-v1-isolation")
+    }
+
+    func testContentBlockingRulesAreValidJSON() throws {
+        let rules = try XCTUnwrap(WebViewCapabilitiesConfiguration.contentBlockingRules)
+        XCTAssertNoThrow(try JSONSerialization.jsonObject(with: Data(rules.utf8)))
+    }
+
+    func testContentBlockingRulesHaveThreeBlockRules() throws {
+        let parsed = try Self.parseRules()
+        XCTAssertEqual(parsed.count, 3)
+        for rule in parsed {
+            let action = try XCTUnwrap(rule["action"] as? [String: Any])
+            XCTAssertEqual(action["type"] as? String, "block")
+        }
+    }
+
+    func testRemoteImagesScriptsAndFontsAreBlockedButSameOriginAllowed() throws {
+        let trigger = try Self.trigger(matchingResourceTypes: ["image", "script", "font"])
+
+        XCTAssertEqual(trigger["url-filter"] as? String, ".*")
+        // Only third-party (remote) loads are blocked, so same-origin assets still load.
+        XCTAssertEqual(trigger["load-type"] as? [String], ["third-party"])
+    }
+
+    func testDataImagesAndFontsAreBlocked() throws {
+        let trigger = try Self.trigger(matchingResourceTypes: ["image", "font"])
+
+        XCTAssertEqual(trigger["url-filter"] as? String, "^data:")
+        // Block regardless of load type — there is no same-origin carve-out for `data:`.
+        XCTAssertNil(trigger["load-type"])
+    }
+
+    func testXHRIsBlocked() throws {
+        let trigger = try Self.trigger(matchingResourceTypes: ["raw"])
+
+        XCTAssertEqual(trigger["url-filter"] as? String, ".*")
+        XCTAssertNil(trigger["load-type"])
+    }
+
+    // MARK: - Helpers
+
+    private static func parseRules() throws -> [[String: Any]] {
+        let json = try XCTUnwrap(WebViewCapabilitiesConfiguration.contentBlockingRules)
+        let object = try JSONSerialization.jsonObject(with: Data(json.utf8))
+        return try XCTUnwrap(object as? [[String: Any]])
+    }
+
+    /// Returns the `trigger` of the single rule whose `resource-type` exactly matches `resourceTypes`.
+    private static func trigger(matchingResourceTypes resourceTypes: [String]) throws -> [String: Any] {
+        let triggers = try Self.parseRules().compactMap { $0["trigger"] as? [String: Any] }
+        let match = triggers.first { trigger in
+            (trigger["resource-type"] as? [String]).map(Set.init) == Set(resourceTypes)
+        }
+        return try XCTUnwrap(match, "No rule blocking resource types \(resourceTypes)")
+    }
+
+}
+
+#endif


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
For the initial version, a `web_view` bundle must be isolated from external sources — customers upload everything in a single bundle. This adds the content-blocking policy that enforces that isolation.

### Description
Adds the fixed content-blocking rules and the compiled-rule-list cache: blocks remote (third-party) images, scripts, and fonts, blocks `data:` images/fonts, and blocks XHR, while allowing same-origin assets. Standalone for now; wired into the renderer in a later PR.

Covered by rule-generation unit tests asserting the emitted block rules.