### PR TITLE
[EXTERNAL] Fix T-SAN crash due to memory misalignment when building with Xcode 27.0 (b1 and b2) (#7070) via @salling

### DIFF
--- a/Sources/FoundationExtensions/Integer+Extensions.swift
+++ b/Sources/FoundationExtensions/Integer+Extensions.swift
@@ -19,7 +19,7 @@ extension UInt32 {
     init(littleEndian32Bits data: Data) {
         assert(data.count == 4, "Data needs to be 32bits: \(data)")
 
-        self.init(littleEndian: data.withUnsafeBytes { $0.load(as: UInt32.self) })
+        self.init(littleEndian: data.withUnsafeBytes { $0.loadUnaligned(as: UInt32.self) })
     }
 
     /// - Returns: the `Data` representation as little-endian 32 bits.


### PR DESCRIPTION
@salling wrote in #7070:

The PR fixes a crash when building with Xcode 27.0b1 and running with thread sanitizer.

<img width="1486" height="975" alt="Screenshot 2026-06-22 at 22 45 36" src="https://github.com/user-attachments/assets/ea0a39b2-59c2-48fa-834a-85580bacc8a8" />

### Checklist
- [x] If applicable, unit tests (N/A)
- [x] If applicable, create follow-up issues for `purchases-android` and hybrids (N/A)

### Motivation
I noticed spurious crashes when running my app in simulator when compiling with Xcode 27.0b1. Enabling thread sanitizer made the crash happen every time. [There's speculation that the new compiler has introduced changes](https://mastodon.social/@Catfish_Man/116754876910708158) in how memory is aligned.

### Description
I ran the app with t-san after my change, and it worked fine.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line memory-access fix in a small helper; semantics unchanged for 4-byte inputs and existing unit tests still apply.
> 
> **Overview**
> **`UInt32(littleEndian32Bits:)`** now reads four bytes with **`loadUnaligned(as: UInt32.self)`** instead of **`load(as:)`**, so parsing stays valid when the underlying `Data` buffer is not naturally aligned for a 32-bit integer.
> 
> That initializer is used on the signing path (e.g. intermediate key expiration in **`Signing`**). Behavior for correctly sized 4-byte payloads is unchanged; the fix targets crashes under **Xcode 27 beta** with **Thread Sanitizer**, where strict aligned loads can fault.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26c809f1767cc7bc2db9533f0615b3437ff78a3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->