### PR TITLE
feat: web_view bidirectional postMessage bridge

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 		2C2AEB0F2CA64E0E00A50F38 /* Template1Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2AEB0E2CA64E0E00A50F38 /* Template1Preview.swift */; };
 		2C2AEB3B2CA7209F00A50F38 /* PaywallPackageComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2AEB3A2CA7209F00A50F38 /* PaywallPackageComponent.swift */; };
 		2C2AEB3F2CA7235300A50F38 /* PaywallPurchaseButtonComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2AEB3E2CA7235300A50F38 /* PaywallPurchaseButtonComponent.swift */; };
+		2C3AEEFAE8349B661875E37E /* PaywallWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29FEA8B4082FEAC3D83A4E41 /* PaywallWebViewController.swift */; };
 		2C6CC1162B8D2B6900432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6CC1152B8D2B6800432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift */; };
 		2C74571F2CE7028E004ACE52 /* ScreenCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C74571E2CE7028A004ACE52 /* ScreenCondition.swift */; };
 		2C7457212CE702BB004ACE52 /* PackageContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7457202CE702BB004ACE52 /* PackageContext.swift */; };
@@ -870,6 +871,7 @@
 		57FDAAC028493C13009A48F1 /* MockSandboxEnvironmentDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FDAABF28493C13009A48F1 /* MockSandboxEnvironmentDetector.swift */; };
 		57FFD2512922DBED00A9A878 /* MockStoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FFD2502922DBED00A9A878 /* MockStoreTransaction.swift */; };
 		57FFD2522922DBED00A9A878 /* MockStoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FFD2502922DBED00A9A878 /* MockStoreTransaction.swift */; };
+		58DEBF0E38BFD23227FEE8CA /* View+PaywallWebViewMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4A8B53E9C85445991210DE /* View+PaywallWebViewMessage.swift */; };
 		5A6B1C303D4E5F60718293A4 /* IsPurchaseAllowedByRestoreBehaviorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A6B1C2F3D4E5F60718293A4 /* IsPurchaseAllowedByRestoreBehaviorResponse.swift */; };
 		5BCB9749FDD9493A14B6B870 /* WebViewComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E4F88A43B27C659F48DE31A /* WebViewComponentViewModel.swift */; };
 		5FCB03AADDD3423993AD7C29 /* PaywallLoadingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFE7B86606D743B4929124FD /* PaywallLoadingKey.swift */; };
@@ -1585,6 +1587,7 @@
 		043FB8686FEB4A31B9CF48C8 /* PlatformInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformInfoTests.swift; sourceTree = "<group>"; };
 		077AC81FEBE38D1468AE8670 /* VideoAutoplayHandlerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VideoAutoplayHandlerTests.swift; sourceTree = "<group>"; };
 		077FB0E4EC264B2EA08C4521 /* GetRemoteConfigOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetRemoteConfigOperation.swift; sourceTree = "<group>"; };
+		0A4A8B53E9C85445991210DE /* View+PaywallWebViewMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "View+PaywallWebViewMessage.swift"; sourceTree = "<group>"; };
 		0DD50FFC7C0F48B6A0FDE360 /* PaywallPromoOfferCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallPromoOfferCacheTests.swift; sourceTree = "<group>"; };
 		0E4CCD8E9E454A2EB3760E06 /* ButtonComponentViewModelMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponentViewModelMappingTests.swift; sourceTree = "<group>"; };
 		13B0EAB50136613F69FAA3BB /* SynchronizedUserDefaultsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SynchronizedUserDefaultsTests.swift; sourceTree = "<group>"; };
@@ -1695,6 +1698,7 @@
 		1EFA95112CDBA58F00CA5951 /* MockRedeemWebPurchaseAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRedeemWebPurchaseAPI.swift; sourceTree = "<group>"; };
 		1EFA95142CDBAB7500CA5951 /* MockWebPurchaseRedemptionHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWebPurchaseRedemptionHelper.swift; sourceTree = "<group>"; };
 		26AAFBADBA3F4E339D041135 /* WorkflowStepEventCoordinatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowStepEventCoordinatorTests.swift; sourceTree = "<group>"; };
+		29FEA8B4082FEAC3D83A4E41 /* PaywallWebViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaywallWebViewController.swift; sourceTree = "<group>"; };
 		2A5E77D02F10B3B500BC5900 /* RevocationReason.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RevocationReason.swift; sourceTree = "<group>"; };
 		2C08B2E82CD40DBF0024857B /* ButtonComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponentTests.swift; sourceTree = "<group>"; };
 		2C08B3062CD55D590024857B /* FlexHStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlexHStack.swift; sourceTree = "<group>"; };
@@ -1944,6 +1948,7 @@
 		35AAEB482BBB17B500A12548 /* DiagnosticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsEvent.swift; sourceTree = "<group>"; };
 		35AAEB4A2BBC380600A12548 /* DiagnosticsFileHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsFileHandlerTests.swift; sourceTree = "<group>"; };
 		35AB6D392BBEE3150076B103 /* DiagnosticsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsTracker.swift; sourceTree = "<group>"; };
+		35B980E8E16B96C118751F2D /* PaywallWebViewBridgeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaywallWebViewBridgeTests.swift; sourceTree = "<group>"; };
 		35C05DBF2BC84F5800109308 /* DiagnosticsSynchronizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsSynchronizerTests.swift; sourceTree = "<group>"; };
 		35C05DC72BC8510000109308 /* DiagnosticsTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsTrackerTests.swift; sourceTree = "<group>"; };
 		35C272A02BC4084C005A0CE8 /* MockDiagnosticsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDiagnosticsTracker.swift; sourceTree = "<group>"; };
@@ -3208,6 +3213,7 @@
 				E0405C692DEAEFE6F36A9411 /* WebViewComponentTests.swift */,
 				83AC793744895AD08CE7D052 /* PaywallWebViewValueTests.swift */,
 				7BBAC2CA1200CCC7453CAD61 /* PaywallWebViewMessageParserTests.swift */,
+				35B980E8E16B96C118751F2D /* PaywallWebViewBridgeTests.swift */,
 			);
 			path = PaywallsV2;
 			sourceTree = "<group>";
@@ -4766,6 +4772,7 @@
 				863C9FCC9388B370BDAF36C9 /* WebViewComponentView.swift */,
 				8E4F88A43B27C659F48DE31A /* WebViewComponentViewModel.swift */,
 				D3108BDE9CA157DCAA4D5A65 /* PaywallWebViewMessageParser.swift */,
+				29FEA8B4082FEAC3D83A4E41 /* PaywallWebViewController.swift */,
 			);
 			name = WebView;
 			path = WebView;
@@ -5754,6 +5761,7 @@
 				887A60632C1D037000E1A461 /* View+PresentPaywallFooter.swift */,
 				887A60642C1D037000E1A461 /* View+PurchaseRestoreCompleted.swift */,
 				1E8A607E2CDCE5EC0034ACF3 /* View+OnRedeemWebPurchaseAttempt.swift */,
+				0A4A8B53E9C85445991210DE /* View+PaywallWebViewMessage.swift */,
 			);
 			path = RevenueCatUI;
 			sourceTree = "<group>";
@@ -8389,6 +8397,8 @@
 				FFDE30D78DAFB1C58C5D44EF /* PaywallWebViewValue.swift in Sources */,
 				C3B1410F98F1A5B647081D02 /* PaywallWebViewMessage.swift in Sources */,
 				7D4C28B5FDD5D38E1055A107 /* PaywallWebViewMessageParser.swift in Sources */,
