### PR TITLE
feat: web_view message model + parser

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -943,6 +943,7 @@
 		77AABEB82F0C23450018C1D3 /* PurchasesStoreMessagesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77AABEB72F0C23450018C1D3 /* PurchasesStoreMessagesTests.swift */; };
 		77BA1AB12CCBAB80009BF0EA /* RootViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77BA1AB02CCBAB80009BF0EA /* RootViewModel.swift */; };
 		77BA1AB32CCBB6EE009BF0EA /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77BA1AB22CCBB6EE009BF0EA /* RootView.swift */; };
+		7D4C28B5FDD5D38E1055A107 /* PaywallWebViewMessageParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3108BDE9CA157DCAA4D5A65 /* PaywallWebViewMessageParser.swift */; };
 		7DFF88B0441F83F94C8E855F /* VideoAutoplayHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36ECF1E76DAADD986E3D0E5A /* VideoAutoplayHandler.swift */; };
 		7F7F7B1E66E1D8705F06DE51 /* Value+Decodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D92889EDE72E0BC5C030EF03 /* Value+Decodable.swift */; };
 		802593752FE06CDA005AF6DF /* StateUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802593742FE06CDA005AF6DF /* StateUpdate.swift */; };
@@ -1255,6 +1256,7 @@
 		B8A6F391F64046E96A343339 /* PredicateConformanceFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60BA9A763EB70A332E2C63CE /* PredicateConformanceFixture.swift */; };
 		C074AAE036B449898E1FEF58 /* CustomPaywallVariables.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93B46553B99148F3A60B8BFB /* CustomPaywallVariables.swift */; };
 		C1311C20A12B3813D86A2EDF /* WorkflowPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA3AA2BC4C1B8CE7E9A3B59 /* WorkflowPreview.swift */; };
+		C3B1410F98F1A5B647081D02 /* PaywallWebViewMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6984A7B406AB52B4E75555CD /* PaywallWebViewMessage.swift */; };
 		C53CDAA4FC3E6B51CC70D724 /* WorkflowPaywallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800A129055A298C390AED0B5 /* WorkflowPaywallView.swift */; };
 		C808D299537245E695865C31 /* CapturingLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = E51CFC7D19BE49D2BA1A79CC /* CapturingLogger.swift */; };
 		D012440C2FD02DC90043B43B /* RewardVerificationResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D012440B2FD02DC90043B43B /* RewardVerificationResultTests.swift */; };
