### PR TITLE
feat(remote-config): add observability logs

### DIFF
--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -22,8 +22,17 @@ enum RemoteConfigStrings {
     case duplicateSourceURL(String)
     case failedToParseResponse(Error)
     case malformedBlobRef(String)
+    case notModified
+    case prefetchEnqueued(Int)
+    case prefetchingBlobCount(Int)
+    case receivedConfiguration(activeTopics: [String], changedTopics: [String])
+    case refreshing(domain: String, manifestPresent: Bool, isAppBackgrounded: Bool)
     case refreshFailed(BackendError)
     case skippingInvalidBlob(String)
+    case persistedConfiguration(domain: String, activeTopicCount: Int, referencedBlobCount: Int)
+    case sourceUnhealthy(ref: String, hasNextSource: Bool)
+    case storedBlob(String, byteCount: Int, URL)
+    case storedInlineBlob(String, byteCount: Int)
 
 }
 
@@ -60,10 +69,33 @@ extension RemoteConfigStrings: LogMessage {
             "\(error.localizedDescription)"
         case let .malformedBlobRef(ref):
             return "Refusing remote config blob operation with malformed ref '\(ref)'."
+        case .notModified:
+            return "Remote config was not modified. Keeping cached configuration."
+        case let .prefetchEnqueued(count):
+            return "Enqueued \(count) remote config blob prefetch downloads."
+        case let .prefetchingBlobCount(count):
+            return "Prefetching \(count) remote config blobs requested by the latest configuration."
+        case let .receivedConfiguration(activeTopics, changedTopics):
+            return "Received remote config with \(activeTopics.count) active topics " +
+                "(\(activeTopics.sorted().joined(separator: ", "))) and \(changedTopics.count) changed topics " +
+                "(\(changedTopics.sorted().joined(separator: ", ")))."
+        case let .refreshing(domain, manifestPresent, isAppBackgrounded):
+            return "Refreshing remote config for domain '\(domain)' " +
+                "(manifestPresent: \(manifestPresent), isAppBackgrounded: \(isAppBackgrounded))."
         case let .refreshFailed(error):
             return "Remote config refresh failed. Keeping cached configuration. Error: \(error)"
         case let .skippingInvalidBlob(ref):
             return "Skipping remote config blob '\(ref)': checksum verification failed."
+        case let .persistedConfiguration(domain, activeTopicCount, referencedBlobCount):
+            return "Persisted remote config for domain '\(domain)' with \(activeTopicCount) active topics " +
+                "and \(referencedBlobCount) referenced blobs."
+        case let .sourceUnhealthy(ref, hasNextSource):
+            return "Marked remote config blob source unhealthy while downloading blob '\(ref)' " +
+                "(hasNextSource: \(hasNextSource))."
+        case let .storedBlob(ref, byteCount, url):
+            return "Stored remote config blob '\(ref)' with \(byteCount) bytes downloaded from \(url.absoluteString)."
+        case let .storedInlineBlob(ref, byteCount):
+            return "Stored inline remote config blob '\(ref)' with \(byteCount) bytes."
         }
     }
 

