### PR TITLE
feat(remote-config): add merged blob data API

### DIFF
--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -22,6 +22,9 @@ enum RemoteConfigStrings {
     case duplicateSourceURL(String)
     case failedToParseResponse(Error)
     case malformedBlobRef(String)
+    case mergeItemsBlobDataDisabled(topic: RemoteConfigTopic, itemKeys: [String])
+    case mergeItemsBlobDataEmpty(topic: RemoteConfigTopic)
+    case mergeItemsBlobDataUnavailableItems(topic: RemoteConfigTopic, itemKeys: [String])
     case notModified
     case prefetchEnqueued(Int)
     case prefetchingBlobCount(Int)
@@ -71,6 +74,14 @@ extension RemoteConfigStrings: LogMessage {
             "\(error.localizedDescription)"
         case let .malformedBlobRef(ref):
             return "Refusing remote config blob operation with malformed ref '\(ref)'."
+        case let .mergeItemsBlobDataDisabled(topic, itemKeys):
+            return "Unable to merge remote config blob data for topic '\(topic.wireName)': " +
+                "remote config is disabled. Requested item keys: \(itemKeys.sorted().joined(separator: ", "))."
+        case let .mergeItemsBlobDataEmpty(topic):
+            return "Unable to merge remote config blob data for topic '\(topic.wireName)': no item keys requested."
+        case let .mergeItemsBlobDataUnavailableItems(topic, itemKeys):
+            return "Unable to merge remote config blob data for topic '\(topic.wireName)': " +
+                "unavailable item keys: \(itemKeys.sorted().joined(separator: ", "))."
         case .notModified:
             return "Remote config was not modified. Keeping cached configuration."
         case let .prefetchEnqueued(count):

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -95,14 +95,14 @@ extension RemoteConfigManagerType {
             return nil
         }
 
-        var mergedBlobValues: [String: AnyDecodable] = [:]
+        var mergedBlobValues: [String: Any] = [:]
         for itemKey in uniqueItemKeys {
             guard let resolvedBlob = resolvedBlobs[itemKey],
                   let data = resolvedBlob else { return nil }
-            mergedBlobValues[itemKey] = try JSONDecoder.default.decode(AnyDecodable.self, from: data)
+            mergedBlobValues[itemKey] = try JSONDecoder.default.decode(AnyDecodable.self, from: data).asAny
         }
 
-        let mergedData = try JSONEncoder.default.encode(mergedBlobValues)
+        let mergedData = try JSONSerialization.data(withJSONObject: mergedBlobValues)
         return try JSONDecoder.default.decode(type, from: mergedData)
     }
 

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -36,8 +36,86 @@ protocol RemoteConfigManagerType: AnyObject {
         itemKey: String,
         as type: T.Type
     ) async throws -> T?
+
+    /// Decodes multiple blob payloads into one keyed JSON object.
+    ///
+    /// Each requested item must be backed by `blob_ref`. The merged object is keyed by item key, so item
+    /// `translations` contributes to the `translations` field of `T`.
+    func mergeItemsBlobData<T: Decodable>(
+        for topic: RemoteConfigTopic,
+        itemKeys: [String],
+        as type: T.Type
+    ) async throws -> T?
+
     func clearCache()
     func close()
+
+}
+
+extension RemoteConfigManagerType {
+
+    func mergeItemsBlobData<T: Decodable>(
+        for topic: RemoteConfigTopic,
+        itemKeys: [String],
+        as type: T.Type
+    ) async throws -> T? {
+        let uniqueItemKeys = Self.uniqueItemKeys(itemKeys)
+        guard !uniqueItemKeys.isEmpty else {
+            Logger.warn(Strings.remoteConfig.mergeItemsBlobDataEmpty(topic: topic))
+            return nil
+        }
+        guard !self.isDisabled else {
+            Logger.warn(Strings.remoteConfig.mergeItemsBlobDataDisabled(topic: topic, itemKeys: uniqueItemKeys))
+            return nil
+        }
+
+        let resolvedBlobs = await withTaskGroup(of: (String, Data?).self) { group in
+            for itemKey in uniqueItemKeys {
+                group.addTask {
+                    return (itemKey, await self.blobData(for: topic, itemKey: itemKey))
+                }
+            }
+
+            var resolvedBlobs: [String: Data?] = [:]
+            for await (itemKey, data) in group {
+                resolvedBlobs.updateValue(data, forKey: itemKey)
+            }
+            return resolvedBlobs
+        }
+
+        var mergedBlobValues: [String: AnyDecodable] = [:]
+        let unavailableItemKeys = uniqueItemKeys.filter { itemKey in
+            guard let resolvedBlob = resolvedBlobs[itemKey] else { return true }
+            return resolvedBlob == nil
+        }
+        guard unavailableItemKeys.isEmpty else {
+            Logger.warn(Strings.remoteConfig.mergeItemsBlobDataUnavailableItems(
+                topic: topic,
+                itemKeys: unavailableItemKeys
+            ))
+            return nil
+        }
+
+        for itemKey in uniqueItemKeys {
+            guard let resolvedBlob = resolvedBlobs[itemKey],
+                  let data = resolvedBlob else { return nil }
+            mergedBlobValues[itemKey] = try JSONDecoder.default.decode(AnyDecodable.self, from: data)
+        }
+
+        let mergedData = try JSONEncoder.default.encode(mergedBlobValues)
+        return try JSONDecoder.default.decode(type, from: mergedData)
+    }
+
+    private static func uniqueItemKeys(_ itemKeys: [String]) -> [String] {
+        var seen: Set<String> = []
+        var uniqueItemKeys: [String] = []
+
+        for itemKey in itemKeys where seen.insert(itemKey).inserted {
+            uniqueItemKeys.append(itemKey)
+        }
+
+        return uniqueItemKeys
+    }
 
 }
 

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -83,7 +83,6 @@ extension RemoteConfigManagerType {
             return resolvedBlobs
         }
 
