### PR TITLE
Decode id on PaywallComponent.PackageComponent

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 		2A5E77D12F10B3B500BC5900 /* RevocationReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5E77D02F10B3B500BC5900 /* RevocationReason.swift */; };
 		2B699E6661ECFB93B146A2D9 /* SynchronizedUserDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B0EAB50136613F69FAA3BB /* SynchronizedUserDefaultsTests.swift */; };
 		2C08B2E92CD40DBF0024857B /* ButtonComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C08B2E82CD40DBF0024857B /* ButtonComponentTests.swift */; };
+		3D3FCA672E03ABA71D7C0AF3 /* PackageComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5FC914F4E87D00963A8F1D /* PackageComponentTests.swift */; };
 		2C08B3072CD55D660024857B /* FlexHStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C08B3062CD55D590024857B /* FlexHStack.swift */; };
 		2C08B3172CDA44440024857B /* ViewModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C08B3162CDA443A0024857B /* ViewModelFactory.swift */; };
 		2C08B3352CDD165B0024857B /* PaywallComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C08B3342CDD16550024857B /* PaywallComponentViewModel.swift */; };
@@ -1693,6 +1694,7 @@
 		1EFA95142CDBAB7500CA5951 /* MockWebPurchaseRedemptionHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWebPurchaseRedemptionHelper.swift; sourceTree = "<group>"; };
 		26AAFBADBA3F4E339D041135 /* WorkflowStepEventCoordinatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowStepEventCoordinatorTests.swift; sourceTree = "<group>"; };
 		2C08B2E82CD40DBF0024857B /* ButtonComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponentTests.swift; sourceTree = "<group>"; };
+		0C5FC914F4E87D00963A8F1D /* PackageComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageComponentTests.swift; sourceTree = "<group>"; };
 		2C08B3062CD55D590024857B /* FlexHStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlexHStack.swift; sourceTree = "<group>"; };
 		2C08B3162CDA443A0024857B /* ViewModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelFactory.swift; sourceTree = "<group>"; };
 		2C08B3342CDD16550024857B /* PaywallComponentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallComponentViewModel.swift; sourceTree = "<group>"; };
@@ -3464,6 +3466,7 @@
 				03A98CEE2D1EE040009BCA61 /* FallbackComponentTests.swift */,
 				2C08B2E82CD40DBF0024857B /* ButtonComponentTests.swift */,
 				038213DA2DD4979A003C02C3 /* PurchaseButtonComponentTests.swift */,
+				0C5FC914F4E87D00963A8F1D /* PackageComponentTests.swift */,
 				2C8EC6DE2CCD27A100D6CCF8 /* PartialComponentTests.swift */,
 				16DA8ECC2E4EE33700283940 /* ImageComponentTests.swift */,
 				16DA8EF32E4F7A2500283940 /* VideoComponentTests.swift */,
@@ -7885,6 +7888,7 @@
 				751BE2CF2EC64FE50011C4CB /* PostReceiptDataOperationFactoryTests.swift in Sources */,
 				57D04BB827D947C6006DAC06 /* HTTPResponseTests.swift in Sources */,
 				2C08B2E92CD40DBF0024857B /* ButtonComponentTests.swift in Sources */,
+				3D3FCA672E03ABA71D7C0AF3 /* PackageComponentTests.swift in Sources */,
 				5796A38127D6B78500653165 /* BaseBackendTest.swift in Sources */,
 				351B516226D44BEE00BD2BD7 /* CustomerInfoManagerTests.swift in Sources */,
 				1622D3FB2E900DE000C20E3C /* ChecksumTests.swift in Sources */,

--- a/Sources/Paywalls/Components/PaywallPackageComponent.swift
+++ b/Sources/Paywalls/Components/PaywallPackageComponent.swift
@@ -26,6 +26,7 @@ import Foundation
         @_spi(Internal) public let applePromoOfferProductCode: String?
         public let stack: PaywallComponent.StackComponent
         public let name: String?
+        public let id: String?
 
         public let overrides: ComponentOverrides<PartialPackageComponent>?
 
@@ -36,6 +37,7 @@ import Foundation
             applePromoOfferProductCode: String?,
             stack: PaywallComponent.StackComponent,
             name: String? = nil,