--- a/Sources/Networking/RemoteConfigBlobFetcher.swift
+++ b/Sources/Networking/RemoteConfigBlobFetcher.swift
@@ -127,8 +127,10 @@ private actor RemoteConfigBlobFetchScheduler {
         let wouldDownload: (String) -> Bool = { ref in
             RemoteConfigBlobRefHelpers.isValid(ref) && !self.blobStore.contains(ref: ref)
         }
+        let enqueuedCount = refs.filter(wouldDownload).count
 
-        if refs.contains(where: wouldDownload) {
+        if enqueuedCount > 0 {
+            Logger.verbose(Strings.remoteConfig.prefetchEnqueued(enqueuedCount))
             self.restartBlobSourcesIfExhausted()
         }
 
@@ -163,7 +165,12 @@ private actor RemoteConfigBlobFetchScheduler {
                         return false
                     }
 
-                    return self.blobStore.write(ref: ref, bytes: bytes)
+                    let didWrite = self.blobStore.write(ref: ref, bytes: bytes)
+                    if didWrite {
+                        Logger.verbose(Strings.remoteConfig.storedBlob(ref, byteCount: bytes.count, url))
+                    }
+
+                    return didWrite
                 }
             } catch {
                 Logger.error(Strings.remoteConfig.failedToDownloadBlob(ref, url, error))
@@ -172,6 +179,10 @@ private actor RemoteConfigBlobFetchScheduler {
                 }
 
                 self.sourceProvider.reportUnhealthy(source)
+                Logger.verbose(Strings.remoteConfig.sourceUnhealthy(
+                    ref: ref,
+                    hasNextSource: self.sourceProvider.getCurrent(for: .blob) != nil
+                ))
                 if self.blobStore.contains(ref: ref) {
                     return true
                 }

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -11,13 +11,9 @@ protocol RemoteConfigManagerType: AnyObject {
 
     /// Whether remote config should be ignored for the current manager lifetime.
     var isDisabled: Bool { get }
-
     func refreshRemoteConfig(isAppBackgrounded: Bool)
-
     func refreshRemoteConfigIfStale(isAppBackgrounded: Bool)
-
     func clearCache()
-
     func close()
 
 }
@@ -93,6 +89,10 @@ final class RemoteConfigManager: RemoteConfigManagerType {
             manifest: persisted?.manifest,
             prefetchedBlobs: self.cachedPrefetchedBlobRefs(from: persisted)
         )
+
+        Logger.verbose(Strings.remoteConfig.refreshing(
+            domain: request.domain, manifestPresent: request.manifest != nil, isAppBackgrounded: isAppBackgrounded
+        ))
 
         self.enqueueRefreshIfCurrent(
             request: request,
@@ -203,6 +203,7 @@ private extension RemoteConfigManager {
         defer { self.releaseGuardIfOwned(requestEpoch: requestEpoch) }
 
         guard let container = fetchResult.container else {
+            Logger.debug(Strings.remoteConfig.notModified)
             self.markRefreshedIfCurrent(requestEpoch)
             return
         }
@@ -288,6 +289,10 @@ private extension RemoteConfigManager {
         previous: PersistedRemoteConfiguration?,
         response: RemoteConfiguration
     ) -> Bool {
+        Logger.debug(Strings.remoteConfig.receivedConfiguration(
+            activeTopics: response.activeTopics, changedTopics: Array(response.topics.entries.keys)
+        ))
+
         let postSyncTopics = self.postSyncTopics(
             previous: previous,
             response: response
@@ -309,7 +314,16 @@ private extension RemoteConfigManager {
 
         self.extractInlineBlobs(from: container, keepingOnly: postSyncReferencedBlobRefs)
         self.blobStore.retainOnly(postSyncReferencedBlobRefs)
-        self.blobFetcher.prefetch(refs: response.prefetchBlobs)
+
+        Logger.debug(Strings.remoteConfig.persistedConfiguration(
+            domain: response.domain,
+            activeTopicCount: response.activeTopics.count,
+            referencedBlobCount: postSyncReferencedBlobRefs.count
+        ))
+
+        let refsToPrefetch = response.prefetchBlobs.filter { !self.blobStore.contains(ref: $0) }
+        Logger.verbose(Strings.remoteConfig.prefetchingBlobCount(refsToPrefetch.count))
+        self.blobFetcher.prefetch(refs: refsToPrefetch)
 
         return true
     }
@@ -359,7 +373,9 @@ private extension RemoteConfigManager {
                         )
                     }
 
-                    self.blobStore.write(ref: ref, bytes: bytes)
+                    if self.blobStore.write(ref: ref, bytes: bytes) {
+                        Logger.verbose(Strings.remoteConfig.storedInlineBlob(ref, byteCount: bytes.count))
+                    }
                 }
             } catch {
                 Logger.error(Strings.remoteConfig.skippingInvalidBlob(ref))
@@ -378,15 +394,6 @@ private extension BackendError {
         }
 
         return 400...499 ~= statusCode.rawValue
-    }
-
-}
-
-fileprivate extension RemoteConfiguration.Topics {
-
-    /// All blob refs referenced by this topic collection.
-    var blobRefs: Set<String> {
-        return Set(self.entries.values.flatMap { $0.values.compactMap(\.blobRef) })
     }
 
 }

--- a/Sources/Networking/Responses/RemoteConfiguration.swift
+++ b/Sources/Networking/Responses/RemoteConfiguration.swift
@@ -161,6 +161,15 @@ extension RemoteConfiguration.Topics: Codable {
 
 }
 
+extension RemoteConfiguration.Topics {
+
+    /// All blob refs referenced by this topic collection.
+    var blobRefs: Set<String> {
+        return Set(self.entries.values.flatMap { $0.values.compactMap(\.blobRef) })
+    }
+
+}
+
 private struct DynamicCodingKey: CodingKey, Hashable {
 
     let stringValue: String


### PR DESCRIPTION
Builds on iOS PR #7130 and should be aligned with Android PR RevenueCat/purchases-android#3705.

Adds additional logging for more observability of the remote config feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only changes plus skipping already-cached refs for prefetch; no auth, networking contract, or persistence schema changes.
> 
> **Overview**
> Adds **verbose/debug logging** across the remote config refresh and blob pipeline so support and engineering can trace sync without changing core behavior.
> 
> **Refresh and persistence:** Logs when a refresh starts (domain, manifest, background state), when the server returns **not modified**, when a new configuration is received (active/changed topic names), and after a successful disk persist (topic and referenced blob counts).
> 
> **Blob downloads:** Logs successful network and inline blob stores (ref + byte count), unhealthy source failover (and whether another source exists), prefetch enqueue counts in the fetcher, and how many blobs the manager still needs to prefetch (refs already on disk are skipped before calling prefetch).
> 
> **Cleanup:** Moves `RemoteConfiguration.Topics.blobRefs` from `RemoteConfigManager` into `RemoteConfiguration.swift` (no logic change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6228d7d92eb5cd68ba4d7f6b08b7e332a55295ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->