### PR TITLE
feat(remote-config): add production signing integration tests

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -2914,6 +2914,7 @@
 		A1B2C3D42FE2000000000008 /* RemoteConfigDiskCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigDiskCacheTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE200000000000A /* RemoteConfigManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigManagerTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE200000000000E /* RemoteConfigBlobStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobStoreTests.swift; sourceTree = "<group>"; };
+		A1B2C3D42FE300000000001 /* ProductionRemoteConfigIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductionRemoteConfigIntegrationTests.swift; sourceTree = "<group>"; };
 		E31E8A264E9F4375A3B29D78 /* RemoteConfigurationDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigurationDecodingTests.swift; sourceTree = "<group>"; };
 		FEDA000000000000000000A1 /* WeightedSourceSelectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightedSourceSelectorTests.swift; sourceTree = "<group>"; };
 		FEDA000000000000000000C1 /* RemoteConfigSourceProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigSourceProviderTests.swift; sourceTree = "<group>"; };
@@ -4088,6 +4089,7 @@
 			isa = PBXGroup;
 			children = (
 				8337DD6D2E0A7CFE000798BF /* paywall-preview-resources */,
+				A1B2C3D42FE300000000000 /* BackendIntegrationTests */,
 				2DD500EF2C519EB4009C19B7 /* TestingApps */,
 				2DAC5F7326F13C9800C5258F /* StoreKitUnitTests */,
 				57B425A3275800B60075BDC4 /* Test Plans */,
@@ -4613,6 +4615,14 @@
 				A1B2C3D42FE200000000000A /* RemoteConfigManagerTests.swift */,
 			);
 			path = RemoteConfig;
