### PR TITLE
Expose preferred UI locale override APIs to Objective-C

### DIFF
--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -383,7 +383,7 @@ import Foundation
         /// - Parameter preferredUILocaleOverride: A locale string in the format "language_region" (e.g., "en_US").
         ///
         /// Defaults to `nil`, which means using the default user locale for RevenueCatUI components.
-        public func with(preferredUILocaleOverride: String?) -> Builder {
+        @objc public func with(preferredUILocaleOverride: String?) -> Builder {
             self.preferredLocale = preferredUILocaleOverride
             return self
         }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1820,7 +1820,7 @@ extension Purchases {
     ///
     /// Setting this will affect the display of RevenueCat UI components, such as the Paywalls.
     /// - Important: This method only takes effect after `Purchases` has been configured.
-    public func overridePreferredUILocale(_ locale: String?) {
+    @objc public func overridePreferredUILocale(_ locale: String?) {
         guard locale != self.systemInfo.preferredLocaleOverride else {
             return
         }

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCConfigurationAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCConfigurationAPI.m
@@ -13,7 +13,8 @@
 
 + (void)checkAPI {
     RCConfigurationBuilder *builder = [RCConfiguration builderWithAPIKey:@""];
-    RCConfiguration *config __unused = [[[[[[[[[[[[[[builder withApiKey:@""]
+    RCConfiguration *config __unused = [[[[[[[[[[[[[[[builder withApiKey:@""]
+                                                    withPreferredUILocaleOverride:@"de_DE"]
                                                    withPurchasesAreCompletedBy:RCPurchasesAreCompletedByRevenueCat storeKitVersion:RCStoreKitVersion2]
                                                   withUserDefaults:NSUserDefaults.standardUserDefaults]
                                                  withAppUserID:@""]

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCPurchasesAPI.m
@@ -86,6 +86,8 @@ NSURL *url;
     RCPackage *pack;
 
     [p invalidateCustomerInfoCache];
+    [p overridePreferredUILocale:@"de_DE"];
+    [p overridePreferredUILocale:nil];
 
     NSDictionary<NSString *, NSString *> *attributes = nil;
     RCAttribution __unused *attribution = p.attribution;

--- a/api/revenuecat-api-ios-simulator.swiftinterface
+++ b/api/revenuecat-api-ios-simulator.swiftinterface
@@ -1577,7 +1577,7 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func with(storeKitVersion version: RevenueCat.StoreKitVersion) -> RevenueCat.Configuration.Builder
     @objc public func with(automaticDeviceIdentifierCollectionEnabled: Swift.Bool) -> RevenueCat.Configuration.Builder
     @objc public func build() -> RevenueCat.Configuration
-    public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    @objc public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
     @objc deinit
   }
   @objc deinit
@@ -2250,7 +2250,7 @@ extension RevenueCat.Purchases {
   public static let paywallImageDownloadSession: Foundation.URLSession
 }
 extension RevenueCat.Purchases {
-  final public func overridePreferredUILocale(_ locale: Swift.String?)
+  @objc final public func overridePreferredUILocale(_ locale: Swift.String?)
 }
 extension RevenueCat.Purchases {
   @discardableResult

--- a/api/revenuecat-api-ios.swiftinterface
+++ b/api/revenuecat-api-ios.swiftinterface
@@ -1577,7 +1577,7 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func with(storeKitVersion version: RevenueCat.StoreKitVersion) -> RevenueCat.Configuration.Builder
     @objc public func with(automaticDeviceIdentifierCollectionEnabled: Swift.Bool) -> RevenueCat.Configuration.Builder
     @objc public func build() -> RevenueCat.Configuration
-    public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    @objc public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
     @objc deinit
   }
   @objc deinit
@@ -2250,7 +2250,7 @@ extension RevenueCat.Purchases {
   public static let paywallImageDownloadSession: Foundation.URLSession
 }
 extension RevenueCat.Purchases {
-  final public func overridePreferredUILocale(_ locale: Swift.String?)
+  @objc final public func overridePreferredUILocale(_ locale: Swift.String?)
 }
 extension RevenueCat.Purchases {
   @discardableResult

--- a/api/revenuecat-api-macos.swiftinterface
+++ b/api/revenuecat-api-macos.swiftinterface
@@ -1544,7 +1544,7 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func with(storeKitVersion version: RevenueCat.StoreKitVersion) -> RevenueCat.Configuration.Builder
     @objc public func with(automaticDeviceIdentifierCollectionEnabled: Swift.Bool) -> RevenueCat.Configuration.Builder
     @objc public func build() -> RevenueCat.Configuration
-    public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    @objc public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
     @objc deinit
   }
   @objc deinit
@@ -2189,7 +2189,7 @@ extension RevenueCat.Purchases {
   public static let paywallImageDownloadSession: Foundation.URLSession
 }
 extension RevenueCat.Purchases {
-  final public func overridePreferredUILocale(_ locale: Swift.String?)
+  @objc final public func overridePreferredUILocale(_ locale: Swift.String?)
 }
 extension RevenueCat.Purchases {
   @discardableResult

--- a/api/revenuecat-api-tvos-simulator.swiftinterface
+++ b/api/revenuecat-api-tvos-simulator.swiftinterface
@@ -1544,7 +1544,7 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func with(storeKitVersion version: RevenueCat.StoreKitVersion) -> RevenueCat.Configuration.Builder
     @objc public func with(automaticDeviceIdentifierCollectionEnabled: Swift.Bool) -> RevenueCat.Configuration.Builder
     @objc public func build() -> RevenueCat.Configuration
-    public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    @objc public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
     @objc deinit
   }
   @objc deinit
@@ -2181,7 +2181,7 @@ extension RevenueCat.Purchases {
   public static let paywallImageDownloadSession: Foundation.URLSession
 }
 extension RevenueCat.Purchases {
-  final public func overridePreferredUILocale(_ locale: Swift.String?)
+  @objc final public func overridePreferredUILocale(_ locale: Swift.String?)
 }
 extension RevenueCat.Purchases {
   @discardableResult

--- a/api/revenuecat-api-tvos.swiftinterface
+++ b/api/revenuecat-api-tvos.swiftinterface
@@ -1544,7 +1544,7 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func with(storeKitVersion version: RevenueCat.StoreKitVersion) -> RevenueCat.Configuration.Builder
     @objc public func with(automaticDeviceIdentifierCollectionEnabled: Swift.Bool) -> RevenueCat.Configuration.Builder
     @objc public func build() -> RevenueCat.Configuration
-    public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    @objc public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
     @objc deinit
   }
   @objc deinit
@@ -2181,7 +2181,7 @@ extension RevenueCat.Purchases {
   public static let paywallImageDownloadSession: Foundation.URLSession
 }
 extension RevenueCat.Purchases {
-  final public func overridePreferredUILocale(_ locale: Swift.String?)
+  @objc final public func overridePreferredUILocale(_ locale: Swift.String?)
 }
 extension RevenueCat.Purchases {
   @discardableResult

--- a/api/revenuecat-api-visionos-simulator.swiftinterface
+++ b/api/revenuecat-api-visionos-simulator.swiftinterface
@@ -1577,7 +1577,7 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func with(storeKitVersion version: RevenueCat.StoreKitVersion) -> RevenueCat.Configuration.Builder
     @objc public func with(automaticDeviceIdentifierCollectionEnabled: Swift.Bool) -> RevenueCat.Configuration.Builder
     @objc public func build() -> RevenueCat.Configuration
-    public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    @objc public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
     @objc deinit
   }
   @objc deinit
@@ -2250,7 +2250,7 @@ extension RevenueCat.Purchases {
   public static let paywallImageDownloadSession: Foundation.URLSession
 }
 extension RevenueCat.Purchases {
-  final public func overridePreferredUILocale(_ locale: Swift.String?)
+  @objc final public func overridePreferredUILocale(_ locale: Swift.String?)
 }
 extension RevenueCat.Purchases {
   @discardableResult

--- a/api/revenuecat-api-visionos.swiftinterface
+++ b/api/revenuecat-api-visionos.swiftinterface
@@ -1577,7 +1577,7 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func with(storeKitVersion version: RevenueCat.StoreKitVersion) -> RevenueCat.Configuration.Builder
     @objc public func with(automaticDeviceIdentifierCollectionEnabled: Swift.Bool) -> RevenueCat.Configuration.Builder
     @objc public func build() -> RevenueCat.Configuration
-    public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    @objc public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
     @objc deinit
   }
   @objc deinit
@@ -2250,7 +2250,7 @@ extension RevenueCat.Purchases {
   public static let paywallImageDownloadSession: Foundation.URLSession
 }
 extension RevenueCat.Purchases {
-  final public func overridePreferredUILocale(_ locale: Swift.String?)
+  @objc final public func overridePreferredUILocale(_ locale: Swift.String?)
 }
 extension RevenueCat.Purchases {
   @discardableResult

--- a/api/revenuecat-api-watchos-simulator.swiftinterface
+++ b/api/revenuecat-api-watchos-simulator.swiftinterface
@@ -1545,7 +1545,7 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func with(storeKitVersion version: RevenueCat.StoreKitVersion) -> RevenueCat.Configuration.Builder
     @objc public func with(automaticDeviceIdentifierCollectionEnabled: Swift.Bool) -> RevenueCat.Configuration.Builder
     @objc public func build() -> RevenueCat.Configuration
-    public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    @objc public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
     @objc deinit
   }
   @objc deinit
@@ -2182,7 +2182,7 @@ extension RevenueCat.Purchases {
   public static let paywallImageDownloadSession: Foundation.URLSession
 }
 extension RevenueCat.Purchases {
-  final public func overridePreferredUILocale(_ locale: Swift.String?)
+  @objc final public func overridePreferredUILocale(_ locale: Swift.String?)
 }
 extension RevenueCat.Purchases {
   @discardableResult

--- a/api/revenuecat-api-watchos.swiftinterface
+++ b/api/revenuecat-api-watchos.swiftinterface
@@ -1545,7 +1545,7 @@ extension RevenueCat.PaywallViewMode : Swift.Codable {
     @objc public func with(storeKitVersion version: RevenueCat.StoreKitVersion) -> RevenueCat.Configuration.Builder
     @objc public func with(automaticDeviceIdentifierCollectionEnabled: Swift.Bool) -> RevenueCat.Configuration.Builder
     @objc public func build() -> RevenueCat.Configuration
-    public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+    @objc public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
     @objc deinit
   }
   @objc deinit
@@ -2182,7 +2182,7 @@ extension RevenueCat.Purchases {
   public static let paywallImageDownloadSession: Foundation.URLSession
 }
 extension RevenueCat.Purchases {
-  final public func overridePreferredUILocale(_ locale: Swift.String?)
+  @objc final public func overridePreferredUILocale(_ locale: Swift.String?)
 }
 extension RevenueCat.Purchases {
   @discardableResult


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
purchases-kmp binds to this SDK via Kotlin/Native cinterop, which only sees the Objective-C surface. The preferred UI locale override APIs are Swift-only, so KMP cannot use them (SDK-4394).

### Description
Adds `@objc` to `Configuration.Builder.with(preferredUILocaleOverride:)` and `Purchases.overridePreferredUILocale(_:)`, matching the sibling methods. Additive ObjC exposure, no Swift API change. ObjC API testers updated to cover the new selectors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive ObjC surface only; no Swift API or runtime logic changes beyond what callers could already do from Swift.
> 
> **Overview**
> **Objective-C and Kotlin/Native consumers** can now set the RevenueCat UI locale the same way Swift apps already could, via configuration at build time and runtime override on `Purchases`.
> 
> Adds `@objc` to `Configuration.Builder.with(preferredUILocaleOverride:)` and `Purchases.overridePreferredUILocale(_:)` so they appear on the ObjC bridge (needed for purchases-kmp cinterop). Swift signatures and behavior are unchanged. Published `swiftinterface` stubs and ObjC API testers were updated to exercise `withPreferredUILocaleOverride:` and `overridePreferredUILocale:`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebc6a0bc109349bf4fbb8937c73a8c67be479d1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->