### PR TITLE
feat(remote-config): add APIs for reading topic/blob data from RemoteConfigManager

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -950,6 +950,7 @@
 		A1B2C3D42FE2000000000004 /* RemoteConfigManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE2000000000003 /* RemoteConfigManager.swift */; };
 		A1B2C3D42FE200000000000D /* RemoteConfigBlobStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE200000000000C /* RemoteConfigBlobStore.swift */; };
 		A1B2C3D42FE2000000000006 /* RemoteConfigStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE2000000000005 /* RemoteConfigStrings.swift */; };
+		A1B2C3D42FE7000000000002 /* RemoteConfigTopic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE7000000000001 /* RemoteConfigTopic.swift */; };
 		A1B2C3D42FE6000000000002 /* RemoteConfigBlobRefHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE6000000000001 /* RemoteConfigBlobRefHelpers.swift */; };
 		A1B2C3D42FE6000000000004 /* RemoteConfigBlobDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE6000000000003 /* RemoteConfigBlobDownloader.swift */; };
 		A1B2C3D42FE6000000000006 /* RemoteConfigBlobFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE6000000000005 /* RemoteConfigBlobFetcher.swift */; };
@@ -2929,6 +2930,7 @@
 		A1B2C3D42FE2000000000003 /* RemoteConfigManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigManager.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE200000000000C /* RemoteConfigBlobStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobStore.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE2000000000005 /* RemoteConfigStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigStrings.swift; sourceTree = "<group>"; };
+		A1B2C3D42FE7000000000001 /* RemoteConfigTopic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigTopic.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE6000000000001 /* RemoteConfigBlobRefHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobRefHelpers.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE6000000000003 /* RemoteConfigBlobDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobDownloader.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE6000000000005 /* RemoteConfigBlobFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobFetcher.swift; sourceTree = "<group>"; };
@@ -4595,6 +4597,7 @@
 				A1B2C3D42FE200000000000C /* RemoteConfigBlobStore.swift */,
 				A1B2C3D42FE2000000000001 /* RemoteConfigDiskCache.swift */,
 				A1B2C3D42FE2000000000003 /* RemoteConfigManager.swift */,
+				A1B2C3D42FE7000000000001 /* RemoteConfigTopic.swift */,
 				A1B2C3D42FE1000000000011 /* RemoteConfigSignatureContextProvider.swift */,
 			);
 			path = Networking;
@@ -7257,6 +7260,7 @@
 				A1B2C3D42FE2000000000002 /* RemoteConfigDiskCache.swift in Sources */,
 				A1B2C3D42FE2000000000004 /* RemoteConfigManager.swift in Sources */,
 				A1B2C3D42FE2000000000006 /* RemoteConfigStrings.swift in Sources */,
+				A1B2C3D42FE7000000000002 /* RemoteConfigTopic.swift in Sources */,
 				A1B2C3D42FE1000000000010 /* RemoteConfigSignatureContextProvider.swift in Sources */,
 				DB3395DD2F840A790079250C /* WorkflowResponseAction.swift in Sources */,
 				2CD72944268A826F00BFC976 /* Date+Extensions.swift in Sources */,

