### PR TITLE
feat(workflows): gate paywall impressions by step screen_type

### DIFF
--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -792,6 +792,13 @@ extension PurchaseHandler {
         self.paywallEventTracker.trackPaywallImpression(eventData)
     }
 
+    /// Clears the active paywall session (without discarding its tracked events) so subsequent purchase
+    /// events are unattributed until the next impression. Used when a non-paywall workflow step becomes
+    /// current: it reports no impression, and a purchase there must not attribute to the prior step.
+    func clearActivePaywallSession() {
+        self.activePaywallSessionID = nil
+    }
+
     func componentInteractionLogger(sessionID: PaywallEvent.SessionID) -> ComponentInteractionLogger {
         return self.paywallEventTracker.componentInteractionLogger(sessionID: sessionID)
     }

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -96,6 +96,11 @@ struct PaywallsV2View: View {
     /// The workflow step's `screen_type` classification, used to gate impression reporting. `nil` for
     /// standalone paywalls and for workflow steps the backend did not tag (see `stepScreenType`).
     private let workflowScreenType: [String]?
+    /// Workflow attribution for the impression event (`presented_workflow_id` / `presented_step_id` in
+    /// the post-receipt body, see #7024). Orthogonal to `workflowScreenType`: gating decides whether the
+    /// event fires; these identify which workflow step it came from. `nil` for standalone paywalls.
+    private let workflowId: String?
+    private let stepId: String?
     @State
     private var didFinishEligibilityCheck: Bool = {
         #if DEBUG
@@ -131,7 +136,9 @@ struct PaywallsV2View: View {
         introEligibilityContext: IntroOfferEligibilityContext? = nil,
         selectedPackageContextOverride: PackageContext? = nil,
         isActiveWorkflowPage: Bool? = nil,
-        workflowScreenType: [String]? = nil
+        workflowScreenType: [String]? = nil,
+        workflowId: String? = nil,
+        stepId: String? = nil
     ) {
         let uiConfigProvider = UIConfigProvider(
             uiConfig: paywallComponents.uiConfig,
@@ -152,6 +159,8 @@ struct PaywallsV2View: View {
         self.closeWorkflowAction = closeWorkflowAction
         self.isActiveWorkflowPage = isActiveWorkflowPage
         self.workflowScreenType = workflowScreenType
+        self.workflowId = workflowId
+        self.stepId = stepId
         self._paywallPromoOfferCache = .init(wrappedValue: promoOfferCache ?? PaywallPromoOfferCache(
             subscriptionHistoryTracker: purchaseHandler.subscriptionHistoryTracker
         ))
@@ -416,6 +425,21 @@ struct PaywallsV2View: View {
         )
     }
 
+    /// Stamps workflow attribution onto a paywall event's data so the post-receipt body can send
+    /// `presented_workflow_id` / `presented_step_id` (#7024). Orthogonal to the `screen_type` gate
+    /// (``shouldReportPaywallImpression`` decides whether the event fires at all); both are `nil` for
+    /// standalone paywalls. Mirrors Android's `PaywallEvent.Data.withCurrentWorkflowMetadata`.
+    static func applyingWorkflowAttribution(
+        to data: PaywallEvent.Data,
+        workflowId: String?,
+        stepId: String?
+    ) -> PaywallEvent.Data {
+        var data = data
+        data.workflowId = workflowId
+        data.stepId = stepId
+        return data
+    }
+
     private func firePaywallImpression(sessionID: PaywallEvent.SessionID? = nil) {
         // A workflow step the backend did not classify as a paywall reports no paywall events. Clear
         // any active session so a purchase here is unattributed, not charged to the prior paywall step.
@@ -482,7 +506,7 @@ struct PaywallsV2View: View {
             compontentsData = self.paywallComponentsData
         }
 
-        var data = PaywallEvent.Data(
+        let data = PaywallEvent.Data(
             offering: self.offering,
             paywallComponentsData: compontentsData,
             sessionID: sessionID ?? self.paywallSessionID,
@@ -491,9 +515,7 @@ struct PaywallsV2View: View {
             darkMode: self.colorScheme == .dark,
             source: self.paywallSource
         )
-        data.workflowId = self.workflowId
-        data.stepId = self.stepId
-        return data
+        return Self.applyingWorkflowAttribution(to: data, workflowId: self.workflowId, stepId: self.stepId)
     }
 
 }

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -93,8 +93,9 @@ struct PaywallsV2View: View {
     /// activation (becoming / ceasing to be the current step) rather than on SwiftUI's view lifecycle.
     /// `nil` keeps the standalone-paywall behavior of tracking on `onAppear` / `onDisappear`.
     private let isActiveWorkflowPage: Bool?
-    private let workflowId: String?
-    private let stepId: String?
+    /// The workflow step's `screen_type` classification, used to gate impression reporting. `nil` for
+    /// standalone paywalls and for workflow steps the backend did not tag (see `stepScreenType`).
+    private let workflowScreenType: [String]?
     @State
     private var didFinishEligibilityCheck: Bool = {
         #if DEBUG
@@ -130,8 +131,7 @@ struct PaywallsV2View: View {
         introEligibilityContext: IntroOfferEligibilityContext? = nil,
         selectedPackageContextOverride: PackageContext? = nil,
         isActiveWorkflowPage: Bool? = nil,
-        workflowId: String? = nil,
-        stepId: String? = nil
+        workflowScreenType: [String]? = nil
     ) {
         let uiConfigProvider = UIConfigProvider(
             uiConfig: paywallComponents.uiConfig,
@@ -151,8 +151,7 @@ struct PaywallsV2View: View {
         self.onDismiss = onDismiss
         self.closeWorkflowAction = closeWorkflowAction
         self.isActiveWorkflowPage = isActiveWorkflowPage
-        self.workflowId = workflowId
-        self.stepId = stepId
+        self.workflowScreenType = workflowScreenType
         self._paywallPromoOfferCache = .init(wrappedValue: promoOfferCache ?? PaywallPromoOfferCache(
             subscriptionHistoryTracker: purchaseHandler.subscriptionHistoryTracker
         ))
@@ -324,7 +323,7 @@ struct PaywallsV2View: View {
                 // by `onChangeOf(self.isActiveWorkflowPage)` below. A page mounted while not current
                 // (isActiveWorkflowPage == false) waits until it becomes current.
                 guard self.isActiveWorkflowPage != false else { return }
-                self.firePaywallViewed()
+                self.firePaywallImpression()
             }
             .task {
                 guard !self.didFinishEligibilityCheck else {
@@ -396,12 +395,35 @@ struct PaywallsV2View: View {
                 guard isActive == true else { return }
                 let freshSession: PaywallEvent.SessionID = .init()
                 self.paywallSessionID = freshSession
-                self.firePaywallViewed(sessionID: freshSession)
+                self.firePaywallImpression(sessionID: freshSession)
             }
 
     }
 
-    private func firePaywallViewed(sessionID: PaywallEvent.SessionID? = nil) {
+    static func shouldReportPaywallImpression(
+        isActiveWorkflowPage: Bool?,
+        workflowScreenType: [String]?
+    ) -> Bool {
+        guard isActiveWorkflowPage != nil else { return true }
+        guard let screenType = workflowScreenType else { return true }
+        return screenType.contains(WorkflowScreenType.paywall)
+    }
+
+    private var reportsPaywallImpression: Bool {
+        Self.shouldReportPaywallImpression(
+            isActiveWorkflowPage: self.isActiveWorkflowPage,
+            workflowScreenType: self.workflowScreenType
+        )
+    }
+
+    private func firePaywallImpression(sessionID: PaywallEvent.SessionID? = nil) {
+        // A workflow step the backend did not classify as a paywall reports no paywall events. Clear
+        // any active session so a purchase here is unattributed, not charged to the prior paywall step.
+        guard self.reportsPaywallImpression else {
+            self.purchaseHandler.clearActivePaywallSession()
+            return
+        }
+
         let forDefaultPaywall: Bool
         if let errorInfo = self.paywallComponentsData.errorInfo, !errorInfo.isEmpty {
             forDefaultPaywall = true
@@ -419,6 +441,8 @@ struct PaywallsV2View: View {
     }
 
     private func firePaywallClose() {
+        guard self.reportsPaywallImpression else { return }
+
         if self.isActiveWorkflowPage == nil {
             // Standalone paywall: close whichever session is active (unchanged behavior).
             self.purchaseHandler.trackPaywallClose()

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -461,8 +461,8 @@ struct WorkflowPaywallView: View {
             selectedPackageContextOverride: page.packageContext,
             // Drives per-visit paywall_viewed / paywall_close: this page is the current workflow step.
             isActiveWorkflowPage: isActive,
-            workflowId: self.context.workflow.id,
-            stepId: page.stepId
+            // Gates impression reporting: only steps tagged as paywalls report a paywall impression.
+            workflowScreenType: page.screenType
         )
         .environment(\.workflowPackageContext, page.effectiveWorkflowPackageContext)
         .environment(\.workflowTriggerAction, { componentId in
@@ -705,6 +705,7 @@ struct WorkflowPaywallView: View {
         return .init(
             stepId: stepId,
             content: .init(paywallComponents: paywallComponents, offering: offering),
+            screenType: step.stepScreenType,
             headerComponent: screen.componentsConfig.base.header,
             showCloseButton: showCloseButton,
             introOfferEligibilityContext: .init(introEligibilityChecker: introEligibilityChecker),
@@ -805,6 +806,9 @@ private struct RenderedPage: Identifiable {
     let id = UUID()
     let stepId: String
     let content: CurrentStepContent
+    /// The step's `screen_type` classification (`nil` when the backend did not tag it). Drives whether
+    /// this page reports a paywall impression. See `PaywallsV2View.shouldReportPaywallImpression`.
+    let screenType: [String]?
     let headerComponent: PaywallComponent.HeaderComponent?
     let showCloseButton: Bool
     /// Page-scoped so late async eligibility checks cannot overwrite another workflow step.

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -462,7 +462,10 @@ struct WorkflowPaywallView: View {
             // Drives per-visit paywall_viewed / paywall_close: this page is the current workflow step.
             isActiveWorkflowPage: isActive,
             // Gates impression reporting: only steps tagged as paywalls report a paywall impression.
-            workflowScreenType: page.screenType
+            workflowScreenType: page.screenType,
+            // Workflow attribution on the impression event (#7024), orthogonal to the screen_type gate.
+            workflowId: self.context.workflow.id,
+            stepId: page.stepId
         )
         .environment(\.workflowPackageContext, page.effectiveWorkflowPackageContext)
         .environment(\.workflowTriggerAction, { componentId in

--- a/Sources/Networking/Responses/WorkflowsResponse.swift
+++ b/Sources/Networking/Responses/WorkflowsResponse.swift
@@ -59,13 +59,21 @@ import Foundation
     case unknown
 }
 
+/// Step `screen_type` classification (returned by the backend under `metadata.screen_type`), used to
+/// decide which workflow steps report a paywall impression.
+@_spi(Internal) public enum WorkflowScreenType {
+
+    static let metadataKey = "screen_type"
+
+    public static let paywall = "paywall"
+
+}
+
 @_spi(Internal) public struct WorkflowStep {
 
     public let id: String
     let type: String
     public let screenId: String?
-    @DefaultDecodable.EmptyArray
-    var screenType: [String]
     @DefaultDecodable.EmptyDictionary
     var paramValues: [String: AnyDecodable]
     @DefaultDecodable.EmptyArray
@@ -77,12 +85,24 @@ import Foundation
 
     public var stepTriggers: [WorkflowTrigger] { triggers }
     public var stepTriggerActions: [String: WorkflowTriggerAction] { triggerActions }
-    public var stepScreenType: [String] { screenType }
     let metadata: [String: AnyDecodable]?
 
-    // `screenType`, `paramValues`, `outputs`, and `metadata` carry backend step config that the
-    // renderer doesn't read, and `paramValues`/`outputs`/`metadata` are typed with the internal
-    // `AnyDecodable`, so they're defaulted rather than exposed.
+    /// The step's `screen_type` from the backend (`metadata.screen_type`). `nil` = untagged (older
+    /// workflows), `[]` = tagged with no known type; the distinction drives impression gating. Key is
+    /// literal snake_case: `convertFromSnakeCase` skips keys inside `[String: AnyDecodable]`.
+    public var stepScreenType: [String]? {
+        guard case let .array(values)? = self.metadata?[WorkflowScreenType.metadataKey] else {
+            return nil
+        }
+        return values.compactMap { element in
+            guard case let .string(value) = element else { return nil }
+            return value
+        }
+    }
+
+    // `paramValues`, `outputs`, and `metadata` carry backend step config that the renderer doesn't
+    // read directly (`metadata` is surfaced only via `stepScreenType`), and are typed with the
+    // internal `AnyDecodable`, so they're defaulted rather than exposed.
     @_spi(Internal) public init(
         id: String,
         type: String,
@@ -93,7 +113,6 @@ import Foundation
         self.id = id
         self.type = type
         self.screenId = screenId
-        self.screenType = []
         self.paramValues = [:]
         self.triggers = triggers
         self.outputs = [:]

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallsV2ViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallsV2ViewTests.swift
@@ -141,4 +141,60 @@ final class PromoEligibilityPackageInfosTests: TestCase {
 
 }
 
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+final class ShouldReportPaywallImpressionTests: TestCase {
+
+    func testStandalonePaywallAlwaysReports() {
+        // Standalone paywalls have no workflow screen_type and must keep reporting impressions.
+        expect(PaywallsV2View.shouldReportPaywallImpression(
+            isActiveWorkflowPage: nil,
+            workflowScreenType: nil
+        )) == true
+        expect(PaywallsV2View.shouldReportPaywallImpression(
+            isActiveWorkflowPage: nil,
+            workflowScreenType: ["survey"]
+        )) == true
+    }
+
+    func testWorkflowPaywallStepReports() {
+        expect(PaywallsV2View.shouldReportPaywallImpression(
+            isActiveWorkflowPage: true,
+            workflowScreenType: [WorkflowScreenType.paywall]
+        )) == true
+    }
+
+    func testWorkflowUntaggedStepReportsToPreserveBehavior() {
+        // Older/untagged workflows (nil screen_type) must keep firing impressions so a backend that
+        // has not rolled out screen analytics is not silently muted.
+        expect(PaywallsV2View.shouldReportPaywallImpression(
+            isActiveWorkflowPage: true,
+            workflowScreenType: nil
+        )) == true
+    }
+
+    func testWorkflowStepTaggedNonPaywallDoesNotReport() {
+        expect(PaywallsV2View.shouldReportPaywallImpression(
+            isActiveWorkflowPage: true,
+            workflowScreenType: []
+        )) == false
+        expect(PaywallsV2View.shouldReportPaywallImpression(
+            isActiveWorkflowPage: true,
+            workflowScreenType: ["survey"]
+        )) == false
+    }
+
+    func testInactiveWorkflowPageGatedBySameRule() {
+        // `isActiveWorkflowPage == false` is still a workflow page; the screen_type rule applies.
+        expect(PaywallsV2View.shouldReportPaywallImpression(
+            isActiveWorkflowPage: false,
+            workflowScreenType: [WorkflowScreenType.paywall]
+        )) == true
+        expect(PaywallsV2View.shouldReportPaywallImpression(
+            isActiveWorkflowPage: false,
+            workflowScreenType: ["survey"]
+        )) == false
+    }
+
+}
+
 #endif

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallsV2ViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallsV2ViewTests.swift
@@ -197,4 +197,49 @@ final class ShouldReportPaywallImpressionTests: TestCase {
 
 }
 
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+final class ApplyingWorkflowAttributionTests: TestCase {
+
+    private func makeData(workflowId: String? = nil, stepId: String? = nil) -> PaywallEvent.Data {
+        PaywallEvent.Data(
+            paywallIdentifier: "paywall-abc",
+            offeringIdentifier: "offering-1",
+            paywallRevision: 1,
+            sessionID: .init(),
+            displayMode: .fullScreen,
+            localeIdentifier: "en_US",
+            darkMode: false,
+            workflowId: workflowId,
+            stepId: stepId
+        )
+    }
+
+    // The seam #7024 wires and the screen_type work removed: a workflow paywall step's impression event
+    // must carry the workflow + step so the post-receipt body sends presented_workflow_id/step_id.
+    func testStampsWorkflowAndStepIdOnWorkflowStep() {
+        let result = PaywallsV2View.applyingWorkflowAttribution(
+            to: self.makeData(),
+            workflowId: "wf_test",
+            stepId: "step_1"
+        )
+
+        expect(result.workflowId) == "wf_test"
+        expect(result.stepId) == "step_1"
+    }
+
+    // Standalone paywalls (and untagged steps with no IDs) carry no attribution, so the post-receipt
+    // body omits presented_workflow_id/step_id rather than sending stale values.
+    func testLeavesAttributionNilForStandalonePaywall() {
+        let result = PaywallsV2View.applyingWorkflowAttribution(
+            to: self.makeData(workflowId: "stale", stepId: "stale"),
+            workflowId: nil,
+            stepId: nil
+        )
+
+        expect(result.workflowId).to(beNil())
+        expect(result.stepId).to(beNil())
+    }
+
+}
+
 #endif

--- a/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
@@ -535,6 +535,31 @@ class PurchaseHandlerTests: TestCase {
         expect(handler.trackPaywallClose(sessionID: sessionA)) == false
     }
 
+    func testClearActivePaywallSessionMakesPurchaseEventsUnattributed() async throws {
+        let handler: PurchaseHandler = .mock()
+
+        let eventData = PaywallEvent.Data(
+            paywallIdentifier: TestData.paywallWithIntroOffer.id,
+            offeringIdentifier: TestData.offeringWithIntroOffer.identifier,
+            paywallRevision: TestData.paywallWithIntroOffer.revision,
+            sessionID: .init(),
+            displayMode: .fullScreen,
+            localeIdentifier: "en_US",
+            darkMode: false,
+            source: nil
+        )
+
+        // A paywall step is impressed, so purchase events resolve against its session.
+        handler.trackPaywallImpression(eventData)
+        expect(handler.createPurchaseInitiatedEvent(package: TestData.packageWithIntroOffer)).toNot(beNil())
+
+        // Navigating onto a non-paywall workflow step clears the active session (see the gate in
+        // `PaywallsV2View.firePaywallImpression`). A purchase there is now unattributed rather than
+        // charged to the prior paywall step's session.
+        handler.clearActivePaywallSession()
+        expect(handler.createPurchaseInitiatedEvent(package: TestData.packageWithIntroOffer)).to(beNil())
+    }
+
     func testPaywallSourceIsPropagatedToTrackedEvents() async throws {
         let source = PaywallSource.customerCenter
         let trackedEvents: Atomic<[PaywallEvent]> = .init([])

--- a/Tests/UnitTests/Networking/Workflows/WorkflowResponseTests.swift
+++ b/Tests/UnitTests/Networking/Workflows/WorkflowResponseTests.swift
@@ -326,6 +326,65 @@ class WorkflowResponseTests: TestCase {
         expect(step.metadata).to(beNil())
     }
 
+    func testDecodeWorkflowStepScreenTypeFromMetadata() throws {
+        let json = """
+        {
+          "id": "step_1",
+          "type": "screen",
+          "metadata": { "screen_type": ["paywall"] }
+        }
+        """.data(using: .utf8)!
+
+        let step = try JSONDecoder.default.decode(WorkflowStep.self, from: json)
+
+        expect(step.stepScreenType) == ["paywall"]
+    }
+
+    func testDecodeWorkflowStepScreenTypeEmptyWhenTaggedEmpty() throws {
+        // A step the backend tagged with no known type. `[]` (not `nil`) means "explicitly not a
+        // paywall", which suppresses the impression.
+        let json = """
+        {
+          "id": "step_1",
+          "type": "screen",
+          "metadata": { "screen_type": [] }
+        }
+        """.data(using: .utf8)!
+
+        let step = try JSONDecoder.default.decode(WorkflowStep.self, from: json)
+
+        expect(step.stepScreenType) == []
+    }
+
+    func testDecodeWorkflowStepScreenTypeNilWhenKeyAbsent() throws {
+        // Older workflows omit `screen_type`. `nil` (not `[]`) preserves the always-report behavior.
+        let json = """
+        {
+          "id": "step_1",
+          "type": "screen",
+          "metadata": { "other_key": "value" }
+        }
+        """.data(using: .utf8)!
+
+        let step = try JSONDecoder.default.decode(WorkflowStep.self, from: json)
+
+        expect(step.stepScreenType).to(beNil())
+    }
+
+    func testDecodeWorkflowStepScreenTypeNilWhenMetadataNull() throws {
+        let json = """
+        {
+          "id": "step_1",
+          "type": "screen",
+          "metadata": null
+        }
+        """.data(using: .utf8)!
+
+        let step = try JSONDecoder.default.decode(WorkflowStep.self, from: json)
+
+        expect(step.stepScreenType).to(beNil())
+    }
+
     func testDecodeWorkflowStepMatchingActualBackendResponse() throws {
         let json = """
         {


### PR DESCRIPTION
### Motivation

Second split out of #6947, landing the additive workflow features on `main` independently of the always-on flag removal. This PR re-lands **gating paywall impressions by step `screen_type`** (originally #7021, merged into the stack-base branch rather than `main`) directly onto `main`, on top of #7103 (#6958).

Part of splitting #6947. Stack:
- #7103 — #6958 preview injection (merged)
- **This PR** — #7021 gate impressions by `screen_type`
- (next) #7029 gate all events by `screen_type` (stacks on this)
- #6947 — the flag removal itself, held until the workflow-or-throw path is verified on-device

### Description

A workflow step the backend did not classify as a paywall (via `metadata.screen_type`) should not report a paywall impression. This PR:
- adds `WorkflowScreenType` and changes `WorkflowStep.stepScreenType` to optional `[String]?` read from `metadata.screen_type` (`nil` = untagged/older workflows, `[]` = tagged with no known type; the distinction drives gating);
- adds `PaywallsV2View.shouldReportPaywallImpression(...)` and gates impression/close reporting on it (renaming `firePaywallViewed` -> `firePaywallImpression`);
- adds `PurchaseHandler.clearActivePaywallSession()` so a purchase on a non-paywall step is unattributed rather than charged to the prior paywall step.

### Why it's safe to land on main without the flag removal

This only changes the workflow render/parse path, which on `main` executes only when `workflowsEndpointEnabled` is on. It sits dormant-but-correct behind the existing flag.

### On-device verification (baguette)

Built this branch into PaywallsTester (`-EnableWorkflowsEndpoint`) and drove a two-screen workflow (`wfdfd1d372810545e6`) headlessly with [`baguette`](https://github.com/RevenueCat), capturing the simulator unified log. Temporary `🥖[gating]` logs were added locally to observe the gating decision and the workflow attribution (these are not part of the diff).

The workflow's two steps are tagged differently, so each exercises a different branch:

| Step | `metadata.screen_type` | Expected | Observed |
| --- | --- | --- | --- |
| `hHCNHWr` (intro screen) | `[]` (tagged, not a paywall) | suppress impression | **SUPPRESSED** |
| `c9a19044` (paywall screen) | `["paywall"]` | report impression + attribution | **REPORTED**, `workflowId=wfdfd1d372810545e6` |

```text
# Screen 1 — screen_type [] → suppressed
🥖[gating] firePaywallImpression step=hHCNHWr screenType=[] isActiveWorkflowPage=true reports=false
🥖[gating] SUPPRESSED impression for step=hHCNHWr

# Screen 2 — screen_type ["paywall"] → reported, with #7024 attribution preserved
🥖[gating] firePaywallImpression step=c9a19044-… screenType=["paywall"] isActiveWorkflowPage=true reports=true
🥖[gating] REPORTED impression step=c9a19044-… workflowId=wfdfd1d372810545e6
```

This confirms both behaviors together: the `screen_type` gate suppresses the non-paywall step and fires on the paywall step, and the reported impression still carries `workflowId`/`stepId` (the #7024 attribution this PR keeps orthogonal to the gate).

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: gate-paywall-impressions-by-screen-type re-land onto main (split out of #6947)
- Branch: `facu/workflows-screen-type-impressions-main`
- Author / human owner: facumenzella
- Agent(s): Claude Code (Opus 4.8, 1M context)
- Session source: current conversation (2026-06-29)
- Generated: 2026-06-29
- Context document version: 1

## Goal

Split #6947 into independently-mergeable PRs. This PR extracts the #7021 "gate impressions by `screen_type`" feature onto `main`, after #7103 (#6958) landed.

## Initial Prompt

"I need to be able to split this PR up, so I can merge things without breaking main." Follow-ups directed extracting the additive features (#6958/#7021/#7029) as separate PRs onto main and keeping the flag removal (F) in #6947.

## Important Follow-up Prompts

- "just merged A, how would B look" -> previewed the cherry-pick of #7021 onto the updated main.
- "let's go with B" -> push it as a draft, same flow as A.

## Agent Contribution

- Cherry-picked #7021 (`67851e91`) onto a fresh branch off the updated `origin/main` (which now includes #6958 via #7103).
- Confirmed the cherry-pick applies with **zero conflicts** — landing #6958 first aligned the shared `WorkflowsResponse.swift` base.

## Human Decisions

- Keep the flag removal in #6947; extract additive features separately; land B as a draft after A merged.

## Key Implementation Decisions

- Decision: land #7021 on top of #7103 (not the original stack base).
  - Rationale: #7021 builds on #6958's `WorkflowsResponse` changes; with #6958 in main the cherry-pick is conflict-free.

## Files / Symbols Touched

- `Sources/Networking/Responses/WorkflowsResponse.swift` — Symbols: `WorkflowScreenType`, `WorkflowStep.stepScreenType` (now `[String]?` from `metadata.screen_type`). Review: the `nil` vs `[]` distinction and the snake_case key handling note.
- `RevenueCatUI/Templates/V2/PaywallsV2View.swift` — Symbols: `shouldReportPaywallImpression`, `reportsPaywallImpression`, `firePaywallImpression` (renamed from `firePaywallViewed`), `workflowScreenType` (replaces `workflowId`/`stepId`). Review: impression + close gating.
- `RevenueCatUI/Templates/V2/WorkflowPaywallView.swift` — threads `screenType`/`stepScreenType`.
- `RevenueCatUI/Purchasing/PurchaseHandler.swift` — Symbols: `clearActivePaywallSession()`.
- `Tests/RevenueCatUITests/PaywallsV2/PaywallsV2ViewTests.swift`, `Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift`, `Tests/UnitTests/Networking/Workflows/WorkflowResponseTests.swift` — coverage rides along.

## Dependencies / Config / Migrations

- None.

## Validation

- Commands run:
  - `git cherry-pick -x 67851e91`: applied with 0 textual conflicts, but did NOT compile on current main (dangling `self.workflowId` after #7024 landed); fixed by restoring the attribution wiring (see the reconciliation commit).
  - `xcodebuild build -scheme RevenueCatUI`: **BUILD SUCCEEDED** locally.
  - `xcodebuild test -only-testing:RevenueCatUITests/ApplyingWorkflowAttributionTests -only-testing:RevenueCatUITests/ShouldReportPaywallImpressionTests`: 7 tests passed.
- On-device: PaywallsTester run via `baguette`, both workflow steps exercised — non-paywall step suppressed, paywall step reported with `workflowId` attribution (see "On-device verification" above).
- CI: `run-revenuecat-ui-ios-26` to verify the full UI suite on main. Draft until green.

## Validation Gaps

- Local UI snapshot tests not run (sim-only snapshot flakiness); deferred to CI.
- The `🥖[gating]` logs used for on-device verification are local-only and not part of the diff.

## Review Focus

- Is `stepScreenType` returning `nil` for untagged workflows the right signal to keep impression reporting on (back-compat with older workflows)?
- `clearActivePaywallSession()` on a non-paywall step: confirm a subsequent purchase is genuinely unattributed rather than dropped.

## Risks / Reviewer Notes

- Risk: behavioral change to impression/close firing (more than #6958, which was a pure new entry point).
  - Evidence: gated by `reportsPaywallImpression`; only reachable on the workflow path, which is flag-gated on main.

## Non-goals / Out of Scope

- The flag removal (stays in #6947). The #7029 events gating (next PR, stacks on this one).

## Omitted Context

- Raw transcript, unrelated exploration, repetitive attempts, and chain-of-thought-style content were omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall analytics and purchase-event attribution on workflow navigation; behavior is flag-gated on main but mis-tagged steps could suppress impressions or leave purchases unattributed.
> 
> **Overview**
> Workflow paywall **impression and close** reporting now respects backend **`metadata.screen_type`**: only steps tagged with `"paywall"` fire paywall events when the screen is part of a workflow. Standalone paywalls are unchanged.
> 
> **Parsing:** `WorkflowStep` no longer decodes a top-level `screen_type` array; it exposes optional `stepScreenType` from `metadata.screen_type`, with **`nil`** (untagged / legacy) still treated as reportable and **`[]` or non-paywall tags** suppressing impressions.
> 
> **UI / attribution:** `PaywallsV2View` takes `workflowScreenType`, uses `shouldReportPaywallImpression` to gate `firePaywallImpression` and `firePaywallClose` (renamed from `firePaywallViewed`), and on suppressed steps calls **`PurchaseHandler.clearActivePaywallSession()`** so purchases are not attributed to a prior paywall step. Workflow attribution (`workflowId` / `stepId`) is applied via **`applyingWorkflowAttribution`**, separate from the gate. `WorkflowPaywallView` threads `step.stepScreenType` into each page.
> 
> **Tests** cover gating rules, attribution stamping, session clearing, and JSON decoding for `screen_type`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98e5436e6e67a5bd3b842d7163a4f14f5817a132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->