### PR TITLE
feat: PaywallWebViewValue for web_view messaging

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1419,6 +1419,7 @@
 		FEDA000000000000000000D2 /* RemoteConfigSourceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA000000000000000000C2 /* RemoteConfigSourceProvider.swift */; };
 		FEDA000000000000000000E1 /* MockRemoteConfigSourceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA000000000000000000E0 /* MockRemoteConfigSourceProvider.swift */; };
 		FEDA000000000000000000E2 /* MockRemoteConfigSourceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA000000000000000000E0 /* MockRemoteConfigSourceProvider.swift */; };
+		FFDE30D78DAFB1C58C5D44EF /* PaywallWebViewValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC98EB915E05F1CFDFD0687D /* PaywallWebViewValue.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -2536,6 +2537,7 @@
 		834DFBE817EAEDDF0179F323 /* PaywallZLayerScrollPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaywallZLayerScrollPolicyTests.swift; path = Tests/RevenueCatUITests/PaywallsV2/PaywallZLayerScrollPolicyTests.swift; sourceTree = SOURCE_ROOT; };
 		839F34382E3BC574006355B0 /* PlatformColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformColor.swift; sourceTree = "<group>"; };
 		839F343A2E3BC5C4006355B0 /* PlatformBezierPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformBezierPath.swift; sourceTree = "<group>"; };
+		83AC793744895AD08CE7D052 /* PaywallWebViewValueTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaywallWebViewValueTests.swift; sourceTree = "<group>"; };
 		83EE33252E1E20360011CF1C /* PaywallPreviewResourcesLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallPreviewResourcesLoader.swift; sourceTree = "<group>"; };
 		84C3F1AC1D7E1E64341D3936 /* Pods_RevenueCat_PurchasesTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RevenueCat_PurchasesTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		863C9FCC9388B370BDAF36C9 /* WebViewComponentView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewComponentView.swift; sourceTree = "<group>"; };
@@ -2800,6 +2802,7 @@
 		AAE17E010000000000000002 /* EntitlementReward.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntitlementReward.swift; sourceTree = "<group>"; };
 		AAE17E010000000000000004 /* RewardVerificationStatusResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardVerificationStatusResponseTests.swift; sourceTree = "<group>"; };
 		AC06C294F30E7D8000000002 /* SelectedPackageId.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedPackageId.swift; sourceTree = "<group>"; };
+		AC98EB915E05F1CFDFD0687D /* PaywallWebViewValue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaywallWebViewValue.swift; sourceTree = "<group>"; };
 		AD5000000000000000ADAD01 /* AdsStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdsStrings.swift; sourceTree = "<group>"; };
 		AD5000000000000000ADAD03 /* AdRewardEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdRewardEvents.swift; sourceTree = "<group>"; };
 		AD5000000000000000ADAD05 /* AdReward+TestExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AdReward+TestExtensions.swift"; sourceTree = "<group>"; };
@@ -3198,6 +3201,7 @@
 				8BAF5880071599951932A6A1 /* ImageComponentViewTests.swift */,
 				BC6D9D5964DA2EA53FAEB2F5 /* WebViewCapabilitiesTests.swift */,
 				E0405C692DEAEFE6F36A9411 /* WebViewComponentTests.swift */,
+				83AC793744895AD08CE7D052 /* PaywallWebViewValueTests.swift */,
 			);
 			path = PaywallsV2;
 			sourceTree = "<group>";
@@ -5548,6 +5552,7 @@
 				57B1D7B12F2A1F1800A77E21 /* PaywallSourceEnvironment.swift */,
 				887A5FDC2C1D037000E1A461 /* Variables.swift */,
 				93B46553B99148F3A60B8BFB /* CustomPaywallVariables.swift */,
+				AC98EB915E05F1CFDFD0687D /* PaywallWebViewValue.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -8373,6 +8378,7 @@
 				9EA7410B386848B365F44AED /* WebViewCapabilitiesConfiguration.swift in Sources */,
 				854C4F7B377DFBD17B5C5740 /* WebViewComponentView.swift in Sources */,
 				5BCB9749FDD9493A14B6B870 /* WebViewComponentViewModel.swift in Sources */,