@@ -2451,6 +2453,7 @@
 		645D8E14F3E2F79FAC1C2FA0 /* RulesEngineEvaluateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RulesEngineEvaluateTests.swift; sourceTree = "<group>"; };
 		65279ABC122869A50AEB8A27 /* ExitOffer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExitOffer.swift; sourceTree = "<group>"; };
 		68E47E21986D2C234ADB62E8 /* PredicateFixtureTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PredicateFixtureTests.swift; sourceTree = "<group>"; };
+		6984A7B406AB52B4E75555CD /* PaywallWebViewMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaywallWebViewMessage.swift; sourceTree = "<group>"; };
 		6A10AD61D82EB73FC5338DA2 /* WorkflowNavigator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowNavigator.swift; sourceTree = "<group>"; };
 		6E52F908EB90930822406495 /* WorkflowManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowManager.swift; sourceTree = "<group>"; };
 		6EFD5F7BD8404B6E828C4E10 /* WorkflowPaywallViewTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowPaywallViewTests.swift; sourceTree = "<group>"; };
@@ -2518,6 +2521,7 @@
 		77FA6A5AF22C868D06B1C144 /* WebViewComponent.json */ = {isa = PBXFileReference; includeInIndex = 1; path = WebViewComponent.json; sourceTree = "<group>"; };
 		78B1498BA2288B4643B248A5 /* PurchasesWorkflowTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PurchasesWorkflowTests.swift; sourceTree = "<group>"; };
 		7AA86A1D9F5AE92988B20230 /* WorkflowContextTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowContextTests.swift; sourceTree = "<group>"; };
+		7BBAC2CA1200CCC7453CAD61 /* PaywallWebViewMessageParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaywallWebViewMessageParserTests.swift; sourceTree = "<group>"; };
 		7F1B03A2D59CC0822C02186A /* EvaluationError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EvaluationError.swift; sourceTree = "<group>"; };
 		800A129055A298C390AED0B5 /* WorkflowPaywallView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowPaywallView.swift; sourceTree = "<group>"; };
 		802593742FE06CDA005AF6DF /* StateUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateUpdate.swift; sourceTree = "<group>"; };
@@ -2896,6 +2900,7 @@
 		D01244182FD02FC30043B43B /* RewardVerificationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardVerificationResult.swift; sourceTree = "<group>"; };
 		D08C42672FD995C20035A009 /* RewardVerificationToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardVerificationToken.swift; sourceTree = "<group>"; };
 		D0DA20992F23BBEC00BA3B77 /* AdEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdEventTests.swift; sourceTree = "<group>"; };
+		D3108BDE9CA157DCAA4D5A65 /* PaywallWebViewMessageParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaywallWebViewMessageParser.swift; sourceTree = "<group>"; };
 		D4E5F60718293A4B5C6D7E8F /* MiscOperators.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MiscOperators.swift; sourceTree = "<group>"; };
 		D794960D6EA8C55B44471D40 /* PredicateConformanceRunner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PredicateConformanceRunner.swift; sourceTree = "<group>"; };
 		D92889EDE72E0BC5C030EF03 /* Value+Decodable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Value+Decodable.swift"; sourceTree = "<group>"; };
@@ -3202,6 +3207,7 @@
 				BC6D9D5964DA2EA53FAEB2F5 /* WebViewCapabilitiesTests.swift */,
 				E0405C692DEAEFE6F36A9411 /* WebViewComponentTests.swift */,
 				83AC793744895AD08CE7D052 /* PaywallWebViewValueTests.swift */,
+				7BBAC2CA1200CCC7453CAD61 /* PaywallWebViewMessageParserTests.swift */,
 			);
 			path = PaywallsV2;
 			sourceTree = "<group>";
@@ -4759,6 +4765,7 @@
 				BECBCE280B1AB66FD155FA74 /* WebViewCapabilitiesConfiguration.swift */,
 				863C9FCC9388B370BDAF36C9 /* WebViewComponentView.swift */,
 				8E4F88A43B27C659F48DE31A /* WebViewComponentViewModel.swift */,
+				D3108BDE9CA157DCAA4D5A65 /* PaywallWebViewMessageParser.swift */,
 			);
 			name = WebView;
 			path = WebView;
@@ -5553,6 +5560,7 @@
 				887A5FDC2C1D037000E1A461 /* Variables.swift */,
 				93B46553B99148F3A60B8BFB /* CustomPaywallVariables.swift */,
 				AC98EB915E05F1CFDFD0687D /* PaywallWebViewValue.swift */,
+				6984A7B406AB52B4E75555CD /* PaywallWebViewMessage.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -8379,6 +8387,8 @@
 				854C4F7B377DFBD17B5C5740 /* WebViewComponentView.swift in Sources */,
 				5BCB9749FDD9493A14B6B870 /* WebViewComponentViewModel.swift in Sources */,
 				FFDE30D78DAFB1C58C5D44EF /* PaywallWebViewValue.swift in Sources */,
