### PR TITLE
other(remote-config): read ui_config via remote config

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -567,6 +567,7 @@
 		5733B18E27FF586A00EC2045 /* BackendError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733B18D27FF586A00EC2045 /* BackendError.swift */; };
 		5733B1A427FF9F8300EC2045 /* NetworkErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733B1A327FF9F8300EC2045 /* NetworkErrorTests.swift */; };
 		5733B1A827FFBCC800EC2045 /* BackendErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733B1A727FFBCC800EC2045 /* BackendErrorTests.swift */; };
+		AD787D4FC44F9C3638DCDEF9 /* UiConfigProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371E0615EDF883698273BC59 /* UiConfigProviderTests.swift */; };
 		5733B1AA27FFBCF900EC2045 /* BaseErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733B1A927FFBCF900EC2045 /* BaseErrorTests.swift */; };
 		5733D00928CFA7A4008638D8 /* MockPaymentQueueWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733D00828CFA7A4008638D8 /* MockPaymentQueueWrapper.swift */; };
 		5733D01128D00354008638D8 /* PromotionalOfferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733D01028D00354008638D8 /* PromotionalOfferTests.swift */; };
@@ -601,6 +602,7 @@
 		574A2EE7282C3F0800150D40 /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574A2EE6282C3F0800150D40 /* AnyDecodable.swift */; };
 		574A2EE9282C403800150D40 /* AnyDecodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574A2EE8282C403800150D40 /* AnyDecodableTests.swift */; };
 		574A2F3F282D75E300150D40 /* OfferingsDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574A2F3E282D75E300150D40 /* OfferingsDecodingTests.swift */; };
+		3AC9CEA8FC6D49A3EB7D7393 /* PublishedWorkflowCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3DF79A7BCAA00FD8DCBD07 /* PublishedWorkflowCodableTests.swift */; };
 		574A2F4B282D7AEA00150D40 /* PostOfferResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574A2F4A282D7AEA00150D40 /* PostOfferResponse.swift */; };
 		574A2F4F282D7B9E00150D40 /* PostOfferDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574A2F4E282D7B9E00150D40 /* PostOfferDecodingTests.swift */; };
 		5751379527F4C4D80064AB2C /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5751379427F4C4D80064AB2C /* Optional+Extensions.swift */; };
@@ -948,6 +950,7 @@
 		A1B2C3D42FE4000000000002 /* RCContainerCompressionFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE4000000000001 /* RCContainerCompressionFixtureTests.swift */; };
 		A1B2C3D42FE2000000000002 /* RemoteConfigDiskCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE2000000000001 /* RemoteConfigDiskCache.swift */; };
 		A1B2C3D42FE2000000000004 /* RemoteConfigManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE2000000000003 /* RemoteConfigManager.swift */; };
+		B8EF700CBF25815EC2BF1253 /* UiConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB021C52E3CCC5EB17FFF795 /* UiConfigProvider.swift */; };
 		A1B2C3D42FE200000000000D /* RemoteConfigBlobStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE200000000000C /* RemoteConfigBlobStore.swift */; };
 		A1B2C3D42FE2000000000006 /* RemoteConfigStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE2000000000005 /* RemoteConfigStrings.swift */; };
 		A1B2C3D42FE7000000000002 /* RemoteConfigTopic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE7000000000001 /* RemoteConfigTopic.swift */; };
@@ -2168,6 +2171,7 @@
 		5733B18D27FF586A00EC2045 /* BackendError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendError.swift; sourceTree = "<group>"; };
 		5733B1A327FF9F8300EC2045 /* NetworkErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorTests.swift; sourceTree = "<group>"; };
 		5733B1A727FFBCC800EC2045 /* BackendErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendErrorTests.swift; sourceTree = "<group>"; };
+		371E0615EDF883698273BC59 /* UiConfigProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UiConfigProviderTests.swift; sourceTree = "<group>"; };
 		5733B1A927FFBCF900EC2045 /* BaseErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseErrorTests.swift; sourceTree = "<group>"; };
 		5733D00828CFA7A4008638D8 /* MockPaymentQueueWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPaymentQueueWrapper.swift; sourceTree = "<group>"; };
 		5733D01028D00354008638D8 /* PromotionalOfferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionalOfferTests.swift; sourceTree = "<group>"; };
@@ -2199,6 +2203,7 @@
 		574A2EE6282C3F0800150D40 /* AnyDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyDecodable.swift; sourceTree = "<group>"; };
 		574A2EE8282C403800150D40 /* AnyDecodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyDecodableTests.swift; sourceTree = "<group>"; };
 		574A2F3E282D75E300150D40 /* OfferingsDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfferingsDecodingTests.swift; sourceTree = "<group>"; };
+		5C3DF79A7BCAA00FD8DCBD07 /* PublishedWorkflowCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishedWorkflowCodableTests.swift; sourceTree = "<group>"; };
 		574A2F4A282D7AEA00150D40 /* PostOfferResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostOfferResponse.swift; sourceTree = "<group>"; };
 		574A2F4E282D7B9E00150D40 /* PostOfferDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostOfferDecodingTests.swift; sourceTree = "<group>"; };
 		5751379427F4C4D80064AB2C /* Optional+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+Extensions.swift"; sourceTree = "<group>"; };
@@ -2928,6 +2933,7 @@
 		A1B2C3D42FE4000000000001 /* RCContainerCompressionFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RCContainerCompressionFixtureTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE2000000000001 /* RemoteConfigDiskCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigDiskCache.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE2000000000003 /* RemoteConfigManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigManager.swift; sourceTree = "<group>"; };
+		DB021C52E3CCC5EB17FFF795 /* UiConfigProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UiConfigProvider.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE200000000000C /* RemoteConfigBlobStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobStore.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE2000000000005 /* RemoteConfigStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigStrings.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE7000000000001 /* RemoteConfigTopic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigTopic.swift; sourceTree = "<group>"; };
@@ -4597,6 +4603,7 @@
 				A1B2C3D42FE200000000000C /* RemoteConfigBlobStore.swift */,
 				A1B2C3D42FE2000000000001 /* RemoteConfigDiskCache.swift */,
 				A1B2C3D42FE2000000000003 /* RemoteConfigManager.swift */,