--- a/Sources/Networking/RemoteConfigDiskCache.swift
+++ b/Sources/Networking/RemoteConfigDiskCache.swift
@@ -11,6 +11,8 @@ protocol RemoteConfigDiskCacheType: AnyObject {
 
     func read() -> PersistedRemoteConfiguration?
 
+    func topic(_ topic: RemoteConfigTopic) -> RemoteConfiguration.ConfigTopic?
+
     @discardableResult
     func write(_ configuration: PersistedRemoteConfiguration) -> Bool
 
@@ -102,8 +104,8 @@ final class RemoteConfigDiskCache: RemoteConfigDiskCacheType {
 
 extension RemoteConfigDiskCache: RemoteConfigTopicStoreType {
 
-    func topic(_ name: String) -> RemoteConfiguration.ConfigTopic? {
-        return self.read()?.topics.entries[name]
+    func topic(_ topic: RemoteConfigTopic) -> RemoteConfiguration.ConfigTopic? {
+        return self.read()?.topics.entries[topic.wireName]
     }
 
 }

--- a/Sources/Networking/RemoteConfigDiskCache.swift
+++ b/Sources/Networking/RemoteConfigDiskCache.swift
@@ -7,11 +7,17 @@
 
 import Foundation
 
-protocol RemoteConfigDiskCacheType: AnyObject {
+/// Read-only access to a topic's persisted item index (metadata only, no blob bytes or waiting).
+protocol RemoteConfigTopicStoreType: AnyObject {
+
+    /// The saved items for `topic`, or `nil` when nothing has been persisted yet.
+    func topic(_ topic: RemoteConfigTopic) -> RemoteConfiguration.ConfigTopic?
+
+}
+
+protocol RemoteConfigDiskCacheType: RemoteConfigTopicStoreType {
 
     func read() -> PersistedRemoteConfiguration?
-
-    func topic(_ topic: RemoteConfigTopic) -> RemoteConfiguration.ConfigTopic?
 
     @discardableResult
     func write(_ configuration: PersistedRemoteConfiguration) -> Bool

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -93,7 +93,7 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     private var isClosed = false
     private var epoch = 0
     private var lastRefreshedAt: Date?
-    private var refreshContinuations: [CheckedContinuation<Bool, Never>] = []
+    private var refreshContinuations: [CheckedContinuation<Void, Never>] = []
 
     init(
         remoteConfigAPI: RemoteConfigAPIType,
@@ -195,7 +195,7 @@ final class RemoteConfigManager: RemoteConfigManagerType {
             self.blobStore.clear()
             return self.drainRefreshContinuations()
         }
-        continuations.forEach { $0.resume(returning: true) }
+        continuations.forEach { $0.resume() }
     }
 
     func close() {
@@ -205,7 +205,7 @@ final class RemoteConfigManager: RemoteConfigManagerType {
             self.isRefreshing = false
             return self.drainRefreshContinuations()
         }
-        continuations.forEach { $0.resume(returning: true) }
+        continuations.forEach { $0.resume() }
     }
 
 }
@@ -266,13 +266,13 @@ private extension RemoteConfigManager {
     @discardableResult
     func releaseGuardIfOwned(requestEpoch: Int) -> Bool {
         let continuations = self.lock.perform {
-            guard self.epoch == requestEpoch else { return nil as [CheckedContinuation<Bool, Never>]? }
+            guard self.epoch == requestEpoch else { return nil as [CheckedContinuation<Void, Never>]? }
             self.isRefreshing = false
             return self.drainRefreshContinuations()
         }
         guard let continuations else { return false }
 
-        continuations.forEach { $0.resume(returning: true) }
+        continuations.forEach { $0.resume() }
         return true
     }
 
@@ -320,7 +320,7 @@ private extension RemoteConfigManager {
         requestEpoch: Int
     ) {
         let continuations = self.lock.perform {
-            guard self.epoch == requestEpoch else { return nil as [CheckedContinuation<Bool, Never>]? }
+            guard self.epoch == requestEpoch else { return nil as [CheckedContinuation<Void, Never>]? }
 
             self.disableRefreshIfNeeded(for: error)
             self.isRefreshing = false
@@ -329,7 +329,7 @@ private extension RemoteConfigManager {
         }
 
         guard let continuations else { return }
-        continuations.forEach { $0.resume(returning: true) }
+        continuations.forEach { $0.resume() }
 
         Logger.error(Strings.remoteConfig.refreshFailed(error))
     }
@@ -370,21 +370,24 @@ private extension RemoteConfigManager {
     }
 
     func awaitInFlightRefresh() async -> Bool {
-        return await withCheckedContinuation { continuation in
-            let shouldResume = self.lock.perform {
+        var didRegisterWaiter = false
+        await withCheckedContinuation { continuation in
+            didRegisterWaiter = self.lock.perform {
                 guard self.isRefreshing else { return false }
 
                 self.refreshContinuations.append(continuation)
                 return true
             }
 
-            if !shouldResume {
-                continuation.resume(returning: false)
+            if !didRegisterWaiter {
+                continuation.resume()
             }
         }
+
+        return didRegisterWaiter
     }
 
-    func drainRefreshContinuations() -> [CheckedContinuation<Bool, Never>] {
+    func drainRefreshContinuations() -> [CheckedContinuation<Void, Never>] {
         defer { self.refreshContinuations = [] }
 
         return self.refreshContinuations

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -139,6 +139,12 @@ final class RemoteConfigManager: RemoteConfigManagerType {
         }
     }
 
+    private var canReadCommittedState: Bool {
+        return self.lock.perform {
+            !self.isDisabledInternal && !self.isClosed
+        }
+    }
+
     func refreshRemoteConfig(isAppBackgrounded: Bool) {
         guard let requestEpoch = self.prepareRefreshIfNeeded() else { return }
 
@@ -169,24 +175,26 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     }
 
     func topic(_ topic: RemoteConfigTopic) async -> RemoteConfiguration.ConfigTopic? {
-        guard !self.isDisabled else { return nil }
+        guard self.canReadCommittedState else { return nil }
         if let topic = await self.committedTopic(topic) {
-            return self.isDisabled ? nil : topic
+            return self.canReadCommittedState ? topic : nil
         }
 
         await self.awaitConfigForRead()
 
-        return self.isDisabled ? nil : await self.committedTopic(topic)
+        let topic = await self.committedTopic(topic)
+        return self.canReadCommittedState ? topic : nil
     }
 
     func blobData(for topic: RemoteConfigTopic, itemKey: String) async -> Data? {
-        guard !self.isDisabled else { return nil }
+        guard self.canReadCommittedState else { return nil }
 
         if let item = await self.committedTopic(topic)?[itemKey] {
             return await self.blobData(for: item)
         }
 
         await self.awaitConfigForRead()
+        guard self.canReadCommittedState else { return nil }
         guard let item = await self.committedTopic(topic)?[itemKey] else { return nil }
 
         return await self.blobData(for: item)
@@ -436,10 +444,13 @@ private extension RemoteConfigManager {
     func blobData(for item: RemoteConfiguration.ConfigItem) async -> Data? {
         guard let ref = item.blobRef else { return nil }
 
-        guard !self.isDisabled,
+        guard self.canReadCommittedState,
               await self.blobFetcher.ensureDownloaded(ref: ref) else { return nil }
 
-        return await self.readBlob(ref: ref)
+        guard self.canReadCommittedState else { return nil }
+
+        let data = await self.readBlob(ref: ref)
+        return self.canReadCommittedState ? data : nil
     }
 
     /// Reads committed blob bytes off the caller's executor.

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -88,6 +88,9 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     private let dateProvider: DateProvider
     private let cacheDurationInSeconds: (Bool) -> TimeInterval
 
+    /// Runs blocking committed-state reads away from the caller's executor.
+    private let readQueue = DispatchQueue(label: "com.revenuecat.remote-config.read")
+
     /// Serializes refresh ownership, epoch checks, and cache mutations against `clearCache()` and `close()`.
     private let lock = Lock()
 
@@ -167,24 +170,24 @@ final class RemoteConfigManager: RemoteConfigManagerType {
 
     func topic(_ topic: RemoteConfigTopic) async -> RemoteConfiguration.ConfigTopic? {
         guard !self.isDisabled else { return nil }
-        if let topic = self.diskCache.topic(topic) {
+        if let topic = await self.committedTopic(topic) {
             return topic
         }
 
         await self.awaitConfigForRead()
 
-        return self.isDisabled ? nil : self.diskCache.topic(topic)
+        return self.isDisabled ? nil : await self.committedTopic(topic)
     }
 
     func blobData(for topic: RemoteConfigTopic, itemKey: String) async -> Data? {
         guard !self.isDisabled else { return nil }
 
-        if let item = self.diskCache.topic(topic)?[itemKey] {
+        if let item = await self.committedTopic(topic)?[itemKey] {
             return await self.blobData(for: item)
         }
 
         await self.awaitConfigForRead()
-        guard let item = self.diskCache.topic(topic)?[itemKey] else { return nil }
+        guard let item = await self.committedTopic(topic)?[itemKey] else { return nil }
 
         return await self.blobData(for: item)
     }
@@ -419,6 +422,13 @@ private extension RemoteConfigManager {
         return self.refreshContinuations
     }
 
+    /// Reads committed topic metadata off the caller's executor.
+    func committedTopic(_ topic: RemoteConfigTopic) async -> RemoteConfiguration.ConfigTopic? {
+        return await self.performRead {
+            self.diskCache.topic(topic)
+        }
+    }
+
     /// Resolves an external blob item through the high-priority fetch path.
     ///
     /// Inline item metadata is returned by `topic(_:)`; this method only returns bytes for items backed by
@@ -429,7 +439,23 @@ private extension RemoteConfigManager {
         guard !self.isDisabled,
               await self.blobFetcher.ensureDownloaded(ref: ref) else { return nil }
 
-        return self.blobStore.read(ref: ref)
+        return await self.readBlob(ref: ref)
+    }
+
+    /// Reads committed blob bytes off the caller's executor.
+    func readBlob(ref: String) async -> Data? {
+        return await self.performRead {
+            self.blobStore.read(ref: ref)
+        }
+    }
+
+    /// Performs small blocking cache reads on the manager's read queue.
+    func performRead<T>(_ operation: @escaping () -> T) async -> T {
+        return await withCheckedContinuation { continuation in
+            self.readQueue.async {
+                continuation.resume(returning: operation())
+            }
+        }
     }
 
     /// Replays only requested prefetch blobs that are still present in the blob store.

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -87,12 +87,29 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     private let currentUserProvider: CurrentUserProvider
     private let dateProvider: DateProvider
     private let cacheDurationInSeconds: (Bool) -> TimeInterval
+
+    /// Serializes refresh ownership, epoch checks, and cache mutations against `clearCache()` and `close()`.
     private let lock = Lock()
+
+    /// Tracks the single config refresh whose completion read APIs may await.
     private var isRefreshing = false
+
+    /// Session-scoped kill switch set by disabling client errors. This is intentionally not reset by cache clears.
     private var isDisabledInternal = false
+
+    /// Teardown guard that prevents new refresh work after `close()`.
     private var isClosed = false
+
+    /// Incremented when local state is invalidated so late responses from older users/sessions are dropped.
     private var epoch = 0
+
+    /// In-memory staleness marker. Only successful `200` and `204` responses mark the config fresh.
     private var lastRefreshedAt: Date?
+
+    /// Read callers waiting for the current refresh to finish before rereading committed config state.
+    ///
+    /// These continuations carry no result because callers decide what to do by rereading disk state after the
+    /// refresh, clear, close, or failure completes.
     private var refreshContinuations: [CheckedContinuation<Void, Never>] = []
 
     init(
@@ -358,6 +375,10 @@ private extension RemoteConfigManager {
         self.lastRefreshedAt = self.dateProvider.now()
     }
 
+    /// Waits for committed config state to become available for read APIs.
+    ///
+    /// A read first joins existing refresh work. If no refresh is in flight and remote config is still enabled, it
+    /// starts one foreground refresh and waits for that attempt before the caller rereads disk state.
     func awaitConfigForRead() async {
         if await self.awaitInFlightRefresh() {
             return
@@ -369,6 +390,10 @@ private extension RemoteConfigManager {
         _ = await self.awaitInFlightRefresh()
     }
 
+    /// Joins the current refresh if one is active.
+    ///
+    /// Returns `true` only when the caller actually waited on refresh completion. Returning `false` lets callers
+    /// decide whether to start a new refresh attempt.
     func awaitInFlightRefresh() async -> Bool {
         var didRegisterWaiter = false
         await withCheckedContinuation { continuation in
@@ -387,12 +412,17 @@ private extension RemoteConfigManager {
         return didRegisterWaiter
     }
 
+    /// Removes and returns all read waiters so they can be resumed outside the lock.
     func drainRefreshContinuations() -> [CheckedContinuation<Void, Never>] {
         defer { self.refreshContinuations = [] }
 
         return self.refreshContinuations
     }
 
+    /// Resolves an external blob item through the high-priority fetch path.
+    ///
+    /// Inline item metadata is returned by `topic(_:)`; this method only returns bytes for items backed by
+    /// `blob_ref`.
     func blobData(for item: RemoteConfiguration.ConfigItem) async -> Data? {
         guard let ref = item.blobRef else { return nil }
 

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -388,16 +388,16 @@ private extension RemoteConfigManager {
 
     /// Waits for committed config state to become available for read APIs.
     ///
-    /// A read first joins existing refresh work. If no refresh is in flight and remote config is still enabled, it
-    /// starts one foreground refresh and waits for that attempt before the caller rereads disk state.
+    /// A read first joins existing refresh work. If no refresh is in flight and remote config is still readable, it
+    /// starts one foreground refresh only when stale and waits for that attempt before the caller rereads disk state.
     func awaitConfigForRead() async {
         if await self.awaitInFlightRefresh() {
             return
         }
 
-        guard !self.isDisabled else { return }
+        guard self.canReadCommittedState else { return }
 
-        self.refreshRemoteConfig(isAppBackgrounded: false)
+        self.refreshRemoteConfigIfStale(isAppBackgrounded: false)
         _ = await self.awaitInFlightRefresh()
     }
 

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -171,7 +171,7 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     func topic(_ topic: RemoteConfigTopic) async -> RemoteConfiguration.ConfigTopic? {
         guard !self.isDisabled else { return nil }
         if let topic = await self.committedTopic(topic) {
-            return topic
+            return self.isDisabled ? nil : topic
         }
 
         await self.awaitConfigForRead()

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -7,12 +7,21 @@
 
 import Foundation
 
+// swiftlint:disable file_length
+
 protocol RemoteConfigManagerType: AnyObject {
 
     /// Whether remote config should be ignored for the current manager lifetime.
     var isDisabled: Bool { get }
     func refreshRemoteConfig(isAppBackgrounded: Bool)
     func refreshRemoteConfigIfStale(isAppBackgrounded: Bool)
+    func topic(_ topic: RemoteConfigTopic) async -> RemoteConfiguration.ConfigTopic?
+    func blobData(for topic: RemoteConfigTopic, itemKey: String) async -> Data?
+    func blobData<T: Decodable>(
+        for topic: RemoteConfigTopic,
+        itemKey: String,
+        as type: T.Type
+    ) async throws -> T?
     func clearCache()
     func close()
 
@@ -25,6 +34,22 @@ final class NoOpRemoteConfigManager: RemoteConfigManagerType {
     func refreshRemoteConfig(isAppBackgrounded: Bool) {}
 
     func refreshRemoteConfigIfStale(isAppBackgrounded: Bool) {}
+
+    func topic(_ topic: RemoteConfigTopic) async -> RemoteConfiguration.ConfigTopic? {
+        return nil
+    }
+
+    func blobData(for topic: RemoteConfigTopic, itemKey: String) async -> Data? {
+        return nil
+    }
+
+    func blobData<T: Decodable>(
+        for topic: RemoteConfigTopic,
+        itemKey: String,
+        as type: T.Type
+    ) async throws -> T? {
+        return nil
+    }
 
     func clearCache() {}
 
@@ -54,6 +79,7 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     private var isClosed = false
     private var epoch = 0
     private var lastRefreshedAt: Date?
+    private var refreshContinuations: [CheckedContinuation<Bool, Never>] = []
 
     init(
         remoteConfigAPI: RemoteConfigAPIType,
@@ -108,26 +134,64 @@ final class RemoteConfigManager: RemoteConfigManagerType {
         self.refreshRemoteConfig(isAppBackgrounded: isAppBackgrounded)
     }
 
+    func topic(_ topic: RemoteConfigTopic) async -> RemoteConfiguration.ConfigTopic? {
+        guard !self.isDisabled else { return nil }
+        if let topic = self.diskCache.topic(topic) {
+            return topic
+        }
+
+        await self.awaitConfigForRead()
+
+        return self.isDisabled ? nil : self.diskCache.topic(topic)
+    }
+
+    func blobData(for topic: RemoteConfigTopic, itemKey: String) async -> Data? {
+        guard !self.isDisabled else { return nil }
+
+        if let item = self.diskCache.topic(topic)?[itemKey] {
+            return await self.blobData(for: item)
+        }
+
+        await self.awaitConfigForRead()
+        guard let item = self.diskCache.topic(topic)?[itemKey] else { return nil }
+
+        return await self.blobData(for: item)
+    }
+
+    func blobData<T: Decodable>(
+        for topic: RemoteConfigTopic,
+        itemKey: String,
+        as type: T.Type
+    ) async throws -> T? {
+        guard let data = await self.blobData(for: topic, itemKey: itemKey) else { return nil }
+
+        return try JSONDecoder.default.decode(type, from: data)
+    }
+
     /// Wipes cached remote config state, for example after an identity change.
     ///
     /// The epoch bump, refresh-guard release, and cache wipe are serialized with response persistence so a late
     /// response for a previous user is either fully persisted before the wipe or dropped after the epoch changes.
     func clearCache() {
-        self.lock.perform {
+        let continuations = self.lock.perform {
             self.epoch += 1
             self.isRefreshing = false
             self.lastRefreshedAt = nil
             self.diskCache.clear()
             self.blobStore.clear()
+            return self.drainRefreshContinuations()
         }
+        continuations.forEach { $0.resume(returning: true) }
     }
 
     func close() {
-        self.lock.perform {
+        let continuations = self.lock.perform {
             self.epoch += 1
             self.isClosed = true
             self.isRefreshing = false
+            return self.drainRefreshContinuations()
         }
+        continuations.forEach { $0.resume(returning: true) }
     }
 
 }
@@ -187,11 +251,15 @@ private extension RemoteConfigManager {
 
     @discardableResult
     func releaseGuardIfOwned(requestEpoch: Int) -> Bool {
-        return self.lock.perform {
-            guard self.epoch == requestEpoch else { return false }
+        let continuations = self.lock.perform {
+            guard self.epoch == requestEpoch else { return nil as [CheckedContinuation<Bool, Never>]? }
             self.isRefreshing = false
-            return true
+            return self.drainRefreshContinuations()
         }
+        guard let continuations else { return false }
+
+        continuations.forEach { $0.resume(returning: true) }
+        return true
     }
 
     func handleSuccess(
@@ -237,16 +305,17 @@ private extension RemoteConfigManager {
         _ error: BackendError,
         requestEpoch: Int
     ) {
-        let isCurrentFailure = self.lock.perform {
-            guard self.epoch == requestEpoch else { return false }
+        let continuations = self.lock.perform {
+            guard self.epoch == requestEpoch else { return nil as [CheckedContinuation<Bool, Never>]? }
 
             self.disableRefreshIfNeeded(for: error)
             self.isRefreshing = false
 
-            return true
+            return self.drainRefreshContinuations()
         }
 
-        guard isCurrentFailure else { return }
+        guard let continuations else { return }
+        continuations.forEach { $0.resume(returning: true) }
 
         Logger.error(Strings.remoteConfig.refreshFailed(error))
     }
@@ -273,6 +342,47 @@ private extension RemoteConfigManager {
 
     func markRefreshed() {
         self.lastRefreshedAt = self.dateProvider.now()
+    }
+
+    func awaitConfigForRead() async {
+        if await self.awaitInFlightRefresh() {
+            return
+        }
+
+        guard !self.isDisabled else { return }
+
+        self.refreshRemoteConfig(isAppBackgrounded: false)
+        _ = await self.awaitInFlightRefresh()
+    }
+
+    func awaitInFlightRefresh() async -> Bool {
+        return await withCheckedContinuation { continuation in
+            let shouldResume = self.lock.perform {
+                guard self.isRefreshing else { return false }
+
+                self.refreshContinuations.append(continuation)
+                return true
+            }
+
+            if !shouldResume {
+                continuation.resume(returning: false)
+            }
+        }
+    }
+
+    func drainRefreshContinuations() -> [CheckedContinuation<Bool, Never>] {
+        defer { self.refreshContinuations = [] }
+
+        return self.refreshContinuations
+    }
+
+    func blobData(for item: RemoteConfiguration.ConfigItem) async -> Data? {
+        guard let ref = item.blobRef else { return nil }
+
+        guard !self.isDisabled,
+              await self.blobFetcher.ensureDownloaded(ref: ref) else { return nil }
+
+        return self.blobStore.read(ref: ref)
     }
 
     /// Replays only requested prefetch blobs that are still present in the blob store.

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -148,56 +148,32 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     func refreshRemoteConfig(isAppBackgrounded: Bool) {
         guard let requestEpoch = self.prepareRefreshIfNeeded() else { return }
 
-        let persisted = self.diskCache.read()
-        let request = RemoteConfigRequest(
-            appUserID: self.currentUserProvider.currentAppUserID,
-            domain: persisted?.domain ?? Self.defaultDomain,
-            manifest: persisted?.manifest,
-            prefetchedBlobs: self.cachedPrefetchedBlobRefs(from: persisted)
-        )
-
-        Logger.verbose(Strings.remoteConfig.refreshing(
-            domain: request.domain, manifestPresent: request.manifest != nil, isAppBackgrounded: isAppBackgrounded
-        ))
-
-        self.enqueueRefreshIfCurrent(
-            request: request,
-            persisted: persisted,
-            isAppBackgrounded: isAppBackgrounded,
-            requestEpoch: requestEpoch
-        )
+        self.startRefresh(isAppBackgrounded: isAppBackgrounded, requestEpoch: requestEpoch)
     }
 
     func refreshRemoteConfigIfStale(isAppBackgrounded: Bool) {
-        guard self.shouldRefresh(isAppBackgrounded: isAppBackgrounded) else { return }
+        guard let requestEpoch = self.prepareRefreshIfStale(isAppBackgrounded: isAppBackgrounded) else { return }
 
-        self.refreshRemoteConfig(isAppBackgrounded: isAppBackgrounded)
+        self.startRefresh(isAppBackgrounded: isAppBackgrounded, requestEpoch: requestEpoch)
     }
 
     func topic(_ topic: RemoteConfigTopic) async -> RemoteConfiguration.ConfigTopic? {
-        guard self.canReadCommittedState else { return nil }
-        if let topic = await self.committedTopic(topic) {
-            return self.canReadCommittedState ? topic : nil
+        return await self.readCommittedState(refreshIfMissing: true) {
+            await self.committedTopic(topic)
         }
-
-        await self.awaitConfigForRead()
-
-        let topic = await self.committedTopic(topic)
-        return self.canReadCommittedState ? topic : nil
     }
 
     func blobData(for topic: RemoteConfigTopic, itemKey: String) async -> Data? {
-        guard self.canReadCommittedState else { return nil }
-
-        if let item = await self.committedTopic(topic)?[itemKey] {
-            return await self.blobData(for: item)
+        guard let itemSnapshot = await self.readCommittedStateSnapshot(refreshIfMissing: true, {
+            await self.committedTopic(topic)?[itemKey]
+        }),
+              let item = itemSnapshot.value else {
+            return nil
         }
 
-        await self.awaitConfigForRead()
-        guard self.canReadCommittedState else { return nil }
-        guard let item = await self.committedTopic(topic)?[itemKey] else { return nil }
-
-        return await self.blobData(for: item)
+        return await self.readCommittedState(epoch: itemSnapshot.epoch) {
+            await self.blobData(for: item)
+        }
     }
 
     func blobData<T: Decodable>(
@@ -250,14 +226,46 @@ private extension RemoteConfigManager {
         }
     }
 
-    func shouldRefresh(isAppBackgrounded: Bool) -> Bool {
+    func prepareRefreshIfStale(
+        isAppBackgrounded: Bool,
+        expectedEpoch: Int? = nil
+    ) -> Int? {
         return self.lock.perform {
-            guard !self.isClosed else { return false }
-            guard let lastRefreshedAt = self.lastRefreshedAt else { return true }
+            guard !self.isRefreshing,
+                  !self.isDisabledInternal,
+                  !self.isClosed else { return nil }
+            if let expectedEpoch {
+                guard self.epoch == expectedEpoch else { return nil }
+            }
+            if let lastRefreshedAt = self.lastRefreshedAt {
+                guard self.dateProvider.now().timeIntervalSince(lastRefreshedAt)
+                    > self.cacheDurationInSeconds(isAppBackgrounded) else { return nil }
+            }
 
-            return self.dateProvider.now().timeIntervalSince(lastRefreshedAt)
-                > self.cacheDurationInSeconds(isAppBackgrounded)
+            self.isRefreshing = true
+            return self.epoch
         }
+    }
+
+    func startRefresh(isAppBackgrounded: Bool, requestEpoch: Int) {
+        let persisted = self.diskCache.read()
+        let request = RemoteConfigRequest(
+            appUserID: self.currentUserProvider.currentAppUserID,
+            domain: persisted?.domain ?? Self.defaultDomain,
+            manifest: persisted?.manifest,
+            prefetchedBlobs: self.cachedPrefetchedBlobRefs(from: persisted)
+        )
+
+        Logger.verbose(Strings.remoteConfig.refreshing(
+            domain: request.domain, manifestPresent: request.manifest != nil, isAppBackgrounded: isAppBackgrounded
+        ))
+
+        self.enqueueRefreshIfCurrent(
+            request: request,
+            persisted: persisted,
+            isAppBackgrounded: isAppBackgrounded,
+            requestEpoch: requestEpoch
+        )
     }
 
     func enqueueRefreshIfCurrent(
@@ -388,16 +396,31 @@ private extension RemoteConfigManager {
 
     /// Waits for committed config state to become available for read APIs.
     ///
-    /// A read first joins existing refresh work. If no refresh is in flight and remote config is still readable, it
-    /// starts one foreground refresh only when stale and waits for that attempt before the caller rereads disk state.
-    func awaitConfigForRead() async {
+    /// A read first joins existing refresh work. If no refresh is in flight and remote config is still readable,
+    /// it starts one foreground refresh only when stale and waits for that attempt before the caller rereads
+    /// disk state. When an epoch is supplied, the wait/refresh is skipped if cache state changed since the
+    /// caller's initial committed read.
+    func awaitConfigForRead(expectedEpoch: Int? = nil) async {
+        if let expectedEpoch, !self.isReadable(epoch: expectedEpoch) {
+            return
+        }
+
         if await self.awaitInFlightRefresh() {
             return
         }
 
-        guard self.canReadCommittedState else { return }
+        if let expectedEpoch {
+            guard self.isReadable(epoch: expectedEpoch) else { return }
+        } else {
+            guard self.canReadCommittedState else { return }
+        }
 
-        self.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        if let requestEpoch = self.prepareRefreshIfStale(
+            isAppBackgrounded: false,
+            expectedEpoch: expectedEpoch
+        ) {
+            self.startRefresh(isAppBackgrounded: false, requestEpoch: requestEpoch)
+        }
         _ = await self.awaitInFlightRefresh()
     }
 
@@ -430,6 +453,71 @@ private extension RemoteConfigManager {
         return self.refreshContinuations
     }
 
+    /// Reads committed state only if the manager remains on the same epoch for the whole operation.
+    ///
+    /// If the value is missing, callers may opt into the read-facade behavior of awaiting or triggering one
+    /// foreground refresh before reading again. If `clearCache()`, `close()`, or disable happens during either
+    /// read, the result is discarded.
+    func readCommittedState<T>(
+        refreshIfMissing: Bool = false,
+        _ operation: () async -> T?
+    ) async -> T? {
+        return await self.readCommittedStateSnapshot(refreshIfMissing: refreshIfMissing, operation)?.value
+    }
+
+    func readCommittedState<T>(
+        epoch: Int,
+        _ operation: () async -> T?
+    ) async -> T? {
+        return await self.readCommittedStateSnapshot(epoch: epoch, operation)?.value
+    }
+
+    func readCommittedStateSnapshot<T>(
+        refreshIfMissing: Bool = false,
+        _ operation: () async -> T?
+    ) async -> (value: T?, epoch: Int)? {
+        guard let result = await self.readCurrentCommittedState(operation) else { return nil }
+        if result.value != nil || !refreshIfMissing {
+            return result
+        }
+
+        await self.awaitConfigForRead(expectedEpoch: result.epoch)
+        guard self.isReadable(epoch: result.epoch) else { return nil }
+
+        return await self.readCommittedStateSnapshot(epoch: result.epoch, operation)
+    }
+
+    func readCurrentCommittedState<T>(_ operation: () async -> T?) async -> (value: T?, epoch: Int)? {
+        guard let epoch = self.currentReadableEpoch() else { return nil }
+
+        return await self.readCommittedStateSnapshot(epoch: epoch, operation)
+    }
+
+    func readCommittedStateSnapshot<T>(
+        epoch: Int,
+        _ operation: () async -> T?
+    ) async -> (value: T?, epoch: Int)? {
+        guard self.isReadable(epoch: epoch) else { return nil }
+
+        let value = await operation()
+
+        return self.isReadable(epoch: epoch) ? (value, epoch) : nil
+    }
+
+    func currentReadableEpoch() -> Int? {
+        return self.lock.perform {
+            guard !self.isDisabledInternal, !self.isClosed else { return nil }
+
+            return self.epoch
+        }
+    }
+
+    func isReadable(epoch: Int) -> Bool {
+        return self.lock.perform {
+            !self.isDisabledInternal && !self.isClosed && self.epoch == epoch
+        }
+    }
+
     /// Reads committed topic metadata off the caller's executor.
     func committedTopic(_ topic: RemoteConfigTopic) async -> RemoteConfiguration.ConfigTopic? {
         return await self.performRead {
@@ -444,13 +532,9 @@ private extension RemoteConfigManager {
     func blobData(for item: RemoteConfiguration.ConfigItem) async -> Data? {
         guard let ref = item.blobRef else { return nil }
 
-        guard self.canReadCommittedState,
-              await self.blobFetcher.ensureDownloaded(ref: ref) else { return nil }
+        guard await self.blobFetcher.ensureDownloaded(ref: ref) else { return nil }
 
-        guard self.canReadCommittedState else { return nil }
-
-        let data = await self.readBlob(ref: ref)
-        return self.canReadCommittedState ? data : nil
+        return await self.readBlob(ref: ref)
     }
 
     /// Reads committed blob bytes off the caller's executor.

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -15,8 +15,22 @@ protocol RemoteConfigManagerType: AnyObject {
     var isDisabled: Bool { get }
     func refreshRemoteConfig(isAppBackgrounded: Bool)
     func refreshRemoteConfigIfStale(isAppBackgrounded: Bool)
+
+    /// Returns the committed item index for a known topic.
+    ///
+    /// If the topic is not cached, this waits for an in-flight refresh or triggers one foreground refresh before
+    /// reading again. Returns `nil` when the endpoint is disabled or the topic is still unavailable after refresh.
     func topic(_ topic: RemoteConfigTopic) async -> RemoteConfiguration.ConfigTopic?
+
+    /// Returns the blob payload bytes for an item referenced by `blob_ref`.
+    ///
+    /// Inline item metadata is exposed through `topic(_:)`; items without `blob_ref` return `nil`. Missing items
+    /// wait for an in-flight refresh or trigger one foreground refresh before resolving the blob on demand.
     func blobData(for topic: RemoteConfigTopic, itemKey: String) async -> Data?
+
+    /// Decodes a blob payload as a concrete `Decodable` type.
+    ///
+    /// Returns `nil` when the item or blob is unavailable. Throws when bytes are available but cannot be decoded.
     func blobData<T: Decodable>(
         for topic: RemoteConfigTopic,
         itemKey: String,

--- a/Sources/Networking/RemoteConfigSourceProvider.swift
+++ b/Sources/Networking/RemoteConfigSourceProvider.swift
@@ -64,14 +64,6 @@ protocol RemoteConfigSourceProviderType: AnyObject {
 
 }
 
-/// Read-only access to a topic's persisted item index (metadata only — no blob bytes, no waiting).
-protocol RemoteConfigTopicStoreType: AnyObject {
-
-    /// The saved items for `topic`, or `nil` when nothing has been persisted yet.
-    func topic(_ topic: RemoteConfigTopic) -> RemoteConfiguration.ConfigTopic?
-
-}
-
 /// The address book for remote config: hands out the current healthy api and blob sources and
 /// falls back to the next one when a source is reported unhealthy. Each purpose fails over
 /// independently.

--- a/Sources/Networking/RemoteConfigSourceProvider.swift
+++ b/Sources/Networking/RemoteConfigSourceProvider.swift
@@ -67,8 +67,8 @@ protocol RemoteConfigSourceProviderType: AnyObject {
 /// Read-only access to a topic's persisted item index (metadata only — no blob bytes, no waiting).
 protocol RemoteConfigTopicStoreType: AnyObject {
 
-    /// The saved items for `name`, or `nil` when the topic is unknown / nothing has been persisted yet.
-    func topic(_ name: String) -> RemoteConfiguration.ConfigTopic?
+    /// The saved items for `topic`, or `nil` when nothing has been persisted yet.
+    func topic(_ topic: RemoteConfigTopic) -> RemoteConfiguration.ConfigTopic?
 
 }
 
@@ -86,7 +86,6 @@ protocol RemoteConfigTopicStoreType: AnyObject {
 /// - Note: Thread-safe.
 final class RemoteConfigSourceProvider: RemoteConfigSourceProviderType {
 
-    private static let sourcesTopicName = "sources"
     private static let apiItem = "api"
     private static let blobItem = "blob"
     private static let sourcesKey = "sources"
@@ -182,7 +181,7 @@ final class RemoteConfigSourceProvider: RemoteConfigSourceProviderType {
     /// rebuild happened. Callers must hold `lock`.
     @discardableResult
     private func rebuildIfNeeded() -> Bool {
-        let topic = self.topicStore.topic(Self.sourcesTopicName)
+        let topic = self.topicStore.topic(.sources)
         guard topic != self.sourcesTopic else { return false }
 
         // Seed the new generation past any token the previous one could have handed out, so reports

--- a/Sources/Networking/RemoteConfigTopic.swift
+++ b/Sources/Networking/RemoteConfigTopic.swift
@@ -1,0 +1,24 @@
+//
+//  RemoteConfigTopic.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+
+/// Remote config topics that SDK code can read through `RemoteConfigManager`.
+///
+/// The sync path remains string-keyed so unknown server topics can still be persisted.
+/// The read facade uses this closed set to avoid arbitrary or misspelled topic reads.
+enum RemoteConfigTopic: String {
+
+    case workflows
+    case uiConfig = "ui_config"
+    case sources
+
+    var wireName: String {
+        return self.rawValue
+    }
+
+}

--- a/Sources/Networking/Responses/RemoteConfiguration.swift
+++ b/Sources/Networking/Responses/RemoteConfiguration.swift
@@ -69,8 +69,8 @@ extension RemoteConfiguration {
     ///
     /// Items are arbitrary topic-specific JSON. `blob_ref` and `prefetch` are the only
     /// reserved keys the SDK interprets; every other key is preserved in `content`.
-    /// Payloads may be inline in `content` or external via `blobRef`, depending on what
-    /// the server chooses for a given response.
+    /// An item's blob payload is addressed by `blobRef`; `content` is the inline topic
+    /// metadata exposed through the topic index, not blob bytes returned by `blobData`.
     struct ConfigItem: Codable, Equatable {
         /// When present, the item's payload is an external static blob addressed by this ref.
         let blobRef: String?

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobFetcherTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobFetcherTests.swift
@@ -466,8 +466,8 @@ private final class BlobFetcherSourceTopicStore: RemoteConfigTopicStoreType {
         self.sourcesTopic = sourcesTopic
     }
 
-    func topic(_ name: String) -> RemoteConfiguration.ConfigTopic? {
-        return name == "sources" ? self.sourcesTopic : nil
+    func topic(_ topic: RemoteConfigTopic) -> RemoteConfiguration.ConfigTopic? {
+        return topic == .sources ? self.sourcesTopic : nil
     }
 
 }

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigDiskCacheTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigDiskCacheTests.swift
@@ -108,6 +108,23 @@ final class RemoteConfigDiskCacheTests: TestCase {
         expect(read.topics) == topics
     }
 
+    func testTopicReturnsTypedTopicMetadata() {
+        let sourcesItem = RemoteConfiguration.ConfigItem(content: ["url": "https://api.revenuecat.com"])
+        let workflowsItem = RemoteConfiguration.ConfigItem(blobRef: "workflowBlob")
+        self.cache.write(PersistedRemoteConfiguration(
+            manifest: "v1.1710000100.sources:etag1,workflows:etag2",
+            activeTopics: ["sources", "workflows"],
+            topics: .init(entries: [
+                "sources": ["api": sourcesItem],
+                "workflows": ["default": workflowsItem]
+            ])
+        ))
+
+        expect(self.cache.topic(.sources)?["api"]) == sourcesItem
+        expect(self.cache.topic(.workflows)?["default"]) == workflowsItem
+        expect(self.cache.topic(.uiConfig)).to(beNil())
+    }
+
     func testTopicsPersistUntypedMetadataRoundTrip() throws {
         let metadataItem = RemoteConfiguration.ConfigItem(
             content: [

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -203,6 +203,28 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 0
     }
 
+    @MainActor
+    func testTopicReadsCommittedMetadataOffMainThread() async {
+        let item = RemoteConfiguration.ConfigItem(content: ["url": "https://api.revenuecat.com"])
+        let persisted = Self.persisted(
+            manifest: "v1.1710000100.sources:etag1",
+            topics: .init(entries: ["sources": ["api": item]])
+        )
+        let lock = Lock()
+        var readThreadIsMain: Bool?
+        self.diskCache.readHandler = {
+            lock.perform {
+                readThreadIsMain = Thread.isMainThread
+            }
+            return persisted
+        }
+
+        let topic = await self.manager.topic(.sources)
+
+        expect(topic?["api"]) == item
+        expect(lock.perform { readThreadIsMain }) == false
+    }
+
     func testBlobDataReturnsNilForItemWithoutBlobRef() async {
         self.diskCache.stubbedRead = Self.persisted(
             manifest: "v1.1710000100.sources:etag1",

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -878,11 +878,12 @@ final class RemoteConfigManagerTests: TestCase {
         )
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
+        let readCountAfterDisabling = self.diskCache.invokedReadCount
 
         let data = await self.manager.blobData(for: .workflows, itemKey: "default")
 
         expect(data).to(beNil())
-        expect(self.diskCache.invokedReadCount) == 2
+        expect(self.diskCache.invokedReadCount) == readCountAfterDisabling
         expect(self.blobFetcher.invokedEnsureDownloadedRefs).to(beEmpty())
         expect(self.blobStore.invokedReadRefs).to(beEmpty())
     }

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -190,6 +190,174 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.blobStore.invokedCachedRefsCount) == 1
     }
 
+    func testTopicReturnsCommittedMetadataWithoutRefreshing() async {
+        let item = RemoteConfiguration.ConfigItem(content: ["url": "https://api.revenuecat.com"])
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.sources:etag1",
+            topics: .init(entries: ["sources": ["api": item]])
+        )
+
+        let topic = await self.manager.topic(.sources)
+
+        expect(topic?["api"]) == item
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 0
+    }
+
+    func testBlobDataReturnsNilForItemWithoutBlobRef() async {
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.sources:etag1",
+            topics: .init(entries: [
+                "sources": ["api": .init(content: ["priority": 100, "url": "https://api.revenuecat.com"])]
+            ])
+        )
+
+        let data = await self.manager.blobData(for: .sources, itemKey: "api")
+
+        expect(data).to(beNil())
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 0
+        expect(self.blobFetcher.invokedEnsureDownloadedRefs).to(beEmpty())
+        expect(self.blobStore.invokedReadRefs).to(beEmpty())
+    }
+
+    func testTopicReturnsInlineMetadata() async throws {
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.sources:etag1",
+            topics: .init(entries: [
+                "sources": ["api": .init(content: ["priority": 100, "url": "https://api.revenuecat.com"])]
+            ])
+        )
+
+        let topic = try XCTUnwrap(await self.manager.topic(.sources))
+
+        expect(topic["api"]?.content["priority"]) == 100
+        expect(topic["api"]?.content["url"]) == "https://api.revenuecat.com"
+    }
+
+    func testTopicColdReadTriggersForegroundRefresh() async throws {
+        self.diskCache.writeHandler = { configuration in
+            self.diskCache.stubbedRead = configuration
+            return true
+        }
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.sources:etag2",
+          "active_topics": ["sources"],
+          "topics": {
+            "sources": {
+              "api": { "url": "https://api.revenuecat.com" }
+            }
+          }
+        }
+        """
+
+        let task = Task {
+            await self.manager.topic(.sources)
+        }
+        await self.waitForRemoteConfigRequestCount(1)
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.isAppBackgrounded) == false
+        self.remoteConfigAPI.complete(
+            with: .success(.test(container: try Self.container(config: response)))
+        )
+
+        let topic = try XCTUnwrap(await task.value)
+        expect(topic["api"]?.content["url"]) == "https://api.revenuecat.com"
+    }
+
+    func testTopicWaitsForInFlightRefreshBeforeReturningMissingTopic() async throws {
+        self.diskCache.writeHandler = { configuration in
+            self.diskCache.stubbedRead = configuration
+            return true
+        }
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.sources:etag2",
+          "active_topics": ["sources"],
+          "topics": {
+            "sources": {
+              "api": { "url": "https://api.revenuecat.com" }
+            }
+          }
+        }
+        """
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        let task = Task {
+            await self.manager.topic(.sources)
+        }
+        await self.waitForRemoteConfigRequestCount(1)
+        await self.waitForDiskCacheReadCount(2)
+        self.remoteConfigAPI.complete(
+            with: .success(.test(container: try Self.container(config: response)))
+        )
+
+        let topic = try XCTUnwrap(await task.value)
+        expect(topic["api"]?.content["url"]) == "https://api.revenuecat.com"
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+    }
+
+    func testTopicReturnsNilWhenRemoteConfigIsDisabledEvenWithCachedTopic() async {
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.sources:etag1",
+            topics: .init(entries: [
+                "sources": ["api": .init(content: ["url": "https://api.revenuecat.com"])]
+            ])
+        )
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
+
+        let topic = await self.manager.topic(.sources)
+
+        expect(topic).to(beNil())
+    }
+
+    func testBlobDataDecodesExternalBlob() async throws {
+        let ref = RCContainerTestData.blobRef(for: #"{"id":"workflow"}"#.asData)
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.workflows:etag1",
+            topics: .init(entries: ["workflows": ["default": .init(blobRef: ref)]])
+        )
+        self.blobStore.stubbedReadDataByRef[ref] = #"{"id":"workflow"}"#.asData
+
+        let value = try await self.manager.blobData(for: .workflows, itemKey: "default", as: WorkflowPayload.self)
+
+        expect(value) == WorkflowPayload(id: "workflow")
+        expect(self.blobFetcher.invokedEnsureDownloadedRefs) == [ref]
+        expect(self.blobStore.invokedReadRefs) == [ref]
+    }
+
+    func testBlobDataReturnsNilWhenExternalBlobDownloadFails() async {
+        let ref = RCContainerTestData.blobRef(for: #"{"id":"workflow"}"#.asData)
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.workflows:etag1",
+            topics: .init(entries: ["workflows": ["default": .init(blobRef: ref)]])
+        )
+        self.blobFetcher.stubbedEnsureDownloadedResult = false
+
+        let data = await self.manager.blobData(for: .workflows, itemKey: "default")
+
+        expect(data).to(beNil())
+        expect(self.blobFetcher.invokedEnsureDownloadedRefs) == [ref]
+        expect(self.blobStore.invokedReadRefs).to(beEmpty())
+    }
+
+    func testBlobDataThrowsWhenPresentDataCannotDecode() async throws {
+        let ref = RCContainerTestData.blobRef(for: #"{"id":1}"#.asData)
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.workflows:etag1",
+            topics: .init(entries: ["workflows": ["default": .init(blobRef: ref)]])
+        )
+        self.blobStore.stubbedReadDataByRef[ref] = #"{"id":1}"#.asData
+
+        do {
+            _ = try await self.manager.blobData(for: .workflows, itemKey: "default", as: WorkflowPayload.self)
+            fail("Expected decoding to fail")
+        } catch {
+            expect(error).toNot(beNil())
+        }
+    }
+
     func testContainerResponsePersistsServerManifestAndChangedTopics() throws {
         self.diskCache.stubbedRead = nil
         let response = """
@@ -492,6 +660,183 @@ final class RemoteConfigManagerTests: TestCase {
         expect(Self.blobRefsByTopic(from: self.diskCache.invokedWriteParameter?.topics)) == ["sources": ["newBlob"]]
     }
 
+    func testBlobDataWaitsForInFlightRefreshBeforeReturningMissingItem() async throws {
+        let blob = #"{"id":"workflow"}"#.asData
+        let ref = RCContainerTestData.blobRef(for: blob)
+        self.diskCache.writeHandler = { configuration in
+            self.diskCache.stubbedRead = configuration
+            return true
+        }
+        self.blobStore.stubbedReadDataByRef[ref] = blob
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.workflows:etag2",
+          "active_topics": ["workflows"],
+          "topics": {
+            "workflows": {
+              "default": { "blob_ref": "\(ref)" }
+            }
+          }
+        }
+        """
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        let task = Task {
+            await self.manager.blobData(for: .workflows, itemKey: "default")
+        }
+        await self.waitForRemoteConfigRequestCount(1)
+        await self.waitForDiskCacheReadCount(2)
+        self.remoteConfigAPI.complete(
+            with: .success(.test(container: try Self.container(config: response)))
+        )
+
+        let data = try XCTUnwrap(await task.value)
+        expect(data) == blob
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+    }
+
+    func testBlobDataColdReadTriggersForegroundRefresh() async throws {
+        let blob = #"{"id":"workflow"}"#.asData
+        let ref = RCContainerTestData.blobRef(for: blob)
+        self.diskCache.writeHandler = { configuration in
+            self.diskCache.stubbedRead = configuration
+            return true
+        }
+        self.blobStore.stubbedReadDataByRef[ref] = blob
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.workflows:etag2",
+          "active_topics": ["workflows"],
+          "topics": {
+            "workflows": {
+              "default": { "blob_ref": "\(ref)" }
+            }
+          }
+        }
+        """
+
+        let task = Task {
+            await self.manager.blobData(for: .workflows, itemKey: "default")
+        }
+        await self.waitForRemoteConfigRequestCount(1)
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.isAppBackgrounded) == false
+        self.remoteConfigAPI.complete(
+            with: .success(.test(container: try Self.container(config: response)))
+        )
+
+        let data = try XCTUnwrap(await task.value)
+        expect(data) == blob
+    }
+
+    func testBlobDataColdReadUsesCurrentAppUserIDWhenTriggeringRefresh() async {
+        self.currentUserProvider.mockAppUserID = "new-user"
+
+        let task = Task {
+            await self.manager.blobData(for: .sources, itemKey: "api")
+        }
+        await self.waitForRemoteConfigRequestCount(1)
+        self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
+        _ = await task.value
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.appUserID) == "new-user"
+    }
+
+    func testBlobDataNoContentRefreshCompletesWaitingRead() async {
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+
+        let task = Task {
+            await self.manager.blobData(for: .sources, itemKey: "api")
+        }
+        await self.waitForRemoteConfigRequestCount(1)
+        await self.waitForDiskCacheReadCount(2)
+        self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
+
+        expect(await task.value).to(beNil())
+    }
+
+    func testBlobDataFailedRefreshCompletesWaitingRead() async {
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+
+        let task = Task {
+            await self.manager.blobData(for: .sources, itemKey: "api")
+        }
+        await self.waitForRemoteConfigRequestCount(1)
+        await self.waitForDiskCacheReadCount(2)
+        self.remoteConfigAPI.complete(with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1)))))
+
+        expect(await task.value).to(beNil())
+    }
+
+    func testBlobDataMalformedRefreshCompletesWaitingRead() async throws {
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+
+        let task = Task {
+            await self.manager.blobData(for: .sources, itemKey: "api")
+        }
+        await self.waitForRemoteConfigRequestCount(1)
+        await self.waitForDiskCacheReadCount(2)
+        self.remoteConfigAPI.complete(
+            with: .success(.test(container: try Self.container(config: "{ not valid json")))
+        )
+
+        expect(await task.value).to(beNil())
+    }
+
+    func testBlobDataClearCacheCompletesWaitingRead() async {
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+
+        let task = Task {
+            await self.manager.blobData(for: .sources, itemKey: "api")
+        }
+        await self.waitForRemoteConfigRequestCount(1)
+        await self.waitForDiskCacheReadCount(2)
+        self.manager.clearCache()
+
+        expect(await task.value).to(beNil())
+    }
+
+    func testBlobDataCloseCompletesWaitingRead() async {
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+
+        let task = Task {
+            await self.manager.blobData(for: .sources, itemKey: "api")
+        }
+        await self.waitForRemoteConfigRequestCount(1)
+        await self.waitForDiskCacheReadCount(2)
+        self.manager.close()
+
+        expect(await task.value).to(beNil())
+    }
+
+    func testBlobDataDoesNotTriggerRefreshWhenRemoteConfigIsDisabled() async {
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
+
+        let data = await self.manager.blobData(for: .sources, itemKey: "api")
+
+        expect(data).to(beNil())
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+    }
+
+    func testBlobDataDoesNotFetchExternalBlobWhenRemoteConfigIsDisabled() async {
+        let ref = RCContainerTestData.blobRef(for: #"{"id":"workflow"}"#.asData)
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.workflows:etag1",
+            topics: .init(entries: ["workflows": ["default": .init(blobRef: ref)]])
+        )
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
+
+        let data = await self.manager.blobData(for: .workflows, itemKey: "default")
+
+        expect(data).to(beNil())
+        expect(self.diskCache.invokedReadCount) == 2
+        expect(self.blobFetcher.invokedEnsureDownloadedRefs).to(beEmpty())
+        expect(self.blobStore.invokedReadRefs).to(beEmpty())
+    }
+
     func testContainerResponseCachesInlineContentElements() throws {
         let blob = "blob payload".asData
         let blobRef = RCContainerTestData.blobRef(for: blob)
@@ -518,6 +863,41 @@ final class RemoteConfigManagerTests: TestCase {
 
         expect(self.blobStore.invokedWriteParameters?.ref) == blobRef
         expect(self.blobStore.invokedWriteParameters?.data) == blob
+    }
+
+    func testBlobDataReadsContainerInlineBlobAfterItIsStored() async throws {
+        let blob = #"{"id":"workflow"}"#.asData
+        let blobRef = RCContainerTestData.blobRef(for: blob)
+        self.diskCache.writeHandler = { configuration in
+            self.diskCache.stubbedRead = configuration
+            return true
+        }
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.workflows:etag2",
+          "active_topics": ["workflows"],
+          "topics": {
+            "workflows": {
+              "default": { "blob_ref": "\(blobRef)" }
+            }
+          }
+        }
+        """
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(
+            with: .success(.test(
+                container: try Self.container(config: response, contentElements: [blob]),
+                verificationResult: .verified
+            ))
+        )
+
+        let data = await self.manager.blobData(for: .workflows, itemKey: "default")
+
+        expect(data) == blob
+        expect(self.blobFetcher.invokedEnsureDownloadedRefs) == [blobRef]
+        expect(self.blobStore.invokedReadRefs) == [blobRef]
     }
 
     func testSingleElementFixtureCachesReferencedWorkflowBlob() throws {
@@ -1130,6 +1510,44 @@ private extension RemoteConfigManagerTests {
         ))
     }
 
+    func waitForRemoteConfigRequestCount(
+        _ count: Int,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        let deadline = Date().addingTimeInterval(2)
+        while Date() < deadline {
+            if self.remoteConfigAPI.invokedGetRemoteConfigCount >= count {
+                return
+            }
+
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        XCTFail("Timed out waiting for \(count) remote config requests", file: file, line: line)
+    }
+
+    func waitForDiskCacheReadCount(
+        _ count: Int,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        let deadline = Date().addingTimeInterval(2)
+        while Date() < deadline {
+            if self.diskCache.invokedReadCount >= count {
+                return
+            }
+
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        XCTFail("Timed out waiting for \(count) disk cache reads", file: file, line: line)
+    }
+
+    struct WorkflowPayload: Decodable, Equatable {
+        let id: String
+    }
+
 }
 
 private extension RemoteConfigFetchResult {
@@ -1208,6 +1626,10 @@ private final class MockRemoteConfigDiskCache: RemoteConfigDiskCacheType {
         return self.readHandler?() ?? self.stubbedRead
     }
 
+    func topic(_ topic: RemoteConfigTopic) -> RemoteConfiguration.ConfigTopic? {
+        return self.read()?.topics.entries[topic.wireName]
+    }
+
     @discardableResult
     func write(_ configuration: PersistedRemoteConfiguration) -> Bool {
         self.invokedWriteCount += 1
@@ -1226,10 +1648,12 @@ private final class MockRemoteConfigDiskCache: RemoteConfigDiskCacheType {
 private final class MockRemoteConfigBlobStore: RemoteConfigBlobStoreType {
 
     var stubbedContainsRefs: Set<String> = []
+    var stubbedReadDataByRef: [String: Data] = [:]
 
     private(set) var invokedWriteCount = 0
     private(set) var invokedWriteParameters: (ref: String, data: Data)?
     private(set) var invokedWriteParametersList: [(ref: String, data: Data)] = []
+    private(set) var invokedReadRefs: [String] = []
     private(set) var invokedCachedRefsCount = 0
     private(set) var invokedRetainOnlyCount = 0
     private(set) var invokedRetainOnlyParameters: Set<String>?
@@ -1240,7 +1664,12 @@ private final class MockRemoteConfigBlobStore: RemoteConfigBlobStoreType {
     }
 
     func read(ref: String) -> Data? {
-        return nil
+        self.invokedReadRefs.append(ref)
+        if let data = self.stubbedReadDataByRef[ref] {
+            return data
+        }
+
+        return self.invokedWriteParametersList.last { $0.ref == ref }?.data
     }
 
     @discardableResult
@@ -1274,6 +1703,8 @@ private final class MockRemoteConfigBlobStore: RemoteConfigBlobStoreType {
 
 private final class MockRemoteConfigBlobFetcher: RemoteConfigBlobFetcherType {
 
+    var stubbedEnsureDownloadedResult = true
+
     private(set) var invokedEnsureDownloadedRefs: [String] = []
     private(set) var invokedEnsureAllDownloadedRefs: [String] = []
     private(set) var invokedPrefetchCount = 0
@@ -1281,7 +1712,7 @@ private final class MockRemoteConfigBlobFetcher: RemoteConfigBlobFetcherType {
 
     func ensureDownloaded(ref: String) async -> Bool {
         self.invokedEnsureDownloadedRefs.append(ref)
-        return true
+        return self.stubbedEnsureDownloadedResult
     }
 
     func ensureAllDownloaded(refs: [String]) async -> Bool {

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -267,7 +267,8 @@ final class RemoteConfigManagerTests: TestCase {
             ])
         )
 
-        let topic = try XCTUnwrap(await self.manager.topic(.sources))
+        let maybeTopic = await self.manager.topic(.sources)
+        let topic = try XCTUnwrap(maybeTopic)
 
         expect(topic["api"]?.content["priority"]) == 100
         expect(topic["api"]?.content["url"]) == "https://api.revenuecat.com"
@@ -300,7 +301,8 @@ final class RemoteConfigManagerTests: TestCase {
             with: .success(.test(container: try Self.container(config: response)))
         )
 
-        let topic = try XCTUnwrap(await task.value)
+        let maybeTopic = await task.value
+        let topic = try XCTUnwrap(maybeTopic)
         expect(topic["api"]?.content["url"]) == "https://api.revenuecat.com"
     }
 
@@ -332,7 +334,8 @@ final class RemoteConfigManagerTests: TestCase {
             with: .success(.test(container: try Self.container(config: response)))
         )
 
-        let topic = try XCTUnwrap(await task.value)
+        let maybeTopic = await task.value
+        let topic = try XCTUnwrap(maybeTopic)
         expect(topic["api"]?.content["url"]) == "https://api.revenuecat.com"
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
     }
@@ -731,7 +734,8 @@ final class RemoteConfigManagerTests: TestCase {
             with: .success(.test(container: try Self.container(config: response)))
         )
 
-        let data = try XCTUnwrap(await task.value)
+        let maybeData = await task.value
+        let data = try XCTUnwrap(maybeData)
         expect(data) == blob
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
     }
@@ -766,7 +770,8 @@ final class RemoteConfigManagerTests: TestCase {
             with: .success(.test(container: try Self.container(config: response)))
         )
 
-        let data = try XCTUnwrap(await task.value)
+        let maybeData = await task.value
+        let data = try XCTUnwrap(maybeData)
         expect(data) == blob
     }
 

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -108,6 +108,36 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 0
     }
 
+    func testTopicReturnsNilAfterCloseWithoutReadingCache() async {
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.sources:etag1",
+            topics: .init(entries: ["sources": ["api": .init(content: ["url": .string("https://api.revenuecat.com")])]])
+        )
+        self.manager.close()
+
+        let topic = await self.manager.topic(.sources)
+
+        expect(topic).to(beNil())
+        expect(self.diskCache.invokedReadCount) == 0
+    }
+
+    func testBlobDataReturnsNilAfterCloseWithoutReadingOrFetching() async {
+        let ref = RCContainerTestData.blobRef(for: #"{"id":"workflow"}"#.asData)
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.workflows:etag1",
+            topics: .init(entries: ["workflows": ["default": .init(blobRef: ref)]])
+        )
+        self.blobStore.stubbedReadDataByRef[ref] = #"{"id":"workflow"}"#.asData
+        self.manager.close()
+
+        let data = await self.manager.blobData(for: .workflows, itemKey: "default")
+
+        expect(data).to(beNil())
+        expect(self.diskCache.invokedReadCount) == 0
+        expect(self.blobFetcher.invokedEnsureDownloadedRefs).to(beEmpty())
+        expect(self.blobStore.invokedReadRefs).to(beEmpty())
+    }
+
     func testResponseThatArrivesAfterCloseDoesNotPersist() throws {
         let response = """
         {

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -946,6 +946,57 @@ final class RemoteConfigManagerTests: TestCase {
         expect(data).to(beNil())
     }
 
+    func testTopicDoesNotReturnStaleReadWhenCacheIsClearedDuringRead() async {
+        let readStarted = DispatchSemaphore(value: 0)
+        let releaseRead = DispatchSemaphore(value: 0)
+        self.diskCache.readHandler = {
+            readStarted.signal()
+            _ = releaseRead.wait(timeout: .now() + .seconds(5))
+            return Self.persisted(
+                manifest: "v1.1710000100.sources:etag1",
+                topics: .init(entries: ["sources": ["api": .init(content: ["url": .string("stale")])]])
+            )
+        }
+
+        let task = Task {
+            await self.manager.topic(.sources)
+        }
+        expect(readStarted.wait(timeout: .now() + .seconds(5))) == .success
+
+        self.manager.clearCache()
+        releaseRead.signal()
+
+        let topic = await task.value
+        expect(topic).to(beNil())
+    }
+
+    func testBlobDataDoesNotFetchStaleItemWhenCacheIsClearedDuringRead() async {
+        let ref = RCContainerTestData.blobRef(for: #"{"id":"workflow"}"#.asData)
+        let readStarted = DispatchSemaphore(value: 0)
+        let releaseRead = DispatchSemaphore(value: 0)
+        self.diskCache.readHandler = {
+            readStarted.signal()
+            _ = releaseRead.wait(timeout: .now() + .seconds(5))
+            return Self.persisted(
+                manifest: "v1.1710000100.workflows:etag1",
+                topics: .init(entries: ["workflows": ["default": .init(blobRef: ref)]])
+            )
+        }
+
+        let task = Task {
+            await self.manager.blobData(for: .workflows, itemKey: "default")
+        }
+        expect(readStarted.wait(timeout: .now() + .seconds(5))) == .success
+
+        self.manager.clearCache()
+        releaseRead.signal()
+
+        let data = await task.value
+        expect(data).to(beNil())
+        expect(self.blobFetcher.invokedEnsureDownloadedRefs).to(beEmpty())
+        expect(self.blobStore.invokedReadRefs).to(beEmpty())
+    }
+
     func testBlobDataCloseCompletesWaitingRead() async {
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -947,52 +947,44 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testTopicDoesNotReturnStaleReadWhenCacheIsClearedDuringRead() async {
-        let readStarted = DispatchSemaphore(value: 0)
-        let releaseRead = DispatchSemaphore(value: 0)
+        var didClearDuringRead = false
         self.diskCache.readHandler = {
-            readStarted.signal()
-            _ = releaseRead.wait(timeout: .now() + .seconds(5))
+            if !didClearDuringRead {
+                didClearDuringRead = true
+                self.manager.clearCache()
+            }
+
             return Self.persisted(
                 manifest: "v1.1710000100.sources:etag1",
                 topics: .init(entries: ["sources": ["api": .init(content: ["url": .string("stale")])]])
             )
         }
 
-        let task = Task {
-            await self.manager.topic(.sources)
-        }
-        expect(readStarted.wait(timeout: .now() + .seconds(5))) == .success
+        let topic = await self.manager.topic(.sources)
 
-        self.manager.clearCache()
-        releaseRead.signal()
-
-        let topic = await task.value
         expect(topic).to(beNil())
+        expect(self.diskCache.invokedClearCount) == 1
     }
 
     func testBlobDataDoesNotFetchStaleItemWhenCacheIsClearedDuringRead() async {
         let ref = RCContainerTestData.blobRef(for: #"{"id":"workflow"}"#.asData)
-        let readStarted = DispatchSemaphore(value: 0)
-        let releaseRead = DispatchSemaphore(value: 0)
+        var didClearDuringRead = false
         self.diskCache.readHandler = {
-            readStarted.signal()
-            _ = releaseRead.wait(timeout: .now() + .seconds(5))
+            if !didClearDuringRead {
+                didClearDuringRead = true
+                self.manager.clearCache()
+            }
+
             return Self.persisted(
                 manifest: "v1.1710000100.workflows:etag1",
                 topics: .init(entries: ["workflows": ["default": .init(blobRef: ref)]])
             )
         }
 
-        let task = Task {
-            await self.manager.blobData(for: .workflows, itemKey: "default")
-        }
-        expect(readStarted.wait(timeout: .now() + .seconds(5))) == .success
+        let data = await self.manager.blobData(for: .workflows, itemKey: "default")
 
-        self.manager.clearCache()
-        releaseRead.signal()
-
-        let data = await task.value
         expect(data).to(beNil())
+        expect(self.diskCache.invokedClearCount) == 1
         expect(self.blobFetcher.invokedEnsureDownloadedRefs).to(beEmpty())
         expect(self.blobStore.invokedReadRefs).to(beEmpty())
     }

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -336,6 +336,41 @@ final class RemoteConfigManagerTests: TestCase {
         expect(topic["api"]?.content["url"]) == "https://api.revenuecat.com"
     }
 
+    func testTopicMissingAfterFreshRefreshDoesNotTriggerAnotherRefresh() async throws {
+        self.diskCache.writeHandler = { configuration in
+            self.diskCache.stubbedRead = configuration
+            return true
+        }
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.sources:etag2",
+          "active_topics": ["sources"],
+          "topics": {
+            "sources": {
+              "api": { "url": "https://api.revenuecat.com" }
+            }
+          }
+        }
+        """
+
+        let firstRead = Task {
+            await self.manager.topic(.workflows)
+        }
+        await self.waitForRemoteConfigRequestCount(1)
+        self.remoteConfigAPI.complete(
+            with: .success(.test(container: try Self.container(config: response)))
+        )
+
+        let firstTopic = await firstRead.value
+        expect(firstTopic).to(beNil())
+
+        let secondRead = await self.manager.topic(.workflows)
+
+        expect(secondRead).to(beNil())
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+    }
+
     func testTopicWaitsForInFlightRefreshBeforeReturningMissingTopic() async throws {
         self.diskCache.writeHandler = { configuration in
             self.diskCache.stubbedRead = configuration
@@ -803,6 +838,41 @@ final class RemoteConfigManagerTests: TestCase {
         let maybeData = await task.value
         let data = try XCTUnwrap(maybeData)
         expect(data) == blob
+    }
+
+    func testBlobDataMissingItemAfterFreshRefreshDoesNotTriggerAnotherRefresh() async throws {
+        self.diskCache.writeHandler = { configuration in
+            self.diskCache.stubbedRead = configuration
+            return true
+        }
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.workflows:etag2",
+          "active_topics": ["workflows"],
+          "topics": {
+            "workflows": {
+              "other": { "one": 1 }
+            }
+          }
+        }
+        """
+
+        let firstRead = Task {
+            await self.manager.blobData(for: .workflows, itemKey: "default")
+        }
+        await self.waitForRemoteConfigRequestCount(1)
+        self.remoteConfigAPI.complete(
+            with: .success(.test(container: try Self.container(config: response)))
+        )
+
+        let firstData = await firstRead.value
+        expect(firstData).to(beNil())
+
+        let secondRead = await self.manager.blobData(for: .workflows, itemKey: "default")
+
+        expect(secondRead).to(beNil())
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
     }
 
     func testBlobDataColdReadUsesCurrentAppUserIDWhenTriggeringRefresh() async {

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -203,6 +203,24 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 0
     }
 
+    func testTopicReturnsNilWhenRemoteConfigIsDisabledDuringCommittedRead() async {
+        let item = RemoteConfiguration.ConfigItem(content: ["url": "https://api.revenuecat.com"])
+        let persisted = Self.persisted(
+            manifest: "v1.1710000100.sources:etag1",
+            topics: .init(entries: ["sources": ["api": item]])
+        )
+        self.diskCache.stubbedRead = persisted
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.diskCache.readHandler = {
+            self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
+            return persisted
+        }
+
+        let topic = await self.manager.topic(.sources)
+
+        expect(topic).to(beNil())
+    }
+
     @MainActor
     func testTopicReadsCommittedMetadataOffMainThread() async {
         let item = RemoteConfiguration.ConfigItem(content: ["url": "https://api.revenuecat.com"])

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -775,7 +775,8 @@ final class RemoteConfigManagerTests: TestCase {
         await self.waitForDiskCacheReadCount(2)
         self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
 
-        expect(await task.value).to(beNil())
+        let data = await task.value
+        expect(data).to(beNil())
     }
 
     func testBlobDataFailedRefreshCompletesWaitingRead() async {
@@ -788,7 +789,8 @@ final class RemoteConfigManagerTests: TestCase {
         await self.waitForDiskCacheReadCount(2)
         self.remoteConfigAPI.complete(with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1)))))
 
-        expect(await task.value).to(beNil())
+        let data = await task.value
+        expect(data).to(beNil())
     }
 
     func testBlobDataMalformedRefreshCompletesWaitingRead() async throws {
@@ -803,7 +805,8 @@ final class RemoteConfigManagerTests: TestCase {
             with: .success(.test(container: try Self.container(config: "{ not valid json")))
         )
 
-        expect(await task.value).to(beNil())
+        let data = await task.value
+        expect(data).to(beNil())
     }
 
     func testBlobDataClearCacheCompletesWaitingRead() async {
@@ -816,7 +819,8 @@ final class RemoteConfigManagerTests: TestCase {
         await self.waitForDiskCacheReadCount(2)
         self.manager.clearCache()
 
-        expect(await task.value).to(beNil())
+        let data = await task.value
+        expect(data).to(beNil())
     }
 
     func testBlobDataCloseCompletesWaitingRead() async {
@@ -829,7 +833,8 @@ final class RemoteConfigManagerTests: TestCase {
         await self.waitForDiskCacheReadCount(2)
         self.manager.close()
 
-        expect(await task.value).to(beNil())
+        let data = await task.value
+        expect(data).to(beNil())
     }
 
     func testBlobDataDoesNotTriggerRefreshWhenRemoteConfigIsDisabled() async {

--- a/Tests/UnitTests/Networking/RemoteConfigSourceProviderTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfigSourceProviderTests.swift
@@ -468,8 +468,8 @@ private final class FakeTopicStore: RemoteConfigTopicStoreType {
         self.sources = sources
     }
 
-    func topic(_ name: String) -> RemoteConfiguration.ConfigTopic? {
-        return name == "sources" ? self.sources : nil
+    func topic(_ topic: RemoteConfigTopic) -> RemoteConfiguration.ConfigTopic? {
+        return topic == .sources ? self.sources : nil
     }
 
 }

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -694,6 +694,22 @@ final class MockRemoteConfigManager: RemoteConfigManagerType {
         self.invokedRefreshRemoteConfigIfStaleParametersList.append(isAppBackgrounded)
     }
 
+    func topic(_ topic: RemoteConfigTopic) async -> RemoteConfiguration.ConfigTopic? {
+        return nil
+    }
+
+    func blobData(for topic: RemoteConfigTopic, itemKey: String) async -> Data? {
+        return nil
+    }
+
+    func blobData<T: Decodable>(
+        for topic: RemoteConfigTopic,
+        itemKey: String,
+        as type: T.Type
+    ) async throws -> T? {
+        return nil
+    }
+
     func clearCache() {
         self.invokedClearCacheCount += 1
     }


### PR DESCRIPTION
Part of a stack of PRs, builds on #7132 and is aligned with Android PR RevenueCat/purchases-android#3703.

## Descriptions
Introduces APIs for consumers of the `RemoteConfigManager` to finally integrate with it. 

Main concepts
- Introduces the `RemoteConfigTopic` enum, with all topics the SDK supports
- Adds the `topic(topic)` method for asynchronously retrieving the topic with it's metadata
- Adds methods for retrieving the `blobData` for a given topic
  - One overload for immediately getting a deserialized generic type that conforms to Codable
  - And one that just returns the underlying raw `Data`

## Using the RemoteConfig infrastructure 
From now on it is quite straightforward to use the remote config infrastructure (although still behind a feature flag)

(example)
```swift
let workflowsTopic = await manager.topic(.workflows)
let workflow = try await manager.blobData(
  for: .workflows,
  itemKey: "workflow_id",
  as: WorkflowPayload.self
)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New async read/refresh coordination and epoch semantics in `RemoteConfigManager` affect how config is observed under cache clears and concurrent refreshes; behavior is heavily tested but is non-trivial SDK infrastructure.
> 
> **Overview**
> Adds a **consumer-facing read layer** on `RemoteConfigManager` so SDK code can load remote config topics and blob payloads without touching string topic names or cache details directly.
> 
> Introduces **`RemoteConfigTopic`** (`workflows`, `ui_config`, `sources`) and wires **`topic(_:)`** to return committed topic metadata from disk. **`blobData(for:itemKey:)`** returns raw bytes for `blob_ref` items (with a **`Decodable`** overload); inline-only items stay on the topic index.
> 
> Read paths **wait on an in-flight refresh**, may **kick off a foreground refresh** when data is missing/stale, run blocking disk/blob reads on a **background read queue**, and use **epoch checks** so results are dropped after `clearCache()`, `close()`, or disable—refresh completion now **resumes read waiters**. `RemoteConfigTopicStoreType` lives on the disk cache with typed `topic(_:)`; source failover reads **`.sources`** via the enum. Docs on `ConfigItem` clarify that **`content` is index metadata**, not blob bytes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a8c47ec26ee8b4c8a8009223ad128f3753bca75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->