+				C3B1410F98F1A5B647081D02 /* PaywallWebViewMessage.swift in Sources */,
+				7D4C28B5FDD5D38E1055A107 /* PaywallWebViewMessageParser.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RevenueCatUI/Data/PaywallWebViewMessage.swift
+++ b/RevenueCatUI/Data/PaywallWebViewMessage.swift
@@ -1,0 +1,61 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PaywallWebViewMessage.swift
+
+import Foundation
+
+#if !os(tvOS) // For Paywalls V2
+
+/// A validated message sent from a Paywalls V2 `web_view` component to your app.
+///
+/// Messages are delivered to the handler registered with `View/onPaywallWebViewMessage(_:)`.
+/// The SDK only delivers messages that pass validation: the envelope is well-formed, the
+/// ``componentID`` matches the `web_view` component's identifier, and all values are JSON-compatible.
+///
+/// The known message types are:
+/// - `"rc:step-loaded"`: the web content finished loading. No additional fields.
+/// - `"rc:step-complete"`: the web flow completed. ``responses`` carries the collected values.
+/// - `"rc:request-variables"`: the web content is asking for variables. The SDK automatically
+///   replies with SDK-managed and paywall custom variables; your handler may send additional ones.
+/// - `"rc:error"`: the web content reported an error described by ``error``.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public struct PaywallWebViewMessage: Sendable, Equatable {
+
+    /// The identifier of the `web_view` component that produced this message. Matches the
+    /// component's `id` in the paywall configuration.
+    public let componentID: String
+
+    /// The message type, e.g. `"rc:step-complete"`. Exposed as a string so new message types
+    /// can be introduced without a source-breaking change for consumers.
+    public let type: String
+
+    /// The responses collected by the web flow. Only populated for `"rc:step-complete"` messages.
+    public let responses: [String: PaywallWebViewValue]?
+
+    /// The error reported by the web content. Only populated for `"rc:error"` messages.
+    public let error: String?
+
+    /// Creates a message. Intended for SDK and test use; app code receives instances via the
+    /// message handler rather than constructing them.
+    public init(
+        componentID: String,
+        type: String,
+        responses: [String: PaywallWebViewValue]? = nil,
+        error: String? = nil
+    ) {
+        self.componentID = componentID
+        self.type = type
+        self.responses = responses
+        self.error = error
+    }
+
+}
+
+#endif

--- a/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewMessageParser.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewMessageParser.swift
@@ -1,0 +1,153 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PaywallWebViewMessageParser.swift
+
+import Foundation
+
+#if !os(tvOS) // For Paywalls V2
+
+/// Known message types in the Paywalls V2 `web_view` postMessage protocol (`protocol_version: 1`).
+/// A caseless namespace (not consumer-facing) so the public ``PaywallWebViewMessage/type`` stays a
+/// plain string.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+enum PaywallWebViewMessageType {
+
+    static let stepLoaded = "rc:step-loaded"
+    static let stepComplete = "rc:step-complete"
+    static let requestVariables = "rc:request-variables"
+    static let error = "rc:error"
+
+    /// Native → web messages.
+    static let variables = "rc:variables"
+
+}
+
+/// Validates and parses raw `web_view` message bodies into typed ``PaywallWebViewMessage`` values.
+///
+/// Deliberately `WebKit`-free: it accepts the already-extracted `WKScriptMessage.body` as `Any`
+/// so the full validation surface is unit-testable without a live `WKWebView`.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct PaywallWebViewMessageParser {
+
+    /// Maximum size (in bytes of the serialized JSON) accepted for a single inbound message.
+    static let maxPayloadBytes = 64 * 1024
+
+    enum ParseError: Error, Equatable {
+        case notAnObject
+        case missingType
+        case missingComponentID
+        case componentIDMismatch(expected: String, received: String)
+        case oversizedPayload(bytes: Int)
+        case invalidResponses
+        case missingError
+        case invalidValue
+        /// Known-but-unsupported or entirely unknown message type — dropped per v1 policy.
+        case unsupportedType(String)
+    }
+
+    private enum Keys {
+        static let type = "type"
+        static let componentID = "component_id"
+        static let responses = "responses"
+        static let error = "error"
+    }
+
+    /// The identifier of the `web_view` component this parser accepts messages for.
+    let expectedComponentID: String
+
+    func parse(_ body: Any) -> Result<PaywallWebViewMessage, ParseError> {
+        guard let dictionary = body as? [String: Any] else {
+            return .failure(.notAnObject)
+        }
+
+        // Reject non-JSON-serializable bodies up front. `isValidJSONObject` is used before
+        // `data(withJSONObject:)` because the latter raises an (uncatchable) `NSException` rather
+        // than throwing a Swift error for invalid types such as `Date`.
+        guard JSONSerialization.isValidJSONObject(dictionary) else {
+            return .failure(.invalidValue)
+        }
+
+        // Enforce the payload size limit before allocating typed values.
+        if let serialized = try? JSONSerialization.data(withJSONObject: dictionary) {
+            guard serialized.count <= Self.maxPayloadBytes else {
+                return .failure(.oversizedPayload(bytes: serialized.count))
+            }
+        }
+
+        guard let type = dictionary[Keys.type] as? String else {
+            return .failure(.missingType)
+        }
+
+        guard let componentID = dictionary[Keys.componentID] as? String else {
+            return .failure(.missingComponentID)
+        }
+
+        guard componentID == self.expectedComponentID else {
+            return .failure(.componentIDMismatch(expected: self.expectedComponentID, received: componentID))
+        }
+
+        return self.message(type: type, componentID: componentID, dictionary: dictionary)
+    }
+
+    private func message(
+        type: String,
+        componentID: String,
+        dictionary: [String: Any]
+    ) -> Result<PaywallWebViewMessage, ParseError> {
+        switch type {
+        case PaywallWebViewMessageType.stepLoaded,
+             PaywallWebViewMessageType.requestVariables:
+            return .success(.init(componentID: componentID, type: type))
+
+        case PaywallWebViewMessageType.stepComplete:
+            return Self.stepComplete(type: type, componentID: componentID, dictionary: dictionary)
+
+        case PaywallWebViewMessageType.error:
+            guard let errorMessage = dictionary[Keys.error] as? String else {
+                return .failure(.missingError)
+            }
+            return .success(.init(componentID: componentID, type: type, error: errorMessage))
+
+        default:
+            // Unknown message types are dropped in v1.
+            return .failure(.unsupportedType(type))
+        }
+    }
+
+    private static func stepComplete(
+        type: String,
+        componentID: String,
+        dictionary: [String: Any]
+    ) -> Result<PaywallWebViewMessage, ParseError> {
+        guard let rawResponses = dictionary[Keys.responses] else {
+            return .success(.init(componentID: componentID, type: type))
+        }
+        guard let object = rawResponses as? [String: Any],
+              let converted = Self.convert(object: object) else {
+            return .failure(.invalidResponses)
+        }
+        return .success(.init(componentID: componentID, type: type, responses: converted))
+    }
+
+    private static func convert(object: [String: Any]) -> [String: PaywallWebViewValue]? {
+        var result: [String: PaywallWebViewValue] = [:]
+        result.reserveCapacity(object.count)
+        for (key, value) in object {
+            guard let converted = PaywallWebViewValue(jsonObject: value) else {
+                return nil
+            }
+            result[key] = converted
+        }
+        return result
+    }
+
+}
+
+#endif

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewMessageParserTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewMessageParserTests.swift
@@ -1,0 +1,246 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PaywallWebViewMessageParserTests.swift
+
+@_spi(Internal) @testable import RevenueCat
+@testable import RevenueCatUI
+import XCTest
+
+#if !os(tvOS)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+final class PaywallWebViewMessageParserTests: TestCase {
+
+    private static let componentID = "promo_web_view"
+
+    private func parser(componentID: String = "promo_web_view") -> PaywallWebViewMessageParser {
+        PaywallWebViewMessageParser(expectedComponentID: componentID)
+    }
+
+    // MARK: - Message parsing: valid
+
+    func testParsesStepLoaded() throws {
+        let result = self.parser().parse([
+            "type": "rc:step-loaded",
+            "component_id": Self.componentID
+        ])
+
+        let message = try result.get()
+        XCTAssertEqual(message.type, "rc:step-loaded")
+        XCTAssertEqual(message.componentID, Self.componentID)
+        XCTAssertNil(message.responses)
+        XCTAssertNil(message.error)
+    }
+
+    func testParsesStepCompleteWithResponses() throws {
+        let result = self.parser().parse([
+            "type": "rc:step-complete",
+            "component_id": Self.componentID,
+            "responses": [
+                "selected_plan": "annual",
+                "accepted_terms": true
+            ]
+        ])
+
+        let message = try result.get()
+        XCTAssertEqual(message.type, "rc:step-complete")
+        XCTAssertEqual(message.responses?["selected_plan"], .string("annual"))
+        XCTAssertEqual(message.responses?["accepted_terms"], .bool(true))
+    }
+
+    func testParsesStepCompleteWithoutResponses() throws {
+        let result = self.parser().parse([
+            "type": "rc:step-complete",
+            "component_id": Self.componentID
+        ])
+
+        let message = try result.get()
+        XCTAssertNil(message.responses)
+    }
+
+    func testParsesRequestVariables() throws {
+        let result = self.parser().parse([
+            "type": "rc:request-variables",
+            "component_id": Self.componentID
+        ])
+
+        XCTAssertEqual(try result.get().type, "rc:request-variables")
+    }
+
+    func testParsesError() throws {
+        let result = self.parser().parse([
+            "type": "rc:error",
+            "component_id": Self.componentID,
+            "error": "Something went wrong"
+        ])
+
+        let message = try result.get()
+        XCTAssertEqual(message.type, "rc:error")
+        XCTAssertEqual(message.error, "Something went wrong")
+    }
+
+    // MARK: - Message parsing: invalid
+
+    func testRejectsNonObjectBody() {
+        XCTAssertEqual(self.parser().parse("not an object").failure, .notAnObject)
+    }
+
+    func testRejectsMissingType() {
+        let result = self.parser().parse(["component_id": Self.componentID])
+        XCTAssertEqual(result.failure, .missingType)
+    }
+
+    func testRejectsMissingComponentID() {
+        let result = self.parser().parse(["type": "rc:step-loaded"])
+        XCTAssertEqual(result.failure, .missingComponentID)
+    }
+
+    func testRejectsMismatchedComponentID() {
+        let result = self.parser().parse([
+            "type": "rc:step-loaded",
+            "component_id": "a_different_component"
+        ])
+        XCTAssertEqual(
+            result.failure,
+            .componentIDMismatch(expected: Self.componentID, received: "a_different_component")
+        )
+    }
+
+    func testRejectsInvalidResponsesShape() {
+        let result = self.parser().parse([
+            "type": "rc:step-complete",
+            "component_id": Self.componentID,
+            "responses": "not an object"
+        ])
+        XCTAssertEqual(result.failure, .invalidResponses)
+    }
+
+    func testRejectsErrorWithoutErrorField() {
+        let result = self.parser().parse([
+            "type": "rc:error",
+            "component_id": Self.componentID
+        ])
+        XCTAssertEqual(result.failure, .missingError)
+    }
+
+    func testDropsUnknownType() {
+        let result = self.parser().parse([
+            "type": "rc:totally-unknown",
+            "component_id": Self.componentID
+        ])
+        XCTAssertEqual(result.failure, .unsupportedType("rc:totally-unknown"))
+    }
+
+    func testRejectsOversizedPayload() {
+        let huge = String(repeating: "a", count: PaywallWebViewMessageParser.maxPayloadBytes + 1)
+        let result = self.parser().parse([
+            "type": "rc:step-complete",
+            "component_id": Self.componentID,
+            "responses": ["blob": huge]
+        ])
+
+        guard case .oversizedPayload = result.failure else {
+            return XCTFail("Expected .oversizedPayload, got \(String(describing: result.failure))")
+        }
+    }
+
+    func testRejectsExcessivelyNestedResponses() {
+        // Build an array nested deeper than the allowed depth.
+        var nested: Any = "leaf"
+        for _ in 0...(PaywallWebViewValue.maxDepth + 2) {
+            nested = [nested]
+        }
+        let result = self.parser().parse([
+            "type": "rc:step-complete",
+            "component_id": Self.componentID,
+            "responses": ["deep": nested]
+        ])
+        XCTAssertEqual(result.failure, .invalidResponses)
+    }
+
+    func testRejectsNonJSONValueInResponses() {
+        let result = self.parser().parse([
+            "type": "rc:step-complete",
+            "component_id": Self.componentID,
+            "responses": ["when": Date()]
+        ])
+        // A `Date` is not JSON-serializable, so the body fails the up-front size/JSON check.
+        XCTAssertEqual(result.failure, .invalidValue)
+    }
+
+    // MARK: - Protocol message-type constants
+
+    func testMessageTypeConstantsMatchProtocol() {
+        XCTAssertEqual(PaywallWebViewMessageType.stepLoaded, "rc:step-loaded")
+        XCTAssertEqual(PaywallWebViewMessageType.stepComplete, "rc:step-complete")
+        XCTAssertEqual(PaywallWebViewMessageType.requestVariables, "rc:request-variables")
+        XCTAssertEqual(PaywallWebViewMessageType.error, "rc:error")
+        XCTAssertEqual(PaywallWebViewMessageType.variables, "rc:variables")
+    }
+
+    // MARK: - Size limit & richer responses
+
+    func testParserAcceptsLargePayloadUnderLimit() throws {
+        let blob = String(repeating: "a", count: PaywallWebViewMessageParser.maxPayloadBytes / 2)
+        let result = self.parser().parse([
+            "type": "rc:step-complete",
+            "component_id": Self.componentID,
+            "responses": ["blob": blob]
+        ])
+
+        XCTAssertEqual(try result.get().responses?["blob"], .string(blob))
+    }
+
+    func testParserAcceptsResponsesWithNestedJSONValues() throws {
+        let result = self.parser().parse([
+            "type": "rc:step-complete",
+            "component_id": Self.componentID,
+            "responses": [
+                "selected_plan": "annual",
+                "quantity": 3,
+                "accepted_terms": true,
+                "coupon": NSNull(),
+                "addons": ["a", "b"],
+                "meta": ["source": "onboarding"]
+            ]
+        ])
+
+        let responses = try XCTUnwrap(result.get().responses)
+        XCTAssertEqual(responses["selected_plan"], .string("annual"))
+        XCTAssertEqual(responses["quantity"], .number(3))
+        XCTAssertEqual(responses["accepted_terms"], .bool(true))
+        XCTAssertEqual(responses["coupon"], .null)
+        XCTAssertEqual(responses["addons"], .array([.string("a"), .string("b")]))
+        XCTAssertEqual(responses["meta"], .object(["source": .string("onboarding")]))
+    }
+
+    func testParserAcceptsEmptyResponsesObject() throws {
+        let result = self.parser().parse([
+            "type": "rc:step-complete",
+            "component_id": Self.componentID,
+            "responses": [String: Any]()
+        ])
+
+        XCTAssertEqual(try result.get().responses, [:])
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension Result {
+
+    var failure: Failure? {
+        if case .failure(let error) = self { return error }
+        return nil
+    }
+
+}
+
+#endif

--- a/api/revenuecatui-api-ios-simulator.swiftinterface
+++ b/api/revenuecatui-api-ios-simulator.swiftinterface
@@ -251,6 +251,15 @@ extension SwiftUICore.View {
   
 }
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public struct PaywallWebViewMessage : Swift.Sendable, Swift.Equatable {
+  public let componentID: Swift.String
+  public let type: Swift.String
+  public let responses: [Swift.String : RevenueCatUI.PaywallWebViewValue]?
+  public let error: Swift.String?
+  public init(componentID: Swift.String, type: Swift.String, responses: [Swift.String : RevenueCatUI.PaywallWebViewValue]? = nil, error: Swift.String? = nil)
+  public static func == (a: RevenueCatUI.PaywallWebViewMessage, b: RevenueCatUI.PaywallWebViewMessage) -> Swift.Bool
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public struct PaywallWebViewValue : Swift.Sendable, Swift.Equatable, Swift.Hashable {
   public static func string(_ value: Swift.String) -> RevenueCatUI.PaywallWebViewValue
   public static func number(_ value: Swift.Double) -> RevenueCatUI.PaywallWebViewValue

--- a/api/revenuecatui-api-ios.swiftinterface
+++ b/api/revenuecatui-api-ios.swiftinterface
@@ -251,6 +251,15 @@ extension SwiftUICore.View {
   
 }
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public struct PaywallWebViewMessage : Swift.Sendable, Swift.Equatable {
+  public let componentID: Swift.String
+  public let type: Swift.String
+  public let responses: [Swift.String : RevenueCatUI.PaywallWebViewValue]?
+  public let error: Swift.String?
+  public init(componentID: Swift.String, type: Swift.String, responses: [Swift.String : RevenueCatUI.PaywallWebViewValue]? = nil, error: Swift.String? = nil)
+  public static func == (a: RevenueCatUI.PaywallWebViewMessage, b: RevenueCatUI.PaywallWebViewMessage) -> Swift.Bool
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public struct PaywallWebViewValue : Swift.Sendable, Swift.Equatable, Swift.Hashable {
   public static func string(_ value: Swift.String) -> RevenueCatUI.PaywallWebViewValue
   public static func number(_ value: Swift.Double) -> RevenueCatUI.PaywallWebViewValue

--- a/api/revenuecatui-api-macos.swiftinterface
+++ b/api/revenuecatui-api-macos.swiftinterface
@@ -120,6 +120,15 @@ extension SwiftUICore.View {
   
 }
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public struct PaywallWebViewMessage : Swift.Sendable, Swift.Equatable {
+  public let componentID: Swift.String
+  public let type: Swift.String
+  public let responses: [Swift.String : RevenueCatUI.PaywallWebViewValue]?
+  public let error: Swift.String?
+  public init(componentID: Swift.String, type: Swift.String, responses: [Swift.String : RevenueCatUI.PaywallWebViewValue]? = nil, error: Swift.String? = nil)
+  public static func == (a: RevenueCatUI.PaywallWebViewMessage, b: RevenueCatUI.PaywallWebViewMessage) -> Swift.Bool
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public struct PaywallWebViewValue : Swift.Sendable, Swift.Equatable, Swift.Hashable {
   public static func string(_ value: Swift.String) -> RevenueCatUI.PaywallWebViewValue
   public static func number(_ value: Swift.Double) -> RevenueCatUI.PaywallWebViewValue

--- a/api/revenuecatui-api-visionos-simulator.swiftinterface
+++ b/api/revenuecatui-api-visionos-simulator.swiftinterface
@@ -121,6 +121,15 @@ extension SwiftUICore.View {
   
 }
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public struct PaywallWebViewMessage : Swift.Sendable, Swift.Equatable {
+  public let componentID: Swift.String
+  public let type: Swift.String
+  public let responses: [Swift.String : RevenueCatUI.PaywallWebViewValue]?
+  public let error: Swift.String?
+  public init(componentID: Swift.String, type: Swift.String, responses: [Swift.String : RevenueCatUI.PaywallWebViewValue]? = nil, error: Swift.String? = nil)
+  public static func == (a: RevenueCatUI.PaywallWebViewMessage, b: RevenueCatUI.PaywallWebViewMessage) -> Swift.Bool
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public struct PaywallWebViewValue : Swift.Sendable, Swift.Equatable, Swift.Hashable {
   public static func string(_ value: Swift.String) -> RevenueCatUI.PaywallWebViewValue
   public static func number(_ value: Swift.Double) -> RevenueCatUI.PaywallWebViewValue

--- a/api/revenuecatui-api-visionos.swiftinterface
+++ b/api/revenuecatui-api-visionos.swiftinterface
@@ -121,6 +121,15 @@ extension SwiftUICore.View {
   
 }
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public struct PaywallWebViewMessage : Swift.Sendable, Swift.Equatable {
+  public let componentID: Swift.String
+  public let type: Swift.String
+  public let responses: [Swift.String : RevenueCatUI.PaywallWebViewValue]?
+  public let error: Swift.String?
+  public init(componentID: Swift.String, type: Swift.String, responses: [Swift.String : RevenueCatUI.PaywallWebViewValue]? = nil, error: Swift.String? = nil)
+  public static func == (a: RevenueCatUI.PaywallWebViewMessage, b: RevenueCatUI.PaywallWebViewMessage) -> Swift.Bool
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public struct PaywallWebViewValue : Swift.Sendable, Swift.Equatable, Swift.Hashable {
   public static func string(_ value: Swift.String) -> RevenueCatUI.PaywallWebViewValue
   public static func number(_ value: Swift.Double) -> RevenueCatUI.PaywallWebViewValue


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Inbound messages from web content must be validated before the SDK acts on them.

### Description
Adds the public `PaywallWebViewMessage` and the internal `PaywallWebViewMessageParser`, which validates `type`/`component_id`, JSON-serializability, payload size, and nesting depth, and decodes responses into typed `PaywallWebViewValue`s.

Covered by parser valid/invalid and size-limit unit tests.

> Adds public API, so the `revenuecatui` swiftinterface baselines need regenerating — the `check-api-changes-revenuecatui` failure is expected until that runs.