+				DB021C52E3CCC5EB17FFF795 /* UiConfigProvider.swift */,
 				A1B2C3D42FE7000000000001 /* RemoteConfigTopic.swift */,
 				A1B2C3D42FE1000000000011 /* RemoteConfigSignatureContextProvider.swift */,
 			);
@@ -4623,6 +4630,7 @@
 				A1B2C3D42FE2000000000007 /* RemoteConfig */,
 				5733B1A327FF9F8300EC2045 /* NetworkErrorTests.swift */,
 				5733B1A727FFBCC800EC2045 /* BackendErrorTests.swift */,
+				371E0615EDF883698273BC59 /* UiConfigProviderTests.swift */,
 				5733B1A927FFBCF900EC2045 /* BaseErrorTests.swift */,
 				DB7EA7752F964CA200BCC082 /* Workflows */,
 			);
@@ -5094,6 +5102,7 @@
 				5774F9B92805E6E200997128 /* CustomerInfoDecodingTests.swift */,
 				5774F9C02805EA3000997128 /* BaseHTTPResponseTest.swift */,
 				574A2F3E282D75E300150D40 /* OfferingsDecodingTests.swift */,
+				5C3DF79A7BCAA00FD8DCBD07 /* PublishedWorkflowCodableTests.swift */,
 				03A98D312D2441B2009BCA61 /* PaywallDataDecodingTests.swift */,
 				75425E0E2D5DFA9F00E25F60 /* PaywallComponentsDataTests.swift */,
 				E1C0A00ABEEF0001CCDD0001 /* PaywallComponentsConfigHeaderTests.swift */,
@@ -7259,6 +7268,7 @@
 				A1B2C3D42FE200000000000D /* RemoteConfigBlobStore.swift in Sources */,
 				A1B2C3D42FE2000000000002 /* RemoteConfigDiskCache.swift in Sources */,
 				A1B2C3D42FE2000000000004 /* RemoteConfigManager.swift in Sources */,
+				B8EF700CBF25815EC2BF1253 /* UiConfigProvider.swift in Sources */,
 				A1B2C3D42FE2000000000006 /* RemoteConfigStrings.swift in Sources */,
 				A1B2C3D42FE7000000000002 /* RemoteConfigTopic.swift in Sources */,
 				A1B2C3D42FE1000000000010 /* RemoteConfigSignatureContextProvider.swift in Sources */,
@@ -7811,6 +7821,7 @@
 				57E6C27E29723F9E001AFE98 /* SigningTests.swift in Sources */,
 				16DA8EF42E4F7A2500283940 /* VideoComponentTests.swift in Sources */,
 				574A2F3F282D75E300150D40 /* OfferingsDecodingTests.swift in Sources */,
+				3AC9CEA8FC6D49A3EB7D7393 /* PublishedWorkflowCodableTests.swift in Sources */,
 				35E840CE2710E2EB00899AE2 /* MockManageSubscriptionsHelper.swift in Sources */,
 				03A98D322D2441B8009BCA61 /* PaywallDataDecodingTests.swift in Sources */,
 				DB7EA7762F964CA200BCC082 /* WorkflowResponseTests.swift in Sources */,
@@ -7864,6 +7875,7 @@
 				5796A3C027D7D64500653165 /* ResultExtensionsTests.swift in Sources */,
 				351B51A726D450D400BD2BD7 /* SystemInfoTests.swift in Sources */,
 				5733B1A827FFBCC800EC2045 /* BackendErrorTests.swift in Sources */,
+				AD787D4FC44F9C3638DCDEF9 /* UiConfigProviderTests.swift in Sources */,
 				03A98D362D244329009BCA61 /* UIConfigDecodingTests.swift in Sources */,
 				7559DF072E38B05F0050C5B4 /* WebProductToStoreProductConversionTests.swift in Sources */,
 				351B515626D44B2300BD2BD7 /* MockNotificationCenter.swift in Sources */,

--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -33,6 +33,8 @@ enum RemoteConfigStrings {
     case sourceUnhealthy(ref: String, hasNextSource: Bool)
     case storedBlob(String, byteCount: Int, URL)
     case storedInlineBlob(String, byteCount: Int)
+    case uiConfigMissingRequiredPart
+    case uiConfigPartDecodeFailed(itemKey: String, error: Error)
 
 }
 
@@ -96,6 +98,10 @@ extension RemoteConfigStrings: LogMessage {
             return "Stored remote config blob '\(ref)' with \(byteCount) bytes downloaded from \(url.absoluteString)."
         case let .storedInlineBlob(ref, byteCount):
             return "Stored inline remote config blob '\(ref)' with \(byteCount) bytes."
+        case .uiConfigMissingRequiredPart:
+            return "Failed to assemble ui_config: the 'app' or 'localizations' part is unavailable."
+        case let .uiConfigPartDecodeFailed(itemKey, error):
+            return "Failed to decode ui_config part '\(itemKey)': \(error.localizedDescription)"
         }
     }
 

--- a/Sources/Networking/Responses/RevenueCatUI/UIConfig.swift
+++ b/Sources/Networking/Responses/RevenueCatUI/UIConfig.swift
@@ -195,9 +195,27 @@ import Foundation
 
 }
 
+extension UIConfig {
+
+    /// An empty configuration used when a workflow's `ui_config` topic parts are not yet available.
+    static let empty = UIConfig(
+        app: AppConfig(colors: [:], fonts: [:]),
+        localizations: [:],
+        variableConfig: VariableConfig(variableCompatibilityMap: [:], functionCompatibilityMap: [:])
+    )
+
+}
+
 #else
 
 @_spi(Internal) public struct UIConfig: Codable, Equatable, Sendable {
+
+}
+
+extension UIConfig {
+
+    /// An empty configuration used when a workflow's `ui_config` topic parts are not yet available.
+    static let empty = UIConfig()
 
 }
 

