### PR TITLE
feat(workflows): gate all paywall events by step screen_type

### DIFF
--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -101,6 +101,10 @@ struct PaywallsV2View: View {
     /// event fires; these identify which workflow step it came from. `nil` for standalone paywalls.
     private let workflowId: String?
     private let stepId: String?
+    /// Whether this workflow step is the workflow's `singleStepFallbackId`. Only consulted for untagged
+    /// steps (`nil` `screen_type`), where it restores the structural rule of reporting on the fallback
+    /// step alone. Irrelevant for standalone paywalls and tagged steps.
+    private let isWorkflowSingleStepFallback: Bool
     @State
     private var didFinishEligibilityCheck: Bool = {
         #if DEBUG
@@ -138,7 +142,8 @@ struct PaywallsV2View: View {
         isActiveWorkflowPage: Bool? = nil,
         workflowScreenType: [String]? = nil,
         workflowId: String? = nil,
-        stepId: String? = nil
+        stepId: String? = nil,
+        isWorkflowSingleStepFallback: Bool = false
     ) {
         let uiConfigProvider = UIConfigProvider(
             uiConfig: paywallComponents.uiConfig,
@@ -161,6 +166,7 @@ struct PaywallsV2View: View {
         self.workflowScreenType = workflowScreenType
         self.workflowId = workflowId
         self.stepId = stepId
+        self.isWorkflowSingleStepFallback = isWorkflowSingleStepFallback
         self._paywallPromoOfferCache = .init(wrappedValue: promoOfferCache ?? PaywallPromoOfferCache(
             subscriptionHistoryTracker: purchaseHandler.subscriptionHistoryTracker
         ))
@@ -390,7 +396,12 @@ struct PaywallsV2View: View {
             }
             .environment(
                 \.componentInteractionLogger,
-                self.purchaseHandler.componentInteractionLogger(sessionID: self.paywallSessionID)
+                // A non-paywall workflow step reports no paywall events, so install a no-op logger there
+                // instead of one bound to this page's session. Otherwise component interactions would be
+                // the one paywall event still emitted on a non-paywall step.
+                Self.componentInteractionLogger(tracksPaywallEvents: self.tracksPaywallEvents) {
+                    self.purchaseHandler.componentInteractionLogger(sessionID: self.paywallSessionID)
+                }
             )
             .onChangeOf(self.purchaseHandler.hasPurchasedInSession) { hasPurchased in
                 guard hasPurchased else { return }
@@ -409,25 +420,36 @@ struct PaywallsV2View: View {
 
     }
 
-    static func shouldReportPaywallImpression(
+    /// Whether the current step reports paywall events (impression, close, purchase, cancel, exit offer,
+    /// component interaction). Driven by the backend `screen_type` tag:
+    /// - classified as a `paywall` → reports;
+    /// - tagged without `paywall` (including an empty list) → suppressed;
+    /// - untagged (legacy/pre-rollout payloads with no `screen_type`) → falls back to the structural rule,
+    ///   reporting only on the workflow's `singleStepFallbackId` step. When the workflow has no
+    ///   `singleStepFallbackId` either, no step is the fallback, so no paywall events are reported on any
+    ///   step (only workflow events) — intended, not a regression.
+    /// Standalone paywalls (no workflow) always report.
+    static func shouldTrackPaywallEvents(
         isActiveWorkflowPage: Bool?,
-        workflowScreenType: [String]?
+        workflowScreenType: [String]?,
+        isSingleStepFallback: Bool
     ) -> Bool {
         guard isActiveWorkflowPage != nil else { return true }
-        guard let screenType = workflowScreenType else { return true }
+        guard let screenType = workflowScreenType else { return isSingleStepFallback }
         return screenType.contains(WorkflowScreenType.paywall)
     }
 
-    private var reportsPaywallImpression: Bool {
-        Self.shouldReportPaywallImpression(
+    private var tracksPaywallEvents: Bool {
+        Self.shouldTrackPaywallEvents(
             isActiveWorkflowPage: self.isActiveWorkflowPage,
-            workflowScreenType: self.workflowScreenType
+            workflowScreenType: self.workflowScreenType,
+            isSingleStepFallback: self.isWorkflowSingleStepFallback
         )
     }
 
     /// Stamps workflow attribution onto a paywall event's data so the post-receipt body can send
     /// `presented_workflow_id` / `presented_step_id` (#7024). Orthogonal to the `screen_type` gate
-    /// (``shouldReportPaywallImpression`` decides whether the event fires at all); both are `nil` for
+    /// (``shouldTrackPaywallEvents`` decides whether the event fires at all); both are `nil` for
     /// standalone paywalls. Mirrors Android's `PaywallEvent.Data.withCurrentWorkflowMetadata`.
     static func applyingWorkflowAttribution(
         to data: PaywallEvent.Data,
@@ -440,10 +462,19 @@ struct PaywallsV2View: View {
         return data
     }
 
+    /// The component interaction logger for the current step: the real session-bound logger when the step
+    /// tracks paywall events, otherwise a no-op so non-paywall steps emit no `component_interaction` event.
+    static func componentInteractionLogger(
+        tracksPaywallEvents: Bool,
+        makeLogger: () -> ComponentInteractionLogger
+    ) -> ComponentInteractionLogger {
+        tracksPaywallEvents ? makeLogger() : ComponentInteractionLogger()
+    }
+
     private func firePaywallImpression(sessionID: PaywallEvent.SessionID? = nil) {
         // A workflow step the backend did not classify as a paywall reports no paywall events. Clear
         // any active session so a purchase here is unattributed, not charged to the prior paywall step.
-        guard self.reportsPaywallImpression else {
+        guard self.tracksPaywallEvents else {
             self.purchaseHandler.clearActivePaywallSession()
             return
         }
@@ -465,7 +496,7 @@ struct PaywallsV2View: View {
     }
 
     private func firePaywallClose() {
-        guard self.reportsPaywallImpression else { return }
+        guard self.tracksPaywallEvents else { return }
 
         if self.isActiveWorkflowPage == nil {
             // Standalone paywall: close whichever session is active (unchanged behavior).

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -461,11 +461,13 @@ struct WorkflowPaywallView: View {
             selectedPackageContextOverride: page.packageContext,
             // Drives per-visit paywall_viewed / paywall_close: this page is the current workflow step.
             isActiveWorkflowPage: isActive,
-            // Gates impression reporting: only steps tagged as paywalls report a paywall impression.
+            // Gates paywall events: steps tagged as paywalls report; untagged steps fall back to the
+            // single-step-fallback rule.
             workflowScreenType: page.screenType,
             // Workflow attribution on the impression event (#7024), orthogonal to the screen_type gate.
             workflowId: self.context.workflow.id,
-            stepId: page.stepId
+            stepId: page.stepId,
+            isWorkflowSingleStepFallback: page.isSingleStepFallback
         )
         .environment(\.workflowPackageContext, page.effectiveWorkflowPackageContext)
         .environment(\.workflowTriggerAction, { componentId in
@@ -709,6 +711,7 @@ struct WorkflowPaywallView: View {
             stepId: stepId,
             content: .init(paywallComponents: paywallComponents, offering: offering),
             screenType: step.stepScreenType,
+            isSingleStepFallback: stepId == context.workflow.singleStepFallbackId,
             headerComponent: screen.componentsConfig.base.header,
             showCloseButton: showCloseButton,
             introOfferEligibilityContext: .init(introEligibilityChecker: introEligibilityChecker),
@@ -810,8 +813,11 @@ private struct RenderedPage: Identifiable {
     let stepId: String
     let content: CurrentStepContent
     /// The step's `screen_type` classification (`nil` when the backend did not tag it). Drives whether
-    /// this page reports a paywall impression. See `PaywallsV2View.shouldReportPaywallImpression`.
+    /// this page reports paywall events. See `PaywallsV2View.shouldTrackPaywallEvents`.
     let screenType: [String]?
+    /// Whether this step is the workflow's `singleStepFallbackId`. Only used to gate paywall events on
+    /// untagged steps (`nil` `screenType`), restoring the structural fallback-step-only rule.
+    let isSingleStepFallback: Bool
     let headerComponent: PaywallComponent.HeaderComponent?
     let showCloseButton: Bool
     /// Page-scoped so late async eligibility checks cannot overwrite another workflow step.

--- a/Sources/Networking/Responses/WorkflowsResponse.swift
+++ b/Sources/Networking/Responses/WorkflowsResponse.swift
@@ -88,8 +88,9 @@ import Foundation
     let metadata: [String: AnyDecodable]?
 
     /// The step's `screen_type` from the backend (`metadata.screen_type`). `nil` = untagged (older
-    /// workflows), `[]` = tagged with no known type; the distinction drives impression gating. Key is
-    /// literal snake_case: `convertFromSnakeCase` skips keys inside `[String: AnyDecodable]`.
+    /// workflows), `[]` = tagged with no known type; the distinction drives paywall-event gating (see
+    /// `PaywallsV2View.shouldTrackPaywallEvents`). Key is literal snake_case: `convertFromSnakeCase` skips
+    /// keys inside `[String: AnyDecodable]`.
     public var stepScreenType: [String]? {
         guard case let .array(values)? = self.metadata?[WorkflowScreenType.metadataKey] else {
             return nil

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallsV2ViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallsV2ViewTests.swift
@@ -142,56 +142,75 @@ final class PromoEligibilityPackageInfosTests: TestCase {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-final class ShouldReportPaywallImpressionTests: TestCase {
+final class ShouldTrackPaywallEventsTests: TestCase {
 
     func testStandalonePaywallAlwaysReports() {
         // Standalone paywalls have no workflow screen_type and must keep reporting impressions.
-        expect(PaywallsV2View.shouldReportPaywallImpression(
+        expect(PaywallsV2View.shouldTrackPaywallEvents(
             isActiveWorkflowPage: nil,
-            workflowScreenType: nil
+            workflowScreenType: nil,
+            isSingleStepFallback: false
         )) == true
-        expect(PaywallsV2View.shouldReportPaywallImpression(
+        expect(PaywallsV2View.shouldTrackPaywallEvents(
             isActiveWorkflowPage: nil,
-            workflowScreenType: ["survey"]
+            workflowScreenType: ["survey"],
+            isSingleStepFallback: false
         )) == true
     }
 
     func testWorkflowPaywallStepReports() {
-        expect(PaywallsV2View.shouldReportPaywallImpression(
+        // A step tagged as a paywall reports regardless of whether it is the fallback step.
+        expect(PaywallsV2View.shouldTrackPaywallEvents(
             isActiveWorkflowPage: true,
-            workflowScreenType: [WorkflowScreenType.paywall]
+            workflowScreenType: [WorkflowScreenType.paywall],
+            isSingleStepFallback: false
         )) == true
     }
 
-    func testWorkflowUntaggedStepReportsToPreserveBehavior() {
-        // Older/untagged workflows (nil screen_type) must keep firing impressions so a backend that
-        // has not rolled out screen analytics is not silently muted.
-        expect(PaywallsV2View.shouldReportPaywallImpression(
+    func testWorkflowUntaggedStepFallsBackToSingleStepFallback() {
+        // Untagged workflows (nil screen_type, e.g. a backend that has not rolled out screen analytics)
+        // fall back to the structural rule: only the singleStepFallbackId step reports.
+        expect(PaywallsV2View.shouldTrackPaywallEvents(
             isActiveWorkflowPage: true,
-            workflowScreenType: nil
+            workflowScreenType: nil,
+            isSingleStepFallback: true
         )) == true
+        // Untagged and not the fallback step → suppressed. This also covers the owner-confirmed case of a
+        // workflow with no `singleStepFallbackId` at all: `WorkflowPaywallView` derives `isSingleStepFallback`
+        // as `stepId == singleStepFallbackId`, which is `false` for every step when the optional fallback id
+        // is absent, so no paywall events fire on any step (only workflow events).
+        expect(PaywallsV2View.shouldTrackPaywallEvents(
+            isActiveWorkflowPage: true,
+            workflowScreenType: nil,
+            isSingleStepFallback: false
+        )) == false
     }
 
     func testWorkflowStepTaggedNonPaywallDoesNotReport() {
-        expect(PaywallsV2View.shouldReportPaywallImpression(
+        // A tagged step without `paywall` is suppressed even when it is the fallback step.
+        expect(PaywallsV2View.shouldTrackPaywallEvents(
             isActiveWorkflowPage: true,
-            workflowScreenType: []
+            workflowScreenType: [],
+            isSingleStepFallback: true
         )) == false
-        expect(PaywallsV2View.shouldReportPaywallImpression(
+        expect(PaywallsV2View.shouldTrackPaywallEvents(
             isActiveWorkflowPage: true,
-            workflowScreenType: ["survey"]
+            workflowScreenType: ["survey"],
+            isSingleStepFallback: false
         )) == false
     }
 
     func testInactiveWorkflowPageGatedBySameRule() {
         // `isActiveWorkflowPage == false` is still a workflow page; the screen_type rule applies.
-        expect(PaywallsV2View.shouldReportPaywallImpression(
+        expect(PaywallsV2View.shouldTrackPaywallEvents(
             isActiveWorkflowPage: false,
-            workflowScreenType: [WorkflowScreenType.paywall]
+            workflowScreenType: [WorkflowScreenType.paywall],
+            isSingleStepFallback: false
         )) == true
-        expect(PaywallsV2View.shouldReportPaywallImpression(
+        expect(PaywallsV2View.shouldTrackPaywallEvents(
             isActiveWorkflowPage: false,
-            workflowScreenType: ["survey"]
+            workflowScreenType: ["survey"],
+            isSingleStepFallback: false
         )) == false
     }
 
@@ -238,6 +257,66 @@ final class ApplyingWorkflowAttributionTests: TestCase {
 
         expect(result.workflowId).to(beNil())
         expect(result.stepId).to(beNil())
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@MainActor
+final class WorkflowComponentInteractionLoggerTests: TestCase {
+
+    private static let interactionData = PaywallEvent.ComponentInteractionData(
+        componentType: .text,
+        componentName: "link_copy",
+        componentValue: "navigate_to_url"
+    )
+
+    func testNonPaywallStepGetsNoOpLogger() {
+        var factoryInvoked = false
+        let logger = PaywallsV2View.componentInteractionLogger(tracksPaywallEvents: false) {
+            factoryInvoked = true
+            return ComponentInteractionLogger { _ in true }
+        }
+
+        // A non-paywall step must emit no component_interaction: the real logger is never built and the
+        // installed no-op reports nothing.
+        expect(factoryInvoked) == false
+        expect(logger(Self.interactionData)) == false
+    }
+
+    func testPaywallStepGetsRealLogger() async throws {
+        let tracker = PaywallEventTracker(
+            purchases: MockPurchases(
+                purchase: { _, _, _ in
+                    (transaction: nil, customerInfo: TestData.customerInfo, userCancelled: false)
+                },
+                restorePurchases: { TestData.customerInfo },
+                trackEvent: { _ in },
+                customerInfo: { TestData.customerInfo }
+            ),
+            eventDispatcher: PaywallEventTrackerTestDispatcher.value
+        )
+        let eventData: PaywallEvent.Data = .init(
+            offering: TestData.offeringWithIntroOffer,
+            paywall: TestData.paywallWithIntroOffer,
+            sessionID: .init(),
+            displayMode: .fullScreen,
+            locale: .init(identifier: "en_US"),
+            darkMode: false,
+            source: nil
+        )
+        tracker.trackPaywallImpression(eventData)
+
+        let logger = PaywallsV2View.componentInteractionLogger(tracksPaywallEvents: true) {
+            tracker.componentInteractionLogger(sessionID: eventData.sessionIdentifier)
+        }
+
+        // A paywall step uses the real session-bound logger, which reports the interaction.
+        expect(logger(Self.interactionData)) == true
+
+        await Task(priority: .low) {
+            await Task.yield()
+        }.value
     }
 
 }

--- a/Tests/UnitTests/Networking/Workflows/WorkflowResponseTests.swift
+++ b/Tests/UnitTests/Networking/Workflows/WorkflowResponseTests.swift
@@ -357,7 +357,8 @@ class WorkflowResponseTests: TestCase {
     }
 
     func testDecodeWorkflowStepScreenTypeNilWhenKeyAbsent() throws {
-        // Older workflows omit `screen_type`. `nil` (not `[]`) preserves the always-report behavior.
+        // Older workflows omit `screen_type`. `nil` (not `[]`) drives the untagged fallback in the UI
+        // layer (report only on `singleStepFallbackId`); see `PaywallsV2View.shouldTrackPaywallEvents`.
         let json = """
         {
           "id": "step_1",


### PR DESCRIPTION
### Motivation

Third split out of #6947, landing the additive workflow features on `main` independently of the always-on flag removal. This PR re-lands **gating all paywall events by step `screen_type`** (originally #7029, merged into the stack-base branch rather than `main`) directly onto `main`, on top of #7104 (#7021).

Part of splitting #6947. Stack:
- #7103 — #6958 preview injection (merged)
- #7104 — #7021 gate impressions by `screen_type` (merged)
- **This PR** — #7029 gate all events by `screen_type`
- #6947 — the flag removal itself, held until the workflow-or-throw path is verified on-device

### Description

Extends the impression gating from #7104 to cover all paywall events on a workflow step (impression, close, purchase, cancel, exit offer, component interaction). Key changes:
- `shouldReportPaywallImpression` -> `shouldTrackPaywallEvents`, adding an `isSingleStepFallback` input: untagged steps (`nil` `screen_type`) fall back to the structural rule (report only on the workflow's `singleStepFallbackId`), matching the pre-`screen_type` behavior instead of over-reporting;
- a no-op `componentInteractionLogger` for non-paywall steps so they emit no `component_interaction` event;
- threads `isWorkflowSingleStepFallback` from `WorkflowPaywallView`.

### Reconciliation with #7104 (reviewer note)

#7104 restored `workflowId`/`stepId` attribution (#7024) on the impression event, orthogonal to the gate. This PR was authored before that, so the cherry-pick conflicted; resolved by keeping **both** — `workflowScreenType` + `isWorkflowSingleStepFallback` (gating) and `workflowId`/`stepId` (attribution) coexist on `PaywallsV2View`, and `createEventData` still calls `applyingWorkflowAttribution`. This matches Android (`PaywallViewModel.trackPaywallImpressionIfNeeded`: gate decides whether to track; tracked events still carry attribution).

### Why it's safe to land on main without the flag removal

Only changes the workflow render/parse path, which on `main` executes only when `workflowsEndpointEnabled` is on. Dormant-but-correct behind the existing flag.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: gate-all-events-by-screen-type re-land onto main (split out of #6947)
- Branch: `facu/workflow-gate-events-screen-type-main`
- Author / human owner: facumenzella
- Agent(s): Claude Code (Opus 4.8, 1M context)
- Session source: current conversation (2026-06-30)
- Generated: 2026-06-30
- Context document version: 1

## Goal

Split #6947 into independently-mergeable PRs. This PR extracts #7029 ("gate all events by `screen_type`") onto `main`, after #7103 (#6958) and #7104 (#7021) landed.

## Initial Prompt

"I need to be able to split this PR up, so I can merge things without breaking main." Follow-ups extracted the additive features (#6958/#7021/#7029) as separate PRs; "just merged B, let's work on C now."

## Agent Contribution

- Cherry-picked #7029 (`82ece087`) onto a fresh branch off `origin/main` (now containing #7103 + #7104).
- Reconciled the conflict with #7104's restored attribution: kept both gating and attribution on `PaywallsV2View` and its `WorkflowPaywallView` call site; merged the test tails so both `ApplyingWorkflowAttributionTests` (from #7104) and C's `WorkflowComponentInteractionLoggerTests` survive.
- Fixed an argument-order build error (init declares `workflowId`/`stepId` before `isWorkflowSingleStepFallback`; the call site had to match).

## Human Decisions

- Keep the flag removal in #6947; extract additive features separately; work C after B merged.

## Key Implementation Decisions

- Decision: gating (`workflowScreenType` + `isWorkflowSingleStepFallback`) and attribution (`workflowId`/`stepId`) are orthogonal and both kept.
  - Rationale: confirmed against Android — the screen_type gate and workflow attribution are independent; tracked events still carry the workflow/step ids.

## Files / Symbols Touched

- `RevenueCatUI/Templates/V2/PaywallsV2View.swift` — `shouldTrackPaywallEvents` (was `shouldReportPaywallImpression`, + `isSingleStepFallback`), `tracksPaywallEvents`, `componentInteractionLogger`, `isWorkflowSingleStepFallback`; `applyingWorkflowAttribution` retained.
- `RevenueCatUI/Templates/V2/WorkflowPaywallView.swift` — passes `isWorkflowSingleStepFallback` alongside `workflowScreenType`/`workflowId`/`stepId`.
- `Sources/Networking/Responses/WorkflowsResponse.swift`, `Tests/UnitTests/Networking/Workflows/WorkflowResponseTests.swift` — minor.
- `Tests/RevenueCatUITests/PaywallsV2/PaywallsV2ViewTests.swift` — `ShouldTrackPaywallEventsTests` (renamed + fallback cases), `WorkflowComponentInteractionLoggerTests` (new), `ApplyingWorkflowAttributionTests` (kept from #7104).

## Validation

- Commands run:
  - `git cherry-pick -x 82ece087`: 3 conflicts (PaywallsV2View, WorkflowPaywallView, PaywallsV2ViewTests), all "both-added"; resolved keeping gating + attribution.
  - `xcodebuild build -scheme RevenueCatUI`: **BUILD SUCCEEDED** (after fixing argument order).
  - `xcodebuild test -only-testing:.../ShouldTrackPaywallEventsTests -only-testing:.../ApplyingWorkflowAttributionTests -only-testing:.../WorkflowComponentInteractionLoggerTests`: 9 tests passed.
- CI: `run-revenuecat-ui-ios-26` for the full UI suite. Draft until green.

## Validation Gaps

- On-device run not repeated for this PR (the screen_type gate was already verified end-to-end on #7104 via baguette); the component-interaction no-op path is covered by unit tests only.

## Review Focus

- Untagged-step fallback: `isWorkflowSingleStepFallback` derived as `stepId == singleStepFallbackId`; when a workflow has no `singleStepFallbackId`, no step reports (only workflow events) — intended.
- Confirm `applyingWorkflowAttribution` is still invoked by `createEventData` (attribution preserved through C's rename).

## Risks / Reviewer Notes

- Risk: behavioral change broadens suppression from impressions to all paywall events on non-paywall steps.
  - Evidence: gated by `tracksPaywallEvents`; reachable only on the flag-gated workflow path on `main`.

## Non-goals / Out of Scope

- The flag removal (stays in #6947).

## Omitted Context

- Raw transcript, unrelated exploration, repetitive attempts, and chain-of-thought-style content were omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes analytics attribution and suppression on the workflow paywall path (including legacy untagged workflows); behavior is flag-gated on main but alters when paywall events fire and how purchases bind to sessions.
> 
> **Overview**
> Extends workflow **impression** gating to **all paywall events** (impression, close, purchase-related session behavior, and **component_interaction**). The gate is centralized in **`shouldTrackPaywallEvents`** (renamed from `shouldReportPaywallImpression`), with **`tracksPaywallEvents`** driving impression/close and the component interaction environment.
> 
> For workflow steps, **`screen_type`** still decides reporting when present: **`paywall`** → track; tagged without **`paywall`** (including `[]`) → suppress. **Untagged** steps (`nil` `screen_type`) no longer always report—they only track when the step is the workflow’s **`singleStepFallbackId`**, via **`isWorkflowSingleStepFallback`** threaded from **`WorkflowPaywallView`**. Non-tracking steps clear the active paywall session on “impression” so purchases are not attributed to a prior paywall step, and use a **no-op** `componentInteractionLogger` so taps do not emit paywall analytics.
> 
> Standalone paywalls are unchanged (always track). Workflow attribution (`workflowId` / `stepId`) remains orthogonal to the gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b9e9b0f72d2a20c000943ffcb1970c90f90c4f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->