-        var mergedBlobValues: [String: AnyDecodable] = [:]
         let unavailableItemKeys = uniqueItemKeys.filter { itemKey in
             guard let resolvedBlob = resolvedBlobs[itemKey] else { return true }
             return resolvedBlob == nil
@@ -96,6 +95,7 @@ extension RemoteConfigManagerType {
             return nil
         }
 
+        var mergedBlobValues: [String: AnyDecodable] = [:]
         for itemKey in uniqueItemKeys {
             guard let resolvedBlob = resolvedBlobs[itemKey],
                   let data = resolvedBlob else { return nil }

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import Nimble
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 import XCTest
 
 final class RemoteConfigManagerTests: TestCase {
@@ -464,6 +464,352 @@ final class RemoteConfigManagerTests: TestCase {
         } catch {
             expect(error).toNot(beNil())
         }
+    }
+
+    #if !os(tvOS)
+    func testMergeItemsBlobDataMergesUiConfigBlobJSONUnderItemKeys() async throws {
+        let appBlob = #"{"colors": {}, "fonts": {}}"#.asData
+        let localizationsBlob = #"{"en_US": {"day": "Day"}}"#.asData
+        let variableConfigBlob = """
+        {
+          "variable_compatibility_map": { "title": "string" },
+          "function_compatibility_map": { "uppercase": "string" }
+        }
+        """.asData
+        let customVariablesBlob = #"{"user_name": {"type": "string", "default_value": "Friend"}}"#.asData
+        let appRef = RCContainerTestData.blobRef(for: appBlob)
+        let localizationsRef = RCContainerTestData.blobRef(for: localizationsBlob)
+        let variableConfigRef = RCContainerTestData.blobRef(for: variableConfigBlob)
+        let customVariablesRef = RCContainerTestData.blobRef(for: customVariablesBlob)
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.ui_config:etag1",
+            topics: .init(entries: [
+                "ui_config": [
+                    "app": .init(blobRef: appRef),
+                    "localizations": .init(blobRef: localizationsRef),
+                    "variable_config": .init(blobRef: variableConfigRef),
+                    "custom_variables": .init(blobRef: customVariablesRef)
+                ]
+            ])
+        )
+        self.blobStore.stubbedReadDataByRef[appRef] = appBlob
+        self.blobStore.stubbedReadDataByRef[localizationsRef] = localizationsBlob
+        self.blobStore.stubbedReadDataByRef[variableConfigRef] = variableConfigBlob
+        self.blobStore.stubbedReadDataByRef[customVariablesRef] = customVariablesBlob
+
+        let value = try await self.manager.mergeItemsBlobData(
+            for: .uiConfig,
+            itemKeys: ["app", "localizations", "variable_config", "custom_variables"],
+            as: UIConfig.self
+        )
+
+        expect(value?.localizations["en_US"]?["day"]) == "Day"
+        expect(value?.variableConfig.variableCompatibilityMap["title"]) == "string"
+        expect(value?.variableConfig.functionCompatibilityMap["uppercase"]) == "string"
+        expect(value?.customVariables["user_name"]?.type) == "string"
+        expect(value?.customVariables["user_name"]?.defaultValue) == "Friend"
+    }
+    #endif
+
+    func testMergeItemsBlobDataUsesItemKeyAsDecodedPropertyName() async throws {
+        let blob = #"{"value":"favorite"}"#.asData
+        let ref = RCContainerTestData.blobRef(for: blob)
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.workflows:etag1",
+            topics: .init(entries: [
+                "workflows": ["favorite_workflow": .init(blobRef: ref)]
+            ])
+        )
+        self.blobStore.stubbedReadDataByRef[ref] = blob
+
+        let value = try await self.manager.mergeItemsBlobData(
+            for: .workflows,
+            itemKeys: ["favorite_workflow"],
+            as: MergedSnakeCaseWorkflowPayload.self
+        )
+
+        expect(value) == MergedSnakeCaseWorkflowPayload(favoriteWorkflow: .init(value: "favorite"))
+    }
+
+    func testMergeItemsBlobDataDeduplicatesItemKeysPreservingFirstOccurrence() async throws {
+        let blob = #"{"value":"one"}"#.asData
+        let ref = RCContainerTestData.blobRef(for: blob)
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.workflows:etag1",
+            topics: .init(entries: ["workflows": ["wf1": .init(blobRef: ref)]])
+        )
+        self.blobStore.stubbedReadDataByRef[ref] = blob
+
+        let value = try await self.manager.mergeItemsBlobData(
+            for: .workflows,
+            itemKeys: ["wf1", "wf1"],
+            as: SingleMergedWorkflowPayload.self
+        )
+
+        expect(value) == SingleMergedWorkflowPayload(wf1: .init(value: "one"))
+        expect(self.blobFetcher.invokedEnsureDownloadedRefs) == [ref]
+        expect(self.blobStore.invokedReadRefs) == [ref]
+    }
+
+    func testMergeItemsBlobDataReturnsNilForEmptyItemKeysWithoutRefreshingOrReadingBlobs() async throws {
+        let value = try await self.manager.mergeItemsBlobData(
+            for: .workflows,
+            itemKeys: [],
+            as: SingleMergedWorkflowPayload.self
+        )
+
+        expect(value).to(beNil())
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 0
+        expect(self.blobFetcher.invokedEnsureDownloadedRefs).to(beEmpty())
+        expect(self.blobStore.invokedReadRefs).to(beEmpty())
+        self.logger.verifyMessageWasLogged(
+            Strings.remoteConfig.mergeItemsBlobDataEmpty(topic: .workflows),
+            level: .warn
+        )
+    }
+
+    func testMergeItemsBlobDataReturnsNilWhenItemIsMissingAfterRefresh() async throws {
+        self.diskCache.writeHandler = { configuration in
+            self.diskCache.stubbedRead = configuration
+            return true
+        }
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.workflows:etag2",
+          "active_topics": ["workflows"],
+          "topics": {
+            "workflows": {
+              "other": {}
+            }
+          }
+        }
+        """
+
+        let task = Task {
+            try await self.manager.mergeItemsBlobData(
+                for: .workflows,
+                itemKeys: ["wf1"],
+                as: SingleMergedWorkflowPayload.self
+            )
+        }
+        await self.waitForRemoteConfigRequestCount(1)
+        self.remoteConfigAPI.complete(
+            with: .success(.test(container: try Self.container(config: response)))
+        )
+
+        let value = try await task.value
+        expect(value).to(beNil())
+        expect(self.blobFetcher.invokedEnsureDownloadedRefs).to(beEmpty())
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+        self.logger.verifyMessageWasLogged(
+            Strings.remoteConfig.mergeItemsBlobDataUnavailableItems(topic: .workflows, itemKeys: ["wf1"]),
+            level: .warn
+        )
+    }
+
+    func testMergeItemsBlobDataReturnsNilWhenItemHasNoBlobRef() async throws {
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.workflows:etag1",
+            topics: .init(entries: ["workflows": ["wf1": .init(content: ["id": "inline"])]])
+        )
+
+        let value = try await self.manager.mergeItemsBlobData(
+            for: .workflows,
+            itemKeys: ["wf1"],
+            as: SingleMergedWorkflowPayload.self
+        )
+
+        expect(value).to(beNil())
+        expect(self.blobFetcher.invokedEnsureDownloadedRefs).to(beEmpty())
+        self.logger.verifyMessageWasLogged(
+            Strings.remoteConfig.mergeItemsBlobDataUnavailableItems(topic: .workflows, itemKeys: ["wf1"]),
+            level: .warn
+        )
+    }
+
+    func testMergeItemsBlobDataReturnsNilWhenBlobDownloadFails() async throws {
+        let blob = #"{"value":"one"}"#.asData
+        let ref = RCContainerTestData.blobRef(for: blob)
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.workflows:etag1",
+            topics: .init(entries: ["workflows": ["wf1": .init(blobRef: ref)]])
+        )
+        self.blobFetcher.stubbedEnsureDownloadedResult = false
+
+        let value = try await self.manager.mergeItemsBlobData(
+            for: .workflows,
+            itemKeys: ["wf1"],
+            as: SingleMergedWorkflowPayload.self
+        )
+
+        expect(value).to(beNil())
+        expect(self.blobFetcher.invokedEnsureDownloadedRefs) == [ref]
+        expect(self.blobStore.invokedReadRefs).to(beEmpty())
+        self.logger.verifyMessageWasLogged(
+            Strings.remoteConfig.mergeItemsBlobDataUnavailableItems(topic: .workflows, itemKeys: ["wf1"]),
+            level: .warn
+        )
+    }
+
+    func testMergeItemsBlobDataReturnsNilWhenBlobReadFails() async throws {
+        let blob = #"{"value":"one"}"#.asData
+        let ref = RCContainerTestData.blobRef(for: blob)
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.workflows:etag1",
+            topics: .init(entries: ["workflows": ["wf1": .init(blobRef: ref)]])
+        )
+
+        let value = try await self.manager.mergeItemsBlobData(
+            for: .workflows,
+            itemKeys: ["wf1"],
+            as: SingleMergedWorkflowPayload.self
+        )
+
+        expect(value).to(beNil())
+        expect(self.blobFetcher.invokedEnsureDownloadedRefs) == [ref]
+        expect(self.blobStore.invokedReadRefs) == [ref]
+        self.logger.verifyMessageWasLogged(
+            Strings.remoteConfig.mergeItemsBlobDataUnavailableItems(topic: .workflows, itemKeys: ["wf1"]),
+            level: .warn
+        )
+    }
+
+    func testMergeItemsBlobDataColdReadTriggersSingleForegroundRefresh() async throws {
+        let firstBlob = #"{"value":"one"}"#.asData
+        let secondBlob = #"{"value":"two"}"#.asData
+        let firstRef = RCContainerTestData.blobRef(for: firstBlob)
+        let secondRef = RCContainerTestData.blobRef(for: secondBlob)
+        self.diskCache.writeHandler = { configuration in
+            self.diskCache.stubbedRead = configuration
+            return true
+        }
+        self.blobStore.stubbedReadDataByRef[firstRef] = firstBlob
+        self.blobStore.stubbedReadDataByRef[secondRef] = secondBlob
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.workflows:etag2",
+          "active_topics": ["workflows"],
+          "topics": {
+            "workflows": {
+              "wf1": { "blob_ref": "\(firstRef)" },
+              "wf2": { "blob_ref": "\(secondRef)" }
+            }
+          }
+        }
+        """
+
+        let task = Task {
+            try await self.manager.mergeItemsBlobData(
+                for: .workflows,
+                itemKeys: ["wf1", "wf2"],
+                as: MergedWorkflowPayload.self
+            )
+        }
+        await self.waitForRemoteConfigRequestCount(1)
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.isAppBackgrounded) == false
+        self.remoteConfigAPI.complete(
+            with: .success(.test(container: try Self.container(config: response)))
+        )
+
+        let value = try await task.value
+        expect(value) == MergedWorkflowPayload(wf1: .init(value: "one"), wf2: .init(value: "two"))
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+    }
+
+    func testMergeItemsBlobDataReturnsNilWhenRemoteConfigIsDisabledWithoutReadingBlobs() async throws {
+        let blob = #"{"value":"one"}"#.asData
+        let ref = RCContainerTestData.blobRef(for: blob)
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.workflows:etag1",
+            topics: .init(entries: ["workflows": ["wf1": .init(blobRef: ref)]])
+        )
+        self.blobStore.stubbedReadDataByRef[ref] = blob
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
+
+        let value = try await self.manager.mergeItemsBlobData(
+            for: .workflows,
+            itemKeys: ["wf1"],
+            as: SingleMergedWorkflowPayload.self
+        )
+
+        expect(value).to(beNil())
+        expect(self.blobFetcher.invokedEnsureDownloadedRefs).to(beEmpty())
+        expect(self.blobStore.invokedReadRefs).to(beEmpty())
+        self.logger.verifyMessageWasLogged(
+            Strings.remoteConfig.mergeItemsBlobDataDisabled(topic: .workflows, itemKeys: ["wf1"]),
+            level: .warn
+        )
+    }
+
+    func testMergeItemsBlobDataThrowsWhenBlobDataIsNotValidJSON() async throws {
+        let blob = "{ invalid json".asData
+        let ref = RCContainerTestData.blobRef(for: blob)
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.workflows:etag1",
+            topics: .init(entries: ["workflows": ["wf1": .init(blobRef: ref)]])
+        )
+        self.blobStore.stubbedReadDataByRef[ref] = blob
+
+        do {
+            _ = try await self.manager.mergeItemsBlobData(
+                for: .workflows,
+                itemKeys: ["wf1"],
+                as: SingleMergedWorkflowPayload.self
+            )
+            fail("Expected decoding to fail")
+        } catch {
+            expect(error).toNot(beNil())
+        }
+    }
+
+    func testMergeItemsBlobDataThrowsWhenMergedObjectCannotDecode() async throws {
+        let blob = #"{"value":1}"#.asData
+        let ref = RCContainerTestData.blobRef(for: blob)
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.workflows:etag1",
+            topics: .init(entries: ["workflows": ["wf1": .init(blobRef: ref)]])
+        )
+        self.blobStore.stubbedReadDataByRef[ref] = blob
+
+        do {
+            _ = try await self.manager.mergeItemsBlobData(
+                for: .workflows,
+                itemKeys: ["wf1"],
+                as: SingleMergedWorkflowPayload.self
+            )
+            fail("Expected decoding to fail")
+        } catch {
+            expect(error).toNot(beNil())
+        }
+    }
+
+    func testMergeItemsBlobDataSupportsNonObjectJSONValues() async throws {
+        let stringBlob = #""hello""#.asData
+        let intBlob = "42".asData
+        let stringRef = RCContainerTestData.blobRef(for: stringBlob)
+        let intRef = RCContainerTestData.blobRef(for: intBlob)
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.workflows:etag1",
+            topics: .init(entries: [
+                "workflows": [
+                    "wf1": .init(blobRef: stringRef),
+                    "wf2": .init(blobRef: intRef)
+                ]
+            ])
+        )
+        self.blobStore.stubbedReadDataByRef[stringRef] = stringBlob
+        self.blobStore.stubbedReadDataByRef[intRef] = intBlob
+
+        let value = try await self.manager.mergeItemsBlobData(
+            for: .workflows,
+            itemKeys: ["wf1", "wf2"],
+            as: MergedPrimitivePayload.self
+        )
+
+        expect(value) == MergedPrimitivePayload(wf1: "hello", wf2: 42)
     }
 
     func testContainerResponsePersistsServerManifestAndChangedTopics() throws {
@@ -1740,6 +2086,28 @@ private extension RemoteConfigManagerTests {
 
     struct WorkflowPayload: Decodable, Equatable {
         let id: String
+    }
+
+    struct MergedSection: Decodable, Equatable {
+        let value: String
+    }
+
+    struct MergedWorkflowPayload: Decodable, Equatable {
+        let wf1: MergedSection
+        let wf2: MergedSection
+    }
+
+    struct SingleMergedWorkflowPayload: Decodable, Equatable {
+        let wf1: MergedSection
+    }
+
+    struct MergedSnakeCaseWorkflowPayload: Decodable, Equatable {
+        let favoriteWorkflow: MergedSection
+    }
+
+    struct MergedPrimitivePayload: Decodable, Equatable {
+        let wf1: String
+        let wf2: Int
     }
 
 }

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -2393,13 +2393,22 @@ private final class MockRemoteConfigBlobFetcher: RemoteConfigBlobFetcherType {
 
     var stubbedEnsureDownloadedResult = true
 
-    private(set) var invokedEnsureDownloadedRefs: [String] = []
+    private let lock = Lock()
+    private var _invokedEnsureDownloadedRefs: [String] = []
     private(set) var invokedEnsureAllDownloadedRefs: [String] = []
     private(set) var invokedPrefetchCount = 0
     private(set) var invokedPrefetchRefs: [String] = []
 
+    var invokedEnsureDownloadedRefs: [String] {
+        return self.lock.perform {
+            self._invokedEnsureDownloadedRefs
+        }
+    }
+
     func ensureDownloaded(ref: String) async -> Bool {
-        self.invokedEnsureDownloadedRefs.append(ref)
+        self.lock.perform {
+            self._invokedEnsureDownloadedRefs.append(ref)
+        }
         return self.stubbedEnsureDownloadedResult
     }
 

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import Nimble
-@_spi(Internal) @testable import RevenueCat
+@testable import RevenueCat
 import XCTest
 
 final class RemoteConfigManagerTests: TestCase {
@@ -466,14 +466,12 @@ final class RemoteConfigManagerTests: TestCase {
         }
     }
 
-    #if !os(tvOS)
-    func testMergeItemsBlobDataMergesUiConfigBlobJSONUnderItemKeys() async throws {
-        let appBlob = #"{"colors": {}, "fonts": {}}"#.asData
+    func testMergeItemsBlobDataMergesBlobJSONUnderItemKeys() async throws {
+        let appBlob = #"{"enabled": true}"#.asData
         let localizationsBlob = #"{"en_US": {"day": "Day"}}"#.asData
         let variableConfigBlob = """
         {
-          "variable_compatibility_map": { "title": "string" },
-          "function_compatibility_map": { "uppercase": "string" }
+          "title": "string"
         }
         """.asData
         let customVariablesBlob = #"{"user_name": {"type": "string", "default_value": "Friend"}}"#.asData
@@ -500,16 +498,15 @@ final class RemoteConfigManagerTests: TestCase {
         let value = try await self.manager.mergeItemsBlobData(
             for: .uiConfig,
             itemKeys: ["app", "localizations", "variable_config", "custom_variables"],
-            as: UIConfig.self
+            as: MergedUiConfigLikePayload.self
         )
 
+        expect(value?.app.enabled) == true
         expect(value?.localizations["en_US"]?["day"]) == "Day"
-        expect(value?.variableConfig.variableCompatibilityMap["title"]) == "string"
-        expect(value?.variableConfig.functionCompatibilityMap["uppercase"]) == "string"
+        expect(value?.variableConfig.title) == "string"
         expect(value?.customVariables["user_name"]?.type) == "string"
         expect(value?.customVariables["user_name"]?.defaultValue) == "Friend"
     }
-    #endif
 
     func testMergeItemsBlobDataUsesItemKeyAsDecodedPropertyName() async throws {
         let blob = #"{"value":"favorite"}"#.asData
@@ -2108,6 +2105,26 @@ private extension RemoteConfigManagerTests {
     struct MergedPrimitivePayload: Decodable, Equatable {
         let wf1: String
         let wf2: Int
+    }
+
+    struct MergedUiConfigLikePayload: Decodable, Equatable {
+        let app: MergedUiConfigLikeApp
+        let localizations: [String: [String: String]]
+        let variableConfig: MergedUiConfigLikeVariableConfig
+        let customVariables: [String: MergedUiConfigLikeCustomVariable]
+    }
+
+    struct MergedUiConfigLikeApp: Decodable, Equatable {
+        let enabled: Bool
+    }
+
+    struct MergedUiConfigLikeVariableConfig: Decodable, Equatable {
+        let title: String
+    }
+
+    struct MergedUiConfigLikeCustomVariable: Decodable, Equatable {
+        let type: String
+        let defaultValue: String
     }
 
 }

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -528,6 +528,72 @@ final class RemoteConfigManagerTests: TestCase {
         expect(value) == MergedSnakeCaseWorkflowPayload(favoriteWorkflow: .init(value: "favorite"))
     }
 
+    func testMergeItemsBlobDataPreservesComplexNestedJSONValues() async throws {
+        let firstBlob = """
+        {
+          "metadata": {
+            "title": "Welcome",
+            "enabled": true,
+            "ratio": 0.75,
+            "priority": 2,
+            "tags": ["paywall", "experiment"],
+            "steps": [
+              {
+                "id": "intro",
+                "conditions": {
+                  "countries": ["US", "NL"],
+                  "minimum_version": 3
+                }
+              }
+            ]
+          }
+        }
+        """.asData
+        let secondBlob = """
+        {
+          "flags": {
+            "show_debug": false,
+            "optional_value": null
+          },
+          "variants": [
+            { "id": "control", "weight": 0.4 },
+            { "id": "treatment", "weight": 0.6 }
+          ]
+        }
+        """.asData
+        let firstRef = RCContainerTestData.blobRef(for: firstBlob)
+        let secondRef = RCContainerTestData.blobRef(for: secondBlob)
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.workflows:etag1",
+            topics: .init(entries: [
+                "workflows": [
+                    "wf1": .init(blobRef: firstRef),
+                    "wf2": .init(blobRef: secondRef)
+                ]
+            ])
+        )
+        self.blobStore.stubbedReadDataByRef[firstRef] = firstBlob
+        self.blobStore.stubbedReadDataByRef[secondRef] = secondBlob
+
+        let value = try await self.manager.mergeItemsBlobData(
+            for: .workflows,
+            itemKeys: ["wf1", "wf2"],
+            as: MergedComplexPayload.self
+        )
+
+        expect(value?.wf1.metadata.title) == "Welcome"
+        expect(value?.wf1.metadata.enabled) == true
+        expect(value?.wf1.metadata.ratio) == 0.75
+        expect(value?.wf1.metadata.priority) == 2
+        expect(value?.wf1.metadata.tags) == ["paywall", "experiment"]
+        expect(value?.wf1.metadata.steps.first?.conditions.countries) == ["US", "NL"]
+        expect(value?.wf1.metadata.steps.first?.conditions.minimumVersion) == 3
+        expect(value?.wf2.flags.showDebug) == false
+        expect(value?.wf2.flags.optionalValue).to(beNil())
+        expect(value?.wf2.variants.map(\.id)) == ["control", "treatment"]
+        expect(value?.wf2.variants.map(\.weight)) == [0.4, 0.6]
+    }
+
     func testMergeItemsBlobDataDeduplicatesItemKeysPreservingFirstOccurrence() async throws {
         let blob = #"{"value":"one"}"#.asData
         let ref = RCContainerTestData.blobRef(for: blob)
@@ -2105,6 +2171,49 @@ private extension RemoteConfigManagerTests {
     struct MergedPrimitivePayload: Decodable, Equatable {
         let wf1: String
         let wf2: Int
+    }
+
+    struct MergedComplexPayload: Decodable, Equatable {
+        let wf1: ComplexFirstBlob
+        let wf2: ComplexSecondBlob
+    }
+
+    struct ComplexFirstBlob: Decodable, Equatable {
+        let metadata: ComplexMetadata
+    }
+
+    struct ComplexMetadata: Decodable, Equatable {
+        let title: String
+        let enabled: Bool
+        let ratio: Double
+        let priority: Int
+        let tags: [String]
+        let steps: [ComplexStep]
+    }
+
+    struct ComplexStep: Decodable, Equatable {
+        let id: String
+        let conditions: ComplexConditions
+    }
+
+    struct ComplexConditions: Decodable, Equatable {
+        let countries: [String]
+        let minimumVersion: Int
+    }
+
+    struct ComplexSecondBlob: Decodable, Equatable {
+        let flags: ComplexFlags
+        let variants: [ComplexVariant]
+    }
+
+    struct ComplexFlags: Decodable, Equatable {
+        let showDebug: Bool
+        let optionalValue: String?
+    }
+
+    struct ComplexVariant: Decodable, Equatable {
+        let id: String
+        let weight: Double
     }
 
     struct MergedUiConfigLikePayload: Decodable, Equatable {

--- a/Tests/UnitTests/Networking/UiConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/UiConfigProviderTests.swift
@@ -17,8 +17,6 @@ import XCTest
 
 @_spi(Internal) @testable import RevenueCat
 
-#if !os(tvOS)
-
 class UiConfigProviderTests: TestCase {
 
     private var mockManager: MockRemoteConfigManager!
@@ -152,5 +150,3 @@ class UiConfigProviderTests: TestCase {
     }
 
 }
-
-#endif

--- a/Tests/UnitTests/Networking/UiConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/UiConfigProviderTests.swift
@@ -17,6 +17,8 @@ import XCTest
 
 @_spi(Internal) @testable import RevenueCat
 
+#if !os(tvOS)
+
 class UiConfigProviderTests: TestCase {
 
     private var mockManager: MockRemoteConfigManager!
@@ -150,3 +152,5 @@ class UiConfigProviderTests: TestCase {
     }
 
 }
+
+#endif


### PR DESCRIPTION
Aligned with RevenueCat/purchases-android#3725.

## Description
Adds the `mergeItemsBlobData` API for fetching an object (Codable type) that is constructed out of multiple data blobs. This allows for for example the `UIConfig` object to be easily fetched as one `UIConfig.type`, while the underlying data is coming from multiple blobs (`localizations`, `variable_config`, etc). 

This is implemented in an all-or-nothing approach, if one or multiple blobs fail to be fetched `null` is returned to the caller. Because of the nature of the regular `blobData` error handling on iOS (decoding failures `throw`, so the method is throwing), decoding errors here will also throw for consistency. However this is slightly different from Android.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public-style remote config API that drives parallel blob reads and refresh behavior; mis-keyed merges or partial blob availability silently return nil, so downstream UI config assembly must handle that contract.
> 
> **Overview**
> Adds **`mergeItemsBlobData`** on `RemoteConfigManagerType` so callers can decode several `blob_ref` items from one topic into a single `Decodable` type, with each remote-config item key becoming a top-level JSON field (e.g. assembling `ui_config` from `app`, `localizations`, `variable_config`, and `custom_variables`).
> 
> The default implementation deduplicates keys, loads blobs concurrently via existing `blobData`, merges parsed JSON with `JSONSerialization`, then decodes `T`. It is **all-or-nothing**: empty keys, disabled remote config, or any missing/non-blob item yields **`nil`** with new warn logs; invalid JSON or shape mismatches **throw**, matching single-item `blobData` behavior.
> 
> Unit coverage exercises success paths (including snake_case keys and primitives), failure modes, cold-read refresh, and a thread-safe tweak to the blob-fetcher mock for parallel fetches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 878689936f78db6416bf8ec50b7e3677384173d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->