### PR TITLE
perf(remote-config): cache persisted config in memory in RemoteConfigDiskCache

### DIFF
--- a/Sources/Networking/RemoteConfigDiskCache.swift
+++ b/Sources/Networking/RemoteConfigDiskCache.swift
@@ -65,6 +65,8 @@ final class RemoteConfigDiskCache: RemoteConfigDiskCacheType {
 
     private let cache: SynchronizedLargeItemCache
 
+    private let inMemoryConfiguration: Atomic<PersistedRemoteConfiguration?> = .init(nil)
+
     init(
         cache: SynchronizedLargeItemCache = .init(
             cache: FileManager.default,
@@ -76,11 +78,14 @@ final class RemoteConfigDiskCache: RemoteConfigDiskCacheType {
     }
 
     func read() -> PersistedRemoteConfiguration? {
-        do {
-            return try self.cache.value(forKey: Self.fileName)
-        } catch {
-            Logger.error(Strings.remoteConfig.failedToReadCache(error))
-            return nil
+        return self.inMemoryConfiguration.modify { cached in
+            if let cached {
+                return cached
+            }
+
+            let configuration = self.readFromDisk()
+            cached = configuration
+            return configuration
         }
     }
 
@@ -91,11 +96,23 @@ final class RemoteConfigDiskCache: RemoteConfigDiskCacheType {
             Logger.error(Strings.remoteConfig.failedToWriteCache)
         }
 
+        self.inMemoryConfiguration.value = configuration
+
         return didWrite
     }
 
     func clear() {
         self.cache.clear()
+        self.inMemoryConfiguration.value = nil
+    }
+
+    private func readFromDisk() -> PersistedRemoteConfiguration? {
+        do {
+            return try self.cache.value(forKey: Self.fileName)
+        } catch {
+            Logger.error(Strings.remoteConfig.failedToReadCache(error))
+            return nil
+        }
     }
 
 }

--- a/Sources/Networking/RemoteConfigDiskCache.swift
+++ b/Sources/Networking/RemoteConfigDiskCache.swift
@@ -65,7 +65,7 @@ final class RemoteConfigDiskCache: RemoteConfigDiskCacheType {
 
     private let cache: SynchronizedLargeItemCache
 
-    private let inMemoryConfiguration: Atomic<CacheState> = .init(.notLoaded)
+    private let snapshot: Atomic<Snapshot> = .init(.notLoaded)
 
     init(
         cache: SynchronizedLargeItemCache = .init(
@@ -78,11 +78,11 @@ final class RemoteConfigDiskCache: RemoteConfigDiskCacheType {
     }
 
     func read() -> PersistedRemoteConfiguration? {
-        return self.inMemoryConfiguration.modify { state in
-            switch state {
+        return self.snapshot.modify { snapshot in
+            switch snapshot {
             case .notLoaded:
                 let configuration = self.readFromDisk()
-                state = .loaded(configuration)
+                snapshot = .loaded(configuration)
                 return configuration
             case .loaded(let configuration):
                 return configuration
@@ -97,14 +97,14 @@ final class RemoteConfigDiskCache: RemoteConfigDiskCacheType {
             Logger.error(Strings.remoteConfig.failedToWriteCache)
         }
 
-        self.inMemoryConfiguration.value = .loaded(configuration)
+        self.snapshot.value = .loaded(configuration)
 
         return didWrite
     }
 
     func clear() {
         self.cache.clear()
-        self.inMemoryConfiguration.value = .loaded(nil)
+        self.snapshot.value = .loaded(nil)
     }
 
     private func readFromDisk() -> PersistedRemoteConfiguration? {
@@ -120,10 +120,10 @@ final class RemoteConfigDiskCache: RemoteConfigDiskCacheType {
 
 extension RemoteConfigDiskCache {
 
-    /// Tracks whether the persisted configuration has been loaded into memory yet, so `read()`
-    /// only hits disk once. `.loaded(nil)` means we've already checked and nothing is persisted,
-    /// avoiding repeated disk reads while no configuration exists.
-    private enum CacheState {
+    /// In-memory snapshot of the persisted configuration, so `read()` only hits disk once.
+    /// `.loaded(nil)` means we've already checked and nothing is persisted, avoiding repeated
+    /// disk reads while no configuration exists.
+    private enum Snapshot {
         case notLoaded
         case loaded(PersistedRemoteConfiguration?)
     }

--- a/Sources/Networking/RemoteConfigDiskCache.swift
+++ b/Sources/Networking/RemoteConfigDiskCache.swift
@@ -65,7 +65,7 @@ final class RemoteConfigDiskCache: RemoteConfigDiskCacheType {
 
     private let cache: SynchronizedLargeItemCache
 
-    private let inMemoryConfiguration: Atomic<PersistedRemoteConfiguration?> = .init(nil)
+    private let inMemoryConfiguration: Atomic<CacheState> = .init(.notLoaded)
 
     init(
         cache: SynchronizedLargeItemCache = .init(
@@ -78,14 +78,15 @@ final class RemoteConfigDiskCache: RemoteConfigDiskCacheType {
     }
 
     func read() -> PersistedRemoteConfiguration? {
-        return self.inMemoryConfiguration.modify { cached in
-            if let cached {
-                return cached
+        return self.inMemoryConfiguration.modify { state in
+            switch state {
+            case .notLoaded:
+                let configuration = self.readFromDisk()
+                state = .loaded(configuration)
+                return configuration
+            case .loaded(let configuration):
+                return configuration
             }
-
-            let configuration = self.readFromDisk()
-            cached = configuration
-            return configuration
         }
     }
 
@@ -96,14 +97,14 @@ final class RemoteConfigDiskCache: RemoteConfigDiskCacheType {
             Logger.error(Strings.remoteConfig.failedToWriteCache)
         }
 
-        self.inMemoryConfiguration.value = configuration
+        self.inMemoryConfiguration.value = .loaded(configuration)
 
         return didWrite
     }
 
     func clear() {
         self.cache.clear()
-        self.inMemoryConfiguration.value = nil
+        self.inMemoryConfiguration.value = .loaded(nil)
     }
 
     private func readFromDisk() -> PersistedRemoteConfiguration? {
@@ -113,6 +114,18 @@ final class RemoteConfigDiskCache: RemoteConfigDiskCacheType {
             Logger.error(Strings.remoteConfig.failedToReadCache(error))
             return nil
         }
+    }
+
+}
+
+extension RemoteConfigDiskCache {
+
+    /// Tracks whether the persisted configuration has been loaded into memory yet, so `read()`
+    /// only hits disk once. `.loaded(nil)` means we've already checked and nothing is persisted,
+    /// avoiding repeated disk reads while no configuration exists.
+    private enum CacheState {
+        case notLoaded
+        case loaded(PersistedRemoteConfiguration?)
     }
 
 }

--- a/Sources/Networking/RemoteConfigDiskCache.swift
+++ b/Sources/Networking/RemoteConfigDiskCache.swift
@@ -93,11 +93,11 @@ final class RemoteConfigDiskCache: RemoteConfigDiskCacheType {
     @discardableResult
     func write(_ configuration: PersistedRemoteConfiguration) -> Bool {
         let didWrite = self.cache.set(codable: configuration, forKey: Self.fileName)
-        if !didWrite {
+        if didWrite {
+            self.snapshot.value = .loaded(configuration)
+        } else {
             Logger.error(Strings.remoteConfig.failedToWriteCache)
         }
-
-        self.snapshot.value = .loaded(configuration)
 
         return didWrite
     }

--- a/Sources/Networking/RemoteConfigDiskCache.swift
+++ b/Sources/Networking/RemoteConfigDiskCache.swift
@@ -92,19 +92,23 @@ final class RemoteConfigDiskCache: RemoteConfigDiskCacheType {
 
     @discardableResult
     func write(_ configuration: PersistedRemoteConfiguration) -> Bool {
-        let didWrite = self.cache.set(codable: configuration, forKey: Self.fileName)
-        if didWrite {
-            self.snapshot.value = .loaded(configuration)
-        } else {
-            Logger.error(Strings.remoteConfig.failedToWriteCache)
-        }
+        return self.snapshot.modify { snapshot in
+            let didWrite = self.cache.set(codable: configuration, forKey: Self.fileName)
+            if didWrite {
+                snapshot = .loaded(configuration)
+            } else {
+                Logger.error(Strings.remoteConfig.failedToWriteCache)
+            }
 
-        return didWrite
+            return didWrite
+        }
     }
 
     func clear() {
-        self.cache.clear()
-        self.snapshot.value = .loaded(nil)
+        self.snapshot.modify { snapshot in
+            self.cache.clear()
+            snapshot = .loaded(nil)
+        }
     }
 
     private func readFromDisk() -> PersistedRemoteConfiguration? {

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigDiskCacheTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigDiskCacheTests.swift
@@ -154,6 +154,41 @@ final class RemoteConfigDiskCacheTests: TestCase {
         expect(self.cache.read()).to(beNil())
     }
 
+    func testReadCachesMissAfterDecodingFailureAndDoesNotReadDiskAgain() throws {
+        try FileManager.default.createDirectory(
+            at: self.fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+        try "{ this is not valid json".asData.write(to: self.fileURL)
+
+        // First read fails to decode and caches the miss.
+        expect(self.cache.read()).to(beNil())
+
+        // Persist a valid configuration to disk behind the cache's back.
+        self.makeCache().write(PersistedRemoteConfiguration(
+            manifest: "v1.1710000100.sources:etag1",
+            activeTopics: ["sources"]
+        ))
+
+        // The miss is cached, so disk is not read again.
+        expect(self.cache.read()).to(beNil())
+    }
+
+    func testReadCachesMissWhenNothingPersistedAndDoesNotReadDiskAgain() throws {
+        // First read finds nothing on disk and caches the miss.
+        expect(self.cache.read()).to(beNil())
+
+        // Persist a valid configuration to disk behind the cache's back.
+        self.makeCache().write(PersistedRemoteConfiguration(
+            manifest: "v1.1710000100.sources:etag1",
+            activeTopics: ["sources"]
+        ))
+
+        // The miss is cached, so disk is not read again.
+        expect(self.cache.read()).to(beNil())
+    }
+
     func testReadDefaultsMissingTopicsToEmpty() throws {
         try FileManager.default.createDirectory(
             at: self.fileURL.deletingLastPathComponent(),

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigDiskCacheTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigDiskCacheTests.swift
@@ -247,6 +247,23 @@ final class RemoteConfigDiskCacheTests: TestCase {
         self.logger.verifyMessageWasLogged(Strings.remoteConfig.failedToWriteCache, level: .error)
     }
 
+    func testFailedWriteDoesNotUpdateSnapshot() {
+        self.cache = RemoteConfigDiskCache(cache: .init(
+            cache: MockSimpleCache(cacheDirectory: nil),
+            basePath: RemoteConfigDiskCache.basePath
+        ))
+
+        let didWrite = self.cache.write(PersistedRemoteConfiguration(
+            manifest: "v1.1710000100.sources:etag1",
+            activeTopics: ["sources"],
+            topics: RemoteConfiguration.Topics(entries: ["sources": ["default": .init(blobRef: "blobRefA")]])
+        ))
+
+        expect(didWrite) == false
+        expect(self.cache.read()).to(beNil())
+        expect(self.cache.topic("sources")).to(beNil())
+    }
+
     func testWriteOverwritesPreviousSnapshot() throws {
         self.cache.write(PersistedRemoteConfiguration(
             domain: "app",

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigDiskCacheTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigDiskCacheTests.swift
@@ -15,6 +15,7 @@ final class RemoteConfigDiskCacheTests: TestCase {
     private var rootURL: URL!
     private var cacheDirectoryURL: URL!
     private var fileURL: URL!
+    private var directoryType: DirectoryHelper.DirectoryType!
     private var cache: RemoteConfigDiskCache!
 
     override func setUpWithError() throws {
@@ -24,19 +25,14 @@ final class RemoteConfigDiskCacheTests: TestCase {
             .appendingPathComponent("RemoteConfigDiskCacheTests-\(UUID().uuidString)", isDirectory: true)
 
         #if os(tvOS)
-        let directoryType = DirectoryHelper.DirectoryType.cache
+        self.directoryType = DirectoryHelper.DirectoryType.cache
         #else
-        let directoryType = DirectoryHelper.DirectoryType.applicationSupport(overrideURL: self.rootURL)
+        self.directoryType = DirectoryHelper.DirectoryType.applicationSupport(overrideURL: self.rootURL)
         #endif
 
-        let synchronizedCache = SynchronizedLargeItemCache(
-            cache: FileManager.default,
-            basePath: RemoteConfigDiskCache.basePath,
-            directoryType: directoryType
-        )
-        self.cache = RemoteConfigDiskCache(cache: synchronizedCache)
+        self.cache = self.makeCache()
 
-        self.cacheDirectoryURL = try XCTUnwrap(DirectoryHelper.baseUrl(for: directoryType))
+        self.cacheDirectoryURL = try XCTUnwrap(DirectoryHelper.baseUrl(for: self.directoryType))
             .appendingPathComponent(RemoteConfigDiskCache.basePath, isDirectory: true)
         try? FileManager.default.removeItem(at: self.cacheDirectoryURL)
 
@@ -50,9 +46,19 @@ final class RemoteConfigDiskCacheTests: TestCase {
         self.cache = nil
         self.fileURL = nil
         self.cacheDirectoryURL = nil
+        self.directoryType = nil
         self.rootURL = nil
 
         try super.tearDownWithError()
+    }
+
+    /// A fresh cache pointing at the same directory, with an empty in-memory cache so reads hit disk.
+    private func makeCache() -> RemoteConfigDiskCache {
+        return RemoteConfigDiskCache(cache: SynchronizedLargeItemCache(
+            cache: FileManager.default,
+            basePath: RemoteConfigDiskCache.basePath,
+            directoryType: self.directoryType
+        ))
     }
 
     func testReadReturnsNilWhenNothingHasBeenPersisted() {
@@ -75,7 +81,7 @@ final class RemoteConfigDiskCacheTests: TestCase {
             prefetchBlobs: prefetchBlobs,
             topics: topics
         ))
-        let read = try XCTUnwrap(self.cache.read())
+        let read = try XCTUnwrap(self.makeCache().read())
 
         expect(read.domain) == "app"
         expect(read.manifest) == manifest
@@ -103,7 +109,7 @@ final class RemoteConfigDiskCacheTests: TestCase {
             prefetchBlobs: [],
             topics: topics
         ))
-        let read = try XCTUnwrap(self.cache.read())
+        let read = try XCTUnwrap(self.makeCache().read())
 
         expect(read.topics) == topics
     }
@@ -132,7 +138,7 @@ final class RemoteConfigDiskCacheTests: TestCase {
             activeTopics: ["sources"],
             topics: topics
         ))
-        let read = try XCTUnwrap(self.cache.read())
+        let read = try XCTUnwrap(self.makeCache().read())
 
         expect(read.topics) == topics
     }
@@ -220,7 +226,7 @@ final class RemoteConfigDiskCacheTests: TestCase {
             prefetchBlobs: []
         ))
 
-        let read = try XCTUnwrap(self.cache.read())
+        let read = try XCTUnwrap(self.makeCache().read())
 
         expect(read.manifest) == "v1.1710000100.sources:new"
     }
@@ -236,12 +242,106 @@ final class RemoteConfigDiskCacheTests: TestCase {
         self.cache.clear()
 
         expect(self.cache.read()).to(beNil())
+        expect(self.makeCache().read()).to(beNil())
     }
 
     func testClearIsNoOpWhenNothingHasBeenPersisted() {
         self.cache.clear()
 
         expect(self.cache.read()).to(beNil())
+    }
+
+    func testTopicReturnsPersistedTopic() throws {
+        let sourcesTopic: RemoteConfiguration.ConfigTopic = ["default": .init(blobRef: "blobRefA")]
+        self.cache.write(PersistedRemoteConfiguration(
+            manifest: "v1.1710000100.sources:etag1",
+            activeTopics: ["sources"],
+            topics: RemoteConfiguration.Topics(entries: ["sources": sourcesTopic])
+        ))
+
+        expect(self.cache.topic("sources")) == sourcesTopic
+    }
+
+    func testTopicReturnsNilForUnknownTopic() {
+        self.cache.write(PersistedRemoteConfiguration(
+            manifest: "v1.1710000100.sources:etag1",
+            activeTopics: ["sources"],
+            topics: RemoteConfiguration.Topics(entries: ["sources": ["default": .init(blobRef: "blobRefA")]])
+        ))
+
+        expect(self.cache.topic("unknown")).to(beNil())
+    }
+
+    func testTopicReturnsNilWhenNothingHasBeenPersisted() {
+        expect(self.cache.topic("sources")).to(beNil())
+    }
+
+    func testReadAndTopicServeFromMemoryAfterFirstLoad() throws {
+        let sourcesTopic: RemoteConfiguration.ConfigTopic = ["default": .init(blobRef: "blobRefA")]
+        self.cache.write(PersistedRemoteConfiguration(
+            manifest: "v1.1710000100.sources:etag1",
+            activeTopics: ["sources"],
+            topics: RemoteConfiguration.Topics(entries: ["sources": sourcesTopic])
+        ))
+
+        // Populate the in-memory cache.
+        expect(self.cache.topic("sources")) == sourcesTopic
+
+        // Delete the persisted file behind the cache's back.
+        try FileManager.default.removeItem(at: self.fileURL)
+
+        // Both `read()` and `topic(_:)` are still served from the in-memory cache.
+        expect(self.cache.read()).toNot(beNil())
+        expect(self.cache.topic("sources")) == sourcesTopic
+    }
+
+    func testReadLazilyLoadsFromDiskThenServesFromMemory() throws {
+        // Persist through one instance so the data only lives on disk for a fresh instance.
+        self.cache.write(PersistedRemoteConfiguration(
+            manifest: "v1.1710000100.sources:etag1",
+            activeTopics: ["sources"],
+            topics: RemoteConfiguration.Topics(entries: ["sources": ["default": .init(blobRef: "blobRefA")]])
+        ))
+
+        let freshCache = self.makeCache()
+
+        // First read lazily loads from disk.
+        expect(freshCache.read()?.manifest) == "v1.1710000100.sources:etag1"
+
+        // Once loaded, subsequent reads are served from memory even if the file is gone.
+        try FileManager.default.removeItem(at: self.fileURL)
+        expect(freshCache.read()?.manifest) == "v1.1710000100.sources:etag1"
+    }
+
+    func testTopicReflectsLatestWrite() throws {
+        self.cache.write(PersistedRemoteConfiguration(
+            manifest: "v1.1710000100.sources:old",
+            activeTopics: ["sources"],
+            topics: RemoteConfiguration.Topics(entries: ["sources": ["default": .init(blobRef: "old")]])
+        ))
+        expect(self.cache.topic("sources")) == ["default": .init(blobRef: "old")]
+
+        let newTopic: RemoteConfiguration.ConfigTopic = ["default": .init(blobRef: "new")]
+        self.cache.write(PersistedRemoteConfiguration(
+            manifest: "v1.1710000100.sources:new",
+            activeTopics: ["sources"],
+            topics: RemoteConfiguration.Topics(entries: ["sources": newTopic])
+        ))
+
+        expect(self.cache.topic("sources")) == newTopic
+    }
+
+    func testTopicReturnsNilAfterClear() throws {
+        self.cache.write(PersistedRemoteConfiguration(
+            manifest: "v1.1710000100.sources:etag1",
+            activeTopics: ["sources"],
+            topics: RemoteConfiguration.Topics(entries: ["sources": ["default": .init(blobRef: "blobRefA")]])
+        ))
+        expect(self.cache.topic("sources")).toNot(beNil())
+
+        self.cache.clear()
+
+        expect(self.cache.topic("sources")).to(beNil())
     }
 
 }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests

### Motivation
`RemoteConfigSourceProvider.currentAPISource()` calls `topic(_:)` on the hot path (main-API host resolution), which read the persisted config from disk on every call. Follow-up to [a discussion](https://github.com/RevenueCat/purchases-ios/pull/7123#discussion_r3519495267) in #7123.

### Description
`RemoteConfigDiskCache` now keeps an in-memory copy of the persisted `PersistedRemoteConfiguration`, so `read()`/`topic(_:)` are served from memory. It's set on `write`, cleared on `clear`, and lazily loaded from disk on the first `read`. Fully self-contained in `RemoteConfigDiskCache`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes caching semantics on a networking hot path: a cached miss or stale in-memory state won't see disk updates until write/clear or a new instance, which could affect API host resolution if external processes mutate the file.
> 
> **Overview**
> Adds an **in-memory snapshot** to `RemoteConfigDiskCache` so repeated `read()` and `topic(_:)` calls avoid hitting disk on the hot path (e.g. main-API host resolution).
> 
> `read()` now lazily loads once into an `Atomic<Snapshot>` (`notLoaded` → `loaded(configuration?)`), returns cached values on later calls, and **caches misses** (empty or failed decode) so absent/corrupt files are not re-read every time. Successful `write` updates the snapshot; failed writes leave it unchanged; `clear` wipes disk and sets `.loaded(nil)`.
> 
> Unit tests were extended with `makeCache()` for fresh instances, disk round-trips via new instances, and coverage for snapshot behavior (miss caching, memory serving after file deletion, lazy load, `topic`/`clear`/failed write).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fbc404b0f1b50d15ea157bcc2d20f6d94c5a10b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->