### PR TITLE
fix(remote-config): avoid strong-linking Compression.Algorithm.brotli

### DIFF
--- a/Sources/Networking/RCContainer+Compression.swift
+++ b/Sources/Networking/RCContainer+Compression.swift
@@ -33,6 +33,21 @@ extension RCContainer.Element.ContentEncoding {
         }
     }
 
+    /// The Compression algorithm used to decode brotli payloads, or `nil` when the running OS
+    /// doesn't provide brotli.
+    ///
+    /// We deliberately avoid referencing `Compression.Algorithm.brotli` directly. The SDK declares
+    /// the whole `Algorithm` enum (including `.brotli`) as available since iOS 13 without a per-case
+    /// availability annotation, so the compiler strong-links the `.brotli` symbol. That symbol only
+    /// exists in the runtime starting on iOS 16 / macOS 13 / tvOS 16 / watchOS 9, so referencing the
+    /// case crashes at load time (`dlopen` "Symbol not found") on earlier runtimes such as an iOS 15
+    /// simulator. Building the algorithm from the `COMPRESSION_BROTLI` C constant emits no such
+    /// symbol and doubles as a runtime capability check: the initializer returns `nil` when the
+    /// running OS doesn't recognize brotli.
+    static var brotliAlgorithm: Algorithm? {
+        return Algorithm(rawValue: COMPRESSION_BROTLI)
+    }
+
 }
 
 private extension RCContainer.Element.ContentEncoding {
@@ -79,35 +94,31 @@ private extension RCContainer.Element.ContentEncoding {
     }
 
     static func brotliDecompressed(_ bytes: UnsafeRawBufferPointer) throws -> Data {
-        if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
-            do {
-                return try Self.brotliDecompressedOnSupportedOS(bytes)
-            } catch {
-                throw RCContainer.Parser.FormatError.contentDecompressionFailed(Self.brotli.rawValue)
-            }
-        } else {
+        // See `brotliAlgorithm` for why we probe availability this way instead of using `.brotli`.
+        guard let algorithm = Self.brotliAlgorithm else {
             throw RCContainer.Parser.FormatError.unsupportedContentEncoding(Self.brotli.rawValue)
         }
-    }
 
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    static func brotliDecompressedOnSupportedOS(_ bytes: UnsafeRawBufferPointer) throws -> Data {
-        var offset = 0
-        let filter = try InputFilter(.decompress, using: .brotli) { requestedLength -> Data? in
-            guard offset < bytes.count else { return nil }
+        do {
+            var offset = 0
+            let filter = try InputFilter(.decompress, using: algorithm) { requestedLength -> Data? in
+                guard offset < bytes.count else { return nil }
 
-            let endOffset = min(offset + requestedLength, bytes.count)
-            let chunk = bytes[offset..<endOffset]
-            offset = endOffset
-            return Data(chunk)
+                let endOffset = min(offset + requestedLength, bytes.count)
+                let chunk = bytes[offset..<endOffset]
+                offset = endOffset
+                return Data(chunk)
+            }
+
+            var output = Data()
+            while let chunk = try filter.readData(ofLength: Self.outputChunkSize) {
+                output.append(chunk)
+            }
+
+            return output
+        } catch {
+            throw RCContainer.Parser.FormatError.contentDecompressionFailed(Self.brotli.rawValue)
         }
-
-        var output = Data()
-        while let chunk = try filter.readData(ofLength: Self.outputChunkSize) {
-            output.append(chunk)
-        }
-
-        return output
     }
 
 }

--- a/Sources/Networking/RCContainer+Element.swift
+++ b/Sources/Networking/RCContainer+Element.swift
@@ -5,6 +5,7 @@
 //  Created by RevenueCat.
 //  Copyright © 2026 RevenueCat, Inc. All rights reserved.
 
+import Compression
 import CryptoKit
 import Foundation
 
@@ -187,11 +188,11 @@ extension RCContainer.Element {
             case .none, .gzip:
                 return true
             case .brotli:
-                if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
-                    return true
-                } else {
-                    return false
-                }
+                // Brotli decoding relies on `Compression.Algorithm.brotli`, whose runtime symbol only
+                // exists on iOS 16+ / macOS 13+ / tvOS 16+ / watchOS 9+. Probe it via the C constant
+                // rather than the case (see `brotliAlgorithm`) so we neither strong-link a missing
+                // symbol nor advertise brotli support on runtimes that lack it.
+                return Self.brotliAlgorithm != nil
             case .zstd, .unsupported:
                 return false
             }

--- a/Tests/UnitTests/Networking/RCContainer/RCContainerTestData.swift
+++ b/Tests/UnitTests/Networking/RCContainer/RCContainerTestData.swift
@@ -447,19 +447,18 @@ private extension RCContainerTestData {
     }
 
     static func brotliCompressed(_ data: Data) throws -> Data {
-        if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
-            return try Self.brotliCompressedOnSupportedOS(data)
-        } else {
+        // Build the algorithm from the C constant instead of referencing `.brotli` directly. See
+        // `RCContainer.Element.ContentEncoding.brotliAlgorithm`: referencing the case strong-links a
+        // symbol that is missing on runtimes before iOS 16 / macOS 13 / tvOS 16 / watchOS 9, which
+        // would crash this test bundle at load time on older simulators.
+        guard let algorithm = RCContainer.Element.ContentEncoding.brotliAlgorithm else {
             throw RCContainer.Parser.FormatError.unsupportedContentEncoding(
                 RCContainer.Element.ContentEncoding.brotli.rawValue
             )
         }
-    }
 
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    static func brotliCompressedOnSupportedOS(_ data: Data) throws -> Data {
         var output = Data()
-        let filter = try OutputFilter(.compress, using: .brotli) { chunk in
+        let filter = try OutputFilter(.compress, using: algorithm) { chunk in
             if let chunk {
                 output.append(chunk)
             }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
`Compression.Algorithm.brotli` is declared available since iOS 13 in the SDK, so the compiler strong-links its symbol. That symbol only exists at runtime on iOS 16+/macOS 13+/tvOS 16+/watchOS 9+, so the RC Container brotli support added in #7107 crashed at load (`dlopen` "Symbol not found") on older simulator runtimes like iOS 15.5 — no `@available` guard prevents this.

See error on CI [here](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/40160/workflows/3fcc465f-6c5f-42a9-9598-d4a82d9d68dc/jobs/648239)
> xctest (9266) encountered an error (Failed to load the test bundle. If you believe this error represents a bug, please attach the result bundle at /Users/distiller/purchases-ios/fastlane/test_output/xctest/ios/RevenueCat.xcresult. (Underlying Error: The bundle “UnitTests” couldn’t be loaded. The bundle couldn’t be loaded. Try reinstalling the bundle. dlopen(/Users/distiller/Library/Developer/Xcode/DerivedData/RevenueCat-etwwovrsjatlsobqeniqyhgbqoaq/Build/Products/Debug-iphonesimulator/UnitTests.xctest/UnitTests, 0x0109): Symbol not found: _$s11Compression9AlgorithmO6brotliyA2CmFWC

### Description
- Build the algorithm from the `COMPRESSION_BROTLI` C constant via `Algorithm(rawValue:)` so no brotli symbol is emitted; `nil` means the OS lacks brotli.
- `ContentEncoding.isSupported` now uses that runtime check, so we stop advertising brotli where it can't decode.
- Apply the same change to the test compression helper so the test bundle no longer references the symbol.

Verified `RevenueCat.o` no longer contains the undefined `…AlgorithmO6brotli…` symbol; SDK + tests build.