### PR TITLE
feat(remote-config): add blob fetcher

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -946,9 +946,14 @@
 		A1B2C3D42FE2000000000004 /* RemoteConfigManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE2000000000003 /* RemoteConfigManager.swift */; };
 		A1B2C3D42FE200000000000D /* RemoteConfigBlobStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE200000000000C /* RemoteConfigBlobStore.swift */; };
 		A1B2C3D42FE2000000000006 /* RemoteConfigStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE2000000000005 /* RemoteConfigStrings.swift */; };
+		A1B2C3D42FE6000000000002 /* RemoteConfigBlobRefHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE6000000000001 /* RemoteConfigBlobRefHelpers.swift */; };
+		A1B2C3D42FE6000000000004 /* RemoteConfigBlobDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE6000000000003 /* RemoteConfigBlobDownloader.swift */; };
+		A1B2C3D42FE6000000000006 /* RemoteConfigBlobFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE6000000000005 /* RemoteConfigBlobFetcher.swift */; };
 		A1B2C3D42FE2000000000009 /* RemoteConfigDiskCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE2000000000008 /* RemoteConfigDiskCacheTests.swift */; };
 		A1B2C3D42FE200000000000B /* RemoteConfigManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE200000000000A /* RemoteConfigManagerTests.swift */; };
 		A1B2C3D42FE200000000000F /* RemoteConfigBlobStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE200000000000E /* RemoteConfigBlobStoreTests.swift */; };
+		A1B2C3D42FE6000000000008 /* RemoteConfigBlobFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE6000000000007 /* RemoteConfigBlobFetcherTests.swift */; };
+		A1B2C3D42FE600000000000A /* RemoteConfigBlobDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE6000000000009 /* RemoteConfigBlobDownloaderTests.swift */; };
 		7648885717DC2DB5009DD01B /* MinMaxOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = C812AE8BAE0546D2F4ACEF35 /* MinMaxOperators.swift */; };
 		7707A94C2CAD93AC006E0313 /* PaywallButtonComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7707A94B2CAD93AC006E0313 /* PaywallButtonComponent.swift */; };
 		7707A94E2CAD94D2006E0313 /* ButtonComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7707A94D2CAD94D2006E0313 /* ButtonComponentViewModel.swift */; };
@@ -2915,9 +2920,14 @@
 		A1B2C3D42FE2000000000003 /* RemoteConfigManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigManager.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE200000000000C /* RemoteConfigBlobStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobStore.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE2000000000005 /* RemoteConfigStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigStrings.swift; sourceTree = "<group>"; };
+		A1B2C3D42FE6000000000001 /* RemoteConfigBlobRefHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobRefHelpers.swift; sourceTree = "<group>"; };
+		A1B2C3D42FE6000000000003 /* RemoteConfigBlobDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobDownloader.swift; sourceTree = "<group>"; };
+		A1B2C3D42FE6000000000005 /* RemoteConfigBlobFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobFetcher.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE2000000000008 /* RemoteConfigDiskCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigDiskCacheTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE200000000000A /* RemoteConfigManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigManagerTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE200000000000E /* RemoteConfigBlobStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobStoreTests.swift; sourceTree = "<group>"; };
+		A1B2C3D42FE6000000000007 /* RemoteConfigBlobFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobFetcherTests.swift; sourceTree = "<group>"; };
+		A1B2C3D42FE6000000000009 /* RemoteConfigBlobDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobDownloaderTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE300000000001 /* ProductionRemoteConfigIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductionRemoteConfigIntegrationTests.swift; sourceTree = "<group>"; };
 		E31E8A264E9F4375A3B29D78 /* RemoteConfigurationDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigurationDecodingTests.swift; sourceTree = "<group>"; };
 		FEDA000000000000000000A1 /* WeightedSourceSelectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightedSourceSelectorTests.swift; sourceTree = "<group>"; };
@@ -4567,6 +4577,9 @@
 				F3A2DB969D72432B87F48C5F /* RemoteConfigAPI.swift */,
 				FEDA000000000000000000A2 /* WeightedSourceSelector.swift */,
 				FEDA000000000000000000C2 /* RemoteConfigSourceProvider.swift */,
+				A1B2C3D42FE6000000000001 /* RemoteConfigBlobRefHelpers.swift */,
+				A1B2C3D42FE6000000000003 /* RemoteConfigBlobDownloader.swift */,
+				A1B2C3D42FE6000000000005 /* RemoteConfigBlobFetcher.swift */,
 				A1B2C3D42FE200000000000C /* RemoteConfigBlobStore.swift */,
 				A1B2C3D42FE2000000000001 /* RemoteConfigDiskCache.swift */,
 				A1B2C3D42FE2000000000003 /* RemoteConfigManager.swift */,
