### PR TITLE
feat(remote-config): disable refresh after client errors

### DIFF
--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -9,6 +9,9 @@ import Foundation
 
 protocol RemoteConfigManagerType: AnyObject {
 
+    /// Whether remote config should be ignored for the current manager lifetime.
+    var isDisabled: Bool { get }
+
     func refreshRemoteConfig(isAppBackgrounded: Bool)
 
     func clearCache()
@@ -31,6 +34,7 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     private let currentUserProvider: CurrentUserProvider
     private let lock = Lock()
     private var isRefreshing = false
+    private var isDisabledInternal = false
     private var epoch = 0
 
     init(
@@ -45,6 +49,12 @@ final class RemoteConfigManager: RemoteConfigManagerType {
         self.blobStore = blobStore
         self.blobFetcher = blobFetcher
         self.currentUserProvider = currentUserProvider
+    }
+
+    var isDisabled: Bool {
+        return self.lock.perform {
+            self.isDisabledInternal
+        }
     }
 
     func refreshRemoteConfig(isAppBackgrounded: Bool) {
@@ -85,7 +95,8 @@ private extension RemoteConfigManager {
 
     func prepareRefreshIfNeeded() -> Int? {
         return self.lock.perform {
-            guard !self.isRefreshing else { return nil }
+            guard !self.isRefreshing,
+                  !self.isDisabledInternal else { return nil }
             self.isRefreshing = true
             return self.epoch
         }
@@ -167,9 +178,24 @@ private extension RemoteConfigManager {
         _ error: BackendError,
         requestEpoch: Int
     ) {
-        if self.releaseGuardIfOwned(requestEpoch: requestEpoch) {
-            Logger.error(Strings.remoteConfig.refreshFailed(error))
+        let isCurrentFailure = self.lock.perform {
+            guard self.epoch == requestEpoch else { return false }
+
+            self.disableRefreshIfNeeded(for: error)
+            self.isRefreshing = false
+
+            return true
         }
+
+        guard isCurrentFailure else { return }
+
+        Logger.error(Strings.remoteConfig.refreshFailed(error))
+    }
+
+    func disableRefreshIfNeeded(for error: BackendError) {
+        guard error.isRemoteConfigDisablingClientError else { return }
+
+        self.isDisabledInternal = true
     }
 
     func isCurrent(_ requestEpoch: Int) -> Bool {
@@ -267,6 +293,19 @@ private extension RemoteConfigManager {
                 Logger.error(Strings.remoteConfig.skippingInvalidBlob(ref))
             }
         }
+    }
+
+}
+
+private extension BackendError {
+
+    /// Client errors disable remote config refreshes as a safety mechanism for the current manager lifetime.
+    var isRemoteConfigDisablingClientError: Bool {
+        guard case let .networkError(.errorResponse(_, statusCode, _)) = self else {
+            return false
+        }
+
+        return 400...499 ~= statusCode.rawValue
     }
 
 }

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -49,6 +49,10 @@ final class RemoteConfigManagerTests: TestCase {
         try super.tearDownWithError()
     }
 
+    func testIsDisabledDefaultsToFalse() {
+        expect(self.manager.isDisabled) == false
+    }
+
     func testFirstRunSendsDefaultAppDomainManifest() throws {
         self.diskCache.stubbedRead = nil
 
@@ -303,6 +307,71 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.blobStore.invokedWriteCount) == 0
         expect(self.blobStore.invokedRetainOnlyCount) == 0
         expect(self.blobFetcher.invokedPrefetchCount) == 0
+    }
+
+    func testFourHundredResponseDisablesRemoteConfig() {
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.sources:etag1"
+        )
+
+        expect(self.manager.isDisabled) == false
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .invalidRequest)))
+        expect(self.manager.isDisabled) == true
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+        expect(self.diskCache.invokedReadCount) == 1
+        expect(self.diskCache.invokedWriteCount) == 0
+        expect(self.blobStore.invokedWriteCount) == 0
+        expect(self.blobStore.invokedRetainOnlyCount) == 0
+        expect(self.blobFetcher.invokedPrefetchCount) == 0
+    }
+
+    func testTooManyRequestsResponseDisablesRemoteConfig() {
+        expect(self.manager.isDisabled) == false
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .tooManyRequests)))
+        expect(self.manager.isDisabled) == true
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+        expect(self.diskCache.invokedReadCount) == 1
+    }
+
+    func testServerErrorDoesNotDisableRemoteConfig() {
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
+        expect(self.manager.isDisabled) == false
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
+        expect(self.diskCache.invokedReadCount) == 2
+    }
+
+    func testTransportNetworkErrorDoesNotDisableRemoteConfig() {
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(
+            with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1))))
+        )
+        expect(self.manager.isDisabled) == false
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
+        expect(self.diskCache.invokedReadCount) == 2
+    }
+
+    func testClearCacheDoesNotReenableDisabledRemoteConfigRefresh() {
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
+        expect(self.manager.isDisabled) == true
+        self.manager.clearCache()
+        expect(self.manager.isDisabled) == true
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+        expect(self.diskCache.invokedClearCount) == 1
+        expect(self.blobStore.invokedClearCount) == 1
     }
 
     func testMalformedConfigPayloadLeavesCacheUntouched() throws {
@@ -814,6 +883,23 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 3
     }
 
