### PR TITLE
feat(remote-config): add RemoteConfigSourceProvider for source failover

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -121,6 +121,8 @@
 		1D58A16C2ED59AD90086809D /* ConnectionErrorReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D58A16B2ED59AD90086809D /* ConnectionErrorReason.swift */; };
 		1D73D6612EBDD5CB00A9F0F3 /* MockHTTPRequestTimeoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D73D6602EBDD5CB00A9F0F3 /* MockHTTPRequestTimeoutManager.swift */; };
 		1D73D6622EBDD5CB00A9F0F3 /* MockHTTPRequestTimeoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D73D6602EBDD5CB00A9F0F3 /* MockHTTPRequestTimeoutManager.swift */; };
+		FEDA000000000000000000E1 /* MockRemoteConfigSourceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA000000000000000000E0 /* MockRemoteConfigSourceProvider.swift */; };
+		FEDA000000000000000000E2 /* MockRemoteConfigSourceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA000000000000000000E0 /* MockRemoteConfigSourceProvider.swift */; };
 		1D76F2532F921C8F00863AF8 /* ComponentInteractionData+Factories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D76F2522F921C8F00863AF8 /* ComponentInteractionData+Factories.swift */; };
 		1D76F25A2F921CA100863AF8 /* PlanSelectionDefaultPackage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D76F2592F921CA100863AF8 /* PlanSelectionDefaultPackage.swift */; };
 		1DB9B2A72E57373900252D58 /* OfferingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB9B2A62E57373600252D58 /* OfferingTests.swift */; };
@@ -1634,6 +1636,7 @@
 		1D291F712F154834008E4FDA /* CacheStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheStrings.swift; sourceTree = "<group>"; };
 		1D58A16B2ED59AD90086809D /* ConnectionErrorReason.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionErrorReason.swift; sourceTree = "<group>"; };
 		1D73D6602EBDD5CB00A9F0F3 /* MockHTTPRequestTimeoutManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHTTPRequestTimeoutManager.swift; sourceTree = "<group>"; };
+		FEDA000000000000000000E0 /* MockRemoteConfigSourceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRemoteConfigSourceProvider.swift; sourceTree = "<group>"; };
 		1D76F2522F921C8F00863AF8 /* ComponentInteractionData+Factories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ComponentInteractionData+Factories.swift"; sourceTree = "<group>"; };
 		1D76F2592F921CA100863AF8 /* PlanSelectionDefaultPackage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanSelectionDefaultPackage.swift; sourceTree = "<group>"; };
 		1D76F25B2F921D3500863AF8 /* PaywallEventTrackerTestDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallEventTrackerTestDispatcher.swift; sourceTree = "<group>"; };
@@ -4127,6 +4130,7 @@
 				351B515926D44B6200BD2BD7 /* MockAttributionFetcher.swift */,
 				351B514426D449E600BD2BD7 /* MockAttributionTypeFactory.swift */,
 				1D73D6602EBDD5CB00A9F0F3 /* MockHTTPRequestTimeoutManager.swift */,
+				FEDA000000000000000000E0 /* MockRemoteConfigSourceProvider.swift */,
 				351B514026D4498F00BD2BD7 /* MockBackend.swift */,
 				4FA4C9722A16D3AC007D2803 /* MockBackendConfiguration.swift */,
 				A563F585271E072B00246E0C /* MockBeginRefundRequestHelper.swift */,
@@ -6994,6 +6998,7 @@
 				57057FF928B0048900995F21 /* TestLogHandler.swift in Sources */,
 				4F69EB0A2A14406E00ED6D4B /* Matchers.swift in Sources */,
 				1D73D6612EBDD5CB00A9F0F3 /* MockHTTPRequestTimeoutManager.swift in Sources */,
+				FEDA000000000000000000E1 /* MockRemoteConfigSourceProvider.swift in Sources */,
 				7571BE9F2D672B2C00A2C8B6 /* TrialOrIntroPriceEligibilityCheckerUIPreviewModeTests.swift in Sources */,
 				2D90F8C226FD20F7009B9142 /* MockETagManager.swift in Sources */,
 				2D90F8B526FD2093009B9142 /* MockSystemInfo.swift in Sources */,
@@ -7827,6 +7832,7 @@
 				2C8EC6DF2CCD27A500D6CCF8 /* PartialComponentTests.swift in Sources */,
 				351B51A326D450BC00BD2BD7 /* DictionaryExtensionsTests.swift in Sources */,
 				1D73D6622EBDD5CB00A9F0F3 /* MockHTTPRequestTimeoutManager.swift in Sources */,
+				FEDA000000000000000000E2 /* MockRemoteConfigSourceProvider.swift in Sources */,
 				4FB2B5512AA7DBA40087EDB5 /* MockFileHandler.swift in Sources */,
 				758593482E37F77700B8E6CE /* WebBillingProductsDecodingTests.swift in Sources */,
 				03A98CEF2D1EE048009BCA61 /* FallbackComponentTests.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -413,6 +413,7 @@
 		37E35C8515C5E2D01B0AF5C1 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3507939634ED5A9280544 /* Strings.swift */; };
 		3B41364A5DFC4039B3026F40 /* RemoteConfigAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A2DB969D72432B87F48C5F /* RemoteConfigAPI.swift */; };
 		FEDA000000000000000000B2 /* WeightedSourceSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA000000000000000000A2 /* WeightedSourceSelector.swift */; };
+		FEDA000000000000000000D2 /* RemoteConfigSourceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA000000000000000000C2 /* RemoteConfigSourceProvider.swift */; };
 		3DD6C3CC5EC6B69E9DA9571D /* Evaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B78483ACCDD62ABD40AF8827 /* Evaluator.swift */; };
 		424117A427E05CDDE5CAB803 /* LogicOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EF5BB0DF2CED359AB0089B4 /* LogicOperators.swift */; };
 		42F1DF385E3C1F9903A07FBF /* ProductsFetcherSK1.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB3CBAA73855779FE828CE2 /* ProductsFetcherSK1.swift */; };
@@ -972,6 +973,7 @@
 		839F343B2E3BC5C8006355B0 /* PlatformBezierPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839F343A2E3BC5C4006355B0 /* PlatformBezierPath.swift */; };
 		858195FCF0E04E3CAA99F9BB /* RemoteConfigurationDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E31E8A264E9F4375A3B29D78 /* RemoteConfigurationDecodingTests.swift */; };
 		FEDA000000000000000000B1 /* WeightedSourceSelectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA000000000000000000A1 /* WeightedSourceSelectorTests.swift */; };
+		FEDA000000000000000000D1 /* RemoteConfigSourceProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA000000000000000000C1 /* RemoteConfigSourceProviderTests.swift */; };
 		887A5FBD2C1D036200E1A461 /* RevenueCatUIDev.h in Headers */ = {isa = PBXBuildFile; fileRef = 887A5FBC2C1D036200E1A461 /* RevenueCatUIDev.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		887A60672C1D037000E1A461 /* PaywallError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A5FC72C1D037000E1A461 /* PaywallError.swift */; };
 		887A60682C1D037000E1A461 /* TemplateError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A5FC82C1D037000E1A461 /* TemplateError.swift */; };
@@ -2901,6 +2903,7 @@
 		A1B2C3D42FE2000000000008 /* RemoteConfigDiskCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigDiskCacheTests.swift; sourceTree = "<group>"; };
 		E31E8A264E9F4375A3B29D78 /* RemoteConfigurationDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigurationDecodingTests.swift; sourceTree = "<group>"; };
 		FEDA000000000000000000A1 /* WeightedSourceSelectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightedSourceSelectorTests.swift; sourceTree = "<group>"; };
+		FEDA000000000000000000C1 /* RemoteConfigSourceProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigSourceProviderTests.swift; sourceTree = "<group>"; };
 		E35BAD07C46D469D8CC7C396 /* RemoteConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfiguration.swift; sourceTree = "<group>"; };
 		E51CFC7D19BE49D2BA1A79CC /* CapturingLogger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CapturingLogger.swift; sourceTree = "<group>"; };
 		E78770053AB84EF380CC0C1D /* TextComponentViewLoadingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextComponentViewLoadingTests.swift; sourceTree = "<group>"; };
@@ -2909,6 +2912,7 @@
 		F1A05E9E1B04B32B832DB194 /* PaywallCountdownComponent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaywallCountdownComponent.swift; sourceTree = "<group>"; };
 		F3A2DB969D72432B87F48C5F /* RemoteConfigAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigAPI.swift; sourceTree = "<group>"; };
 		FEDA000000000000000000A2 /* WeightedSourceSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightedSourceSelector.swift; sourceTree = "<group>"; };
+		FEDA000000000000000000C2 /* RemoteConfigSourceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigSourceProvider.swift; sourceTree = "<group>"; };
 		F468C7BCEB786BEC80277ECA /* WorkflowNavigatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowNavigatorTests.swift; sourceTree = "<group>"; };
 		F516BD28282434070083480B /* StoreKit2StorefrontListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2StorefrontListener.swift; sourceTree = "<group>"; };
 		F516BD322828FDD90083480B /* StoreKit2StorefrontListenerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2StorefrontListenerTests.swift; sourceTree = "<group>"; };
@@ -4539,6 +4543,7 @@
 				A1B2C3D42FE1000000000008 /* RCContainer+Parser.swift */,
 				F3A2DB969D72432B87F48C5F /* RemoteConfigAPI.swift */,
 				FEDA000000000000000000A2 /* WeightedSourceSelector.swift */,
+				FEDA000000000000000000C2 /* RemoteConfigSourceProvider.swift */,
 				A1B2C3D42FE2000000000001 /* RemoteConfigDiskCache.swift */,
 				A1B2C3D42FE1000000000011 /* RemoteConfigSignatureContextProvider.swift */,
 			);
@@ -4556,6 +4561,7 @@
 				35D832FF262FAD8000E60AC5 /* ETagManagerTests.swift */,
 				1D20E1D72EBCF82900ABE4CD /* HTTPRequestTimeoutManager.swift */,
 				FEDA000000000000000000A1 /* WeightedSourceSelectorTests.swift */,
+				FEDA000000000000000000C1 /* RemoteConfigSourceProviderTests.swift */,
 				B380D69A27726AB500984578 /* DNSCheckerTests.swift */,
 				576C8AD827D2BCB90058FA6E /* HTTPRequestTests.swift */,
 				57DC9F4927CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift */,
@@ -7167,6 +7173,7 @@
 				DB3395E12F840AA60079250C /* WorkflowsAPI.swift in Sources */,
 				3B41364A5DFC4039B3026F40 /* RemoteConfigAPI.swift in Sources */,
 				FEDA000000000000000000B2 /* WeightedSourceSelector.swift in Sources */,
+				FEDA000000000000000000D2 /* RemoteConfigSourceProvider.swift in Sources */,
 				E6B064598F674333A29E0781 /* RemoteConfigCallback.swift in Sources */,
 				A6CC43904EBD4860BFD2BD85 /* GetRemoteConfigOperation.swift in Sources */,
 				D62A9C83BFD14E5FA0452CC7 /* RemoteConfiguration.swift in Sources */,
@@ -7729,6 +7736,7 @@
 				DB7EA7762F964CA200BCC082 /* WorkflowResponseTests.swift in Sources */,
 				858195FCF0E04E3CAA99F9BB /* RemoteConfigurationDecodingTests.swift in Sources */,
 				FEDA000000000000000000B1 /* WeightedSourceSelectorTests.swift in Sources */,
+				FEDA000000000000000000D1 /* RemoteConfigSourceProviderTests.swift in Sources */,
 				A1B2C3D42FE1000000000004 /* RCContainerTests.swift in Sources */,
 				A1B2C3D42FE100000000000D /* RCContainerBackwardsCompatibilityTests.swift in Sources */,
 				A1B2C3D42FE100000000000E /* RCContainerTestData.swift in Sources */,

--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -11,6 +11,7 @@ enum RemoteConfigStrings {
 
     case failedToReadCache(Error)
     case failedToWriteCache
+    case duplicateSourceURL(String)
 
 }
 
@@ -22,6 +23,9 @@ extension RemoteConfigStrings: LogMessage {
             return "Failed to read remote config cache from disk: \(error.localizedDescription)"
         case .failedToWriteCache:
             return "Failed to write remote config cache to disk."
+        case let .duplicateSourceURL(url):
+            return "Found remote config sources sharing the same URL with conflicting priority/weight " +
+                "(\(url)). Keeping the highest-priority one, tie-broken by weight."
         }
     }
 