--- a/Sources/Networking/Responses/WorkflowsResponse.swift
+++ b/Sources/Networking/Responses/WorkflowsResponse.swift
@@ -201,6 +201,44 @@ import Foundation
         self.metadata = nil
     }
 
+    /// Internal-only full initializer: unlike the public one above, this preserves `metadata`.
+    init(
+        id: String,
+        displayName: String,
+        initialStepId: String,
+        singleStepFallbackId: String?,
+        steps: [String: WorkflowStep],
+        screens: [String: WorkflowScreen],
+        uiConfig: UIConfig,
+        contentMaxWidth: Int?,
+        metadata: [String: AnyDecodable]?
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.initialStepId = initialStepId
+        self.singleStepFallbackId = singleStepFallbackId
+        self.steps = steps
+        self.screens = screens
+        self.uiConfig = uiConfig
+        self.contentMaxWidth = contentMaxWidth
+        self.metadata = metadata
+    }
+
+    /// Returns a copy with `uiConfig` replaced. Unlike the public initializer, this preserves `metadata`.
+    func withUiConfig(_ uiConfig: UIConfig) -> PublishedWorkflow {
+        return PublishedWorkflow(
+            id: self.id,
+            displayName: self.displayName,
+            initialStepId: self.initialStepId,
+            singleStepFallbackId: self.singleStepFallbackId,
+            steps: self.steps,
+            screens: self.screens,
+            uiConfig: uiConfig,
+            contentMaxWidth: self.contentMaxWidth,
+            metadata: self.metadata
+        )
+    }
+
 }
 
 @_spi(Internal) public struct WorkflowDataResult {
@@ -266,7 +304,51 @@ extension WorkflowScreen: Codable, Equatable, Sendable {
 
 }
 
-extension PublishedWorkflow: Codable, Equatable, Sendable {}
+extension PublishedWorkflow: Codable, Equatable, Sendable {
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case displayName
+        case initialStepId
+        case singleStepFallbackId
+        case steps
+        case screens
+        case uiConfig
+        case contentMaxWidth
+        case metadata
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.displayName = try container.decode(String.self, forKey: .displayName)
+        self.initialStepId = try container.decode(String.self, forKey: .initialStepId)
+        self.singleStepFallbackId = try container.decodeIfPresent(String.self, forKey: .singleStepFallbackId)
+        self.steps = try container.decode([String: WorkflowStep].self, forKey: .steps)
+        self.screens = try container.decode([String: WorkflowScreen].self, forKey: .screens)
+        // Not sent by the remote-config `workflows` topic body (ui_config is its own topic there);
+        // the legacy per-workflow response still embeds it inline, so this stays a fallback rather
+        // than the only path.
+        self.uiConfig = try container.decodeIfPresent(UIConfig.self, forKey: .uiConfig) ?? .empty
+        self.contentMaxWidth = try container.decodeIfPresent(Int.self, forKey: .contentMaxWidth)
+        self.metadata = try container.decodeIfPresent([String: AnyDecodable].self, forKey: .metadata)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.id, forKey: .id)
+        try container.encode(self.displayName, forKey: .displayName)
+        try container.encode(self.initialStepId, forKey: .initialStepId)
+        try container.encodeIfPresent(self.singleStepFallbackId, forKey: .singleStepFallbackId)
+        try container.encode(self.steps, forKey: .steps)
+        try container.encode(self.screens, forKey: .screens)
+        try container.encode(self.uiConfig, forKey: .uiConfig)
+        try container.encodeIfPresent(self.contentMaxWidth, forKey: .contentMaxWidth)
+        try container.encodeIfPresent(self.metadata, forKey: .metadata)
+    }
+
+}
+
 extension WorkflowDataResult: Codable, Equatable, Sendable {}
 
 extension PublishedWorkflow: HTTPResponseBody {}

