### PR TITLE
Add CI build step for app extension safe API checks

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1070,7 +1070,7 @@ jobs:
           no_output_timeout: 30m
       - slack-notify-on-fail
 
-  build-app-extension-safe:
+  check-app-extension-safe-api-usage:
     executor:
       name: macos-executor
       xcode_version: "26.5"
@@ -2442,7 +2442,7 @@ workflows:
             - approve-full-tests
           context:
             - slack-secrets
-      - build-app-extension-safe:
+      - check-app-extension-safe-api-usage:
           requires:
             - approve-full-tests
           context:
@@ -2502,7 +2502,7 @@ workflows:
             - installation-tests-carthage
             - api-tests
             - spm-receipt-parser
-            - build-app-extension-safe
+            - check-app-extension-safe-api-usage
             - revenuecat-admob-tests
             - deploy-purchase-tester
             - run-all-maestro-e2e-tests
@@ -2761,6 +2761,9 @@ workflows:
       - spm-receipt-parser:
           context:
             - slack-secrets
+      - check-app-extension-safe-api-usage:
+          context:
+            - slack-secrets
       - spm-revenuecat-ui-ios-15:
           context:
             - slack-secrets
@@ -2841,6 +2844,7 @@ workflows:
             - run-test-tvos-and-macos
             - run-test-watchos
             - spm-receipt-parser
+            - check-app-extension-safe-api-usage
             - spm-revenuecat-ui-ios-15
             - spm-revenuecat-ui-ios-16
             - run-revenuecat-ui-ios-18-and-17

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1070,6 +1070,31 @@ jobs:
           no_output_timeout: 30m
       - slack-notify-on-fail
 
+  build-app-extension-safe:
+    executor:
+      name: macos-executor
+      xcode_version: "26.5"
+    steps:
+      - checkout
+      - install-dependencies
+      - run:
+          name: Build RevenueCat with app extension safe APIs
+          command: bundle exec fastlane build_with_app_extension_safe_apis scheme:RevenueCat
+          no_output_timeout: 30m
+      - run:
+          name: Build RevenueCat_CustomEntitlementComputation with app extension safe APIs
+          command: bundle exec fastlane build_with_app_extension_safe_apis scheme:RevenueCat_CustomEntitlementComputation
+          no_output_timeout: 30m
+      - run:
+          name: Build ReceiptParser with app extension safe APIs
+          command: bundle exec fastlane build_with_app_extension_safe_apis scheme:"ReceiptParser (RevenueCat Workspace)"
+          no_output_timeout: 30m
+      - run:
+          name: Build RevenueCatUI with app extension safe APIs
+          command: bundle exec fastlane build_with_app_extension_safe_apis scheme:RevenueCatUI
+          no_output_timeout: 30m
+      - slack-notify-on-fail
+
   run-test-ios-18-and-17:
     executor:
       name: macos-executor
@@ -2417,6 +2442,11 @@ workflows:
             - approve-full-tests
           context:
             - slack-secrets
+      - build-app-extension-safe:
+          requires:
+            - approve-full-tests
+          context:
+            - slack-secrets
       - deploy-purchase-tester:
           dry_run: true
           requires:
@@ -2472,6 +2502,7 @@ workflows:
             - installation-tests-carthage
             - api-tests
             - spm-receipt-parser
+            - build-app-extension-safe
             - revenuecat-admob-tests
             - deploy-purchase-tester
             - run-all-maestro-e2e-tests

--- a/.circleci/generate-requested-jobs-config.js
+++ b/.circleci/generate-requested-jobs-config.js
@@ -17,7 +17,7 @@ const JOBS = {
   "backend-integration-tests-custom-entitlements": ["slack-secrets"],
   "backend-integration-tests-offline": ["slack-secrets"],
   "backend-integration-tests-other": ["slack-secrets"],
-  "build-app-extension-safe": ["slack-secrets"],
+  "check-app-extension-safe-api-usage": ["slack-secrets"],
   "build-xcode-265": ["slack-secrets"],
   "build-tv-watch-mac-and-visionos": ["slack-secrets"],
   "check-api-changes-revenuecat": ["slack-secrets-ios"],

--- a/.circleci/generate-requested-jobs-config.js
+++ b/.circleci/generate-requested-jobs-config.js
@@ -17,6 +17,7 @@ const JOBS = {
   "backend-integration-tests-custom-entitlements": ["slack-secrets"],
   "backend-integration-tests-offline": ["slack-secrets"],
   "backend-integration-tests-other": ["slack-secrets"],
+  "build-app-extension-safe": ["slack-secrets"],
   "build-xcode-265": ["slack-secrets"],
   "build-tv-watch-mac-and-visionos": ["slack-secrets"],
   "check-api-changes-revenuecat": ["slack-secrets-ios"],

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -919,6 +919,25 @@ platform :ios do
     build_release(platform: 'visionOS', scheme: 'RevenueCatUI')
   end
 
+  desc "Build a scheme with app-extension-safe API checks enabled"
+  lane :build_with_app_extension_safe_apis do |options|
+    scheme = options[:scheme] || UI.user_error!("Missing required option: scheme")
+
+    xcodebuild(
+      workspace: "RevenueCat.xcworkspace",
+      scheme: scheme,
+      destination: "generic/platform=iOS",
+      sdk: "iphoneos",
+      configuration: "Release",
+      xcargs: [
+        'CODE_SIGN_IDENTITY=""',
+        "CODE_SIGNING_REQUIRED=NO",
+        "ONLY_ACTIVE_ARCH=YES",
+        "APPLICATION_EXTENSION_API_ONLY=YES"
+      ].join(" ")
+    )
+  end
+
   desc "macOS build"
   lane :build_mac do |options|
     load_spm_dependencies


### PR DESCRIPTION
Adds a new CI step that will compile all SDK artifacts using the app-extension safe APIs only, through the `APPLICATION_EXTENSION_API_ONLY` build setting. This flag isn't set by default (obviously) so it's hard to catch these kinds of issues.

This should prevent us from accidentally shipping code that uses app extension unsafe APIs in the future. Preventing issues like https://github.com/RevenueCat/purchases-ios/issues/7122

Demo: https://app.circleci.com/pipelines/gh/RevenueCat/purchases-ios/40253/workflows/28fbd9bb-ac26-49e4-999e-34c01b29a07e/jobs/651138

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI and Fastlane build wiring; they do not alter default SDK build settings for customers, only add an extra compile gate.
> 
> **Overview**
> Adds **CI coverage** so SDK targets are built with **`APPLICATION_EXTENSION_API_ONLY=YES`**, catching use of APIs that are not allowed in app extensions before release.
> 
> A new Fastlane lane **`build_with_app_extension_safe_apis`** runs Release **iOS device** `xcodebuild` for a given scheme with that flag (alongside the usual unsigned build settings). CircleCI job **`check-app-extension-safe-api-usage`** (Xcode 26.5) invokes it for **`RevenueCat`**, **`RevenueCat_CustomEntitlementComputation`**, **`ReceiptParser (RevenueCat Workspace)`**, and **`RevenueCatUI`**.
> 
> The job is wired into the **full PR test suite** (after `approve-full-tests`), **`all-tasks-passed`**, **`release-or-main`**, and the **on-demand jobs** allowlist in **`generate-requested-jobs-config.js`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b911924666158b3749b94230b801c4d7d853b54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->