### PR TITLE
other(networking): remove unused workflows OperationQueue and HTTP path cases

### DIFF
--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -49,7 +49,6 @@ class Backend {
                                           operationDispatcher: operationDispatcher,
                                           operationQueue: QueueProvider.createBackendQueue(),
                                           diagnosticsQueue: QueueProvider.createDiagnosticsQueue(),
-                                          workflowsQueue: QueueProvider.createWorkflowsQueue(),
                                           systemInfo: systemInfo,
                                           offlineCustomerInfoCreator: offlineCustomerInfoCreator,
                                           dateProvider: dateProvider)
@@ -249,8 +248,6 @@ extension Backend {
 
     enum QueueProvider {
 
-        private static let maxConcurrentWorkflowOperations = 4
-
         static func createBackendQueue() -> OperationQueue {
             let operationQueue = OperationQueue()
             operationQueue.name = "RC Backend Queue"
@@ -263,16 +260,6 @@ extension Backend {
             operationQueue.name = "RC Diagnostics Queue"
             operationQueue.maxConcurrentOperationCount = 1
             operationQueue.qualityOfService = .background
-            return operationQueue
-        }
-
-        static func createWorkflowsQueue() -> OperationQueue {
-            let operationQueue = OperationQueue()
-            operationQueue.name = "RC Workflows Queue"
-            // No longer used: workflows now read through RemoteConfigManager, not a dedicated
-            // backend endpoint. Left in place pending removal in a follow-up (also removes this
-            // queue's construction/threading through BackendConfiguration).
-            operationQueue.maxConcurrentOperationCount = Self.maxConcurrentWorkflowOperations
             return operationQueue
         }
 

--- a/Sources/Networking/BackendConfiguration.swift
+++ b/Sources/Networking/BackendConfiguration.swift
@@ -20,7 +20,6 @@ class BackendConfiguration {
     let operationDispatcher: OperationDispatcher
     let operationQueue: OperationQueue
     let diagnosticsQueue: OperationQueue
-    let workflowsQueue: OperationQueue
     let dateProvider: DateProvider
     let systemInfo: SystemInfo
     let offlineCustomerInfoCreator: OfflineCustomerInfoCreator?
@@ -29,7 +28,6 @@ class BackendConfiguration {
          operationDispatcher: OperationDispatcher,
          operationQueue: OperationQueue,
          diagnosticsQueue: OperationQueue,
-         workflowsQueue: OperationQueue,
          systemInfo: SystemInfo,
          offlineCustomerInfoCreator: OfflineCustomerInfoCreator?,
          dateProvider: DateProvider = DateProvider()) {
@@ -37,7 +35,6 @@ class BackendConfiguration {
         self.operationDispatcher = operationDispatcher
         self.operationQueue = operationQueue
         self.diagnosticsQueue = diagnosticsQueue
-        self.workflowsQueue = workflowsQueue
         self.offlineCustomerInfoCreator = offlineCustomerInfoCreator
         self.dateProvider = dateProvider
         self.systemInfo = systemInfo
@@ -54,7 +51,7 @@ extension BackendConfiguration: NetworkConfiguration {}
 extension BackendConfiguration {
 
     /// Adds the `operation` to an `OperationQueue` (based on `CallbackCacheStatus`) potentially adding a random delay.
-    /// Defaults to the shared serial `operationQueue`; pass `workflowsQueue` to run concurrently off the serial queue.
+    /// Defaults to the shared serial `operationQueue`; pass a different `queue` to run concurrently off it.
     func addCacheableOperation<T: CacheableNetworkOperation>(
         with factory: CacheableNetworkOperationFactory<T>,
         delay: JitterableDelay,

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -145,8 +145,6 @@ extension HTTPRequest {
         case getProductEntitlementMapping
         case getCustomerCenterConfig(appUserID: String)
         case getVirtualCurrencies(appUserID: String)
-        case getWorkflows(appUserID: String, type: String?)
-        case getWorkflow(appUserID: String, workflowId: String)
         case postRedeemWebPurchase
         case postCreateTicket
         case isPurchaseAllowedByRestoreBehavior(appUserID: String)
@@ -198,14 +196,6 @@ extension HTTPRequest.Path: HTTPRequestPath {
             return "/v1/offerings"
         case .getProductEntitlementMapping:
             return "/v1/product_entitlement_mapping"
-        case let .getWorkflows(_, type):
-            let base = "/workflows/v1/workflows"
-            if let type = type {
-                return "\(base)?type=\(Self.escape(type))"
-            }
-            return base
-        case let .getWorkflow(_, workflowId):
-            return "/workflows/v1/workflows/\(Self.escape(workflowId))"
         case let .remoteConfig(domain):
             return "/v1/config/\(Self.escape(domain))"
         default:
@@ -234,8 +224,6 @@ extension HTTPRequest.Path: HTTPRequestPath {
         switch self {
         case .getCustomerInfo,
                 .getOfferings,
-                .getWorkflows,
-                .getWorkflow,
                 .getIntroEligibility,
                 .logIn,
                 .postAttributionData,
@@ -264,8 +252,6 @@ extension HTTPRequest.Path: HTTPRequestPath {
         switch self {
         case .getCustomerInfo,
                 .getOfferings,
-                .getWorkflows,
-                .getWorkflow,
                 .getIntroEligibility,
                 .logIn,
                 .postAttributionData,
@@ -298,8 +284,6 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .getOfferings,
                 .getProductEntitlementMapping,
                 .getVirtualCurrencies,
-                .getWorkflows,
-                .getWorkflow,
                 .appHealthReport,
                 .appHealthReportAvailability,
                 .isPurchaseAllowedByRestoreBehavior,
@@ -330,9 +314,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .remoteConfig,
                 .rewardVerificationStatus:
             return true
-        case .getWorkflow,
-                .getWorkflows,
-                .getOfferings,
+        case .getOfferings,
                 .getIntroEligibility,
                 .postSubscriberAttributes,
                 .postAttributionData,
@@ -410,16 +392,6 @@ extension HTTPRequest.Path: HTTPRequestPath {
         case let .getVirtualCurrencies(appUserID):
             return "subscribers/\(Self.escape(appUserID))/virtual_currencies"
 
-        case let .getWorkflow(appUserID, workflowId):
-            return "subscribers/\(Self.escape(appUserID))/workflows/\(Self.escape(workflowId))"
-
-        case let .getWorkflows(appUserID, type):
-            let base = "subscribers/\(Self.escape(appUserID))/workflows"
-            if let type = type {
-                return "\(base)?type=\(Self.escape(type))"
-            }
-            return base
-
         case .postCreateTicket:
             return "customercenter/support/create-ticket"
         case let .isPurchaseAllowedByRestoreBehavior(appUserID):
@@ -440,12 +412,6 @@ extension HTTPRequest.Path: HTTPRequestPath {
 
         case .getOfferings:
             return "get_offerings"
-
-        case .getWorkflow:
-            return "get_workflow"
-
-        case .getWorkflows:
-            return "get_workflows"
 
         case .getIntroEligibility:
             return "get_intro_eligibility"

--- a/Tests/UnitTests/Mocks/MockBackendConfiguration.swift
+++ b/Tests/UnitTests/Mocks/MockBackendConfiguration.swift
@@ -31,7 +31,6 @@ class MockBackendConfiguration: BackendConfiguration {
             operationDispatcher: MockOperationDispatcher(),
             operationQueue: Backend.QueueProvider.createBackendQueue(),
             diagnosticsQueue: Backend.QueueProvider.createDiagnosticsQueue(),
-            workflowsQueue: Backend.QueueProvider.createWorkflowsQueue(),
             systemInfo: systemInfo,
             offlineCustomerInfoCreator: MockOfflineCustomerInfoCreator(),
             dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate)

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -81,7 +81,6 @@ class BaseBackendTests: TestCase {
             operationDispatcher: self.operationDispatcher,
             operationQueue: MockBackend.QueueProvider.createBackendQueue(),
             diagnosticsQueue: MockBackend.QueueProvider.createDiagnosticsQueue(),
-            workflowsQueue: MockBackend.QueueProvider.createWorkflowsQueue(),
             systemInfo: self.systemInfo,
             offlineCustomerInfoCreator: self.mockOfflineCustomerInfoCreator,
             dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate)

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -37,8 +37,6 @@ class HTTPRequestTests: TestCase {
         .health,
         .getProductEntitlementMapping,
         .rewardVerificationStatus(appUserID: userID, clientTransactionID: clientTransactionID),
-        .getWorkflows(appUserID: userID, type: nil),
-        .getWorkflow(appUserID: userID, workflowId: "wf_1"),
         .remoteConfig(domain: "app")
     ]
     private static let unauthenticatedPaths: Set<HTTPRequest.Path> = [
@@ -56,8 +54,6 @@ class HTTPRequestTests: TestCase {
         .getOfferings(appUserID: userID),
         .getProductEntitlementMapping,
         .rewardVerificationStatus(appUserID: userID, clientTransactionID: clientTransactionID),
-        .getWorkflows(appUserID: userID, type: nil),
-        .getWorkflow(appUserID: userID, workflowId: "wf_1"),
         .remoteConfig(domain: "app")
     ]
     private static let pathsThatRequireNonce: Set<HTTPRequest.Path> = [
@@ -176,9 +172,7 @@ class HTTPRequestTests: TestCase {
 
         expect(staticEndpoints) == [
             .getOfferings(appUserID: Self.userID),
-            .getProductEntitlementMapping,
-            .getWorkflows(appUserID: Self.userID, type: nil),
-            .getWorkflow(appUserID: Self.userID, workflowId: "wf_1")
+            .getProductEntitlementMapping
         ]
     }
 
@@ -205,14 +199,6 @@ class HTTPRequestTests: TestCase {
             case .getOfferings:
                 XCTAssertEqual(fallbackUrlsPaths,
                                ["https://api-production.8-lives-cat.io/v1/offerings"])
-            case .getWorkflows(_, let type):
-                let expected = type.map {
-                    "https://api-production.8-lives-cat.io/workflows/v1/workflows?type=\($0)"
-                } ?? "https://api-production.8-lives-cat.io/workflows/v1/workflows"
-                XCTAssertEqual(fallbackUrlsPaths, [expected])
-            case let .getWorkflow(_, workflowId):
-                XCTAssertEqual(fallbackUrlsPaths,
-                               ["https://api-production.8-lives-cat.io/workflows/v1/workflows/\(workflowId)"])
             case .remoteConfig:
                 XCTAssertEqual(fallbackUrlsPaths,
                                ["https://api-production.8-lives-cat.io/v1/config/app"])
@@ -222,28 +208,12 @@ class HTTPRequestTests: TestCase {
         }
     }
 
-    func testGetWorkflowsFallbackUrlIncludesTypeParam() {
-        let path = HTTPRequest.Path.getWorkflows(appUserID: Self.userID, type: "PAYWALL")
-        XCTAssertEqual(
-            path.fallbackUrls.map { $0.absoluteString },
-            ["https://api-production.8-lives-cat.io/workflows/v1/workflows?type=PAYWALL"]
-        )
-    }
-
     func testRemoteConfigPathEscapesDomain() {
         let path = HTTPRequest.Path.remoteConfig(domain: "app workflows/project")
 
         expect(path.relativePath) == "/v1/config/app%20workflows%2Fproject"
         expect(path.fallbackUrls.map { $0.absoluteString })
             == ["https://api-production.8-lives-cat.io/v1/config/app%20workflows%2Fproject"]
-    }
-
-    func testGetWorkflowFallbackUrlEscapesWorkflowId() {
-        let path = HTTPRequest.Path.getWorkflow(appUserID: Self.userID, workflowId: "wf id/with special")
-        XCTAssertEqual(
-            path.fallbackUrls.map { $0.absoluteString },
-            ["https://api-production.8-lives-cat.io/workflows/v1/workflows/wf%20id%2Fwith%20special"]
-        )
     }
 
     func testUserIDEscaping() {

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
@@ -69,7 +69,6 @@ final class RemoteConfigIntegrationTests: TestCase {
             operationDispatcher: self.operationDispatcher,
             operationQueue: MockBackend.QueueProvider.createBackendQueue(),
             diagnosticsQueue: MockBackend.QueueProvider.createDiagnosticsQueue(),
-            workflowsQueue: MockBackend.QueueProvider.createWorkflowsQueue(),
             systemInfo: self.systemInfo,
             offlineCustomerInfoCreator: MockOfflineCustomerInfoCreator(),
             dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate)

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -81,7 +81,6 @@ class BasePurchasesTests: TestCase {
                                           operationDispatcher: self.mockOperationDispatcher,
                                           operationQueue: MockBackend.QueueProvider.createBackendQueue(),
                                           diagnosticsQueue: MockBackend.QueueProvider.createDiagnosticsQueue(),
-                                          workflowsQueue: MockBackend.QueueProvider.createWorkflowsQueue(),
                                           systemInfo: self.systemInfo,
                                           offlineCustomerInfoCreator: MockOfflineCustomerInfoCreator(),
                                           dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate))

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -69,7 +69,6 @@ class BackendSubscriberAttributesTests: TestCase {
                                           operationDispatcher: MockOperationDispatcher(),
                                           operationQueue: MockBackend.QueueProvider.createBackendQueue(),
                                           diagnosticsQueue: MockBackend.QueueProvider.createDiagnosticsQueue(),
-                                          workflowsQueue: MockBackend.QueueProvider.createWorkflowsQueue(),
                                           systemInfo: self.systemInfo,
                                           offlineCustomerInfoCreator: MockOfflineCustomerInfoCreator(),
                                           dateProvider: self.dateProvider)
@@ -437,7 +436,6 @@ class BackendSubscriberAttributesTests: TestCase {
                                           operationDispatcher: MockOperationDispatcher(),
                                           operationQueue: MockBackend.QueueProvider.createBackendQueue(),
                                           diagnosticsQueue: MockBackend.QueueProvider.createDiagnosticsQueue(),
-                                          workflowsQueue: MockBackend.QueueProvider.createWorkflowsQueue(),
                                           systemInfo: self.systemInfo,
                                           offlineCustomerInfoCreator: MockOfflineCustomerInfoCreator(),
                                           dateProvider: dateProvider)
@@ -507,7 +505,6 @@ class BackendSubscriberAttributesTests: TestCase {
                                           operationDispatcher: MockOperationDispatcher(),
                                           operationQueue: MockBackend.QueueProvider.createBackendQueue(),
                                           diagnosticsQueue: MockBackend.QueueProvider.createDiagnosticsQueue(),
-                                          workflowsQueue: MockBackend.QueueProvider.createWorkflowsQueue(),
                                           systemInfo: self.systemInfo,
                                           offlineCustomerInfoCreator: MockOfflineCustomerInfoCreator(),
                                           dateProvider: dateProvider)
@@ -568,7 +565,6 @@ class BackendSubscriberAttributesTests: TestCase {
                                           operationDispatcher: MockOperationDispatcher(),
                                           operationQueue: MockBackend.QueueProvider.createBackendQueue(),
                                           diagnosticsQueue: MockBackend.QueueProvider.createDiagnosticsQueue(),
-                                          workflowsQueue: MockBackend.QueueProvider.createWorkflowsQueue(),
                                           systemInfo: self.systemInfo,
                                           offlineCustomerInfoCreator: MockOfflineCustomerInfoCreator(),
                                           dateProvider: dateProvider)


### PR DESCRIPTION
### Motivation

Stacked on #7144. That PR deliberately deferred two pieces of dead-code cleanup that don't block compilation on their own: an unused `OperationQueue` and some now-dead HTTP path cases.

### Description

Removes the dedicated workflows `OperationQueue` (`Backend.swift`'s `createWorkflowsQueue()`, `BackendConfiguration.swift`'s `workflowsQueue` property/init param): it was allocated on every `Backend` init but only ever consumed by the now-deleted `WorkflowsAPI`'s prefetch path — confirmed via grep that nothing passes it as `addCacheableOperation`'s `queue:` argument anymore.

Also removes `HTTPRequestPath.swift`'s dead `.getWorkflow`/`.getWorkflows` enum cases, across all 7 places they appeared (case declarations, `fallbackRelativePath`, `authenticated`, `shouldSendEtag`, `supportsSignatureVerification`, `needsNonceForSigning`, `pathComponent`, `name`), plus the matching test trims.

<details>
<summary>AI session context</summary>

## Metadata

- PR: (assigned on open)
- Branch: `facu/workflows-cleanup-orphaned-wiring`
- Author / human owner: facumenzella
- Agent(s): Claude Code (Sonnet 5)
- Session source: current conversation
- Generated: 2026-07-06
- Context document version: 1

## Goal

Sixth PR in the workflows-via-remote-config stack (#7140, #7142, #7141, #7143, #7144). Finishes the dead-code cleanup #7144 deliberately deferred.

## Initial Prompt

Continuation of "we're also missing cleaning up any workflows code that we've added, that's no longer used, or that does not go through the config endpoint", specifically the "two PRs" split chosen for that cleanup.

## Agent Contribution

- Confirmed via grep that `workflowsQueue` was never actually passed as `addCacheableOperation`'s `queue:` argument anywhere (its only would-be consumer, `WorkflowsAPI.getWorkflow`'s prefetch branch, was deleted in #7144).
- Removed both dead pieces and every downstream reference (`BackendConfiguration`'s init/property, `Backend.swift`'s construction, `QueueProvider.createWorkflowsQueue()`, 5 test call sites for the queue; the two `HTTPRequest.Path` enum cases and their arms across 7 switch statements, plus `HTTPRequestTests.swift`'s two dedicated tests and 3 shared path-array entries).
- Ran a `codex exec` review-and-fix loop (plain + adversarial, in parallel) — both returned ship with no findings on the first pass.
- Ran `/simplify` (4 parallel angles: reuse, simplification, efficiency, altitude) — all four confirmed clean, no further changes, converging the loop.
- Verified via `xcodebuild ... -only-testing:UnitTests/HTTPRequestTests` (28/28 passed) and a broader run including `WorkflowManagerTests`/`WorkflowsConfigProviderTests`/`PurchasesWorkflowTests`/`BackendSubscriberAttributesTests` — the only failures were the same pre-existing environmental snapshot mismatches already confirmed unrelated in #7144 (11/60 failures, all in `BackendSubscriberAttributesTests`, same `X-Installation-Method: spm` vs stale-reference cause).

## Human Decisions

- None beyond the earlier "two PRs" split decision inherited from #7144.

## Files / Symbols Touched

- `Sources/Networking/Backend.swift` — removed `workflowsAPI`-adjacent `createWorkflowsQueue()`/`maxConcurrentWorkflowOperations`, and the `workflowsQueue:` argument at its `BackendConfiguration` construction site.
- `Sources/Networking/BackendConfiguration.swift` — removed the `workflowsQueue` property and init param; corrected `addCacheableOperation`'s doc comment (no longer references the deleted queue by name).
- `Sources/Networking/HTTPClient/HTTPRequestPath.swift` — removed `.getWorkflow`/`.getWorkflows` cases and all 7 switch arms.
- `Tests/UnitTests/Mocks/MockBackendConfiguration.swift`, `Tests/UnitTests/Networking/Backend/BaseBackendTest.swift`, `Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift`, `Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift` — dropped the `workflowsQueue:` argument from their `BackendConfiguration(...)` construction.
- `Tests/UnitTests/Networking/HTTPRequestTests.swift` — removed `testGetWorkflowsFallbackUrlIncludesTypeParam`/`testGetWorkflowFallbackUrlEscapesWorkflowId`, and the `.getWorkflow`/`.getWorkflows` entries from the `paths`/`pathsWithSignatureVerification` shared fixture arrays plus `testStaticEndpoints`'/`testPathsWithFallbackUrls`' case handling.

## Dependencies / Config / Migrations

- None. Purely internal deletions.

## Validation

- Commands run:
  - `swift build`: succeeded.
  - `xcodebuild -workspace RevenueCat-Tuist.xcworkspace -scheme UnitTests -only-testing:UnitTests/HTTPRequestTests test`: 28/28 passed.
  - Broader run (`HTTPRequestTests`, `WorkflowManagerTests`, `WorkflowsConfigProviderTests`, `PurchasesWorkflowTests`, `BackendSubscriberAttributesTests`): 49/60 passed; the 11 failures are the same pre-existing `BackendSubscriberAttributesTests` snapshot-environment mismatch already confirmed unrelated in #7144.
  - `swiftlint`: no violations.
- Manual verification: grepped the whole repo (`Sources/`, `RevenueCatUI/`, `Tests/`, `Examples/`, `fastlane/`, `scripts/`, `Tests/APITesters/`) for the removed symbols before and after — zero remaining references.
- CI: not yet observed (PR just opened).

## Validation Gaps

- CI not yet observed.

## Review Focus

- Confirm the `HTTPRequestPath.swift` switch statements remain exhaustive and correct after the case removal (each was checked individually, but worth a second look given 7 separate switches were touched).

## Risks / Reviewer Notes

- None identified. Pure deletion of confirmed-dead code; no behavior change for any live path.

## Non-goals / Out of Scope

- Nothing further deferred — this closes out the workflows dead-code cleanup started in #7144.

## Omitted Context

Raw transcript and the broader stack history (#7140/#7142/#7141/#7143/#7144, each with their own AI session context blocks) were omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Confirmed-dead internal deletions with no live call sites; behavior for workflow resolution via remote config is unchanged.
> 
> **Overview**
> Finishes dead-code cleanup after workflows moved to **remote config** (`WorkflowsConfigProvider` / `RemoteConfigManager`) instead of dedicated backend workflow endpoints.
> 
> **Backend wiring:** Drops the unused **workflows `OperationQueue`** — `createWorkflowsQueue()`, `BackendConfiguration.workflowsQueue`, and its use at `Backend` init — plus a doc tweak on `addCacheableOperation` so it no longer names that queue.
> 
> **HTTP layer:** Removes **`HTTPRequest.Path` cases** `.getWorkflow` and `.getWorkflows` and all related path metadata (fallback URLs, auth, ETags, signature verification, nonce, `pathComponent`, `name`).
> 
> **Tests:** Stops passing `workflowsQueue` into `BackendConfiguration` in mocks/base tests and trims `HTTPRequestTests` fixtures and workflow-specific fallback/escape tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9495a56f6eae7863e3c0ad5d08cbf56967931751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->