### PR TITLE
feat(remote-config): persist full topic index

### DIFF
--- a/Sources/Networking/RemoteConfigDiskCache.swift
+++ b/Sources/Networking/RemoteConfigDiskCache.swift
@@ -24,23 +24,20 @@ struct PersistedRemoteConfiguration: Codable, Equatable {
     let manifest: String
     let activeTopics: [String]
     let prefetchBlobs: [String]
-    let topicBlobRefs: [String: [String]]
-    let lastRefreshAt: Date?
+    let topics: RemoteConfiguration.Topics
 
     init(
         domain: String = RemoteConfiguration.defaultDomain,
         manifest: String,
         activeTopics: [String] = [],
         prefetchBlobs: [String] = [],
-        topicBlobRefs: [String: [String]] = [:],
-        lastRefreshAt: Date? = nil
+        topics: RemoteConfiguration.Topics = .init()
     ) {
         self.domain = domain
         self.manifest = manifest
         self.activeTopics = activeTopics
         self.prefetchBlobs = prefetchBlobs
-        self.topicBlobRefs = topicBlobRefs
-        self.lastRefreshAt = lastRefreshAt
+        self.topics = topics
     }
 
     init(from decoder: Decoder) throws {
@@ -50,8 +47,7 @@ struct PersistedRemoteConfiguration: Codable, Equatable {
             manifest: try container.decode(String.self, forKey: .manifest),
             activeTopics: try container.decodeIfPresent([String].self, forKey: .activeTopics) ?? [],
             prefetchBlobs: try container.decodeIfPresent([String].self, forKey: .prefetchBlobs) ?? [],
-            topicBlobRefs: try container.decodeIfPresent([String: [String]].self, forKey: .topicBlobRefs) ?? [:],
-            lastRefreshAt: try container.decodeIfPresent(Date.self, forKey: .lastRefreshAt)
+            topics: try container.decodeIfPresent(RemoteConfiguration.Topics.self, forKey: .topics) ?? .init()
         )
     }
 
@@ -60,8 +56,7 @@ struct PersistedRemoteConfiguration: Codable, Equatable {
         case manifest
         case activeTopics
         case prefetchBlobs
-        case topicBlobRefs
-        case lastRefreshAt
+        case topics
     }
 
 }

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -24,7 +24,6 @@ final class RemoteConfigManager: RemoteConfigManagerType {
 
     private let remoteConfigAPI: RemoteConfigAPIType
     private let diskCache: RemoteConfigDiskCacheType
-    private let dateProvider: DateProvider
     private let isRefreshing: Atomic<Bool> = false
     private let blobStore: RemoteConfigBlobStoreType
     private let currentUserProvider: CurrentUserProvider
@@ -33,14 +32,12 @@ final class RemoteConfigManager: RemoteConfigManagerType {
         remoteConfigAPI: RemoteConfigAPIType,
         diskCache: RemoteConfigDiskCacheType,
         blobStore: RemoteConfigBlobStoreType,
-        currentUserProvider: CurrentUserProvider,
-        dateProvider: DateProvider = DateProvider()
+        currentUserProvider: CurrentUserProvider
     ) {
         self.remoteConfigAPI = remoteConfigAPI
         self.diskCache = diskCache
         self.blobStore = blobStore
         self.currentUserProvider = currentUserProvider
-        self.dateProvider = dateProvider
     }
 
     func refreshRemoteConfig(isAppBackgrounded: Bool) {
@@ -99,10 +96,7 @@ private extension RemoteConfigManager {
         container: RemoteConfigContainer?,
         previous: PersistedRemoteConfiguration?
     ) {
-        guard let container else {
-            self.persistLastRefreshAt(previous: previous)
-            return
-        }
+        guard let container else { return }
 
         do {
             let response = try container.configElement.withDecodedPayloadBytes { bytes in
@@ -112,13 +106,13 @@ private extension RemoteConfigManager {
                 )
             }
 
-            let postSyncTopicBlobRefs = self.postSyncTopicBlobRefs(
+            let postSyncTopics = self.postSyncTopics(
                 previous: previous,
                 response: response
             )
             let postSyncReferencedBlobRefs = self.postSyncReferencedBlobRefs(
                 response: response,
-                postSyncTopicBlobRefs: postSyncTopicBlobRefs
+                postSyncTopics: postSyncTopics
             )
 
             let persistedConfiguration = PersistedRemoteConfiguration(
@@ -126,8 +120,7 @@ private extension RemoteConfigManager {
                 manifest: response.manifest,
                 activeTopics: response.activeTopics,
                 prefetchBlobs: response.prefetchBlobs,
-                topicBlobRefs: postSyncTopicBlobRefs,
-                lastRefreshAt: self.dateProvider.now()
+                topics: postSyncTopics
             )
 
             guard self.diskCache.write(persistedConfiguration) else { return }
@@ -139,30 +132,19 @@ private extension RemoteConfigManager {
         }
     }
 
-    func persistLastRefreshAt(previous: PersistedRemoteConfiguration?) {
-        guard let previous else { return }
-
-        self.diskCache.write(PersistedRemoteConfiguration(
-            domain: previous.domain,
-            manifest: previous.manifest,
-            activeTopics: previous.activeTopics,
-            prefetchBlobs: previous.prefetchBlobs,
-            topicBlobRefs: previous.topicBlobRefs,
-            lastRefreshAt: self.dateProvider.now()
-        ))
-    }
-
-    /// Returns the topic blob refs that should be persisted after this response is applied.
+    /// Returns the full topic index that should be persisted after this response is applied.
     ///
-    /// Changed topics overwrite previous refs, unchanged active topics keep previous refs, and inactive topics
+    /// Changed topics overwrite previous entries, unchanged active topics keep previous entries, and inactive topics
     /// are removed.
-    func postSyncTopicBlobRefs(
+    func postSyncTopics(
         previous: PersistedRemoteConfiguration?,
         response: RemoteConfiguration
-    ) -> [String: [String]] {
-        return (previous?.topicBlobRefs ?? [:])
-            .merging(response.topics.topicBlobRefs) { _, changed in changed }
+    ) -> RemoteConfiguration.Topics {
+        let entries = (previous?.topics.entries ?? [:])
+            .merging(response.topics.entries) { _, changed in changed }
             .filter { topic, _ in response.activeTopics.contains(topic) }
+
+        return RemoteConfiguration.Topics(entries: entries)
     }
 
     /// Returns the post-sync set of blob refs the SDK should keep locally.
@@ -171,9 +153,9 @@ private extension RemoteConfigManager {
     /// response topics with previously persisted unchanged topics.
     func postSyncReferencedBlobRefs(
         response: RemoteConfiguration,
-        postSyncTopicBlobRefs: [String: [String]]
+        postSyncTopics: RemoteConfiguration.Topics
     ) -> Set<String> {
-        return Set(response.prefetchBlobs).union(postSyncTopicBlobRefs.values.flatMap { $0 })
+        return Set(response.prefetchBlobs).union(postSyncTopics.blobRefs)
     }
 
     /// Writes valid inline content elements that are referenced by this config response.
@@ -201,11 +183,9 @@ private extension RemoteConfigManager {
 
 fileprivate extension RemoteConfiguration.Topics {
 
-    /// The blob refs each changed topic's items reference, keyed by topic name.
-    var topicBlobRefs: [String: [String]] {
-        return self.entries.mapValues { topic in
-            topic.values.compactMap(\.blobRef).sorted()
-        }
+    /// All blob refs referenced by this topic collection.
+    var blobRefs: Set<String> {
+        return Set(self.entries.values.flatMap { $0.values.compactMap(\.blobRef) })
     }
 
 }

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigDiskCacheTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigDiskCacheTests.swift
@@ -59,23 +59,21 @@ final class RemoteConfigDiskCacheTests: TestCase {
         expect(self.cache.read()).to(beNil())
     }
 
-    func testWriteThenReadRoundTripsManifestAndTopicBlobRefs() throws {
+    func testWriteThenReadRoundTripsManifestAndTopics() throws {
         let manifest = "v1.1710000100.product_entitlement_mapping:etag2,sources:etag1"
         let activeTopics = ["sources", "product_entitlement_mapping"]
-        let topicBlobRefs = [
-            "sources": ["blobRefA"],
-            "product_entitlement_mapping": ["pemBlob"]
-        ]
+        let topics = RemoteConfiguration.Topics(entries: [
+            "sources": ["default": .init(blobRef: "blobRefA")],
+            "product_entitlement_mapping": ["default": .init(blobRef: "pemBlob")]
+        ])
         let prefetchBlobs = ["blobRefA", "pemBlob"]
-        let lastRefreshAt = Date(timeIntervalSince1970: 1_710_000_100)
 
         self.cache.write(PersistedRemoteConfiguration(
             domain: "app",
             manifest: manifest,
             activeTopics: activeTopics,
             prefetchBlobs: prefetchBlobs,
-            topicBlobRefs: topicBlobRefs,
-            lastRefreshAt: lastRefreshAt
+            topics: topics
         ))
         let read = try XCTUnwrap(self.cache.read())
 
@@ -83,25 +81,60 @@ final class RemoteConfigDiskCacheTests: TestCase {
         expect(read.manifest) == manifest
         expect(read.activeTopics) == activeTopics
         expect(read.prefetchBlobs) == prefetchBlobs
-        expect(read.topicBlobRefs) == topicBlobRefs
-        expect(read.lastRefreshAt) == lastRefreshAt
+        expect(read.topics) == topics
     }
 
-    func testInlineOnlyTopicsPersistWithEmptyBlobRefList() throws {
+    func testInlineOnlyTopicsPersistWithContent() throws {
         let manifest = "v1.1710000100.sources:etag1"
-        let topicBlobRefs = ["sources": [String]()]
+        let inlineItem = RemoteConfiguration.ConfigItem(
+            content: [
+                "priority": 100,
+                "url": "https://api.revenuecat.com"
+            ]
+        )
+        let topics = RemoteConfiguration.Topics(entries: [
+            "sources": ["api": inlineItem]
+        ])
 
         self.cache.write(PersistedRemoteConfiguration(
             domain: "app",
             manifest: manifest,
             activeTopics: ["sources"],
             prefetchBlobs: [],
-            topicBlobRefs: topicBlobRefs,
-            lastRefreshAt: Date()
+            topics: topics
         ))
         let read = try XCTUnwrap(self.cache.read())
 
-        expect(read.topicBlobRefs) == topicBlobRefs
+        expect(read.topics) == topics
+    }
+
+    func testTopicsPersistUntypedMetadataRoundTrip() throws {
+        let metadataItem = RemoteConfiguration.ConfigItem(
+            content: [
+                "array": ["one", 2, true],
+                "bool": true,
+                "double": 1.5,
+                "int": 100,
+                "nested": [
+                    "enabled": false,
+                    "name": "nested"
+                ],
+                "null": nil,
+                "string": "value"
+            ]
+        )
+        let topics = RemoteConfiguration.Topics(entries: [
+            "sources": ["api": metadataItem]
+        ])
+
+        self.cache.write(PersistedRemoteConfiguration(
+            manifest: "v1.1710000100.sources:etag1",
+            activeTopics: ["sources"],
+            topics: topics
+        ))
+        let read = try XCTUnwrap(self.cache.read())
+
+        expect(read.topics) == topics
     }
 
     func testReadReturnsNilWhenPersistedFileIsCorrupt() throws {
@@ -115,7 +148,7 @@ final class RemoteConfigDiskCacheTests: TestCase {
         expect(self.cache.read()).to(beNil())
     }
 
-    func testReadToleratesOldFormatByDroppingUnknownTopicBodies() throws {
+    func testReadDefaultsMissingTopicsToEmpty() throws {
         try FileManager.default.createDirectory(
             at: self.fileURL.deletingLastPathComponent(),
             withIntermediateDirectories: true,
@@ -123,23 +156,14 @@ final class RemoteConfigDiskCacheTests: TestCase {
         )
         try """
         {
-          "manifest": "v1.1710000100.sources:etag1",
-          "topics": {
-            "sources": {
-              "default": { "blob_ref": "oldBlob" }
-            }
-          }
+          "manifest": "v1.1710000100.sources:etag1"
         }
         """.asData.write(to: self.fileURL)
 
         let read = try XCTUnwrap(self.cache.read())
 
-        expect(read.domain) == "app"
         expect(read.manifest) == "v1.1710000100.sources:etag1"
-        expect(read.activeTopics).to(beEmpty())
-        expect(read.prefetchBlobs).to(beEmpty())
-        expect(read.topicBlobRefs).to(beEmpty())
-        expect(read.lastRefreshAt).to(beNil())
+        expect(read.topics.entries).to(beEmpty())
     }
 
     func testWriteCreatesDirectoryWhenAbsent() {
@@ -147,9 +171,7 @@ final class RemoteConfigDiskCacheTests: TestCase {
             domain: "app",
             manifest: "v1.1710000100.sources:etag1",
             activeTopics: [],
-            prefetchBlobs: [],
-            topicBlobRefs: [:],
-            lastRefreshAt: Date()
+            prefetchBlobs: []
         ))
 
         expect(FileManager.default.fileExists(atPath: self.fileURL.path)) == true
@@ -160,9 +182,7 @@ final class RemoteConfigDiskCacheTests: TestCase {
             domain: "app",
             manifest: "v1.1710000100.sources:etag1",
             activeTopics: [],
-            prefetchBlobs: [],
-            topicBlobRefs: [:],
-            lastRefreshAt: Date()
+            prefetchBlobs: []
         ))
 
         expect(self.fileURL.deletingLastPathComponent().lastPathComponent) == "remote_config"
@@ -180,9 +200,7 @@ final class RemoteConfigDiskCacheTests: TestCase {
             domain: "app",
             manifest: "v1.1710000100.sources:etag1",
             activeTopics: [],
-            prefetchBlobs: [],
-            topicBlobRefs: [:],
-            lastRefreshAt: nil
+            prefetchBlobs: []
         ))
 
         self.logger.verifyMessageWasLogged(Strings.remoteConfig.failedToWriteCache, level: .error)
@@ -193,17 +211,13 @@ final class RemoteConfigDiskCacheTests: TestCase {
             domain: "app",
             manifest: "v1.1710000100.sources:old",
             activeTopics: [],
-            prefetchBlobs: [],
-            topicBlobRefs: [:],
-            lastRefreshAt: Date(timeIntervalSince1970: 1)
+            prefetchBlobs: []
         ))
         self.cache.write(PersistedRemoteConfiguration(
             domain: "app",
             manifest: "v1.1710000100.sources:new",
             activeTopics: ["sources"],
-            prefetchBlobs: [],
-            topicBlobRefs: [:],
-            lastRefreshAt: Date(timeIntervalSince1970: 2)
+            prefetchBlobs: []
         ))
 
         let read = try XCTUnwrap(self.cache.read())
@@ -216,9 +230,7 @@ final class RemoteConfigDiskCacheTests: TestCase {
             domain: "app",
             manifest: "v1.1710000100.sources:etag1",
             activeTopics: ["sources"],
-            prefetchBlobs: [],
-            topicBlobRefs: [:],
-            lastRefreshAt: Date()
+            prefetchBlobs: []
         ))
 
         self.cache.clear()

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -12,12 +12,10 @@ import XCTest
 
 final class RemoteConfigManagerTests: TestCase {
 
-    private static let lastRefreshAt = Date(timeIntervalSince1970: 1_710_000_100)
     private static let appUserID = "app-user-id"
 
     private var remoteConfigAPI: MockRemoteConfigAPI!
     private var diskCache: MockRemoteConfigDiskCache!
-    private var dateProvider: MockDateProvider!
     private var blobStore: MockRemoteConfigBlobStore!
     private var currentUserProvider: MockCurrentUserProvider!
     private var manager: RemoteConfigManager!
@@ -27,21 +25,18 @@ final class RemoteConfigManagerTests: TestCase {
 
         self.remoteConfigAPI = MockRemoteConfigAPI()
         self.diskCache = MockRemoteConfigDiskCache()
-        self.dateProvider = MockDateProvider(stubbedNow: Self.lastRefreshAt)
         self.blobStore = MockRemoteConfigBlobStore()
         self.currentUserProvider = MockCurrentUserProvider(mockAppUserID: Self.appUserID)
         self.manager = RemoteConfigManager(
             remoteConfigAPI: self.remoteConfigAPI,
             diskCache: self.diskCache,
             blobStore: self.blobStore,
-            currentUserProvider: self.currentUserProvider,
-            dateProvider: self.dateProvider
+            currentUserProvider: self.currentUserProvider
         )
     }
 
     override func tearDownWithError() throws {
         self.manager = nil
-        self.dateProvider = nil
         self.blobStore = nil
         self.currentUserProvider = nil
         self.diskCache = nil
@@ -68,7 +63,7 @@ final class RemoteConfigManagerTests: TestCase {
             domain: "custom",
             manifest: persistedManifest,
             prefetchBlobs: ["prefetchedBlob"],
-            topicBlobRefs: [:]
+            topics: .init()
         )
 
         self.manager.refreshRemoteConfig(isAppBackgrounded: true)
@@ -98,7 +93,7 @@ final class RemoteConfigManagerTests: TestCase {
         self.diskCache.stubbedRead = PersistedRemoteConfiguration(
             manifest: "v1.1710000100.sources:etag1",
             prefetchBlobs: ["cachedBlob", "purgedBlob"],
-            topicBlobRefs: [:]
+            topics: .init()
         )
 
         self.manager.refreshRemoteConfig(isAppBackgrounded: true)
@@ -107,7 +102,7 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.blobStore.invokedCachedRefsCount) == 1
     }
 
-    func testContainerResponsePersistsServerManifestAndChangedTopicBlobRefs() throws {
+    func testContainerResponsePersistsServerManifestAndChangedTopics() throws {
         self.diskCache.stubbedRead = nil
         let response = """
         {
@@ -134,8 +129,7 @@ final class RemoteConfigManagerTests: TestCase {
             == "v1.1710000100.sources:etag2"
         expect(self.diskCache.invokedWriteParameter?.activeTopics) == ["sources"]
         expect(self.diskCache.invokedWriteParameter?.prefetchBlobs) == ["newBlob"]
-        expect(self.diskCache.invokedWriteParameter?.topicBlobRefs) == ["sources": ["newBlob"]]
-        expect(self.diskCache.invokedWriteParameter?.lastRefreshAt) == Self.lastRefreshAt
+        expect(Self.blobRefsByTopic(from: self.diskCache.invokedWriteParameter?.topics)) == ["sources": ["newBlob"]]
     }
 
     func testContainerResponseDecodesCompressedConfigElement() throws {
@@ -164,13 +158,13 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.diskCache.invokedWriteParameter?.manifest) == "v1.1710000100.sources:etag2"
     }
 
-    func testContainerResponseMergesUnchangedTopicRefsAndPrunesDroppedTopics() throws {
+    func testContainerResponseMergesUnchangedTopicsAndPrunesDroppedTopics() throws {
         self.diskCache.stubbedRead = Self.persisted(
             manifest: "v1.1710000100.product_entitlement_mapping:pemEtag1,sources:etag1",
-            topicBlobRefs: [
-                "sources": ["oldSources"],
-                "product_entitlement_mapping": ["pemBlob"]
-            ]
+            topics: .init(entries: [
+                "sources": ["default": .init(blobRef: "oldSources")],
+                "product_entitlement_mapping": ["default": .init(blobRef: "pemBlob")]
+            ])
         )
         let response = """
         {
@@ -190,17 +184,21 @@ final class RemoteConfigManagerTests: TestCase {
             with: .success(.test(container: try Self.container(config: response)))
         )
 
-        expect(self.diskCache.invokedWriteParameter?.topicBlobRefs) == ["sources": ["newSources"]]
+        expect(Self.blobRefsByTopic(from: self.diskCache.invokedWriteParameter?.topics)) == ["sources": ["newSources"]]
         expect(self.blobStore.invokedRetainOnlyParameters) == Set(["newSources"])
     }
 
-    func testContainerResponseKeepsPreviousRefsForUnchangedTopicsStillActive() throws {
+    func testContainerResponseKeepsPreviousEntriesForUnchangedTopicsStillActive() throws {
+        let previousProductMapping = RemoteConfiguration.ConfigItem(
+            blobRef: "pemBlob",
+            content: ["format": "v1"]
+        )
         self.diskCache.stubbedRead = Self.persisted(
             manifest: "v1.1710000100.product_entitlement_mapping:pemEtag1,sources:etag1",
-            topicBlobRefs: [
-                "sources": ["oldSources"],
-                "product_entitlement_mapping": ["pemBlob"]
-            ]
+            topics: .init(entries: [
+                "sources": ["default": .init(blobRef: "oldSources")],
+                "product_entitlement_mapping": ["default": previousProductMapping]
+            ])
         )
         let response = """
         {
@@ -220,13 +218,15 @@ final class RemoteConfigManagerTests: TestCase {
             with: .success(.test(container: try Self.container(config: response)))
         )
 
-        expect(self.diskCache.invokedWriteParameter?.topicBlobRefs) == [
+        expect(Self.blobRefsByTopic(from: self.diskCache.invokedWriteParameter?.topics)) == [
             "sources": ["newSources"],
             "product_entitlement_mapping": ["pemBlob"]
         ]
+        expect(self.diskCache.invokedWriteParameter?.topics.entries["product_entitlement_mapping"]?["default"])
+            == previousProductMapping
     }
 
-    func testContainerResponsePersistsEmptyBlobRefListForInlineOnlyChangedTopics() throws {
+    func testContainerResponsePersistsInlineOnlyChangedTopics() throws {
         let response = """
         {
           "domain": "app",
@@ -248,32 +248,26 @@ final class RemoteConfigManagerTests: TestCase {
             with: .success(.test(container: try Self.container(config: response)))
         )
 
-        expect(self.diskCache.invokedWriteParameter?.topicBlobRefs) == ["sources": []]
+        let item = self.diskCache.invokedWriteParameter?.topics.entries["sources"]?["api"]
+        expect(item?.blobRef).to(beNil())
+        expect(item?.content["url"]) == "https://api.revenuecat.com"
+        expect(item?.content["priority"]) == 100
     }
 
-    func testNoContentResponseUpdatesLastRefreshAtForPersistedCache() {
+    func testNoContentResponseWithPersistedCacheLeavesCacheUntouched() {
         let previous = Self.persisted(
             domain: "app",
             manifest: "v1.1710000100.sources:etag1",
             activeTopics: ["sources"],
             prefetchBlobs: ["prefetchBlob"],
-            topicBlobRefs: ["sources": ["sourceBlob"]],
-            lastRefreshAt: Date(timeIntervalSince1970: 1)
+            topics: .init(entries: ["sources": ["default": .init(blobRef: "sourceBlob")]])
         )
         self.diskCache.stubbedRead = previous
 
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
 
-        expect(self.diskCache.invokedWriteCount) == 1
-        expect(self.diskCache.invokedWriteParameter) == PersistedRemoteConfiguration(
-            domain: previous.domain,
-            manifest: previous.manifest,
-            activeTopics: previous.activeTopics,
-            prefetchBlobs: previous.prefetchBlobs,
-            topicBlobRefs: previous.topicBlobRefs,
-            lastRefreshAt: Self.lastRefreshAt
-        )
+        expect(self.diskCache.invokedWriteCount) == 0
         expect(self.blobStore.invokedWriteCount) == 0
         expect(self.blobStore.invokedRetainOnlyCount) == 0
     }
@@ -338,7 +332,7 @@ final class RemoteConfigManagerTests: TestCase {
         )
 
         expect(self.diskCache.invokedWriteCount) == 1
-        expect(self.diskCache.invokedWriteParameter?.topicBlobRefs) == ["sources": ["newBlob"]]
+        expect(Self.blobRefsByTopic(from: self.diskCache.invokedWriteParameter?.topics)) == ["sources": ["newBlob"]]
     }
 
     func testContainerResponseCachesInlineContentElements() throws {
@@ -384,8 +378,8 @@ final class RemoteConfigManagerTests: TestCase {
         )
 
         expect(self.diskCache.invokedWriteParameter?.activeTopics) == ["workflows"]
-        expect(self.diskCache.invokedWriteParameter?.topicBlobRefs) == [
-            "workflows": [workflowBlobRef, summerWorkflowBlobRef].sorted()
+        expect(Self.blobRefsByTopic(from: self.diskCache.invokedWriteParameter?.topics)) == [
+            "workflows": [workflowBlobRef, summerWorkflowBlobRef]
         ]
         expect(self.blobStore.invokedWriteParameters?.ref) == workflowBlobRef
         expect(self.blobStore.invokedWriteParameters?.data) == RCContainerTestData.workflowBlob
@@ -450,7 +444,7 @@ final class RemoteConfigManagerTests: TestCase {
         )
 
         expect(self.blobStore.invokedWriteCount) == 0
-        expect(self.diskCache.invokedWriteParameter?.topicBlobRefs) == ["sources": [blobRef]]
+        expect(Self.blobRefsByTopic(from: self.diskCache.invokedWriteParameter?.topics)) == ["sources": [blobRef]]
     }
 
     func testContainerResponseSkipsGzipInlineContentElementWithTrailingBytes() throws {
@@ -484,7 +478,7 @@ final class RemoteConfigManagerTests: TestCase {
         )
 
         expect(self.blobStore.invokedWriteCount) == 0
-        expect(self.diskCache.invokedWriteParameter?.topicBlobRefs) == ["sources": [blobRef]]
+        expect(Self.blobRefsByTopic(from: self.diskCache.invokedWriteParameter?.topics)) == ["sources": [blobRef]]
     }
 
     func testContainerResponseCachesOnlyReferencedInlineContentElements() throws {
@@ -645,7 +639,7 @@ final class RemoteConfigManagerTests: TestCase {
         self.diskCache.stubbedWriteResult = false
         self.diskCache.stubbedRead = PersistedRemoteConfiguration(
             manifest: "v1.1710000100.sources:etag1",
-            topicBlobRefs: ["sources": [oldRef]]
+            topics: .init(entries: ["sources": ["default": .init(blobRef: oldRef)]])
         )
         let blob = "new".asData
         let response = """
@@ -683,17 +677,23 @@ private extension RemoteConfigManagerTests {
         manifest: String,
         activeTopics: [String] = [],
         prefetchBlobs: [String] = [],
-        topicBlobRefs: [String: [String]] = [:],
-        lastRefreshAt: Date? = nil
+        topics: RemoteConfiguration.Topics = .init()
     ) -> PersistedRemoteConfiguration {
         return PersistedRemoteConfiguration(
             domain: domain,
             manifest: manifest,
             activeTopics: activeTopics,
             prefetchBlobs: prefetchBlobs,
-            topicBlobRefs: topicBlobRefs,
-            lastRefreshAt: lastRefreshAt
+            topics: topics
         )
+    }
+
+    static func blobRefsByTopic(from topics: RemoteConfiguration.Topics?) -> [String: Set<String>] {
+        guard let topics else { return [:] }
+
+        return topics.entries.mapValues { topic in
+            Set(topic.values.compactMap(\.blobRef))
+        }
     }
 
     static func container(


### PR DESCRIPTION
Part of a stack of PRs, builds on #7107 and should be aligned with Android PR RevenueCat/purchases-android#3673.

## Description
- Persists the full topic index (list of `Topic`'s) rather than just the referenced blob refs
- Adds round-trip encoding/decoding tests, including with a variety of metadata types
- Removes the `lastRefreshAt` since we'll be introducing a new concept for this soon in a follow up 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-disk cache shape and refresh persistence behavior (204 no longer bumps cache); existing installs without `topics` decode to empty topics until the next successful sync.
> 
> **Overview**
> **Persisted remote config** now stores `RemoteConfiguration.Topics` (full topic/item payloads including inline `content` and `blobRef`) instead of a derived `topicBlobRefs` map and **`lastRefreshAt`**. Disk decode defaults missing `topics` to empty.
> 
> **`RemoteConfigManager`** merges and prunes topics via `postSyncTopics` (same merge rules as before), derives retained blob refs from `postSyncTopics.blobRefs`, and **no longer writes the cache** on a nil/204 container response—`persistLastRefreshAt` and `DateProvider` are removed.
> 
> Unit tests cover topic round-trip, untyped metadata, inline-only topics, and updated manager expectations (unchanged topics keep full `ConfigItem` entries).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5648afbb4c9411271579e2d4e47b560fc178c8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->