### PR TITLE
fix(remote-config): avoid using Brotli compression on iOS versions below 16.0

### DIFF
--- a/Sources/Networking/RCContainer+Compression.swift
+++ b/Sources/Networking/RCContainer+Compression.swift
@@ -79,21 +79,21 @@ private extension RCContainer.Element.ContentEncoding {
     }
 
     static func brotliDecompressed(_ bytes: UnsafeRawBufferPointer) throws -> Data {
-        if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
-            do {
-                return try Self.brotliDecompressedOnSupportedOS(bytes)
-            } catch {
-                throw RCContainer.Parser.FormatError.contentDecompressionFailed(Self.brotli.rawValue)
-            }
-        } else {
-            throw RCContainer.Parser.FormatError.unsupportedContentEncoding(Self.brotli.rawValue)
+        do {
+            return try Self.brotliDecompressedBytes(bytes)
+        } catch let error as RCContainer.Parser.FormatError {
+            throw error
+        } catch {
+            throw RCContainer.Parser.FormatError.contentDecompressionFailed(Self.brotli.rawValue)
         }
     }
 
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    static func brotliDecompressedOnSupportedOS(_ bytes: UnsafeRawBufferPointer) throws -> Data {
+    static func brotliDecompressedBytes(_ bytes: UnsafeRawBufferPointer) throws -> Data {
         var offset = 0
-        let filter = try InputFilter(.decompress, using: .brotli) { requestedLength -> Data? in
+        let filter = try InputFilter(
+            .decompress,
+            using: try Self.brotliCompressionAlgorithm
+        ) { requestedLength -> Data? in
             guard offset < bytes.count else { return nil }
 
             let endOffset = min(offset + requestedLength, bytes.count)

--- a/Sources/Networking/RCContainer+Element.swift
+++ b/Sources/Networking/RCContainer+Element.swift
@@ -5,6 +5,7 @@
 //  Created by RevenueCat.
 //  Copyright © 2026 RevenueCat, Inc. All rights reserved.
 
+import Compression
 import CryptoKit
 import Foundation
 
@@ -187,11 +188,7 @@ extension RCContainer.Element {
             case .none, .gzip:
                 return true
             case .brotli:
-                if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
-                    return true
-                } else {
-                    return false
-                }
+                return (try? Self.brotliCompressionAlgorithm) != nil
             case .zstd, .unsupported:
                 return false
             }
@@ -212,6 +209,25 @@ extension RCContainer.Element {
         }
 
         private static let encodingPreference: [Self] = [.brotli, .gzip, .none]
+
+        static var brotliCompressionAlgorithm: Algorithm {
+            get throws {
+                // Apple's docs list Brotli as available earlier, but iOS 15 simulator
+                // runtimes have failed to resolve the Swift Compression enum symbol.
+                // Advertise Brotli only on iOS 16+ equivalents as the conservative path.
+                if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+                    // Use the C constant instead of `Algorithm.brotli` to avoid a load-time
+                    // link to a Swift enum-case symbol that is missing on some older runtimes.
+                    guard let algorithm = Algorithm(rawValue: COMPRESSION_BROTLI) else {
+                        throw RCContainer.Parser.FormatError.unsupportedContentEncoding(Self.brotli.rawValue)
+                    }
+
+                    return algorithm
+                } else {
+                    throw RCContainer.Parser.FormatError.unsupportedContentEncoding(Self.brotli.rawValue)
+                }
+            }
+        }
 
     }
 

--- a/Tests/UnitTests/Networking/RCContainer/RCContainerTestData.swift
+++ b/Tests/UnitTests/Networking/RCContainer/RCContainerTestData.swift
@@ -5,6 +5,8 @@
 //  Created by RevenueCat.
 //  Copyright © 2026 RevenueCat, Inc. All rights reserved.
 
+// swiftlint:disable file_length
+
 import Compression
 import Foundation
 import XCTest
@@ -447,19 +449,15 @@ private extension RCContainerTestData {
     }
 
     static func brotliCompressed(_ data: Data) throws -> Data {
-        if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
-            return try Self.brotliCompressedOnSupportedOS(data)
-        } else {
-            throw RCContainer.Parser.FormatError.unsupportedContentEncoding(
-                RCContainer.Element.ContentEncoding.brotli.rawValue
-            )
-        }
+        return try Self.brotliCompressedBytes(data)
     }
 
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    static func brotliCompressedOnSupportedOS(_ data: Data) throws -> Data {
+    static func brotliCompressedBytes(_ data: Data) throws -> Data {
         var output = Data()
-        let filter = try OutputFilter(.compress, using: .brotli) { chunk in
+        let filter = try OutputFilter(
+            .compress,
+            using: try RCContainer.Element.ContentEncoding.brotliCompressionAlgorithm
+        ) { chunk in
             if let chunk {
                 output.append(chunk)
             }


### PR DESCRIPTION
Brotli support [should be available](https://developer.apple.com/documentation/compression/algorithm/brotli) from iOS 13+. However we've been seeing runtime failures on CI on iOS 15, where the symbol(s) can't be loaded.

Therefore we're taking a bit of a more conservative approach and limiting Brotli use to iOS 16+. Since usage numbers on lower versions are low anyways, we figured it's better to be safe than sorry.

We're also avoiding the use of the `Algorithm.brotli` enum case for the same reason. We're using the C constant in order to construct the enum case manually. Which should be the same (and safe) according to https://developer.apple.com/forums/thread/732868?answerId=757540022#757540022


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only which encodings are advertised and how Brotli is invoked; gzip and uncompressed paths are unchanged, with limited impact on low-OS traffic.
> 
> **Overview**
> **Brotli for RC Container payloads is now treated as supported only on iOS 16+ / macOS 13+ (and matching tvOS/watchOS),** down from the previous iOS 15+ gate. On older OS versions, Brotli is reported as unsupported so negotiation falls back to gzip/none instead of failing at runtime on missing Compression symbols (seen on iOS 15 CI).
> 
> Brotli compress/decompress paths no longer reference **`Algorithm.brotli`** directly. They use a shared **`brotliCompressionAlgorithm`** helper that builds the algorithm from **`COMPRESSION_BROTLI`**, and **`isSupported`** for `.brotli` follows that helper. Unit test fixture compression was aligned with the same helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca15a3236c5b8f0c8ef7356ab67754d8b8442788. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->