+    func testStaleFourHundredResponseDoesNotDisableRemoteConfig() {
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.clearCache()
+        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+
+        self.remoteConfigAPI.complete(at: 0, with: .failure(Self.backendError(statusCode: .invalidRequest)))
+        expect(self.manager.isDisabled) == false
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
+
+        self.remoteConfigAPI.complete(at: 1, with: .success(.test(container: nil)))
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 3
+    }
+
     func testManagerCanSyncAgainAfterClearCache() throws {
         self.diskCache.stubbedRead = nil
         let response = """
@@ -916,6 +1002,13 @@ private extension RemoteConfigManagerTests {
         }
     }
 
+    static func backendError(statusCode: HTTPStatusCode) -> BackendError {
+        return .networkError(.errorResponse(
+            .init(code: .unknownError, originalCode: BackendErrorCode.unknownError.rawValue),
+            statusCode
+        ))
+    }
+
     static func container(
         config: String,
         contentElements: [Data] = []
@@ -1008,9 +1101,11 @@ private final class MockRemoteConfigDiskCache: RemoteConfigDiskCacheType {
 
     private(set) var invokedWriteCount = 0
     private(set) var invokedWriteParameter: PersistedRemoteConfiguration?
+    private(set) var invokedReadCount = 0
     private(set) var invokedClearCount = 0
 
     func read() -> PersistedRemoteConfiguration? {
+        self.invokedReadCount += 1
         return self.readHandler?() ?? self.stubbedRead
     }
 


### PR DESCRIPTION
## Description

As a safety feature we'd like to be able to kill the remote config mechanism in the SDKs in case any issues arise. This PR makes sure that in case a 4xx error is received the remote config mechanism shuts itself down for the current session.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote-config networking behavior on client errors (including all 4xx, not only explicit kill codes), which could stop config updates until a new manager/session if misclassified errors occur.
> 
> **Overview**
> Adds a **session-scoped kill switch** for remote config: after any **4xx** HTTP error on a refresh, the manager stops issuing further refreshes for the rest of that manager instance’s lifetime.
> 
> Exposes **`isDisabled`** on `RemoteConfigManagerType` and blocks **`prepareRefreshIfNeeded`** when disabled. **`handleFailure`** now applies disable under the same lock as the epoch check so stale responses (e.g. after **`clearCache`**) cannot flip the flag; **`clearCache`** still clears disk/blob state but **does not** re-enable refresh. Only **`BackendError`** network **errorResponse** paths with status **400–499** trigger disable—5xx and transport errors keep retry behavior.
> 
> Unit tests cover 400/429, non-disabling 5xx/transport, disabled refresh short-circuiting API/cache work, and stale 4xx after cache clear.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae98799d4a7cdb8f5204603ce049dae480100010. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->