### PR TITLE
fix(paywalls-v2): fix package selection resetting unexpectedly when switching tabs

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -2394,6 +2394,7 @@
 		57BF87582967880C00424254 /* MockCachingTrialOrIntroPriceEligibilityChecker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockCachingTrialOrIntroPriceEligibilityChecker.swift; sourceTree = "<group>"; };
 		57BFCD0A2EEB0E56009E5844 /* TabsPackageInheritanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsPackageInheritanceTests.swift; sourceTree = "<group>"; };
 		57BFCD0F2EEB1234009E5844 /* TabsPackageSelectionResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsPackageSelectionResolverTests.swift; sourceTree = "<group>"; };
+		0AA5FEF26985445B9576D005 /* TabsComponentDuplicateInstanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsComponentDuplicateInstanceTests.swift; sourceTree = "<group>"; };
 		57C0BB6829F840BD00827807 /* FrameworkDisambiguation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameworkDisambiguation.swift; sourceTree = "<group>"; };
 		57C2931428BFEF4F0054EDFC /* PurchasesError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesError.swift; sourceTree = "<group>"; };
 		57C381B62791E593009E3940 /* StoreKit2TransactionListenerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2TransactionListenerTests.swift; sourceTree = "<group>"; };
@@ -3188,6 +3189,7 @@
 				FD4253DD2F1DBD7E0073D2DE /* FileImageLoaderTests.swift */,
 				57BFCD0F2EEB1234009E5844 /* TabsPackageSelectionResolverTests.swift */,
 				57BFCD0A2EEB0E56009E5844 /* TabsPackageInheritanceTests.swift */,
+				0AA5FEF26985445B9576D005 /* TabsComponentDuplicateInstanceTests.swift */,
 				E7EAAD1DC166ABD68E484EAA /* RootViewSheetDismissalTests.swift */,
 				83EE33252E1E20360011CF1C /* PaywallPreviewResourcesLoader.swift */,
 				038EC8222DE7A8AC00786C42 /* TakeScreenshot.swift */,

--- a/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentView.swift
@@ -121,13 +121,11 @@ struct LoadedTabsComponentView: View {
     private let workflowDefaultPackage: Package?
     private let onDismiss: () -> Void
 
-    @StateObject
+    @ObservedObject
     private var tabControlContext: TabControlContext
 
     @State
     private var tierPackageContexts: [String: PackageContext]
-
-    @State var wasConfigured: Bool = false
 
     // MARK: - Parent's Own Selection Tracking
     //
@@ -169,8 +167,9 @@ struct LoadedTabsComponentView: View {
         }
     }
 
