### PR TITLE
feat(remote-config): RemoteConfigManager cache invalidation

### DIFF
--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -28,7 +28,7 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     private let diskCache: RemoteConfigDiskCacheType
     private let blobStore: RemoteConfigBlobStoreType
     private let currentUserProvider: CurrentUserProvider
-    private let cacheLock = Lock()
+    private let lock = Lock()
     private var isRefreshing = false
     private var epoch = 0
 
@@ -68,7 +68,7 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     /// The epoch bump, refresh-guard release, and cache wipe are serialized with response persistence so a late
     /// response for a previous user is either fully persisted before the wipe or dropped after the epoch changes.
     func clearCache() {
-        self.cacheLock.perform {
+        self.lock.perform {
             self.epoch += 1
             self.isRefreshing = false
             self.diskCache.clear()
@@ -81,7 +81,7 @@ final class RemoteConfigManager: RemoteConfigManagerType {
 private extension RemoteConfigManager {
 
     func prepareRefreshIfNeeded() -> Int? {
-        return self.cacheLock.perform {
+        return self.lock.perform {
             guard !self.isRefreshing else { return nil }
             self.isRefreshing = true
             return self.epoch
@@ -94,7 +94,7 @@ private extension RemoteConfigManager {
         isAppBackgrounded: Bool,
         requestEpoch: Int
     ) {
-        self.cacheLock.perform {
+        self.lock.perform {
             guard self.epoch == requestEpoch else { return }
 
             self.remoteConfigAPI.getRemoteConfig(
@@ -119,7 +119,7 @@ private extension RemoteConfigManager {
 
     @discardableResult
     func releaseGuardIfOwned(requestEpoch: Int) -> Bool {
-        return self.cacheLock.perform {
+        return self.lock.perform {
             guard self.epoch == requestEpoch else { return false }
             self.isRefreshing = false
             return true
@@ -132,10 +132,9 @@ private extension RemoteConfigManager {
         requestEpoch: Int
     ) {
         guard self.isCurrent(requestEpoch) else { return }
-        guard let container = fetchResult.container else {
-            self.releaseGuardIfOwned(requestEpoch: requestEpoch)
-            return
-        }
+        defer { self.releaseGuardIfOwned(requestEpoch: requestEpoch) }
+
+        guard let container = fetchResult.container else { return }
 
         do {
             let response = try container.configElement.withDecodedPayloadBytes { bytes in
@@ -145,7 +144,7 @@ private extension RemoteConfigManager {
                 )
             }
 
-            self.cacheLock.perform {
+            self.lock.perform {
                 guard self.epoch == requestEpoch else { return }
                 self.persist(
                     container: container,
@@ -157,7 +156,6 @@ private extension RemoteConfigManager {
             Logger.error(Strings.remoteConfig.failedToParseResponse(error))
         }
 
-        self.releaseGuardIfOwned(requestEpoch: requestEpoch)
     }
 
     func handleFailure(
@@ -170,7 +168,7 @@ private extension RemoteConfigManager {
     }
 
     func isCurrent(_ requestEpoch: Int) -> Bool {
-        return self.cacheLock.perform {
+        return self.lock.perform {
             self.epoch == requestEpoch
         }
     }

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -94,6 +94,8 @@ private extension RemoteConfigManager {
         isAppBackgrounded: Bool,
         requestEpoch: Int
     ) {
+        // Keep the epoch check and operation enqueue atomic with clearCache(), so a clear cannot slip in between them.
+        // This assumes getRemoteConfig only registers/enqueues work and does not synchronously call its completion.
         self.lock.perform {
             guard self.epoch == requestEpoch else { return }
 

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -11,6 +11,8 @@ protocol RemoteConfigManagerType: AnyObject {
 
     func refreshRemoteConfig(isAppBackgrounded: Bool)
 
+    func clearCache()
+
 }
 
 /// Coordinates a single remote config refresh.
@@ -24,9 +26,11 @@ final class RemoteConfigManager: RemoteConfigManagerType {
 
     private let remoteConfigAPI: RemoteConfigAPIType
     private let diskCache: RemoteConfigDiskCacheType
-    private let isRefreshing: Atomic<Bool> = false
     private let blobStore: RemoteConfigBlobStoreType
     private let currentUserProvider: CurrentUserProvider
+    private let cacheLock = Lock()
+    private var isRefreshing = false
+    private var epoch = 0
 
     init(
         remoteConfigAPI: RemoteConfigAPIType,
@@ -41,7 +45,7 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     }
 
     func refreshRemoteConfig(isAppBackgrounded: Bool) {
-        guard self.beginRefreshIfNeeded() else { return }
+        guard let requestEpoch = self.prepareRefreshIfNeeded() else { return }
 
         let persisted = self.diskCache.read()
         let request = RemoteConfigRequest(
@@ -51,19 +55,37 @@ final class RemoteConfigManager: RemoteConfigManagerType {
             prefetchedBlobs: self.cachedPrefetchedBlobRefs(from: persisted)
         )
 
+        guard self.isCurrent(requestEpoch) else { return }
+
         self.remoteConfigAPI.getRemoteConfig(
             request: request,
             isAppBackgrounded: isAppBackgrounded
         ) { [weak self] result in
             guard let self else { return }
-            defer { self.endRefresh() }
 
             switch result {
             case let .success(fetchResult):
-                self.persist(container: fetchResult.container, previous: persisted)
+                self.handleSuccess(
+                    fetchResult,
+                    previous: persisted,
+                    requestEpoch: requestEpoch
+                )
             case let .failure(error):
-                Logger.error(Strings.remoteConfig.refreshFailed(error))
+                self.handleFailure(error, requestEpoch: requestEpoch)
             }
+        }
+    }
+
+    /// Wipes cached remote config state, for example after an identity change.
+    ///
+    /// The epoch bump, refresh-guard release, and cache wipe are serialized with response persistence so a late
+    /// response for a previous user is either fully persisted before the wipe or dropped after the epoch changes.
+    func clearCache() {
+        self.cacheLock.perform {
+            self.epoch += 1
+            self.isRefreshing = false
+            self.diskCache.clear()
+            self.blobStore.clear()
         }
     }
 
@@ -71,16 +93,70 @@ final class RemoteConfigManager: RemoteConfigManagerType {
 
 private extension RemoteConfigManager {
 
-    func beginRefreshIfNeeded() -> Bool {
-        return self.isRefreshing.modify { isRefreshing in
-            guard !isRefreshing else { return false }
-            isRefreshing = true
+    func prepareRefreshIfNeeded() -> Int? {
+        return self.cacheLock.perform {
+            guard !self.isRefreshing else { return nil }
+            self.isRefreshing = true
+            return self.epoch
+        }
+    }
+
+    @discardableResult
+    func releaseGuardIfOwned(requestEpoch: Int) -> Bool {
+        return self.cacheLock.perform {
+            guard self.epoch == requestEpoch else { return false }
+            self.isRefreshing = false
             return true
         }
     }
 
-    func endRefresh() {
-        self.isRefreshing.value = false
+    func handleSuccess(
+        _ fetchResult: RemoteConfigFetchResult,
+        previous: PersistedRemoteConfiguration?,
+        requestEpoch: Int
+    ) {
+        guard self.isCurrent(requestEpoch) else { return }
+        guard let container = fetchResult.container else {
+            self.releaseGuardIfOwned(requestEpoch: requestEpoch)
+            return
+        }
+
+        do {
+            let response = try container.configElement.withDecodedPayloadBytes { bytes in
+                try JSONDecoder.default.decode(
+                    RemoteConfiguration.self,
+                    from: Data(bytes)
+                )
+            }
+
+            self.cacheLock.perform {
+                guard self.epoch == requestEpoch else { return }
+                self.persist(
+                    container: container,
+                    previous: previous,
+                    response: response
+                )
+            }
+        } catch {
+            Logger.error(Strings.remoteConfig.failedToParseResponse(error))
+        }
+
+        self.releaseGuardIfOwned(requestEpoch: requestEpoch)
+    }
+
+    func handleFailure(
+        _ error: BackendError,
+        requestEpoch: Int
+    ) {
+        if self.releaseGuardIfOwned(requestEpoch: requestEpoch) {
+            Logger.error(Strings.remoteConfig.refreshFailed(error))
+        }
+    }
+
+    func isCurrent(_ requestEpoch: Int) -> Bool {
+        return self.cacheLock.perform {
+            self.epoch == requestEpoch
+        }
     }
 
     /// Replays only requested prefetch blobs that are still present in the blob store.
@@ -93,43 +169,31 @@ private extension RemoteConfigManager {
 
     /// Persists the config sync state and any valid inline blobs from a successful container response.
     func persist(
-        container: RemoteConfigContainer?,
-        previous: PersistedRemoteConfiguration?
+        container: RemoteConfigContainer,
+        previous: PersistedRemoteConfiguration?,
+        response: RemoteConfiguration
     ) {
-        guard let container else { return }
+        let postSyncTopics = self.postSyncTopics(
+            previous: previous,
+            response: response
+        )
+        let postSyncReferencedBlobRefs = self.postSyncReferencedBlobRefs(
+            response: response,
+            postSyncTopics: postSyncTopics
+        )
 
-        do {
-            let response = try container.configElement.withDecodedPayloadBytes { bytes in
-                try JSONDecoder.default.decode(
-                    RemoteConfiguration.self,
-                    from: Data(bytes)
-                )
-            }
+        let persistedConfiguration = PersistedRemoteConfiguration(
+            domain: response.domain,
+            manifest: response.manifest,
+            activeTopics: response.activeTopics,
+            prefetchBlobs: response.prefetchBlobs,
+            topics: postSyncTopics
+        )
 
-            let postSyncTopics = self.postSyncTopics(
-                previous: previous,
-                response: response
-            )
-            let postSyncReferencedBlobRefs = self.postSyncReferencedBlobRefs(
-                response: response,
-                postSyncTopics: postSyncTopics
-            )
+        guard self.diskCache.write(persistedConfiguration) else { return }
 
-            let persistedConfiguration = PersistedRemoteConfiguration(
-                domain: response.domain,
-                manifest: response.manifest,
-                activeTopics: response.activeTopics,
-                prefetchBlobs: response.prefetchBlobs,
-                topics: postSyncTopics
-            )
-
-            guard self.diskCache.write(persistedConfiguration) else { return }
-
-            self.extractInlineBlobs(from: container, keepingOnly: postSyncReferencedBlobRefs)
-            self.blobStore.retainOnly(postSyncReferencedBlobRefs)
-        } catch {
-            Logger.error(Strings.remoteConfig.failedToParseResponse(error))
-        }
+        self.extractInlineBlobs(from: container, keepingOnly: postSyncReferencedBlobRefs)
+        self.blobStore.retainOnly(postSyncReferencedBlobRefs)
     }
 
     /// Returns the full topic index that should be persisted after this response is applied.

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -55,25 +55,12 @@ final class RemoteConfigManager: RemoteConfigManagerType {
             prefetchedBlobs: self.cachedPrefetchedBlobRefs(from: persisted)
         )
 
-        guard self.isCurrent(requestEpoch) else { return }
-
-        self.remoteConfigAPI.getRemoteConfig(
+        self.enqueueRefreshIfCurrent(
             request: request,
-            isAppBackgrounded: isAppBackgrounded
-        ) { [weak self] result in
-            guard let self else { return }
-
-            switch result {
-            case let .success(fetchResult):
-                self.handleSuccess(
-                    fetchResult,
-                    previous: persisted,
-                    requestEpoch: requestEpoch
-                )
-            case let .failure(error):
-                self.handleFailure(error, requestEpoch: requestEpoch)
-            }
-        }
+            persisted: persisted,
+            isAppBackgrounded: isAppBackgrounded,
+            requestEpoch: requestEpoch
+        )
     }
 
     /// Wipes cached remote config state, for example after an identity change.
@@ -98,6 +85,35 @@ private extension RemoteConfigManager {
             guard !self.isRefreshing else { return nil }
             self.isRefreshing = true
             return self.epoch
+        }
+    }
+
+    func enqueueRefreshIfCurrent(
+        request: RemoteConfigRequest,
+        persisted: PersistedRemoteConfiguration?,
+        isAppBackgrounded: Bool,
+        requestEpoch: Int
+    ) {
+        self.cacheLock.perform {
+            guard self.epoch == requestEpoch else { return }
+
+            self.remoteConfigAPI.getRemoteConfig(
+                request: request,
+                isAppBackgrounded: isAppBackgrounded
+            ) { [weak self] result in
+                guard let self else { return }
+
+                switch result {
+                case let .success(fetchResult):
+                    self.handleSuccess(
+                        fetchResult,
+                        previous: persisted,
+                        requestEpoch: requestEpoch
+                    )
+                case let .failure(error):
+                    self.handleFailure(error, requestEpoch: requestEpoch)
+                }
+            }
         }
     }
 

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -731,6 +731,39 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 3
     }
 
+    func testStaleContainerResponseDoesNotReleaseNewerRefreshGuard() throws {
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.sources:etag2",
+          "active_topics": ["sources"],
+          "topics": {
+            "sources": {
+              "default": { "blob_ref": "newBlob" }
+            }
+          }
+        }
+        """
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.clearCache()
+        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+
+        self.remoteConfigAPI.complete(
+            at: 0,
+            with: .success(.test(container: try Self.container(config: response)))
+        )
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
+        expect(self.diskCache.invokedWriteCount) == 0
+
+        self.remoteConfigAPI.complete(at: 1, with: .success(.test(container: nil)))
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 3
+    }
+
     func testStaleErrorResponseDoesNotReleaseNewerRefreshGuard() {
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.manager.clearCache()

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -668,6 +668,162 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.blobStore.invokedRetainOnlyCount) == 0
     }
 
+    func testClearCacheWipesDiskCacheAndBlobStore() {
+        self.manager.clearCache()
+
+        expect(self.diskCache.invokedClearCount) == 1
+        expect(self.blobStore.invokedClearCount) == 1
+    }
+
+    func testResponseThatArrivesAfterClearCacheDoesNotPersist() throws {
+        self.diskCache.stubbedRead = nil
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.sources:etag2",
+          "active_topics": ["sources"],
+          "topics": {
+            "sources": {
+              "default": { "blob_ref": "newBlob" }
+            }
+          }
+        }
+        """
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.clearCache()
+        self.remoteConfigAPI.complete(
+            at: 0,
+            with: .success(.test(container: try Self.container(config: response)))
+        )
+
+        expect(self.diskCache.invokedWriteCount) == 0
+        expect(self.blobStore.invokedWriteCount) == 0
+        expect(self.blobStore.invokedRetainOnlyCount) == 0
+    }
+
+    func testClearCacheWhileBuildingRequestDoesNotSendStaleRequest() {
+        self.diskCache.readHandler = { [manager] in
+            manager?.clearCache()
+            return nil
+        }
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 0
+        expect(self.diskCache.invokedClearCount) == 1
+        expect(self.blobStore.invokedClearCount) == 1
+    }
+
+    func testStaleNoContentResponseDoesNotReleaseNewerRefreshGuard() {
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.clearCache()
+        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+
+        self.remoteConfigAPI.complete(at: 0, with: .success(.test(container: nil)))
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
+
+        self.remoteConfigAPI.complete(at: 1, with: .success(.test(container: nil)))
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 3
+    }
+
+    func testStaleErrorResponseDoesNotReleaseNewerRefreshGuard() {
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.clearCache()
+        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+
+        self.remoteConfigAPI.complete(
+            at: 0,
+            with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1))))
+        )
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
+
+        self.remoteConfigAPI.complete(at: 1, with: .success(.test(container: nil)))
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 3
+    }
+
+    func testManagerCanSyncAgainAfterClearCache() throws {
+        self.diskCache.stubbedRead = nil
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.sources:etag2",
+          "active_topics": ["sources"],
+          "topics": {
+            "sources": {
+              "default": { "blob_ref": "newBlob" }
+            }
+          }
+        }
+        """
+
+        self.manager.clearCache()
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(
+            with: .success(.test(container: try Self.container(config: response)))
+        )
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+        expect(self.diskCache.invokedWriteCount) == 1
+    }
+
+    func testClearCacheDuringPersistWaitsAndWipesAfterWrite() throws {
+        self.diskCache.stubbedRead = nil
+        let writeStarted = DispatchSemaphore(value: 0)
+        let releaseWrite = DispatchSemaphore(value: 0)
+        let clearEntered = DispatchSemaphore(value: 0)
+        let writeReleaseResult: Atomic<DispatchTimeoutResult?> = nil
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.sources:etag2",
+          "active_topics": ["sources"],
+          "topics": {
+            "sources": {
+              "default": { "blob_ref": "newBlob" }
+            }
+          }
+        }
+        """
+        let container = try Self.container(config: response)
+        self.diskCache.writeHandler = { _ in
+            writeStarted.signal()
+            writeReleaseResult.value = releaseWrite.wait(timeout: .now() + .seconds(5))
+            return true
+        }
+        self.diskCache.clearHandler = {
+            clearEntered.signal()
+        }
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        DispatchQueue.global().async {
+            self.remoteConfigAPI.complete(
+                with: .success(.test(container: container))
+            )
+        }
+        expect(writeStarted.wait(timeout: .now() + .seconds(5))) == .success
+
+        DispatchQueue.global().async {
+            self.manager.clearCache()
+        }
+
+        expect(clearEntered.wait(timeout: .now() + .milliseconds(200))) == .timedOut
+
+        releaseWrite.signal()
+        expect(clearEntered.wait(timeout: .now() + .seconds(5))) == .success
+        expect(writeReleaseResult.value) == .success
+        expect(self.diskCache.invokedWriteCount) == 1
+        expect(self.diskCache.invokedClearCount) == 1
+    }
+
 }
 
 private extension RemoteConfigManagerTests {
@@ -747,8 +903,12 @@ private final class MockRemoteConfigAPI: RemoteConfigAPIType {
         request: RemoteConfigRequest,
         isAppBackgrounded: Bool
     )?
+    private(set) var invokedGetRemoteConfigParametersList: [(
+        request: RemoteConfigRequest,
+        isAppBackgrounded: Bool
+    )] = []
 
-    private var completion: Backend.ResponseHandler<RemoteConfigFetchResult>?
+    private var completions: [Backend.ResponseHandler<RemoteConfigFetchResult>] = []
 
     func getRemoteConfig(
         request: RemoteConfigRequest,
@@ -757,11 +917,19 @@ private final class MockRemoteConfigAPI: RemoteConfigAPIType {
     ) {
         self.invokedGetRemoteConfigCount += 1
         self.invokedGetRemoteConfigParameters = (request, isAppBackgrounded)
-        self.completion = completion
+        self.invokedGetRemoteConfigParametersList.append((request, isAppBackgrounded))
+        self.completions.append(completion)
     }
 
     func complete(with result: Result<RemoteConfigFetchResult, BackendError>) {
-        self.completion?(result)
+        self.completions.last?(result)
+    }
+
+    func complete(
+        at index: Int,
+        with result: Result<RemoteConfigFetchResult, BackendError>
+    ) {
+        self.completions[index](result)
     }
 
 }
@@ -770,13 +938,16 @@ private final class MockRemoteConfigDiskCache: RemoteConfigDiskCacheType {
 
     var stubbedRead: PersistedRemoteConfiguration?
     var stubbedWriteResult = true
+    var readHandler: (() -> PersistedRemoteConfiguration?)?
+    var writeHandler: ((PersistedRemoteConfiguration) -> Bool)?
+    var clearHandler: (() -> Void)?
 
     private(set) var invokedWriteCount = 0
     private(set) var invokedWriteParameter: PersistedRemoteConfiguration?
     private(set) var invokedClearCount = 0
 
     func read() -> PersistedRemoteConfiguration? {
-        return self.stubbedRead
+        return self.readHandler?() ?? self.stubbedRead
     }
 
     @discardableResult
@@ -784,11 +955,12 @@ private final class MockRemoteConfigDiskCache: RemoteConfigDiskCacheType {
         self.invokedWriteCount += 1
         self.invokedWriteParameter = configuration
 
-        return self.stubbedWriteResult
+        return self.writeHandler?(configuration) ?? self.stubbedWriteResult
     }
 
     func clear() {
         self.invokedClearCount += 1
+        self.clearHandler?()
     }
 
 }


### PR DESCRIPTION
Part of a stack of PRs, builds on #7110 and should be aligned with Android PR #3621.

## Description
- Implements the `clearCache()` method on the `RemoteConfigManager`
- This adds support for cache invalidation in preparation for it being wired up later
  - To be used later for cache invalidation on user identity changes
- Adds a locking mechanism ensuring any in-flight or pending refreshes during cache invalidation will not overwrite the (cleared) cache after the operation finishes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrency and persistence ordering for remote config sync; mistakes could leak stale config across identity changes or stall refreshes, though behavior is heavily unit-tested.
> 
> **Overview**
> Adds **`clearCache()`** on `RemoteConfigManager` to wipe disk cache and blob store (intended for identity changes later), and replaces the refresh guard with a **`Lock` + epoch** model so invalidation and in-flight refreshes cannot race.
> 
> Refresh now tags each attempt with an **epoch** at start: enqueue skips the network call if `clearCache()` ran before enqueue; success and failure handlers **drop stale responses** and only release `isRefreshing` when the epoch still matches, so late writes cannot repopulate a cleared cache or block a newer sync.
> 
> Unit tests cover clear behavior, stale responses after clear, clear during request build, refresh-guard ownership across clear/resync, and serialization of clear vs persist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fb252870aba19e96492ec6d39dbb85ac65ad0a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->