+				FFDE30D78DAFB1C58C5D44EF /* PaywallWebViewValue.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RevenueCatUI/Data/PaywallWebViewValue.swift
+++ b/RevenueCatUI/Data/PaywallWebViewValue.swift
@@ -1,0 +1,201 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PaywallWebViewValue.swift
+
+import Foundation
+
+#if !os(tvOS) // For Paywalls V2
+
+/// A JSON-compatible value exchanged between a Paywalls V2 `web_view` component and your app.
+///
+/// Values mirror the JSON types allowed by the web view message protocol: strings, numbers,
+/// booleans, arrays, objects, and null. Functions, binary data, dates, and other platform-specific
+/// objects are not representable.
+///
+/// Modeled as a `struct` wrapping a private storage type (rather than an `enum`) so that adding new
+/// representable types in the future is not a source-breaking change for consumers.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public struct PaywallWebViewValue: Sendable, Equatable, Hashable {
+
+    private indirect enum Storage: Sendable, Equatable, Hashable {
+        case string(String)
+        case number(Double)
+        case bool(Bool)
+        case array([PaywallWebViewValue])
+        case object([String: PaywallWebViewValue])
+        case null
+    }
+
+    private let storage: Storage
+
+    private init(_ storage: Storage) {
+        self.storage = storage
+    }
+
+    /// Creates a string value.
+    public static func string(_ value: String) -> PaywallWebViewValue {
+        PaywallWebViewValue(.string(value))
+    }
+
+    /// Creates a numeric value.
+    public static func number(_ value: Double) -> PaywallWebViewValue {
+        PaywallWebViewValue(.number(value))
+    }
+
+    /// Creates a boolean value.
+    public static func bool(_ value: Bool) -> PaywallWebViewValue {
+        PaywallWebViewValue(.bool(value))
+    }
+
+    /// Creates an array value.
+    public static func array(_ value: [PaywallWebViewValue]) -> PaywallWebViewValue {
+        PaywallWebViewValue(.array(value))
+    }
+
+    /// Creates an object (dictionary) value.
+    public static func object(_ value: [String: PaywallWebViewValue]) -> PaywallWebViewValue {
+        PaywallWebViewValue(.object(value))
+    }
+
+    /// A null value.
+    public static let null = PaywallWebViewValue(.null)
+
+    // MARK: - Accessors
+
+    /// The string payload if this value was created as a string, otherwise `nil`.
+    public var stringValue: String? {
+        if case .string(let value) = self.storage { return value }
+        return nil
+    }
+
+    /// The numeric payload if this value was created as a number, otherwise `nil`.
+    public var numberValue: Double? {
+        if case .number(let value) = self.storage { return value }
+        return nil
+    }
+
+    /// The boolean payload if this value was created as a boolean, otherwise `nil`.
+    public var boolValue: Bool? {
+        if case .bool(let value) = self.storage { return value }
+        return nil
+    }
+
+    /// The array payload if this value was created as an array, otherwise `nil`.
+    public var arrayValue: [PaywallWebViewValue]? {
+        if case .array(let value) = self.storage { return value }
+        return nil
+    }
+
+    /// The object payload if this value was created as an object, otherwise `nil`.
+    public var objectValue: [String: PaywallWebViewValue]? {
+        if case .object(let value) = self.storage { return value }
+        return nil
+    }
+
+    /// Whether this value is null.
+    public var isNull: Bool {
+        if case .null = self.storage { return true }
+        return false
+    }
+
+}
+
+// MARK: - Foundation / JSON bridging
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension PaywallWebViewValue {
+
+    /// The maximum nesting depth allowed when converting a JSON object tree. Mirrors the limit
+    /// enforced by the message parser so that conversion and validation agree.
+    static let maxDepth = 32
+
+    /// Creates a value from a Foundation JSON object (as produced by `WKScriptMessage.body` or
+    /// `JSONSerialization`). Returns `nil` if the object contains any non-JSON value or exceeds
+    /// ``maxDepth``.
+    ///
+    /// Boolean `NSNumber`s are disambiguated from numeric `NSNumber`s so JavaScript `true`/`false`
+    /// map to ``bool(_:)`` rather than ``number(_:)``.
+    init?(jsonObject: Any, depth: Int = 0) {
+        guard depth <= Self.maxDepth else { return nil }
+
+        switch jsonObject {
+        case is NSNull:
+            self = .null
+
+        case let number as NSNumber:
+            // `NSNumber` wrapping a `Bool` is bridged distinctly from numeric values.
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                self = .bool(number.boolValue)
+            } else {
+                self = .number(number.doubleValue)
+            }
+
+        case let string as String:
+            self = .string(string)
+
+        case let array as [Any]:
+            guard let converted = Self.convert(array: array, depth: depth) else { return nil }
+            self = .array(converted)
+
+        case let object as [String: Any]:
+            guard let converted = Self.convert(object: object, depth: depth) else { return nil }
+            self = .object(converted)
+
+        default:
+            // Dates, binary blobs, functions, and any other non-JSON type are rejected.
+            return nil
+        }
+    }
+
+    private static func convert(array: [Any], depth: Int) -> [PaywallWebViewValue]? {
+        var converted: [PaywallWebViewValue] = []
+        converted.reserveCapacity(array.count)
+        for element in array {
+            guard let value = PaywallWebViewValue(jsonObject: element, depth: depth + 1) else {
+                return nil
+            }
+            converted.append(value)
+        }
+        return converted
+    }
+
+    private static func convert(object: [String: Any], depth: Int) -> [String: PaywallWebViewValue]? {
+        var converted: [String: PaywallWebViewValue] = [:]
+        converted.reserveCapacity(object.count)
+        for (key, element) in object {
+            guard let value = PaywallWebViewValue(jsonObject: element, depth: depth + 1) else {
+                return nil
+            }
+            converted[key] = value
+        }
+        return converted
+    }
+
+    /// A Foundation representation suitable for `JSONSerialization`.
+    var jsonObject: Any {
+        switch self.storage {
+        case .string(let value):
+            return value
+        case .number(let value):
+            return value
+        case .bool(let value):
+            return value
+        case .array(let values):
+            return values.map { $0.jsonObject }
+        case .object(let values):
+            return values.mapValues { $0.jsonObject }
+        case .null:
+            return NSNull()
+        }
+    }
+
+}
+
+#endif

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewValueTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewValueTests.swift
@@ -1,0 +1,128 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PaywallWebViewValueTests.swift
+
+@_spi(Internal) @testable import RevenueCat
+@testable import RevenueCatUI
+import XCTest
+
+#if !os(tvOS)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+final class PaywallWebViewValueTests: TestCase {
+
+    // MARK: - JSON-object conversion
+
+    func testValueConvertsJSONTypes() {
+        XCTAssertEqual(PaywallWebViewValue(jsonObject: "hi"), .string("hi"))
+        XCTAssertEqual(PaywallWebViewValue(jsonObject: 42 as NSNumber)?.numberValue, 42)
+        XCTAssertEqual(PaywallWebViewValue(jsonObject: true as NSNumber), .bool(true))
+        XCTAssertEqual(PaywallWebViewValue(jsonObject: NSNull()), .null)
+        XCTAssertEqual(
+            PaywallWebViewValue(jsonObject: ["a", "b"]),
+            .array([.string("a"), .string("b")])
+        )
+        XCTAssertEqual(
+            PaywallWebViewValue(jsonObject: ["k": "v"]),
+            .object(["k": .string("v")])
+        )
+    }
+
+    func testValueDisambiguatesBoolFromNumber() {
+        let boolValue = PaywallWebViewValue(jsonObject: true as NSNumber)
+        XCTAssertEqual(boolValue?.boolValue, true)
+        XCTAssertNil(boolValue?.numberValue)
+
+        let numberValue = PaywallWebViewValue(jsonObject: 1 as NSNumber)
+        XCTAssertEqual(numberValue?.numberValue, 1)
+        XCTAssertNil(numberValue?.boolValue)
+    }
+
+    func testValueRejectsNonJSON() {
+        XCTAssertNil(PaywallWebViewValue(jsonObject: Date()))
+        XCTAssertNil(PaywallWebViewValue(jsonObject: ["ok", Date()]))
+    }
+
+    // MARK: - Accessors, round-trip, depth, hashing
+
+    func testValueAccessorsReturnNilForMismatchedTypes() {
+        XCTAssertNil(PaywallWebViewValue.string("x").numberValue)
+        XCTAssertNil(PaywallWebViewValue.string("x").boolValue)
+        XCTAssertNil(PaywallWebViewValue.number(1).stringValue)
+        XCTAssertNil(PaywallWebViewValue.bool(true).numberValue)
+        XCTAssertNil(PaywallWebViewValue.string("x").arrayValue)
+        XCTAssertNil(PaywallWebViewValue.string("x").objectValue)
+        XCTAssertFalse(PaywallWebViewValue.string("x").isNull)
+        XCTAssertTrue(PaywallWebViewValue.null.isNull)
+    }
+
+    func testValueNullBridgesToNSNull() {
+        XCTAssertTrue(PaywallWebViewValue.null.jsonObject is NSNull)
+    }
+
+    func testValueRoundTripsThroughJSONSerialization() throws {
+        let original: PaywallWebViewValue = .object([
+            "s": .string("hello"),
+            "n": .number(42),
+            "b": .bool(true),
+            "null": .null,
+            "arr": .array([.number(1), .object(["deep": .string("v")])])
+        ])
+
+        let data = try JSONSerialization.data(withJSONObject: original.jsonObject)
+        let decoded = try XCTUnwrap(PaywallWebViewValue(jsonObject: JSONSerialization.jsonObject(with: data)))
+
+        XCTAssertEqual(decoded, original)
+    }
+
+    func testValueConvertsNestedContainers() {
+        let value = PaywallWebViewValue(jsonObject: [
+            "list": [["k": 1], ["k": 2]]
+        ])
+
+        XCTAssertEqual(value, .object([
+            "list": .array([.object(["k": .number(1)]), .object(["k": .number(2)])])
+        ]))
+    }
+
+    func testValueConvertsAtMaxDepth() {
+        XCTAssertNotNil(PaywallWebViewValue(jsonObject: Self.nested(depth: PaywallWebViewValue.maxDepth)))
+    }
+
+    func testValueRejectsBeyondMaxDepth() {
+        XCTAssertNil(PaywallWebViewValue(jsonObject: Self.nested(depth: PaywallWebViewValue.maxDepth + 1)))
+    }
+
+    func testValueIsHashableAndEquatable() {
+        let lhs: PaywallWebViewValue = .object(["a": .array([.number(1), .null])])
+        let rhs: PaywallWebViewValue = .object(["a": .array([.number(1), .null])])
+        let other: PaywallWebViewValue = .object(["a": .array([.number(2), .null])])
+
+        XCTAssertEqual(lhs, rhs)
+        XCTAssertEqual(lhs.hashValue, rhs.hashValue)
+        XCTAssertNotEqual(lhs, other)
+        XCTAssertEqual(Set([lhs, rhs, other]).count, 2)
+    }
+
+    // MARK: - Helpers
+
+    /// Builds an `Any` JSON value made of `depth` nested arrays around a leaf string. The leaf is
+    /// processed at recursion depth `depth`, exercising ``PaywallWebViewValue/maxDepth``.
+    private static func nested(depth: Int) -> Any {
+        var value: Any = "leaf"
+        for _ in 0..<depth {
+            value = [value]
+        }
+        return value
+    }
+
+}
+
+#endif

--- a/api/revenuecatui-api-ios-simulator.swiftinterface
+++ b/api/revenuecatui-api-ios-simulator.swiftinterface
@@ -250,6 +250,38 @@ extension SwiftUICore.View {
   @_Concurrency.MainActor @preconcurrency public func customPaywallVariables(_ variables: [Swift.String : RevenueCatUI.CustomVariableValue]) -> some SwiftUICore.View
   
 }
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public struct PaywallWebViewValue : Swift.Sendable, Swift.Equatable, Swift.Hashable {
+  public static func string(_ value: Swift.String) -> RevenueCatUI.PaywallWebViewValue
+  public static func number(_ value: Swift.Double) -> RevenueCatUI.PaywallWebViewValue
+  public static func bool(_ value: Swift.Bool) -> RevenueCatUI.PaywallWebViewValue
+  public static func array(_ value: [RevenueCatUI.PaywallWebViewValue]) -> RevenueCatUI.PaywallWebViewValue
+  public static func object(_ value: [Swift.String : RevenueCatUI.PaywallWebViewValue]) -> RevenueCatUI.PaywallWebViewValue
+  public static let null: RevenueCatUI.PaywallWebViewValue
+  public var stringValue: Swift.String? {
+    get
+  }
+  public var numberValue: Swift.Double? {
+    get
+  }
+  public var boolValue: Swift.Bool? {
+    get
+  }
+  public var arrayValue: [RevenueCatUI.PaywallWebViewValue]? {
+    get
+  }
+  public var objectValue: [Swift.String : RevenueCatUI.PaywallWebViewValue]? {
+    get
+  }
+  public var isNull: Swift.Bool {
+    get
+  }
+  public static func == (a: RevenueCatUI.PaywallWebViewValue, b: RevenueCatUI.PaywallWebViewValue) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
 public struct ResumeAction : Swift.Sendable {
   public init(action: @escaping @Sendable (Swift.Bool) -> Swift.Void)
   @_Concurrency.MainActor public func resume(shouldProceed: Swift.Bool)

--- a/api/revenuecatui-api-ios.swiftinterface
+++ b/api/revenuecatui-api-ios.swiftinterface
@@ -250,6 +250,38 @@ extension SwiftUICore.View {
   @_Concurrency.MainActor @preconcurrency public func customPaywallVariables(_ variables: [Swift.String : RevenueCatUI.CustomVariableValue]) -> some SwiftUICore.View
   
 }
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public struct PaywallWebViewValue : Swift.Sendable, Swift.Equatable, Swift.Hashable {
+  public static func string(_ value: Swift.String) -> RevenueCatUI.PaywallWebViewValue
+  public static func number(_ value: Swift.Double) -> RevenueCatUI.PaywallWebViewValue
+  public static func bool(_ value: Swift.Bool) -> RevenueCatUI.PaywallWebViewValue
+  public static func array(_ value: [RevenueCatUI.PaywallWebViewValue]) -> RevenueCatUI.PaywallWebViewValue
+  public static func object(_ value: [Swift.String : RevenueCatUI.PaywallWebViewValue]) -> RevenueCatUI.PaywallWebViewValue
+  public static let null: RevenueCatUI.PaywallWebViewValue
+  public var stringValue: Swift.String? {
+    get
+  }
+  public var numberValue: Swift.Double? {
+    get
+  }
+  public var boolValue: Swift.Bool? {
+    get
+  }
+  public var arrayValue: [RevenueCatUI.PaywallWebViewValue]? {
+    get
+  }
+  public var objectValue: [Swift.String : RevenueCatUI.PaywallWebViewValue]? {
+    get
+  }
+  public var isNull: Swift.Bool {
+    get
+  }
+  public static func == (a: RevenueCatUI.PaywallWebViewValue, b: RevenueCatUI.PaywallWebViewValue) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
 public struct ResumeAction : Swift.Sendable {
   public init(action: @escaping @Sendable (Swift.Bool) -> Swift.Void)
   @_Concurrency.MainActor public func resume(shouldProceed: Swift.Bool)

--- a/api/revenuecatui-api-macos.swiftinterface
+++ b/api/revenuecatui-api-macos.swiftinterface
@@ -119,6 +119,38 @@ extension SwiftUICore.View {
   @_Concurrency.MainActor @preconcurrency public func customPaywallVariables(_ variables: [Swift.String : RevenueCatUI.CustomVariableValue]) -> some SwiftUICore.View
   
 }
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public struct PaywallWebViewValue : Swift.Sendable, Swift.Equatable, Swift.Hashable {
+  public static func string(_ value: Swift.String) -> RevenueCatUI.PaywallWebViewValue
+  public static func number(_ value: Swift.Double) -> RevenueCatUI.PaywallWebViewValue
+  public static func bool(_ value: Swift.Bool) -> RevenueCatUI.PaywallWebViewValue
+  public static func array(_ value: [RevenueCatUI.PaywallWebViewValue]) -> RevenueCatUI.PaywallWebViewValue
+  public static func object(_ value: [Swift.String : RevenueCatUI.PaywallWebViewValue]) -> RevenueCatUI.PaywallWebViewValue
+  public static let null: RevenueCatUI.PaywallWebViewValue
+  public var stringValue: Swift.String? {
+    get
+  }
+  public var numberValue: Swift.Double? {
+    get
+  }
+  public var boolValue: Swift.Bool? {
+    get
+  }
+  public var arrayValue: [RevenueCatUI.PaywallWebViewValue]? {
+    get
+  }
+  public var objectValue: [Swift.String : RevenueCatUI.PaywallWebViewValue]? {
+    get
+  }
+  public var isNull: Swift.Bool {
+    get
+  }
+  public static func == (a: RevenueCatUI.PaywallWebViewValue, b: RevenueCatUI.PaywallWebViewValue) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
 public struct ResumeAction : Swift.Sendable {
   public init(action: @escaping @Sendable (Swift.Bool) -> Swift.Void)
   @_Concurrency.MainActor public func resume(shouldProceed: Swift.Bool)

--- a/api/revenuecatui-api-visionos-simulator.swiftinterface
+++ b/api/revenuecatui-api-visionos-simulator.swiftinterface
@@ -120,6 +120,38 @@ extension SwiftUICore.View {
   @_Concurrency.MainActor @preconcurrency public func customPaywallVariables(_ variables: [Swift.String : RevenueCatUI.CustomVariableValue]) -> some SwiftUICore.View
   
 }
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public struct PaywallWebViewValue : Swift.Sendable, Swift.Equatable, Swift.Hashable {
+  public static func string(_ value: Swift.String) -> RevenueCatUI.PaywallWebViewValue
+  public static func number(_ value: Swift.Double) -> RevenueCatUI.PaywallWebViewValue
+  public static func bool(_ value: Swift.Bool) -> RevenueCatUI.PaywallWebViewValue
+  public static func array(_ value: [RevenueCatUI.PaywallWebViewValue]) -> RevenueCatUI.PaywallWebViewValue
+  public static func object(_ value: [Swift.String : RevenueCatUI.PaywallWebViewValue]) -> RevenueCatUI.PaywallWebViewValue
+  public static let null: RevenueCatUI.PaywallWebViewValue
+  public var stringValue: Swift.String? {
+    get
+  }
+  public var numberValue: Swift.Double? {
+    get
+  }
+  public var boolValue: Swift.Bool? {
+    get
+  }
+  public var arrayValue: [RevenueCatUI.PaywallWebViewValue]? {
+    get
+  }
+  public var objectValue: [Swift.String : RevenueCatUI.PaywallWebViewValue]? {
+    get
+  }
+  public var isNull: Swift.Bool {
+    get
+  }
+  public static func == (a: RevenueCatUI.PaywallWebViewValue, b: RevenueCatUI.PaywallWebViewValue) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
 public struct ResumeAction : Swift.Sendable {
   public init(action: @escaping @Sendable (Swift.Bool) -> Swift.Void)
   @_Concurrency.MainActor public func resume(shouldProceed: Swift.Bool)

--- a/api/revenuecatui-api-visionos.swiftinterface
+++ b/api/revenuecatui-api-visionos.swiftinterface
@@ -120,6 +120,38 @@ extension SwiftUICore.View {
   @_Concurrency.MainActor @preconcurrency public func customPaywallVariables(_ variables: [Swift.String : RevenueCatUI.CustomVariableValue]) -> some SwiftUICore.View
   
 }
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public struct PaywallWebViewValue : Swift.Sendable, Swift.Equatable, Swift.Hashable {
+  public static func string(_ value: Swift.String) -> RevenueCatUI.PaywallWebViewValue
+  public static func number(_ value: Swift.Double) -> RevenueCatUI.PaywallWebViewValue
+  public static func bool(_ value: Swift.Bool) -> RevenueCatUI.PaywallWebViewValue
+  public static func array(_ value: [RevenueCatUI.PaywallWebViewValue]) -> RevenueCatUI.PaywallWebViewValue
+  public static func object(_ value: [Swift.String : RevenueCatUI.PaywallWebViewValue]) -> RevenueCatUI.PaywallWebViewValue
+  public static let null: RevenueCatUI.PaywallWebViewValue
+  public var stringValue: Swift.String? {
+    get
+  }
+  public var numberValue: Swift.Double? {
+    get
+  }
+  public var boolValue: Swift.Bool? {
+    get
+  }
+  public var arrayValue: [RevenueCatUI.PaywallWebViewValue]? {
+    get
+  }
+  public var objectValue: [Swift.String : RevenueCatUI.PaywallWebViewValue]? {
+    get
+  }
+  public var isNull: Swift.Bool {
+    get
+  }
+  public static func == (a: RevenueCatUI.PaywallWebViewValue, b: RevenueCatUI.PaywallWebViewValue) -> Swift.Bool
+  public func hash(into hasher: inout Swift.Hasher)
+  public var hashValue: Swift.Int {
+    get
+  }
+}
 public struct ResumeAction : Swift.Sendable {
   public init(action: @escaping @Sendable (Swift.Bool) -> Swift.Void)
   @_Concurrency.MainActor public func resume(shouldProceed: Swift.Bool)


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
The postMessage bridge needs a JSON-compatible value type to carry message payloads to and from web content.

### Description
Adds the public `PaywallWebViewValue` (string/number/bool/array/object/null). Modeled as a struct wrapping private storage rather than an enum, so adding representable types later isn't a source-breaking change. First of the bridge PRs.

Covered by conversion, round-trip, depth-limit, and hashing unit tests.

> Adds public API, so the `revenuecatui` swiftinterface baselines need regenerating — the `check-api-changes-revenuecatui` failure is expected until that runs.