-    /// `tabControlContext` is nil in production (the view owns its context); tests may pass
-    /// an external instance to drive tab switches programmatically without UI interaction.
+    /// `tabControlContext` is nil in production (the view reuses the shared instance owned by
+    /// `viewModel`); tests may pass an external instance to drive tab switches programmatically
+    /// without UI interaction.
     init(viewModel: TabsComponentViewModel,
          parentPackageContext: PackageContext,
          workflowDefaultPackage: Package? = nil,
@@ -180,13 +179,7 @@ struct LoadedTabsComponentView: View {
         self.workflowDefaultPackage = workflowDefaultPackage
         self.onDismiss = onDismiss
 
-        self._tabControlContext = .init(wrappedValue: tabControlContext ?? TabControlContext(
-            controlStackViewModel: viewModel.controlStackViewModel,
-            tabIds: viewModel.tabIds,
-            defaultTabId: viewModel.defaultTabId,
-            name: viewModel.name,
-            tabContextNamesById: viewModel.tabContextNamesById
-        ))
+        self.tabControlContext = tabControlContext ?? viewModel.tabControlContext
 
         // Store the parent's initial selection for restoration when switching to package-less tabs
         self._parentOwnedPackage = .init(initialValue: parentPackageContext.package)
@@ -291,8 +284,8 @@ struct LoadedTabsComponentView: View {
                 self.workflowDefaultPackage ?? activeTabViewModel.defaultSelectedPackage
             )
             .onAppear {
-                if !wasConfigured {
-                    self.wasConfigured = true
+                if !self.viewModel.didSeedInitialState {
+                    self.viewModel.didSeedInitialState = true
                     // Seed the store with the initial selection so components that react to the tab
                     // render their correct state on first appearance. A no-op when the declared
                     // default already matches the initial tab.

--- a/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentViewModel.swift
@@ -32,6 +32,35 @@ class TabsComponentViewModel {
     let defaultTabId: String?
     let name: String?
 
+    /// Guards the one-time propagation of the initially active tab's package into the parent
+    /// `PackageContext` on first appearance (see `LoadedTabsComponentView`'s `onAppear`).
+    ///
+    /// This lives on the view model rather than as `@State` on the view because SwiftUI's
+    /// `ViewThatFits` (used to decide whether paywall content needs to scroll) evaluates both of
+    /// its candidate branches to measure them, which constructs a second, non-displayed
+    /// `LoadedTabsComponentView` sharing this same view model instance. That duplicate's own
+    /// `onAppear` fires with its own fresh, never-interacted-with tab state; a per-view `@State`
+    /// guard can't prevent it from re-seeding and clobbering a selection the user already made via
+    /// the real, visible instance. Anchoring the guard here makes it visible to every instance
+    /// backed by this view model.
+    var didSeedInitialState = false
+
+    /// The single `TabControlContext` shared by every `LoadedTabsComponentView` instance backed by
+    /// this view model — including `ViewThatFits`'s duplicate measurement candidates.
+    ///
+    /// `TabControlContext` used to be owned per-view (`@StateObject`), so a duplicate instance got
+    /// its own fresh copy defaulting to `defaultTabId` instead of reflecting whichever tab the user
+    /// actually selected. Owning it here means every instance reads and writes the same
+    /// `selectedTabId`, so a duplicate that later becomes the displayed one still shows the tab the
+    /// user picked instead of silently reverting.
+    lazy var tabControlContext = TabControlContext(
+        controlStackViewModel: self.controlStackViewModel,
+        tabIds: self.tabIds,
+        defaultTabId: self.defaultTabId,
+        name: self.name,
+        tabContextNamesById: self.tabContextNamesById
+    )
+
     /// State-store updates, dispatched when the selected tab changes
     /// (e.g. `{ "set": "<tab state key>", "to": "$value" }`, where `$value`
     /// is the newly selected tab id). `nil`/empty when the paywall declares no tab state.

--- a/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentViewModel.swift
@@ -32,27 +32,14 @@ class TabsComponentViewModel {
     let defaultTabId: String?
     let name: String?
 
-    /// Guards the one-time propagation of the initially active tab's package into the parent
-    /// `PackageContext` on first appearance (see `LoadedTabsComponentView`'s `onAppear`).
-    ///
-    /// This lives on the view model rather than as `@State` on the view because SwiftUI's
-    /// `ViewThatFits` (used to decide whether paywall content needs to scroll) evaluates both of
-    /// its candidate branches to measure them, which constructs a second, non-displayed
-    /// `LoadedTabsComponentView` sharing this same view model instance. That duplicate's own
-    /// `onAppear` fires with its own fresh, never-interacted-with tab state; a per-view `@State`
-    /// guard can't prevent it from re-seeding and clobbering a selection the user already made via
-    /// the real, visible instance. Anchoring the guard here makes it visible to every instance
-    /// backed by this view model.
+    /// Guards the one-time propagation of the initial tab's package into the parent
+    /// `PackageContext`. Lives here, not as per-view `@State`, so SwiftUI's duplicate
+    /// `LoadedTabsComponentView` instances (from `ViewThatFits` measuring both of its branches)
+    /// share the guard instead of each re-seeding and clobbering a real tab switch.
     var didSeedInitialState = false
 
-    /// The single `TabControlContext` shared by every `LoadedTabsComponentView` instance backed by
-    /// this view model — including `ViewThatFits`'s duplicate measurement candidates.
-    ///
-    /// `TabControlContext` used to be owned per-view (`@StateObject`), so a duplicate instance got
-    /// its own fresh copy defaulting to `defaultTabId` instead of reflecting whichever tab the user
-    /// actually selected. Owning it here means every instance reads and writes the same
-    /// `selectedTabId`, so a duplicate that later becomes the displayed one still shows the tab the
-    /// user picked instead of silently reverting.
+    /// The `TabControlContext` shared by every `LoadedTabsComponentView` backed by this view
+    /// model, so a `ViewThatFits` duplicate can't diverge from the tab the user actually selected.
     lazy var tabControlContext = TabControlContext(
         controlStackViewModel: self.controlStackViewModel,
         tabIds: self.tabIds,

--- a/Tests/RevenueCatUITests/PaywallsV2/TabsComponentDuplicateInstanceTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/TabsComponentDuplicateInstanceTests.swift
@@ -1,0 +1,231 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  TabsComponentDuplicateInstanceTests.swift
+//
+
+import Nimble
+@_spi(Internal) import RevenueCat
+@testable import RevenueCatUI
+import SwiftUI
+import XCTest
+
+#if os(iOS)
+
+/// Regression test for a bug where a paywall's "manage subscription" footer button (shown/hidden
+/// via a `selected_package_condition` override) froze on the initially active tab's package no
+/// matter which tab the user actually selected.
+///
+/// Root cause: SwiftUI's `ViewThatFits` (used by `scrollableIfNecessaryWhenAvailable` to decide
+/// whether paywall content needs to scroll) evaluates both of its candidate branches to measure
+/// their ideal size. That constructs a second, non-displayed `LoadedTabsComponentView` sharing the
+/// same `TabsComponentViewModel` and parent `PackageContext` as the real, visible one. Before the
+/// fix, that duplicate got its own fresh, per-view `TabControlContext` and `onAppear` guard, so it
+/// defaulted back to the first tab and unconditionally re-seeded that tab's package into the
+/// shared `PackageContext`, clobbering whatever the user actually selected via the real, visible
+/// instance.
+///
+/// Fix: `TabControlContext` and the one-time seed guard now live on the shared
+/// `TabsComponentViewModel`, so every instance — including duplicates — reads and writes the same
+/// selected-tab state.
+///
+/// This test reproduces the duplicate instance directly (bypassing `ViewThatFits` itself, which
+/// isn't practical to drive from a unit test) by hosting two `LoadedTabsComponentView`s backed by
+/// the same `TabsComponentViewModel` and the same shared `PackageContext`, mirroring what SwiftUI
+/// constructs internally when measuring the "fits without scrolling" candidate.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@MainActor
+final class TabsComponentDuplicateInstanceTests: TestCase {
+
+    func testDuplicateTabsInstanceDoesNotClobberRealTabSwitch() throws {
+        let (viewModel, tab1Package, tab2Package, tab2Id) = try Self.makeTabsViewModel()
+
+        let packageContext = PackageContext(
+            package: nil,
+            variableContext: .init(packages: [tab1Package, tab2Package])
+        )
+
+        // Neither instance is given an explicit TabControlContext, matching production: both
+        // resolve to the shared `viewModel.tabControlContext`.
+        let realView = Self.makeHostableView(
+            viewModel: viewModel,
+            packageContext: packageContext,
+            tabControlContext: nil
+        )
+
+        let (realWindow, _) = Self.host(realView)
+        defer {
+            realWindow.isHidden = true
+            realWindow.rootViewController = nil
+        }
+
+        // The real, visible instance seeds tab 1's package on first appearance.
+        expect(packageContext.package?.identifier) == tab1Package.identifier
+
+        // The user switches to tab 2 via the real, interactive instance. Production code drives
+        // this through TabControlButtonComponentView tapping the shared context; mutate it
+        // directly to isolate the seeding/sharing behavior from tap-gesture plumbing.
+        viewModel.tabControlContext.selectedTabId = tab2Id
+        RunLoop.main.run(until: Date().addingTimeInterval(0.3))
+        realWindow.rootViewController?.view.setNeedsLayout()
+        realWindow.rootViewController?.view.layoutIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+
+        expect(packageContext.package?.identifier) == tab2Package.identifier
+
+        // Simulate ViewThatFits' non-displayed measurement candidate: a second
+        // LoadedTabsComponentView backed by the SAME TabsComponentViewModel and the SAME shared
+        // PackageContext.
+        let phantomView = Self.makeHostableView(
+            viewModel: viewModel,
+            packageContext: packageContext,
+            tabControlContext: nil
+        )
+
+        let (phantomWindow, _) = Self.host(phantomView)
+        defer {
+            phantomWindow.isHidden = true
+            phantomWindow.rootViewController = nil
+        }
+
+        // The phantom's onAppear must not clobber the user's real selection.
+        expect(packageContext.package?.identifier) == tab2Package.identifier
+
+        // And the phantom shares the SAME tab-selection state as the real instance — so if it were
+        // ever promoted to the displayed instance (e.g. ViewThatFits swapping which candidate is on
+        // screen), the pills would still show tab 2 instead of silently reverting to tab 1.
+        expect(viewModel.tabControlContext.selectedTabId) == tab2Id
+    }
+
+}
+
+// MARK: - Helpers
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension TabsComponentDuplicateInstanceTests {
+
+    static func makeTabsViewModel() throws -> (
+        viewModel: TabsComponentViewModel,
+        tab1Package: Package,
+        tab2Package: Package,
+        tab2Id: String
+    ) {
+        let uiConfigProvider = UIConfigProvider(uiConfig: PreviewUIConfig.make())
+        let localization = LocalizationProvider(
+            locale: Locale(identifier: "en_US"),
+            localizedStrings: ["package_label": .string("Package")]
+        )
+        let factory = ViewModelFactory()
+        let tab1Package = TestData.monthlyPackage
+        let tab2Package = TestData.annualPackage
+        let offering = Offering(
+            identifier: "test",
+            serverDescription: "",
+            availablePackages: [tab1Package, tab2Package],
+            webCheckoutUrl: nil
+        )
+
+        let tab1Id = "tab1"
+        let tab2Id = "tab2"
+
+        let tabsComponent = PaywallComponent.TabsComponent(
+            control: .init(
+                type: .buttons,
+                stack: PaywallComponent.StackComponent(components: [
+                    .tabControlButton(PaywallComponent.TabControlButtonComponent(
+                        tabId: tab1Id,
+                        stack: makeTextStack()
+                    )),
+                    .tabControlButton(PaywallComponent.TabControlButtonComponent(
+                        tabId: tab2Id,
+                        stack: makeTextStack()
+                    ))
+                ])
+            ),
+            tabs: [
+                .init(id: tab1Id, stack: makeStackWithPackage(packageID: tab1Package.identifier)),
+                .init(id: tab2Id, stack: makeStackWithPackage(packageID: tab2Package.identifier))
+            ],
+            defaultTabId: tab1Id
+        )
+
+        guard case .tabs(let tabsViewModel) = try factory.toViewModel(
+            component: .tabs(tabsComponent),
+            packageValidator: factory.packageValidator,
+            offering: offering,
+            localizationProvider: localization,
+            uiConfigProvider: uiConfigProvider,
+            colorScheme: .light
+        ) else {
+            XCTFail("Expected a .tabs PaywallComponentViewModel")
+            throw XCTSkip("Test setup failed")
+        }
+
+        return (tabsViewModel, tab1Package, tab2Package, tab2Id)
+    }
+
+    static func makeHostableView(
+        viewModel: TabsComponentViewModel,
+        packageContext: PackageContext,
+        tabControlContext: TabControlContext?
+    ) -> some View {
+        LoadedTabsComponentView(
+            viewModel: viewModel,
+            parentPackageContext: packageContext,
+            onDismiss: {},
+            tabControlContext: tabControlContext
+        )
+        .environmentObject(packageContext)
+        .environmentObject(IntroOfferEligibilityContext(
+            introEligibilityChecker: BaseSnapshotTest.eligibleChecker
+        ))
+        .environmentObject(PaywallPromoOfferCache(
+            subscriptionHistoryTracker: SubscriptionHistoryTracker()
+        ))
+        .environment(\.screenCondition, .compact)
+        .environment(\.componentViewState, .default)
+        .environment(\.safeAreaInsets, EdgeInsets())
+        .environment(\.selectedPackageId, nil)
+        .frame(width: 400, height: 600)
+    }
+
+    static func makeStackWithPackage(packageID: String) -> PaywallComponent.StackComponent {
+        PaywallComponent.StackComponent(components: [
+            .package(PaywallComponent.PackageComponent(
+                packageID: packageID,
+                isSelectedByDefault: true,
+                visible: nil,
+                applePromoOfferProductCode: nil,
+                stack: makeTextStack()
+            ))
+        ])
+    }
+
+    static func makeTextStack() -> PaywallComponent.StackComponent {
+        PaywallComponent.StackComponent(components: [
+            .text(PaywallComponent.TextComponent(
+                text: "package_label",
+                color: .init(light: .hex("#000000"))
+            ))
+        ])
+    }
+
+    static func host<Content: View>(_ view: Content) -> (UIWindow, UIView) {
+        let controller = UIHostingController(rootView: view)
+        let window = UIWindow(frame: CGRect(origin: .zero, size: CGSize(width: 400, height: 600)))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        controller.view.layoutIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.2))
+        return (window, controller.view)
+    }
+
+}
+
+#endif

--- a/Tests/RevenueCatUITests/PaywallsV2/TabsComponentDuplicateInstanceTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/TabsComponentDuplicateInstanceTests.swift
@@ -18,27 +18,11 @@ import XCTest
 
 #if os(iOS)
 
-/// Regression test for a bug where a paywall's "manage subscription" footer button (shown/hidden
-/// via a `selected_package_condition` override) froze on the initially active tab's package no
-/// matter which tab the user actually selected.
-///
-/// Root cause: SwiftUI's `ViewThatFits` (used by `scrollableIfNecessaryWhenAvailable` to decide
-/// whether paywall content needs to scroll) evaluates both of its candidate branches to measure
-/// their ideal size. That constructs a second, non-displayed `LoadedTabsComponentView` sharing the
-/// same `TabsComponentViewModel` and parent `PackageContext` as the real, visible one. Before the
-/// fix, that duplicate got its own fresh, per-view `TabControlContext` and `onAppear` guard, so it
-/// defaulted back to the first tab and unconditionally re-seeded that tab's package into the
-/// shared `PackageContext`, clobbering whatever the user actually selected via the real, visible
-/// instance.
-///
-/// Fix: `TabControlContext` and the one-time seed guard now live on the shared
-/// `TabsComponentViewModel`, so every instance — including duplicates — reads and writes the same
-/// selected-tab state.
-///
-/// This test reproduces the duplicate instance directly (bypassing `ViewThatFits` itself, which
-/// isn't practical to drive from a unit test) by hosting two `LoadedTabsComponentView`s backed by
-/// the same `TabsComponentViewModel` and the same shared `PackageContext`, mirroring what SwiftUI
-/// constructs internally when measuring the "fits without scrolling" candidate.
+/// Regression test: `ViewThatFits` measures both of its candidate branches, which constructs a
+/// second, non-displayed `LoadedTabsComponentView` sharing the same view model and parent
+/// `PackageContext` as the real one. That duplicate used to clobber the user's real tab selection
+/// on `onAppear`. Reproduces it directly (`ViewThatFits` itself isn't practical to drive from a
+/// unit test) by hosting two view instances backed by the same view model and `PackageContext`.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @MainActor
 final class TabsComponentDuplicateInstanceTests: TestCase {
@@ -68,9 +52,7 @@ final class TabsComponentDuplicateInstanceTests: TestCase {
         // The real, visible instance seeds tab 1's package on first appearance.
         expect(packageContext.package?.identifier) == tab1Package.identifier
 
-        // The user switches to tab 2 via the real, interactive instance. Production code drives
-        // this through TabControlButtonComponentView tapping the shared context; mutate it
-        // directly to isolate the seeding/sharing behavior from tap-gesture plumbing.
+        // Mutate the shared context directly instead of tapping, to isolate this from gesture plumbing.
         viewModel.tabControlContext.selectedTabId = tab2Id
         RunLoop.main.run(until: Date().addingTimeInterval(0.3))
         realWindow.rootViewController?.view.setNeedsLayout()
@@ -79,9 +61,7 @@ final class TabsComponentDuplicateInstanceTests: TestCase {
 
         expect(packageContext.package?.identifier) == tab2Package.identifier
 
-        // Simulate ViewThatFits' non-displayed measurement candidate: a second
-        // LoadedTabsComponentView backed by the SAME TabsComponentViewModel and the SAME shared
-        // PackageContext.
+        // Simulate ViewThatFits' non-displayed candidate: a second view backed by the same view model.
         let phantomView = Self.makeHostableView(
             viewModel: viewModel,
             packageContext: packageContext,
@@ -97,9 +77,7 @@ final class TabsComponentDuplicateInstanceTests: TestCase {
         // The phantom's onAppear must not clobber the user's real selection.
         expect(packageContext.package?.identifier) == tab2Package.identifier
 
-        // And the phantom shares the SAME tab-selection state as the real instance — so if it were
-        // ever promoted to the displayed instance (e.g. ViewThatFits swapping which candidate is on
-        // screen), the pills would still show tab 2 instead of silently reverting to tab 1.
+        // And the phantom shares the same tab-selection state, not a fresh default.
         expect(viewModel.tabControlContext.selectedTabId) == tab2Id
     }
 

--- a/Tests/RevenueCatUITests/PaywallsV2/TabsPackageSelectionResolverTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/TabsPackageSelectionResolverTests.swift
@@ -130,6 +130,7 @@ final class TabsPackageSelectionResolverTests: TestCase {
         expect(plan.tabUpdate).to(beNil())
         expect(plan.parentUpdate).to(beNil())
     }
+
 }
 
 #endif


### PR DESCRIPTION
### Motivation

Support case: on a tabbed paywall with a footer button gated by a `selected_package_condition` rule, footer content (and any other package-scoped content outside the Tabs component) froze on whichever tab's package happened to be seeded first, no matter which tab was actually selected. Turned out to be a general bug, not specific to that footer setup — it hits any package-scoped content outside a Tabs component.

Root cause: SwiftUI's `ViewThatFits` (used to decide if paywall content needs scrolling) evaluates both of its candidate branches to measure them, silently constructing a second, non-displayed `LoadedTabsComponentView` backed by the same `TabsComponentViewModel`. That duplicate's own `onAppear` fired with fresh, never-interacted tab state and clobbered the package the user had actually selected.

### Description

Moved the one-time seed guard (`didSeedInitialState`) and the tab-selection state (`TabControlContext`) off per-view `@State`/`@StateObject` and onto the shared `TabsComponentViewModel` instance, so every instance backed by that view model — including `ViewThatFits`'s duplicate — reads and writes the same state instead of a fresh, defaulted copy.

Added `TabsComponentDuplicateInstanceTests` which hosts two real `LoadedTabsComponentView`s backed by the same view model and shared `PackageContext`, mirroring what `ViewThatFits` constructs internally, and confirms the duplicate can't clobber a real tab switch. Verified RED→GREEN against the bug, and live against a real tabbed paywall via a headless `xcodebuild` + `simctl` + tap-automation rig.

Full debug log (root cause writeup, RED/GREEN test output, review history): https://claude.ai/code/artifact/07844e4a-bdde-40b2-a574-52956ef2c759
<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: Not captured (created via `gh pr create`)
- Branch: `facu/fix-tabs-footer-package-clobber`
- Author / human owner: facumenzella
- Agent(s): Claude Code (Sonnet 5), with independent verification passes from Codex (`review` + `adversarial-review`)
- Session source: current conversation
- Generated: 2026-07-07
- Context document version: 1

## Goal

Fix a customer-reported bug where footer content gated by a `selected_package_condition` rule froze on one tab's package regardless of which tab was actually selected, on a tabbed paywall.

## Initial Prompt

Customer case forwarded with a paywall builder URL and SDK version; asked to use the `mafdet` CLI / `debug-component-overrides` skill to check why the rule appeared "stacked under the standard-package value." Clarified with a screenshot: "no matter which tab you select, the paywall rule that applies is the last one in the preview." Explicit workflow requested: form a root-cause theory → validate through Codex → reproduce live via PaywallsTester + baguette → fix → re-verify the fix live → run `/codex-review-fix-loop`.

## Important Follow-up Prompts

- "wat are you doing? spin up paywalls tester for that paywall" — corrected scope creep where the agent was editing `PaywallsTester`'s test-infra files to add programmatic `SKTestSession` StoreKit loading, instead of using the proper `mafdet paywalls-tester ios spin-up` flow.
- "once the fix is ready, we should record a video with the bug, and a video with the fix and include them in the PR description. We should also include the debug logs dump... we can use an artifact."
- AskUserQuestion decisions: ship the confirmed fix now and track the residual `tierPackageContexts` gap as a follow-up (vs. extending this PR); create a fresh `facu/...` branch off `origin/main` rather than committing on the auto-generated worktree branch.

## Agent Contribution

- Diagnosed the root cause via an Explore sub-agent trace of the view hierarchy plus independent confirmation from two Codex review passes (neither told the ViewThatFits hypothesis in advance).
- Implemented the fix across `TabsComponentViewModel.swift` and `TabsComponentView.swift`.
- Went through two self-corrected iterations after an external advisor review caught that an earlier package-identity-based guard (in `TabsPackageSelectionResolver.swift`) only patched one of two divergent state sinks; that partial fix was reverted in favor of sharing state directly on the view model.
- Wrote `TabsComponentDuplicateInstanceTests.swift`, proved RED against the unfixed code, then GREEN against the fix, in two separate layers (seed-guard sharing, then `TabControlContext` sharing).
- Ran a full `codex-review-fix-loop` pass (review + adversarial-review) against the final diff.
- Live-verified via a headless `xcodebuild` build + `simctl install/launch` + baguette tap-automation rig against a real tabbed paywall (Xcode's GUI was unresponsive in this environment for a live Run-action StoreKit-config test).
- Recorded before/after screen captures via `simctl io recordVideo`; sent directly to the requester rather than embedded here, since they show real app content and video files aren't practical to inline via the API.

## Human Decisions

- Corrected the agent away from editing test-infra files to work around an Xcode GUI limitation.
- Chose "ship now + tracked follow-up" over folding the `tierPackageContexts` sharing into this PR.
- Chose to create a fresh feature branch rather than commit on the worktree's auto-generated branch.

## Key Implementation Decisions

- Decision: Share `TabControlContext` and a `didSeedInitialState` guard on `TabsComponentViewModel` rather than gating the `onAppear` seed with a package-identity heuristic.
  - Rationale: `ViewThatFits` constructs a real second `LoadedTabsComponentView` instance (not just a stale render) backed by the *same* view model instance; a heuristic based on package identity can't distinguish "duplicate never interacted with" from "real tab switch to a different tab," and demonstrably moved the bug from the footer to the tab-pill highlight in an earlier iteration.
  - Rejected: `TabsPackageSelectionResolver.initialSeedPackage(currentParentPackage:tabPackage:)` — a guard that skipped seeding whenever the parent already had *any* package. Passed a first review pass but an adversarial pass and live re-testing showed it just relocated the desync from price/footer to the pill.

## Files / Symbols Touched

- `RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentViewModel.swift`
  - Why: host the shared state (`didSeedInitialState`, `tabControlContext`) that every view instance backed by this view model now reads/writes.
  - Symbols: `TabsComponentViewModel.didSeedInitialState`, `TabsComponentViewModel.tabControlContext`
  - Review relevance: confirm `lazy var tabControlContext` is only ever touched on the main actor (it is, transitively, via SwiftUI).
- `RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentView.swift`
  - Why: `LoadedTabsComponentView` now sources `tabControlContext` from the view model instead of owning it, and the `onAppear` seed guard reads/writes the view model instead of local `@State`.
  - Symbols: `LoadedTabsComponentView.tabControlContext`, `LoadedTabsComponentView.init`, the `onAppear` block in `body`
  - Review relevance: the `@StateObject` → `@ObservedObject` swap; confirm downstream `TabControlContext` consumers (`TabControlButtonComponentView`, `TabControlComponentView`, `TabControlToggleComponentView`) are unaffected (they read it via `.environmentObject`, unchanged).
- `Tests/RevenueCatUITests/PaywallsV2/TabsComponentDuplicateInstanceTests.swift` (new)
  - Why: reproduces the `ViewThatFits`-duplicate scenario directly by hosting two real view instances against the same view model.
  - Symbols: `testDuplicateTabsInstanceDoesNotClobberRealTabSwitch`
  - Review relevance: this is the primary regression coverage for the fix; the resolver-level tests can't exercise this class of bug.
- `Tests/RevenueCatUITests/PaywallsV2/TabsPackageSelectionResolverTests.swift`
  - Why: reverted the 3 tests for the superseded `initialSeedPackage` heuristic.

## Dependencies / Config / Migrations

None captured.

## Validation

- Commands run:
  - `xcodebuild test -workspace RevenueCat-Tuist.xcworkspace -scheme RevenueCatUITests -only-testing:RevenueCatUITests/TabsComponentDuplicateInstanceTests ...` (plus `TabsPackageSelectionResolverTests`, `TabsPackageInheritanceTests`, `TabsComponentStateTests`, `CarouselTabSwitchTests`, `PackageValidatorTests`): 47/47 passed on the final commit.
  - `swiftlint lint --strict` on all changed files: 0 violations.
  - Confirmed RED (test fails against unfixed code) → GREEN (passes with the fix), in two separate layers, via targeted `git stash` of just the source changes.
- Manual verification:
  - Live device verification against a real tabbed paywall via headless build + `simctl` + baguette taps: 4+ consecutive real tab switches across the paywall's three tabs, with pill, package card, and footer/purchase button consistent on every tap, both before and after the `@ObservedObject` ownership swap.
- CI: Not captured (not yet run; PR just opened).

## Validation Gaps

- Could not capture a clean on-camera repro of the *original* bug — the `ViewThatFits` re-measurement that triggers the duplicate instance is layout-timing-dependent, not deterministic per tap. The RED unit test is the reliable reproduction; the "before" video sent to the requester may not show a visible mismatch.
- The `tierPackageContexts` follow-up gap (see PR description) was identified by Codex adversarial review but not confirmed reachable via live testing — `ViewThatFits` actually swapping which candidate is displayed mid-session was never directly observed, only inferred as architecturally possible.
- Did not test on macOS/tvOS/visionOS targets; RevenueCatUITests ran on iOS simulator only.

## Review Focus

- Does the `@StateObject` → `@ObservedObject` change on `tabControlContext` have any SwiftUI lifecycle implications for existing consumers not covered by `TabsComponentDuplicateInstanceTests` or `CarouselTabSwitchTests`?
- Is the `lazy var tabControlContext` on `TabsComponentViewModel` safe given the view model's lifecycle (fresh per paywall presentation, persists across workflow "parked" page revisits)?

## Risks / Reviewer Notes

- Risk: residual `tierPackageContexts` per-instance state (see "Known follow-up" in the PR description).
  - Evidence: found by Codex adversarial review; purchase/price state is unaffected in all tested cases, only a potential pill-highlight cosmetic mismatch.
  - Mitigation: tracked as an explicit follow-up rather than silently dropped; same fix pattern applies.

## Non-goals / Out of Scope

- Hoisting `tierPackageContexts`, `parentOwnedPackage`, `parentOwnedVariableContext`, and `didUserSelectPackage` onto the shared view model (the follow-up).
- Investigating whether `ViewThatFits` can be avoided entirely for subtrees containing stateful, side-effecting components like Tabs.

## Omitted Context

Extensive GUI-automation troubleshooting (Xcode becoming unresponsive/windowless in this environment, working around it via headless `xcodebuild`/`simctl`) was omitted as implementation-environment noise, not review-relevant. Raw multi-pass Codex review transcripts were summarized rather than included in full.

</details>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches paywall purchase/package propagation and SwiftUI ownership (`@StateObject` → `@ObservedObject`); behavior is localized to Tabs but affects all tabbed V2 paywalls.
> 
> **Overview**
> Fixes tabbed paywalls where **package-scoped content outside the Tabs component** (e.g. footer rules on `selected_package_condition`) stayed on the wrong package after switching tabs.
> 
> **Root cause:** Paywall scrolling uses `ViewThatFits`, which measures both branches and can construct a second `LoadedTabsComponentView` for the same `TabsComponentViewModel`. Per-view `@State` / `@StateObject` meant that duplicate got its own `TabControlContext` and one-time `onAppear` seed, resetting parent `PackageContext` to the default tab’s package.
> 
> **Change:** `didSeedInitialState` and a shared `tabControlContext` live on `TabsComponentViewModel` instead of each view instance. `LoadedTabsComponentView` uses `@ObservedObject` on that shared context and only runs initial package/state seeding when `viewModel.didSeedInitialState` is false.
> 
> Adds **`TabsComponentDuplicateInstanceTests`** to host two views on the same view model and assert a “phantom” `onAppear` does not undo a real tab switch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b27f1b001e602f02b85a42bdaeecca2b23add81a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->