--- a/Sources/Networking/Responses/WorkflowsResponse.swift
+++ b/Sources/Networking/Responses/WorkflowsResponse.swift
@@ -326,9 +326,7 @@ extension PublishedWorkflow: Codable, Equatable, Sendable {
         self.singleStepFallbackId = try container.decodeIfPresent(String.self, forKey: .singleStepFallbackId)
         self.steps = try container.decode([String: WorkflowStep].self, forKey: .steps)
         self.screens = try container.decode([String: WorkflowScreen].self, forKey: .screens)
-        // Not sent by the remote-config `workflows` topic body (ui_config is its own topic there);
-        // the legacy per-workflow response still embeds it inline, so this stays a fallback rather
-        // than the only path.
+        // Absent from the remote-config `workflows` topic body (ui_config is its own topic there).
         self.uiConfig = try container.decodeIfPresent(UIConfig.self, forKey: .uiConfig) ?? .empty
         self.contentMaxWidth = try container.decodeIfPresent(Int.self, forKey: .contentMaxWidth)
         self.metadata = try container.decodeIfPresent([String: AnyDecodable].self, forKey: .metadata)

--- a/Sources/Networking/UiConfigProvider.swift
+++ b/Sources/Networking/UiConfigProvider.swift
@@ -1,0 +1,60 @@
+//
+//  UiConfigProvider.swift
+//  RevenueCat
+//
+//  Created by RevenueCat.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+
+/// The topic-specific front door for `ui_config`: four independently-updated blob items — `app`,
+/// `localizations`, `variable_config`, `custom_variables` — that together assemble one ``UIConfig``,
+/// the same shape the legacy offerings response sends pre-assembled in a single JSON object.
+///
+/// Item keys are read through `RemoteConfigManager.blobData(for:itemKey:)` using their literal wire
+/// names (`variable_config`, not `variableConfig`): item keys are raw dictionary keys and are not
+/// affected by `JSONDecoder`'s `.convertFromSnakeCase`, unlike `ConfigItem.content`'s dynamic keys.
+final class UiConfigProvider {
+
+    private let manager: RemoteConfigManagerType
+
+    init(manager: RemoteConfigManagerType) {
+        self.manager = manager
+    }
+
+    /// Assembles a ``UIConfig`` from the `ui_config` topic's parts. Returns `nil` when a required part
+    /// (`app` or `localizations`) is unavailable; `UIConfig`'s own decoding already defaults the rest.
+    ///
+    /// The four parts are unrelated blobs, fetched concurrently rather than one at a time, so a cold
+    /// cache pays for one round trip instead of four sequential ones.
+    func getUiConfig() async -> UIConfig? {
+        let parts = await withTaskGroup(of: (String, Any?).self) { group in
+            for key in Self.partKeys {
+                group.addTask {
+                    guard let data = await self.manager.blobData(for: .uiConfig, itemKey: key) else {
+                        return (key, nil)
+                    }
+                    return (key, try? JSONSerialization.jsonObject(with: data))
+                }
+            }
+
+            return await group.reduce(into: [String: Any]()) { parts, result in
+                let (key, jsonObject) = result
+                parts[key] = jsonObject
+            }
+        }
+
+        guard parts[Self.appKey] != nil, parts[Self.localizationsKey] != nil else {
+            return nil
+        }
+
+        return try? JSONDecoder.default.decode(UIConfig.self, dictionary: parts)
+    }
+
+    private static let appKey = "app"
+    private static let localizationsKey = "localizations"
+    private static let variableConfigKey = "variable_config"
+    private static let customVariablesKey = "custom_variables"
+    private static let partKeys = [appKey, localizationsKey, variableConfigKey, customVariablesKey]
+
+}

--- a/Sources/Networking/UiConfigProvider.swift
+++ b/Sources/Networking/UiConfigProvider.swift
@@ -18,39 +18,63 @@ final class UiConfigProvider {
         self.manager = manager
     }
 
+#if !os(tvOS)
     /// Assembles a ``UIConfig`` from the `ui_config` topic's parts. Returns `nil` when a required part
-    /// (`app` or `localizations`) is unavailable; `UIConfig`'s own decoding already defaults the rest.
+    /// (`app` or `localizations`) is unavailable or fails to decode.
     ///
-    /// The four parts are unrelated blobs, fetched concurrently rather than one at a time, so a cold
-    /// cache pays for one round trip instead of four sequential ones.
+    /// Each part decodes independently: a malformed `variable_config` or `custom_variables` blob falls
+    /// back to its own default instead of invalidating the whole result, since those parts already have
+    /// defaults `UIConfig` can use elsewhere.
     func getUiConfig() async -> UIConfig? {
-        let parts = await withTaskGroup(of: (String, Any?).self) { group in
-            for key in Self.partKeys {
-                group.addTask {
-                    guard let data = await self.manager.blobData(for: .uiConfig, itemKey: key) else {
-                        return (key, nil)
-                    }
-                    return (key, try? JSONSerialization.jsonObject(with: data))
-                }
-            }
+        async let app = self.decodePart(UIConfig.AppConfig.self, itemKey: Self.appKey)
+        async let localizations = self.decodePart([String: [String: String]].self, itemKey: Self.localizationsKey)
+        async let variableConfig = self.decodePart(UIConfig.VariableConfig.self, itemKey: Self.variableConfigKey)
+        async let customVariables = self.decodePart(
+            [String: UIConfig.CustomVariableDefinition].self,
+            itemKey: Self.customVariablesKey
+        )
 
-            return await group.reduce(into: [String: Any]()) { parts, result in
-                let (key, jsonObject) = result
-                parts[key] = jsonObject
-            }
-        }
-
-        guard parts[Self.appKey] != nil, parts[Self.localizationsKey] != nil else {
+        guard let app = await app, let localizations = await localizations else {
+            Logger.warn(Strings.remoteConfig.uiConfigMissingRequiredPart)
             return nil
         }
 
-        return try? JSONDecoder.default.decode(UIConfig.self, dictionary: parts)
+        return UIConfig(
+            app: app,
+            localizations: localizations,
+            variableConfig: await variableConfig ?? Self.defaultVariableConfig,
+            customVariables: await customVariables ?? [:]
+        )
     }
+
+    private func decodePart<T: Decodable>(_ type: T.Type, itemKey: String) async -> T? {
+        do {
+            return try await self.manager.blobData(for: .uiConfig, itemKey: itemKey, as: type)
+        } catch {
+            Logger.error(Strings.remoteConfig.uiConfigPartDecodeFailed(itemKey: itemKey, error: error))
+            return nil
+        }
+    }
+
+    private static let defaultVariableConfig = UIConfig.VariableConfig(
+        variableCompatibilityMap: [:],
+        functionCompatibilityMap: [:]
+    )
+#else
+    // Paywalls V2 (and therefore workflows) aren't supported on tvOS, where `UIConfig` carries no fields.
+    func getUiConfig() async -> UIConfig? {
+        guard await self.manager.blobData(for: .uiConfig, itemKey: Self.appKey) != nil,
+              await self.manager.blobData(for: .uiConfig, itemKey: Self.localizationsKey) != nil else {
+            Logger.warn(Strings.remoteConfig.uiConfigMissingRequiredPart)
+            return nil
+        }
+        return .empty
+    }
+#endif
 
     private static let appKey = "app"
     private static let localizationsKey = "localizations"
     private static let variableConfigKey = "variable_config"
     private static let customVariablesKey = "custom_variables"
-    private static let partKeys = [appKey, localizationsKey, variableConfigKey, customVariablesKey]
 
 }

--- a/Sources/Networking/UiConfigProvider.swift
+++ b/Sources/Networking/UiConfigProvider.swift
@@ -7,13 +7,9 @@
 
 import Foundation
 
-/// The topic-specific front door for `ui_config`: four independently-updated blob items — `app`,
-/// `localizations`, `variable_config`, `custom_variables` — that together assemble one ``UIConfig``,
-/// the same shape the legacy offerings response sends pre-assembled in a single JSON object.
-///
-/// Item keys are read through `RemoteConfigManager.blobData(for:itemKey:)` using their literal wire
-/// names (`variable_config`, not `variableConfig`): item keys are raw dictionary keys and are not
-/// affected by `JSONDecoder`'s `.convertFromSnakeCase`, unlike `ConfigItem.content`'s dynamic keys.
+/// Assembles a ``UIConfig`` from the `ui_config` topic's four blob items (`app`, `localizations`,
+/// `variable_config`, `custom_variables`). Item keys are literal wire names, not camelCased: unlike
+/// `ConfigItem.content`, they're raw dictionary keys and aren't run through `.convertFromSnakeCase`.
 final class UiConfigProvider {
 
     private let manager: RemoteConfigManagerType

--- a/Tests/UnitTests/Networking/Responses/PublishedWorkflowCodableTests.swift
+++ b/Tests/UnitTests/Networking/Responses/PublishedWorkflowCodableTests.swift
@@ -1,0 +1,83 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PublishedWorkflowCodableTests.swift
+//
+//  Created by RevenueCat.
+
+import Foundation
+import Nimble
+import XCTest
+
+@_spi(Internal) @testable import RevenueCat
+
+/// `PublishedWorkflow` has a hand-written `Codable` conformance (needed so `uiConfig` can default when
+/// absent, since the remote-config `workflows` topic body no longer embeds it) rather than the fully
+/// synthesized one it used to have. These tests exist specifically to catch a decode/encode mismatch
+/// that synthesis used to rule out for free.
+class PublishedWorkflowCodableTests: TestCase {
+
+    func testEncodeThenDecodeRoundTripsAllFields() throws {
+        let original = PublishedWorkflow(
+            id: "wf-1",
+            displayName: "Test workflow",
+            initialStepId: "step-1",
+            singleStepFallbackId: "step-2",
+            steps: [:],
+            screens: [:],
+            uiConfig: .empty,
+            contentMaxWidth: 400
+        )
+
+        let data = try JSONEncoder.default.encode(value: original)
+        let decoded = try JSONDecoder.default.decode(PublishedWorkflow.self, jsonData: data)
+
+        expect(decoded) == original
+    }
+
+    func testDecodingWithoutUiConfigDefaultsToEmpty() throws {
+        // The whole point of the custom decoder: the remote-config `workflows` topic body doesn't send
+        // `ui_config` (it's its own topic), unlike the legacy per-workflow response.
+        let json = """
+        {
+          "id": "wf-1",
+          "display_name": "Test",
+          "initial_step_id": "step-1",
+          "steps": {},
+          "screens": {}
+        }
+        """
+        let decoded = try JSONDecoder.default.decode(
+            PublishedWorkflow.self,
+            jsonData: try XCTUnwrap(json.data(using: .utf8))
+        )
+
+        expect(decoded.uiConfig) == .empty
+    }
+
+    func testDecodingWithMetadataPreservesIt() throws {
+        let json = """
+        {
+          "id": "wf-1",
+          "display_name": "Test",
+          "initial_step_id": "step-1",
+          "steps": {},
+          "screens": {},
+          "metadata": { "source": "cdn" }
+        }
+        """
+        let decoded = try JSONDecoder.default.decode(
+            PublishedWorkflow.self,
+            jsonData: try XCTUnwrap(json.data(using: .utf8))
+        )
+
+        expect(decoded.metadata?["source"]) == .string("cdn")
+    }
+
+}

--- a/Tests/UnitTests/Networking/Responses/PublishedWorkflowCodableTests.swift
+++ b/Tests/UnitTests/Networking/Responses/PublishedWorkflowCodableTests.swift
@@ -17,10 +17,8 @@ import XCTest
 
 @_spi(Internal) @testable import RevenueCat
 
-/// `PublishedWorkflow` has a hand-written `Codable` conformance (needed so `uiConfig` can default when
-/// absent, since the remote-config `workflows` topic body no longer embeds it) rather than the fully
-/// synthesized one it used to have. These tests exist specifically to catch a decode/encode mismatch
-/// that synthesis used to rule out for free.
+/// `PublishedWorkflow`'s `Codable` conformance is hand-written, not synthesized, so a decode/encode
+/// mismatch is no longer ruled out for free — these tests catch that.
 class PublishedWorkflowCodableTests: TestCase {
 
     func testEncodeThenDecodeRoundTripsAllFields() throws {
@@ -42,8 +40,6 @@ class PublishedWorkflowCodableTests: TestCase {
     }
 
     func testDecodingWithoutUiConfigDefaultsToEmpty() throws {
-        // The whole point of the custom decoder: the remote-config `workflows` topic body doesn't send
-        // `ui_config` (it's its own topic), unlike the legacy per-workflow response.
         let json = """
         {
           "id": "wf-1",

--- a/Tests/UnitTests/Networking/UiConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/UiConfigProviderTests.swift
@@ -82,6 +82,28 @@ class UiConfigProviderTests: TestCase {
         expect(uiConfig?.customVariables).to(beEmpty())
     }
 
+    func testMalformedVariableConfigFallsBackToDefaultInsteadOfFailingTheWholeAssembly() async throws {
+        // variable_config is syntactically valid JSON but the wrong shape for VariableConfig, which used
+        // to fail the single merged decode of the whole UIConfig, discarding good app/localizations data.
+        self.stub(app: #"{"colors": {}, "fonts": {}}"#, localizations: #"{"en_US": {"day": "Day"}}"#,
+                  variableConfig: #"{"variable_compatibility_map": "not-a-dictionary"}"#, customVariables: nil)
+
+        let uiConfig = await self.provider.getUiConfig()
+
+        expect(uiConfig).toNot(beNil())
+        expect(uiConfig?.localizations["en_US"]?["day"]) == "Day"
+        expect(uiConfig?.variableConfig.variableCompatibilityMap).to(beEmpty())
+        self.logger.verifyMessageWasLogged("Failed to decode ui_config part 'variable_config'", level: .error)
+    }
+
+    func testLogsWarningWhenARequiredPartIsMissing() async throws {
+        self.stub(app: nil, localizations: #"{}"#, variableConfig: nil, customVariables: nil)
+
+        _ = await self.provider.getUiConfig()
+
+        self.logger.verifyMessageWasLogged(Strings.remoteConfig.uiConfigMissingRequiredPart, level: .warn)
+    }
+
     func testRequestsWireItemKeysNotCamelCased() async throws {
         _ = await self.provider.getUiConfig()
 

--- a/Tests/UnitTests/Networking/UiConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/UiConfigProviderTests.swift
@@ -1,0 +1,106 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  UiConfigProviderTests.swift
+//
+//  Created by RevenueCat.
+
+import Foundation
+import Nimble
+import XCTest
+
+@_spi(Internal) @testable import RevenueCat
+
+class UiConfigProviderTests: TestCase {
+
+    private var mockManager: MockRemoteConfigManager!
+    private var provider: UiConfigProvider!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        self.mockManager = MockRemoteConfigManager()
+        self.provider = UiConfigProvider(manager: self.mockManager)
+    }
+
+    func testAssemblesUiConfigFromItsFourParts() async throws {
+        self.stub(
+            app: #"{"colors": {}, "fonts": {}}"#,
+            localizations: #"{"en_US": {"day": "Day"}}"#,
+            variableConfig: #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#,
+            customVariables: #"{"user_name": {"type": "string", "default_value": "Friend"}}"#
+        )
+
+        let uiConfig = await self.provider.getUiConfig()
+
+        expect(uiConfig).toNot(beNil())
+        expect(uiConfig?.localizations["en_US"]?["day"]) == "Day"
+        expect(uiConfig?.customVariables["user_name"]?.type) == "string"
+        expect(uiConfig?.customVariables["user_name"]?.defaultValue) == "Friend"
+    }
+
+    func testReturnsNilWhenAppPartIsMissing() async throws {
+        self.stub(app: nil, localizations: #"{}"#, variableConfig: nil, customVariables: nil)
+
+        let uiConfig = await self.provider.getUiConfig()
+
+        expect(uiConfig).to(beNil())
+    }
+
+    func testReturnsNilWhenLocalizationsPartIsMissing() async throws {
+        self.stub(app: #"{"colors": {}, "fonts": {}}"#, localizations: nil, variableConfig: nil, customVariables: nil)
+
+        let uiConfig = await self.provider.getUiConfig()
+
+        expect(uiConfig).to(beNil())
+    }
+
+    func testAssemblesUiConfigWhenVariableConfigPartIsMissing() async throws {
+        // variableConfig has decode-time defaults, so omitting it entirely must not fail assembly.
+        self.stub(app: #"{"colors": {}, "fonts": {}}"#, localizations: #"{}"#,
+                  variableConfig: nil, customVariables: nil)
+
+        let uiConfig = await self.provider.getUiConfig()
+
+        expect(uiConfig).toNot(beNil())
+    }
+
+    func testAssemblesUiConfigWhenCustomVariablesPartIsMissing() async throws {
+        // customVariables has decode-time defaults, so omitting it entirely must not fail assembly.
+        self.stub(app: #"{"colors": {}, "fonts": {}}"#, localizations: #"{}"#,
+                  variableConfig: nil, customVariables: nil)
+
+        let uiConfig = await self.provider.getUiConfig()
+
+        expect(uiConfig).toNot(beNil())
+        expect(uiConfig?.customVariables).to(beEmpty())
+    }
+
+    func testRequestsWireItemKeysNotCamelCased() async throws {
+        // `variable_config`/`custom_variables` are raw dictionary keys, not run through
+        // `.convertFromSnakeCase`: a camelCased request would silently miss them and this
+        // assertion would fail.
+        _ = await self.provider.getUiConfig()
+
+        let requestedKeys = self.mockManager.invokedBlobDataParameters
+            .filter { $0.topic == .uiConfig }
+            .map(\.itemKey)
+        expect(requestedKeys).to(contain(["app", "localizations", "variable_config", "custom_variables"]))
+    }
+
+    private func stub(app: String?, localizations: String?, variableConfig: String?, customVariables: String?) {
+        var data: [String: Data] = [:]
+        if let app { data["app"] = Data(app.utf8) }
+        if let localizations { data["localizations"] = Data(localizations.utf8) }
+        if let variableConfig { data["variable_config"] = Data(variableConfig.utf8) }
+        if let customVariables { data["custom_variables"] = Data(customVariables.utf8) }
+        self.mockManager.stubbedBlobData[.uiConfig] = data
+    }
+
+}

--- a/Tests/UnitTests/Networking/UiConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/UiConfigProviderTests.swift
@@ -83,9 +83,6 @@ class UiConfigProviderTests: TestCase {
     }
 
     func testRequestsWireItemKeysNotCamelCased() async throws {
-        // `variable_config`/`custom_variables` are raw dictionary keys, not run through
-        // `.convertFromSnakeCase`: a camelCased request would silently miss them and this
-        // assertion would fail.
         _ = await self.provider.getUiConfig()
 
         let requestedKeys = self.mockManager.invokedBlobDataParameters

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -694,12 +694,22 @@ final class MockRemoteConfigManager: RemoteConfigManagerType {
         self.invokedRefreshRemoteConfigIfStaleParametersList.append(isAppBackgrounded)
     }
 
+    var stubbedTopics: [RemoteConfigTopic: RemoteConfiguration.ConfigTopic] = [:]
+    var stubbedBlobData: [RemoteConfigTopic: [String: Data]] = [:]
+    // Atomic because UiConfigProvider now fetches its parts concurrently, so this can be appended to
+    // from multiple tasks at once.
+    private let _invokedBlobDataParameters: Atomic<[(topic: RemoteConfigTopic, itemKey: String)]> = .init([])
+    var invokedBlobDataParameters: [(topic: RemoteConfigTopic, itemKey: String)] {
+        return self._invokedBlobDataParameters.value
+    }
+
     func topic(_ topic: RemoteConfigTopic) async -> RemoteConfiguration.ConfigTopic? {
-        return nil
+        return self.stubbedTopics[topic]
     }
 
     func blobData(for topic: RemoteConfigTopic, itemKey: String) async -> Data? {
-        return nil
+        self._invokedBlobDataParameters.modify { $0.append((topic, itemKey)) }
+        return self.stubbedBlobData[topic]?[itemKey]
     }
 
     func blobData<T: Decodable>(
@@ -707,7 +717,8 @@ final class MockRemoteConfigManager: RemoteConfigManagerType {
         itemKey: String,
         as type: T.Type
     ) async throws -> T? {
-        return nil
+        guard let data = await self.blobData(for: topic, itemKey: itemKey) else { return nil }
+        return try JSONDecoder.default.decode(type, from: data)
     }
 
     func clearCache() {


### PR DESCRIPTION
### Description

`UiConfigProvider` fetches the `ui_config` topic's four independently-updated parts (`app`, `localizations`, `variable_config`, `custom_variables`) concurrently and assembles one `UIConfig`. `PublishedWorkflow` gets a small custom `Codable` conformance so `uiConfig` defaults to `.empty` when absent, since the topic sends it separately rather than embedded in the workflow body.

This is pure new infrastructure and isn't wired into production code yet — that's the next PR.

**Stacked on this:**
- a follow-up PR ports the actual workflows-over-remote-config cutover (`WorkflowsConfigProvider`, `WorkflowManager` rewrite, `OfferingsManager` gating on config readiness) that wires `UiConfigProvider` in and replaces the current per-workflow backend fetch
- a further RevenueCatUI-only follow-up adds a fallback to the offerings-provided paywall when a workflow fetch fails, matching Android's RevenueCat/purchases-android#3709

<details>
<summary>AI session context</summary>

## Metadata

- PR: 7140
- Branch: `facu/ui-config-remote-config`
- Author / human owner: facumenzella
- Agent(s): Claude Code (Sonnet 5)
- Session source: current conversation
- Generated: 2026-07-06
- Context document version: 1

## Goal

Port Android's workflows-via-remote-config feature (originally PR #3666, superseded by the authoritative #3711 → #3716 → #3709 stack) to iOS, split into reviewable stacked PRs. This PR is the first: the `ui_config`-via-remote-config foundation.

## Initial Prompt

"Check https://github.com/RevenueCat/purchases-android/pull/3666. We need to implement this for iOS. Use the port skill. However, I want this to be split into different PRs that make sense." The scope evolved across the session: the user later redirected to compare against the newer, authoritative Android stack (#3711/#3716/#3709), asked for the whole feature to be built first before deciding the PR split, then directed the specific 2-PR split and file boundary used here.

## Important Follow-up Prompts

- "we should also focus on workflows, not on the config architecture" — narrowed scope to what workflows need from `RemoteConfigManager`'s read API, not the config layer itself.
- "see https://github.com/RevenueCat/purchases-android/pull/3711 has a few stacked prs. Compare those against this" — triggered a full re-comparison against Android's real (non-spike) implementation, surfacing the missing `custom_variables` part fixed in this PR.
- "Are you ok with this impl? Is codex too? What about coverage?" — required measuring real `xcrun xccov` line coverage rather than asserting tests were adequate.
- "how many PRs do we have to open? / are those small enough?" — drove the exact 2-PR boundary (this PR + a stacked follow-up), verified with precise `git diff --shortstat` line counts.
- "can we leave the cleanup to another PR?" — deferred two behavior/structure changes (collapsing an `OfferingsConfigGate` abstraction into `WorkflowManager`, and gating a stale-cache path) out of the next PR into a future one; not part of this PR's diff.

## Agent Contribution

- Implemented `UiConfigProvider` (`Sources/Networking/UiConfigProvider.swift`), concurrently fetching and merging the `ui_config` topic's 4 parts.
- Added `UIConfig.empty` static default and a custom `Codable` conformance for `PublishedWorkflow` (`uiConfig` defaults when absent from the wire payload).
- Extended `MockRemoteConfigManager` test double with stubbable/inspectable `topic()`/`blobData()` behavior.
- Wrote `UiConfigProviderTests` and `PublishedWorkflowCodableTests`.
- Ran a 3-round `codex exec` review-and-fix loop on the full feature (of which this is the first slice); one round caught a real Swift structured-concurrency bug (an `async let` for `ui_config` was still implicitly awaited on an early return), fixed by making the workflow-body-then-ui_config read sequential (that fix lives in the stacked follow-up PR, not this one).
- Compared the full implementation against Android's authoritative #3711/#3716/#3709 stack and identified: a missing 4th `ui_config` part (fixed here), a missing RevenueCatUI paywall-fallback (deferred to a third PR), and an architectural divergence (iOS keeps `ui_config` embedded in the workflow model; Android decoupled it) that was deliberately not replicated since iOS's existing `WorkflowPaywallView`/`PurchaseHandler` already consume the embedded shape.

## Human Decisions

- Chose to keep `ui_config` embedded in `PublishedWorkflow` rather than match Android's fully decoupled model, since iOS's existing RevenueCatUI consumers already read it embedded and matching Android would be a much larger, unrelated refactor for no behavioral gain.
- Deliberately did not port `Purchases.awaitGetUiConfig()` (Android's new public API) — nothing on iOS consumes a standalone `ui_config` fetch today.
- Decided the exact 2-PR split (this PR = foundation, next PR = the actual read-path cutover) after the agent measured precise per-file diff sizes.
- Deferred two already-implemented changes (collapsing `OfferingsConfigGate` into `WorkflowManager.awaitReady`, and gating the offerings stale-cache-serve path on config readiness) to a future cleanup PR rather than including them in the upcoming stacked PR.

## Key Implementation Decisions

- Decision: fetch all 4 `ui_config` parts (`app`, `localizations`, `variable_config`, `custom_variables`) concurrently via `withTaskGroup`.
  - Rationale: matches Android's `UiConfigProvider.PART_KEYS`; a cold cache pays for one round trip instead of four sequential ones.
  - Rejected: sequential fetch (simpler but slower on a cold cache).
- Decision: give `PublishedWorkflow` a hand-written `Codable` conformance instead of relying on synthesis.
  - Rationale: the remote-config `workflows` topic body no longer sends `ui_config` inline (it's its own topic), so decoding needs a default; synthesis can't express that.
  - Rejected: making `uiConfig` optional on the type itself (would be a bigger, more disruptive change to a type consumed throughout RevenueCatUI).

## Files / Symbols Touched

- `Sources/Networking/UiConfigProvider.swift`
  - Why: new file, the `ui_config` topic front door.
  - Symbols: `UiConfigProvider.getUiConfig()`
  - Review relevance: confirm the 4 item keys are literal wire snake_case (`variable_config`, `custom_variables`), not camelCased — they're raw dictionary keys, not run through `.convertFromSnakeCase`.
- `Sources/Networking/Responses/RevenueCatUI/UIConfig.swift`
  - Why: added `UIConfig.empty` static default (both `#if !os(tvOS)` and `#else` branches).
  - Symbols: `UIConfig.empty`
- `Sources/Networking/Responses/WorkflowsResponse.swift`
  - Why: `PublishedWorkflow` custom `Codable` conformance (`uiConfig` defaults to `.empty`), plus an internal-only full initializer and a `withUiConfig(_:)` helper used by the stacked follow-up PR.
  - Symbols: `PublishedWorkflow.init(from:)`, `PublishedWorkflow.encode(to:)`, `PublishedWorkflow.withUiConfig(_:)`
- `Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift`
  - Why: `MockRemoteConfigManager` gained `stubbedTopics`/`stubbedBlobData`/`invokedBlobDataParameters` so tests can control `topic()`/`blobData()` responses.
  - Review relevance: `invokedBlobDataParameters` is `Atomic`-wrapped because `UiConfigProvider`'s concurrent fetch can append to it from multiple tasks at once.

## Dependencies / Config / Migrations

- None captured. No new external dependencies, flags, or migrations.

## Validation

- Commands run:
  - `swift build`: succeeded (both `RevenueCat` and `RevenueCat_CustomEntitlementComputation` targets).
  - `xcodebuild -workspace RevenueCat-Tuist.xcworkspace -scheme UnitTests -only-testing:UnitTests/UiConfigProviderTests -only-testing:UnitTests/PublishedWorkflowCodableTests test`: passed.
  - `swiftlint`: no violations on touched files.
- Manual verification:
  - Ran the full `UnitTests` scheme once in this branch's worktree and saw ~320 unrelated failures (missing fixture files, locale-dependent formatting, `X-Installation-Method` snapshot mismatches); reproduced the same failures against a clean, unmodified `origin/main` checkout in the same fresh worktree to confirm they're pre-existing environment/fixture-setup noise specific to a newly created worktree, not caused by this diff.
- CI: Not captured (not yet observed on this PR).

## Validation Gaps

- Coverage was measured (via `xcrun xccov`) for the full feature during the session, but that measurement covered files that span both this PR and the stacked follow-up; a per-PR coverage breakdown was not separately captured for just this PR's slice.

## Review Focus

- Confirm the `ui_config` topic's 4 item keys really are wire-literal snake_case strings on the backend (not camelCase), matching the assumption baked into `UiConfigProvider.partKeys`.
- Confirm `PublishedWorkflow`'s new custom `Codable` doesn't change behavior for the *existing* (pre-remote-config) workflows-over-HTTP response path, which still sends `ui_config` inline today — `decodeIfPresent` should be a strict relaxation, not a behavior change, for that path.

## Risks / Reviewer Notes

- Risk: `UiConfigProvider` and the `PublishedWorkflow` Codable change ship unused by production code until the next PR lands.
  - Evidence: intentional — mirrors how the RemoteConfig read-facade itself (#7134) shipped as inert infrastructure before workflows consumed it.
  - Mitigation: both are fully unit-tested in isolation.

## Non-goals / Out of Scope

- Wiring `UiConfigProvider` into `WorkflowManager`/`OfferingsManager` (next PR).
- A standalone `Purchases.awaitGetUiConfig()` public API (deliberately not ported; nothing on iOS needs it).
- RevenueCatUI paywall-fallback-on-workflow-failure behavior (future PR, matches Android #3709).

## Omitted Context

Raw transcript, the broader multi-round codex review/fix loop transcript, and exploratory branch/PR searches for prior art were omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New inert infrastructure with unit tests; PublishedWorkflow decoding only relaxes missing ui_config to .empty while inline HTTP payloads remain unchanged.
> 
> **Overview**
> Adds **`UiConfigProvider`**, which concurrently loads the remote-config `ui_config` topic’s four blob parts (`app`, `localizations`, `variable_config`, `custom_variables`) and merges them into a single **`UIConfig`**. Required parts must succeed; optional parts decode on their own and fall back to defaults so a bad `variable_config` or `custom_variables` blob does not discard valid app/localizations data.
> 
> **`PublishedWorkflow`** now uses hand-written **`Codable`**: when `ui_config` is missing from the workflows topic payload, **`uiConfig` defaults to `UIConfig.empty`**. Internal helpers **`withUiConfig(_:)`** and a metadata-preserving initializer support a follow-up that will attach assembled config after decode. Remote-config logging covers missing required parts and per-part decode failures.
> 
> **`MockRemoteConfigManager`** gains stubbable blob/topic data and thread-safe recording of blob requests for tests. This slice is **not wired into production paths yet** (next PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c0b21a8f5b8436553dea4ddeb6078b1d6ed5d64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->