### PR TITLE
fix(remote-config): use RemoteConfigTopic enum in disk cache tests

### DIFF
--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigDiskCacheTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigDiskCacheTests.swift
@@ -278,7 +278,7 @@ final class RemoteConfigDiskCacheTests: TestCase {
 
         expect(didWrite) == false
         expect(self.cache.read()).to(beNil())
-        expect(self.cache.topic("sources")).to(beNil())
+        expect(self.cache.topic(.sources)).to(beNil())
     }
 
     func testWriteOverwritesPreviousSnapshot() throws {
@@ -328,21 +328,21 @@ final class RemoteConfigDiskCacheTests: TestCase {
             topics: RemoteConfiguration.Topics(entries: ["sources": sourcesTopic])
         ))
 
-        expect(self.cache.topic("sources")) == sourcesTopic
+        expect(self.cache.topic(.sources)) == sourcesTopic
     }
 
-    func testTopicReturnsNilForUnknownTopic() {
+    func testTopicReturnsNilForTopicNotPersisted() {
         self.cache.write(PersistedRemoteConfiguration(
             manifest: "v1.1710000100.sources:etag1",
             activeTopics: ["sources"],
             topics: RemoteConfiguration.Topics(entries: ["sources": ["default": .init(blobRef: "blobRefA")]])
         ))
 
-        expect(self.cache.topic("unknown")).to(beNil())
+        expect(self.cache.topic(.uiConfig)).to(beNil())
     }
 
     func testTopicReturnsNilWhenNothingHasBeenPersisted() {
-        expect(self.cache.topic("sources")).to(beNil())
+        expect(self.cache.topic(.sources)).to(beNil())
     }
 
     func testReadAndTopicServeFromMemoryAfterFirstLoad() throws {
@@ -354,14 +354,14 @@ final class RemoteConfigDiskCacheTests: TestCase {
         ))
 
         // Populate the in-memory cache.
-        expect(self.cache.topic("sources")) == sourcesTopic
+        expect(self.cache.topic(.sources)) == sourcesTopic
 
         // Delete the persisted file behind the cache's back.
         try FileManager.default.removeItem(at: self.fileURL)
 
         // Both `read()` and `topic(_:)` are still served from the in-memory cache.
         expect(self.cache.read()).toNot(beNil())
-        expect(self.cache.topic("sources")) == sourcesTopic
+        expect(self.cache.topic(.sources)) == sourcesTopic
     }
 
     func testReadLazilyLoadsFromDiskThenServesFromMemory() throws {
@@ -388,7 +388,7 @@ final class RemoteConfigDiskCacheTests: TestCase {
             activeTopics: ["sources"],
             topics: RemoteConfiguration.Topics(entries: ["sources": ["default": .init(blobRef: "old")]])
         ))
-        expect(self.cache.topic("sources")) == ["default": .init(blobRef: "old")]
+        expect(self.cache.topic(.sources)) == ["default": .init(blobRef: "old")]
 
         let newTopic: RemoteConfiguration.ConfigTopic = ["default": .init(blobRef: "new")]
         self.cache.write(PersistedRemoteConfiguration(
@@ -397,7 +397,7 @@ final class RemoteConfigDiskCacheTests: TestCase {
             topics: RemoteConfiguration.Topics(entries: ["sources": newTopic])
         ))
 
-        expect(self.cache.topic("sources")) == newTopic
+        expect(self.cache.topic(.sources)) == newTopic
     }
 
     func testTopicReturnsNilAfterClear() throws {
@@ -406,11 +406,11 @@ final class RemoteConfigDiskCacheTests: TestCase {
             activeTopics: ["sources"],
             topics: RemoteConfiguration.Topics(entries: ["sources": ["default": .init(blobRef: "blobRefA")]])
         ))
-        expect(self.cache.topic("sources")).toNot(beNil())
+        expect(self.cache.topic(.sources)).toNot(beNil())
 
         self.cache.clear()
 
-        expect(self.cache.topic("sources")).to(beNil())
+        expect(self.cache.topic(.sources)).to(beNil())
     }
 
 }


### PR DESCRIPTION
### Motivation
`main` fails to build: PR #7134 changed `RemoteConfigDiskCache.topic(_:)` to take a `RemoteConfigTopic` enum, while PR #7136 added `RemoteConfigDiskCacheTests` that still pass `String` arguments. Each PR built in isolation, but the combination breaks the test target.

### Description
Update the test calls to use the `RemoteConfigTopic` enum cases (`.sources`, `.uiConfig`). The "unknown topic" case is replaced with a valid-but-unpersisted topic, since the enum is a closed set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only updates with no production code changes; low risk aside from ensuring the renamed nil case still matches intended disk-cache behavior.
> 
> **Overview**
> Fixes a **test-target compile break** after `RemoteConfigDiskCache.topic(_:)` was changed to take `RemoteConfigTopic` instead of `String`.
> 
> All `topic(...)` expectations in `RemoteConfigDiskCacheTests` now use enum cases (e.g. `.sources`, `.uiConfig`) instead of raw topic strings. The former **unknown topic** scenario is renamed to **`testTopicReturnsNilForTopicNotPersisted`** and asserts `nil` for a valid enum case (`.uiConfig`) that was not written to the cache, since the topic set is closed and arbitrary strings are no longer representable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0262bbb2d50aad49e9f82fa4160402bfd795b61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->