### PR TITLE
refactor(remote-config): prefer lowest priority number for source ordering

### DIFF
--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -44,7 +44,7 @@ extension RemoteConfigStrings: LogMessage {
             return "Failed to write remote config cache to disk."
         case let .duplicateSourceURL(url):
             return "Found remote config sources sharing the same URL with conflicting priority/weight " +
-                "(\(url)). Keeping the highest-priority one, tie-broken by weight."
+                "(\(url)). Keeping the highest-priority one (lowest priority number), tie-broken by weight."
         case let .failedToParseResponse(error):
             return "Failed to parse remote config response. Keeping cached configuration. Error: " +
             "\(error.localizedDescription)"

--- a/Sources/Networking/RemoteConfigSourceProvider.swift
+++ b/Sources/Networking/RemoteConfigSourceProvider.swift
@@ -100,8 +100,9 @@ final class RemoteConfigSourceProvider: RemoteConfigSourceProviderType {
         }
     }
 
-    /// Collapses duplicate urls to the occurrence with the highest priority (tie-broken by weight),
-    /// keeping first-seen order. Done once at init so reads never need to re-dedupe.
+    /// Collapses duplicate urls to the occurrence with the highest priority (i.e. the lowest
+    /// `priority` number, tie-broken by weight), keeping first-seen order. Done once at init so
+    /// reads never need to re-dedupe.
     private static func dedupe(_ sources: [RemoteConfigSource]) -> [RemoteConfigSource] {
         var bestByURL: [String: RemoteConfigSource] = [:]
         var order: [String] = []
@@ -114,7 +115,7 @@ final class RemoteConfigSourceProvider: RemoteConfigSourceProviderType {
             if source.priority != existing.priority || source.weight != existing.weight {
                 Logger.warn(Strings.remoteConfig.duplicateSourceURL(source.url))
             }
-            if source.priority > existing.priority ||
+            if source.priority < existing.priority ||
                 (source.priority == existing.priority && source.weight > existing.weight) {
                 bestByURL[source.url] = source
             }

--- a/Sources/Networking/WeightedSourceSelector.swift
+++ b/Sources/Networking/WeightedSourceSelector.swift
@@ -11,7 +11,7 @@ import Foundation
 /// alternatives.
 protocol WeightedSource {
 
-    /// Higher values are preferred. A tier is exhausted before a lower one is considered.
+    /// Lower values are preferred. A tier is exhausted before a higher one is considered.
     var priority: Int { get }
 
     /// Relative likelihood of being chosen among sources tied at the same `priority`.
@@ -38,7 +38,7 @@ private struct SystemWeightedSourceRandomizer: WeightedSourceRandomizer {
 /// Picks which `Source` to use and exposes `current` so callers can advance through the fallback
 /// order when a source is unusable.
 ///
-/// The order is computed up front: priority tiers from highest to lowest, each tier arranged into a
+/// The order is computed up front: priority tiers from lowest to highest, each tier arranged into a
 /// weight-biased random order. Negative weights are treated as `0`; when a group's weights sum to
 /// `0`, the next source is drawn uniformly at random.
 ///
@@ -80,7 +80,7 @@ class WeightedSourceSelector<Source: WeightedSource> {
     ) -> [Source] {
         let sourcesByPriority = Dictionary(grouping: sources, by: { $0.priority })
         return sourcesByPriority.keys
-            .sorted(by: >)
+            .sorted(by: <)
             .flatMap { weightedShuffle(sourcesByPriority[$0] ?? [], randomizer: randomizer) }
     }
 

--- a/Tests/UnitTests/Networking/RemoteConfigSourceProviderTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfigSourceProviderTests.swift
@@ -24,13 +24,13 @@ final class RemoteConfigSourceProviderTests: TestCase {
         expect(provider.getCurrent(for: .blob)).to(beNil())
     }
 
-    func testCurrentSourceReturnsHighestPrioritySource() {
-        let low = Self.source("low", priority: 0, weight: 100)
-        let high = Self.source("high", priority: 10, weight: 1)
+    func testCurrentSourceReturnsLowestPriorityNumberSource() {
+        let low = Self.source("low", priority: 0, weight: 1)
+        let high = Self.source("high", priority: 10, weight: 100)
         let provider = Self.apiProvider([low, high])
 
         let handle = provider.getCurrent(for: .api)
-        expect(handle?.url) == Self.url("high")
+        expect(handle?.url) == Self.url("low")
         expect(handle?.purpose) == .api
     }
 
@@ -48,10 +48,10 @@ final class RemoteConfigSourceProviderTests: TestCase {
         let provider = Self.apiProvider([high, low])
 
         let first = provider.getCurrent(for: .api)
-        expect(first?.url) == Self.url("high")
+        expect(first?.url) == Self.url("low")
 
         provider.reportUnhealthy(first!)
-        expect(provider.getCurrent(for: .api)?.url) == Self.url("low")
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("high")
     }
 
     func testCurrentSourceIsNilWhenExhausted() {
@@ -62,9 +62,9 @@ final class RemoteConfigSourceProviderTests: TestCase {
     }
 
     func testReportUnhealthyWalksFullFallbackOrder() {
-        let first = Self.source("1", priority: 30, weight: 1)
+        let first = Self.source("1", priority: 10, weight: 1)
         let second = Self.source("2", priority: 20, weight: 1)
-        let third = Self.source("3", priority: 10, weight: 1)
+        let third = Self.source("3", priority: 30, weight: 1)
         let provider = Self.apiProvider([first, second, third])
 
         expect(provider.getCurrent(for: .api)?.url) == Self.url("1")
@@ -82,7 +82,7 @@ final class RemoteConfigSourceProviderTests: TestCase {
         let provider = Self.apiProvider([
             Self.source("a", priority: 10, weight: 1),
             Self.source("a", priority: 5, weight: 1),
-            Self.source("b", priority: 0, weight: 1)
+            Self.source("b", priority: 20, weight: 1)
         ])
 
         expect(provider.getCurrent(for: .api)?.url) == Self.url("a")
@@ -92,16 +92,17 @@ final class RemoteConfigSourceProviderTests: TestCase {
         expect(provider.getCurrent(for: .api)).to(beNil())
     }
 
-    func testDedupKeepsHighestPriorityRegardlessOfOrder() {
+    func testDedupKeepsLowestPriorityNumberRegardlessOfOrder() {
         let provider = Self.apiProvider([
-            Self.source("a", priority: 0, weight: 1),
             Self.source("a", priority: 10, weight: 1),
+            Self.source("a", priority: 0, weight: 1),
             Self.source("b", priority: 5, weight: 1)
         ])
 
-        // `a` is kept at priority 10, so it outranks `b` (priority 5) despite appearing first at 0.
+        // `a` is kept at priority 0 (lowest number, i.e. highest priority), so it outranks `b`
+        // (priority 5) despite appearing first at 10.
         expect(provider.getCurrent(for: .api)?.url) == Self.url("a")
-        expect(provider.getCurrent(for: .api)?.source.priority) == 10
+        expect(provider.getCurrent(for: .api)?.source.priority) == 0
         provider.reportUnhealthy(provider.getCurrent(for: .api)!)
         expect(provider.getCurrent(for: .api)?.url) == Self.url("b")
     }
@@ -134,8 +135,8 @@ final class RemoteConfigSourceProviderTests: TestCase {
 
     func testReportingAPIUnhealthyDoesNotAffectBlob() {
         let provider = RemoteConfigSourceProvider(
-            apiSources: [Self.source("api1", priority: 10), Self.source("api2", priority: 0)],
-            blobSources: [Self.source("blob1", priority: 10), Self.source("blob2", priority: 0)],
+            apiSources: [Self.source("api1", priority: 0), Self.source("api2", priority: 10)],
+            blobSources: [Self.source("blob1", priority: 0), Self.source("blob2", priority: 10)],
             randomizer: FakeRandomizer(0)
         )
 
@@ -218,8 +219,8 @@ final class RemoteConfigSourceProviderTests: TestCase {
 
     func testRestartOnlyRewindsRequestedPurpose() {
         let provider = RemoteConfigSourceProvider(
-            apiSources: [Self.source("api1", priority: 10), Self.source("api2", priority: 0)],
-            blobSources: [Self.source("blob1", priority: 10), Self.source("blob2", priority: 0)],
+            apiSources: [Self.source("api1", priority: 0), Self.source("api2", priority: 10)],
+            blobSources: [Self.source("blob1", priority: 0), Self.source("blob2", priority: 10)],
             randomizer: FakeRandomizer(0)
         )
 

--- a/Tests/UnitTests/Networking/WeightedSourceSelectorTests.swift
+++ b/Tests/UnitTests/Networking/WeightedSourceSelectorTests.swift
@@ -25,19 +25,19 @@ final class WeightedSourceSelectorTests: TestCase {
         expect(selector.current) == only
     }
 
-    func testHighestPriorityWins() {
-        let low = TestSource(id: "low", priority: 0, weight: 100)
-        let high = TestSource(id: "high", priority: 10, weight: 1)
+    func testLowestPriorityNumberWins() {
+        let low = TestSource(id: "low", priority: 0, weight: 1)
+        let high = TestSource(id: "high", priority: 10, weight: 100)
         let selector = WeightedSourceSelector(sources: [low, high], randomizer: FakeRandomizer(0))
-        expect(selector.current) == high
+        expect(selector.current) == low
     }
 
-    func testHighestPriorityWinsRegardlessOfOrder() {
-        let low1 = TestSource(id: "low1", priority: 0, weight: 100)
-        let high = TestSource(id: "high", priority: 5, weight: 1)
-        let low2 = TestSource(id: "low2", priority: 0, weight: 100)
-        let selector = WeightedSourceSelector(sources: [low1, high, low2], randomizer: FakeRandomizer(0))
-        expect(selector.current) == high
+    func testLowestPriorityNumberWinsRegardlessOfOrder() {
+        let high1 = TestSource(id: "high1", priority: 10, weight: 100)
+        let low = TestSource(id: "low", priority: 5, weight: 1)
+        let high2 = TestSource(id: "high2", priority: 10, weight: 100)
+        let selector = WeightedSourceSelector(sources: [high1, low, high2], randomizer: FakeRandomizer(0))
+        expect(selector.current) == low
     }
 
     // MARK: - Weighted random tie-breaking (weights [30, 70])
@@ -94,7 +94,7 @@ final class WeightedSourceSelectorTests: TestCase {
         // last resort: tried after its weighted peer, yet still before any lower-priority source.
         let weighted = TestSource(id: "weighted", priority: 10, weight: 50)
         let zero = TestSource(id: "zero", priority: 10, weight: 0)
-        let lowerPriority = TestSource(id: "lower", priority: 0, weight: 100)
+        let lowerPriority = TestSource(id: "lower", priority: 20, weight: 100)
         let selector = WeightedSourceSelector(
             sources: [weighted, zero, lowerPriority],
             randomizer: FakeRandomizer(0)
@@ -126,9 +126,9 @@ final class WeightedSourceSelectorTests: TestCase {
         let low = TestSource(id: "low", priority: 0, weight: 1)
         let selector = WeightedSourceSelector(sources: [high, low], randomizer: FakeRandomizer(0))
 
-        expect(selector.current) == high
-        expect(selector.advance()) == low
         expect(selector.current) == low
+        expect(selector.advance()) == high
+        expect(selector.current) == high
     }
 
     func testAdvanceReturnsNilWhenSourcesExhausted() {
@@ -136,7 +136,7 @@ final class WeightedSourceSelectorTests: TestCase {
         let low = TestSource(id: "low", priority: 0, weight: 1)
         let selector = WeightedSourceSelector(sources: [high, low], randomizer: FakeRandomizer(0))
 
-        expect(selector.advance()) == low
+        expect(selector.advance()) == high
         expect(selector.advance()).to(beNil())
         expect(selector.current).to(beNil())
     }
@@ -177,10 +177,10 @@ final class WeightedSourceSelectorTests: TestCase {
         let low = TestSource(id: "low", priority: 0, weight: 1)
         let selector = WeightedSourceSelector(sources: [high, low], randomizer: FakeRandomizer(0))
 
-        expect(selector.advance()) == low
+        expect(selector.advance()) == high
         selector.reset()
-        expect(selector.current) == high
-        expect(selector.advance()) == low
+        expect(selector.current) == low
+        expect(selector.advance()) == high
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
### Motivation
We changed how source priorities work: the lowest `priority` value now wins.

### Description
- Order sources lowest `priority` first (was highest-first).
- Dedupe of duplicate URLs keeps the lowest priority number (highest priority); weight tie-break unchanged.

Android counterpart: https://github.com/RevenueCat/purchases-android/pull/3690

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Inverts which API/blob URLs are chosen and failover order for existing `priority` values in remote config, so misaligned server-side priorities could route traffic differently until configs are updated.
> 
> **Overview**
> **Remote config source selection now treats a lower `priority` integer as more preferred** (previously the largest number won). `WeightedSourceSelector` walks tiers from lowest to highest `priority`, and duplicate-URL dedupe in `RemoteConfigSourceProvider` keeps the entry with the smallest `priority` (weight tie-break unchanged).
> 
> Docs and the duplicate-URL log string in `RemoteConfigStrings` were updated to describe “lowest priority number = highest priority.” Unit tests were adjusted to match the new ordering and fallback sequence, consistent with the Android counterpart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1548f08d8753e362490c1c65ae6f61a5bffafd89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->