### PR TITLE
fix(remote-config): rearm exhausted blob sources + in memory knownRefs

### DIFF
--- a/Sources/Networking/RemoteConfigBlobFetcher.swift
+++ b/Sources/Networking/RemoteConfigBlobFetcher.swift
@@ -124,7 +124,11 @@ private actor RemoteConfigBlobFetchScheduler {
 
     /// Enqueues low-priority work without a waiting continuation.
     func prefetch(refs: [String]) {
-        if refs.contains(where: { RemoteConfigBlobRefHelpers.isValid($0) && !self.blobStore.contains(ref: $0) }) {
+        let wouldDownload: (String) -> Bool = { ref in
+            RemoteConfigBlobRefHelpers.isValid(ref) && !self.blobStore.contains(ref: ref)
+        }
+
+        if refs.contains(where: wouldDownload) {
             self.restartBlobSourcesIfExhausted()
         }
 

--- a/Sources/Networking/RemoteConfigBlobFetcher.swift
+++ b/Sources/Networking/RemoteConfigBlobFetcher.swift
@@ -93,7 +93,12 @@ private actor RemoteConfigBlobFetchScheduler {
     /// Enqueues a high-priority consumer request and suspends until that ref resolves.
     func ensureDownloaded(ref: String) async -> Bool {
         return await withCheckedContinuation { continuation in
-            self.enqueue(ref: ref, priority: .high, continuation: continuation)
+            self.enqueue(
+                ref: ref,
+                priority: .high,
+                continuation: continuation,
+                restartsExhaustedSources: true
+            )
         }
     }
 
@@ -119,6 +124,10 @@ private actor RemoteConfigBlobFetchScheduler {
 
     /// Enqueues low-priority work without a waiting continuation.
     func prefetch(refs: [String]) {
+        if refs.contains(where: { RemoteConfigBlobRefHelpers.isValid($0) && !self.blobStore.contains(ref: $0) }) {
+            self.restartBlobSourcesIfExhausted()
+        }
+
         for ref in refs {
             self.enqueue(ref: ref, priority: .low, continuation: nil)
         }
@@ -195,7 +204,8 @@ private actor RemoteConfigBlobFetchScheduler {
     private func enqueue(
         ref: String,
         priority: Priority,
-        continuation: CheckedContinuation<Bool, Never>?
+        continuation: CheckedContinuation<Bool, Never>?,
+        restartsExhaustedSources: Bool = false
     ) {
         guard RemoteConfigBlobRefHelpers.isValid(ref) else {
             Logger.error(Strings.remoteConfig.malformedBlobRef(ref))
@@ -206,6 +216,10 @@ private actor RemoteConfigBlobFetchScheduler {
         guard !self.blobStore.contains(ref: ref) else {
             continuation?.resume(returning: true)
             return
+        }
+
+        if restartsExhaustedSources {
+            self.restartBlobSourcesIfExhausted()
         }
 
         // Coalesce duplicate queued requests into one future download, keeping every waiting consumer.
@@ -237,6 +251,11 @@ private actor RemoteConfigBlobFetchScheduler {
             continuations: continuation.map { [$0] } ?? []
         )
         self.scheduleDownloads()
+    }
+
+    /// Starts a new blob-source pass when a previous request exhausted every known source.
+    private func restartBlobSourcesIfExhausted() {
+        self.sourceProvider.restartIfExhausted(for: .blob)
     }
 
     /// Starts queued downloads until the concurrency limit is reached.

--- a/Sources/Networking/RemoteConfigBlobStore.swift
+++ b/Sources/Networking/RemoteConfigBlobStore.swift
@@ -133,7 +133,10 @@ private extension RemoteConfigBlobStore {
             var data = Data()
             data.append(contentsOf: bytes.bindMemory(to: UInt8.self))
             try data.write(to: fileURL, options: .atomic)
-            var refs = self.loadedRefsWithoutLock()
+            guard var refs = self.knownRefs else {
+                return true
+            }
+
             refs.insert(ref)
             self.knownRefs = refs
             return true
@@ -147,13 +150,17 @@ private extension RemoteConfigBlobStore {
         let validRefs = refs.filter(RemoteConfigBlobRefHelpers.isValid)
         refs.subtracting(validRefs).forEach { Logger.error(Strings.remoteConfig.malformedBlobRef($0)) }
 
-        guard let directoryURL = self.directoryURL,
-              let contents = try? self.fileManager.contentsOfDirectory(
+        guard let directoryURL = self.directoryURL else {
+            self.knownRefs = []
+            return
+        }
+
+        guard let contents = try? self.fileManager.contentsOfDirectory(
                 at: directoryURL,
                 includingPropertiesForKeys: [.isRegularFileKey],
                 options: []
               ) else {
-            self.knownRefs = []
+            self.knownRefs = nil
             return
         }
 
@@ -165,7 +172,7 @@ private extension RemoteConfigBlobStore {
             }
         }
 
-        self.knownRefs = self.loadedRefsWithoutLock().intersection(validRefs)
+        self.knownRefs = self.scannedRefsWithoutLock()?.intersection(validRefs)
     }
 
     func clearWithoutLock() {
@@ -177,11 +184,11 @@ private extension RemoteConfigBlobStore {
 
         do {
             try self.fileManager.removeItem(at: directoryURL)
+            self.knownRefs = []
         } catch {
             Logger.error(Strings.remoteConfig.failedToClearBlobStore(error))
+            self.knownRefs = nil
         }
-
-        self.knownRefs = []
     }
 
     static let blobsDirectoryName = "blobs"
@@ -208,14 +215,27 @@ private extension RemoteConfigBlobStore {
             return knownRefs
         }
 
+        guard self.directoryURL != nil else {
+            self.knownRefs = []
+            return []
+        }
+
+        guard let scannedRefs = self.scannedRefsWithoutLock() else {
+            return []
+        }
+
+        self.knownRefs = scannedRefs
+        return scannedRefs
+    }
+
+    func scannedRefsWithoutLock() -> Set<String>? {
         guard let directoryURL = self.directoryURL,
               let contents = try? self.fileManager.contentsOfDirectory(
                 at: directoryURL,
                 includingPropertiesForKeys: [.isRegularFileKey],
                 options: []
               ) else {
-            self.knownRefs = []
-            return []
+            return nil
         }
 
         let scannedRefs = contents.reduce(into: Set<String>()) { refs, fileURL in
@@ -226,7 +246,6 @@ private extension RemoteConfigBlobStore {
 
             refs.insert(fileURL.lastPathComponent)
         }
-        self.knownRefs = scannedRefs
         return scannedRefs
     }
 

--- a/Sources/Networking/RemoteConfigBlobStore.swift
+++ b/Sources/Networking/RemoteConfigBlobStore.swift
@@ -27,6 +27,10 @@ final class RemoteConfigBlobStore: RemoteConfigBlobStoreType {
     private let directoryURL: URL?
     private let lock = Lock(.nonRecursive)
 
+    /// Refs known to be on disk. Loaded once from a disk scan, then kept in sync by writes, pruning, and clear.
+    /// If disk and index ever diverge, `read(ref:)` evicts stale refs on a miss so later fetches can recover.
+    private var knownRefs: Set<String>?
+
     init(
         fileManager: FileManager = .default,
         directoryURL: URL? = RemoteConfigBlobStore.defaultDirectoryURL
@@ -80,16 +84,13 @@ final class RemoteConfigBlobStore: RemoteConfigBlobStoreType {
 private extension RemoteConfigBlobStore {
 
     func containsWithoutLock(ref: String) -> Bool {
-        guard let fileURL = self.fileURL(for: ref) else {
-            return false
-        }
-
-        return self.isRegularFile(fileURL)
+        return self.loadedRefsWithoutLock().contains(ref)
     }
 
     func readWithoutLock(ref: String) -> Data? {
         guard let fileURL = self.fileURL(for: ref),
-              self.fileManager.fileExists(atPath: fileURL.path) else {
+              self.isRegularFile(fileURL) else {
+            self.knownRefs?.remove(ref)
             return nil
         }
 
@@ -125,6 +126,9 @@ private extension RemoteConfigBlobStore {
             var data = Data()
             data.append(contentsOf: bytes.bindMemory(to: UInt8.self))
             try data.write(to: fileURL, options: .atomic)
+            var refs = self.loadedRefsWithoutLock()
+            refs.insert(ref)
+            self.knownRefs = refs
             return true
         } catch {
             Logger.error(Strings.remoteConfig.failedToWriteBlob(ref, error))
@@ -133,23 +137,7 @@ private extension RemoteConfigBlobStore {
     }
 
     func cachedRefsWithoutLock() -> Set<String> {
-        guard let directoryURL = self.directoryURL,
-              let contents = try? self.fileManager.contentsOfDirectory(
-                at: directoryURL,
-                includingPropertiesForKeys: [.isRegularFileKey],
-                options: []
-              ) else {
-            return []
-        }
-
-        return contents.reduce(into: Set<String>()) { refs, fileURL in
-            guard self.isRegularFile(fileURL),
-                  RemoteConfigBlobRefHelpers.isValid(fileURL.lastPathComponent) else {
-                return
-            }
-
-            refs.insert(fileURL.lastPathComponent)
-        }
+        return self.loadedRefsWithoutLock()
     }
 
     func retainOnlyWithoutLock(_ refs: Set<String>) {
@@ -162,6 +150,7 @@ private extension RemoteConfigBlobStore {
                 includingPropertiesForKeys: [.isRegularFileKey],
                 options: []
               ) else {
+            self.knownRefs = []
             return
         }
 
@@ -172,11 +161,14 @@ private extension RemoteConfigBlobStore {
                 Logger.error(Strings.remoteConfig.failedToDeleteBlob(fileURL.lastPathComponent, error))
             }
         }
+
+        self.knownRefs = self.loadedRefsWithoutLock().intersection(validRefs)
     }
 
     func clearWithoutLock() {
         guard let directoryURL = self.directoryURL,
               self.fileManager.fileExists(atPath: directoryURL.path) else {
+            self.knownRefs = []
             return
         }
 
@@ -185,6 +177,8 @@ private extension RemoteConfigBlobStore {
         } catch {
             Logger.error(Strings.remoteConfig.failedToClearBlobStore(error))
         }
+
+        self.knownRefs = []
     }
 
     static let blobsDirectoryName = "blobs"
@@ -205,4 +199,32 @@ private extension RemoteConfigBlobStore {
     func isRegularFile(_ fileURL: URL) -> Bool {
         return (try? fileURL.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true
     }
+
+    func loadedRefsWithoutLock() -> Set<String> {
+        if let knownRefs {
+            return knownRefs
+        }
+
+        guard let directoryURL = self.directoryURL,
+              let contents = try? self.fileManager.contentsOfDirectory(
+                at: directoryURL,
+                includingPropertiesForKeys: [.isRegularFileKey],
+                options: []
+              ) else {
+            self.knownRefs = []
+            return []
+        }
+
+        let scannedRefs = contents.reduce(into: Set<String>()) { refs, fileURL in
+            guard self.isRegularFile(fileURL),
+                  RemoteConfigBlobRefHelpers.isValid(fileURL.lastPathComponent) else {
+                return
+            }
+
+            refs.insert(fileURL.lastPathComponent)
+        }
+        self.knownRefs = scannedRefs
+        return scannedRefs
+    }
+
 }

--- a/Sources/Networking/RemoteConfigBlobStore.swift
+++ b/Sources/Networking/RemoteConfigBlobStore.swift
@@ -63,7 +63,7 @@ final class RemoteConfigBlobStore: RemoteConfigBlobStoreType {
 
     func cachedRefs() -> Set<String> {
         return self.lock.perform {
-            return self.cachedRefsWithoutLock()
+            return self.loadedRefsWithoutLock()
         }
     }
 
@@ -84,7 +84,14 @@ final class RemoteConfigBlobStore: RemoteConfigBlobStoreType {
 private extension RemoteConfigBlobStore {
 
     func containsWithoutLock(ref: String) -> Bool {
-        return self.loadedRefsWithoutLock().contains(ref)
+        guard self.loadedRefsWithoutLock().contains(ref),
+              let fileURL = self.fileURL(for: ref),
+              self.isRegularFile(fileURL) else {
+            self.knownRefs?.remove(ref)
+            return false
+        }
+
+        return true
     }
 
     func readWithoutLock(ref: String) -> Data? {
@@ -134,10 +141,6 @@ private extension RemoteConfigBlobStore {
             Logger.error(Strings.remoteConfig.failedToWriteBlob(ref, error))
             return false
         }
-    }
-
-    func cachedRefsWithoutLock() -> Set<String> {
-        return self.loadedRefsWithoutLock()
     }
 
     func retainOnlyWithoutLock(_ refs: Set<String>) {

--- a/Sources/Networking/RemoteConfigSourceProvider.swift
+++ b/Sources/Networking/RemoteConfigSourceProvider.swift
@@ -58,6 +58,10 @@ protocol RemoteConfigSourceProviderType: AnyObject {
     /// Rewinds the given purpose to its first source, e.g. to start fresh on a new fetch cycle.
     func restart(for purpose: RemoteConfigSourceHandle.Purpose)
 
+    /// Rewinds the given purpose only if every known source for it has already been exhausted.
+    @discardableResult
+    func restartIfExhausted(for purpose: RemoteConfigSourceHandle.Purpose) -> Bool
+
 }
 
 /// Read-only access to a topic's persisted item index (metadata only — no blob bytes, no waiting).
@@ -149,6 +153,21 @@ final class RemoteConfigSourceProvider: RemoteConfigSourceProviderType {
             if !self.rebuildIfNeeded() {
                 self.failover(for: purpose).restart()
             }
+        }
+    }
+
+    @discardableResult
+    func restartIfExhausted(for purpose: RemoteConfigSourceHandle.Purpose) -> Bool {
+        return self.lock.perform {
+            if self.rebuildIfNeeded() {
+                return true
+            }
+
+            let failover = self.failover(for: purpose)
+            guard failover.current == nil else { return false }
+
+            failover.restart()
+            return true
         }
     }
 

--- a/Tests/UnitTests/Mocks/MockRemoteConfigSourceProvider.swift
+++ b/Tests/UnitTests/Mocks/MockRemoteConfigSourceProvider.swift
@@ -31,4 +31,11 @@ final class MockRemoteConfigSourceProvider: RemoteConfigSourceProviderType {
         self.restartedPurposes.append(purpose)
     }
 
+    private(set) var restartIfExhaustedPurposes: [RemoteConfigSourceHandle.Purpose] = []
+    var stubbedRestartIfExhaustedResult = false
+    func restartIfExhausted(for purpose: RemoteConfigSourceHandle.Purpose) -> Bool {
+        self.restartIfExhaustedPurposes.append(purpose)
+        return self.stubbedRestartIfExhaustedResult
+    }
+
 }

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobFetcherTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobFetcherTests.swift
@@ -141,7 +141,51 @@ final class RemoteConfigBlobFetcherTests: TestCase {
 
         let result = await task.value
         expect(result) == false
+        expect(self.downloader.requestedRefs) == [ref]
         expect(self.blobStore.invokedWriteCount) == 0
+    }
+
+    func testEnsureDownloadedRestartsExhaustedSourcesForNewRequest() async {
+        let failingRef = Self.ref(for: "failing".asData)
+        let recoveryPayload = "recovery".asData
+        let recoveryRef = Self.ref(for: recoveryPayload)
+
+        let failing = Task { await self.fetcher.ensureDownloaded(ref: failingRef) }
+        await self.downloader.waitForRequestCount(1)
+        self.downloader.complete(ref: failingRef, with: .failure(TestError()))
+
+        let failingResult = await failing.value
+        expect(failingResult) == false
+
+        let recovery = Task { await self.fetcher.ensureDownloaded(ref: recoveryRef) }
+        await self.downloader.waitForRequestCount(2)
+        self.downloader.complete(ref: recoveryRef, with: .success(recoveryPayload))
+
+        let recoveryResult = await recovery.value
+        expect(recoveryResult) == true
+        expect(self.downloader.requestedRefs) == [failingRef, recoveryRef]
+        expect(self.blobStore.invokedWriteParameters?.data) == recoveryPayload
+    }
+
+    func testPrefetchRestartsExhaustedSourcesForNewRequest() async {
+        let failingRef = Self.ref(for: "failing".asData)
+        let recoveryPayload = "prefetch recovery".asData
+        let recoveryRef = Self.ref(for: recoveryPayload)
+
+        let failing = Task { await self.fetcher.ensureDownloaded(ref: failingRef) }
+        await self.downloader.waitForRequestCount(1)
+        self.downloader.complete(ref: failingRef, with: .failure(TestError()))
+
+        let failingResult = await failing.value
+        expect(failingResult) == false
+
+        self.fetcher.prefetch(refs: [recoveryRef])
+        await self.downloader.waitForRequestCount(2)
+        self.downloader.complete(ref: recoveryRef, with: .success(recoveryPayload))
+        await self.waitForScheduledTaskToReachFetcher()
+
+        expect(self.downloader.requestedRefs) == [failingRef, recoveryRef]
+        expect(self.blobStore.invokedWriteParameters?.data) == recoveryPayload
     }
 
     func testNetworkFailureRetriesNextSource() async {

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobStoreTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobStoreTests.swift
@@ -93,6 +93,16 @@ final class RemoteConfigBlobStoreTests: TestCase {
         expect(self.blobStore.contains(ref: Self.refA)) == false
     }
 
+    func testContainsSelfHealsCachedRefsWhenUnderlyingFileIsGone() throws {
+        self.write(ref: Self.refA, data: Data([1]))
+        expect(self.blobStore.contains(ref: Self.refA)) == true
+
+        try FileManager.default.removeItem(at: self.directoryURL.appendingPathComponent(Self.refA))
+
+        expect(self.blobStore.contains(ref: Self.refA)) == false
+        expect(self.blobStore.cachedRefs()).to(beEmpty())
+    }
+
     func testRetainOnlyDeletesUnreferencedBlobs() {
         self.write(ref: Self.refA, data: Data([1]))
         self.write(ref: Self.refB, data: Data([2]))

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobStoreTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobStoreTests.swift
@@ -83,6 +83,17 @@ final class RemoteConfigBlobStoreTests: TestCase {
         expect(self.blobStore.cachedRefs()) == [Self.refA, Self.refB]
     }
 
+    func testCachedRefsRetriesDiskScanAfterTransientDirectoryListingFailure() {
+        self.write(ref: Self.refA, data: Data([1]))
+        let fileManager = FailingFileManager()
+        let reopened = RemoteConfigBlobStore(fileManager: fileManager, directoryURL: self.directoryURL)
+
+        fileManager.failNextContentsOfDirectory = true
+
+        expect(reopened.cachedRefs()).to(beEmpty())
+        expect(reopened.cachedRefs()) == [Self.refA]
+    }
+
     func testReadSelfHealsCachedRefsWhenUnderlyingFileIsGone() throws {
         self.write(ref: Self.refA, data: Data([1]))
         expect(self.blobStore.contains(ref: Self.refA)) == true
@@ -171,6 +182,19 @@ final class RemoteConfigBlobStoreTests: TestCase {
         expect(FileManager.default.fileExists(atPath: self.directoryURL.path)) == false
     }
 
+    func testClearFailureDoesNotMarkExistingRefsAsMissing() {
+        let fileManager = FailingFileManager()
+        self.blobStore = RemoteConfigBlobStore(fileManager: fileManager, directoryURL: self.directoryURL)
+        self.write(ref: Self.refA, data: Data([1]))
+        expect(self.blobStore.contains(ref: Self.refA)) == true
+
+        fileManager.failNextRemoveItem = true
+        self.blobStore.clear()
+
+        expect(self.blobStore.contains(ref: Self.refA)) == true
+        expect(self.blobStore.cachedRefs()) == [Self.refA]
+    }
+
     func testClearIsNoOpWhenNothingHasBeenWritten() {
         self.blobStore.clear()
 
@@ -234,6 +258,39 @@ private extension RemoteConfigBlobStoreTests {
         return data.withUnsafeBytes { bytes in
             self.blobStore.write(ref: ref, bytes: bytes)
         }
+    }
+
+}
+
+private final class FailingFileManager: FileManager {
+
+    var failNextContentsOfDirectory = false
+    var failNextRemoveItem = false
+
+    override func contentsOfDirectory(
+        at url: URL,
+        includingPropertiesForKeys keys: [URLResourceKey]?,
+        options mask: FileManager.DirectoryEnumerationOptions = []
+    ) throws -> [URL] {
+        if self.failNextContentsOfDirectory {
+            self.failNextContentsOfDirectory = false
+            throw CocoaError(.fileReadUnknown)
+        }
+
+        return try super.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: keys,
+            options: mask
+        )
+    }
+
+    override func removeItem(at URL: URL) throws {
+        if self.failNextRemoveItem {
+            self.failNextRemoveItem = false
+            throw CocoaError(.fileWriteUnknown)
+        }
+
+        try super.removeItem(at: URL)
     }
 
 }

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobStoreTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobStoreTests.swift
@@ -51,6 +51,15 @@ final class RemoteConfigBlobStoreTests: TestCase {
         expect(self.blobStore.contains(ref: Self.refA)) == true
     }
 
+    func testContainsAndCachedRefsLoadBlobsFromPreviousInstance() {
+        self.write(ref: Self.refA, data: Data([1]))
+
+        let reopened = RemoteConfigBlobStore(directoryURL: self.directoryURL)
+
+        expect(reopened.contains(ref: Self.refA)) == true
+        expect(reopened.cachedRefs()) == [Self.refA]
+    }
+
     func testContainsReturnsFalseForDirectoryWithValidRefName() throws {
         try FileManager.default.createDirectory(
             at: self.directoryURL.appendingPathComponent(Self.refA, isDirectory: true),
@@ -74,6 +83,16 @@ final class RemoteConfigBlobStoreTests: TestCase {
         expect(self.blobStore.cachedRefs()) == [Self.refA, Self.refB]
     }
 
+    func testReadSelfHealsCachedRefsWhenUnderlyingFileIsGone() throws {
+        self.write(ref: Self.refA, data: Data([1]))
+        expect(self.blobStore.contains(ref: Self.refA)) == true
+
+        try FileManager.default.removeItem(at: self.directoryURL.appendingPathComponent(Self.refA))
+
+        expect(self.blobStore.read(ref: Self.refA)).to(beNil())
+        expect(self.blobStore.contains(ref: Self.refA)) == false
+    }
+
     func testRetainOnlyDeletesUnreferencedBlobs() {
         self.write(ref: Self.refA, data: Data([1]))
         self.write(ref: Self.refB, data: Data([2]))
@@ -82,6 +101,21 @@ final class RemoteConfigBlobStoreTests: TestCase {
 
         expect(self.blobStore.contains(ref: Self.refA)) == true
         expect(self.blobStore.contains(ref: Self.refB)) == false
+    }
+
+    func testRetainOnlyPrunesOrphanTempFilesAndInvalidNamedFiles() throws {
+        self.write(ref: Self.refA, data: Data([1]))
+        let orphanTemp = self.directoryURL.appendingPathComponent("rc_blob_orphan.tmp")
+        let invalidNamed = self.directoryURL.appendingPathComponent("not-a-valid-ref")
+        try Data([9]).write(to: orphanTemp)
+        try Data([9]).write(to: invalidNamed)
+
+        self.blobStore.retainOnly([Self.refA])
+
+        expect(FileManager.default.fileExists(atPath: orphanTemp.path)) == false
+        expect(FileManager.default.fileExists(atPath: invalidNamed.path)) == false
+        expect(self.blobStore.contains(ref: Self.refA)) == true
+        expect(self.blobStore.cachedRefs()) == [Self.refA]
     }
 
     func testRetainOnlyWithEmptySetClearsBlobs() {

--- a/Tests/UnitTests/Networking/RemoteConfigSourceProviderTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfigSourceProviderTests.swift
@@ -268,6 +268,56 @@ final class RemoteConfigSourceProviderTests: TestCase {
         expect(provider.getCurrent(for: .api)?.url) == Self.url("b")
     }
 
+    // MARK: - restartIfExhausted
+
+    func testRestartIfExhaustedRewindsAndReturnsTrueOnceSourcesAreExhausted() {
+        let provider = Self.apiProvider([Self.source("a"), Self.source("b")])
+
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!)
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!)
+        expect(provider.getCurrent(for: .api)).to(beNil())
+
+        expect(provider.restartIfExhausted(for: .api)) == true
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("a")
+    }
+
+    func testRestartIfExhaustedIsNoOpAndReturnsFalseWhileSourceIsCurrent() {
+        let provider = Self.apiProvider([Self.source("a"), Self.source("b")])
+
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!)
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("b")
+
+        expect(provider.restartIfExhausted(for: .api)) == false
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("b")
+    }
+
+    func testRestartIfExhaustedOnlyRewindsRequestedPurpose() {
+        let provider = Self.provider(
+            api: [Self.source("api1", priority: 0)],
+            blob: [Self.source("blob1", priority: 0), Self.source("blob2", priority: 10)]
+        )
+
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!)
+        provider.reportUnhealthy(provider.getCurrent(for: .blob)!)
+        expect(provider.getCurrent(for: .api)).to(beNil())
+
+        expect(provider.restartIfExhausted(for: .api)) == true
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("api1")
+        expect(provider.getCurrent(for: .blob)?.url) == Self.url("blob2")
+    }
+
+    func testRestartIfExhaustedReturnsTrueWhenChangedSourcesTopicAlreadyRearmedTheList() {
+        let store = FakeTopicStore(Self.sourcesTopic(api: [Self.source("a"), Self.source("b")], blob: []))
+        let provider = RemoteConfigSourceProvider(topicStore: store, randomizer: FakeRandomizer(0))
+
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!)
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("b")
+
+        store.sources = Self.sourcesTopic(api: [Self.source("x"), Self.source("y")], blob: [])
+        expect(provider.restartIfExhausted(for: .api)) == true
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("x")
+    }
+
     // MARK: - Sources topic changes
 
     func testChangedSourcesTopicRebuildsAndRestartsFromTheTop() {


### PR DESCRIPTION
Part of a stack of PRs, builds on https://github.com/RevenueCat/purchases-ios/pull/7118 and should be aligned with https://github.com/RevenueCat/purchases-android/pull/3698.

## Description
Like the Android equivalent, this PR is two fold;

Implements resetting the `sourceProvider` to start at the top of the list of blob sources again after exhausting all resources. By design we only reset on a new request from a consumer, not while downloading a list of sources when all sources fail for example.

This PR also introduces the in memory `knownRefs` list. Keeping track of a list of blob refs known to be on disk. This list is used for quick lookups. However we also have a self-healing component that gets triggered if upon reading a blob ref from disk it turns out the ref is no longer stored on disk. At that point the in-memory list will be updated to remove that blob ref, so future fetches can download it again and not get stuck.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches blob download failover and cache correctness paths; behavior changes are intentional recovery fixes with broad unit test coverage, but mistakes could cause extra network traffic or missed cache hits.
> 
> **Overview**
> Fixes remote config blob downloads getting stuck after all blob CDN sources are exhausted, and makes the on-disk blob cache faster and self-healing.
> 
> **Blob source rearm:** Adds `restartIfExhausted(for:)` on the source provider so failover rewinds to the first blob source only when there is no current source left. `ensureDownloaded` and prefetch (when any ref would actually be downloaded) call this before enqueueing, so a later consumer or prefetch can retry from the top without resetting mid-failover on the same request.
> 
> **In-memory `knownRefs`:** `RemoteConfigBlobStore` keeps a lazy-loaded set of refs believed on disk instead of scanning the directory on every `contains` / `cachedRefs`. Writes, `retainOnly`, and `clear` keep the set in sync; `read` / `contains` drop stale refs when the file is missing so the fetcher does not treat deleted blobs as cached. `retainOnly` also refreshes the index from a scan and prunes orphan temp/invalid files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8536c7425f775a5c862d4b3c6e7144efdc1b7298. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->