+			sourceTree = "<group>";
+		};
+		A1B2C3D42FE300000000000 /* BackendIntegrationTests */ = {
+			isa = PBXGroup;
+			children = (
+				A1B2C3D42FE300000000001 /* ProductionRemoteConfigIntegrationTests.swift */,
+			);
+			path = BackendIntegrationTests;
 			sourceTree = "<group>";
 		};
 		35E840C1270FB45600899AE2 /* Support */ = {

--- a/Tests/BackendIntegrationTests/ProductionRemoteConfigIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/ProductionRemoteConfigIntegrationTests.swift
@@ -20,16 +20,16 @@ import XCTest
 @MainActor
 class BaseProductionRemoteConfigIntegrationTests: BaseBackendIntegrationTests {
 
-    private static let appUserID = "integrationTestRemoteConfigUser"
     private static let domain = RemoteConfiguration.defaultDomain
 
     private lazy var remoteConfigAPI = self.createRemoteConfigAPI()
+    private lazy var appUserID = self.createAppUserID()
 
     func fetchRemoteConfig(manifest: String? = nil) async throws -> RemoteConfigFetchResult {
         return try await withCheckedThrowingContinuation { continuation in
             self.remoteConfigAPI.getRemoteConfig(
                 request: .init(
-                    appUserID: Self.appUserID,
+                    appUserID: self.appUserID,
                     domain: Self.domain,
                     manifest: manifest,
                     prefetchedBlobs: []
@@ -73,6 +73,16 @@ class BaseProductionRemoteConfigIntegrationTests: BaseBackendIntegrationTests {
 }
 
 private extension BaseProductionRemoteConfigIntegrationTests {
+
+    func createAppUserID() -> String {
+        let rawIdentifier = "\(type(of: self)).\(self.name)"
+        let allowedCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+        let sanitizedIdentifier = rawIdentifier.unicodeScalars.map { scalar in
+            allowedCharacters.contains(scalar) ? Character(scalar) : "-"
+        }
+
+        return "integrationTestRemoteConfigUser-\(String(sanitizedIdentifier))"
+    }
 
     func createRemoteConfigAPI() -> RemoteConfigAPI {
         let systemInfo = SystemInfo(

--- a/Tests/BackendIntegrationTests/ProductionRemoteConfigIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/ProductionRemoteConfigIntegrationTests.swift
@@ -1,0 +1,151 @@
+//
+//  ProductionRemoteConfigIntegrationTests.swift
+//  BackendIntegrationTests
+//
+//  Created by Rick van der Linden on 29/06/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+//
+
+import Nimble
+import XCTest
+
+#if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+@_spi(Internal) @testable import RevenueCat_CustomEntitlementComputation
+#else
+@_spi(Internal) @testable import RevenueCat
+#endif
+
+// swiftlint:disable type_name
+
+@MainActor
+class BaseProductionRemoteConfigIntegrationTests: BaseBackendIntegrationTests {
+
+    private static let appUserID = "integrationTestRemoteConfigUser"
+    private static let domain = RemoteConfiguration.defaultDomain
+
+    private lazy var remoteConfigAPI = self.createRemoteConfigAPI()
+
+    func fetchRemoteConfig(manifest: String? = nil) async throws -> RemoteConfigFetchResult {
+        return try await withCheckedThrowingContinuation { continuation in
+            self.remoteConfigAPI.getRemoteConfig(
+                request: .init(
+                    appUserID: Self.appUserID,
+                    domain: Self.domain,
+                    manifest: manifest,
+                    prefetchedBlobs: []
+                ),
+                isAppBackgrounded: false
+            ) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
+
+    func remoteConfiguration(from container: RemoteConfigContainer) throws -> RemoteConfiguration {
+        return try container.configElement.withPayloadBytes { bytes in
+            try JSONDecoder.default.decode(
+                RemoteConfiguration.self,
+                from: Data(bytes)
+            )
+        }
+    }
+
+    func verifyRemoteConfiguration(_ configuration: RemoteConfiguration) {
+        expect(configuration.domain) == Self.domain
+        expect(configuration.manifest).toNot(beEmpty())
+    }
+
+    func verifyContainerResponse(_ result: RemoteConfigFetchResult) throws -> RemoteConfiguration {
+        expect(result.verificationResult) == .verified
+
+        let container = try XCTUnwrap(result.container)
+        let configuration = try self.remoteConfiguration(from: container)
+        self.verifyRemoteConfiguration(configuration)
+
+        return configuration
+    }
+
+    func verifyNoContentResponse(_ result: RemoteConfigFetchResult) {
+        expect(result.verificationResult) == .verified
+        expect(result.container).to(beNil())
+    }
+
+}
+
+private extension BaseProductionRemoteConfigIntegrationTests {
+
+    func createRemoteConfigAPI() -> RemoteConfigAPI {
+        let systemInfo = SystemInfo(
+            platformInfo: nil,
+            finishTransactions: true,
+            storeKitVersion: Self.storeKitVersion,
+            apiKey: self.apiKey,
+            responseVerificationMode: Self.responseVerificationMode,
+            dangerousSettings: DangerousSettings(),
+            isAppBackgrounded: false,
+            preferredLocalesProvider: PreferredLocalesProvider(preferredLocaleOverride: nil)
+        )
+        let backend = Backend(
+            systemInfo: systemInfo,
+            eTagManager: ETagManager(),
+            operationDispatcher: .default,
+            attributionFetcher: AttributionFetcher(
+                attributionFactory: AttributionTypeFactory(),
+                systemInfo: systemInfo
+            ),
+            offlineCustomerInfoCreator: nil,
+            diagnosticsTracker: nil
+        )
+
+        return backend.remoteConfigAPI
+    }
+
+}
+
+final class ProductionRemoteConfigIntegrationTests: BaseProductionRemoteConfigIntegrationTests {
+
+    override class var responseVerificationMode: Signing.ResponseVerificationMode {
+        return .informational(Signing.loadPublicKey())
+    }
+
+    func testCanFetchRemoteConfig() async throws {
+        let result = try await self.fetchRemoteConfig()
+
+        _ = try self.verifyContainerResponse(result)
+    }
+
+    func testReplayingManifestReturnsNoContent() async throws {
+        let configuration = try self.verifyContainerResponse(
+            try await self.fetchRemoteConfig()
+        )
+
+        let result = try await self.fetchRemoteConfig(manifest: configuration.manifest)
+
+        self.verifyNoContentResponse(result)
+    }
+
+}
+
+final class EnforcedProductionRemoteConfigIntegrationTests: BaseProductionRemoteConfigIntegrationTests {
+
+    override class var responseVerificationMode: Signing.ResponseVerificationMode {
+        return .enforced(Signing.loadPublicKey())
+    }
+
+    func testVerifiesSignedResponseWhenVerificationIsEnforced() async throws {
+        let result = try await self.fetchRemoteConfig()
+
+        _ = try self.verifyContainerResponse(result)
+    }
+
+    func testVerifiesNoContentResponseWhenVerificationIsEnforced() async throws {
+        let configuration = try self.verifyContainerResponse(
+            try await self.fetchRemoteConfig()
+        )
+
+        let result = try await self.fetchRemoteConfig(manifest: configuration.manifest)
+
+        self.verifyNoContentResponse(result)
+    }
+
+}


### PR DESCRIPTION
Part of a stack of PRs, builds on #7080.

Adds the equivalent  integration tests as added in RevenueCat/purchases-android#3659.

Makes an empty request for the default domain to the `/v1/config` endpoint, with a follow up request with the received manifest, ensuring the second responds is a 204 no content one.

Asserts on the signature verification for both responses, both in the informational as well as enforced verification mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions with no production SDK behavior changes; risk is limited to CI flakiness or credentials for live backend calls.
> 
> **Overview**
> Adds **production backend integration tests** for remote config under `Tests/BackendIntegrationTests/`, wired into the Xcode project.
> 
> A shared `BaseProductionRemoteConfigIntegrationTests` helper calls `RemoteConfigAPI.getRemoteConfig` against the default domain, decodes the container, and asserts **signature verification is `.verified`** for both full and empty responses. Concrete suites cover **informational** and **enforced** `ResponseVerificationMode`: initial fetch returns a non-empty manifest on the expected domain; a second request with that manifest expects **no container** (204-style no content) while still verifying the response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c8ec3093d37d51f650ea8ddb75f90f2d38f11bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->