--- a/Sources/Networking/RemoteConfigSourceProvider.swift
+++ b/Sources/Networking/RemoteConfigSourceProvider.swift
@@ -35,9 +35,7 @@ struct RemoteConfigEndpoint<Source: RemoteConfigSource> {
 /// Hands out the current healthy remote config endpoint and falls back to the next one when the
 /// current endpoint is reported unhealthy. Order is computed once via `WeightedSourceSelector`.
 ///
-/// - Note: Thread-safe. If several callers hold the same endpoint and all report it unhealthy, only
-///   the first report advances; the rest carry a stale `token` and are ignored, so a single failing
-///   endpoint can't advance the order more than once.
+/// - Note: Thread-safe.
 final class RemoteConfigSourceProvider<Source: RemoteConfigSource> {
 
     private let selector: WeightedSourceSelector<Source>
@@ -61,6 +59,8 @@ final class RemoteConfigSourceProvider<Source: RemoteConfigSource> {
     /// is no longer the current one.
     func reportUnhealthy(_ endpoint: RemoteConfigEndpoint<Source>) {
         self.lock.perform {
+            // Stale token: a concurrent caller already advanced past this endpoint. Ignore so a
+            // single failing endpoint can't advance the order more than once.
             guard endpoint.token == self.currentToken else { return }
             self.advance()
         }

--- a/Sources/Networking/RemoteConfigSourceProvider.swift
+++ b/Sources/Networking/RemoteConfigSourceProvider.swift
@@ -23,17 +23,12 @@ struct RemoteConfigSources {
     let api: [RemoteConfigSource]
     let blob: [RemoteConfigSource]
 
-    init(api: [RemoteConfigSource], blob: [RemoteConfigSource]) {
-        self.api = api
-        self.blob = blob
-    }
-
 }
 
 /// An endpoint handed out by a `RemoteConfigSourceProvider`. Report it back via `reportUnhealthy(_:)`
 /// to fall back to the next source. The `url` is its identity: a report is ignored once the provider
 /// has already moved past that url.
-struct RemoteConfigEndpoint: WeightedSource, Equatable {
+struct RemoteConfigEndpoint: WeightedSource {
 
     enum Kind {
         case api
@@ -47,10 +42,6 @@ struct RemoteConfigEndpoint: WeightedSource, Equatable {
     var url: String { self.source.url }
     var priority: Int { self.source.priority }
     var weight: Int { self.source.weight }
-
-    static func == (lhs: RemoteConfigEndpoint, rhs: RemoteConfigEndpoint) -> Bool {
-        return lhs.kind == rhs.kind && lhs.url == rhs.url
-    }
 
 }
 

--- a/Sources/Networking/RemoteConfigSourceProvider.swift
+++ b/Sources/Networking/RemoteConfigSourceProvider.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A remote config source: a URL plus the metadata used to order sources.
-struct RemoteConfigSource: WeightedSource, Equatable {
+struct RemoteConfigSource {
 
     /// A plain URL or a URL format with placeholders (e.g. `{blob_ref}`), to be resolved by the caller.
     let url: String
@@ -18,12 +18,12 @@ struct RemoteConfigSource: WeightedSource, Equatable {
 }
 
 /// The api and blob sources for the remote config, as provided by the `sources` topic.
-struct RemoteConfigSources: Equatable {
+struct RemoteConfigSources {
 
     let api: [RemoteConfigSource]
     let blob: [RemoteConfigSource]
 
-    init(api: [RemoteConfigSource] = [], blob: [RemoteConfigSource] = []) {
+    init(api: [RemoteConfigSource], blob: [RemoteConfigSource]) {
         self.api = api
         self.blob = blob
     }
@@ -41,19 +41,15 @@ struct RemoteConfigEndpoint: WeightedSource, Equatable {
     }
 
     let kind: Kind
+    let source: RemoteConfigSource
 
     /// A plain URL or a URL format with placeholders, to be resolved by the caller.
-    let url: String
+    var url: String { self.source.url }
+    var priority: Int { self.source.priority }
+    var weight: Int { self.source.weight }
 
-    /// Selection metadata, used to order endpoints within a kind.
-    let priority: Int
-    let weight: Int
-
-    init(kind: Kind, url: String, priority: Int = 0, weight: Int = 0) {
-        self.kind = kind
-        self.url = url
-        self.priority = priority
-        self.weight = weight
+    static func == (lhs: RemoteConfigEndpoint, rhs: RemoteConfigEndpoint) -> Bool {
+        return lhs.kind == rhs.kind && lhs.url == rhs.url
     }
 
 }
@@ -69,8 +65,8 @@ protocol RemoteConfigSourceProviderType: AnyObject {
     /// Falls back to the next source for the endpoint's kind. No-op if `endpoint` is no longer current.
     func reportUnhealthy(_ endpoint: RemoteConfigEndpoint)
 
-    /// Rewinds both api and blob to their first source, e.g. to start fresh on a new fetch cycle.
-    func restart()
+    /// Rewinds the given kind to its first source, e.g. to start fresh on a new fetch cycle.
+    func restart(_ kind: RemoteConfigEndpoint.Kind)
 
 }
 
@@ -104,26 +100,37 @@ final class RemoteConfigSourceProvider: RemoteConfigSourceProviderType {
         }
     }
 
-    func restart() {
-        self.api.restart()
-        self.blob.restart()
+    func restart(_ kind: RemoteConfigEndpoint.Kind) {
+        switch kind {
+        case .api: self.api.restart()
+        case .blob: self.blob.restart()
+        }
     }
 
-    /// Builds the endpoints for a kind, keeping the first occurrence of each url and dropping later
-    /// duplicates. Done once here so endpoints never need to be rebuilt on reads.
+    /// Builds the endpoints for a kind, collapsing duplicate urls to the occurrence with the highest
+    /// priority (tie-broken by weight). Done once here so endpoints never need to be rebuilt on reads.
     private static func endpoints(
         from sources: [RemoteConfigSource],
         kind: RemoteConfigEndpoint.Kind
     ) -> [RemoteConfigEndpoint] {
-        var seenURLs = Set<String>()
-        return sources.compactMap { source in
-            guard seenURLs.insert(source.url).inserted else { return nil }
-            return RemoteConfigEndpoint(
-                kind: kind,
-                url: source.url,
-                priority: source.priority,
-                weight: source.weight
-            )
+        var bestByURL: [String: RemoteConfigSource] = [:]
+        var order: [String] = []
+        for source in sources {
+            guard let existing = bestByURL[source.url] else {
+                bestByURL[source.url] = source
+                order.append(source.url)
+                continue
+            }
+            if source.priority != existing.priority || source.weight != existing.weight {
+                Logger.debug(Strings.remoteConfig.duplicateSourceURL(source.url))
+            }
+            if source.priority > existing.priority ||
+                (source.priority == existing.priority && source.weight > existing.weight) {
+                bestByURL[source.url] = source
+            }
+        }
+        return order.compactMap { url in
+            bestByURL[url].map { RemoteConfigEndpoint(kind: kind, source: $0) }
         }
     }
 

--- a/Sources/Networking/RemoteConfigSourceProvider.swift
+++ b/Sources/Networking/RemoteConfigSourceProvider.swift
@@ -25,17 +25,18 @@ struct RemoteConfigSources {
 
 }
 
-/// An endpoint handed out by a `RemoteConfigSourceProvider`. Report it back via `reportUnhealthy(_:)`
-/// to fall back to the next source. The `url` is its identity: a report is ignored once the provider
-/// has already moved past that url.
-struct RemoteConfigEndpoint: WeightedSource {
+/// A source handed out by a `RemoteConfigSourceProvider`, tagged with its purpose (api or blob).
+/// Report it back via `reportUnhealthy(_:)` to fall back to the next source. The `url` is its
+/// identity: a report is ignored once the provider has already moved past that url.
+struct RemoteConfigSourceHandle: WeightedSource {
 
-    enum Kind {
+    /// What the source is used for: calling the config api or downloading a blob.
+    enum Purpose {
         case api
         case blob
     }
 
-    let kind: Kind
+    let purpose: Purpose
     let source: RemoteConfigSource
 
     /// A plain URL or a URL format with placeholders, to be resolved by the caller.
@@ -47,22 +48,22 @@ struct RemoteConfigEndpoint: WeightedSource {
 
 protocol RemoteConfigSourceProviderType: AnyObject {
 
-    /// The current healthy api endpoint, or `nil` once every api source has been reported unhealthy.
-    var currentAPIEndpoint: RemoteConfigEndpoint? { get }
+    /// The current healthy api source, or `nil` once every api source has been reported unhealthy.
+    var currentAPISource: RemoteConfigSourceHandle? { get }
 
-    /// The current healthy blob endpoint, or `nil` once every blob source has been reported unhealthy.
-    var currentBlobEndpoint: RemoteConfigEndpoint? { get }
+    /// The current healthy blob source, or `nil` once every blob source has been reported unhealthy.
+    var currentBlobSource: RemoteConfigSourceHandle? { get }
 
-    /// Falls back to the next source for the endpoint's kind. No-op if `endpoint` is no longer current.
-    func reportUnhealthy(_ endpoint: RemoteConfigEndpoint)
+    /// Falls back to the next source for the handle's purpose. No-op if `handle` is no longer current.
+    func reportUnhealthy(_ handle: RemoteConfigSourceHandle)
 
-    /// Rewinds the given kind to its first source, e.g. to start fresh on a new fetch cycle.
-    func restart(_ kind: RemoteConfigEndpoint.Kind)
+    /// Rewinds the given purpose to its first source, e.g. to start fresh on a new fetch cycle.
+    func restart(for purpose: RemoteConfigSourceHandle.Purpose)
 
 }
 
-/// The address book for remote config: hands out the current healthy api and blob endpoints and
-/// falls back to the next one when an endpoint is reported unhealthy. Each kind fails over
+/// The address book for remote config: hands out the current healthy api and blob sources and
+/// falls back to the next one when a source is reported unhealthy. Each purpose fails over
 /// independently. Sources are deduped by url and ordered once via `WeightedSourceSelector`.
 ///
 /// - Note: Thread-safe.
@@ -72,38 +73,38 @@ final class RemoteConfigSourceProvider: RemoteConfigSourceProviderType {
     private let blob: SourceFailover
 
     init(sources: RemoteConfigSources, randomizer: WeightedSourceRandomizer? = nil) {
-        self.api = SourceFailover(endpoints: Self.endpoints(from: sources.api, kind: .api), randomizer: randomizer)
-        self.blob = SourceFailover(endpoints: Self.endpoints(from: sources.blob, kind: .blob), randomizer: randomizer)
+        self.api = SourceFailover(handles: Self.handles(from: sources.api, purpose: .api), randomizer: randomizer)
+        self.blob = SourceFailover(handles: Self.handles(from: sources.blob, purpose: .blob), randomizer: randomizer)
     }
 
-    var currentAPIEndpoint: RemoteConfigEndpoint? {
+    var currentAPISource: RemoteConfigSourceHandle? {
         return self.api.current
     }
 
-    var currentBlobEndpoint: RemoteConfigEndpoint? {
+    var currentBlobSource: RemoteConfigSourceHandle? {
         return self.blob.current
     }
 
-    func reportUnhealthy(_ endpoint: RemoteConfigEndpoint) {
-        switch endpoint.kind {
-        case .api: self.api.reportUnhealthy(url: endpoint.url)
-        case .blob: self.blob.reportUnhealthy(url: endpoint.url)
+    func reportUnhealthy(_ handle: RemoteConfigSourceHandle) {
+        switch handle.purpose {
+        case .api: self.api.reportUnhealthy(url: handle.url)
+        case .blob: self.blob.reportUnhealthy(url: handle.url)
         }
     }
 
-    func restart(_ kind: RemoteConfigEndpoint.Kind) {
-        switch kind {
+    func restart(for purpose: RemoteConfigSourceHandle.Purpose) {
+        switch purpose {
         case .api: self.api.restart()
         case .blob: self.blob.restart()
         }
     }
 
-    /// Builds the endpoints for a kind, collapsing duplicate urls to the occurrence with the highest
-    /// priority (tie-broken by weight). Done once here so endpoints never need to be rebuilt on reads.
-    private static func endpoints(
+    /// Builds the handles for a purpose, collapsing duplicate urls to the occurrence with the highest
+    /// priority (tie-broken by weight). Done once here so handles never need to be rebuilt on reads.
+    private static func handles(
         from sources: [RemoteConfigSource],
-        kind: RemoteConfigEndpoint.Kind
-    ) -> [RemoteConfigEndpoint] {
+        purpose: RemoteConfigSourceHandle.Purpose
+    ) -> [RemoteConfigSourceHandle] {
         var bestByURL: [String: RemoteConfigSource] = [:]
         var order: [String] = []
         for source in sources {
@@ -121,32 +122,32 @@ final class RemoteConfigSourceProvider: RemoteConfigSourceProviderType {
             }
         }
         return order.compactMap { url in
-            bestByURL[url].map { RemoteConfigEndpoint(kind: kind, source: $0) }
+            bestByURL[url].map { RemoteConfigSourceHandle(purpose: purpose, source: $0) }
         }
     }
 
 }
 
-/// Walks a single list of endpoints in fallback order, using each endpoint's url as its identity so a
+/// Walks a single list of handles in fallback order, using each handle's url as its identity so a
 /// stale `reportUnhealthy(url:)` (one the list has already moved past) is ignored.
 ///
 /// - Note: Thread-safe.
 private final class SourceFailover {
 
-    private let selector: WeightedSourceSelector<RemoteConfigEndpoint>
+    private let selector: WeightedSourceSelector<RemoteConfigSourceHandle>
     private let lock = Lock()
 
-    init(endpoints: [RemoteConfigEndpoint], randomizer: WeightedSourceRandomizer?) {
-        self.selector = WeightedSourceSelector(sources: endpoints, randomizer: randomizer)
+    init(handles: [RemoteConfigSourceHandle], randomizer: WeightedSourceRandomizer?) {
+        self.selector = WeightedSourceSelector(sources: handles, randomizer: randomizer)
     }
 
-    var current: RemoteConfigEndpoint? {
+    var current: RemoteConfigSourceHandle? {
         return self.lock.perform { self.selector.current }
     }
 
     func reportUnhealthy(url: String) {
         self.lock.perform {
-            // Only advance when the report is about the current endpoint: a url the list has already
+            // Only advance when the report is about the current source: a url the list has already
             // moved past (e.g. from a concurrent caller) no longer matches, so it can't advance twice.
             guard self.selector.current?.url == url else { return }
             self.selector.advance()

--- a/Sources/Networking/RemoteConfigSourceProvider.swift
+++ b/Sources/Networking/RemoteConfigSourceProvider.swift
@@ -106,7 +106,7 @@ final class RemoteConfigSourceProvider: RemoteConfigSourceProviderType {
                 continue
             }
             if source.priority != existing.priority || source.weight != existing.weight {
-                Logger.debug(Strings.remoteConfig.duplicateSourceURL(source.url))
+                Logger.warn(Strings.remoteConfig.duplicateSourceURL(source.url))
             }
             if source.priority > existing.priority ||
                 (source.priority == existing.priority && source.weight > existing.weight) {

--- a/Sources/Networking/RemoteConfigSourceProvider.swift
+++ b/Sources/Networking/RemoteConfigSourceProvider.swift
@@ -1,0 +1,90 @@
+//
+//  RemoteConfigSourceProvider.swift
+//  RevenueCat
+//
+//  Created by Antonio Pallares on 26/06/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+
+/// A remote config source, plus the metadata used to order sources.
+protocol RemoteConfigSource: WeightedSource {
+
+    /// A plain URL or a URL format with placeholders (e.g. `{blob_ref}`), to be resolved by the caller.
+    var url: String { get }
+
+}
+
+/// An endpoint handed out by a `RemoteConfigSourceProvider`. The `token` lets the provider ignore
+/// `reportUnhealthy(_:)` calls about an endpoint it has already moved past.
+struct RemoteConfigEndpoint<Source: RemoteConfigSource> {
+
+    let source: Source
+
+    fileprivate let token: UUID
+
+    var url: String { self.source.url }
+
+    fileprivate init(source: Source, token: UUID) {
+        self.source = source
+        self.token = token
+    }
+
+}
+
+/// Hands out the current healthy remote config endpoint and falls back to the next one when the
+/// current endpoint is reported unhealthy. Order is computed once via `WeightedSourceSelector`.
+///
+/// - Note: Thread-safe. If several callers hold the same endpoint and all report it unhealthy, only
+///   the first report advances; the rest carry a stale `token` and are ignored, so a single failing
+///   endpoint can't advance the order more than once.
+final class RemoteConfigSourceProvider<Source: RemoteConfigSource> {
+
+    private let selector: WeightedSourceSelector<Source>
+    private let lock = Lock()
+
+    /// Regenerated on every `advance()` so previously handed-out endpoints become stale.
+    private var currentToken = UUID()
+
+    init(sources: [Source], randomizer: WeightedSourceRandomizer? = nil) {
+        self.selector = WeightedSourceSelector(sources: sources, randomizer: randomizer)
+    }
+
+    /// The current healthy endpoint, or `nil` once every source has been reported unhealthy.
+    var currentEndpoint: RemoteConfigEndpoint<Source>? {
+        return self.lock.perform {
+            self.makeCurrentEndpoint()
+        }
+    }
+
+    /// Advances to the next source so the next `currentEndpoint` read returns it. No-op if `endpoint`
+    /// is no longer the current one.
+    func reportUnhealthy(_ endpoint: RemoteConfigEndpoint<Source>) {
+        self.lock.perform {
+            guard endpoint.token == self.currentToken else { return }
+            self.advance()
+        }
+    }
+
+    /// Rewinds to the first source in the fallback order, e.g. to start fresh on a new fetch cycle.
+    func restart() {
+        self.lock.perform {
+            self.selector.reset()
+            self.currentToken = UUID()
+        }
+    }
+
+    /// Moves to the next source and invalidates previously handed-out endpoints.
+    /// Must be called while holding `lock`.
+    private func advance() {
+        self.selector.advance()
+        self.currentToken = UUID()
+    }
+
+    /// Must be called while holding `lock`.
+    private func makeCurrentEndpoint() -> RemoteConfigEndpoint<Source>? {
+        guard let source = self.selector.current else { return nil }
+        return RemoteConfigEndpoint(source: source, token: self.currentToken)
+    }
+
+}

--- a/Sources/Networking/RemoteConfigSourceProvider.swift
+++ b/Sources/Networking/RemoteConfigSourceProvider.swift
@@ -7,84 +7,156 @@
 
 import Foundation
 
-/// A remote config source, plus the metadata used to order sources.
-protocol RemoteConfigSource: WeightedSource {
+/// A remote config source: a URL plus the metadata used to order sources.
+struct RemoteConfigSource: WeightedSource, Equatable {
 
     /// A plain URL or a URL format with placeholders (e.g. `{blob_ref}`), to be resolved by the caller.
-    var url: String { get }
+    let url: String
+    let priority: Int
+    let weight: Int
 
 }
 
-/// An endpoint handed out by a `RemoteConfigSourceProvider`. The `token` lets the provider ignore
-/// `reportUnhealthy(_:)` calls about an endpoint it has already moved past.
-struct RemoteConfigEndpoint<Source: RemoteConfigSource> {
+/// The api and blob sources for the remote config, as provided by the `sources` topic.
+struct RemoteConfigSources: Equatable {
 
-    let source: Source
+    let api: [RemoteConfigSource]
+    let blob: [RemoteConfigSource]
 
-    fileprivate let token: UUID
-
-    var url: String { self.source.url }
-
-    fileprivate init(source: Source, token: UUID) {
-        self.source = source
-        self.token = token
+    init(api: [RemoteConfigSource] = [], blob: [RemoteConfigSource] = []) {
+        self.api = api
+        self.blob = blob
     }
 
 }
 
-/// Hands out the current healthy remote config endpoint and falls back to the next one when the
-/// current endpoint is reported unhealthy. Order is computed once via `WeightedSourceSelector`.
+/// An endpoint handed out by a `RemoteConfigSourceProvider`. Report it back via `reportUnhealthy(_:)`
+/// to fall back to the next source. The `url` is its identity: a report is ignored once the provider
+/// has already moved past that url.
+struct RemoteConfigEndpoint: WeightedSource, Equatable {
+
+    enum Kind {
+        case api
+        case blob
+    }
+
+    let kind: Kind
+
+    /// A plain URL or a URL format with placeholders, to be resolved by the caller.
+    let url: String
+
+    /// Selection metadata, used to order endpoints within a kind.
+    let priority: Int
+    let weight: Int
+
+    init(kind: Kind, url: String, priority: Int = 0, weight: Int = 0) {
+        self.kind = kind
+        self.url = url
+        self.priority = priority
+        self.weight = weight
+    }
+
+}
+
+protocol RemoteConfigSourceProviderType: AnyObject {
+
+    /// The current healthy api endpoint, or `nil` once every api source has been reported unhealthy.
+    var currentAPIEndpoint: RemoteConfigEndpoint? { get }
+
+    /// The current healthy blob endpoint, or `nil` once every blob source has been reported unhealthy.
+    var currentBlobEndpoint: RemoteConfigEndpoint? { get }
+
+    /// Falls back to the next source for the endpoint's kind. No-op if `endpoint` is no longer current.
+    func reportUnhealthy(_ endpoint: RemoteConfigEndpoint)
+
+    /// Rewinds both api and blob to their first source, e.g. to start fresh on a new fetch cycle.
+    func restart()
+
+}
+
+/// The address book for remote config: hands out the current healthy api and blob endpoints and
+/// falls back to the next one when an endpoint is reported unhealthy. Each kind fails over
+/// independently. Sources are deduped by url and ordered once via `WeightedSourceSelector`.
 ///
 /// - Note: Thread-safe.
-final class RemoteConfigSourceProvider<Source: RemoteConfigSource> {
+final class RemoteConfigSourceProvider: RemoteConfigSourceProviderType {
 
-    private let selector: WeightedSourceSelector<Source>
+    private let api: SourceFailover
+    private let blob: SourceFailover
+
+    init(sources: RemoteConfigSources, randomizer: WeightedSourceRandomizer? = nil) {
+        self.api = SourceFailover(endpoints: Self.endpoints(from: sources.api, kind: .api), randomizer: randomizer)
+        self.blob = SourceFailover(endpoints: Self.endpoints(from: sources.blob, kind: .blob), randomizer: randomizer)
+    }
+
+    var currentAPIEndpoint: RemoteConfigEndpoint? {
+        return self.api.current
+    }
+
+    var currentBlobEndpoint: RemoteConfigEndpoint? {
+        return self.blob.current
+    }
+
+    func reportUnhealthy(_ endpoint: RemoteConfigEndpoint) {
+        switch endpoint.kind {
+        case .api: self.api.reportUnhealthy(url: endpoint.url)
+        case .blob: self.blob.reportUnhealthy(url: endpoint.url)
+        }
+    }
+
+    func restart() {
+        self.api.restart()
+        self.blob.restart()
+    }
+
+    /// Builds the endpoints for a kind, keeping the first occurrence of each url and dropping later
+    /// duplicates. Done once here so endpoints never need to be rebuilt on reads.
+    private static func endpoints(
+        from sources: [RemoteConfigSource],
+        kind: RemoteConfigEndpoint.Kind
+    ) -> [RemoteConfigEndpoint] {
+        var seenURLs = Set<String>()
+        return sources.compactMap { source in
+            guard seenURLs.insert(source.url).inserted else { return nil }
+            return RemoteConfigEndpoint(
+                kind: kind,
+                url: source.url,
+                priority: source.priority,
+                weight: source.weight
+            )
+        }
+    }
+
+}
+
+/// Walks a single list of endpoints in fallback order, using each endpoint's url as its identity so a
+/// stale `reportUnhealthy(url:)` (one the list has already moved past) is ignored.
+///
+/// - Note: Thread-safe.
+private final class SourceFailover {
+
+    private let selector: WeightedSourceSelector<RemoteConfigEndpoint>
     private let lock = Lock()
 
-    /// Regenerated on every `advance()` so previously handed-out endpoints become stale.
-    private var currentToken = UUID()
-
-    init(sources: [Source], randomizer: WeightedSourceRandomizer? = nil) {
-        self.selector = WeightedSourceSelector(sources: sources, randomizer: randomizer)
+    init(endpoints: [RemoteConfigEndpoint], randomizer: WeightedSourceRandomizer?) {
+        self.selector = WeightedSourceSelector(sources: endpoints, randomizer: randomizer)
     }
 
-    /// The current healthy endpoint, or `nil` once every source has been reported unhealthy.
-    var currentEndpoint: RemoteConfigEndpoint<Source>? {
-        return self.lock.perform {
-            self.makeCurrentEndpoint()
-        }
+    var current: RemoteConfigEndpoint? {
+        return self.lock.perform { self.selector.current }
     }
 
-    /// Advances to the next source so the next `currentEndpoint` read returns it. No-op if `endpoint`
-    /// is no longer the current one.
-    func reportUnhealthy(_ endpoint: RemoteConfigEndpoint<Source>) {
+    func reportUnhealthy(url: String) {
         self.lock.perform {
-            // Stale token: a concurrent caller already advanced past this endpoint. Ignore so a
-            // single failing endpoint can't advance the order more than once.
-            guard endpoint.token == self.currentToken else { return }
-            self.advance()
+            // Only advance when the report is about the current endpoint: a url the list has already
+            // moved past (e.g. from a concurrent caller) no longer matches, so it can't advance twice.
+            guard self.selector.current?.url == url else { return }
+            self.selector.advance()
         }
     }
 
-    /// Rewinds to the first source in the fallback order, e.g. to start fresh on a new fetch cycle.
     func restart() {
-        self.lock.perform {
-            self.selector.reset()
-            self.currentToken = UUID()
-        }
-    }
-
-    /// Moves to the next source and invalidates previously handed-out endpoints.
-    /// Must be called while holding `lock`.
-    private func advance() {
-        self.selector.advance()
-        self.currentToken = UUID()
-    }
-
-    /// Must be called while holding `lock`.
-    private func makeCurrentEndpoint() -> RemoteConfigEndpoint<Source>? {
-        guard let source = self.selector.current else { return nil }
-        return RemoteConfigEndpoint(source: source, token: self.currentToken)
+        self.lock.perform { self.selector.reset() }
     }
 
 }

--- a/Sources/Networking/RemoteConfigSourceProvider.swift
+++ b/Sources/Networking/RemoteConfigSourceProvider.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A remote config source: a URL plus the metadata used to order sources.
-struct RemoteConfigSource {
+struct RemoteConfigSource: WeightedSource {
 
     /// A plain URL or a URL format with placeholders (e.g. `{blob_ref}`), to be resolved by the caller.
     let url: String
@@ -18,9 +18,10 @@ struct RemoteConfigSource {
 }
 
 /// A source handed out by a `RemoteConfigSourceProvider`, tagged with its purpose (api or blob).
-/// Report it back via `reportUnhealthy(_:)` to fall back to the next source. The `url` is its
-/// identity: a report is ignored once the provider has already moved past that url.
-struct RemoteConfigSourceHandle: WeightedSource {
+/// Report it back via `reportUnhealthy(_:)` to fall back to the next source. The opaque `token`
+/// is its identity: a report is ignored once the provider has moved past it (via fallback or
+/// `restart(for:)`), so stale or concurrent reports can't advance the order more than once.
+struct RemoteConfigSourceHandle {
 
     /// What the source is used for: calling the config api or downloading a blob.
     enum Purpose {
@@ -31,10 +32,18 @@ struct RemoteConfigSourceHandle: WeightedSource {
     let purpose: Purpose
     let source: RemoteConfigSource
 
+    /// Identifies the handout that produced this handle. Opaque to callers; only meaningful to the
+    /// provider, which uses it to discard stale reports.
+    fileprivate let token: Int
+
     /// A plain URL or a URL format with placeholders, to be resolved by the caller.
     var url: String { self.source.url }
-    var priority: Int { self.source.priority }
-    var weight: Int { self.source.weight }
+
+    fileprivate init(purpose: Purpose, source: RemoteConfigSource, token: Int) {
+        self.purpose = purpose
+        self.source = source
+        self.token = token
+    }
 
 }
 
@@ -66,8 +75,8 @@ final class RemoteConfigSourceProvider: RemoteConfigSourceProviderType {
         blobSources: [RemoteConfigSource],
         randomizer: WeightedSourceRandomizer? = nil
     ) {
-        self.api = SourceFailover(handles: Self.handles(from: apiSources, purpose: .api), randomizer: randomizer)
-        self.blob = SourceFailover(handles: Self.handles(from: blobSources, purpose: .blob), randomizer: randomizer)
+        self.api = SourceFailover(purpose: .api, sources: Self.dedupe(apiSources), randomizer: randomizer)
+        self.blob = SourceFailover(purpose: .blob, sources: Self.dedupe(blobSources), randomizer: randomizer)
     }
 
     func getCurrent(for purpose: RemoteConfigSourceHandle.Purpose) -> RemoteConfigSourceHandle? {
@@ -79,8 +88,8 @@ final class RemoteConfigSourceProvider: RemoteConfigSourceProviderType {
 
     func reportUnhealthy(_ handle: RemoteConfigSourceHandle) {
         switch handle.purpose {
-        case .api: self.api.reportUnhealthy(url: handle.url)
-        case .blob: self.blob.reportUnhealthy(url: handle.url)
+        case .api: self.api.reportUnhealthy(handle)
+        case .blob: self.blob.reportUnhealthy(handle)
         }
     }
 
@@ -91,12 +100,9 @@ final class RemoteConfigSourceProvider: RemoteConfigSourceProviderType {
         }
     }
 
-    /// Builds the handles for a purpose, collapsing duplicate urls to the occurrence with the highest
-    /// priority (tie-broken by weight). Done once here so handles never need to be rebuilt on reads.
-    private static func handles(
-        from sources: [RemoteConfigSource],
-        purpose: RemoteConfigSourceHandle.Purpose
-    ) -> [RemoteConfigSourceHandle] {
+    /// Collapses duplicate urls to the occurrence with the highest priority (tie-broken by weight),
+    /// keeping first-seen order. Done once at init so reads never need to re-dedupe.
+    private static func dedupe(_ sources: [RemoteConfigSource]) -> [RemoteConfigSource] {
         var bestByURL: [String: RemoteConfigSource] = [:]
         var order: [String] = []
         for source in sources {
@@ -113,41 +119,54 @@ final class RemoteConfigSourceProvider: RemoteConfigSourceProviderType {
                 bestByURL[source.url] = source
             }
         }
-        return order.compactMap { url in
-            bestByURL[url].map { RemoteConfigSourceHandle(purpose: purpose, source: $0) }
-        }
+        return order.compactMap { bestByURL[$0] }
     }
 
 }
 
-/// Walks a single list of handles in fallback order, using each handle's url as its identity so a
-/// stale `reportUnhealthy(url:)` (one the list has already moved past) is ignored.
+/// Walks a single list of sources in fallback order. Every handout is stamped with the current
+/// `token`, which is bumped whenever the position changes (fallback or `restart()`). A report only
+/// advances if its handle still carries the current token, so stale or concurrent reports - and
+/// reports left over from before a `restart()` - are ignored.
 ///
 /// - Note: Thread-safe.
 private final class SourceFailover {
 
-    private let selector: WeightedSourceSelector<RemoteConfigSourceHandle>
+    private let purpose: RemoteConfigSourceHandle.Purpose
+    private let selector: WeightedSourceSelector<RemoteConfigSource>
     private let lock = Lock()
+    private var token = 0
 
-    init(handles: [RemoteConfigSourceHandle], randomizer: WeightedSourceRandomizer?) {
-        self.selector = WeightedSourceSelector(sources: handles, randomizer: randomizer)
+    init(
+        purpose: RemoteConfigSourceHandle.Purpose,
+        sources: [RemoteConfigSource],
+        randomizer: WeightedSourceRandomizer?
+    ) {
+        self.purpose = purpose
+        self.selector = WeightedSourceSelector(sources: sources, randomizer: randomizer)
     }
 
     var current: RemoteConfigSourceHandle? {
-        return self.lock.perform { self.selector.current }
+        return self.lock.perform {
+            self.selector.current.map {
+                RemoteConfigSourceHandle(purpose: self.purpose, source: $0, token: self.token)
+            }
+        }
     }
 
-    func reportUnhealthy(url: String) {
+    func reportUnhealthy(_ handle: RemoteConfigSourceHandle) {
         self.lock.perform {
-            // Only advance when the report is about the current source: a url the list has already
-            // moved past (e.g. from a concurrent caller) no longer matches, so it can't advance twice.
-            guard self.selector.current?.url == url else { return }
+            guard handle.token == self.token else { return }
             self.selector.advance()
+            self.token += 1
         }
     }
 
     func restart() {
-        self.lock.perform { self.selector.reset() }
+        self.lock.perform {
+            self.selector.reset()
+            self.token += 1
+        }
     }
 
 }

--- a/Sources/Networking/RemoteConfigSourceProvider.swift
+++ b/Sources/Networking/RemoteConfigSourceProvider.swift
@@ -17,14 +17,6 @@ struct RemoteConfigSource {
 
 }
 
-/// The api and blob sources for the remote config, as provided by the `sources` topic.
-struct RemoteConfigSources {
-
-    let api: [RemoteConfigSource]
-    let blob: [RemoteConfigSource]
-
-}
-
 /// A source handed out by a `RemoteConfigSourceProvider`, tagged with its purpose (api or blob).
 /// Report it back via `reportUnhealthy(_:)` to fall back to the next source. The `url` is its
 /// identity: a report is ignored once the provider has already moved past that url.
@@ -48,11 +40,8 @@ struct RemoteConfigSourceHandle: WeightedSource {
 
 protocol RemoteConfigSourceProviderType: AnyObject {
 
-    /// The current healthy api source, or `nil` once every api source has been reported unhealthy.
-    var currentAPISource: RemoteConfigSourceHandle? { get }
-
-    /// The current healthy blob source, or `nil` once every blob source has been reported unhealthy.
-    var currentBlobSource: RemoteConfigSourceHandle? { get }
+    /// The current healthy source for `purpose`, or `nil` once all of its sources are reported unhealthy.
+    func getCurrent(for purpose: RemoteConfigSourceHandle.Purpose) -> RemoteConfigSourceHandle?
 
     /// Falls back to the next source for the handle's purpose. No-op if `handle` is no longer current.
     func reportUnhealthy(_ handle: RemoteConfigSourceHandle)
@@ -72,17 +61,20 @@ final class RemoteConfigSourceProvider: RemoteConfigSourceProviderType {
     private let api: SourceFailover
     private let blob: SourceFailover
 
-    init(sources: RemoteConfigSources, randomizer: WeightedSourceRandomizer? = nil) {
-        self.api = SourceFailover(handles: Self.handles(from: sources.api, purpose: .api), randomizer: randomizer)
-        self.blob = SourceFailover(handles: Self.handles(from: sources.blob, purpose: .blob), randomizer: randomizer)
+    init(
+        apiSources: [RemoteConfigSource],
+        blobSources: [RemoteConfigSource],
+        randomizer: WeightedSourceRandomizer? = nil
+    ) {
+        self.api = SourceFailover(handles: Self.handles(from: apiSources, purpose: .api), randomizer: randomizer)
+        self.blob = SourceFailover(handles: Self.handles(from: blobSources, purpose: .blob), randomizer: randomizer)
     }
 
-    var currentAPISource: RemoteConfigSourceHandle? {
-        return self.api.current
-    }
-
-    var currentBlobSource: RemoteConfigSourceHandle? {
-        return self.blob.current
+    func getCurrent(for purpose: RemoteConfigSourceHandle.Purpose) -> RemoteConfigSourceHandle? {
+        switch purpose {
+        case .api: return self.api.current
+        case .blob: return self.blob.current
+        }
     }
 
     func reportUnhealthy(_ handle: RemoteConfigSourceHandle) {

--- a/Tests/UnitTests/Mocks/MockRemoteConfigSourceProvider.swift
+++ b/Tests/UnitTests/Mocks/MockRemoteConfigSourceProvider.swift
@@ -1,0 +1,30 @@
+//
+//  MockRemoteConfigSourceProvider.swift
+//  RevenueCat
+//
+//  Created by Antonio Pallares on 26/06/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+//
+
+import Foundation
+@testable import RevenueCat
+
+final class MockRemoteConfigSourceProvider: RemoteConfigSourceProviderType {
+
+    var stubbedCurrentAPIEndpoint: RemoteConfigEndpoint?
+    var currentAPIEndpoint: RemoteConfigEndpoint? { self.stubbedCurrentAPIEndpoint }
+
+    var stubbedCurrentBlobEndpoint: RemoteConfigEndpoint?
+    var currentBlobEndpoint: RemoteConfigEndpoint? { self.stubbedCurrentBlobEndpoint }
+
+    private(set) var reportedUnhealthyEndpoints: [RemoteConfigEndpoint] = []
+    func reportUnhealthy(_ endpoint: RemoteConfigEndpoint) {
+        self.reportedUnhealthyEndpoints.append(endpoint)
+    }
+
+    private(set) var restartCallCount = 0
+    func restart() {
+        self.restartCallCount += 1
+    }
+
+}

--- a/Tests/UnitTests/Mocks/MockRemoteConfigSourceProvider.swift
+++ b/Tests/UnitTests/Mocks/MockRemoteConfigSourceProvider.swift
@@ -11,20 +11,20 @@ import Foundation
 
 final class MockRemoteConfigSourceProvider: RemoteConfigSourceProviderType {
 
-    var stubbedCurrentAPIEndpoint: RemoteConfigEndpoint?
-    var currentAPIEndpoint: RemoteConfigEndpoint? { self.stubbedCurrentAPIEndpoint }
+    var stubbedCurrentAPISource: RemoteConfigSourceHandle?
+    var currentAPISource: RemoteConfigSourceHandle? { self.stubbedCurrentAPISource }
 
-    var stubbedCurrentBlobEndpoint: RemoteConfigEndpoint?
-    var currentBlobEndpoint: RemoteConfigEndpoint? { self.stubbedCurrentBlobEndpoint }
+    var stubbedCurrentBlobSource: RemoteConfigSourceHandle?
+    var currentBlobSource: RemoteConfigSourceHandle? { self.stubbedCurrentBlobSource }
 
-    private(set) var reportedUnhealthyEndpoints: [RemoteConfigEndpoint] = []
-    func reportUnhealthy(_ endpoint: RemoteConfigEndpoint) {
-        self.reportedUnhealthyEndpoints.append(endpoint)
+    private(set) var reportedUnhealthySources: [RemoteConfigSourceHandle] = []
+    func reportUnhealthy(_ handle: RemoteConfigSourceHandle) {
+        self.reportedUnhealthySources.append(handle)
     }
 
-    private(set) var restartedKinds: [RemoteConfigEndpoint.Kind] = []
-    func restart(_ kind: RemoteConfigEndpoint.Kind) {
-        self.restartedKinds.append(kind)
+    private(set) var restartedPurposes: [RemoteConfigSourceHandle.Purpose] = []
+    func restart(for purpose: RemoteConfigSourceHandle.Purpose) {
+        self.restartedPurposes.append(purpose)
     }
 
 }

--- a/Tests/UnitTests/Mocks/MockRemoteConfigSourceProvider.swift
+++ b/Tests/UnitTests/Mocks/MockRemoteConfigSourceProvider.swift
@@ -22,9 +22,9 @@ final class MockRemoteConfigSourceProvider: RemoteConfigSourceProviderType {
         self.reportedUnhealthyEndpoints.append(endpoint)
     }
 
-    private(set) var restartCallCount = 0
-    func restart() {
-        self.restartCallCount += 1
+    private(set) var restartedKinds: [RemoteConfigEndpoint.Kind] = []
+    func restart(_ kind: RemoteConfigEndpoint.Kind) {
+        self.restartedKinds.append(kind)
     }
 
 }

--- a/Tests/UnitTests/Mocks/MockRemoteConfigSourceProvider.swift
+++ b/Tests/UnitTests/Mocks/MockRemoteConfigSourceProvider.swift
@@ -12,10 +12,14 @@ import Foundation
 final class MockRemoteConfigSourceProvider: RemoteConfigSourceProviderType {
 
     var stubbedCurrentAPISource: RemoteConfigSourceHandle?
-    var currentAPISource: RemoteConfigSourceHandle? { self.stubbedCurrentAPISource }
-
     var stubbedCurrentBlobSource: RemoteConfigSourceHandle?
-    var currentBlobSource: RemoteConfigSourceHandle? { self.stubbedCurrentBlobSource }
+
+    func getCurrent(for purpose: RemoteConfigSourceHandle.Purpose) -> RemoteConfigSourceHandle? {
+        switch purpose {
+        case .api: return self.stubbedCurrentAPISource
+        case .blob: return self.stubbedCurrentBlobSource
+        }
+    }
 
     private(set) var reportedUnhealthySources: [RemoteConfigSourceHandle] = []
     func reportUnhealthy(_ handle: RemoteConfigSourceHandle) {

--- a/Tests/UnitTests/Networking/RemoteConfigSourceProviderTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfigSourceProviderTests.swift
@@ -101,7 +101,7 @@ final class RemoteConfigSourceProviderTests: TestCase {
 
         // `a` is kept at priority 10, so it outranks `b` (priority 5) despite appearing first at 0.
         expect(provider.getCurrent(for: .api)?.url) == Self.url("a")
-        expect(provider.getCurrent(for: .api)?.priority) == 10
+        expect(provider.getCurrent(for: .api)?.source.priority) == 10
         provider.reportUnhealthy(provider.getCurrent(for: .api)!)
         expect(provider.getCurrent(for: .api)?.url) == Self.url("b")
     }
@@ -112,7 +112,7 @@ final class RemoteConfigSourceProviderTests: TestCase {
             Self.source("a", priority: 0, weight: 100)
         ])
 
-        expect(provider.getCurrent(for: .api)?.weight) == 100
+        expect(provider.getCurrent(for: .api)?.source.weight) == 100
     }
 
     // MARK: - api / blob independence
@@ -234,6 +234,23 @@ final class RemoteConfigSourceProviderTests: TestCase {
 
         provider.restart(for: .blob)
         expect(provider.getCurrent(for: .blob)?.url) == Self.url("blob1")
+    }
+
+    func testStaleReportFromBeforeRestartIsIgnored() {
+        let provider = Self.apiProvider([Self.source("a"), Self.source("b"), Self.source("c")])
+
+        // A caller grabs `a`, then the provider is restarted before that caller reports back.
+        let stale = provider.getCurrent(for: .api)
+        expect(stale?.url) == Self.url("a")
+        provider.restart(for: .api)
+
+        // The stale report belongs to a pre-restart cycle, so it must not advance past `a`.
+        provider.reportUnhealthy(stale!)
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("a")
+
+        // A handle obtained after the restart still advances normally.
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!)
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("b")
     }
 
     // MARK: - Threading

--- a/Tests/UnitTests/Networking/RemoteConfigSourceProviderTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfigSourceProviderTests.swift
@@ -36,7 +36,7 @@ final class RemoteConfigSourceProviderTests: TestCase {
     func testCurrentEndpointIsStableAcrossReads() {
         let provider = Self.apiProvider([Self.source("a"), Self.source("b")])
 
-        expect(provider.currentAPIEndpoint) == provider.currentAPIEndpoint
+        expect(provider.currentAPIEndpoint?.url) == provider.currentAPIEndpoint?.url
     }
 
     // MARK: - reportUnhealthy advances
@@ -156,7 +156,7 @@ final class RemoteConfigSourceProviderTests: TestCase {
         // Two callers grab the same current endpoint.
         let endpointA = provider.currentAPIEndpoint
         let endpointB = provider.currentAPIEndpoint
-        expect(endpointA) == endpointB
+        expect(endpointA?.url) == endpointB?.url
 
         // Caller A reports it unhealthy: the provider advances.
         provider.reportUnhealthy(endpointA!)

--- a/Tests/UnitTests/Networking/RemoteConfigSourceProviderTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfigSourceProviderTests.swift
@@ -14,178 +14,219 @@ final class RemoteConfigSourceProviderTests: TestCase {
 
     // MARK: - Initial selection
 
-    func testCurrentEndpointIsNilWhenNoSources() {
-        let provider = RemoteConfigSourceProvider<TestSource>(sources: [], randomizer: FakeRandomizer())
-        expect(provider.currentEndpoint).to(beNil())
+    func testCurrentEndpointsAreNilWhenNoSources() {
+        let provider = RemoteConfigSourceProvider(sources: RemoteConfigSources(), randomizer: FakeRandomizer())
+        expect(provider.currentAPIEndpoint).to(beNil())
+        expect(provider.currentBlobEndpoint).to(beNil())
     }
 
     func testCurrentEndpointReturnsHighestPrioritySource() {
-        let low = TestSource(url: Self.url("low"), priority: 0, weight: 100)
-        let high = TestSource(url: Self.url("high"), priority: 10, weight: 1)
-        let provider = RemoteConfigSourceProvider(sources: [low, high], randomizer: FakeRandomizer(0))
+        let low = Self.source("low", priority: 0, weight: 100)
+        let high = Self.source("high", priority: 10, weight: 1)
+        let provider = Self.apiProvider([low, high])
 
-        expect(provider.currentEndpoint?.url) == Self.url("high")
+        let endpoint = provider.currentAPIEndpoint
+        expect(endpoint?.url) == Self.url("high")
+        expect(endpoint?.kind) == .api
     }
 
     func testCurrentEndpointIsStableAcrossReads() {
-        let provider = RemoteConfigSourceProvider(sources: [Self.source("a")], randomizer: FakeRandomizer(0))
+        let provider = Self.apiProvider([Self.source("a"), Self.source("b")])
 
-        expect(provider.currentEndpoint?.source) == provider.currentEndpoint?.source
+        expect(provider.currentAPIEndpoint) == provider.currentAPIEndpoint
     }
 
     // MARK: - reportUnhealthy advances
 
     func testReportUnhealthyAdvancesToNextSource() {
-        let high = TestSource(url: Self.url("high"), priority: 10, weight: 1)
-        let low = TestSource(url: Self.url("low"), priority: 0, weight: 1)
-        let provider = RemoteConfigSourceProvider(sources: [high, low], randomizer: FakeRandomizer(0))
+        let high = Self.source("high", priority: 10, weight: 1)
+        let low = Self.source("low", priority: 0, weight: 1)
+        let provider = Self.apiProvider([high, low])
 
-        let first = provider.currentEndpoint
+        let first = provider.currentAPIEndpoint
         expect(first?.url) == Self.url("high")
 
         provider.reportUnhealthy(first!)
-        expect(provider.currentEndpoint?.url) == Self.url("low")
+        expect(provider.currentAPIEndpoint?.url) == Self.url("low")
     }
 
     func testCurrentEndpointIsNilWhenExhausted() {
-        let provider = RemoteConfigSourceProvider(sources: [Self.source("only")], randomizer: FakeRandomizer(0))
+        let provider = Self.apiProvider([Self.source("only")])
 
-        let only = provider.currentEndpoint
-        provider.reportUnhealthy(only!)
-        expect(provider.currentEndpoint).to(beNil())
+        provider.reportUnhealthy(provider.currentAPIEndpoint!)
+        expect(provider.currentAPIEndpoint).to(beNil())
     }
 
     func testReportUnhealthyWalksFullFallbackOrder() {
-        let first = TestSource(url: Self.url("1"), priority: 30, weight: 1)
-        let second = TestSource(url: Self.url("2"), priority: 20, weight: 1)
-        let third = TestSource(url: Self.url("3"), priority: 10, weight: 1)
-        let provider = RemoteConfigSourceProvider(sources: [first, second, third], randomizer: FakeRandomizer(0))
+        let first = Self.source("1", priority: 30, weight: 1)
+        let second = Self.source("2", priority: 20, weight: 1)
+        let third = Self.source("3", priority: 10, weight: 1)
+        let provider = Self.apiProvider([first, second, third])
 
-        expect(provider.currentEndpoint?.url) == Self.url("1")
-        provider.reportUnhealthy(provider.currentEndpoint!)
-        expect(provider.currentEndpoint?.url) == Self.url("2")
-        provider.reportUnhealthy(provider.currentEndpoint!)
-        expect(provider.currentEndpoint?.url) == Self.url("3")
-        provider.reportUnhealthy(provider.currentEndpoint!)
-        expect(provider.currentEndpoint).to(beNil())
+        expect(provider.currentAPIEndpoint?.url) == Self.url("1")
+        provider.reportUnhealthy(provider.currentAPIEndpoint!)
+        expect(provider.currentAPIEndpoint?.url) == Self.url("2")
+        provider.reportUnhealthy(provider.currentAPIEndpoint!)
+        expect(provider.currentAPIEndpoint?.url) == Self.url("3")
+        provider.reportUnhealthy(provider.currentAPIEndpoint!)
+        expect(provider.currentAPIEndpoint).to(beNil())
+    }
+
+    // MARK: - Dedup
+
+    func testDedupsSourcesByURL() {
+        let provider = Self.apiProvider([
+            Self.source("a", priority: 10, weight: 1),
+            Self.source("a", priority: 5, weight: 1),
+            Self.source("b", priority: 0, weight: 1)
+        ])
+
+        expect(provider.currentAPIEndpoint?.url) == Self.url("a")
+        provider.reportUnhealthy(provider.currentAPIEndpoint!)
+        expect(provider.currentAPIEndpoint?.url) == Self.url("b")
+        provider.reportUnhealthy(provider.currentAPIEndpoint!)
+        expect(provider.currentAPIEndpoint).to(beNil())
+    }
+
+    // MARK: - api / blob independence
+
+    func testAPIAndBlobAreExposedIndependently() {
+        let provider = RemoteConfigSourceProvider(
+            sources: RemoteConfigSources(api: [Self.source("api")], blob: [Self.source("blob")]),
+            randomizer: FakeRandomizer(0)
+        )
+
+        let api = provider.currentAPIEndpoint
+        let blob = provider.currentBlobEndpoint
+        expect(api?.url) == Self.url("api")
+        expect(api?.kind) == .api
+        expect(blob?.url) == Self.url("blob")
+        expect(blob?.kind) == .blob
+    }
+
+    func testReportingAPIUnhealthyDoesNotAffectBlob() {
+        let provider = RemoteConfigSourceProvider(
+            sources: RemoteConfigSources(
+                api: [Self.source("api1", priority: 10), Self.source("api2", priority: 0)],
+                blob: [Self.source("blob1", priority: 10), Self.source("blob2", priority: 0)]
+            ),
+            randomizer: FakeRandomizer(0)
+        )
+
+        provider.reportUnhealthy(provider.currentAPIEndpoint!)
+        expect(provider.currentAPIEndpoint?.url) == Self.url("api2")
+        expect(provider.currentBlobEndpoint?.url) == Self.url("blob1")
+
+        provider.reportUnhealthy(provider.currentBlobEndpoint!)
+        expect(provider.currentAPIEndpoint?.url) == Self.url("api2")
+        expect(provider.currentBlobEndpoint?.url) == Self.url("blob2")
     }
 
     // MARK: - Stale report handling (race conditions)
 
     func testStaleReportIsIgnoredAfterAnotherCallerAdvanced() {
-        let provider = RemoteConfigSourceProvider(
-            sources: [Self.source("a"), Self.source("b"), Self.source("c")],
-            randomizer: FakeRandomizer(0)
-        )
+        let provider = Self.apiProvider([Self.source("a"), Self.source("b"), Self.source("c")])
 
         // Two callers grab the same current endpoint.
-        let endpointA = provider.currentEndpoint
-        let endpointB = provider.currentEndpoint
-        expect(endpointA?.source) == endpointB?.source
+        let endpointA = provider.currentAPIEndpoint
+        let endpointB = provider.currentAPIEndpoint
+        expect(endpointA) == endpointB
 
         // Caller A reports it unhealthy: the provider advances.
         provider.reportUnhealthy(endpointA!)
-        expect(provider.currentEndpoint?.url) == Self.url("b")
+        expect(provider.currentAPIEndpoint?.url) == Self.url("b")
 
         // Caller B reports the *same* (now superseded) endpoint: this must NOT advance again.
         provider.reportUnhealthy(endpointB!)
-        expect(provider.currentEndpoint?.url) == Self.url("b")
+        expect(provider.currentAPIEndpoint?.url) == Self.url("b")
     }
 
     func testReportingSameEndpointTwiceAdvancesOnlyOnce() {
-        let provider = RemoteConfigSourceProvider(
-            sources: [Self.source("a"), Self.source("b"), Self.source("c")],
-            randomizer: FakeRandomizer(0)
-        )
+        let provider = Self.apiProvider([Self.source("a"), Self.source("b"), Self.source("c")])
 
-        let endpoint = provider.currentEndpoint
+        let endpoint = provider.currentAPIEndpoint
         provider.reportUnhealthy(endpoint!)
         provider.reportUnhealthy(endpoint!)
         provider.reportUnhealthy(endpoint!)
 
-        expect(provider.currentEndpoint?.url) == Self.url("b")
+        expect(provider.currentAPIEndpoint?.url) == Self.url("b")
     }
 
     func testReportingFreshEndpointAfterStaleReportStillAdvances() {
-        let provider = RemoteConfigSourceProvider(
-            sources: [Self.source("a"), Self.source("b"), Self.source("c")],
-            randomizer: FakeRandomizer(0)
-        )
+        let provider = Self.apiProvider([Self.source("a"), Self.source("b"), Self.source("c")])
 
-        let stale = provider.currentEndpoint
+        let stale = provider.currentAPIEndpoint
         provider.reportUnhealthy(stale!)              // a -> b
         provider.reportUnhealthy(stale!)              // ignored, still b
 
-        let fresh = provider.currentEndpoint          // b
+        let fresh = provider.currentAPIEndpoint       // b
         provider.reportUnhealthy(fresh!)              // b -> c
-        expect(provider.currentEndpoint?.url) == Self.url("c")
+        expect(provider.currentAPIEndpoint?.url) == Self.url("c")
     }
 
     func testStaleReportOnExhaustedProviderIsIgnored() {
-        let provider = RemoteConfigSourceProvider(
-            sources: [Self.source("a"), Self.source("b")],
-            randomizer: FakeRandomizer(0)
-        )
+        let provider = Self.apiProvider([Self.source("a"), Self.source("b")])
 
-        let first = provider.currentEndpoint
+        let first = provider.currentAPIEndpoint
         provider.reportUnhealthy(first!)
-        let second = provider.currentEndpoint
-        provider.reportUnhealthy(second!)
-        expect(provider.currentEndpoint).to(beNil())
+        provider.reportUnhealthy(provider.currentAPIEndpoint!)
+        expect(provider.currentAPIEndpoint).to(beNil())
 
         // Reporting the original stale endpoint again must not resurrect or change anything.
         provider.reportUnhealthy(first!)
-        expect(provider.currentEndpoint).to(beNil())
+        expect(provider.currentAPIEndpoint).to(beNil())
     }
 
     // MARK: - restart
 
     func testRestartRewindsToFirstSource() {
-        let provider = RemoteConfigSourceProvider(
-            sources: [Self.source("a"), Self.source("b"), Self.source("c")],
-            randomizer: FakeRandomizer(0)
-        )
+        let provider = Self.apiProvider([Self.source("a"), Self.source("b"), Self.source("c")])
 
-        provider.reportUnhealthy(provider.currentEndpoint!)
-        provider.reportUnhealthy(provider.currentEndpoint!)
-        expect(provider.currentEndpoint?.url) == Self.url("c")
+        provider.reportUnhealthy(provider.currentAPIEndpoint!)
+        provider.reportUnhealthy(provider.currentAPIEndpoint!)
+        expect(provider.currentAPIEndpoint?.url) == Self.url("c")
 
         provider.restart()
-        expect(provider.currentEndpoint?.url) == Self.url("a")
+        expect(provider.currentAPIEndpoint?.url) == Self.url("a")
     }
 
-    func testRestartInvalidatesPreviouslyHandedOutEndpoints() {
+    func testRestartRewindsBothKinds() {
         let provider = RemoteConfigSourceProvider(
-            sources: [Self.source("a"), Self.source("b")],
+            sources: RemoteConfigSources(
+                api: [Self.source("api1", priority: 10), Self.source("api2", priority: 0)],
+                blob: [Self.source("blob1", priority: 10), Self.source("blob2", priority: 0)]
+            ),
             randomizer: FakeRandomizer(0)
         )
 
-        let stale = provider.currentEndpoint
-        provider.restart()
+        provider.reportUnhealthy(provider.currentAPIEndpoint!)
+        provider.reportUnhealthy(provider.currentBlobEndpoint!)
+        expect(provider.currentAPIEndpoint?.url) == Self.url("api2")
+        expect(provider.currentBlobEndpoint?.url) == Self.url("blob2")
 
-        // The pre-restart endpoint must not advance the freshly restarted provider.
-        provider.reportUnhealthy(stale!)
-        expect(provider.currentEndpoint?.url) == Self.url("a")
+        provider.restart()
+        expect(provider.currentAPIEndpoint?.url) == Self.url("api1")
+        expect(provider.currentBlobEndpoint?.url) == Self.url("blob1")
     }
 
     // MARK: - Threading
 
     func testConcurrentReportsAdvanceAtMostOncePerEndpoint() {
         let sources = (0..<100).map { Self.source("\($0)") }
-        let provider = RemoteConfigSourceProvider(sources: sources, randomizer: FakeRandomizer(0))
+        let provider = Self.apiProvider(sources)
 
         // Every iteration grabs the current endpoint and reports it unhealthy concurrently. Even
         // with many threads racing, a single endpoint can only advance the provider once, so the
         // provider must walk the fallback order one step at a time and never skip ahead.
         DispatchQueue.concurrentPerform(iterations: 500) { _ in
-            if let endpoint = provider.currentEndpoint {
+            if let endpoint = provider.currentAPIEndpoint {
                 provider.reportUnhealthy(endpoint)
             }
         }
 
         // The exact landing point is timing-dependent, but it must be a valid, reachable URL (or
         // nil if every source happened to be exhausted) — never a corrupted/torn state.
-        if let url = provider.currentEndpoint?.url {
+        if let url = provider.currentAPIEndpoint?.url {
             expect(sources.map { $0.url }).to(contain(url))
         }
     }
@@ -194,13 +235,13 @@ final class RemoteConfigSourceProviderTests: TestCase {
         // Drive the provider to exhaustion by always reporting the *current* endpoint. Collect every
         // distinct URL handed out; because stale reports are ignored, no source may be skipped.
         let sources = (0..<50).map { Self.source("\($0)") }
-        let provider = RemoteConfigSourceProvider(sources: sources, randomizer: FakeRandomizer(0))
+        let provider = Self.apiProvider(sources)
 
         let seen = Atomic<Set<String>>([])
         let group = DispatchGroup()
         for _ in 0..<8 {
             DispatchQueue.global().async(group: group) {
-                while let endpoint = provider.currentEndpoint {
+                while let endpoint = provider.currentAPIEndpoint {
                     seen.modify { $0.insert(endpoint.url) }
                     provider.reportUnhealthy(endpoint)
                 }
@@ -209,7 +250,7 @@ final class RemoteConfigSourceProviderTests: TestCase {
         group.wait()
 
         expect(seen.value) == Set(sources.map { $0.url })
-        expect(provider.currentEndpoint).to(beNil())
+        expect(provider.currentAPIEndpoint).to(beNil())
     }
 
     // MARK: - Helpers
@@ -218,17 +259,13 @@ final class RemoteConfigSourceProviderTests: TestCase {
         return "https://\(host).revenuecat.com"
     }
 
-    private static func source(_ host: String, priority: Int = 0, weight: Int = 0) -> TestSource {
-        return TestSource(url: url(host), priority: priority, weight: weight)
+    private static func source(_ host: String, priority: Int = 0, weight: Int = 0) -> RemoteConfigSource {
+        return RemoteConfigSource(url: url(host), priority: priority, weight: weight)
     }
 
-}
-
-private struct TestSource: RemoteConfigSource, Equatable {
-
-    let url: String
-    let priority: Int
-    let weight: Int
+    private static func apiProvider(_ sources: [RemoteConfigSource]) -> RemoteConfigSourceProvider {
+        return RemoteConfigSourceProvider(sources: RemoteConfigSources(api: sources), randomizer: FakeRandomizer(0))
+    }
 
 }
 

--- a/Tests/UnitTests/Networking/RemoteConfigSourceProviderTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfigSourceProviderTests.swift
@@ -1,0 +1,255 @@
+//
+//  RemoteConfigSourceProviderTests.swift
+//  RevenueCat
+//
+//  Created by Antonio Pallares on 26/06/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+import Nimble
+@testable import RevenueCat
+import XCTest
+
+final class RemoteConfigSourceProviderTests: TestCase {
+
+    // MARK: - Initial selection
+
+    func testCurrentEndpointIsNilWhenNoSources() {
+        let provider = RemoteConfigSourceProvider<TestSource>(sources: [], randomizer: FakeRandomizer())
+        expect(provider.currentEndpoint).to(beNil())
+    }
+
+    func testCurrentEndpointReturnsHighestPrioritySource() {
+        let low = TestSource(url: Self.url("low"), priority: 0, weight: 100)
+        let high = TestSource(url: Self.url("high"), priority: 10, weight: 1)
+        let provider = RemoteConfigSourceProvider(sources: [low, high], randomizer: FakeRandomizer(0))
+
+        expect(provider.currentEndpoint?.url) == Self.url("high")
+    }
+
+    func testCurrentEndpointIsStableAcrossReads() {
+        let provider = RemoteConfigSourceProvider(sources: [Self.source("a")], randomizer: FakeRandomizer(0))
+
+        expect(provider.currentEndpoint?.source) == provider.currentEndpoint?.source
+    }
+
+    // MARK: - reportUnhealthy advances
+
+    func testReportUnhealthyAdvancesToNextSource() {
+        let high = TestSource(url: Self.url("high"), priority: 10, weight: 1)
+        let low = TestSource(url: Self.url("low"), priority: 0, weight: 1)
+        let provider = RemoteConfigSourceProvider(sources: [high, low], randomizer: FakeRandomizer(0))
+
+        let first = provider.currentEndpoint
+        expect(first?.url) == Self.url("high")
+
+        provider.reportUnhealthy(first!)
+        expect(provider.currentEndpoint?.url) == Self.url("low")
+    }
+
+    func testCurrentEndpointIsNilWhenExhausted() {
+        let provider = RemoteConfigSourceProvider(sources: [Self.source("only")], randomizer: FakeRandomizer(0))
+
+        let only = provider.currentEndpoint
+        provider.reportUnhealthy(only!)
+        expect(provider.currentEndpoint).to(beNil())
+    }
+
+    func testReportUnhealthyWalksFullFallbackOrder() {
+        let first = TestSource(url: Self.url("1"), priority: 30, weight: 1)
+        let second = TestSource(url: Self.url("2"), priority: 20, weight: 1)
+        let third = TestSource(url: Self.url("3"), priority: 10, weight: 1)
+        let provider = RemoteConfigSourceProvider(sources: [first, second, third], randomizer: FakeRandomizer(0))
+
+        expect(provider.currentEndpoint?.url) == Self.url("1")
+        provider.reportUnhealthy(provider.currentEndpoint!)
+        expect(provider.currentEndpoint?.url) == Self.url("2")
+        provider.reportUnhealthy(provider.currentEndpoint!)
+        expect(provider.currentEndpoint?.url) == Self.url("3")
+        provider.reportUnhealthy(provider.currentEndpoint!)
+        expect(provider.currentEndpoint).to(beNil())
+    }
+
+    // MARK: - Stale report handling (race conditions)
+
+    func testStaleReportIsIgnoredAfterAnotherCallerAdvanced() {
+        let provider = RemoteConfigSourceProvider(
+            sources: [Self.source("a"), Self.source("b"), Self.source("c")],
+            randomizer: FakeRandomizer(0)
+        )
+
+        // Two callers grab the same current endpoint.
+        let endpointA = provider.currentEndpoint
+        let endpointB = provider.currentEndpoint
+        expect(endpointA?.source) == endpointB?.source
+
+        // Caller A reports it unhealthy: the provider advances.
+        provider.reportUnhealthy(endpointA!)
+        expect(provider.currentEndpoint?.url) == Self.url("b")
+
+        // Caller B reports the *same* (now superseded) endpoint: this must NOT advance again.
+        provider.reportUnhealthy(endpointB!)
+        expect(provider.currentEndpoint?.url) == Self.url("b")
+    }
+
+    func testReportingSameEndpointTwiceAdvancesOnlyOnce() {
+        let provider = RemoteConfigSourceProvider(
+            sources: [Self.source("a"), Self.source("b"), Self.source("c")],
+            randomizer: FakeRandomizer(0)
+        )
+
+        let endpoint = provider.currentEndpoint
+        provider.reportUnhealthy(endpoint!)
+        provider.reportUnhealthy(endpoint!)
+        provider.reportUnhealthy(endpoint!)
+
+        expect(provider.currentEndpoint?.url) == Self.url("b")
+    }
+
+    func testReportingFreshEndpointAfterStaleReportStillAdvances() {
+        let provider = RemoteConfigSourceProvider(
+            sources: [Self.source("a"), Self.source("b"), Self.source("c")],
+            randomizer: FakeRandomizer(0)
+        )
+
+        let stale = provider.currentEndpoint
+        provider.reportUnhealthy(stale!)              // a -> b
+        provider.reportUnhealthy(stale!)              // ignored, still b
+
+        let fresh = provider.currentEndpoint          // b
+        provider.reportUnhealthy(fresh!)              // b -> c
+        expect(provider.currentEndpoint?.url) == Self.url("c")
+    }
+
+    func testStaleReportOnExhaustedProviderIsIgnored() {
+        let provider = RemoteConfigSourceProvider(
+            sources: [Self.source("a"), Self.source("b")],
+            randomizer: FakeRandomizer(0)
+        )
+
+        let first = provider.currentEndpoint
+        provider.reportUnhealthy(first!)
+        let second = provider.currentEndpoint
+        provider.reportUnhealthy(second!)
+        expect(provider.currentEndpoint).to(beNil())
+
+        // Reporting the original stale endpoint again must not resurrect or change anything.
+        provider.reportUnhealthy(first!)
+        expect(provider.currentEndpoint).to(beNil())
+    }
+
+    // MARK: - restart
+
+    func testRestartRewindsToFirstSource() {
+        let provider = RemoteConfigSourceProvider(
+            sources: [Self.source("a"), Self.source("b"), Self.source("c")],
+            randomizer: FakeRandomizer(0)
+        )
+
+        provider.reportUnhealthy(provider.currentEndpoint!)
+        provider.reportUnhealthy(provider.currentEndpoint!)
+        expect(provider.currentEndpoint?.url) == Self.url("c")
+
+        provider.restart()
+        expect(provider.currentEndpoint?.url) == Self.url("a")
+    }
+
+    func testRestartInvalidatesPreviouslyHandedOutEndpoints() {
+        let provider = RemoteConfigSourceProvider(
+            sources: [Self.source("a"), Self.source("b")],
+            randomizer: FakeRandomizer(0)
+        )
+
+        let stale = provider.currentEndpoint
+        provider.restart()
+
+        // The pre-restart endpoint must not advance the freshly restarted provider.
+        provider.reportUnhealthy(stale!)
+        expect(provider.currentEndpoint?.url) == Self.url("a")
+    }
+
+    // MARK: - Threading
+
+    func testConcurrentReportsAdvanceAtMostOncePerEndpoint() {
+        let sources = (0..<100).map { Self.source("\($0)") }
+        let provider = RemoteConfigSourceProvider(sources: sources, randomizer: FakeRandomizer(0))
+
+        // Every iteration grabs the current endpoint and reports it unhealthy concurrently. Even
+        // with many threads racing, a single endpoint can only advance the provider once, so the
+        // provider must walk the fallback order one step at a time and never skip ahead.
+        DispatchQueue.concurrentPerform(iterations: 500) { _ in
+            if let endpoint = provider.currentEndpoint {
+                provider.reportUnhealthy(endpoint)
+            }
+        }
+
+        // The exact landing point is timing-dependent, but it must be a valid, reachable URL (or
+        // nil if every source happened to be exhausted) — never a corrupted/torn state.
+        if let url = provider.currentEndpoint?.url {
+            expect(sources.map { $0.url }).to(contain(url))
+        }
+    }
+
+    func testConcurrentReportsNeverSkipSourcesWhenSerialized() {
+        // Drive the provider to exhaustion by always reporting the *current* endpoint. Collect every
+        // distinct URL handed out; because stale reports are ignored, no source may be skipped.
+        let sources = (0..<50).map { Self.source("\($0)") }
+        let provider = RemoteConfigSourceProvider(sources: sources, randomizer: FakeRandomizer(0))
+
+        let seen = Atomic<Set<String>>([])
+        let group = DispatchGroup()
+        for _ in 0..<8 {
+            DispatchQueue.global().async(group: group) {
+                while let endpoint = provider.currentEndpoint {
+                    seen.modify { $0.insert(endpoint.url) }
+                    provider.reportUnhealthy(endpoint)
+                }
+            }
+        }
+        group.wait()
+
+        expect(seen.value) == Set(sources.map { $0.url })
+        expect(provider.currentEndpoint).to(beNil())
+    }
+
+    // MARK: - Helpers
+
+    private static func url(_ host: String) -> String {
+        return "https://\(host).revenuecat.com"
+    }
+
+    private static func source(_ host: String, priority: Int = 0, weight: Int = 0) -> TestSource {
+        return TestSource(url: url(host), priority: priority, weight: weight)
+    }
+
+}
+
+private struct TestSource: RemoteConfigSource, Equatable {
+
+    let url: String
+    let priority: Int
+    let weight: Int
+
+}
+
+/// Returns queued values from `randomInt(below:)`, clamped into range, repeating the last value
+/// once the queue is drained.
+private final class FakeRandomizer: WeightedSourceRandomizer {
+
+    private let lock = Lock()
+    private var values: [Int]
+    private var index = 0
+
+    init(_ values: Int...) {
+        self.values = values.isEmpty ? [0] : values
+    }
+
+    func randomInt(below bound: Int) -> Int {
+        return self.lock.perform {
+            let value = self.index < self.values.count ? self.values[self.index] : self.values.last!
+            self.index += 1
+            return min(max(0, value), bound - 1)
+        }
+    }
+
+}

--- a/Tests/UnitTests/Networking/RemoteConfigSourceProviderTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfigSourceProviderTests.swift
@@ -15,7 +15,10 @@ final class RemoteConfigSourceProviderTests: TestCase {
     // MARK: - Initial selection
 
     func testCurrentEndpointsAreNilWhenNoSources() {
-        let provider = RemoteConfigSourceProvider(sources: RemoteConfigSources(), randomizer: FakeRandomizer())
+        let provider = RemoteConfigSourceProvider(
+            sources: RemoteConfigSources(api: [], blob: []),
+            randomizer: FakeRandomizer()
+        )
         expect(provider.currentAPIEndpoint).to(beNil())
         expect(provider.currentBlobEndpoint).to(beNil())
     }
@@ -86,6 +89,29 @@ final class RemoteConfigSourceProviderTests: TestCase {
         expect(provider.currentAPIEndpoint?.url) == Self.url("b")
         provider.reportUnhealthy(provider.currentAPIEndpoint!)
         expect(provider.currentAPIEndpoint).to(beNil())
+    }
+
+    func testDedupKeepsHighestPriorityRegardlessOfOrder() {
+        let provider = Self.apiProvider([
+            Self.source("a", priority: 0, weight: 1),
+            Self.source("a", priority: 10, weight: 1),
+            Self.source("b", priority: 5, weight: 1)
+        ])
+
+        // `a` is kept at priority 10, so it outranks `b` (priority 5) despite appearing first at 0.
+        expect(provider.currentAPIEndpoint?.url) == Self.url("a")
+        expect(provider.currentAPIEndpoint?.priority) == 10
+        provider.reportUnhealthy(provider.currentAPIEndpoint!)
+        expect(provider.currentAPIEndpoint?.url) == Self.url("b")
+    }
+
+    func testDedupTieBreaksByWeightForEqualPriority() {
+        let provider = Self.apiProvider([
+            Self.source("a", priority: 0, weight: 1),
+            Self.source("a", priority: 0, weight: 100)
+        ])
+
+        expect(provider.currentAPIEndpoint?.weight) == 100
     }
 
     // MARK: - api / blob independence
@@ -186,11 +212,11 @@ final class RemoteConfigSourceProviderTests: TestCase {
         provider.reportUnhealthy(provider.currentAPIEndpoint!)
         expect(provider.currentAPIEndpoint?.url) == Self.url("c")
 
-        provider.restart()
+        provider.restart(.api)
         expect(provider.currentAPIEndpoint?.url) == Self.url("a")
     }
 
-    func testRestartRewindsBothKinds() {
+    func testRestartOnlyRewindsRequestedKind() {
         let provider = RemoteConfigSourceProvider(
             sources: RemoteConfigSources(
                 api: [Self.source("api1", priority: 10), Self.source("api2", priority: 0)],
@@ -204,8 +230,11 @@ final class RemoteConfigSourceProviderTests: TestCase {
         expect(provider.currentAPIEndpoint?.url) == Self.url("api2")
         expect(provider.currentBlobEndpoint?.url) == Self.url("blob2")
 
-        provider.restart()
+        provider.restart(.api)
         expect(provider.currentAPIEndpoint?.url) == Self.url("api1")
+        expect(provider.currentBlobEndpoint?.url) == Self.url("blob2")
+
+        provider.restart(.blob)
         expect(provider.currentBlobEndpoint?.url) == Self.url("blob1")
     }
 
@@ -264,7 +293,10 @@ final class RemoteConfigSourceProviderTests: TestCase {
     }
 
     private static func apiProvider(_ sources: [RemoteConfigSource]) -> RemoteConfigSourceProvider {
-        return RemoteConfigSourceProvider(sources: RemoteConfigSources(api: sources), randomizer: FakeRandomizer(0))
+        return RemoteConfigSourceProvider(
+            sources: RemoteConfigSources(api: sources, blob: []),
+            randomizer: FakeRandomizer(0)
+        )
     }
 
 }

--- a/Tests/UnitTests/Networking/RemoteConfigSourceProviderTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfigSourceProviderTests.swift
@@ -14,29 +14,29 @@ final class RemoteConfigSourceProviderTests: TestCase {
 
     // MARK: - Initial selection
 
-    func testCurrentEndpointsAreNilWhenNoSources() {
+    func testCurrentSourcesAreNilWhenNoSources() {
         let provider = RemoteConfigSourceProvider(
             sources: RemoteConfigSources(api: [], blob: []),
             randomizer: FakeRandomizer()
         )
-        expect(provider.currentAPIEndpoint).to(beNil())
-        expect(provider.currentBlobEndpoint).to(beNil())
+        expect(provider.currentAPISource).to(beNil())
+        expect(provider.currentBlobSource).to(beNil())
     }
 
-    func testCurrentEndpointReturnsHighestPrioritySource() {
+    func testCurrentSourceReturnsHighestPrioritySource() {
         let low = Self.source("low", priority: 0, weight: 100)
         let high = Self.source("high", priority: 10, weight: 1)
         let provider = Self.apiProvider([low, high])
 
-        let endpoint = provider.currentAPIEndpoint
-        expect(endpoint?.url) == Self.url("high")
-        expect(endpoint?.kind) == .api
+        let handle = provider.currentAPISource
+        expect(handle?.url) == Self.url("high")
+        expect(handle?.purpose) == .api
     }
 
-    func testCurrentEndpointIsStableAcrossReads() {
+    func testCurrentSourceIsStableAcrossReads() {
         let provider = Self.apiProvider([Self.source("a"), Self.source("b")])
 
-        expect(provider.currentAPIEndpoint?.url) == provider.currentAPIEndpoint?.url
+        expect(provider.currentAPISource?.url) == provider.currentAPISource?.url
     }
 
     // MARK: - reportUnhealthy advances
@@ -46,18 +46,18 @@ final class RemoteConfigSourceProviderTests: TestCase {
         let low = Self.source("low", priority: 0, weight: 1)
         let provider = Self.apiProvider([high, low])
 
-        let first = provider.currentAPIEndpoint
+        let first = provider.currentAPISource
         expect(first?.url) == Self.url("high")
 
         provider.reportUnhealthy(first!)
-        expect(provider.currentAPIEndpoint?.url) == Self.url("low")
+        expect(provider.currentAPISource?.url) == Self.url("low")
     }
 
-    func testCurrentEndpointIsNilWhenExhausted() {
+    func testCurrentSourceIsNilWhenExhausted() {
         let provider = Self.apiProvider([Self.source("only")])
 
-        provider.reportUnhealthy(provider.currentAPIEndpoint!)
-        expect(provider.currentAPIEndpoint).to(beNil())
+        provider.reportUnhealthy(provider.currentAPISource!)
+        expect(provider.currentAPISource).to(beNil())
     }
 
     func testReportUnhealthyWalksFullFallbackOrder() {
@@ -66,13 +66,13 @@ final class RemoteConfigSourceProviderTests: TestCase {
         let third = Self.source("3", priority: 10, weight: 1)
         let provider = Self.apiProvider([first, second, third])
 
-        expect(provider.currentAPIEndpoint?.url) == Self.url("1")
-        provider.reportUnhealthy(provider.currentAPIEndpoint!)
-        expect(provider.currentAPIEndpoint?.url) == Self.url("2")
-        provider.reportUnhealthy(provider.currentAPIEndpoint!)
-        expect(provider.currentAPIEndpoint?.url) == Self.url("3")
-        provider.reportUnhealthy(provider.currentAPIEndpoint!)
-        expect(provider.currentAPIEndpoint).to(beNil())
+        expect(provider.currentAPISource?.url) == Self.url("1")
+        provider.reportUnhealthy(provider.currentAPISource!)
+        expect(provider.currentAPISource?.url) == Self.url("2")
+        provider.reportUnhealthy(provider.currentAPISource!)
+        expect(provider.currentAPISource?.url) == Self.url("3")
+        provider.reportUnhealthy(provider.currentAPISource!)
+        expect(provider.currentAPISource).to(beNil())
     }
 
     // MARK: - Dedup
@@ -84,11 +84,11 @@ final class RemoteConfigSourceProviderTests: TestCase {
             Self.source("b", priority: 0, weight: 1)
         ])
 
-        expect(provider.currentAPIEndpoint?.url) == Self.url("a")
-        provider.reportUnhealthy(provider.currentAPIEndpoint!)
-        expect(provider.currentAPIEndpoint?.url) == Self.url("b")
-        provider.reportUnhealthy(provider.currentAPIEndpoint!)
-        expect(provider.currentAPIEndpoint).to(beNil())
+        expect(provider.currentAPISource?.url) == Self.url("a")
+        provider.reportUnhealthy(provider.currentAPISource!)
+        expect(provider.currentAPISource?.url) == Self.url("b")
+        provider.reportUnhealthy(provider.currentAPISource!)
+        expect(provider.currentAPISource).to(beNil())
     }
 
     func testDedupKeepsHighestPriorityRegardlessOfOrder() {
@@ -99,10 +99,10 @@ final class RemoteConfigSourceProviderTests: TestCase {
         ])
 
         // `a` is kept at priority 10, so it outranks `b` (priority 5) despite appearing first at 0.
-        expect(provider.currentAPIEndpoint?.url) == Self.url("a")
-        expect(provider.currentAPIEndpoint?.priority) == 10
-        provider.reportUnhealthy(provider.currentAPIEndpoint!)
-        expect(provider.currentAPIEndpoint?.url) == Self.url("b")
+        expect(provider.currentAPISource?.url) == Self.url("a")
+        expect(provider.currentAPISource?.priority) == 10
+        provider.reportUnhealthy(provider.currentAPISource!)
+        expect(provider.currentAPISource?.url) == Self.url("b")
     }
 
     func testDedupTieBreaksByWeightForEqualPriority() {
@@ -111,7 +111,7 @@ final class RemoteConfigSourceProviderTests: TestCase {
             Self.source("a", priority: 0, weight: 100)
         ])
 
-        expect(provider.currentAPIEndpoint?.weight) == 100
+        expect(provider.currentAPISource?.weight) == 100
     }
 
     // MARK: - api / blob independence
@@ -122,12 +122,12 @@ final class RemoteConfigSourceProviderTests: TestCase {
             randomizer: FakeRandomizer(0)
         )
 
-        let api = provider.currentAPIEndpoint
-        let blob = provider.currentBlobEndpoint
+        let api = provider.currentAPISource
+        let blob = provider.currentBlobSource
         expect(api?.url) == Self.url("api")
-        expect(api?.kind) == .api
+        expect(api?.purpose) == .api
         expect(blob?.url) == Self.url("blob")
-        expect(blob?.kind) == .blob
+        expect(blob?.purpose) == .blob
     }
 
     func testReportingAPIUnhealthyDoesNotAffectBlob() {
@@ -139,13 +139,13 @@ final class RemoteConfigSourceProviderTests: TestCase {
             randomizer: FakeRandomizer(0)
         )
 
-        provider.reportUnhealthy(provider.currentAPIEndpoint!)
-        expect(provider.currentAPIEndpoint?.url) == Self.url("api2")
-        expect(provider.currentBlobEndpoint?.url) == Self.url("blob1")
+        provider.reportUnhealthy(provider.currentAPISource!)
+        expect(provider.currentAPISource?.url) == Self.url("api2")
+        expect(provider.currentBlobSource?.url) == Self.url("blob1")
 
-        provider.reportUnhealthy(provider.currentBlobEndpoint!)
-        expect(provider.currentAPIEndpoint?.url) == Self.url("api2")
-        expect(provider.currentBlobEndpoint?.url) == Self.url("blob2")
+        provider.reportUnhealthy(provider.currentBlobSource!)
+        expect(provider.currentAPISource?.url) == Self.url("api2")
+        expect(provider.currentBlobSource?.url) == Self.url("blob2")
     }
 
     // MARK: - Stale report handling (race conditions)
@@ -153,54 +153,54 @@ final class RemoteConfigSourceProviderTests: TestCase {
     func testStaleReportIsIgnoredAfterAnotherCallerAdvanced() {
         let provider = Self.apiProvider([Self.source("a"), Self.source("b"), Self.source("c")])
 
-        // Two callers grab the same current endpoint.
-        let endpointA = provider.currentAPIEndpoint
-        let endpointB = provider.currentAPIEndpoint
-        expect(endpointA?.url) == endpointB?.url
+        // Two callers grab the same current source.
+        let handleA = provider.currentAPISource
+        let handleB = provider.currentAPISource
+        expect(handleA?.url) == handleB?.url
 
         // Caller A reports it unhealthy: the provider advances.
-        provider.reportUnhealthy(endpointA!)
-        expect(provider.currentAPIEndpoint?.url) == Self.url("b")
+        provider.reportUnhealthy(handleA!)
+        expect(provider.currentAPISource?.url) == Self.url("b")
 
-        // Caller B reports the *same* (now superseded) endpoint: this must NOT advance again.
-        provider.reportUnhealthy(endpointB!)
-        expect(provider.currentAPIEndpoint?.url) == Self.url("b")
+        // Caller B reports the *same* (now superseded) source: this must NOT advance again.
+        provider.reportUnhealthy(handleB!)
+        expect(provider.currentAPISource?.url) == Self.url("b")
     }
 
-    func testReportingSameEndpointTwiceAdvancesOnlyOnce() {
+    func testReportingSameSourceTwiceAdvancesOnlyOnce() {
         let provider = Self.apiProvider([Self.source("a"), Self.source("b"), Self.source("c")])
 
-        let endpoint = provider.currentAPIEndpoint
-        provider.reportUnhealthy(endpoint!)
-        provider.reportUnhealthy(endpoint!)
-        provider.reportUnhealthy(endpoint!)
+        let handle = provider.currentAPISource
+        provider.reportUnhealthy(handle!)
+        provider.reportUnhealthy(handle!)
+        provider.reportUnhealthy(handle!)
 
-        expect(provider.currentAPIEndpoint?.url) == Self.url("b")
+        expect(provider.currentAPISource?.url) == Self.url("b")
     }
 
-    func testReportingFreshEndpointAfterStaleReportStillAdvances() {
+    func testReportingFreshSourceAfterStaleReportStillAdvances() {
         let provider = Self.apiProvider([Self.source("a"), Self.source("b"), Self.source("c")])
 
-        let stale = provider.currentAPIEndpoint
+        let stale = provider.currentAPISource
         provider.reportUnhealthy(stale!)              // a -> b
         provider.reportUnhealthy(stale!)              // ignored, still b
 
-        let fresh = provider.currentAPIEndpoint       // b
+        let fresh = provider.currentAPISource       // b
         provider.reportUnhealthy(fresh!)              // b -> c
-        expect(provider.currentAPIEndpoint?.url) == Self.url("c")
+        expect(provider.currentAPISource?.url) == Self.url("c")
     }
 
     func testStaleReportOnExhaustedProviderIsIgnored() {
         let provider = Self.apiProvider([Self.source("a"), Self.source("b")])
 
-        let first = provider.currentAPIEndpoint
+        let first = provider.currentAPISource
         provider.reportUnhealthy(first!)
-        provider.reportUnhealthy(provider.currentAPIEndpoint!)
-        expect(provider.currentAPIEndpoint).to(beNil())
+        provider.reportUnhealthy(provider.currentAPISource!)
+        expect(provider.currentAPISource).to(beNil())
 
-        // Reporting the original stale endpoint again must not resurrect or change anything.
+        // Reporting the original stale source again must not resurrect or change anything.
         provider.reportUnhealthy(first!)
-        expect(provider.currentAPIEndpoint).to(beNil())
+        expect(provider.currentAPISource).to(beNil())
     }
 
     // MARK: - restart
@@ -208,15 +208,15 @@ final class RemoteConfigSourceProviderTests: TestCase {
     func testRestartRewindsToFirstSource() {
         let provider = Self.apiProvider([Self.source("a"), Self.source("b"), Self.source("c")])
 
-        provider.reportUnhealthy(provider.currentAPIEndpoint!)
-        provider.reportUnhealthy(provider.currentAPIEndpoint!)
-        expect(provider.currentAPIEndpoint?.url) == Self.url("c")
+        provider.reportUnhealthy(provider.currentAPISource!)
+        provider.reportUnhealthy(provider.currentAPISource!)
+        expect(provider.currentAPISource?.url) == Self.url("c")
 
-        provider.restart(.api)
-        expect(provider.currentAPIEndpoint?.url) == Self.url("a")
+        provider.restart(for: .api)
+        expect(provider.currentAPISource?.url) == Self.url("a")
     }
 
-    func testRestartOnlyRewindsRequestedKind() {
+    func testRestartOnlyRewindsRequestedPurpose() {
         let provider = RemoteConfigSourceProvider(
             sources: RemoteConfigSources(
                 api: [Self.source("api1", priority: 10), Self.source("api2", priority: 0)],
@@ -225,43 +225,40 @@ final class RemoteConfigSourceProviderTests: TestCase {
             randomizer: FakeRandomizer(0)
         )
 
-        provider.reportUnhealthy(provider.currentAPIEndpoint!)
-        provider.reportUnhealthy(provider.currentBlobEndpoint!)
-        expect(provider.currentAPIEndpoint?.url) == Self.url("api2")
-        expect(provider.currentBlobEndpoint?.url) == Self.url("blob2")
+        provider.reportUnhealthy(provider.currentAPISource!)
+        provider.reportUnhealthy(provider.currentBlobSource!)
+        expect(provider.currentAPISource?.url) == Self.url("api2")
+        expect(provider.currentBlobSource?.url) == Self.url("blob2")
 
-        provider.restart(.api)
-        expect(provider.currentAPIEndpoint?.url) == Self.url("api1")
-        expect(provider.currentBlobEndpoint?.url) == Self.url("blob2")
+        provider.restart(for: .api)
+        expect(provider.currentAPISource?.url) == Self.url("api1")
+        expect(provider.currentBlobSource?.url) == Self.url("blob2")
 
-        provider.restart(.blob)
-        expect(provider.currentBlobEndpoint?.url) == Self.url("blob1")
+        provider.restart(for: .blob)
+        expect(provider.currentBlobSource?.url) == Self.url("blob1")
     }
 
     // MARK: - Threading
 
-    func testConcurrentReportsAdvanceAtMostOncePerEndpoint() {
+    func testConcurrentReportsOfSameSourceAdvanceExactlyOnce() {
         let sources = (0..<100).map { Self.source("\($0)") }
         let provider = Self.apiProvider(sources)
 
-        // Every iteration grabs the current endpoint and reports it unhealthy concurrently. Even
-        // with many threads racing, a single endpoint can only advance the provider once, so the
-        // provider must walk the fallback order one step at a time and never skip ahead.
+        let first = provider.currentAPISource
+        expect(first?.url) == Self.url("0")
+
+        // Many threads report the *same* source concurrently. The first report advances to the next
+        // source; every other report now refers to a superseded url and must be ignored. So no matter
+        // how the threads interleave, the provider advances exactly one step.
         DispatchQueue.concurrentPerform(iterations: 500) { _ in
-            if let endpoint = provider.currentAPIEndpoint {
-                provider.reportUnhealthy(endpoint)
-            }
+            provider.reportUnhealthy(first!)
         }
 
-        // The exact landing point is timing-dependent, but it must be a valid, reachable URL (or
-        // nil if every source happened to be exhausted) — never a corrupted/torn state.
-        if let url = provider.currentAPIEndpoint?.url {
-            expect(sources.map { $0.url }).to(contain(url))
-        }
+        expect(provider.currentAPISource?.url) == Self.url("1")
     }
 
     func testConcurrentReportsNeverSkipSourcesWhenSerialized() {
-        // Drive the provider to exhaustion by always reporting the *current* endpoint. Collect every
+        // Drive the provider to exhaustion by always reporting the *current* source. Collect every
         // distinct URL handed out; because stale reports are ignored, no source may be skipped.
         let sources = (0..<50).map { Self.source("\($0)") }
         let provider = Self.apiProvider(sources)
@@ -270,16 +267,16 @@ final class RemoteConfigSourceProviderTests: TestCase {
         let group = DispatchGroup()
         for _ in 0..<8 {
             DispatchQueue.global().async(group: group) {
-                while let endpoint = provider.currentAPIEndpoint {
-                    seen.modify { $0.insert(endpoint.url) }
-                    provider.reportUnhealthy(endpoint)
+                while let handle = provider.currentAPISource {
+                    seen.modify { $0.insert(handle.url) }
+                    provider.reportUnhealthy(handle)
                 }
             }
         }
         group.wait()
 
         expect(seen.value) == Set(sources.map { $0.url })
-        expect(provider.currentAPIEndpoint).to(beNil())
+        expect(provider.currentAPISource).to(beNil())
     }
 
     // MARK: - Helpers

--- a/Tests/UnitTests/Networking/RemoteConfigSourceProviderTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfigSourceProviderTests.swift
@@ -16,11 +16,12 @@ final class RemoteConfigSourceProviderTests: TestCase {
 
     func testCurrentSourcesAreNilWhenNoSources() {
         let provider = RemoteConfigSourceProvider(
-            sources: RemoteConfigSources(api: [], blob: []),
+            apiSources: [],
+            blobSources: [],
             randomizer: FakeRandomizer()
         )
-        expect(provider.currentAPISource).to(beNil())
-        expect(provider.currentBlobSource).to(beNil())
+        expect(provider.getCurrent(for: .api)).to(beNil())
+        expect(provider.getCurrent(for: .blob)).to(beNil())
     }
 
     func testCurrentSourceReturnsHighestPrioritySource() {
@@ -28,7 +29,7 @@ final class RemoteConfigSourceProviderTests: TestCase {
         let high = Self.source("high", priority: 10, weight: 1)
         let provider = Self.apiProvider([low, high])
 
-        let handle = provider.currentAPISource
+        let handle = provider.getCurrent(for: .api)
         expect(handle?.url) == Self.url("high")
         expect(handle?.purpose) == .api
     }
@@ -36,7 +37,7 @@ final class RemoteConfigSourceProviderTests: TestCase {
     func testCurrentSourceIsStableAcrossReads() {
         let provider = Self.apiProvider([Self.source("a"), Self.source("b")])
 
-        expect(provider.currentAPISource?.url) == provider.currentAPISource?.url
+        expect(provider.getCurrent(for: .api)?.url) == provider.getCurrent(for: .api)?.url
     }
 
     // MARK: - reportUnhealthy advances
@@ -46,18 +47,18 @@ final class RemoteConfigSourceProviderTests: TestCase {
         let low = Self.source("low", priority: 0, weight: 1)
         let provider = Self.apiProvider([high, low])
 
-        let first = provider.currentAPISource
+        let first = provider.getCurrent(for: .api)
         expect(first?.url) == Self.url("high")
 
         provider.reportUnhealthy(first!)
-        expect(provider.currentAPISource?.url) == Self.url("low")
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("low")
     }
 
     func testCurrentSourceIsNilWhenExhausted() {
         let provider = Self.apiProvider([Self.source("only")])
 
-        provider.reportUnhealthy(provider.currentAPISource!)
-        expect(provider.currentAPISource).to(beNil())
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!)
+        expect(provider.getCurrent(for: .api)).to(beNil())
     }
 
     func testReportUnhealthyWalksFullFallbackOrder() {
@@ -66,13 +67,13 @@ final class RemoteConfigSourceProviderTests: TestCase {
         let third = Self.source("3", priority: 10, weight: 1)
         let provider = Self.apiProvider([first, second, third])
 
-        expect(provider.currentAPISource?.url) == Self.url("1")
-        provider.reportUnhealthy(provider.currentAPISource!)
-        expect(provider.currentAPISource?.url) == Self.url("2")
-        provider.reportUnhealthy(provider.currentAPISource!)
-        expect(provider.currentAPISource?.url) == Self.url("3")
-        provider.reportUnhealthy(provider.currentAPISource!)
-        expect(provider.currentAPISource).to(beNil())
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("1")
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!)
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("2")
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!)
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("3")
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!)
+        expect(provider.getCurrent(for: .api)).to(beNil())
     }
 
     // MARK: - Dedup
@@ -84,11 +85,11 @@ final class RemoteConfigSourceProviderTests: TestCase {
             Self.source("b", priority: 0, weight: 1)
         ])
 
-        expect(provider.currentAPISource?.url) == Self.url("a")
-        provider.reportUnhealthy(provider.currentAPISource!)
-        expect(provider.currentAPISource?.url) == Self.url("b")
-        provider.reportUnhealthy(provider.currentAPISource!)
-        expect(provider.currentAPISource).to(beNil())
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("a")
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!)
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("b")
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!)
+        expect(provider.getCurrent(for: .api)).to(beNil())
     }
 
     func testDedupKeepsHighestPriorityRegardlessOfOrder() {
@@ -99,10 +100,10 @@ final class RemoteConfigSourceProviderTests: TestCase {
         ])
 
         // `a` is kept at priority 10, so it outranks `b` (priority 5) despite appearing first at 0.
-        expect(provider.currentAPISource?.url) == Self.url("a")
-        expect(provider.currentAPISource?.priority) == 10
-        provider.reportUnhealthy(provider.currentAPISource!)
-        expect(provider.currentAPISource?.url) == Self.url("b")
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("a")
+        expect(provider.getCurrent(for: .api)?.priority) == 10
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!)
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("b")
     }
 
     func testDedupTieBreaksByWeightForEqualPriority() {
@@ -111,19 +112,20 @@ final class RemoteConfigSourceProviderTests: TestCase {
             Self.source("a", priority: 0, weight: 100)
         ])
 
-        expect(provider.currentAPISource?.weight) == 100
+        expect(provider.getCurrent(for: .api)?.weight) == 100
     }
 
     // MARK: - api / blob independence
 
     func testAPIAndBlobAreExposedIndependently() {
         let provider = RemoteConfigSourceProvider(
-            sources: RemoteConfigSources(api: [Self.source("api")], blob: [Self.source("blob")]),
+            apiSources: [Self.source("api")],
+            blobSources: [Self.source("blob")],
             randomizer: FakeRandomizer(0)
         )
 
-        let api = provider.currentAPISource
-        let blob = provider.currentBlobSource
+        let api = provider.getCurrent(for: .api)
+        let blob = provider.getCurrent(for: .blob)
         expect(api?.url) == Self.url("api")
         expect(api?.purpose) == .api
         expect(blob?.url) == Self.url("blob")
@@ -132,20 +134,18 @@ final class RemoteConfigSourceProviderTests: TestCase {
 
     func testReportingAPIUnhealthyDoesNotAffectBlob() {
         let provider = RemoteConfigSourceProvider(
-            sources: RemoteConfigSources(
-                api: [Self.source("api1", priority: 10), Self.source("api2", priority: 0)],
-                blob: [Self.source("blob1", priority: 10), Self.source("blob2", priority: 0)]
-            ),
+            apiSources: [Self.source("api1", priority: 10), Self.source("api2", priority: 0)],
+            blobSources: [Self.source("blob1", priority: 10), Self.source("blob2", priority: 0)],
             randomizer: FakeRandomizer(0)
         )
 
-        provider.reportUnhealthy(provider.currentAPISource!)
-        expect(provider.currentAPISource?.url) == Self.url("api2")
-        expect(provider.currentBlobSource?.url) == Self.url("blob1")
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!)
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("api2")
+        expect(provider.getCurrent(for: .blob)?.url) == Self.url("blob1")
 
-        provider.reportUnhealthy(provider.currentBlobSource!)
-        expect(provider.currentAPISource?.url) == Self.url("api2")
-        expect(provider.currentBlobSource?.url) == Self.url("blob2")
+        provider.reportUnhealthy(provider.getCurrent(for: .blob)!)
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("api2")
+        expect(provider.getCurrent(for: .blob)?.url) == Self.url("blob2")
     }
 
     // MARK: - Stale report handling (race conditions)
@@ -154,53 +154,53 @@ final class RemoteConfigSourceProviderTests: TestCase {
         let provider = Self.apiProvider([Self.source("a"), Self.source("b"), Self.source("c")])
 
         // Two callers grab the same current source.
-        let handleA = provider.currentAPISource
-        let handleB = provider.currentAPISource
+        let handleA = provider.getCurrent(for: .api)
+        let handleB = provider.getCurrent(for: .api)
         expect(handleA?.url) == handleB?.url
 
         // Caller A reports it unhealthy: the provider advances.
         provider.reportUnhealthy(handleA!)
-        expect(provider.currentAPISource?.url) == Self.url("b")
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("b")
 
         // Caller B reports the *same* (now superseded) source: this must NOT advance again.
         provider.reportUnhealthy(handleB!)
-        expect(provider.currentAPISource?.url) == Self.url("b")
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("b")
     }
 
     func testReportingSameSourceTwiceAdvancesOnlyOnce() {
         let provider = Self.apiProvider([Self.source("a"), Self.source("b"), Self.source("c")])
 
-        let handle = provider.currentAPISource
+        let handle = provider.getCurrent(for: .api)
         provider.reportUnhealthy(handle!)
         provider.reportUnhealthy(handle!)
         provider.reportUnhealthy(handle!)
 
-        expect(provider.currentAPISource?.url) == Self.url("b")
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("b")
     }
 
     func testReportingFreshSourceAfterStaleReportStillAdvances() {
         let provider = Self.apiProvider([Self.source("a"), Self.source("b"), Self.source("c")])
 
-        let stale = provider.currentAPISource
+        let stale = provider.getCurrent(for: .api)
         provider.reportUnhealthy(stale!)              // a -> b
         provider.reportUnhealthy(stale!)              // ignored, still b
 
-        let fresh = provider.currentAPISource       // b
+        let fresh = provider.getCurrent(for: .api)       // b
         provider.reportUnhealthy(fresh!)              // b -> c
-        expect(provider.currentAPISource?.url) == Self.url("c")
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("c")
     }
 
     func testStaleReportOnExhaustedProviderIsIgnored() {
         let provider = Self.apiProvider([Self.source("a"), Self.source("b")])
 
-        let first = provider.currentAPISource
+        let first = provider.getCurrent(for: .api)
         provider.reportUnhealthy(first!)
-        provider.reportUnhealthy(provider.currentAPISource!)
-        expect(provider.currentAPISource).to(beNil())
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!)
+        expect(provider.getCurrent(for: .api)).to(beNil())
 
         // Reporting the original stale source again must not resurrect or change anything.
         provider.reportUnhealthy(first!)
-        expect(provider.currentAPISource).to(beNil())
+        expect(provider.getCurrent(for: .api)).to(beNil())
     }
 
     // MARK: - restart
@@ -208,34 +208,32 @@ final class RemoteConfigSourceProviderTests: TestCase {
     func testRestartRewindsToFirstSource() {
         let provider = Self.apiProvider([Self.source("a"), Self.source("b"), Self.source("c")])
 
-        provider.reportUnhealthy(provider.currentAPISource!)
-        provider.reportUnhealthy(provider.currentAPISource!)
-        expect(provider.currentAPISource?.url) == Self.url("c")
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!)
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!)
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("c")
 
         provider.restart(for: .api)
-        expect(provider.currentAPISource?.url) == Self.url("a")
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("a")
     }
 
     func testRestartOnlyRewindsRequestedPurpose() {
         let provider = RemoteConfigSourceProvider(
-            sources: RemoteConfigSources(
-                api: [Self.source("api1", priority: 10), Self.source("api2", priority: 0)],
-                blob: [Self.source("blob1", priority: 10), Self.source("blob2", priority: 0)]
-            ),
+            apiSources: [Self.source("api1", priority: 10), Self.source("api2", priority: 0)],
+            blobSources: [Self.source("blob1", priority: 10), Self.source("blob2", priority: 0)],
             randomizer: FakeRandomizer(0)
         )
 
-        provider.reportUnhealthy(provider.currentAPISource!)
-        provider.reportUnhealthy(provider.currentBlobSource!)
-        expect(provider.currentAPISource?.url) == Self.url("api2")
-        expect(provider.currentBlobSource?.url) == Self.url("blob2")
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!)
+        provider.reportUnhealthy(provider.getCurrent(for: .blob)!)
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("api2")
+        expect(provider.getCurrent(for: .blob)?.url) == Self.url("blob2")
 
         provider.restart(for: .api)
-        expect(provider.currentAPISource?.url) == Self.url("api1")
-        expect(provider.currentBlobSource?.url) == Self.url("blob2")
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("api1")
+        expect(provider.getCurrent(for: .blob)?.url) == Self.url("blob2")
 
         provider.restart(for: .blob)
-        expect(provider.currentBlobSource?.url) == Self.url("blob1")
+        expect(provider.getCurrent(for: .blob)?.url) == Self.url("blob1")
     }
 
     // MARK: - Threading
@@ -244,7 +242,7 @@ final class RemoteConfigSourceProviderTests: TestCase {
         let sources = (0..<100).map { Self.source("\($0)") }
         let provider = Self.apiProvider(sources)
 
-        let first = provider.currentAPISource
+        let first = provider.getCurrent(for: .api)
         expect(first?.url) == Self.url("0")
 
         // Many threads report the *same* source concurrently. The first report advances to the next
@@ -254,7 +252,7 @@ final class RemoteConfigSourceProviderTests: TestCase {
             provider.reportUnhealthy(first!)
         }
 
-        expect(provider.currentAPISource?.url) == Self.url("1")
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("1")
     }
 
     func testConcurrentReportsNeverSkipSourcesWhenSerialized() {
@@ -267,7 +265,7 @@ final class RemoteConfigSourceProviderTests: TestCase {
         let group = DispatchGroup()
         for _ in 0..<8 {
             DispatchQueue.global().async(group: group) {
-                while let handle = provider.currentAPISource {
+                while let handle = provider.getCurrent(for: .api) {
                     seen.modify { $0.insert(handle.url) }
                     provider.reportUnhealthy(handle)
                 }
@@ -276,7 +274,7 @@ final class RemoteConfigSourceProviderTests: TestCase {
         group.wait()
 
         expect(seen.value) == Set(sources.map { $0.url })
-        expect(provider.currentAPISource).to(beNil())
+        expect(provider.getCurrent(for: .api)).to(beNil())
     }
 
     // MARK: - Helpers
@@ -291,7 +289,8 @@ final class RemoteConfigSourceProviderTests: TestCase {
 
     private static func apiProvider(_ sources: [RemoteConfigSource]) -> RemoteConfigSourceProvider {
         return RemoteConfigSourceProvider(
-            sources: RemoteConfigSources(api: sources, blob: []),
+            apiSources: sources,
+            blobSources: [],
             randomizer: FakeRandomizer(0)
         )
     }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Groundwork for API/blob source fallback behavior on the config endpoint: a reusable component that picks which source to use and falls back when one fails. Not yet wired into networking.

### Description
- `RemoteConfigSourceProvider` orders sources via `WeightedSourceSelector` from #7077 and exposes `currentEndpoint` / `reportUnhealthy(_:)` / `restart()`.
- Thread-safe + keeps track of the current source using a UUID token so concurrent calls to `reportUnhealthy(_:)` can't advance past a source that actually hasn't failed yet.
- One `RemoteConfigSourceProvider` manages a single source kind. So API and blob endpoints will use separate instances.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New isolated networking helper with no production integration yet; behavior is covered by extensive unit tests.
> 
> **Overview**
> Adds **`RemoteConfigSourceProvider`**, groundwork for remote config **API and blob URL failover** (not wired into fetch/networking yet).
> 
> The provider keeps **separate ordered source lists** for `.api` and `.blob`, using **`WeightedSourceSelector`** for priority/weight ordering. Callers get a **`RemoteConfigSourceHandle`** via `getCurrent(for:)`, advance with `reportUnhealthy(_:)`, and reset a lane with `restart(for:)`. **URL deduplication** at init keeps the highest priority (weight tie-break) and logs **`duplicateSourceURL`** when duplicates disagree.
> 
> **Token-stamped handles** make `reportUnhealthy` ignore stale or duplicate reports (including after `restart`), with **lock-protected** failover for concurrency. Includes **`RemoteConfigSourceProviderType`**, **`MockRemoteConfigSourceProvider`**, and broad unit tests (dedup, independence, stale reports, threading).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acacac1f8178979b6bee7a17cc08bb99d22a301e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->