+            id: String? = nil,
             overrides: ComponentOverrides<PartialPackageComponent>? = nil
         ) {
             self.type = .package
@@ -45,6 +47,7 @@ import Foundation
             self.applePromoOfferProductCode = applePromoOfferProductCode
             self.stack = stack
             self.name = name
+            self.id = id
             self.overrides = overrides
         }
 
@@ -56,6 +59,7 @@ import Foundation
             hasher.combine(applePromoOfferProductCode)
             hasher.combine(stack)
             hasher.combine(name)
+            hasher.combine(id)
             hasher.combine(overrides)
         }
 
@@ -67,6 +71,7 @@ import Foundation
                    lhs.applePromoOfferProductCode == rhs.applePromoOfferProductCode &&
                    lhs.stack == rhs.stack &&
                    lhs.name == rhs.name &&
+                   lhs.id == rhs.id &&
                    lhs.overrides == rhs.overrides
         }
     }
@@ -100,6 +105,7 @@ extension PaywallComponent.PackageComponent {
         case applePromoOfferProductCode
         case stack
         case name
+        case id
         case overrides
     }
 

--- a/Tests/UnitTests/Paywalls/Components/PackageComponentTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/PackageComponentTests.swift
@@ -1,0 +1,132 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PackageComponentTests.swift
+//
+//  Created by Claude on 7/3/2026.
+
+import Nimble
+@_spi(Internal) @testable import RevenueCat
+import XCTest
+
+#if !os(tvOS) // For Paywalls V2
+
+class PackageComponentCodableTests: TestCase {
+
+    let jsonStringDefaultStack = """
+    {
+        "type": "stack",
+        "dimension": {
+            "type": "vertical",
+            "alignment": "center",
+            "distribution": "start"
+        },
+        "size": {
+            "width": { "type": "fill" },
+            "height": { "type": "fill" }
+        },
+        "padding": {
+            "top": 0,
+            "bottom": 0,
+            "leading": 0,
+            "trailing": 0
+        },
+        "margin": {
+            "top": 0,
+            "bottom": 0,
+            "leading": 0,
+            "trailing": 0
+        },
+        "components": []
+    }
+    """
+
+    func testDecodesId() throws {
+        let jsonString = """
+        {
+            "type": "package",
+            "packageId": "$rc_annual",
+            "isSelectedByDefault": true,
+            "id": "kQ_qY2xSNz",
+            "stack": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedPackage = try JSONDecoder.default.decode(PaywallComponent.PackageComponent.self, from: jsonData)
+
+        expect(decodedPackage.id) == "kQ_qY2xSNz"
+    }
+
+    func testIdIsNilWhenAbsent() throws {
+        let jsonString = """
+        {
+            "type": "package",
+            "packageId": "$rc_annual",
+            "isSelectedByDefault": true,
+            "stack": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedPackage = try JSONDecoder.default.decode(PaywallComponent.PackageComponent.self, from: jsonData)
+
+        expect(decodedPackage.id).to(beNil())
+    }
+
+    func testIdRoundTripsThroughEncoding() throws {
+        let jsonString = """
+        {
+            "type": "package",
+            "packageId": "$rc_annual",
+            "isSelectedByDefault": true,
+            "id": "kQ_qY2xSNz",
+            "stack": \(jsonStringDefaultStack)
+        }
+        """
+        let original = try JSONDecoder.default.decode(
+            PaywallComponent.PackageComponent.self,
+            from: jsonString.data(using: .utf8)!
+        )
+
+        let encoded = try JSONEncoder.default.encode(original)
+        let decoded = try JSONDecoder.default.decode(PaywallComponent.PackageComponent.self, from: encoded)
+
+        expect(decoded.id) == "kQ_qY2xSNz"
+        expect(decoded) == original
+    }
+
+    func testTwoPackagesWithSamePackageIDButDifferentIdAreNotEqual() throws {
+        let first = PaywallComponent.PackageComponent(
+            packageID: "$rc_annual",
+            isSelectedByDefault: true,
+            applePromoOfferProductCode: nil,
+            stack: .init(
+                components: [],
+                dimension: .vertical(.center, .start),
+                size: .init(width: .fill, height: .fill)
+            ),
+            id: "component-a"
+        )
+        let second = PaywallComponent.PackageComponent(
+            packageID: "$rc_annual",
+            isSelectedByDefault: true,
+            applePromoOfferProductCode: nil,
+            stack: .init(
+                components: [],
+                dimension: .vertical(.center, .start),
+                size: .init(width: .fill, height: .fill)
+            ),
+            id: "component-b"
+        )
+
+        XCTAssertNotEqual(first, second)
+    }
+
+}
+
+#endif


### PR DESCRIPTION
## Motivation

Follow-up to a review comment on [revenuecat-mobile-ios#841](https://github.com/RevenueCat/revenuecat-mobile-ios/pull/841): a promo-offer mock walk keys results by `packageID`, but the same `packageID` can appear in multiple placements within a paywall's component tree (different tabs, carousel pages, base stack + sticky footer), each potentially configured independently. Keying by `packageID` alone silently collides when placements differ.

The intended fix is to key by each component's own unique `id` instead — but `PaywallComponent.PackageComponent` doesn't currently expose one.

## What's actually happening

The paywall builder already sends a per-component `id` in the wire JSON for **every** component, including packages — confirmed by inspecting real paywall component JSON via the dashboard API. `PackageComponent`'s `CodingKeys` just never listed it, so it was silently discarded on decode.

This isn't a new concept: `ButtonComponent` (`PaywallButtonComponent.swift`) and `TabsComponent.Tab` already decode this exact same `id` field. This PR does the same for `PackageComponent`.

## Changes

- `PaywallPackageComponent.swift`: add `public let id: String?` (optional, default `nil`, mirroring `ButtonComponent`'s exact pattern) and `case id` to `CodingKeys`. Threaded through `init`, `hash(into:)`, and `==`.
- No changes to `PartialPackageComponent`, encoding logic, or any other component type — this is scoped to `PackageComponent` only.

## Testing

New `Tests/UnitTests/Paywalls/Components/PackageComponentTests.swift` (mirrors `ButtonComponentTests.swift`'s structure):
- Decodes `id` when present in JSON.
- `id` is `nil` when absent from JSON (backward compatible with existing paywall configs / cached data).
- Round-trips through encode → decode.
- Two `PackageComponent`s with the same `packageID` but different `id` are correctly `!=` (the actual bug this unblocks).

Verified via `xcodebuild test -project RevenueCat.xcodeproj -scheme RevenueCat -testPlan CI-RevenueCat -only-testing:UnitTests/PackageComponentCodableTests`: all 4 tests pass. Also verified via the Tuist-generated `UnitTests` scheme. `swiftlint lint` clean on changed files.

## Notes for reviewers

- `RevenueCat.xcodeproj/project.pbxproj` changes are a minimal, hand-added 4-line diff (`PBXBuildFile`, `PBXFileReference`, group membership, sources build phase) for the new test file — verified `plutil -lint` passes and the project builds/tests correctly with it.
- This PR only adds the field to `PackageComponent`. It does not change how any consumer (app-side or SDK-side) currently keys by `packageID` — that's a separate follow-up once this lands, tracked against revenuecat-mobile-ios#841's review feedback.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: this PR
- Branch: `facu/package-component-id`
- Author / human owner: facumenzella
- Agent: Claude Code (Sonnet 5)
- Session source: current conversation
- Generated: 2026-07-03

## Goal

Add a per-component `id` to `PaywallComponent.PackageComponent` so app-side consumers can disambiguate the same package appearing in multiple tree placements, unblocking a review comment on revenuecat-mobile-ios#841.

## Initial Prompt

Reviewer (Monika Mateska) on revenuecat-mobile-ios#841 flagged that `PromoOfferCodeReader.codesByPackageID` collides when the same `packageID` appears in multiple component-tree placements with different `applePromoOfferProductCode` values, and suggested keying by component `id` instead — noting the SDK would need to expose one first.

## Agent Contribution

- Verified `PackageComponent` had no `id` field, but that the dashboard already sends one in the wire JSON for every component (confirmed against real paywall data via the RevenueCat API).
- Found precedent: `ButtonComponent` and `TabsComponent.Tab` already decode this exact `id` field, establishing this is a safe, established pattern rather than a novel SDK concept.
- Implemented the field addition mirroring `ButtonComponent`'s exact style (`public let id: String?`, no `@_spi(Internal)` needed beyond the containing extension).
- Wrote `PackageComponentTests.swift` covering decode-present, decode-absent (nil), round-trip, and the actual disambiguation behavior (same packageID, different id → not equal).
- Discovered the `AllTests`/`UnitTests` xctestplans referenced by the `RevenueCat` scheme are stale (removed in a prior unrelated commit, `171b555c1`); worked around by using the still-valid `CI-RevenueCat` test plan rather than attempting to fix that pre-existing, unrelated issue.
- Added the new test file to the legacy, manually-maintained `RevenueCat.xcodeproj` via the `xcodeproj` Ruby gem's file-addition API, then reverted and redid it as a hand-crafted minimal diff after the gem's `save` reformatted/resorted the entire `PBXBuildFile` list (a ~200-line unrelated diff).

## Human Decisions

- Confirmed scope: only fix `PackageComponent`'s missing `id`, not add `id` decoding to every component type (that would be a separate, unscoped consistency change).
- Approved opening this as a standalone SDK PR rather than bundling into the app-side PR.

## Files / Symbols Touched

- `Sources/Paywalls/Components/PaywallPackageComponent.swift`
  - Symbols: `PaywallComponent.PackageComponent.id`, `CodingKeys.id`
  - Review: confirm `id` optionality and default `nil` match `ButtonComponent`'s pattern for backward compatibility with existing decoded/cached data.
- `Tests/UnitTests/Paywalls/Components/PackageComponentTests.swift` (new)
- `RevenueCat.xcodeproj/project.pbxproj`
  - Why: register the new test file with the legacy (non-Tuist-generated) project so `UnitTests` picks it up. Minimal 4-line diff, `plutil -lint` verified.

## Dependencies / Config / Migrations

- None. `id` is a new optional field with a `nil` default — fully backward compatible with existing paywall JSON and any previously-decoded/cached `PackageComponent` instances.

## Validation

- Commands run:
  - `xcodebuild test -project RevenueCat.xcodeproj -scheme RevenueCat -testPlan CI-RevenueCat -only-testing:UnitTests/PackageComponentCodableTests`: **TEST SUCCEEDED**, 4/4 passed.
  - Same 4 tests also verified passing via the Tuist-generated `UnitTests` scheme (`RevenueCat-Tuist.xcworkspace`).
  - `swiftlint lint` on changed Swift files: 0 violations.
- Manual verification: Not run (no visual/UI surface — pure model/Codable change).
- CI: Not captured (pre-merge).

## Validation Gaps

- Did not run the full API-surface tests (`bundle exec fastlane run_api_tests`) — this is a new optional property with a default value on an `@_spi(Internal)` type, which should be additive/non-breaking, but hasn't been explicitly confirmed against the `.swiftinterface` baseline.
- Did not run the full `UnitTests` suite, only the new/targeted test class — a full-suite run would rule out any unexpected interaction (unlikely, given the change is additive and optional).

## Review Focus

- Confirm `@_spi(Internal)` scoping is sufficient here (matching `id` on other components, which also aren't individually marked `@_spi(Internal)` beyond the containing extension).
- Confirm the stale `AllTests`/`UnitTests` xctestplan references (pointing at deleted files) aren't something this PR should also fix — left out of scope as pre-existing and unrelated.

## Risks / Reviewer Notes

- Risk: hand-edited `pbxproj` entries could have subtle formatting/UUID issues despite `plutil -lint` passing and tests succeeding.
  - Evidence: verified end-to-end via two separate full test runs (Tuist-generated workspace and the checked-in project directly).
  - Mitigation: if CI or reviewers prefer, this file could instead be regenerated via whatever process normally produces it, if one exists beyond manual edits.

## Non-goals / Out of Scope

- Actually reworking `PromoOfferCodeReader` (or any other consumer) to key by this new `id` instead of `packageID` — that's the revenuecat-mobile-ios#841 follow-up, blocked on this PR merging and releasing.
- Adding `id` to any other component type that doesn't already have it.
- Fixing the stale `AllTests`/`UnitTests` xctestplan references.

## Omitted Context

- Raw transcript, unrelated exploration, and chain-of-thought-style content were omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional model field with backward-compatible decoding; no purchase or auth logic changes.
> 
> **Overview**
> Adds optional **`id`** to `PaywallComponent.PackageComponent` so paywall JSON can carry the per-placement component id the dashboard already sends (same pattern as `ButtonComponent`).
> 
> The field is wired through **`CodingKeys`**, initializer defaults, **`hash`**, and **`==`**, so two packages with the same `packageId` but different ids are distinguishable. **`PackageComponentTests`** covers decode when present/absent, encode round-trip, and inequality for colliding package ids.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 621d627ea9f53c444e3430ce963d3a31ac8166e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->