### PR TITLE
UIApplication may not be available in extensions

### DIFF
--- a/RevenueCatUI/CustomerCenter/URLUtilities.swift
+++ b/RevenueCatUI/CustomerCenter/URLUtilities.swift
@@ -52,8 +52,8 @@ enum URLUtilities {
     }
 
     static func openURLIfNotAppExtension(_ url: URL) {
-        guard !Self.isAppExtension,
-              let application = Self.sharedUIApplication else {
+        guard !UIApplication.isAppExtension,
+              let application = UIApplication.extensionSafeApplication else {
             return
         }
 
@@ -65,8 +65,8 @@ enum URLUtilities {
     }
 
     static func canOpenURL(_ url: URL) -> Bool {
-        guard !Self.isAppExtension,
-              let application = Self.sharedUIApplication else {
+        guard !UIApplication.isAppExtension,
+              let application = UIApplication.extensionSafeApplication else {
             return false
         }
         return application.canOpenURL(url)
@@ -83,18 +83,6 @@ extension URL {
         default:
             return false
         }
-    }
-
-}
-
-private extension URLUtilities {
-
-    static var isAppExtension: Bool {
-        Bundle.main.bundlePath.hasSuffix(".appex")
-    }
-
-    static var sharedUIApplication: UIApplication? {
-        return UIApplication.value(forKey: "sharedApplication") as? UIApplication
     }
 
 }

--- a/RevenueCatUI/Helpers/RuntimeUtils.swift
+++ b/RevenueCatUI/Helpers/RuntimeUtils.swift
@@ -20,3 +20,21 @@ enum RuntimeUtils {
  #endif
      }
  }
+
+#if canImport(UIKit)
+
+import UIKit
+
+extension UIApplication {
+
+    static var isAppExtension: Bool {
+        Bundle.main.bundlePath.hasSuffix(".appex")
+    }
+
+    static var extensionSafeApplication: UIApplication? {
+        return UIApplication.value(forKey: "sharedApplication") as? UIApplication
+    }
+
+}
+
+#endif

--- a/RevenueCatUI/Helpers/RuntimeUtils.swift
+++ b/RevenueCatUI/Helpers/RuntimeUtils.swift
@@ -21,7 +21,7 @@ enum RuntimeUtils {
      }
  }
 
-#if canImport(UIKit) && !os(wachOS)
+#if canImport(UIKit) && !os(watchOS)
 
 import UIKit
 

--- a/RevenueCatUI/Helpers/RuntimeUtils.swift
+++ b/RevenueCatUI/Helpers/RuntimeUtils.swift
@@ -21,7 +21,7 @@ enum RuntimeUtils {
      }
  }
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(wachOS)
 
 import UIKit
 

--- a/RevenueCatUI/Purchases+PreviewPaywall.swift
+++ b/RevenueCatUI/Purchases+PreviewPaywall.swift
@@ -57,7 +57,7 @@ extension Purchases {
         var presentationContext = viewController
 
         if presentationContext == nil {
-            presentationContext = UIApplication.shared
+            presentationContext = UIApplication.extensionSafeApplication?
                                                .connectedScenes
                                                .compactMap { $0 as? UIWindowScene }
                                                .flatMap { scene -> [(UIScene.ActivationState, UIWindow)] in
@@ -262,6 +262,14 @@ struct PreviewPaywallPresenter {
         }
 
         return true
+    }
+
+}
+
+private extension UIApplication {
+
+    static var extensionSafeApplication: UIApplication? {
+        return UIApplication.value(forKey: "sharedApplication") as? UIApplication
     }
 
 }

--- a/RevenueCatUI/Purchases+PreviewPaywall.swift
+++ b/RevenueCatUI/Purchases+PreviewPaywall.swift
@@ -266,12 +266,4 @@ struct PreviewPaywallPresenter {
 
 }
 
-private extension UIApplication {
-
-    static var extensionSafeApplication: UIApplication? {
-        return UIApplication.value(forKey: "sharedApplication") as? UIApplication
-    }
-
-}
-
 #endif


### PR DESCRIPTION
## Description
Retrieve a dynamically-available instance of `UIApplication` instead of using the `.shared` value, since `.shared` is not available when building in extensions.

Fixes #7122

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change for extension compatibility; main-app behavior should match when a shared application exists, with graceful no-ops when it does not.
> 
> **Overview**
> RevenueCatUI no longer references **`UIApplication.shared`**, which is unavailable when the SDK is built into app extensions. Shared helpers **`UIApplication.isAppExtension`** and **`UIApplication.extensionSafeApplication`** now live on **`RuntimeUtils.swift`** (via a UIKit extension), resolving the shared instance through KVC when not in an extension.
> 
> **`URLUtilities`** drops its private duplicate helpers and uses the new APIs for **`openURLIfNotAppExtension`** and **`canOpenURL`**. **`Purchases+PreviewPaywall`** uses **`extensionSafeApplication`** when auto-picking a presentation root view controller.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e6802d323d287016e95f4a2f30d3bcc4ee80d05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->