+				2C3AEEFAE8349B661875E37E /* PaywallWebViewController.swift in Sources */,
+				58DEBF0E38BFD23227FEE8CA /* View+PaywallWebViewMessage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -111,6 +111,10 @@ enum Strings {
 
     // Web View
     case paywall_web_view_content_rules_failed(Error)
+    case paywall_web_view_missing_id
+    case paywall_web_view_message_rejected(reason: String)
+    case paywall_web_view_post_message_failed(Error)
+    case paywall_web_view_post_message_skipped
 
     // Exit Offers
     case errorFetchingOfferings(Error)
@@ -369,6 +373,16 @@ extension Strings: CustomStringConvertible {
         case .paywall_web_view_content_rules_failed(let error):
             return "Failed to compile content-blocking rules for a web_view component; the page " +
             "remains isolated to its uploaded bundle: \(error)"
+        case .paywall_web_view_missing_id:
+            return "web_view component has no id; the postMessage bridge is disabled for it. " +
+            "Assign an id to the component to enable bidirectional communication."
+        case .paywall_web_view_message_rejected(let reason):
+            return "Rejected a message from a web_view component: \(reason)"
+        case .paywall_web_view_post_message_failed(let error):
+            return "Failed to deliver a message to a web_view component: \(error)"
+        case .paywall_web_view_post_message_skipped:
+            return "Skipped delivering a message to a web_view component because its web view is no " +
+            "longer available or is showing different content."
 
         case .errorFetchingOfferings(let error):
             return "Error fetching offerings: \(error)"

--- a/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewController.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewController.swift
@@ -1,0 +1,142 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PaywallWebViewController.swift
+
+import Foundation
+@_spi(Internal) import RevenueCat
+
+#if canImport(WebKit)
+import WebKit
+#endif
+
+#if !os(tvOS) // For Paywalls V2
+
+/// A handle, passed to your `View/onPaywallWebViewMessage(_:)` handler, for sending messages from
+/// native code back into a Paywalls V2 `web_view` component.
+///
+/// Use it to reply to a `"rc:request-variables"` message with additional variables, or to send any
+/// message that follows the web view protocol envelope. Messages are delivered to the web content
+/// via `window.__revenueCatReceiveMessage(...)`.
+///
+/// Modeled as a concrete `struct` (rather than a protocol) following the SDK convention for
+/// callback-supplied action handles, so methods can be added without a source-breaking change.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@MainActor
+public struct PaywallWebViewController {
+
+    #if canImport(WebKit)
+    private weak var webView: WKWebView?
+    #endif
+
+    private let componentID: String
+    private let expectedLoadedURL: URL?
+
+    #if canImport(WebKit)
+    init(webView: WKWebView?, componentID: String, expectedLoadedURL: URL?) {
+        self.webView = webView
+        self.componentID = componentID
+        self.expectedLoadedURL = expectedLoadedURL
+    }
+    #else
+    init(componentID: String, expectedLoadedURL: URL?) {
+        self.componentID = componentID
+        self.expectedLoadedURL = expectedLoadedURL
+    }
+    #endif
+
+    /// Sends an `"rc:variables"` message to the web content.
+    ///
+    /// - Parameters:
+    ///   - componentID: The component to address. Should match the `componentID` of the message you
+    ///     are replying to.
+    ///   - variables: The variables to deliver to the web content. The `"locale"` top-level key is
+    ///     SDK-managed and reserved.
+    public func postVariables(
+        componentID: String,
+        variables: [String: PaywallWebViewValue]
+    ) {
+        self.postMessage(
+            componentID: componentID,
+            type: PaywallWebViewMessageType.variables,
+            variables: variables
+        )
+    }
+
+    /// Sends a message to the web content following the web view protocol envelope
+    /// `{ "type", "component_id", "variables" }`.
+    ///
+    /// - Parameters:
+    ///   - componentID: The component to address.
+    ///   - type: The message type, e.g. `"rc:variables"`.
+    ///   - variables: The message payload, delivered under the `"variables"` key.
+    public func postMessage(
+        componentID: String,
+        type: String,
+        variables: [String: PaywallWebViewValue]
+    ) {
+        guard let script = Self.receiveMessageScript(
+            componentID: componentID,
+            type: type,
+            variables: variables
+        ) else {
+            return
+        }
+
+        self.evaluate(script: script)
+    }
+
+    /// Builds the envelope `{ "type", "component_id", "variables" }` and wraps it in a guarded call
+    /// to `window.__revenueCatReceiveMessage`. The JSON is produced by `JSONSerialization`, never
+    /// string-interpolated from raw values, so app- or web-supplied strings cannot break out of the
+    /// call. Internal for testability.
+    static func receiveMessageScript(
+        componentID: String,
+        type: String,
+        variables: [String: PaywallWebViewValue]
+    ) -> String? {
+        let envelope: [String: PaywallWebViewValue] = [
+            "type": .string(type),
+            "component_id": .string(componentID),
+            "variables": .object(variables)
+        ]
+
+        let jsonObject = PaywallWebViewValue.object(envelope).jsonObject
+        guard let data = try? JSONSerialization.data(withJSONObject: jsonObject),
+              let json = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        return """
+        (function(){var m=\(json);if(typeof window.__revenueCatReceiveMessage==='function'){\
+        window.__revenueCatReceiveMessage(m);}})();
+        """
+    }
+
+    private func evaluate(script: String) {
+        #if canImport(WebKit)
+        guard let webView = self.webView,
+              self.expectedLoadedURL == nil || webView.url == self.expectedLoadedURL else {
+            // The web view was deallocated or navigated elsewhere — don't post into
+            // unrelated content.
+            Logger.debug(Strings.paywall_web_view_post_message_skipped)
+            return
+        }
+
+        webView.evaluateJavaScript(script) { _, error in
+            if let error {
+                Logger.debug(Strings.paywall_web_view_post_message_failed(error))
+            }
+        }
+        #endif
+    }
+
+}
+
+#endif

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
@@ -39,17 +39,31 @@ struct WebViewComponentView: View {
     @Environment(\.customPaywallVariables)
     private var customVariables
 
+    @Environment(\.paywallWebViewMessageAction)
+    private var webViewMessageAction
+
     var body: some View {
         if viewModel.visible {
             self.content
         }
     }
 
+    /// The current bidirectional-communication configuration for this `web_view`. Rebuilt on each
+    /// `body` evaluation so SDK-managed variables and the app handler stay fresh as the environment
+    /// changes.
+    private var bridge: WebViewBridgeConfiguration {
+        WebViewBridgeConfiguration(
+            componentID: viewModel.componentID,
+            messageAction: webViewMessageAction,
+            baseVariables: PaywallWebViewVariables.base(locale: viewModel.locale)
+        )
+    }
+
     @ViewBuilder
     private var content: some View {
         #if canImport(UIKit) && canImport(WebKit)
         if let resolvedURL = viewModel.resolvedURL(customVariables: customVariables) {
-            WebViewRepresentable(url: resolvedURL, height: $dynamicHeight)
+            WebViewRepresentable(url: resolvedURL, height: $dynamicHeight, bridge: bridge)
                 .modifier(WebViewSizeModifier(size: viewModel.size, measuredHeight: dynamicHeight))
                 .clipped()
                 .background(Color.clear)
@@ -57,7 +71,7 @@ struct WebViewComponentView: View {
         #elseif os(macOS)
         if let resolvedURL = viewModel.resolvedURL(customVariables: customVariables) {
             let macHeight = dynamicHeight ?? Self.initialHeight
-            MacWebViewRepresentable(url: resolvedURL, height: $dynamicHeight)
+            MacWebViewRepresentable(url: resolvedURL, height: $dynamicHeight, bridge: bridge)
                 .modifier(WebViewSizeModifier(size: viewModel.size, measuredHeight: macHeight))
                 .clipped()
                 .background(Color.clear)
@@ -66,6 +80,78 @@ struct WebViewComponentView: View {
         #else
         EmptyView()
         #endif
+    }
+
+}
+
+// MARK: - Bidirectional communication bridge
+
+/// Per-render configuration for the `web_view` postMessage bridge. Captured from the environment in
+/// `WebViewComponentView.body` and refreshed into the coordinator on every `updateUIView`.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct WebViewBridgeConfiguration {
+
+    /// The canonical `component_id`. When `nil` (legacy/partial config without an `id`) the message
+    /// bridge is not installed.
+    let componentID: String?
+    let messageAction: PaywallWebViewMessageAction?
+
+    /// SDK-managed + paywall custom variables sent automatically in response to `rc:request-variables`.
+    let baseVariables: [String: PaywallWebViewValue]
+
+}
+
+/// Builds the SDK-managed variable set exposed to web content. `WebKit`-free so it's unit-testable.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+enum PaywallWebViewVariables {
+
+    /// The SDK-managed variables exposed to web content. Sending the paywall's custom variables is
+    /// out of scope for v1; only `locale` is provided automatically.
+    static func base(locale: Locale) -> [String: PaywallWebViewValue] {
+        return ["locale": .string(self.bcp47Identifier(for: locale))]
+    }
+
+    static func bcp47Identifier(for locale: Locale) -> String {
+        if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+            return locale.identifier(.bcp47)
+        } else {
+            return locale.identifier.replacingOccurrences(of: "_", with: "-")
+        }
+    }
+
+}
+
+/// Dispatches a validated inbound `web_view` message. `WebKit`-free (takes the extracted body and
+/// frame flag) so it's unit-testable without a live `WKWebView`.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+enum PaywallWebViewMessageDispatcher {
+
+    @MainActor
+    static func handle(
+        body: Any,
+        isMainFrame: Bool,
+        componentID: String,
+        controller: PaywallWebViewController,
+        bridge: WebViewBridgeConfiguration
+    ) {
+        guard isMainFrame else {
+            Logger.debug(Strings.paywall_web_view_message_rejected(reason: "message not from the main frame"))
+            return
+        }
+
+        let parser = PaywallWebViewMessageParser(expectedComponentID: componentID)
+        switch parser.parse(body) {
+        case .success(let message):
+            // The SDK always replies to a variables request with the canonical SDK-managed +
+            // custom variables, even when the app installs no handler.
+            if message.type == PaywallWebViewMessageType.requestVariables {
+                controller.postVariables(componentID: message.componentID, variables: bridge.baseVariables)
+            }
+            bridge.messageAction?(message, controller)
+
+        case .failure(let error):
+            Logger.debug(Strings.paywall_web_view_message_rejected(reason: "\(error)"))
+        }
     }
 
 }
@@ -231,6 +317,35 @@ enum PaywallWebViewScripts {
         forMainFrameOnly: true
     )
 
+    /// The native handler name the message bridge posts to. Independent of height reporting.
+    static let messageHandlerName = "rcWebViewMessage"
+
+    /// Injected at document start so the web bundle can call `window.RevenueCatWebView.postMessage`
+    /// before its own scripts run. Native → web messages arrive via `window.__revenueCatReceiveMessage`,
+    /// which the web bundle defines. The bridge exposes no other native surface.
+    static let messageBridgeJavaScriptSource = """
+    (function() {
+      if (window.__rcBridgeInstalled) { return; }
+      window.__rcBridgeInstalled = true;
+
+      window.RevenueCatWebView = window.RevenueCatWebView || {
+        postMessage: function(message) {
+          if (window.webkit &&
+              window.webkit.messageHandlers &&
+              window.webkit.messageHandlers.\(messageHandlerName)) {
+            window.webkit.messageHandlers.\(messageHandlerName).postMessage(message);
+          }
+        }
+      };
+    })();
+    """
+
+    static let messageBridgeUserScript = WKUserScript(
+        source: PaywallWebViewScripts.messageBridgeJavaScriptSource,
+        injectionTime: .atDocumentStart,
+        forMainFrameOnly: true
+    )
+
     /// Attaches the content-blocking rule list (compiling it if necessary), then loads `url`. The
     /// load is deferred until the rules are in place so no request is issued before isolation
     /// applies. Fails closed: if compilation fails the page still loads, already isolated to its
@@ -376,6 +491,74 @@ final class WebViewHeightReporter: NSObject, WKScriptMessageHandler {
 
 }
 
+/// Source of the per-render bridge state a ``WebViewMessageBridge`` needs when a message arrives.
+/// Implemented by the platform coordinators so the bridge can read the current configuration and
+/// loaded URL without duplicating that state.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+protocol WebViewBridgeHost: AnyObject {
+    var bridge: WebViewBridgeConfiguration? { get }
+    var currentURL: URL? { get }
+}
+
+/// Bridges inbound `web_view` postMessage calls to ``PaywallWebViewMessageDispatcher``. Shared by
+/// the iOS and macOS coordinators so the (otherwise identical) registration and dispatch live in
+/// one place. The handler is installed only when the component has a stable `id`.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+final class WebViewMessageBridge: NSObject, WKScriptMessageHandler {
+
+    static let handlerName = PaywallWebViewScripts.messageHandlerName
+
+    private weak var host: WebViewBridgeHost?
+    private var messageHandler: WeakScriptMessageHandler?
+
+    init(host: WebViewBridgeHost) {
+        self.host = host
+    }
+
+    func registerIfNeeded(on webView: WKWebView) {
+        guard self.host?.bridge?.componentID != nil else {
+            Logger.debug(Strings.paywall_web_view_missing_id)
+            return
+        }
+        let handler = WeakScriptMessageHandler(delegate: self)
+        self.messageHandler = handler
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: Self.handlerName)
+        webView.configuration.userContentController.add(handler, name: Self.handlerName)
+    }
+
+    func unregister(from webView: WKWebView) {
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: Self.handlerName)
+        self.messageHandler = nil
+    }
+
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage
+    ) {
+        guard message.name == Self.handlerName,
+              let host = self.host,
+              let bridge = host.bridge,
+              let componentID = bridge.componentID else {
+            return
+        }
+
+        let controller = PaywallWebViewController(
+            webView: message.webView,
+            componentID: componentID,
+            expectedLoadedURL: host.currentURL
+        )
+
+        PaywallWebViewMessageDispatcher.handle(
+            body: message.body,
+            isMainFrame: message.frameInfo.isMainFrame,
+            componentID: componentID,
+            controller: controller,
+            bridge: bridge
+        )
+    }
+
+}
+
 #endif
 
 #if canImport(UIKit) && canImport(WebKit)
@@ -386,6 +569,7 @@ private struct WebViewRepresentable: UIViewRepresentable {
 
     let url: URL
     @Binding var height: CGFloat?
+    let bridge: WebViewBridgeConfiguration
 
     func makeUIView(context: Context) -> WKWebView {
         let webView = AutoSizingWebView()
@@ -404,13 +588,19 @@ private struct WebViewRepresentable: UIViewRepresentable {
         webView.scrollView.pinchGestureRecognizer?.isEnabled = false
         webView.scrollView.delegate = context.coordinator
 
+        context.coordinator.bridge = bridge
         context.coordinator.registerHeightReporting(on: webView)
+        context.coordinator.registerMessageBridgeIfNeeded(on: webView)
         context.coordinator.currentURL = url
         PaywallWebViewScripts.loadIsolated(url: url, on: webView)
         return webView
     }
 
     func updateUIView(_ uiView: WKWebView, context: Context) {
+        // Refresh the bridge config so SDK-managed variables (color scheme) and the app handler
+        // stay current; do not reload the web view on these changes.
+        context.coordinator.bridge = bridge
+
         if context.coordinator.currentURL != url {
             context.coordinator.currentURL = url
             uiView.load(URLRequest(url: url))
@@ -425,6 +615,7 @@ private struct WebViewRepresentable: UIViewRepresentable {
 
     static func dismantleUIView(_ uiView: WKWebView, coordinator: Coordinator) {
         coordinator.unregisterHeightReporting(from: uiView)
+        coordinator.unregisterMessageBridge(from: uiView)
         uiView.navigationDelegate = nil
         uiView.scrollView.delegate = nil
         uiView.stopLoading()
@@ -434,10 +625,11 @@ private struct WebViewRepresentable: UIViewRepresentable {
         Coordinator(height: $height)
     }
 
-    final class Coordinator: NSObject, WKNavigationDelegate, UIScrollViewDelegate {
+    final class Coordinator: NSObject, WKNavigationDelegate, UIScrollViewDelegate, WebViewBridgeHost {
 
         @Binding var height: CGFloat?
         var currentURL: URL?
+        var bridge: WebViewBridgeConfiguration?
 
         private lazy var heightReporter = WebViewHeightReporter { [weak self] newHeight, webView in
             guard let self, newHeight >= 0, abs(newHeight - (self.height ?? 0)) > 0.5 else { return }
@@ -446,6 +638,8 @@ private struct WebViewRepresentable: UIViewRepresentable {
                 (webView as? AutoSizingWebView)?.setContentHeight(newHeight)
             }
         }
+
+        private lazy var messageBridge = WebViewMessageBridge(host: self)
 
         init(height: Binding<CGFloat?>) {
             _height = height
@@ -461,6 +655,14 @@ private struct WebViewRepresentable: UIViewRepresentable {
 
         func reportHeightIfNeeded(in webView: WKWebView) {
             self.heightReporter.reportIfNeeded(in: webView)
+        }
+
+        func registerMessageBridgeIfNeeded(on webView: WKWebView) {
+            self.messageBridge.registerIfNeeded(on: webView)
+        }
+
+        func unregisterMessageBridge(from webView: WKWebView) {
+            self.messageBridge.unregister(from: webView)
         }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
@@ -500,6 +702,7 @@ final class AutoSizingWebView: WKWebView {
         config.allowsInlineMediaPlayback = true
         config.userContentController.addUserScript(PaywallWebViewScripts.disableZoomUserScript)
         config.userContentController.addUserScript(PaywallWebViewScripts.heightReportingUserScript)
+        config.userContentController.addUserScript(PaywallWebViewScripts.messageBridgeUserScript)
         super.init(frame: .zero, configuration: config)
         isOpaque = false
         backgroundColor = .clear
@@ -522,11 +725,14 @@ private struct MacWebViewRepresentable: NSViewRepresentable {
 
     let url: URL
     @Binding var height: CGFloat?
+    let bridge: WebViewBridgeConfiguration
 
     func makeNSView(context: Context) -> WKWebView {
         let webView = WKWebView(frame: .zero, configuration: Self.makeConfiguration())
         webView.navigationDelegate = context.coordinator
+        context.coordinator.bridge = bridge
         context.coordinator.registerHeightReporting(on: webView)
+        context.coordinator.registerMessageBridgeIfNeeded(on: webView)
         context.coordinator.currentURL = url
         PaywallWebViewScripts.loadIsolated(url: url, on: webView)
 
@@ -534,6 +740,8 @@ private struct MacWebViewRepresentable: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: WKWebView, context: Context) {
+        context.coordinator.bridge = bridge
+
         if context.coordinator.currentURL != url {
             context.coordinator.currentURL = url
             nsView.load(URLRequest(url: url))
@@ -544,6 +752,7 @@ private struct MacWebViewRepresentable: NSViewRepresentable {
 
     static func dismantleNSView(_ nsView: WKWebView, coordinator: Coordinator) {
         coordinator.unregisterHeightReporting(from: nsView)
+        coordinator.unregisterMessageBridge(from: nsView)
         nsView.navigationDelegate = nil
         nsView.stopLoading()
         nsView.configuration.websiteDataStore.removeData(
@@ -560,14 +769,16 @@ private struct MacWebViewRepresentable: NSViewRepresentable {
         let config = WKWebViewConfiguration()
         config.websiteDataStore = .nonPersistent()
         config.userContentController.addUserScript(PaywallWebViewScripts.heightReportingUserScript)
+        config.userContentController.addUserScript(PaywallWebViewScripts.messageBridgeUserScript)
 
         return config
     }
 
-    final class Coordinator: NSObject, WKNavigationDelegate {
+    final class Coordinator: NSObject, WKNavigationDelegate, WebViewBridgeHost {
 
         @Binding var height: CGFloat?
         var currentURL: URL?
+        var bridge: WebViewBridgeConfiguration?
 
         private lazy var heightReporter = WebViewHeightReporter { [weak self] newHeight, _ in
             guard let self, newHeight >= 0, abs(newHeight - (self.height ?? 0)) > 0.5 else { return }
@@ -575,6 +786,8 @@ private struct MacWebViewRepresentable: NSViewRepresentable {
                 self.height = newHeight
             }
         }
+
+        private lazy var messageBridge = WebViewMessageBridge(host: self)
 
         init(height: Binding<CGFloat?>) {
             _height = height
@@ -590,6 +803,14 @@ private struct MacWebViewRepresentable: NSViewRepresentable {
 
         func reportHeightIfNeeded(in webView: WKWebView) {
             self.heightReporter.reportIfNeeded(in: webView)
+        }
+
+        func registerMessageBridgeIfNeeded(on webView: WKWebView) {
+            self.messageBridge.registerIfNeeded(on: webView)
+        }
+
+        func unregisterMessageBridge(from webView: WKWebView) {
+            self.messageBridge.unregister(from: webView)
         }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {

--- a/RevenueCatUI/View+PaywallWebViewMessage.swift
+++ b/RevenueCatUI/View+PaywallWebViewMessage.swift
@@ -1,0 +1,106 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  View+PaywallWebViewMessage.swift
+
+import SwiftUI
+
+#if !os(tvOS) // For Paywalls V2
+
+/// A wrapper for the Paywalls V2 `web_view` message handler.
+///
+/// Invoked with each validated message a `web_view` component sends, plus a
+/// ``PaywallWebViewController`` for replying. The closure runs on the main actor; it is not
+/// `Sendable` because the controller holds a reference to the underlying web view.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public struct PaywallWebViewMessageAction {
+
+    private let action: @MainActor (PaywallWebViewMessage, PaywallWebViewController) -> Void
+
+    /// Creates a new web view message action.
+    /// - Parameter action: The closure invoked with each validated message and a controller for
+    ///   sending messages back to the web content.
+    public init(
+        _ action: @escaping @MainActor (PaywallWebViewMessage, PaywallWebViewController) -> Void
+    ) {
+        self.action = action
+    }
+
+    @MainActor
+    func callAsFunction(_ message: PaywallWebViewMessage, _ controller: PaywallWebViewController) {
+        self.action(message, controller)
+    }
+
+}
+
+// MARK: - Environment Key
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct PaywallWebViewMessageActionKey: EnvironmentKey {
+    static let defaultValue: PaywallWebViewMessageAction? = nil
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension EnvironmentValues {
+
+    var paywallWebViewMessageAction: PaywallWebViewMessageAction? {
+        get { self[PaywallWebViewMessageActionKey.self] }
+        set { self[PaywallWebViewMessageActionKey.self] = newValue }
+    }
+
+}
+
+// MARK: - View Modifier
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension View {
+
+    /// Invokes the given closure when a Paywalls V2 `web_view` component sends a message.
+    ///
+    /// The handler receives a validated ``PaywallWebViewMessage`` and a ``PaywallWebViewController``
+    /// it can use to reply. Your app decides what to do with each message — the SDK does not
+    /// automatically dismiss the paywall or start a purchase.
+    ///
+    /// Example:
+    /// ```swift
+    /// PaywallView(offering: offering)
+    ///     .onPaywallWebViewMessage { message, controller in
+    ///         switch message.type {
+    ///         case "rc:step-complete":
+    ///             let responses = message.responses
+    ///             // App decides what to do: dismiss, navigate, log analytics, etc.
+    ///
+    ///         case "rc:request-variables":
+    ///             controller.postVariables(
+    ///                 componentID: message.componentID,
+    ///                 variables: ["app_segment": .string("high_intent")]
+    ///             )
+    ///
+    ///         case "rc:error":
+    ///             // App can log/report the error via message.error.
+    ///             break
+    ///
+    ///         default:
+    ///             break
+    ///         }
+    ///     }
+    /// ```
+    ///
+    /// - Note: For `"rc:request-variables"`, the SDK automatically replies with its SDK-managed
+    ///   variables (`locale`) before invoking this handler, so you only need to send any
+    ///   *additional* variables.
+    public func onPaywallWebViewMessage(
+        _ action: @escaping @MainActor (PaywallWebViewMessage, PaywallWebViewController) -> Void
+    ) -> some View {
+        self.environment(\.paywallWebViewMessageAction, PaywallWebViewMessageAction(action))
+    }
+
+}
+
+#endif

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewBridgeTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewBridgeTests.swift
@@ -1,0 +1,411 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PaywallWebViewBridgeTests.swift
+
+@_spi(Internal) @testable import RevenueCat
+@testable import RevenueCatUI
+import SwiftUI
+import XCTest
+#if canImport(WebKit)
+import WebKit
+#endif
+
+#if !os(tvOS)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@MainActor
+final class PaywallWebViewBridgeTests: TestCase {
+
+    private static let componentID = "promo_web_view"
+
+    // MARK: - SDK-managed variables
+
+    func testBaseVariablesIncludeLocale() {
+        let variables = PaywallWebViewVariables.base(locale: Locale(identifier: "en_US"))
+
+        XCTAssertEqual(variables["locale"], .string("en-US"))
+    }
+
+    // MARK: - Controller envelope / outbound JS
+
+    func testReceiveMessageScriptProducesRFCEnvelope() throws {
+        let script = try XCTUnwrap(PaywallWebViewController.receiveMessageScript(
+            componentID: Self.componentID,
+            type: "rc:variables",
+            variables: [
+                "locale": .string("en-US"),
+                "custom": .object(["plan": .string("annual")])
+            ]
+        ))
+
+        XCTAssertTrue(script.contains("window.__revenueCatReceiveMessage"))
+        XCTAssertTrue(script.contains("typeof window.__revenueCatReceiveMessage==='function'"))
+
+        // The embedded payload must be valid JSON matching the RFC envelope.
+        let json = try XCTUnwrap(self.embeddedJSON(in: script))
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any]
+        )
+        XCTAssertEqual(object["type"] as? String, "rc:variables")
+        XCTAssertEqual(object["component_id"] as? String, Self.componentID)
+        let variables = try XCTUnwrap(object["variables"] as? [String: Any])
+        XCTAssertEqual(variables["locale"] as? String, "en-US")
+    }
+
+    // MARK: - Dispatcher routing
+
+    func testDispatcherRejectsNonMainFrameMessages() {
+        var handled = false
+        PaywallWebViewMessageDispatcher.handle(
+            body: ["type": "rc:step-loaded", "component_id": Self.componentID],
+            isMainFrame: false,
+            componentID: Self.componentID,
+            controller: self.makeController(),
+            bridge: self.bridge { _, _ in handled = true }
+        )
+
+        XCTAssertFalse(handled, "Messages from non-main frames must be dropped")
+    }
+
+    func testDispatcherForwardsValidMessageToHandler() {
+        var received: PaywallWebViewMessage?
+        PaywallWebViewMessageDispatcher.handle(
+            body: [
+                "type": "rc:step-complete",
+                "component_id": Self.componentID,
+                "responses": ["selected_plan": "annual"]
+            ],
+            isMainFrame: true,
+            componentID: Self.componentID,
+            controller: self.makeController(),
+            bridge: self.bridge { message, _ in received = message }
+        )
+
+        XCTAssertEqual(received?.type, "rc:step-complete")
+        XCTAssertEqual(received?.componentID, Self.componentID)
+        XCTAssertEqual(received?.responses?["selected_plan"], .string("annual"))
+    }
+
+    func testDispatcherDropsMismatchedComponentID() {
+        var handled = false
+        PaywallWebViewMessageDispatcher.handle(
+            body: ["type": "rc:step-loaded", "component_id": "other"],
+            isMainFrame: true,
+            componentID: Self.componentID,
+            controller: self.makeController(),
+            bridge: self.bridge { _, _ in handled = true }
+        )
+
+        XCTAssertFalse(handled, "Messages for a different component must be rejected")
+    }
+
+    func testDispatcherStillInvokesHandlerForRequestVariables() {
+        var received: PaywallWebViewMessage?
+        PaywallWebViewMessageDispatcher.handle(
+            body: ["type": "rc:request-variables", "component_id": Self.componentID],
+            isMainFrame: true,
+            componentID: Self.componentID,
+            controller: self.makeController(),
+            bridge: self.bridge(baseVariables: ["locale": .string("en-US")]) { message, _ in received = message }
+        )
+
+        XCTAssertEqual(received?.type, "rc:request-variables")
+    }
+
+    // MARK: - JavaScript injection
+
+    func testBridgeScriptExposesPostMessageAndHandlerName() {
+        let source = PaywallWebViewScripts.messageBridgeJavaScriptSource
+        XCTAssertTrue(source.contains("window.RevenueCatWebView"))
+        XCTAssertTrue(source.contains("postMessage"))
+        XCTAssertTrue(source.contains("window.webkit.messageHandlers.rcWebViewMessage"))
+        XCTAssertTrue(source.contains("__rcBridgeInstalled"))
+    }
+
+    func testBridgeUsesDedicatedHandlerNameSeparateFromHeight() {
+        XCTAssertEqual(PaywallWebViewScripts.messageHandlerName, "rcWebViewMessage")
+        XCTAssertNotEqual(PaywallWebViewScripts.messageHandlerName, "rcWebViewHeight")
+    }
+
+    // MARK: - Outbound JS escaping (security)
+
+    func testReceiveMessageScriptEscapesHostileStringValues() throws {
+        // Quotes, backslashes, newlines, and a literal closing-script sequence must all be confined
+        // to the JSON payload and survive a round-trip exactly — never breaking out of the call.
+        let hostile = "annual\" }); alert('xss'); //\n</script>\\ end\u{2028}\u{2029}"
+        let script = try XCTUnwrap(PaywallWebViewController.receiveMessageScript(
+            componentID: Self.componentID,
+            type: "rc:variables",
+            variables: ["custom": .object(["evil": .string(hostile)])]
+        ))
+
+        let json = try XCTUnwrap(self.embeddedJSON(in: script))
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+        let variables = try XCTUnwrap(object["variables"] as? [String: Any])
+        let custom = try XCTUnwrap(variables["custom"] as? [String: Any])
+        XCTAssertEqual(custom["evil"] as? String, hostile)
+
+        // A raw newline would make the `var m=...` statement a syntax error; it must be escaped.
+        XCTAssertFalse(json.contains("\n"))
+    }
+
+    func testReceiveMessageScriptSerializesAllValueTypes() throws {
+        let script = try XCTUnwrap(PaywallWebViewController.receiveMessageScript(
+            componentID: Self.componentID,
+            type: "rc:variables",
+            variables: [
+                "string": .string("s"),
+                "number": .number(3.5),
+                "bool": .bool(false),
+                "null": .null,
+                "array": .array([.number(1), .string("two")]),
+                "object": .object(["nested": .bool(true)])
+            ]
+        ))
+
+        let json = try XCTUnwrap(self.embeddedJSON(in: script))
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+        let variables = try XCTUnwrap(object["variables"] as? [String: Any])
+        XCTAssertEqual(variables["string"] as? String, "s")
+        XCTAssertEqual(variables["number"] as? Double, 3.5)
+        XCTAssertEqual(variables["bool"] as? Bool, false)
+        XCTAssertTrue(variables["null"] is NSNull)
+        let array = try XCTUnwrap(variables["array"] as? [Any])
+        XCTAssertEqual(array.count, 2)
+        XCTAssertEqual(array.first as? Double, 1)
+        XCTAssertEqual(array.last as? String, "two")
+        XCTAssertEqual((variables["object"] as? [String: Any])?["nested"] as? Bool, true)
+    }
+
+    // MARK: - Variables: locale formatting
+
+    func testBaseVariablesFormatsLanguageOnlyLocale() {
+        let variables = PaywallWebViewVariables.base(locale: Locale(identifier: "fr"))
+
+        XCTAssertEqual(variables["locale"], .string("fr"))
+    }
+
+    func testBaseVariablesFormatsScriptAndRegionLocaleAsBCP47() {
+        let variables = PaywallWebViewVariables.base(locale: Locale(identifier: "zh_Hans_CN"))
+
+        // Must use hyphen separators (BCP-47), never the underscore form.
+        let locale = variables["locale"]?.stringValue
+        XCTAssertEqual(locale?.contains("_"), false)
+        XCTAssertEqual(locale?.contains("zh"), true)
+    }
+
+#if canImport(WebKit)
+
+    // MARK: - WebKit round-trip integration
+
+    func testWebContentPostMessageReachesNativeHandler() {
+        let handlerCalled = self.expectation(description: "native handler invoked")
+        var receivedBody: Any?
+        let handler = TestScriptMessageHandler { message in
+            receivedBody = message.body
+            handlerCalled.fulfill()
+        }
+
+        let config = WKWebViewConfiguration()
+        config.userContentController.addUserScript(PaywallWebViewScripts.messageBridgeUserScript)
+        config.userContentController.add(handler, name: PaywallWebViewScripts.messageHandlerName)
+
+        let webView = self.loadedWebView(html: "<html><body>hi</body></html>", configuration: config)
+
+        webView.evaluateJavaScript(
+            "window.RevenueCatWebView.postMessage("
+            + "{type:'rc:step-complete',component_id:'\(Self.componentID)',responses:{selected_plan:'annual'}}); true"
+        )
+
+        self.wait(for: [handlerCalled], timeout: 10)
+        config.userContentController.removeScriptMessageHandler(forName: PaywallWebViewScripts.messageHandlerName)
+
+        let body = receivedBody as? [String: Any]
+        XCTAssertEqual(body?["type"] as? String, "rc:step-complete")
+        XCTAssertEqual(body?["component_id"] as? String, Self.componentID)
+        XCTAssertEqual((body?["responses"] as? [String: Any])?["selected_plan"] as? String, "annual")
+    }
+
+    func testControllerDeliversVariablesToWebContentIntact() throws {
+        let webView = self.loadedWebView(html: Self.receiverHTML)
+
+        let controller = PaywallWebViewController(
+            webView: webView,
+            componentID: Self.componentID,
+            expectedLoadedURL: webView.url
+        )
+
+        // Include hostile characters to prove escaping survives the real evaluateJavaScript path.
+        let hostile = "annual\" }); //\n</script>\\ end"
+        controller.postVariables(
+            componentID: Self.componentID,
+            variables: ["locale": .string("en-US"), "custom": .object(["plan": .string(hostile)])]
+        )
+
+        let received = try XCTUnwrap(self.pollString(in: webView, script: "window.__rcReceived"))
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(received.utf8)) as? [String: Any]
+        )
+        XCTAssertEqual(object["type"] as? String, "rc:variables")
+        XCTAssertEqual(object["component_id"] as? String, Self.componentID)
+        let variables = try XCTUnwrap(object["variables"] as? [String: Any])
+        XCTAssertEqual(variables["locale"] as? String, "en-US")
+        XCTAssertEqual((variables["custom"] as? [String: Any])?["plan"] as? String, hostile)
+    }
+
+    func testControllerSkipsDeliveryWhenURLMismatches() throws {
+        let webView = self.loadedWebView(html: Self.receiverHTML)
+
+        let controller = PaywallWebViewController(
+            webView: webView,
+            componentID: Self.componentID,
+            expectedLoadedURL: URL(string: "https://different.example.com/elsewhere")!
+        )
+        controller.postVariables(componentID: Self.componentID, variables: ["locale": .string("en-US")])
+
+        // The receive hook must never fire for a mismatched expected URL.
+        let state = try XCTUnwrap(self.pollString(
+            in: webView,
+            script: "window.__rcReceived === null ? 'NULL' : 'GOT'"
+        ))
+        XCTAssertEqual(state, "NULL")
+    }
+
+#endif
+
+    // MARK: - Helpers
+
+    private func bridge(
+        baseVariables: [String: PaywallWebViewValue] = [:],
+        messageAction: @escaping @MainActor (PaywallWebViewMessage, PaywallWebViewController) -> Void
+    ) -> WebViewBridgeConfiguration {
+        WebViewBridgeConfiguration(
+            componentID: Self.componentID,
+            messageAction: PaywallWebViewMessageAction(messageAction),
+            baseVariables: baseVariables
+        )
+    }
+
+    private func makeController() -> PaywallWebViewController {
+        #if canImport(WebKit)
+        return PaywallWebViewController(webView: nil, componentID: Self.componentID, expectedLoadedURL: nil)
+        #else
+        return PaywallWebViewController(componentID: Self.componentID, expectedLoadedURL: nil)
+        #endif
+    }
+
+    /// Extracts the JSON object literal embedded between `var m=` and `;if(typeof` in the receive
+    /// script, for assertion purposes.
+    private func embeddedJSON(in script: String) -> String? {
+        guard let start = script.range(of: "var m="),
+              let end = script.range(of: ";if(typeof") else {
+            return nil
+        }
+        return String(script[start.upperBound..<end.lowerBound])
+    }
+
+#if canImport(WebKit)
+
+    /// HTML whose receive hook stores the last message it gets as a JSON string on `window.__rcReceived`.
+    private static let receiverHTML = """
+    <html><body><script>
+    window.__rcReceived = null;
+    window.__revenueCatReceiveMessage = function(m) { window.__rcReceived = JSON.stringify(m); };
+    </script></body></html>
+    """
+
+    /// Keeps navigation delegates alive for the duration of a test (`WKWebView.navigationDelegate` is weak).
+    private var retainedDelegates: [AnyObject] = []
+
+    private func loadedWebView(
+        html: String,
+        configuration: WKWebViewConfiguration = WKWebViewConfiguration()
+    ) -> WKWebView {
+        if configuration.userContentController.userScripts.isEmpty {
+            configuration.userContentController.addUserScript(PaywallWebViewScripts.messageBridgeUserScript)
+        }
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+
+        let loaded = self.expectation(description: "web view finished loading")
+        let delegate = TestNavigationDelegate { loaded.fulfill() }
+        self.retainedDelegates.append(delegate)
+        webView.navigationDelegate = delegate
+        webView.loadHTMLString(html, baseURL: URL(string: "https://example.com"))
+        self.wait(for: [loaded], timeout: 10)
+
+        return webView
+    }
+
+    /// Repeatedly evaluates `script` until it returns a non-nil string or the timeout elapses.
+    private func pollString(in webView: WKWebView, script: String, timeout: TimeInterval = 5) -> String? {
+        let deadline = Date().addingTimeInterval(timeout)
+        var result: String?
+
+        while result == nil && Date() < deadline {
+            let evaluated = self.expectation(description: "evaluate \(script)")
+            webView.evaluateJavaScript(script) { value, _ in
+                result = value as? String
+                evaluated.fulfill()
+            }
+            self.wait(for: [evaluated], timeout: 2)
+
+            if result == nil {
+                RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+            }
+        }
+
+        return result
+    }
+
+#endif
+
+}
+
+#if canImport(WebKit)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private final class TestScriptMessageHandler: NSObject, WKScriptMessageHandler {
+
+    private let onMessage: (WKScriptMessage) -> Void
+
+    init(onMessage: @escaping (WKScriptMessage) -> Void) {
+        self.onMessage = onMessage
+    }
+
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage
+    ) {
+        self.onMessage(message)
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private final class TestNavigationDelegate: NSObject, WKNavigationDelegate {
+
+    private let onFinish: () -> Void
+    private var finished = false
+
+    init(onFinish: @escaping () -> Void) {
+        self.onFinish = onFinish
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        guard !self.finished else { return }
+        self.finished = true
+        self.onFinish()
+    }
+
+}
+
+#endif
+
+#endif

--- a/api/revenuecatui-api-ios-simulator.swiftinterface
+++ b/api/revenuecatui-api-ios-simulator.swiftinterface
@@ -340,6 +340,11 @@ open class CustomPaywallFontProvider : RevenueCatUI.PaywallFontProvider {
   @available(tvOS, unavailable, introduced: 15.0, message: "RevenueCatUI does not support tvOS yet")
   public typealias Body = @_opaqueReturnTypeOf("$s12RevenueCatUI11PaywallViewV4bodyQrvp", 0) __
 }
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@_Concurrency.MainActor public struct PaywallWebViewController {
+  @_Concurrency.MainActor public func postVariables(componentID: Swift.String, variables: [Swift.String : RevenueCatUI.PaywallWebViewValue])
+  @_Concurrency.MainActor public func postMessage(componentID: Swift.String, type: Swift.String, variables: [Swift.String : RevenueCatUI.PaywallWebViewValue])
+}
 extension RevenueCat.Purchases {
   @available(iOS 15.0, macOS 12.0, *)
   @_Concurrency.MainActor @objc final public func presentPaywall(from url: Foundation.URL, viewController: UIKit.UIViewController?) -> Swift.Bool
@@ -424,6 +429,15 @@ extension RevenueCatUI.PaywallViewController : UIKit.UIAdaptivePresentationContr
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension SwiftUICore.View {
   @_Concurrency.MainActor @preconcurrency public func onWebPurchaseRedemptionAttempt(perform completion: @escaping @Sendable (RevenueCat.WebPurchaseRedemptionResult) -> Swift.Void) -> some SwiftUICore.View
+  
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public struct PaywallWebViewMessageAction {
+  public init(_ action: @escaping @_Concurrency.MainActor (RevenueCatUI.PaywallWebViewMessage, RevenueCatUI.PaywallWebViewController) -> Swift.Void)
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension SwiftUICore.View {
+  @_Concurrency.MainActor @preconcurrency public func onPaywallWebViewMessage(_ action: @escaping @_Concurrency.MainActor (RevenueCatUI.PaywallWebViewMessage, RevenueCatUI.PaywallWebViewController) -> Swift.Void) -> some SwiftUICore.View
   
 }
 public enum PaywallPresentationMode {
@@ -587,5 +601,7 @@ extension RevenueCatUI.CustomerCenterNavigationLink : Swift.Sendable {}
 @available(iOS 15.0, macOS 12.0, watchOS 8.0, *)
 @available(tvOS, unavailable, message: "RevenueCatUI does not support tvOS yet")
 extension RevenueCatUI.PaywallView : Swift.Sendable {}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.PaywallWebViewController : Swift.Sendable {}
 extension RevenueCatUI.PaywallPresentationMode : Swift.Equatable {}
 extension RevenueCatUI.PaywallPresentationMode : Swift.Hashable {}

--- a/api/revenuecatui-api-ios.swiftinterface
+++ b/api/revenuecatui-api-ios.swiftinterface
@@ -340,6 +340,11 @@ open class CustomPaywallFontProvider : RevenueCatUI.PaywallFontProvider {
   @available(tvOS, unavailable, introduced: 15.0, message: "RevenueCatUI does not support tvOS yet")
   public typealias Body = @_opaqueReturnTypeOf("$s12RevenueCatUI11PaywallViewV4bodyQrvp", 0) __
 }
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@_Concurrency.MainActor public struct PaywallWebViewController {
+  @_Concurrency.MainActor public func postVariables(componentID: Swift.String, variables: [Swift.String : RevenueCatUI.PaywallWebViewValue])
+  @_Concurrency.MainActor public func postMessage(componentID: Swift.String, type: Swift.String, variables: [Swift.String : RevenueCatUI.PaywallWebViewValue])
+}
 extension RevenueCat.Purchases {
   @available(iOS 15.0, macOS 12.0, *)
   @_Concurrency.MainActor @objc final public func presentPaywall(from url: Foundation.URL, viewController: UIKit.UIViewController?) -> Swift.Bool
@@ -424,6 +429,15 @@ extension RevenueCatUI.PaywallViewController : UIKit.UIAdaptivePresentationContr
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension SwiftUICore.View {
   @_Concurrency.MainActor @preconcurrency public func onWebPurchaseRedemptionAttempt(perform completion: @escaping @Sendable (RevenueCat.WebPurchaseRedemptionResult) -> Swift.Void) -> some SwiftUICore.View
+  
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public struct PaywallWebViewMessageAction {
+  public init(_ action: @escaping @_Concurrency.MainActor (RevenueCatUI.PaywallWebViewMessage, RevenueCatUI.PaywallWebViewController) -> Swift.Void)
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension SwiftUICore.View {
+  @_Concurrency.MainActor @preconcurrency public func onPaywallWebViewMessage(_ action: @escaping @_Concurrency.MainActor (RevenueCatUI.PaywallWebViewMessage, RevenueCatUI.PaywallWebViewController) -> Swift.Void) -> some SwiftUICore.View
   
 }
 public enum PaywallPresentationMode {
@@ -587,5 +601,7 @@ extension RevenueCatUI.CustomerCenterNavigationLink : Swift.Sendable {}
 @available(iOS 15.0, macOS 12.0, watchOS 8.0, *)
 @available(tvOS, unavailable, message: "RevenueCatUI does not support tvOS yet")
 extension RevenueCatUI.PaywallView : Swift.Sendable {}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.PaywallWebViewController : Swift.Sendable {}
 extension RevenueCatUI.PaywallPresentationMode : Swift.Equatable {}
 extension RevenueCatUI.PaywallPresentationMode : Swift.Hashable {}

--- a/api/revenuecatui-api-macos.swiftinterface
+++ b/api/revenuecatui-api-macos.swiftinterface
@@ -209,9 +209,23 @@ open class CustomPaywallFontProvider : RevenueCatUI.PaywallFontProvider {
   @available(tvOS, unavailable, introduced: 15.0, message: "RevenueCatUI does not support tvOS yet")
   public typealias Body = @_opaqueReturnTypeOf("$s12RevenueCatUI11PaywallViewV4bodyQrvp", 0) __
 }
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@_Concurrency.MainActor public struct PaywallWebViewController {
+  @_Concurrency.MainActor public func postVariables(componentID: Swift.String, variables: [Swift.String : RevenueCatUI.PaywallWebViewValue])
+  @_Concurrency.MainActor public func postMessage(componentID: Swift.String, type: Swift.String, variables: [Swift.String : RevenueCatUI.PaywallWebViewValue])
+}
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension SwiftUICore.View {
   @_Concurrency.MainActor @preconcurrency public func onWebPurchaseRedemptionAttempt(perform completion: @escaping @Sendable (RevenueCat.WebPurchaseRedemptionResult) -> Swift.Void) -> some SwiftUICore.View
+  
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public struct PaywallWebViewMessageAction {
+  public init(_ action: @escaping @_Concurrency.MainActor (RevenueCatUI.PaywallWebViewMessage, RevenueCatUI.PaywallWebViewController) -> Swift.Void)
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension SwiftUICore.View {
+  @_Concurrency.MainActor @preconcurrency public func onPaywallWebViewMessage(_ action: @escaping @_Concurrency.MainActor (RevenueCatUI.PaywallWebViewMessage, RevenueCatUI.PaywallWebViewController) -> Swift.Void) -> some SwiftUICore.View
   
 }
 public enum PaywallPresentationMode {
@@ -365,5 +379,7 @@ extension SwiftUICore.View {
 @available(iOS 15.0, macOS 12.0, watchOS 8.0, *)
 @available(tvOS, unavailable, message: "RevenueCatUI does not support tvOS yet")
 extension RevenueCatUI.PaywallView : Swift.Sendable {}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.PaywallWebViewController : Swift.Sendable {}
 extension RevenueCatUI.PaywallPresentationMode : Swift.Equatable {}
 extension RevenueCatUI.PaywallPresentationMode : Swift.Hashable {}

--- a/api/revenuecatui-api-visionos-simulator.swiftinterface
+++ b/api/revenuecatui-api-visionos-simulator.swiftinterface
@@ -210,6 +210,11 @@ open class CustomPaywallFontProvider : RevenueCatUI.PaywallFontProvider {
   @available(tvOS, unavailable, introduced: 15.0, message: "RevenueCatUI does not support tvOS yet")
   public typealias Body = @_opaqueReturnTypeOf("$s12RevenueCatUI11PaywallViewV4bodyQrvp", 0) __
 }
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@_Concurrency.MainActor public struct PaywallWebViewController {
+  @_Concurrency.MainActor public func postVariables(componentID: Swift.String, variables: [Swift.String : RevenueCatUI.PaywallWebViewValue])
+  @_Concurrency.MainActor public func postMessage(componentID: Swift.String, type: Swift.String, variables: [Swift.String : RevenueCatUI.PaywallWebViewValue])
+}
 extension RevenueCat.Purchases {
   @available(iOS 15.0, macOS 12.0, *)
   @_Concurrency.MainActor @objc final public func presentPaywall(from url: Foundation.URL, viewController: UIKit.UIViewController?) -> Swift.Bool
@@ -294,6 +299,15 @@ extension RevenueCatUI.PaywallViewController : UIKit.UIAdaptivePresentationContr
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension SwiftUICore.View {
   @_Concurrency.MainActor @preconcurrency public func onWebPurchaseRedemptionAttempt(perform completion: @escaping @Sendable (RevenueCat.WebPurchaseRedemptionResult) -> Swift.Void) -> some SwiftUICore.View
+  
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public struct PaywallWebViewMessageAction {
+  public init(_ action: @escaping @_Concurrency.MainActor (RevenueCatUI.PaywallWebViewMessage, RevenueCatUI.PaywallWebViewController) -> Swift.Void)
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension SwiftUICore.View {
+  @_Concurrency.MainActor @preconcurrency public func onPaywallWebViewMessage(_ action: @escaping @_Concurrency.MainActor (RevenueCatUI.PaywallWebViewMessage, RevenueCatUI.PaywallWebViewController) -> Swift.Void) -> some SwiftUICore.View
   
 }
 public enum PaywallPresentationMode {
@@ -447,5 +461,7 @@ extension SwiftUICore.View {
 @available(iOS 15.0, macOS 12.0, watchOS 8.0, *)
 @available(tvOS, unavailable, message: "RevenueCatUI does not support tvOS yet")
 extension RevenueCatUI.PaywallView : Swift.Sendable {}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.PaywallWebViewController : Swift.Sendable {}
 extension RevenueCatUI.PaywallPresentationMode : Swift.Equatable {}
 extension RevenueCatUI.PaywallPresentationMode : Swift.Hashable {}

--- a/api/revenuecatui-api-visionos.swiftinterface
+++ b/api/revenuecatui-api-visionos.swiftinterface
@@ -210,6 +210,11 @@ open class CustomPaywallFontProvider : RevenueCatUI.PaywallFontProvider {
   @available(tvOS, unavailable, introduced: 15.0, message: "RevenueCatUI does not support tvOS yet")
   public typealias Body = @_opaqueReturnTypeOf("$s12RevenueCatUI11PaywallViewV4bodyQrvp", 0) __
 }
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@_Concurrency.MainActor public struct PaywallWebViewController {
+  @_Concurrency.MainActor public func postVariables(componentID: Swift.String, variables: [Swift.String : RevenueCatUI.PaywallWebViewValue])
+  @_Concurrency.MainActor public func postMessage(componentID: Swift.String, type: Swift.String, variables: [Swift.String : RevenueCatUI.PaywallWebViewValue])
+}
 extension RevenueCat.Purchases {
   @available(iOS 15.0, macOS 12.0, *)
   @_Concurrency.MainActor @objc final public func presentPaywall(from url: Foundation.URL, viewController: UIKit.UIViewController?) -> Swift.Bool
@@ -294,6 +299,15 @@ extension RevenueCatUI.PaywallViewController : UIKit.UIAdaptivePresentationContr
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension SwiftUICore.View {
   @_Concurrency.MainActor @preconcurrency public func onWebPurchaseRedemptionAttempt(perform completion: @escaping @Sendable (RevenueCat.WebPurchaseRedemptionResult) -> Swift.Void) -> some SwiftUICore.View
+  
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public struct PaywallWebViewMessageAction {
+  public init(_ action: @escaping @_Concurrency.MainActor (RevenueCatUI.PaywallWebViewMessage, RevenueCatUI.PaywallWebViewController) -> Swift.Void)
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension SwiftUICore.View {
+  @_Concurrency.MainActor @preconcurrency public func onPaywallWebViewMessage(_ action: @escaping @_Concurrency.MainActor (RevenueCatUI.PaywallWebViewMessage, RevenueCatUI.PaywallWebViewController) -> Swift.Void) -> some SwiftUICore.View
   
 }
 public enum PaywallPresentationMode {
@@ -447,5 +461,7 @@ extension SwiftUICore.View {
 @available(iOS 15.0, macOS 12.0, watchOS 8.0, *)
 @available(tvOS, unavailable, message: "RevenueCatUI does not support tvOS yet")
 extension RevenueCatUI.PaywallView : Swift.Sendable {}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.PaywallWebViewController : Swift.Sendable {}
 extension RevenueCatUI.PaywallPresentationMode : Swift.Equatable {}
 extension RevenueCatUI.PaywallPresentationMode : Swift.Hashable {}


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Let a `web_view` component and the host app exchange messages (the public bridge API that ties the stack together).

### Description
Wires the bridge into the iOS and macOS renderers and exposes the public surface: `onPaywallWebViewMessage(_:)`, `PaywallWebViewController`, and `PaywallWebViewMessageAction`. Web content calls `window.RevenueCatWebView.postMessage(...)`; the SDK validates and routes messages and auto-replies to `rc:request-variables` with the SDK-managed `locale`. The app decides all behavior — the SDK never auto-dismisses or purchases. Sending the paywall's custom variables is intentionally out of scope for v1.

Covered by dispatcher/variables/controller-escaping unit tests plus a live WKWebView round-trip test. (Exceeds the 300-line check — `PaywallWebViewController` and the public modifier are necessary new files — hence the `skip-pr-lines-changed-check` label.)

> Adds public API, so the `revenuecatui` swiftinterface baselines need regenerating — the `check-api-changes-revenuecatui` failure is expected until that runs.