@@ -4616,6 +4629,8 @@
 		A1B2C3D42FE2000000000007 /* RemoteConfig */ = {
 			isa = PBXGroup;
 			children = (
+				A1B2C3D42FE6000000000009 /* RemoteConfigBlobDownloaderTests.swift */,
+				A1B2C3D42FE6000000000007 /* RemoteConfigBlobFetcherTests.swift */,
 				A1B2C3D42FE200000000000E /* RemoteConfigBlobStoreTests.swift */,
 				A1B2C3D42FE2000000000008 /* RemoteConfigDiskCacheTests.swift */,
 				A1B2C3D42FE200000000000A /* RemoteConfigManagerTests.swift */,
@@ -7220,6 +7235,9 @@
 				A1B2C3D42FE5000000000002 /* RCContainer+Compression.swift in Sources */,
 				A1B2C3D42FE1000000000005 /* RCContainer+Element.swift in Sources */,
 				A1B2C3D42FE1000000000007 /* RCContainer+Parser.swift in Sources */,
+				A1B2C3D42FE6000000000002 /* RemoteConfigBlobRefHelpers.swift in Sources */,
+				A1B2C3D42FE6000000000004 /* RemoteConfigBlobDownloader.swift in Sources */,
+				A1B2C3D42FE6000000000006 /* RemoteConfigBlobFetcher.swift in Sources */,
 				A1B2C3D42FE200000000000D /* RemoteConfigBlobStore.swift in Sources */,
 				A1B2C3D42FE2000000000002 /* RemoteConfigDiskCache.swift in Sources */,
 				A1B2C3D42FE2000000000004 /* RemoteConfigManager.swift in Sources */,
@@ -7784,6 +7802,8 @@
 				A1B2C3D42FE4000000000002 /* RCContainerCompressionFixtureTests.swift in Sources */,
 				A1B2C3D42FE100000000000E /* RCContainerTestData.swift in Sources */,
 				A1B2C3D42FE200000000000F /* RemoteConfigBlobStoreTests.swift in Sources */,
+				A1B2C3D42FE6000000000008 /* RemoteConfigBlobFetcherTests.swift in Sources */,
+				A1B2C3D42FE600000000000A /* RemoteConfigBlobDownloaderTests.swift in Sources */,
 				A1B2C3D42FE2000000000009 /* RemoteConfigDiskCacheTests.swift in Sources */,
 				A1B2C3D42FE200000000000B /* RemoteConfigManagerTests.swift in Sources */,
 				DB7EA7772F964CA200BCC082 /* WorkflowDetailProcessorTests.swift in Sources */,

--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -16,6 +16,8 @@ enum RemoteConfigStrings {
     case failedToReadCache(Error)
     case failedToWriteBlob(String, Error)
     case failedToWriteCache
+    case failedToBuildBlobURL(String)
+    case failedToDownloadBlob(String, URL, Error)
     case duplicateSourceURL(String)
     case failedToParseResponse(Error)
     case malformedBlobRef(String)
@@ -42,6 +44,11 @@ extension RemoteConfigStrings: LogMessage {
             return "Failed to write remote config blob '\(ref)' to disk: \(error.localizedDescription)"
         case .failedToWriteCache:
             return "Failed to write remote config cache to disk."
+        case let .failedToBuildBlobURL(ref):
+            return "Failed to build remote config blob URL for ref '\(ref)'."
+        case let .failedToDownloadBlob(ref, url, error):
+            return "Failed to download remote config blob '\(ref)' from \(url.absoluteString): " +
+                "\(error.localizedDescription)"
         case let .duplicateSourceURL(url):
             return "Found remote config sources sharing the same URL with conflicting priority/weight " +
                 "(\(url)). Keeping the highest-priority one (lowest priority number), tie-broken by weight."

--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -16,6 +16,7 @@ enum RemoteConfigStrings {
     case failedToReadCache(Error)
     case failedToWriteBlob(String, Error)
     case failedToWriteCache
+    case exhaustedBlobSources(String)
     case failedToBuildBlobURL(String)
     case failedToDownloadBlob(String, URL, Error)
     case duplicateSourceURL(String)
@@ -44,6 +45,8 @@ extension RemoteConfigStrings: LogMessage {
             return "Failed to write remote config blob '\(ref)' to disk: \(error.localizedDescription)"
         case .failedToWriteCache:
             return "Failed to write remote config cache to disk."
+        case let .exhaustedBlobSources(ref):
+            return "Failed to download remote config blob '\(ref)': all blob sources were exhausted."
         case let .failedToBuildBlobURL(ref):
             return "Failed to build remote config blob URL for ref '\(ref)'."
         case let .failedToDownloadBlob(ref, url, error):

--- a/Sources/Networking/RemoteConfigBlobDownloader.swift
+++ b/Sources/Networking/RemoteConfigBlobDownloader.swift
@@ -1,0 +1,58 @@
+//
+//  RemoteConfigBlobDownloader.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+
+protocol RemoteConfigBlobDownloaderType: AnyObject {
+
+    func data(from url: URL) async throws -> Data
+
+}
+
+/// Small `URLSession.dataTask` async adapter for remote config blobs.
+///
+/// This intentionally stays separate from fetcher scheduling so the iOS 13-compatible callback bridge
+/// can be removed cleanly once the SDK can rely on newer async `URLSession` APIs everywhere.
+final class URLSessionRemoteConfigBlobDownloader: RemoteConfigBlobDownloaderType {
+
+    enum Error: Swift.Error, Equatable {
+        case invalidResponse
+        case unexpectedStatusCode(Int)
+    }
+
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    func data(from url: URL) async throws -> Data {
+        return try await withCheckedThrowingContinuation { continuation in
+            let task = self.session.dataTask(with: url) { data, response, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+
+                guard let response = response as? HTTPURLResponse else {
+                    continuation.resume(throwing: Error.invalidResponse)
+                    return
+                }
+
+                guard response.statusCode == 200 else {
+                    continuation.resume(throwing: Error.unexpectedStatusCode(response.statusCode))
+                    return
+                }
+
+                continuation.resume(returning: data ?? Data())
+            }
+
+            task.resume()
+        }
+    }
+
+}

--- a/Sources/Networking/RemoteConfigBlobFetcher.swift
+++ b/Sources/Networking/RemoteConfigBlobFetcher.swift
@@ -154,7 +154,7 @@ private actor RemoteConfigBlobFetchScheduler {
                 }
             } catch {
                 Logger.error(Strings.remoteConfig.failedToDownloadBlob(ref, url, error))
-                guard !self.isBlobUnavailable(error) else {
+                guard self.shouldReportSourceUnhealthy(for: error) else {
                     return false
                 }
 
@@ -169,17 +169,25 @@ private actor RemoteConfigBlobFetchScheduler {
         return false
     }
 
-    /// Whether a completed download proved the blob unavailable without proving the source unhealthy.
-    private func isBlobUnavailable(_ error: Error) -> Bool {
-        guard let downloaderError = error as? URLSessionRemoteConfigBlobDownloader.Error else {
+    /// Whether a download failure is a source-health signal rather than a request-specific outcome.
+    private func shouldReportSourceUnhealthy(for error: Error) -> Bool {
+        if error is CancellationError {
             return false
+        }
+
+        if let urlError = error as? URLError, urlError.code == .cancelled {
+            return false
+        }
+
+        guard let downloaderError = error as? URLSessionRemoteConfigBlobDownloader.Error else {
+            return true
         }
 
         switch downloaderError {
         case let .unexpectedStatusCode(statusCode):
-            return statusCode == HTTPStatusCode.notFoundError.rawValue
+            return statusCode != HTTPStatusCode.notFoundError.rawValue
         case .invalidResponse:
-            return false
+            return true
         }
     }
 

--- a/Sources/Networking/RemoteConfigBlobFetcher.swift
+++ b/Sources/Networking/RemoteConfigBlobFetcher.swift
@@ -10,9 +10,8 @@ import Foundation
 protocol RemoteConfigBlobFetcherType: AnyObject {
 
     func ensureDownloaded(ref: String) async -> Bool
-    func ensureAllDownloaded(refs: [String]) async -> [String: Bool]
+    func ensureAllDownloaded(refs: [String]) async -> Bool
     func prefetch(refs: [String])
-    func fetchAndVerify(ref: String) async -> Bool
 
 }
 
@@ -41,8 +40,8 @@ final class RemoteConfigBlobFetcher: RemoteConfigBlobFetcherType {
         return await self.scheduler.ensureDownloaded(ref: ref)
     }
 
-    /// Ensures multiple consumer-requested blobs are available and returns one result per unique ref.
-    func ensureAllDownloaded(refs: [String]) async -> [String: Bool] {
+    /// Ensures multiple consumer-requested blobs are available and returns whether all unique refs succeeded.
+    func ensureAllDownloaded(refs: [String]) async -> Bool {
         return await self.scheduler.ensureAllDownloaded(refs: refs)
     }
 
@@ -51,11 +50,6 @@ final class RemoteConfigBlobFetcher: RemoteConfigBlobFetcherType {
         Task {
             await self.scheduler.prefetch(refs: refs)
         }
-    }
-
-    /// Ensures a blob is downloaded, verified, and stored through the shared high-priority queue.
-    func fetchAndVerify(ref: String) async -> Bool {
-        return await self.scheduler.fetchAndVerify(ref: ref)
     }
 
 }
@@ -103,23 +97,23 @@ private actor RemoteConfigBlobFetchScheduler {
         }
     }
 
-    /// Fans out high-priority requests for each unique ref and gathers their success states.
-    func ensureAllDownloaded(refs: [String]) async -> [String: Bool] {
+    /// Fans out high-priority requests for each unique ref and succeeds only if every ref is available.
+    func ensureAllDownloaded(refs: [String]) async -> Bool {
         let uniqueRefs = Array(Set(refs))
 
-        return await withTaskGroup(of: (String, Bool).self) { group in
+        return await withTaskGroup(of: Bool.self) { group in
             for ref in uniqueRefs {
                 group.addTask {
-                    return (ref, await self.ensureDownloaded(ref: ref))
+                    return await self.ensureDownloaded(ref: ref)
                 }
             }
 
-            var results: [String: Bool] = [:]
-            for await (ref, result) in group {
-                results[ref] = result
+            var allDownloaded = true
+            for await result in group {
+                allDownloaded = allDownloaded && result
             }
 
-            return results
+            return allDownloaded
         }
     }
 
@@ -128,11 +122,6 @@ private actor RemoteConfigBlobFetchScheduler {
         for ref in refs {
             self.enqueue(ref: ref, priority: .low, continuation: nil)
         }
-    }
-
-    /// Enqueues high-priority fetch work through the same coalescing path used by consumers.
-    func fetchAndVerify(ref: String) async -> Bool {
-        return await self.ensureDownloaded(ref: ref)
     }
 
     /// Performs the actual download, source failover, checksum validation, and disk write.

--- a/Sources/Networking/RemoteConfigBlobFetcher.swift
+++ b/Sources/Networking/RemoteConfigBlobFetcher.swift
@@ -36,20 +36,24 @@ final class RemoteConfigBlobFetcher: RemoteConfigBlobFetcherType {
         )
     }
 
+    /// Ensures a consumer-requested blob is available locally, enqueueing high-priority work if needed.
     func ensureDownloaded(ref: String) async -> Bool {
         return await self.scheduler.ensureDownloaded(ref: ref)
     }
 
+    /// Ensures multiple consumer-requested blobs are available and returns one result per unique ref.
     func ensureAllDownloaded(refs: [String]) async -> [String: Bool] {
         return await self.scheduler.ensureAllDownloaded(refs: refs)
     }
 
+    /// Starts best-effort low-priority downloads for refs the backend suggests warming.
     func prefetch(refs: [String]) {
         Task {
             await self.scheduler.prefetch(refs: refs)
         }
     }
 
+    /// Downloads, verifies, and stores one blob immediately, bypassing queue priority decisions.
     func fetchAndVerify(ref: String) async -> Bool {
         return await self.scheduler.fetchAndVerify(ref: ref)
     }
@@ -92,12 +96,14 @@ private actor RemoteConfigBlobFetchScheduler {
         self.downloader = downloader
     }
 
+    /// Enqueues a high-priority consumer request and suspends until that ref resolves.
     func ensureDownloaded(ref: String) async -> Bool {
         return await withCheckedContinuation { continuation in
             self.enqueue(ref: ref, priority: .high, continuation: continuation)
         }
     }
 
+    /// Fans out high-priority requests for each unique ref and gathers their success states.
     func ensureAllDownloaded(refs: [String]) async -> [String: Bool] {
         let uniqueRefs = Array(Set(refs))
 
@@ -117,12 +123,14 @@ private actor RemoteConfigBlobFetchScheduler {
         }
     }
 
+    /// Enqueues low-priority work without a waiting continuation.
     func prefetch(refs: [String]) {
         for ref in refs {
             self.enqueue(ref: ref, priority: .low, continuation: nil)
         }
     }
 
+    /// Performs the actual download, source failover, checksum validation, and disk write.
     func fetchAndVerify(ref: String) async -> Bool {
         guard RemoteConfigBlobRefHelpers.isValid(ref) else {
             Logger.error(Strings.remoteConfig.malformedBlobRef(ref))
@@ -163,6 +171,7 @@ private actor RemoteConfigBlobFetchScheduler {
         return false
     }
 
+    /// Adds a ref to the scheduler, coalescing duplicate queued or in-flight requests.
     private func enqueue(
         ref: String,
         priority: Priority,
@@ -179,10 +188,12 @@ private actor RemoteConfigBlobFetchScheduler {
             return
         }
 
+        // Coalesce duplicate queued requests into one future download, keeping every waiting consumer.
         if var download = self.queued[ref] {
             if let continuation {
                 download.continuations.append(continuation)
             }
+            // A consumer request upgrades queued prefetch work, but keeps it behind already queued high-priority work.
             if priority.rawValue > download.priority.rawValue {
                 download.priority = priority
                 download.sequence = self.nextSequence()
@@ -191,6 +202,7 @@ private actor RemoteConfigBlobFetchScheduler {
             return
         }
 
+        // If the download already started, only attach this consumer to the in-flight result.
         if self.inFlight.contains(ref) {
             if let continuation {
                 self.activeContinuations[ref, default: []].append(continuation)
@@ -207,6 +219,7 @@ private actor RemoteConfigBlobFetchScheduler {
         self.scheduleDownloads()
     }
 
+    /// Starts queued downloads until the concurrency limit is reached.
     private func scheduleDownloads() {
         while self.inFlight.count < Self.maxConcurrentDownloads,
               let download = self.nextDownload() {
@@ -221,6 +234,7 @@ private actor RemoteConfigBlobFetchScheduler {
         }
     }
 
+    /// Finishes one in-flight ref, wakes all waiting consumers, then fills any newly opened download slot.
     private func complete(ref: String, result: Bool) {
         let continuations = self.activeContinuations.removeValue(forKey: ref) ?? []
         self.inFlight.remove(ref)
@@ -230,6 +244,7 @@ private actor RemoteConfigBlobFetchScheduler {
         self.scheduleDownloads()
     }
 
+    /// Chooses the next queued item by priority first, then FIFO order within that priority.
     private func nextDownload() -> Download? {
         return self.queued.values.sorted {
             if $0.priority != $1.priority {
@@ -240,11 +255,13 @@ private actor RemoteConfigBlobFetchScheduler {
         }.first
     }
 
+    /// Returns a monotonically increasing sequence number used to preserve FIFO ordering.
     private func nextSequence() -> Int {
         defer { self.sequence += 1 }
         return self.sequence
     }
 
+    /// Builds the concrete blob URL from a source format that contains the blob-ref placeholder.
     private func url(
         for ref: String,
         source: RemoteConfigSourceHandle

--- a/Sources/Networking/RemoteConfigBlobFetcher.swift
+++ b/Sources/Networking/RemoteConfigBlobFetcher.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol RemoteConfigBlobFetcherType: AnyObject {
+protocol RemoteConfigBlobFetcherType {
 
     func ensureDownloaded(ref: String) async -> Bool
     func ensureAllDownloaded(refs: [String]) async -> Bool

--- a/Sources/Networking/RemoteConfigBlobFetcher.swift
+++ b/Sources/Networking/RemoteConfigBlobFetcher.swift
@@ -165,6 +165,10 @@ private actor RemoteConfigBlobFetchScheduler {
                 }
             } catch {
                 Logger.error(Strings.remoteConfig.failedToDownloadBlob(ref, url, error))
+                guard !self.isBlobUnavailable(error) else {
+                    return false
+                }
+
                 self.sourceProvider.reportUnhealthy(source)
                 if self.blobStore.contains(ref: ref) {
                     return true
@@ -174,6 +178,20 @@ private actor RemoteConfigBlobFetchScheduler {
 
         Logger.error(Strings.remoteConfig.failedToBuildBlobURL(ref))
         return false
+    }
+
+    /// Whether a completed download proved the blob unavailable without proving the source unhealthy.
+    private func isBlobUnavailable(_ error: Error) -> Bool {
+        guard let downloaderError = error as? URLSessionRemoteConfigBlobDownloader.Error else {
+            return false
+        }
+
+        switch downloaderError {
+        case let .unexpectedStatusCode(statusCode):
+            return statusCode == HTTPStatusCode.notFoundError.rawValue
+        case .invalidResponse:
+            return false
+        }
     }
 
     /// Adds a ref to the scheduler, coalescing duplicate queued or in-flight requests.

--- a/Sources/Networking/RemoteConfigBlobFetcher.swift
+++ b/Sources/Networking/RemoteConfigBlobFetcher.swift
@@ -133,28 +133,34 @@ private actor RemoteConfigBlobFetchScheduler {
             return true
         }
 
-        guard let source = self.sourceProvider.getCurrent(for: .blob),
-              let url = self.url(for: ref, source: source) else {
-            Logger.error(Strings.remoteConfig.failedToBuildBlobURL(ref))
-            return false
-        }
-
-        do {
-            let data = try await self.downloader.data(from: url)
-            return data.withUnsafeBytes { bytes in
-                guard RemoteConfigBlobRefHelpers.isValidPayload(bytes, expectedRef: ref) else {
-                    Logger.error(Strings.remoteConfig.skippingInvalidBlob(ref))
-                    return false
-                }
-
-                return self.blobStore.write(ref: ref, bytes: bytes)
+        while let source = self.sourceProvider.getCurrent(for: .blob) {
+            guard let url = self.url(for: ref, source: source) else {
+                Logger.error(Strings.remoteConfig.failedToBuildBlobURL(ref))
+                self.sourceProvider.reportUnhealthy(source)
+                continue
             }
-        } catch {
-            // swiftlint:disable:next todo
-            // TODO: Report source failures to `RemoteConfigSourceProvider` and retry with the next blob source.
-            Logger.error(Strings.remoteConfig.failedToDownloadBlob(ref, url, error))
-            return false
+
+            do {
+                let data = try await self.downloader.data(from: url)
+                return data.withUnsafeBytes { bytes in
+                    guard RemoteConfigBlobRefHelpers.isValidPayload(bytes, expectedRef: ref) else {
+                        Logger.error(Strings.remoteConfig.skippingInvalidBlob(ref))
+                        return false
+                    }
+
+                    return self.blobStore.write(ref: ref, bytes: bytes)
+                }
+            } catch {
+                Logger.error(Strings.remoteConfig.failedToDownloadBlob(ref, url, error))
+                self.sourceProvider.reportUnhealthy(source)
+                if self.blobStore.contains(ref: ref) {
+                    return true
+                }
+            }
         }
+
+        Logger.error(Strings.remoteConfig.failedToBuildBlobURL(ref))
+        return false
     }
 
     private func enqueue(

--- a/Sources/Networking/RemoteConfigBlobFetcher.swift
+++ b/Sources/Networking/RemoteConfigBlobFetcher.swift
@@ -165,7 +165,7 @@ private actor RemoteConfigBlobFetchScheduler {
             }
         }
 
-        Logger.error(Strings.remoteConfig.failedToBuildBlobURL(ref))
+        Logger.error(Strings.remoteConfig.exhaustedBlobSources(ref))
         return false
     }
 

--- a/Sources/Networking/RemoteConfigBlobFetcher.swift
+++ b/Sources/Networking/RemoteConfigBlobFetcher.swift
@@ -53,7 +53,7 @@ final class RemoteConfigBlobFetcher: RemoteConfigBlobFetcherType {
         }
     }
 
-    /// Downloads, verifies, and stores one blob immediately, bypassing queue priority decisions.
+    /// Ensures a blob is downloaded, verified, and stored through the shared high-priority queue.
     func fetchAndVerify(ref: String) async -> Bool {
         return await self.scheduler.fetchAndVerify(ref: ref)
     }
@@ -130,8 +130,13 @@ private actor RemoteConfigBlobFetchScheduler {
         }
     }
 
-    /// Performs the actual download, source failover, checksum validation, and disk write.
+    /// Enqueues high-priority fetch work through the same coalescing path used by consumers.
     func fetchAndVerify(ref: String) async -> Bool {
+        return await self.ensureDownloaded(ref: ref)
+    }
+
+    /// Performs the actual download, source failover, checksum validation, and disk write.
+    private func downloadVerifyAndStore(ref: String) async -> Bool {
         guard RemoteConfigBlobRefHelpers.isValid(ref) else {
             Logger.error(Strings.remoteConfig.malformedBlobRef(ref))
             return false
@@ -228,7 +233,7 @@ private actor RemoteConfigBlobFetchScheduler {
             self.activeContinuations[download.ref] = download.continuations
 
             Task {
-                let result = await self.fetchAndVerify(ref: download.ref)
+                let result = await self.downloadVerifyAndStore(ref: download.ref)
                 self.complete(ref: download.ref, result: result)
             }
         }

--- a/Sources/Networking/RemoteConfigBlobFetcher.swift
+++ b/Sources/Networking/RemoteConfigBlobFetcher.swift
@@ -1,0 +1,254 @@
+//
+//  RemoteConfigBlobFetcher.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+
+protocol RemoteConfigBlobFetcherType: AnyObject {
+
+    func ensureDownloaded(ref: String) async -> Bool
+    func ensureAllDownloaded(refs: [String]) async -> [String: Bool]
+    func prefetch(refs: [String])
+    func fetchAndVerify(ref: String) async -> Bool
+
+}
+
+/// Downloads remote config blobs into the same content-addressed store used for inline blobs.
+///
+/// On-demand requests are high priority. Prefetches are low priority and can be boosted if a consumer
+/// later requests the same ref before the download starts.
+final class RemoteConfigBlobFetcher: RemoteConfigBlobFetcherType {
+
+    private let scheduler: RemoteConfigBlobFetchScheduler
+
+    init(
+        blobStore: RemoteConfigBlobStoreType,
+        sourceProvider: RemoteConfigSourceProviderType,
+        downloader: RemoteConfigBlobDownloaderType = URLSessionRemoteConfigBlobDownloader()
+    ) {
+        self.scheduler = RemoteConfigBlobFetchScheduler(
+            blobStore: blobStore,
+            sourceProvider: sourceProvider,
+            downloader: downloader
+        )
+    }
+
+    func ensureDownloaded(ref: String) async -> Bool {
+        return await self.scheduler.ensureDownloaded(ref: ref)
+    }
+
+    func ensureAllDownloaded(refs: [String]) async -> [String: Bool] {
+        return await self.scheduler.ensureAllDownloaded(refs: refs)
+    }
+
+    func prefetch(refs: [String]) {
+        Task {
+            await self.scheduler.prefetch(refs: refs)
+        }
+    }
+
+    func fetchAndVerify(ref: String) async -> Bool {
+        return await self.scheduler.fetchAndVerify(ref: ref)
+    }
+
+}
+
+private actor RemoteConfigBlobFetchScheduler {
+
+    private enum Priority: Int {
+        case low
+        case high
+    }
+
+    private struct Download {
+        let ref: String
+        var priority: Priority
+        var sequence: Int
+        var continuations: [CheckedContinuation<Bool, Never>]
+    }
+
+    private static let maxConcurrentDownloads = 4
+    private static let blobRefPlaceholder = "{blob_ref}"
+
+    private let blobStore: RemoteConfigBlobStoreType
+    private let sourceProvider: RemoteConfigSourceProviderType
+    private let downloader: RemoteConfigBlobDownloaderType
+
+    private var queued: [String: Download] = [:]
+    private var activeContinuations: [String: [CheckedContinuation<Bool, Never>]] = [:]
+    private var inFlight: Set<String> = []
+    private var sequence = 0
+
+    init(
+        blobStore: RemoteConfigBlobStoreType,
+        sourceProvider: RemoteConfigSourceProviderType,
+        downloader: RemoteConfigBlobDownloaderType
+    ) {
+        self.blobStore = blobStore
+        self.sourceProvider = sourceProvider
+        self.downloader = downloader
+    }
+
+    func ensureDownloaded(ref: String) async -> Bool {
+        return await withCheckedContinuation { continuation in
+            self.enqueue(ref: ref, priority: .high, continuation: continuation)
+        }
+    }
+
+    func ensureAllDownloaded(refs: [String]) async -> [String: Bool] {
+        let uniqueRefs = Array(Set(refs))
+
+        return await withTaskGroup(of: (String, Bool).self) { group in
+            for ref in uniqueRefs {
+                group.addTask {
+                    return (ref, await self.ensureDownloaded(ref: ref))
+                }
+            }
+
+            var results: [String: Bool] = [:]
+            for await (ref, result) in group {
+                results[ref] = result
+            }
+
+            return results
+        }
+    }
+
+    func prefetch(refs: [String]) {
+        for ref in refs {
+            self.enqueue(ref: ref, priority: .low, continuation: nil)
+        }
+    }
+
+    func fetchAndVerify(ref: String) async -> Bool {
+        guard RemoteConfigBlobRefHelpers.isValid(ref) else {
+            Logger.error(Strings.remoteConfig.malformedBlobRef(ref))
+            return false
+        }
+
+        guard !self.blobStore.contains(ref: ref) else {
+            return true
+        }
+
+        guard let source = self.sourceProvider.getCurrent(for: .blob),
+              let url = self.url(for: ref, source: source) else {
+            Logger.error(Strings.remoteConfig.failedToBuildBlobURL(ref))
+            return false
+        }
+
+        do {
+            let data = try await self.downloader.data(from: url)
+            return data.withUnsafeBytes { bytes in
+                guard RemoteConfigBlobRefHelpers.isValidPayload(bytes, expectedRef: ref) else {
+                    Logger.error(Strings.remoteConfig.skippingInvalidBlob(ref))
+                    return false
+                }
+
+                return self.blobStore.write(ref: ref, bytes: bytes)
+            }
+        } catch {
+            // swiftlint:disable:next todo
+            // TODO: Report source failures to `RemoteConfigSourceProvider` and retry with the next blob source.
+            Logger.error(Strings.remoteConfig.failedToDownloadBlob(ref, url, error))
+            return false
+        }
+    }
+
+    private func enqueue(
+        ref: String,
+        priority: Priority,
+        continuation: CheckedContinuation<Bool, Never>?
+    ) {
+        guard RemoteConfigBlobRefHelpers.isValid(ref) else {
+            Logger.error(Strings.remoteConfig.malformedBlobRef(ref))
+            continuation?.resume(returning: false)
+            return
+        }
+
+        guard !self.blobStore.contains(ref: ref) else {
+            continuation?.resume(returning: true)
+            return
+        }
+
+        if var download = self.queued[ref] {
+            if let continuation {
+                download.continuations.append(continuation)
+            }
+            if priority.rawValue > download.priority.rawValue {
+                download.priority = priority
+                download.sequence = self.nextSequence()
+            }
+            self.queued[ref] = download
+            return
+        }
+
+        if self.inFlight.contains(ref) {
+            if let continuation {
+                self.activeContinuations[ref, default: []].append(continuation)
+            }
+            return
+        }
+
+        self.queued[ref] = Download(
+            ref: ref,
+            priority: priority,
+            sequence: self.nextSequence(),
+            continuations: continuation.map { [$0] } ?? []
+        )
+        self.scheduleDownloads()
+    }
+
+    private func scheduleDownloads() {
+        while self.inFlight.count < Self.maxConcurrentDownloads,
+              let download = self.nextDownload() {
+            self.queued[download.ref] = nil
+            self.inFlight.insert(download.ref)
+            self.activeContinuations[download.ref] = download.continuations
+
+            Task {
+                let result = await self.fetchAndVerify(ref: download.ref)
+                self.complete(ref: download.ref, result: result)
+            }
+        }
+    }
+
+    private func complete(ref: String, result: Bool) {
+        let continuations = self.activeContinuations.removeValue(forKey: ref) ?? []
+        self.inFlight.remove(ref)
+        let resolvedResult = result || self.blobStore.contains(ref: ref)
+        continuations.forEach { $0.resume(returning: resolvedResult) }
+
+        self.scheduleDownloads()
+    }
+
+    private func nextDownload() -> Download? {
+        return self.queued.values.sorted {
+            if $0.priority != $1.priority {
+                return $0.priority.rawValue > $1.priority.rawValue
+            }
+
+            return $0.sequence < $1.sequence
+        }.first
+    }
+
+    private func nextSequence() -> Int {
+        defer { self.sequence += 1 }
+        return self.sequence
+    }
+
+    private func url(
+        for ref: String,
+        source: RemoteConfigSourceHandle
+    ) -> URL? {
+        // Blob sources are URL formats, not base URLs: the backend must provide the blob-ref placeholder.
+        guard source.url.contains(Self.blobRefPlaceholder) else {
+            return nil
+        }
+
+        return URL(string: source.url.replacingOccurrences(of: Self.blobRefPlaceholder, with: ref))
+    }
+
+}

--- a/Sources/Networking/RemoteConfigBlobRefHelpers.swift
+++ b/Sources/Networking/RemoteConfigBlobRefHelpers.swift
@@ -1,0 +1,46 @@
+//
+//  RemoteConfigBlobRefHelpers.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import CryptoKit
+import Foundation
+
+enum RemoteConfigBlobRefHelpers {
+
+    static func isValid(_ ref: String) -> Bool {
+        return ref.range(of: Self.validRefPattern, options: .regularExpression) != nil
+    }
+
+    static func ref(for bytes: UnsafeRawBufferPointer) -> String {
+        var hash = SHA256()
+        hash.update(bufferPointer: bytes)
+
+        return Self.base64URLString(from: Array(hash.finalize().prefix(Self.checksumSize)))
+    }
+
+    static func isValidPayload(
+        _ bytes: UnsafeRawBufferPointer,
+        expectedRef ref: String
+    ) -> Bool {
+        return self.isValid(ref) && self.ref(for: bytes) == ref
+    }
+
+}
+
+private extension RemoteConfigBlobRefHelpers {
+
+    static let checksumSize = 24
+    static let validRefPattern = #"^[A-Za-z0-9_-]{32}$"#
+
+    static func base64URLString(from bytes: [UInt8]) -> String {
+        return Data(bytes)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+}

--- a/Sources/Networking/RemoteConfigBlobStore.swift
+++ b/Sources/Networking/RemoteConfigBlobStore.swift
@@ -10,10 +10,11 @@ import Foundation
 protocol RemoteConfigBlobStoreType: AnyObject {
     func contains(ref: String) -> Bool
     func read(ref: String) -> Data?
+    @discardableResult
     func write(
         ref: String,
         bytes: UnsafeRawBufferPointer
-    )
+    ) -> Bool
     func cachedRefs() -> Set<String>
     func retainOnly(_ refs: Set<String>)
     func clear()
@@ -55,18 +56,19 @@ final class RemoteConfigBlobStore: RemoteConfigBlobStoreType {
         }
     }
 
+    @discardableResult
     func write(
         ref: String,
         bytes: UnsafeRawBufferPointer
-    ) {
+    ) -> Bool {
         guard let directoryURL = self.directoryURL else {
             Logger.error(Strings.remoteConfig.cacheURLNotAvailable)
-            return
+            return false
         }
 
         guard let fileURL = self.fileURL(for: ref) else {
             Logger.error(Strings.remoteConfig.malformedBlobRef(ref))
-            return
+            return false
         }
 
         do {
@@ -79,8 +81,10 @@ final class RemoteConfigBlobStore: RemoteConfigBlobStoreType {
             var data = Data()
             data.append(contentsOf: bytes.bindMemory(to: UInt8.self))
             try data.write(to: fileURL, options: .atomic)
+            return true
         } catch {
             Logger.error(Strings.remoteConfig.failedToWriteBlob(ref, error))
+            return false
         }
     }
 
@@ -96,7 +100,7 @@ final class RemoteConfigBlobStore: RemoteConfigBlobStoreType {
 
         return contents.reduce(into: Set<String>()) { refs, fileURL in
             guard self.isRegularFile(fileURL),
-                  Self.isValidRef(fileURL.lastPathComponent) else {
+                  RemoteConfigBlobRefHelpers.isValid(fileURL.lastPathComponent) else {
                 return
             }
 
@@ -105,7 +109,7 @@ final class RemoteConfigBlobStore: RemoteConfigBlobStoreType {
     }
 
     func retainOnly(_ refs: Set<String>) {
-        let validRefs = refs.filter(Self.isValidRef)
+        let validRefs = refs.filter(RemoteConfigBlobRefHelpers.isValid)
         refs.subtracting(validRefs).forEach { Logger.error(Strings.remoteConfig.malformedBlobRef($0)) }
 
         guard let directoryURL = self.directoryURL,
@@ -143,20 +147,14 @@ final class RemoteConfigBlobStore: RemoteConfigBlobStoreType {
 
 private extension RemoteConfigBlobStore {
     static let blobsDirectoryName = "blobs"
-    static let validRefPattern = #"^[A-Za-z0-9_-]{32}$"#
-
     static var defaultDirectoryURL: URL? {
         return DirectoryHelper.baseUrl(for: RemoteConfigDiskCache.directoryType)?
             .appendingPathComponent(RemoteConfigDiskCache.basePath, isDirectory: true)
             .appendingPathComponent(Self.blobsDirectoryName, isDirectory: true)
     }
 
-    static func isValidRef(_ ref: String) -> Bool {
-        return ref.range(of: Self.validRefPattern, options: .regularExpression) != nil
-    }
-
     func fileURL(for ref: String) -> URL? {
-        guard Self.isValidRef(ref) else {
+        guard RemoteConfigBlobRefHelpers.isValid(ref) else {
             return nil
         }
 

--- a/Sources/Networking/RemoteConfigBlobStore.swift
+++ b/Sources/Networking/RemoteConfigBlobStore.swift
@@ -25,6 +25,7 @@ final class RemoteConfigBlobStore: RemoteConfigBlobStoreType {
 
     private let fileManager: FileManager
     private let directoryURL: URL?
+    private let lock = Lock(.nonRecursive)
 
     init(
         fileManager: FileManager = .default,
@@ -35,6 +36,50 @@ final class RemoteConfigBlobStore: RemoteConfigBlobStoreType {
     }
 
     func contains(ref: String) -> Bool {
+        return self.lock.perform {
+            return self.containsWithoutLock(ref: ref)
+        }
+    }
+
+    func read(ref: String) -> Data? {
+        return self.lock.perform {
+            return self.readWithoutLock(ref: ref)
+        }
+    }
+
+    @discardableResult
+    func write(
+        ref: String,
+        bytes: UnsafeRawBufferPointer
+    ) -> Bool {
+        return self.lock.perform {
+            return self.writeWithoutLock(ref: ref, bytes: bytes)
+        }
+    }
+
+    func cachedRefs() -> Set<String> {
+        return self.lock.perform {
+            return self.cachedRefsWithoutLock()
+        }
+    }
+
+    func retainOnly(_ refs: Set<String>) {
+        self.lock.perform {
+            self.retainOnlyWithoutLock(refs)
+        }
+    }
+
+    func clear() {
+        self.lock.perform {
+            self.clearWithoutLock()
+        }
+    }
+
+}
+
+private extension RemoteConfigBlobStore {
+
+    func containsWithoutLock(ref: String) -> Bool {
         guard let fileURL = self.fileURL(for: ref) else {
             return false
         }
@@ -42,7 +87,7 @@ final class RemoteConfigBlobStore: RemoteConfigBlobStoreType {
         return self.isRegularFile(fileURL)
     }
 
-    func read(ref: String) -> Data? {
+    func readWithoutLock(ref: String) -> Data? {
         guard let fileURL = self.fileURL(for: ref),
               self.fileManager.fileExists(atPath: fileURL.path) else {
             return nil
@@ -56,8 +101,7 @@ final class RemoteConfigBlobStore: RemoteConfigBlobStoreType {
         }
     }
 
-    @discardableResult
-    func write(
+    func writeWithoutLock(
         ref: String,
         bytes: UnsafeRawBufferPointer
     ) -> Bool {
@@ -88,7 +132,7 @@ final class RemoteConfigBlobStore: RemoteConfigBlobStoreType {
         }
     }
 
-    func cachedRefs() -> Set<String> {
+    func cachedRefsWithoutLock() -> Set<String> {
         guard let directoryURL = self.directoryURL,
               let contents = try? self.fileManager.contentsOfDirectory(
                 at: directoryURL,
@@ -108,7 +152,7 @@ final class RemoteConfigBlobStore: RemoteConfigBlobStoreType {
         }
     }
 
-    func retainOnly(_ refs: Set<String>) {
+    func retainOnlyWithoutLock(_ refs: Set<String>) {
         let validRefs = refs.filter(RemoteConfigBlobRefHelpers.isValid)
         refs.subtracting(validRefs).forEach { Logger.error(Strings.remoteConfig.malformedBlobRef($0)) }
 
@@ -130,7 +174,7 @@ final class RemoteConfigBlobStore: RemoteConfigBlobStoreType {
         }
     }
 
-    func clear() {
+    func clearWithoutLock() {
         guard let directoryURL = self.directoryURL,
               self.fileManager.fileExists(atPath: directoryURL.path) else {
             return
@@ -143,9 +187,6 @@ final class RemoteConfigBlobStore: RemoteConfigBlobStoreType {
         }
     }
 
-}
-
-private extension RemoteConfigBlobStore {
     static let blobsDirectoryName = "blobs"
     static var defaultDirectoryURL: URL? {
         return DirectoryHelper.baseUrl(for: RemoteConfigDiskCache.directoryType)?

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -19,7 +19,7 @@ protocol RemoteConfigManagerType: AnyObject {
 ///
 /// This manager currently owns only manifest replay, inline blob extraction, and config-state persistence.
 // swiftlint:disable:next todo
-/// TODO: Remove this interim scope once network blob fetching, topic handler dispatch, and SDK lifecycle wiring land.
+/// TODO: Remove this interim scope once topic handler dispatch and SDK lifecycle wiring land.
 final class RemoteConfigManager: RemoteConfigManagerType {
 
     private static let defaultDomain = "app"
@@ -27,6 +27,7 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     private let remoteConfigAPI: RemoteConfigAPIType
     private let diskCache: RemoteConfigDiskCacheType
     private let blobStore: RemoteConfigBlobStoreType
+    private let blobFetcher: RemoteConfigBlobFetcherType
     private let currentUserProvider: CurrentUserProvider
     private let lock = Lock()
     private var isRefreshing = false
@@ -36,11 +37,13 @@ final class RemoteConfigManager: RemoteConfigManagerType {
         remoteConfigAPI: RemoteConfigAPIType,
         diskCache: RemoteConfigDiskCacheType,
         blobStore: RemoteConfigBlobStoreType,
+        blobFetcher: RemoteConfigBlobFetcherType,
         currentUserProvider: CurrentUserProvider
     ) {
         self.remoteConfigAPI = remoteConfigAPI
         self.diskCache = diskCache
         self.blobStore = blobStore
+        self.blobFetcher = blobFetcher
         self.currentUserProvider = currentUserProvider
     }
 
@@ -210,6 +213,7 @@ private extension RemoteConfigManager {
 
         self.extractInlineBlobs(from: container, keepingOnly: postSyncReferencedBlobRefs)
         self.blobStore.retainOnly(postSyncReferencedBlobRefs)
+        self.blobFetcher.prefetch(refs: response.prefetchBlobs)
     }
 
     /// Returns the full topic index that should be persisted after this response is applied.
@@ -250,7 +254,13 @@ private extension RemoteConfigManager {
 
             do {
                 try element.withDecodedPayloadBytes { bytes in
-                    try element.validateChecksum(decodedPayloadBytes: bytes)
+                    guard RemoteConfigBlobRefHelpers.isValidPayload(bytes, expectedRef: ref) else {
+                        throw RCContainer.Parser.FormatError.checksumMismatch(
+                            expected: ref,
+                            actual: RemoteConfigBlobRefHelpers.ref(for: bytes)
+                        )
+                    }
+
                     self.blobStore.write(ref: ref, bytes: bytes)
                 }
             } catch {

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobDownloaderTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobDownloaderTests.swift
@@ -1,0 +1,124 @@
+//
+//  RemoteConfigBlobDownloaderTests.swift
+//  UnitTests
+//
+//  Created by Rick van der Linden.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+import Nimble
+@testable import RevenueCat
+import XCTest
+
+final class RemoteConfigBlobDownloaderTests: TestCase {
+
+    override func tearDown() {
+        MockRemoteConfigBlobURLProtocol.handler = nil
+
+        super.tearDown()
+    }
+
+    func testDataReturnsResponseBodyForSuccessfulHTTPStatus() async throws {
+        let url = try XCTUnwrap(URL(string: "https://example.com/blob"))
+        let expectedData = "blob".asData
+        MockRemoteConfigBlobURLProtocol.handler = { request in
+            return (
+                try Self.response(url: try XCTUnwrap(request.url), statusCode: 200),
+                expectedData
+            )
+        }
+
+        let data = try await self.downloader().data(from: url)
+
+        expect(data) == expectedData
+    }
+
+    func testDataThrowsForUnsuccessfulHTTPStatus() async throws {
+        let url = try XCTUnwrap(URL(string: "https://example.com/blob"))
+        MockRemoteConfigBlobURLProtocol.handler = { request in
+            return (
+                try Self.response(url: try XCTUnwrap(request.url), statusCode: 404),
+                Data()
+            )
+        }
+
+        do {
+            _ = try await self.downloader().data(from: url)
+            fail("Expected downloader to throw")
+        } catch let error as URLSessionRemoteConfigBlobDownloader.Error {
+            expect(error) == .unexpectedStatusCode(404)
+        }
+    }
+
+    func testDataThrowsForNonOKSuccessfulHTTPStatus() async throws {
+        let url = try XCTUnwrap(URL(string: "https://example.com/blob"))
+        MockRemoteConfigBlobURLProtocol.handler = { request in
+            return (
+                try Self.response(url: try XCTUnwrap(request.url), statusCode: 204),
+                Data()
+            )
+        }
+
+        do {
+            _ = try await self.downloader().data(from: url)
+            fail("Expected downloader to throw")
+        } catch let error as URLSessionRemoteConfigBlobDownloader.Error {
+            expect(error) == .unexpectedStatusCode(204)
+        }
+    }
+
+}
+
+private extension RemoteConfigBlobDownloaderTests {
+
+    func downloader() -> URLSessionRemoteConfigBlobDownloader {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockRemoteConfigBlobURLProtocol.self]
+        return URLSessionRemoteConfigBlobDownloader(session: URLSession(configuration: configuration))
+    }
+
+    static func response(
+        url: URL,
+        statusCode: Int
+    ) throws -> HTTPURLResponse {
+        return try XCTUnwrap(HTTPURLResponse(
+            url: url,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        ))
+    }
+
+}
+
+private final class MockRemoteConfigBlobURLProtocol: URLProtocol {
+
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        return true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            self.client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+
+        do {
+            let (response, data) = try handler(self.request)
+            self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            self.client?.urlProtocol(self, didLoad: data)
+            self.client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            self.client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() { }
+
+}

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobFetcherTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobFetcherTests.swift
@@ -1,0 +1,450 @@
+//
+//  RemoteConfigBlobFetcherTests.swift
+//  UnitTests
+//
+//  Created by Rick van der Linden.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+import Nimble
+@testable import RevenueCat
+import XCTest
+
+final class RemoteConfigBlobFetcherTests: TestCase {
+
+    private var blobStore: MockFetcherBlobStore!
+    private var downloader: SuspendingRemoteConfigBlobDownloader!
+    private var sourceProvider: RemoteConfigSourceProvider!
+    private var fetcher: RemoteConfigBlobFetcher!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        self.blobStore = MockFetcherBlobStore()
+        self.downloader = SuspendingRemoteConfigBlobDownloader()
+        self.sourceProvider = Self.sourceProvider(url: Self.templateURL)
+        self.fetcher = RemoteConfigBlobFetcher(
+            blobStore: self.blobStore,
+            sourceProvider: self.sourceProvider,
+            downloader: self.downloader
+        )
+    }
+
+    override func tearDownWithError() throws {
+        self.downloader.cancelAll()
+        self.fetcher = nil
+        self.sourceProvider = nil
+        self.downloader = nil
+        self.blobStore = nil
+
+        try super.tearDownWithError()
+    }
+
+    func testCachedBlobReturnsTrueWithoutNetwork() async {
+        let ref = Self.ref(for: "cached".asData)
+        self.blobStore.stubbedContainsRefs = [ref]
+
+        let result = await self.fetcher.ensureDownloaded(ref: ref)
+
+        expect(result) == true
+        expect(self.downloader.requestedRefs).to(beEmpty())
+        expect(self.blobStore.invokedWriteCount) == 0
+    }
+
+    func testMalformedRefReturnsFalseWithoutSourceNetworkOrStoreAccess() async {
+        let result = await self.fetcher.ensureDownloaded(ref: "not-a-valid-ref")
+
+        expect(result) == false
+        expect(self.downloader.requestedRefs).to(beEmpty())
+        expect(self.blobStore.invokedContainsRefs).to(beEmpty())
+        expect(self.blobStore.invokedWriteCount) == 0
+    }
+
+    func testDownloadsFromPlaceholderURLVerifiesAndStoresBlob() async throws {
+        let payload = "a blob payload".asData
+        let ref = Self.ref(for: payload)
+
+        let task = Task { await self.fetcher.ensureDownloaded(ref: ref) }
+        await self.downloader.waitForRequestCount(1)
+        self.downloader.complete(ref: ref, with: .success(payload))
+
+        let result = await task.value
+
+        expect(result) == true
+        expect(self.downloader.requestedURLs.map(\.absoluteString)) == [
+            Self.templateURL.replacingOccurrences(of: Self.placeholder, with: ref)
+        ]
+        expect(self.blobStore.invokedWriteParameters?.ref) == ref
+        expect(self.blobStore.invokedWriteParameters?.data) == payload
+    }
+
+    func testSourceWithoutBlobRefPlaceholderReturnsFalseWithoutNetwork() async {
+        let ref = Self.ref(for: "missing placeholder".asData)
+        self.sourceProvider = Self.sourceProvider(url: Self.urlWithoutPlaceholder)
+        self.fetcher = RemoteConfigBlobFetcher(
+            blobStore: self.blobStore,
+            sourceProvider: self.sourceProvider,
+            downloader: self.downloader
+        )
+
+        let result = await self.fetcher.ensureDownloaded(ref: ref)
+
+        expect(result) == false
+        expect(self.downloader.requestedURLs).to(beEmpty())
+        expect(self.blobStore.invokedWriteCount) == 0
+    }
+
+    func testChecksumMismatchReturnsFalseAndDoesNotWrite() async {
+        let ref = Self.ref(for: "expected".asData)
+
+        let task = Task { await self.fetcher.ensureDownloaded(ref: ref) }
+        await self.downloader.waitForRequestCount(1)
+        self.downloader.complete(ref: ref, with: .success("tampered".asData))
+
+        let result = await task.value
+        expect(result) == false
+        expect(self.blobStore.invokedWriteCount) == 0
+    }
+
+    func testNetworkFailureReturnsFalseAndDoesNotWrite() async {
+        let ref = Self.ref(for: "failing".asData)
+
+        let task = Task { await self.fetcher.ensureDownloaded(ref: ref) }
+        await self.downloader.waitForRequestCount(1)
+        self.downloader.complete(ref: ref, with: .failure(TestError()))
+
+        let result = await task.value
+        expect(result) == false
+        expect(self.blobStore.invokedWriteCount) == 0
+    }
+
+    func testNetworkFailureReturnsTrueWhenBlobIsCachedConcurrently() async {
+        let ref = Self.ref(for: "cached concurrently".asData)
+
+        let task = Task { await self.fetcher.ensureDownloaded(ref: ref) }
+        await self.downloader.waitForRequestCount(1)
+        self.blobStore.stubbedContainsRefs.insert(ref)
+        self.downloader.complete(ref: ref, with: .failure(TestError()))
+
+        let result = await task.value
+        expect(result) == true
+        expect(self.blobStore.invokedWriteCount) == 0
+    }
+
+    func testWriteFailureReturnsFalseWhenBlobWasNotCached() async {
+        let payload = "unpersisted".asData
+        let ref = Self.ref(for: payload)
+        self.blobStore.stubbedWriteResult = false
+
+        let task = Task { await self.fetcher.ensureDownloaded(ref: ref) }
+        await self.downloader.waitForRequestCount(1)
+        self.downloader.complete(ref: ref, with: .success(payload))
+
+        let result = await task.value
+        expect(result) == false
+        expect(self.blobStore.invokedWriteCount) == 1
+    }
+
+    func testMissingSourceReturnsFalse() async {
+        self.sourceProvider = Self.sourceProvider(urls: [])
+        self.fetcher = RemoteConfigBlobFetcher(
+            blobStore: self.blobStore,
+            sourceProvider: self.sourceProvider,
+            downloader: self.downloader
+        )
+        let ref = Self.ref(for: "missing source".asData)
+
+        let result = await self.fetcher.ensureDownloaded(ref: ref)
+
+        expect(result) == false
+        expect(self.downloader.requestedRefs).to(beEmpty())
+    }
+
+    func testFetchAndVerifyUsesSameVerificationAndStorePath() async {
+        let payload = "direct fetch".asData
+        let ref = Self.ref(for: payload)
+
+        let task = Task { await self.fetcher.fetchAndVerify(ref: ref) }
+        await self.downloader.waitForRequestCount(1)
+        self.downloader.complete(ref: ref, with: .success(payload))
+
+        let result = await task.value
+        expect(result) == true
+        expect(self.blobStore.invokedWriteParameters?.ref) == ref
+    }
+
+    func testConcurrentRequestsForSameRefShareSingleDownload() async {
+        let payload = "shared".asData
+        let ref = Self.ref(for: payload)
+
+        let first = Task { await self.fetcher.ensureDownloaded(ref: ref) }
+        await self.downloader.waitForRequestCount(1)
+        let second = Task { await self.fetcher.ensureDownloaded(ref: ref) }
+        await self.downloader.waitForRequestCount(1)
+        self.downloader.complete(ref: ref, with: .success(payload))
+
+        let firstResult = await first.value
+        let secondResult = await second.value
+        expect(firstResult) == true
+        expect(secondResult) == true
+        expect(self.downloader.requestedRefs) == [ref]
+        expect(self.blobStore.invokedWriteCount) == 1
+    }
+
+    func testDifferentRefsRunConcurrentlyUpToWorkerLimit() async {
+        let refs = (0..<6).map { Self.ref(for: "blob-\($0)".asData) }
+
+        self.fetcher.prefetch(refs: refs)
+
+        await self.downloader.waitForRequestCount(4)
+        expect(self.downloader.activeRequestCount) == 4
+
+        self.downloader.complete(ref: refs[0], with: .success("blob-0".asData))
+        await self.downloader.waitForRequestCount(5)
+        expect(Array(self.downloader.requestedRefs.prefix(4))) == Array(refs.prefix(4))
+    }
+
+    func testPrefetchSchedulesLowPriorityRefs() async {
+        let refs = (0..<4).map { Self.ref(for: "prefetch-\($0)".asData) }
+
+        self.fetcher.prefetch(refs: refs)
+
+        await self.downloader.waitForRequestCount(4)
+        expect(Set(self.downloader.requestedRefs)) == Set(refs)
+    }
+
+    func testOnDemandRequestRunsBeforeQueuedPrefetches() async {
+        let prefetchRefs = (0..<5).map { Self.ref(for: "prefetch-\($0)".asData) }
+        let onDemandPayload = "on demand".asData
+        let onDemandRef = Self.ref(for: onDemandPayload)
+
+        self.fetcher.prefetch(refs: prefetchRefs)
+        await self.downloader.waitForRequestCount(4)
+
+        let onDemand = Task { await self.fetcher.ensureDownloaded(ref: onDemandRef) }
+        await self.waitForScheduledTaskToReachFetcher()
+        self.downloader.complete(ref: prefetchRefs[0], with: .success("prefetch-0".asData))
+
+        await self.downloader.waitForRequestCount(5)
+        expect(self.downloader.requestedRefs[4]) == onDemandRef
+
+        self.downloader.complete(ref: onDemandRef, with: .success(onDemandPayload))
+        let result = await onDemand.value
+        expect(result) == true
+    }
+
+    func testOnDemandRequestBoostsAndJoinsQueuedPrefetch() async {
+        let prefetchRefs = (0..<5).map { Self.ref(for: "prefetch-\($0)".asData) }
+        let boostedPayload = "boosted".asData
+        let boostedRef = Self.ref(for: boostedPayload)
+
+        self.fetcher.prefetch(refs: prefetchRefs + [boostedRef])
+        await self.downloader.waitForRequestCount(4)
+
+        let boosted = Task { await self.fetcher.ensureDownloaded(ref: boostedRef) }
+        await self.waitForScheduledTaskToReachFetcher()
+        self.downloader.complete(ref: prefetchRefs[0], with: .success("prefetch-0".asData))
+
+        await self.downloader.waitForRequestCount(5)
+        expect(self.downloader.requestedRefs[4]) == boostedRef
+        expect(self.downloader.requestedRefs.filter { $0 == boostedRef }).to(haveCount(1))
+
+        self.downloader.complete(ref: boostedRef, with: .success(boostedPayload))
+        let result = await boosted.value
+        expect(result) == true
+    }
+
+    func testEnsureAllDownloadedReturnsPerRefResults() async {
+        let successPayload = "success".asData
+        let successRef = Self.ref(for: successPayload)
+        let failureRef = Self.ref(for: "failure".asData)
+
+        let task = Task { await self.fetcher.ensureAllDownloaded(refs: [successRef, failureRef]) }
+        await self.downloader.waitForRequestCount(2)
+        self.downloader.complete(ref: successRef, with: .success(successPayload))
+        self.downloader.complete(ref: failureRef, with: .failure(TestError()))
+
+        let result = await task.value
+        expect(result) == [
+            successRef: true,
+            failureRef: false
+        ]
+    }
+
+}
+
+private extension RemoteConfigBlobFetcherTests {
+
+    static let placeholder = "{blob_ref}"
+    static let templateURL = "https://config.revenuecat-static.com/\(placeholder)"
+    static let urlWithoutPlaceholder = "https://config.revenuecat-static.com/blobs"
+
+    static func sourceProvider(url: String) -> RemoteConfigSourceProvider {
+        return self.sourceProvider(urls: [url])
+    }
+
+    static func sourceProvider(urls: [String]) -> RemoteConfigSourceProvider {
+        let sourcesTopic: RemoteConfiguration.ConfigTopic = [
+            "blob": RemoteConfiguration.ConfigItem(content: [
+                "sources": .array(urls.map { url in
+                    .object([
+                        "url_format": .string(url),
+                        "priority": .int(0),
+                        "weight": .int(1)
+                    ])
+                })
+            ])
+        ]
+
+        return RemoteConfigSourceProvider(
+            topicStore: BlobFetcherSourceTopicStore(sourcesTopic)
+        )
+    }
+
+    static func ref(for data: Data) -> String {
+        return data.withUnsafeBytes { RemoteConfigBlobRefHelpers.ref(for: $0) }
+    }
+
+    func waitForScheduledTaskToReachFetcher() async {
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+    }
+
+    struct TestError: Error { }
+
+}
+
+private final class BlobFetcherSourceTopicStore: RemoteConfigTopicStoreType {
+
+    private let sourcesTopic: RemoteConfiguration.ConfigTopic?
+
+    init(_ sourcesTopic: RemoteConfiguration.ConfigTopic?) {
+        self.sourcesTopic = sourcesTopic
+    }
+
+    func topic(_ name: String) -> RemoteConfiguration.ConfigTopic? {
+        return name == "sources" ? self.sourcesTopic : nil
+    }
+
+}
+
+private final class MockFetcherBlobStore: RemoteConfigBlobStoreType {
+
+    var stubbedContainsRefs: Set<String> = []
+    var stubbedWriteResult = true
+
+    private(set) var invokedContainsRefs: [String] = []
+    private(set) var invokedWriteCount = 0
+    private(set) var invokedWriteParameters: (ref: String, data: Data)?
+
+    func contains(ref: String) -> Bool {
+        self.invokedContainsRefs.append(ref)
+        return self.stubbedContainsRefs.contains(ref)
+    }
+
+    func read(ref: String) -> Data? {
+        return nil
+    }
+
+    @discardableResult
+    func write(
+        ref: String,
+        bytes: UnsafeRawBufferPointer
+    ) -> Bool {
+        self.invokedWriteCount += 1
+        var data = Data()
+        data.append(contentsOf: bytes.bindMemory(to: UInt8.self))
+        self.invokedWriteParameters = (ref, data)
+        if self.stubbedWriteResult {
+            self.stubbedContainsRefs.insert(ref)
+        }
+        return self.stubbedWriteResult
+    }
+
+    func cachedRefs() -> Set<String> {
+        return self.stubbedContainsRefs
+    }
+
+    func retainOnly(_ refs: Set<String>) { }
+
+    func clear() { }
+
+}
+
+private final class SuspendingRemoteConfigBlobDownloader: RemoteConfigBlobDownloaderType {
+
+    private struct PendingRequest {
+        let url: URL
+        let continuation: CheckedContinuation<Data, Error>
+    }
+
+    private let lock = Lock()
+    private var pendingRequests: [PendingRequest] = []
+    private var requestedURLHistory: [URL] = []
+
+    var requestedURLs: [URL] {
+        return self.lock.perform { self.requestedURLHistory }
+    }
+
+    var requestedRefs: [String] {
+        return self.requestedURLs.map(\.lastPathComponent)
+    }
+
+    var activeRequestCount: Int {
+        return self.lock.perform { self.pendingRequests.count }
+    }
+
+    func data(from url: URL) async throws -> Data {
+        return try await withCheckedThrowingContinuation { continuation in
+            self.lock.perform {
+                self.requestedURLHistory.append(url)
+                self.pendingRequests.append(PendingRequest(url: url, continuation: continuation))
+            }
+        }
+    }
+
+    func complete(ref: String, with result: Result<Data, Error>) {
+        let request = self.lock.perform {
+            guard let index = self.pendingRequests.firstIndex(where: { $0.url.lastPathComponent == ref }) else {
+                return nil as PendingRequest?
+            }
+
+            return self.pendingRequests.remove(at: index)
+        }
+
+        switch result {
+        case let .success(data):
+            request?.continuation.resume(returning: data)
+        case let .failure(error):
+            request?.continuation.resume(throwing: error)
+        }
+    }
+
+    func waitForRequestCount(
+        _ count: Int,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        let deadline = Date().addingTimeInterval(2)
+        while Date() < deadline {
+            if self.requestedURLs.count >= count {
+                return
+            }
+
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        XCTFail("Timed out waiting for \(count) requests", file: file, line: line)
+    }
+
+    func cancelAll() {
+        let requests = self.lock.perform { () -> [PendingRequest] in
+            let requests = self.pendingRequests
+            self.pendingRequests = []
+            return requests
+        }
+
+        requests.forEach { $0.continuation.resume(throwing: CancellationError()) }
+    }
+
+}

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobFetcherTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobFetcherTests.swift
@@ -251,19 +251,6 @@ final class RemoteConfigBlobFetcherTests: TestCase {
         expect(self.downloader.requestedRefs).to(beEmpty())
     }
 
-    func testFetchAndVerifyUsesSameVerificationAndStorePath() async {
-        let payload = "direct fetch".asData
-        let ref = Self.ref(for: payload)
-
-        let task = Task { await self.fetcher.fetchAndVerify(ref: ref) }
-        await self.downloader.waitForRequestCount(1)
-        self.downloader.complete(ref: ref, with: .success(payload))
-
-        let result = await task.value
-        expect(result) == true
-        expect(self.blobStore.invokedWriteParameters?.ref) == ref
-    }
-
     func testConcurrentRequestsForSameRefShareSingleDownload() async {
         let payload = "shared".asData
         let ref = Self.ref(for: payload)
@@ -271,24 +258,6 @@ final class RemoteConfigBlobFetcherTests: TestCase {
         let first = Task { await self.fetcher.ensureDownloaded(ref: ref) }
         await self.downloader.waitForRequestCount(1)
         let second = Task { await self.fetcher.ensureDownloaded(ref: ref) }
-        await self.downloader.waitForRequestCount(1)
-        self.downloader.complete(ref: ref, with: .success(payload))
-
-        let firstResult = await first.value
-        let secondResult = await second.value
-        expect(firstResult) == true
-        expect(secondResult) == true
-        expect(self.downloader.requestedRefs) == [ref]
-        expect(self.blobStore.invokedWriteCount) == 1
-    }
-
-    func testFetchAndVerifyJoinsInFlightDownloadForSameRef() async {
-        let payload = "shared direct fetch".asData
-        let ref = Self.ref(for: payload)
-
-        let first = Task { await self.fetcher.ensureDownloaded(ref: ref) }
-        await self.downloader.waitForRequestCount(1)
-        let second = Task { await self.fetcher.fetchAndVerify(ref: ref) }
         await self.downloader.waitForRequestCount(1)
         self.downloader.complete(ref: ref, with: .success(payload))
 
@@ -363,7 +332,7 @@ final class RemoteConfigBlobFetcherTests: TestCase {
         expect(result) == true
     }
 
-    func testEnsureAllDownloadedReturnsPerRefResults() async {
+    func testEnsureAllDownloadedReturnsFalseWhenAnyRefFails() async {
         let successPayload = "success".asData
         let successRef = Self.ref(for: successPayload)
         let failureRef = Self.ref(for: "failure".asData)
@@ -374,10 +343,7 @@ final class RemoteConfigBlobFetcherTests: TestCase {
         self.downloader.complete(ref: failureRef, with: .failure(TestError()))
 
         let result = await task.value
-        expect(result) == [
-            successRef: true,
-            failureRef: false
-        ]
+        expect(result) == false
     }
 
 }

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobFetcherTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobFetcherTests.swift
@@ -175,6 +175,33 @@ final class RemoteConfigBlobFetcherTests: TestCase {
 
     func testNotFoundDoesNotMarkSourceUnhealthyOrRetryNextSource() async {
         let missingRef = Self.ref(for: "missing blob".asData)
+
+        await self.assertFailureDoesNotMarkSourceUnhealthyOrRetryNextSource(
+            failingRef: missingRef,
+            with: .failure(URLSessionRemoteConfigBlobDownloader.Error.unexpectedStatusCode(404))
+        )
+    }
+
+    func testCancellationDoesNotMarkSourceUnhealthyOrRetryNextSource() async {
+        await self.assertFailureDoesNotMarkSourceUnhealthyOrRetryNextSource(
+            failingRef: Self.ref(for: "cancelled blob".asData),
+            with: .failure(CancellationError())
+        )
+    }
+
+    func testURLSessionCancellationDoesNotMarkSourceUnhealthyOrRetryNextSource() async {
+        await self.assertFailureDoesNotMarkSourceUnhealthyOrRetryNextSource(
+            failingRef: Self.ref(for: "url session cancelled blob".asData),
+            with: .failure(URLError(.cancelled))
+        )
+    }
+
+    private func assertFailureDoesNotMarkSourceUnhealthyOrRetryNextSource(
+        failingRef: String,
+        with result: Result<Data, Error>,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
         let availablePayload = "available blob".asData
         let availableRef = Self.ref(for: availablePayload)
         self.sourceProvider = Self.sourceProvider(urls: [
@@ -187,24 +214,21 @@ final class RemoteConfigBlobFetcherTests: TestCase {
             downloader: self.downloader
         )
 
-        let missing = Task { await self.fetcher.ensureDownloaded(ref: missingRef) }
-        await self.downloader.waitForRequestCount(1)
-        self.downloader.complete(
-            ref: missingRef,
-            with: .failure(URLSessionRemoteConfigBlobDownloader.Error.unexpectedStatusCode(404))
-        )
+        let failing = Task { await self.fetcher.ensureDownloaded(ref: failingRef) }
+        await self.downloader.waitForRequestCount(1, file: file, line: line)
+        self.downloader.complete(ref: failingRef, with: result)
 
-        let missingResult = await missing.value
-        expect(missingResult) == false
+        let failingResult = await failing.value
+        expect(failingResult) == false
 
         let available = Task { await self.fetcher.ensureDownloaded(ref: availableRef) }
-        await self.downloader.waitForRequestCount(2)
+        await self.downloader.waitForRequestCount(2, file: file, line: line)
         self.downloader.complete(ref: availableRef, with: .success(availablePayload))
 
         let availableResult = await available.value
         expect(availableResult) == true
         expect(self.downloader.requestedURLs.map(\.absoluteString)) == [
-            Self.templateURL.replacingOccurrences(of: Self.placeholder, with: missingRef),
+            Self.templateURL.replacingOccurrences(of: Self.placeholder, with: failingRef),
             Self.templateURL.replacingOccurrences(of: Self.placeholder, with: availableRef)
         ]
     }

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobFetcherTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobFetcherTests.swift
@@ -94,6 +94,32 @@ final class RemoteConfigBlobFetcherTests: TestCase {
         expect(self.blobStore.invokedWriteCount) == 0
     }
 
+    func testSourceWithoutBlobRefPlaceholderRetriesNextSource() async {
+        let payload = "valid fallback".asData
+        let ref = Self.ref(for: payload)
+        self.sourceProvider = Self.sourceProvider(urls: [
+            Self.urlWithoutPlaceholder,
+            Self.backupTemplateURL
+        ])
+        self.fetcher = RemoteConfigBlobFetcher(
+            blobStore: self.blobStore,
+            sourceProvider: self.sourceProvider,
+            downloader: self.downloader
+        )
+
+        let task = Task { await self.fetcher.ensureDownloaded(ref: ref) }
+        await self.downloader.waitForRequestCount(1)
+        self.downloader.complete(ref: ref, with: .success(payload))
+
+        let result = await task.value
+
+        expect(result) == true
+        expect(self.downloader.requestedURLs.map(\.absoluteString)) == [
+            Self.backupTemplateURL.replacingOccurrences(of: Self.placeholder, with: ref)
+        ]
+        expect(self.blobStore.invokedWriteParameters?.data) == payload
+    }
+
     func testChecksumMismatchReturnsFalseAndDoesNotWrite() async {
         let ref = Self.ref(for: "expected".asData)
 
@@ -116,6 +142,35 @@ final class RemoteConfigBlobFetcherTests: TestCase {
         let result = await task.value
         expect(result) == false
         expect(self.blobStore.invokedWriteCount) == 0
+    }
+
+    func testNetworkFailureRetriesNextSource() async {
+        let payload = "fallback payload".asData
+        let ref = Self.ref(for: payload)
+        self.sourceProvider = Self.sourceProvider(urls: [
+            Self.templateURL,
+            Self.backupTemplateURL
+        ])
+        self.fetcher = RemoteConfigBlobFetcher(
+            blobStore: self.blobStore,
+            sourceProvider: self.sourceProvider,
+            downloader: self.downloader
+        )
+
+        let task = Task { await self.fetcher.ensureDownloaded(ref: ref) }
+        await self.downloader.waitForRequestCount(1)
+        self.downloader.complete(ref: ref, with: .failure(TestError()))
+        await self.downloader.waitForRequestCount(2)
+        self.downloader.complete(ref: ref, with: .success(payload))
+
+        let result = await task.value
+
+        expect(result) == true
+        expect(self.downloader.requestedURLs.map(\.absoluteString)) == [
+            Self.templateURL.replacingOccurrences(of: Self.placeholder, with: ref),
+            Self.backupTemplateURL.replacingOccurrences(of: Self.placeholder, with: ref)
+        ]
+        expect(self.blobStore.invokedWriteParameters?.data) == payload
     }
 
     func testNetworkFailureReturnsTrueWhenBlobIsCachedConcurrently() async {
@@ -277,6 +332,7 @@ private extension RemoteConfigBlobFetcherTests {
 
     static let placeholder = "{blob_ref}"
     static let templateURL = "https://config.revenuecat-static.com/\(placeholder)"
+    static let backupTemplateURL = "https://config-backup.revenuecat-static.com/\(placeholder)"
     static let urlWithoutPlaceholder = "https://config.revenuecat-static.com/blobs"
 
     static func sourceProvider(url: String) -> RemoteConfigSourceProvider {
@@ -286,10 +342,10 @@ private extension RemoteConfigBlobFetcherTests {
     static func sourceProvider(urls: [String]) -> RemoteConfigSourceProvider {
         let sourcesTopic: RemoteConfiguration.ConfigTopic = [
             "blob": RemoteConfiguration.ConfigItem(content: [
-                "sources": .array(urls.map { url in
+                "sources": .array(urls.enumerated().map { priority, url in
                     .object([
                         "url_format": .string(url),
-                        "priority": .int(0),
+                        "priority": .int(priority),
                         "weight": .int(1)
                     ])
                 })

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobFetcherTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobFetcherTests.swift
@@ -173,6 +173,42 @@ final class RemoteConfigBlobFetcherTests: TestCase {
         expect(self.blobStore.invokedWriteParameters?.data) == payload
     }
 
+    func testNotFoundDoesNotMarkSourceUnhealthyOrRetryNextSource() async {
+        let missingRef = Self.ref(for: "missing blob".asData)
+        let availablePayload = "available blob".asData
+        let availableRef = Self.ref(for: availablePayload)
+        self.sourceProvider = Self.sourceProvider(urls: [
+            Self.templateURL,
+            Self.backupTemplateURL
+        ])
+        self.fetcher = RemoteConfigBlobFetcher(
+            blobStore: self.blobStore,
+            sourceProvider: self.sourceProvider,
+            downloader: self.downloader
+        )
+
+        let missing = Task { await self.fetcher.ensureDownloaded(ref: missingRef) }
+        await self.downloader.waitForRequestCount(1)
+        self.downloader.complete(
+            ref: missingRef,
+            with: .failure(URLSessionRemoteConfigBlobDownloader.Error.unexpectedStatusCode(404))
+        )
+
+        let missingResult = await missing.value
+        expect(missingResult) == false
+
+        let available = Task { await self.fetcher.ensureDownloaded(ref: availableRef) }
+        await self.downloader.waitForRequestCount(2)
+        self.downloader.complete(ref: availableRef, with: .success(availablePayload))
+
+        let availableResult = await available.value
+        expect(availableResult) == true
+        expect(self.downloader.requestedURLs.map(\.absoluteString)) == [
+            Self.templateURL.replacingOccurrences(of: Self.placeholder, with: missingRef),
+            Self.templateURL.replacingOccurrences(of: Self.placeholder, with: availableRef)
+        ]
+    }
+
     func testNetworkFailureReturnsTrueWhenBlobIsCachedConcurrently() async {
         let ref = Self.ref(for: "cached concurrently".asData)
 

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobFetcherTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobFetcherTests.swift
@@ -246,6 +246,24 @@ final class RemoteConfigBlobFetcherTests: TestCase {
         expect(self.blobStore.invokedWriteCount) == 1
     }
 
+    func testFetchAndVerifyJoinsInFlightDownloadForSameRef() async {
+        let payload = "shared direct fetch".asData
+        let ref = Self.ref(for: payload)
+
+        let first = Task { await self.fetcher.ensureDownloaded(ref: ref) }
+        await self.downloader.waitForRequestCount(1)
+        let second = Task { await self.fetcher.fetchAndVerify(ref: ref) }
+        await self.downloader.waitForRequestCount(1)
+        self.downloader.complete(ref: ref, with: .success(payload))
+
+        let firstResult = await first.value
+        let secondResult = await second.value
+        expect(firstResult) == true
+        expect(secondResult) == true
+        expect(self.downloader.requestedRefs) == [ref]
+        expect(self.blobStore.invokedWriteCount) == 1
+    }
+
     func testDifferentRefsRunConcurrentlyUpToWorkerLimit() async {
         let refs = (0..<6).map { Self.ref(for: "blob-\($0)".asData) }
 

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobStoreTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobStoreTests.swift
@@ -38,7 +38,7 @@ final class RemoteConfigBlobStoreTests: TestCase {
     func testWriteThenReadRoundTripsBlobBytes() throws {
         let data = Data([1, 2, 3, 4, 5])
 
-        self.write(ref: Self.refA, data: data)
+        expect(self.write(ref: Self.refA, data: data)) == true
 
         expect(self.blobStore.read(ref: Self.refA)) == data
     }
@@ -136,7 +136,7 @@ final class RemoteConfigBlobStoreTests: TestCase {
     func testMalformedRefIsRejectedAndCannotEscapeBlobDirectory() {
         let malformedRef = "../escape"
 
-        self.write(ref: malformedRef, data: Data([1, 2, 3]))
+        expect(self.write(ref: malformedRef, data: Data([1, 2, 3]))) == false
 
         expect(self.blobStore.contains(ref: malformedRef)) == false
         expect(self.blobStore.read(ref: malformedRef)).to(beNil())
@@ -153,8 +153,9 @@ private extension RemoteConfigBlobStoreTests {
     static let refA = "AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHH"
     static let refB = "IIIIJJJJKKKKLLLLMMMMNNNNOOOOPPPP"
 
-    func write(ref: String, data: Data) {
-        data.withUnsafeBytes { bytes in
+    @discardableResult
+    func write(ref: String, data: Data) -> Bool {
+        return data.withUnsafeBytes { bytes in
             self.blobStore.write(ref: ref, bytes: bytes)
         }
     }

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobStoreTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobStoreTests.swift
@@ -146,6 +146,38 @@ final class RemoteConfigBlobStoreTests: TestCase {
         ) == false
     }
 
+    func testRetainOnlyWaitsForInProgressWrite() {
+        let fileManager = BlockingFileManager()
+        self.blobStore = RemoteConfigBlobStore(fileManager: fileManager, directoryURL: self.directoryURL)
+
+        let writeFinished = DispatchSemaphore(value: 0)
+        let retainStarted = DispatchSemaphore(value: 0)
+        let retainFinished = DispatchSemaphore(value: 0)
+
+        let data = Data([1])
+        DispatchQueue.global().async {
+            self.write(ref: Self.refA, data: data)
+            writeFinished.signal()
+        }
+
+        expect(fileManager.waitForDirectoryCreation()) == true
+
+        DispatchQueue.global().async {
+            retainStarted.signal()
+            self.blobStore.retainOnly([Self.refA])
+            retainFinished.signal()
+        }
+
+        expect(retainStarted.wait(timeout: .now() + 1)) == .success
+        expect(fileManager.waitForContentsOfDirectory(timeout: .now() + 0.1)) == false
+
+        fileManager.unblockDirectoryCreation()
+
+        expect(writeFinished.wait(timeout: .now() + 1)) == .success
+        expect(retainFinished.wait(timeout: .now() + 1)) == .success
+        expect(fileManager.waitForContentsOfDirectory()) == true
+    }
+
 }
 
 private extension RemoteConfigBlobStoreTests {
@@ -158,6 +190,54 @@ private extension RemoteConfigBlobStoreTests {
         return data.withUnsafeBytes { bytes in
             self.blobStore.write(ref: ref, bytes: bytes)
         }
+    }
+
+}
+
+private final class BlockingFileManager: FileManager {
+
+    private let enteredDirectoryCreation = DispatchSemaphore(value: 0)
+    private let allowDirectoryCreation = DispatchSemaphore(value: 0)
+    private let enteredContentsOfDirectory = DispatchSemaphore(value: 0)
+
+    override func createDirectory(
+        at url: URL,
+        withIntermediateDirectories createIntermediates: Bool,
+        attributes: [FileAttributeKey: Any]? = nil
+    ) throws {
+        self.enteredDirectoryCreation.signal()
+        _ = self.allowDirectoryCreation.wait(timeout: .now() + 5)
+
+        try super.createDirectory(
+            at: url,
+            withIntermediateDirectories: createIntermediates,
+            attributes: attributes
+        )
+    }
+
+    override func contentsOfDirectory(
+        at url: URL,
+        includingPropertiesForKeys keys: [URLResourceKey]?,
+        options mask: FileManager.DirectoryEnumerationOptions = []
+    ) throws -> [URL] {
+        self.enteredContentsOfDirectory.signal()
+        return try super.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: keys,
+            options: mask
+        )
+    }
+
+    func waitForDirectoryCreation(timeout: DispatchTime = .now() + 1) -> Bool {
+        return self.enteredDirectoryCreation.wait(timeout: timeout) == .success
+    }
+
+    func waitForContentsOfDirectory(timeout: DispatchTime = .now() + 1) -> Bool {
+        return self.enteredContentsOfDirectory.wait(timeout: timeout) == .success
+    }
+
+    func unblockDirectoryCreation() {
+        self.allowDirectoryCreation.signal()
     }
 
 }

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -17,6 +17,7 @@ final class RemoteConfigManagerTests: TestCase {
     private var remoteConfigAPI: MockRemoteConfigAPI!
     private var diskCache: MockRemoteConfigDiskCache!
     private var blobStore: MockRemoteConfigBlobStore!
+    private var blobFetcher: MockRemoteConfigBlobFetcher!
     private var currentUserProvider: MockCurrentUserProvider!
     private var manager: RemoteConfigManager!
 
@@ -26,17 +27,20 @@ final class RemoteConfigManagerTests: TestCase {
         self.remoteConfigAPI = MockRemoteConfigAPI()
         self.diskCache = MockRemoteConfigDiskCache()
         self.blobStore = MockRemoteConfigBlobStore()
+        self.blobFetcher = MockRemoteConfigBlobFetcher()
         self.currentUserProvider = MockCurrentUserProvider(mockAppUserID: Self.appUserID)
         self.manager = RemoteConfigManager(
             remoteConfigAPI: self.remoteConfigAPI,
             diskCache: self.diskCache,
             blobStore: self.blobStore,
+            blobFetcher: self.blobFetcher,
             currentUserProvider: self.currentUserProvider
         )
     }
 
     override func tearDownWithError() throws {
         self.manager = nil
+        self.blobFetcher = nil
         self.blobStore = nil
         self.currentUserProvider = nil
         self.diskCache = nil
@@ -270,6 +274,7 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.diskCache.invokedWriteCount) == 0
         expect(self.blobStore.invokedWriteCount) == 0
         expect(self.blobStore.invokedRetainOnlyCount) == 0
+        expect(self.blobFetcher.invokedPrefetchCount) == 0
     }
 
     func testNoContentResponseWithNoPersistedCacheLeavesCacheUntouched() {
@@ -281,6 +286,7 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.diskCache.invokedWriteCount) == 0
         expect(self.blobStore.invokedWriteCount) == 0
         expect(self.blobStore.invokedRetainOnlyCount) == 0
+        expect(self.blobFetcher.invokedPrefetchCount) == 0
     }
 
     func testBackendErrorLeavesCacheUntouched() {
@@ -296,6 +302,7 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.diskCache.invokedWriteCount) == 0
         expect(self.blobStore.invokedWriteCount) == 0
         expect(self.blobStore.invokedRetainOnlyCount) == 0
+        expect(self.blobFetcher.invokedPrefetchCount) == 0
     }
 
     func testMalformedConfigPayloadLeavesCacheUntouched() throws {
@@ -307,6 +314,7 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.diskCache.invokedWriteCount) == 0
         expect(self.blobStore.invokedWriteCount) == 0
         expect(self.blobStore.invokedRetainOnlyCount) == 0
+        expect(self.blobFetcher.invokedPrefetchCount) == 0
     }
 
     func testConfigDecodingUsesOnlyContainerConfigElement() throws {
@@ -631,6 +639,29 @@ final class RemoteConfigManagerTests: TestCase {
         )
 
         expect(self.diskCache.invokedWriteParameter?.prefetchBlobs) == [cachedRef, missingRef]
+    }
+
+    func testContainerResponsePrefetchesServerPrefetchBlobRefs() throws {
+        let cachedRef = RCContainerTestData.blobRef(for: "cached".asData)
+        let missingRef = RCContainerTestData.blobRef(for: "missing".asData)
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.sources:etag2",
+          "active_topics": ["sources"],
+          "prefetch_blobs": ["\(cachedRef)", "\(missingRef)"]
+        }
+        """
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(
+            with: .success(.test(
+                container: try Self.container(config: response),
+                verificationResult: .verified
+            ))
+        )
+
+        expect(self.blobFetcher.invokedPrefetchRefs) == [cachedRef, missingRef]
     }
 
     func testContainerResponseDoesNotPruneBlobStoreWhenCacheWriteFails() throws {
@@ -1018,15 +1049,17 @@ private final class MockRemoteConfigBlobStore: RemoteConfigBlobStoreType {
         return nil
     }
 
+    @discardableResult
     func write(
         ref: String,
         bytes: UnsafeRawBufferPointer
-    ) {
+    ) -> Bool {
         self.invokedWriteCount += 1
         var data = Data()
         data.append(contentsOf: bytes.bindMemory(to: UInt8.self))
         self.invokedWriteParameters = (ref, data)
         self.invokedWriteParametersList.append((ref, data))
+        return true
     }
 
     func cachedRefs() -> Set<String> {
@@ -1041,6 +1074,36 @@ private final class MockRemoteConfigBlobStore: RemoteConfigBlobStoreType {
 
     func clear() {
         self.invokedClearCount += 1
+    }
+
+}
+
+private final class MockRemoteConfigBlobFetcher: RemoteConfigBlobFetcherType {
+
+    private(set) var invokedEnsureDownloadedRefs: [String] = []
+    private(set) var invokedEnsureAllDownloadedRefs: [String] = []
+    private(set) var invokedPrefetchCount = 0
+    private(set) var invokedPrefetchRefs: [String] = []
+    private(set) var invokedFetchAndVerifyRefs: [String] = []
+
+    func ensureDownloaded(ref: String) async -> Bool {
+        self.invokedEnsureDownloadedRefs.append(ref)
+        return true
+    }
+
+    func ensureAllDownloaded(refs: [String]) async -> [String: Bool] {
+        self.invokedEnsureAllDownloadedRefs = refs
+        return Dictionary(uniqueKeysWithValues: refs.map { ($0, true) })
+    }
+
+    func prefetch(refs: [String]) {
+        self.invokedPrefetchCount += 1
+        self.invokedPrefetchRefs = refs
+    }
+
+    func fetchAndVerify(ref: String) async -> Bool {
+        self.invokedFetchAndVerifyRefs.append(ref)
+        return true
     }
 
 }

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -1084,26 +1084,20 @@ private final class MockRemoteConfigBlobFetcher: RemoteConfigBlobFetcherType {
     private(set) var invokedEnsureAllDownloadedRefs: [String] = []
     private(set) var invokedPrefetchCount = 0
     private(set) var invokedPrefetchRefs: [String] = []
-    private(set) var invokedFetchAndVerifyRefs: [String] = []
 
     func ensureDownloaded(ref: String) async -> Bool {
         self.invokedEnsureDownloadedRefs.append(ref)
         return true
     }
 
-    func ensureAllDownloaded(refs: [String]) async -> [String: Bool] {
+    func ensureAllDownloaded(refs: [String]) async -> Bool {
         self.invokedEnsureAllDownloadedRefs = refs
-        return Dictionary(uniqueKeysWithValues: refs.map { ($0, true) })
+        return true
     }
 
     func prefetch(refs: [String]) {
         self.invokedPrefetchCount += 1
         self.invokedPrefetchRefs = refs
-    }
-
-    func fetchAndVerify(ref: String) async -> Bool {
-        self.invokedFetchAndVerifyRefs.append(ref)
-        return true
     }
 
 }


### PR DESCRIPTION
Part of a stack of PRs, builds on #7111 and should be aligned with RevenueCat/purchases-android#3679.

## Description
Introduces the `RemoteConfigBlobFetch`, responsible for orchestrating the fetching/downloading of external remote config blobs.

Main concepts
- Prefetching blobs can be done through `prefetch(refs: [String])` (this runs with lower priority)
- Downloading blobs right away can be done through `ensureDownloaded(ref: String)` / `ensureAllDownloaded(refs: [String])`. 
  - This runs with higher priority since it's explicitly asked for
- A max total of 4 concurrent network requests will be made
- If a blob is requested while prefetching it's priority will be bumped to high
- At most 1 active download will be inflight per blob. Even if requested 5 times simultaneously. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New async networking and disk writes on the remote-config path with concurrency and source-health logic; changes are well-tested but affect config blob integrity and CDN failover behavior.
> 
> **Overview**
> Adds **network blob fetching** for remote config: blobs download from CDN-style URL templates (with `{blob_ref}`), are **SHA256 checksum–verified**, and land in the existing content-addressed disk store.
> 
> **`RemoteConfigBlobFetcher`** orchestrates downloads via an actor-backed scheduler: up to **4 concurrent** requests, **high-priority** `ensureDownloaded` / `ensureAllDownloaded` vs **low-priority** `prefetch`, request **coalescing** per ref, and **priority boosting** when a prefetch ref is needed on demand. Failures **fail over** across `RemoteConfigSourceProvider` blob sources (404/cancel do not mark sources unhealthy).
> 
> Supporting pieces: **`URLSessionRemoteConfigBlobDownloader`**, shared **`RemoteConfigBlobRefHelpers`** for ref format and payload validation (also used for inline blob extraction), **`RemoteConfigBlobStore`** made thread-safe with a lock and **`write` returning `Bool`**, plus new log strings.
> 
> **`RemoteConfigManager`** takes a `blobFetcher` dependency and, after a successful persist, calls **`prefetch`** for server `prefetch_blobs` (on-demand ensure is not wired here yet). Unit tests cover downloader, fetcher scheduling/failover, store locking, and manager prefetch behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d62fd6a239bf832838c5af86e8953b2aa5edfd26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->