### PR TITLE
feat(remote-config): wire up remote config manager behind feature flag

### DIFF
--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -33,6 +33,7 @@ class IdentityManager: CurrentUserProvider {
     private let attributeSyncing: AttributeSyncing
     // Nil when the workflows endpoint is disabled, so no workflows state is touched on identity changes.
     private let workflowsCache: WorkflowsCache?
+    // Weak because RemoteConfigManager keeps IdentityManager as its CurrentUserProvider.
     weak var remoteConfigManager: RemoteConfigManagerType?
 
     private static let anonymousRegex = #"\$RCAnonymousID:([a-z0-9]{32})$"#

--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -33,6 +33,7 @@ class IdentityManager: CurrentUserProvider {
     private let attributeSyncing: AttributeSyncing
     // Nil when the workflows endpoint is disabled, so no workflows state is touched on identity changes.
     private let workflowsCache: WorkflowsCache?
+    weak var remoteConfigManager: RemoteConfigManagerType?
 
     private static let anonymousRegex = #"\$RCAnonymousID:([a-z0-9]{32})$"#
 
@@ -164,6 +165,7 @@ private extension IdentityManager {
             if case let .success((customerInfo, _)) = result {
                 self.deviceCache.clearCaches(oldAppUserID: oldAppUserID, andSaveWithNewUserID: newAppUserID)
                 self.workflowsCache?.clearCache()
+                self.remoteConfigManager?.clearCache()
                 self.customerInfoManager.cache(customerInfo: customerInfo, appUserID: newAppUserID)
                 self.copySubscriberAttributesToNewUserIfOldIsAnonymous(oldAppUserID: oldAppUserID,
                                                                        newAppUserID: newAppUserID)
@@ -198,6 +200,7 @@ private extension IdentityManager {
     func resetCacheAndSave(newUserID: String) {
         self.deviceCache.clearCaches(oldAppUserID: currentAppUserID, andSaveWithNewUserID: newUserID)
         self.workflowsCache?.clearCache()
+        self.remoteConfigManager?.clearCache()
         self.deviceCache.clearLatestNetworkAndAdvertisingIdsSent(appUserID: currentAppUserID)
         self.backend.clearHTTPClientCaches()
     }

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -99,6 +99,17 @@ class SystemInfo {
         return ProcessInfo.processInfo.arguments.contains("-EnableWorkflowsEndpoint")
     }
 
+    /// Whether remote config lifecycle wiring is enabled. Temporary gate while remote config is being rolled out.
+    var remoteConfigEnabled: Bool {
+        guard !self.dangerousSettings.customEntitlementComputation else { return false }
+
+        #if ENABLE_REMOTE_CONFIG
+        return true
+        #else
+        return false
+        #endif
+    }
+
     var isDebugBuild: Bool {
 #if DEBUG
         return true

--- a/Sources/Networking/RemoteConfigDiskCache.swift
+++ b/Sources/Networking/RemoteConfigDiskCache.swift
@@ -100,6 +100,14 @@ final class RemoteConfigDiskCache: RemoteConfigDiskCacheType {
 
 }
 
+extension RemoteConfigDiskCache: RemoteConfigTopicStoreType {
+
+    func topic(_ name: String) -> RemoteConfiguration.ConfigTopic? {
+        return self.read()?.topics.entries[name]
+    }
+
+}
+
 extension RemoteConfigDiskCache {
 
     static let basePath = "remote_config"

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -14,7 +14,25 @@ protocol RemoteConfigManagerType: AnyObject {
 
     func refreshRemoteConfig(isAppBackgrounded: Bool)
 
+    func refreshRemoteConfigIfStale(isAppBackgrounded: Bool)
+
     func clearCache()
+
+    func close()
+
+}
+
+final class NoOpRemoteConfigManager: RemoteConfigManagerType {
+
+    let isDisabled = true
+
+    func refreshRemoteConfig(isAppBackgrounded: Bool) {}
+
+    func refreshRemoteConfigIfStale(isAppBackgrounded: Bool) {}
+
+    func clearCache() {}
+
+    func close() {}
 
 }
 
@@ -32,23 +50,31 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     private let blobStore: RemoteConfigBlobStoreType
     private let blobFetcher: RemoteConfigBlobFetcherType
     private let currentUserProvider: CurrentUserProvider
+    private let dateProvider: DateProvider
+    private let cacheDurationInSeconds: (Bool) -> TimeInterval
     private let lock = Lock()
     private var isRefreshing = false
     private var isDisabledInternal = false
+    private var isClosed = false
     private var epoch = 0
+    private var lastRefreshedAt: Date?
 
     init(
         remoteConfigAPI: RemoteConfigAPIType,
         diskCache: RemoteConfigDiskCacheType,
         blobStore: RemoteConfigBlobStoreType,
         blobFetcher: RemoteConfigBlobFetcherType,
-        currentUserProvider: CurrentUserProvider
+        currentUserProvider: CurrentUserProvider,
+        dateProvider: DateProvider = DateProvider(),
+        cacheDurationInSeconds: @escaping (Bool) -> TimeInterval = { _ in 60 * 5.0 }
     ) {
         self.remoteConfigAPI = remoteConfigAPI
         self.diskCache = diskCache
         self.blobStore = blobStore
         self.blobFetcher = blobFetcher
         self.currentUserProvider = currentUserProvider
+        self.dateProvider = dateProvider
+        self.cacheDurationInSeconds = cacheDurationInSeconds
     }
 
     var isDisabled: Bool {
@@ -76,6 +102,12 @@ final class RemoteConfigManager: RemoteConfigManagerType {
         )
     }
 
+    func refreshRemoteConfigIfStale(isAppBackgrounded: Bool) {
+        guard self.shouldRefresh(isAppBackgrounded: isAppBackgrounded) else { return }
+
+        self.refreshRemoteConfig(isAppBackgrounded: isAppBackgrounded)
+    }
+
     /// Wipes cached remote config state, for example after an identity change.
     ///
     /// The epoch bump, refresh-guard release, and cache wipe are serialized with response persistence so a late
@@ -84,8 +116,17 @@ final class RemoteConfigManager: RemoteConfigManagerType {
         self.lock.perform {
             self.epoch += 1
             self.isRefreshing = false
+            self.lastRefreshedAt = nil
             self.diskCache.clear()
             self.blobStore.clear()
+        }
+    }
+
+    func close() {
+        self.lock.perform {
+            self.epoch += 1
+            self.isClosed = true
+            self.isRefreshing = false
         }
     }
 
@@ -96,9 +137,20 @@ private extension RemoteConfigManager {
     func prepareRefreshIfNeeded() -> Int? {
         return self.lock.perform {
             guard !self.isRefreshing,
-                  !self.isDisabledInternal else { return nil }
+                  !self.isDisabledInternal,
+                  !self.isClosed else { return nil }
             self.isRefreshing = true
             return self.epoch
+        }
+    }
+
+    func shouldRefresh(isAppBackgrounded: Bool) -> Bool {
+        return self.lock.perform {
+            guard !self.isClosed else { return false }
+            guard let lastRefreshedAt = self.lastRefreshedAt else { return true }
+
+            return self.dateProvider.now().timeIntervalSince(lastRefreshedAt)
+                > self.cacheDurationInSeconds(isAppBackgrounded)
         }
     }
 
@@ -150,7 +202,10 @@ private extension RemoteConfigManager {
         guard self.isCurrent(requestEpoch) else { return }
         defer { self.releaseGuardIfOwned(requestEpoch: requestEpoch) }
 
-        guard let container = fetchResult.container else { return }
+        guard let container = fetchResult.container else {
+            self.markRefreshedIfCurrent(requestEpoch)
+            return
+        }
 
         do {
             let response = try container.configElement.withDecodedPayloadBytes { bytes in
@@ -167,6 +222,7 @@ private extension RemoteConfigManager {
                     previous: previous,
                     response: response
                 )
+                self.markRefreshed()
             }
         } catch {
             Logger.error(Strings.remoteConfig.failedToParseResponse(error))
@@ -202,6 +258,18 @@ private extension RemoteConfigManager {
         return self.lock.perform {
             self.epoch == requestEpoch
         }
+    }
+
+    func markRefreshedIfCurrent(_ requestEpoch: Int) {
+        self.lock.perform {
+            guard self.epoch == requestEpoch else { return }
+
+            self.markRefreshed()
+        }
+    }
+
+    func markRefreshed() {
+        self.lastRefreshedAt = self.dateProvider.now()
     }
 
     /// Replays only requested prefetch blobs that are still present in the blob store.

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -217,12 +217,14 @@ private extension RemoteConfigManager {
 
             self.lock.perform {
                 guard self.epoch == requestEpoch else { return }
-                self.persist(
+                let didPersist = self.persist(
                     container: container,
                     previous: previous,
                     response: response
                 )
-                self.markRefreshed()
+                if didPersist {
+                    self.markRefreshed()
+                }
             }
         } catch {
             Logger.error(Strings.remoteConfig.failedToParseResponse(error))
@@ -285,7 +287,7 @@ private extension RemoteConfigManager {
         container: RemoteConfigContainer,
         previous: PersistedRemoteConfiguration?,
         response: RemoteConfiguration
-    ) {
+    ) -> Bool {
         let postSyncTopics = self.postSyncTopics(
             previous: previous,
             response: response
@@ -303,11 +305,13 @@ private extension RemoteConfigManager {
             topics: postSyncTopics
         )
 
-        guard self.diskCache.write(persistedConfiguration) else { return }
+        guard self.diskCache.write(persistedConfiguration) else { return false }
 
         self.extractInlineBlobs(from: container, keepingOnly: postSyncReferencedBlobRefs)
         self.blobStore.retainOnly(postSyncReferencedBlobRefs)
         self.blobFetcher.prefetch(refs: response.prefetchBlobs)
+
+        return true
     }
 
     /// Returns the full topic index that should be persisted after this response is applied.

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -286,6 +286,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
     private let productsManager: ProductsManagerType
     private let customerInfoManager: CustomerInfoManager
     private let eventsManager: EventsManagerType?
+    private let remoteConfigManager: RemoteConfigManagerType
 
     private var _adTracker: Any?
 
@@ -501,6 +502,29 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                                               ? workflowsCache : nil,
                                               appUserID: appUserID
         )
+        let remoteConfigManager: RemoteConfigManagerType = {
+            guard systemInfo.remoteConfigEnabled else { return NoOpRemoteConfigManager() }
+
+            let diskCache = RemoteConfigDiskCache()
+            let blobStore = RemoteConfigBlobStore()
+            let sourceProvider = RemoteConfigSourceProvider(topicStore: diskCache)
+            let blobFetcher = RemoteConfigBlobFetcher(
+                blobStore: blobStore,
+                sourceProvider: sourceProvider
+            )
+
+            return RemoteConfigManager(
+                remoteConfigAPI: backend.remoteConfigAPI,
+                diskCache: diskCache,
+                blobStore: blobStore,
+                blobFetcher: blobFetcher,
+                currentUserProvider: identityManager,
+                cacheDurationInSeconds: { isAppBackgrounded in
+                    deviceCache.cacheDurationInSeconds(isAppBackgrounded: isAppBackgrounded)
+                }
+            )
+        }()
+        identityManager.remoteConfigManager = remoteConfigManager
 
         let eventsManager: EventsManagerType?
         if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *),
@@ -725,6 +749,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                   productsManager: productsManager,
                   offeringsManager: offeringsManager,
                   workflowManager: workflowManager,
+                  remoteConfigManager: remoteConfigManager,
                   offlineEntitlementsManager: offlineEntitlementsManager,
                   purchasesOrchestrator: purchasesOrchestrator,
                   purchasedProductsFetcher: purchasedProductsFetcher,
@@ -760,6 +785,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
          productsManager: ProductsManagerType,
          offeringsManager: OfferingsManager,
          workflowManager: WorkflowManager,
+         remoteConfigManager: RemoteConfigManagerType,
          offlineEntitlementsManager: OfflineEntitlementsManager,
          purchasesOrchestrator: PurchasesOrchestrator,
          purchasedProductsFetcher: PurchasedProductsFetcherType?,
@@ -814,6 +840,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.productsManager = productsManager
         self.offeringsManager = offeringsManager
         self.workflowManager = workflowManager
+        self.remoteConfigManager = systemInfo.remoteConfigEnabled ? remoteConfigManager : NoOpRemoteConfigManager()
         self.offlineEntitlementsManager = offlineEntitlementsManager
         self.purchasesOrchestrator = purchasesOrchestrator
         self.purchasedProductsFetcher = purchasedProductsFetcher
@@ -826,6 +853,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.currentConfiguration = currentConfiguration
 
         super.init()
+
+        self.identityManager.remoteConfigManager = self.remoteConfigManager
 
         Logger.verbose(Strings.configure.purchases_init(self, paymentQueueWrapper))
 
@@ -884,6 +913,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.notificationCenter.removeObserver(self)
         self.paymentQueueWrapper.sk1Wrapper?.delegate = nil
         self.paymentQueueWrapper.sk2Wrapper?.delegate = nil
+        self.remoteConfigManager.close()
         self.customerInfoObservationDisposable?()
         self.privateDelegate = nil
     }
@@ -1055,6 +1085,7 @@ public extension Purchases {
 
             self.systemInfo.isApplicationBackgrounded { isAppBackgrounded in
                 self.updateOfferingsCache(isAppBackgrounded: isAppBackgrounded)
+                self.remoteConfigManager.refreshRemoteConfig(isAppBackgrounded: isAppBackgrounded)
             }
         }
     }
@@ -1200,6 +1231,7 @@ extension Purchases {
 
         self.systemInfo.isApplicationBackgrounded { isBackgrounded in
             self.updateOfferingsCache(isAppBackgrounded: isBackgrounded)
+            self.remoteConfigManager.refreshRemoteConfig(isAppBackgrounded: isBackgrounded)
         }
     }
 
@@ -2735,6 +2767,8 @@ private extension Purchases {
         if self.deviceCache.isOfferingsCacheStale(isAppBackgrounded: isAppBackgrounded) {
             self.updateOfferingsCache(isAppBackgrounded: isAppBackgrounded)
         }
+
+        self.remoteConfigManager.refreshRemoteConfigIfStale(isAppBackgrounded: isAppBackgrounded)
     }
 
     func updateAllCaches(completion: ((Result<CustomerInfo, PublicError>) -> Void)?) {
@@ -2769,6 +2803,7 @@ private extension Purchases {
         }
 
         self.updateOfferingsCache(isAppBackgrounded: isAppBackgrounded)
+        self.remoteConfigManager.refreshRemoteConfig(isAppBackgrounded: isAppBackgrounded)
     }
 
     // Used when delegate is being set

--- a/Tests/UnitTests/Identity/IdentityManagerTests.swift
+++ b/Tests/UnitTests/Identity/IdentityManagerTests.swift
@@ -356,6 +356,20 @@ class IdentityManagerTests: TestCase {
         expect(self.mockDeviceCache.clearWorkflowsListResponseCacheCount) == 1
     }
 
+    func testLogInClearsRemoteConfigCache() {
+        self.mockDeviceCache.stubbedAppUserID = "anonymous"
+        let manager = self.create(appUserID: nil)
+        let remoteConfigManager = MockRemoteConfigManager()
+        manager.remoteConfigManager = remoteConfigManager
+        self.mockIdentityAPI.stubbedLogInCompletionResult = .success((mockCustomerInfo, true))
+
+        waitUntil { completed in
+            manager.logIn(appUserID: "myUser") { _ in completed() }
+        }
+
+        expect(remoteConfigManager.invokedClearCacheCount) == 1
+    }
+
     func testLogOutClearsWorkflowsCache() {
         let manager = self.create(appUserID: nil)
         self.mockDeviceCache.stubbedAppUserID = "myUser"
@@ -368,6 +382,19 @@ class IdentityManagerTests: TestCase {
         expect(self.mockDeviceCache.clearWorkflowsListResponseCacheCount) == 1
     }
 
+    func testLogOutClearsRemoteConfigCache() {
+        let manager = self.create(appUserID: nil)
+        let remoteConfigManager = MockRemoteConfigManager()
+        manager.remoteConfigManager = remoteConfigManager
+        self.mockDeviceCache.stubbedAppUserID = "myUser"
+
+        waitUntil { completed in
+            manager.logOut { _ in completed() }
+        }
+
+        expect(remoteConfigManager.invokedClearCacheCount) == 1
+    }
+
     func testSwitchUserClearsWorkflowsCache() {
         let manager = self.create(appUserID: nil)
         self.mockDeviceCache.stubbedAppUserID = "myUser"
@@ -376,6 +403,17 @@ class IdentityManagerTests: TestCase {
         manager.switchUser(to: "newUser")
 
         expect(self.mockDeviceCache.clearWorkflowsListResponseCacheCount) == 1
+    }
+
+    func testSwitchUserClearsRemoteConfigCache() {
+        let manager = self.create(appUserID: nil)
+        let remoteConfigManager = MockRemoteConfigManager()
+        manager.remoteConfigManager = remoteConfigManager
+        self.mockDeviceCache.stubbedAppUserID = "myUser"
+
+        manager.switchUser(to: "newUser")
+
+        expect(remoteConfigManager.invokedClearCacheCount) == 1
     }
 
     func testLogInSyncsAttributes() {

--- a/Tests/UnitTests/Mocks/MockSystemInfo.swift
+++ b/Tests/UnitTests/Mocks/MockSystemInfo.swift
@@ -17,6 +17,7 @@ class MockSystemInfo: SystemInfo {
     var stubbedIsSandbox: Bool?
     var stubbedIsDebugBuild: Bool?
     var stubbedWorkflowsEndpointEnabled: Bool?
+    var stubbedRemoteConfigEnabled: Bool?
     var stubbedStorefront: StorefrontType?
     var stubbedApiKeyValidationResult: Configuration.APIKeyValidationResult?
 
@@ -104,6 +105,12 @@ class MockSystemInfo: SystemInfo {
 
     override var workflowsEndpointEnabled: Bool {
         return self.stubbedWorkflowsEndpointEnabled ?? super.workflowsEndpointEnabled
+    }
+
+    override var remoteConfigEnabled: Bool {
+        guard !self.dangerousSettings.customEntitlementComputation else { return false }
+
+        return self.stubbedRemoteConfigEnabled ?? super.remoteConfigEnabled
     }
 
     override var isDebugBuild: Bool {

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -19,6 +19,7 @@ final class RemoteConfigManagerTests: TestCase {
     private var blobStore: MockRemoteConfigBlobStore!
     private var blobFetcher: MockRemoteConfigBlobFetcher!
     private var currentUserProvider: MockCurrentUserProvider!
+    private var dateProvider: MockCurrentDateProvider!
     private var manager: RemoteConfigManager!
 
     override func setUpWithError() throws {
@@ -29,12 +30,18 @@ final class RemoteConfigManagerTests: TestCase {
         self.blobStore = MockRemoteConfigBlobStore()
         self.blobFetcher = MockRemoteConfigBlobFetcher()
         self.currentUserProvider = MockCurrentUserProvider(mockAppUserID: Self.appUserID)
+        self.dateProvider = MockCurrentDateProvider()
+        let dateProvider = self.dateProvider!
         self.manager = RemoteConfigManager(
             remoteConfigAPI: self.remoteConfigAPI,
             diskCache: self.diskCache,
             blobStore: self.blobStore,
             blobFetcher: self.blobFetcher,
-            currentUserProvider: self.currentUserProvider
+            currentUserProvider: self.currentUserProvider,
+            dateProvider: dateProvider,
+            cacheDurationInSeconds: { isAppBackgrounded in
+                isAppBackgrounded ? 10 : 5
+            }
         )
     }
 
@@ -43,6 +50,7 @@ final class RemoteConfigManagerTests: TestCase {
         self.blobFetcher = nil
         self.blobStore = nil
         self.currentUserProvider = nil
+        self.dateProvider = nil
         self.diskCache = nil
         self.remoteConfigAPI = nil
 
@@ -51,6 +59,78 @@ final class RemoteConfigManagerTests: TestCase {
 
     func testIsDisabledDefaultsToFalse() {
         expect(self.manager.isDisabled) == false
+    }
+
+    func testRefreshRemoteConfigIfStaleRefreshesWhenNeverRefreshed() {
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+    }
+
+    func testNoContentResponseMarksRefreshAsFresh() {
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
+
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+    }
+
+    func testFailureDoesNotMarkRefreshAsFresh() {
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1)))))
+
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
+    }
+
+    func testRefreshRemoteConfigIfStaleUsesForegroundAndBackgroundDurations() {
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
+
+        self.dateProvider.advance(by: 6)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: true)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
+    }
+
+    func testClosePreventsNewRefreshes() {
+        self.manager.close()
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 0
+    }
+
+    func testResponseThatArrivesAfterCloseDoesNotPersist() throws {
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.sources:etag2",
+          "active_topics": ["sources"],
+          "topics": {
+            "sources": {
+              "default": { "blob_ref": "newBlob" }
+            }
+          }
+        }
+        """
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.close()
+        self.remoteConfigAPI.complete(
+            with: .success(.test(container: try Self.container(config: response)))
+        )
+
+        expect(self.diskCache.invokedWriteCount) == 0
+        expect(self.blobStore.invokedWriteCount) == 0
+        expect(self.blobStore.invokedRetainOnlyCount) == 0
     }
 
     func testFirstRunSendsDefaultAppDomainManifest() throws {

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -848,6 +848,25 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.blobStore.invokedRetainOnlyCount) == 0
     }
 
+    func testContainerResponseDoesNotMarkRefreshAsFreshWhenCacheWriteFails() throws {
+        self.diskCache.stubbedWriteResult = false
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.sources:etag2",
+          "active_topics": ["sources"]
+        }
+        """
+
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(
+            with: .success(.test(container: try Self.container(config: response)))
+        )
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
+    }
+
     func testClearCacheWipesDiskCacheAndBlobStore() {
         self.manager.clearCache()
 

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -131,6 +131,7 @@ class BasePurchasesTests: TestCase {
         self.mockStoreMessagesHelper = .init()
         self.mockWinBackOfferEligibilityCalculator = MockWinBackOfferEligibilityCalculator()
         self.mockVirtualCurrencyManager = MockVirtualCurrencyManager()
+        self.mockRemoteConfigManager = MockRemoteConfigManager()
         self.webPurchaseRedemptionHelper = .init(backend: self.backend,
                                                  identityManager: self.identityManager,
                                                  customerInfoManager: self.customerInfoManager)
@@ -201,6 +202,7 @@ class BasePurchasesTests: TestCase {
     var webPurchaseRedemptionHelper: WebPurchaseRedemptionHelper!
     var diagnosticsTracker: DiagnosticsTrackerType?
     var mockVirtualCurrencyManager: MockVirtualCurrencyManager!
+    var mockRemoteConfigManager: MockRemoteConfigManager!
     var mockLocalTransactionMetadataStore: MockLocalTransactionMetadataStore!
     var transactionMetadataSyncHelper: TransactionMetadataSyncHelper!
 
@@ -349,6 +351,7 @@ class BasePurchasesTests: TestCase {
                                     paywallCache: self.paywallCache,
                                     operationDispatcher: self.mockOperationDispatcher
                                    ),
+                                   remoteConfigManager: self.mockRemoteConfigManager,
                                    offlineEntitlementsManager: self.mockOfflineEntitlementsManager,
                                    purchasesOrchestrator: self.purchasesOrchestrator,
                                    purchasedProductsFetcher: self.mockPurchasedProductsFetcher,
@@ -670,6 +673,37 @@ extension BasePurchasesTests {
 extension BasePurchasesTests.MockBackend: @unchecked Sendable {}
 extension BasePurchasesTests.MockOfferingsAPI: @unchecked Sendable {}
 
+final class MockRemoteConfigManager: RemoteConfigManagerType {
+
+    var isDisabled = false
+
+    private(set) var invokedRefreshRemoteConfigCount = 0
+    private(set) var invokedRefreshRemoteConfigIfStaleCount = 0
+    private(set) var invokedClearCacheCount = 0
+    private(set) var invokedCloseCount = 0
+    private(set) var invokedRefreshRemoteConfigParametersList: [Bool] = []
+    private(set) var invokedRefreshRemoteConfigIfStaleParametersList: [Bool] = []
+
+    func refreshRemoteConfig(isAppBackgrounded: Bool) {
+        self.invokedRefreshRemoteConfigCount += 1
+        self.invokedRefreshRemoteConfigParametersList.append(isAppBackgrounded)
+    }
+
+    func refreshRemoteConfigIfStale(isAppBackgrounded: Bool) {
+        self.invokedRefreshRemoteConfigIfStaleCount += 1
+        self.invokedRefreshRemoteConfigIfStaleParametersList.append(isAppBackgrounded)
+    }
+
+    func clearCache() {
+        self.invokedClearCacheCount += 1
+    }
+
+    func close() {
+        self.invokedCloseCount += 1
+    }
+
+}
+
 private extension BasePurchasesTests {
 
     func clearReferences() {
@@ -707,6 +741,7 @@ private extension BasePurchasesTests {
         self.paywallCache = nil
         self.eventsManager = nil
         self.webPurchaseRedemptionHelper = nil
+        self.mockRemoteConfigManager = nil
         self.transactionMetadataSyncHelper = nil
         self.mockLocalTransactionMetadataStore = nil
         self.purchases = nil

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -23,6 +23,41 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         expect(self.purchases).toNot(beNil())
     }
 
+    func testRemoteConfigFeatureOffUsesNoOpManager() {
+        self.setupPurchases()
+
+        self.notificationCenter.fireNotifications()
+
+        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigCount) == 0
+        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigIfStaleCount) == 0
+    }
+
+    func testRemoteConfigFeatureOnRefreshesDuringLifecycleCacheUpdates() {
+        self.systemInfo.stubbedRemoteConfigEnabled = true
+        self.setupPurchases()
+
+        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigCount).toEventually(equal(1))
+
+        self.notificationCenter.fireNotifications()
+
+        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigIfStaleCount) == 1
+        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigCount) == 1
+    }
+
+    func testRemoteConfigIsNoOpInCustomEntitlementsComputationMode() {
+        self.systemInfo = MockSystemInfo(finishTransactions: true, customEntitlementsComputation: true)
+        self.systemInfo.stubbedRemoteConfigEnabled = true
+
+        self.initializePurchasesInstance(appUserId: Self.appUserID)
+
+        self.notificationCenter.fireNotifications()
+        self.purchases.logOut(completion: nil)
+        self.purchases.internalSwitchUser(to: "new-user")
+
+        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigCount) == 0
+        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigIfStaleCount) == 0
+    }
+
     #if !os(watchOS)
     func testUsingSharedInstanceWithoutInitializingThrowsAssertion() {
         expect {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
@@ -61,10 +61,15 @@ class PurchasesLogInTests: BasePurchasesLogInTests {
     }
 
     func testLogOutWithSuccess() {
+        self.systemInfo.stubbedRemoteConfigEnabled = true
+        self.systemInfo.stubbedIsApplicationBackgrounded = true
+        Purchases.clearSingleton()
+        self.initializePurchasesInstance(appUserId: Self.appUserID)
         self.identityManager.mockLogOutError = nil
         self.backend.overrideCustomerInfoResult = .success(Self.mockLoggedOutInfo)
 
         expect(self.backend.getCustomerInfoCallCount).toEventually(equal(1))
+        let baselineRemoteConfigRefreshCount = self.mockRemoteConfigManager.invokedRefreshRemoteConfigCount
 
         let result = waitUntilValue { completed in
             self.purchases.logOut { customerInfo, error in
@@ -77,6 +82,8 @@ class PurchasesLogInTests: BasePurchasesLogInTests {
 
         expect(self.backend.getCustomerInfoCallCount) == 2
         expect(self.identityManager.invokedLogOutCount) == 1
+        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigCount) == baselineRemoteConfigRefreshCount + 1
+        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigParametersList.last) == true
     }
 
     func testLogOutWithFailure() {
@@ -129,6 +136,19 @@ class PurchasesLogInTests: BasePurchasesLogInTests {
         expect(self.mockOfferingsManager.invokedUpdateOfferingsCacheCount) == baselineOfferingsCallCount + 1
     }
 
+    func testSwitchUserRefreshesRemoteConfigWhenEnabled() {
+        self.systemInfo.stubbedRemoteConfigEnabled = true
+        self.systemInfo.stubbedIsApplicationBackgrounded = true
+        Purchases.clearSingleton()
+        self.initializePurchasesInstance(appUserId: "old-test-user-id")
+        let baselineRefreshCount = self.mockRemoteConfigManager.invokedRefreshRemoteConfigCount
+
+        self.purchases.internalSwitchUser(to: "test-user-id")
+
+        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigCount) == baselineRefreshCount + 1
+        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigParametersList.last) == true
+    }
+
     func testSwitchUserNoOpIfAppUserIDIsSameAsCurrent() {
         self.systemInfo = MockSystemInfo(finishTransactions: true, customEntitlementsComputation: true)
         Purchases.clearSingleton()
@@ -150,12 +170,15 @@ class PurchasesLogInTests: BasePurchasesLogInTests {
         let isAppBackgrounded: Bool = .random()
 
         self.systemInfo.stubbedIsApplicationBackgrounded = isAppBackgrounded
+        self.systemInfo.stubbedRemoteConfigEnabled = true
+        Purchases.clearSingleton()
+        self.initializePurchasesInstance(appUserId: nil)
 
         self.identityManager.mockAppUserID = Self.mockLoggedInInfo.originalAppUserId
         self.identityManager.mockIsAnonymous = false
         self.identityManager.mockLogInResult = .success((Self.mockLoggedInInfo, true))
 
-        expect(self.mockOfferingsManager.invokedUpdateOfferingsCacheCount) == 1
+        let baselineOfferingsCallCount = self.mockOfferingsManager.invokedUpdateOfferingsCacheCount
 
         waitUntil { completed in
             self.purchases.logIn(Self.appUserID) { _, _, _ in
@@ -163,17 +186,22 @@ class PurchasesLogInTests: BasePurchasesLogInTests {
             }
         }
 
-        expect(self.mockOfferingsManager.invokedUpdateOfferingsCacheCount) == 2
+        expect(self.mockOfferingsManager.invokedUpdateOfferingsCacheCount) == baselineOfferingsCallCount + 1
 
         let parameters = try XCTUnwrap(self.mockOfferingsManager.invokedUpdateOfferingsCacheParameters)
         expect(parameters.appUserID) == Self.mockLoggedInInfo.originalAppUserId
         expect(parameters.isAppBackgrounded) == isAppBackgrounded
+        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigParametersList.last) == isAppBackgrounded
     }
 
     func testLogInFailureDoesNotUpdateOfferingsCache() {
+        self.systemInfo.stubbedRemoteConfigEnabled = true
+        Purchases.clearSingleton()
+        self.initializePurchasesInstance(appUserId: nil)
         self.identityManager.mockLogInResult = .failure(.networkError(.offlineConnection()))
 
-        expect(self.mockOfferingsManager.invokedUpdateOfferingsCacheCount) == 1
+        let baselineOfferingsCallCount = self.mockOfferingsManager.invokedUpdateOfferingsCacheCount
+        let baselineRemoteConfigRefreshCount = self.mockRemoteConfigManager.invokedRefreshRemoteConfigCount
 
         waitUntil { completed in
             self.purchases.logIn(Self.appUserID) { _, _, _ in
@@ -181,7 +209,8 @@ class PurchasesLogInTests: BasePurchasesLogInTests {
             }
         }
 
-        expect(self.mockOfferingsManager.invokedUpdateOfferingsCacheCount) == 1
+        expect(self.mockOfferingsManager.invokedUpdateOfferingsCacheCount) == baselineOfferingsCallCount
+        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigCount) == baselineRemoteConfigRefreshCount
     }
 
     // MARK: - StaticString appUserID

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -258,6 +258,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
                                 paywallCache: MockPaywallCacheWarming(),
                                 operationDispatcher: mockOperationDispatcher
                               ),
+                              remoteConfigManager: NoOpRemoteConfigManager(),
                               offlineEntitlementsManager: mockOfflineEntitlementsManager,
                               purchasesOrchestrator: purchasesOrchestrator,
                               purchasedProductsFetcher: mockPurchasedProductsFetcher,


### PR DESCRIPTION
Part of a stack of PRs, builds on #7120 and should be aligned with RevenueCat/purchases-android#3691.

## Description
This wires the `RemoteConfigManager` into the SDKs lifecycle. 

- Behind a compile time feature flag, `ENABLE_REMOTE_CONFIG` and only when not in CEC mode
  - When not available the remote config manager will be a no-op (`NoOpRemoteConfigManager`). Ensuring the rest of the codebase can stay as-is
  - Note: this also mean this isn't CI tested at the moment
- The remote config will be refreshed on app launch and on app foreground (assuming the cache is stale)
  - Cache staleness is done through the existing mechanisms and timings
- The fetched config still isn't used at the moment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core SDK init, identity transitions, and background/foreground cache paths; behavior is gated but adds network and cache coordination that could affect timing or stale data if mis-wired.
> 
> **Overview**
> Wires **remote config** into `Purchases` lifecycle behind `ENABLE_REMOTE_CONFIG` (disabled in custom entitlements computation). When off, a **`NoOpRemoteConfigManager`** is used so call sites stay unchanged.
> 
> **`RemoteConfigManager`** gains staleness-aware **`refreshRemoteConfigIfStale`** (reusing `DeviceCache` foreground/background TTLs), **`close()`** on teardown, and refresh bookkeeping so empty-but-successful responses count as fresh while failures and failed disk writes do not. **`IdentityManager`** clears remote config on login, logout, and user switch via a weak back-reference.
> 
> **`Purchases`** constructs the real manager (disk cache as topic store, blob store/fetcher) when enabled, refreshes on launch (`updateAllCaches`), foreground when stale, and after successful login, logout, and switch user. Fetched config is still not consumed by product features yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 816d14d132724343bfc4a0299ebf19ad198d62da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->