### PR TITLE
fix(remote-config): bind refresh requests to identity clears

### DIFF
--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -160,7 +160,6 @@ private extension IdentityManager {
 
         self.backend.identity.logIn(currentAppUserID: oldAppUserID, newAppUserID: newAppUserID) { result in
             if case let .success((customerInfo, _)) = result {
-                self.workflowsCache?.clearCache()
                 self.remoteConfigManager?.clearCache(forAppUserID: newAppUserID)
                 self.deviceCache.clearCaches(oldAppUserID: oldAppUserID, andSaveWithNewUserID: newAppUserID)
                 self.customerInfoManager.cache(customerInfo: customerInfo, appUserID: newAppUserID)
@@ -196,7 +195,6 @@ private extension IdentityManager {
 
     func resetCacheAndSave(newUserID: String) {
         let oldAppUserID = self.currentAppUserID
-        self.workflowsCache?.clearCache()
         self.remoteConfigManager?.clearCache(forAppUserID: newUserID)
         self.deviceCache.clearCaches(oldAppUserID: oldAppUserID, andSaveWithNewUserID: newUserID)
         self.deviceCache.clearLatestNetworkAndAdvertisingIdsSent(appUserID: currentAppUserID)

--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -160,8 +160,9 @@ private extension IdentityManager {
 
         self.backend.identity.logIn(currentAppUserID: oldAppUserID, newAppUserID: newAppUserID) { result in
             if case let .success((customerInfo, _)) = result {
+                self.workflowsCache?.clearCache()
+                self.remoteConfigManager?.clearCache(forAppUserID: newAppUserID)
                 self.deviceCache.clearCaches(oldAppUserID: oldAppUserID, andSaveWithNewUserID: newAppUserID)
-                self.remoteConfigManager?.clearCache()
                 self.customerInfoManager.cache(customerInfo: customerInfo, appUserID: newAppUserID)
                 self.copySubscriberAttributesToNewUserIfOldIsAnonymous(oldAppUserID: oldAppUserID,
                                                                        newAppUserID: newAppUserID)
@@ -194,8 +195,10 @@ extension IdentityManager: @unchecked Sendable {}
 private extension IdentityManager {
 
     func resetCacheAndSave(newUserID: String) {
-        self.deviceCache.clearCaches(oldAppUserID: currentAppUserID, andSaveWithNewUserID: newUserID)
-        self.remoteConfigManager?.clearCache()
+        let oldAppUserID = self.currentAppUserID
+        self.workflowsCache?.clearCache()
+        self.remoteConfigManager?.clearCache(forAppUserID: newUserID)
+        self.deviceCache.clearCaches(oldAppUserID: oldAppUserID, andSaveWithNewUserID: newUserID)
         self.deviceCache.clearLatestNetworkAndAdvertisingIdsSent(appUserID: currentAppUserID)
         self.backend.clearHTTPClientCaches()
     }

--- a/Sources/Misc/Codable/AnyDecodable.swift
+++ b/Sources/Misc/Codable/AnyDecodable.swift
@@ -84,6 +84,8 @@ extension AnyDecodable: Encodable {
 
 extension AnyDecodable: Hashable {}
 
+extension AnyDecodable: Sendable {}
+
 // MARK: - Expressible by Literal
 
 extension AnyDecodable: ExpressibleByNilLiteral {

--- a/Sources/Networking/BackendConfiguration.swift
+++ b/Sources/Networking/BackendConfiguration.swift
@@ -58,9 +58,9 @@ extension BackendConfiguration {
         cacheStatus: CallbackCacheStatus,
         queue: OperationQueue? = nil
     ) {
-        let targetQueue = queue ?? self.operationQueue
+        let targetQueue = SendableOperationQueue(value: queue ?? self.operationQueue)
         self.operationDispatcher.dispatchOnWorkerThread(jitterableDelay: delay) {
-            targetQueue.addCacheableOperation(with: factory, cacheStatus: cacheStatus)
+            targetQueue.value.addCacheableOperation(with: factory, cacheStatus: cacheStatus)
         }
     }
 
@@ -80,3 +80,9 @@ extension BackendConfiguration {
 // - `OperationQueue` is not `Sendable` as of Swift 5.7
 // - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.
 extension BackendConfiguration: @unchecked Sendable {}
+
+private struct SendableOperationQueue: @unchecked Sendable {
+
+    let value: OperationQueue
+
+}

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -228,9 +228,10 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     private let dateProvider: DateProvider
     private let cacheDurationInSeconds: (Bool) -> TimeInterval
 
+    /// Immutable per-request snapshot chosen under `lock`.
     fileprivate struct RefreshRequestContext {
         let epoch: Int
-        let appUserID: String
+        let requestAppUserID: String
     }
 
     /// Runs blocking committed-state reads away from the caller's executor.
@@ -251,12 +252,13 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     /// Incremented when local state is invalidated so late responses from older users/sessions are dropped.
     private var epoch = 0
 
-    /// User ID to use for refreshes after an identity-bound cache clear.
+    /// App user ID captured by an identity-bound cache clear.
     ///
-    /// Before the first identity change, refreshes use the app user ID passed by the caller. During an identity change,
-    /// this is set atomically with the epoch bump so any refresh that races the device-cache user update syncs for the
-    /// incoming user instead of the previous one.
-    private var appUserIDForRefreshes: String?
+    /// Most refresh callers pass the current user they see at the callsite. During login/switch/logout, `clearCache`
+    /// can bump the epoch before every caller observes the new user from `CurrentUserProvider`. Storing the cleared
+    /// identity under the same lock makes refresh preparation pick `identityBoundAppUserID ?? callerAppUserID` and
+    /// snapshot that with the epoch, so a request is either created for the cleared identity or treated as stale later.
+    private var identityBoundAppUserID: String?
 
     /// In-memory staleness marker. Only successful `200` and `204` responses mark the config fresh.
     private var lastRefreshedAt: Date?
@@ -356,7 +358,7 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     func clearCache(forAppUserID appUserID: String) {
         let continuations = self.lock.perform {
             self.epoch += 1
-            self.appUserIDForRefreshes = appUserID
+            self.identityBoundAppUserID = appUserID
             self.isRefreshing = false
             self.lastRefreshedAt = nil
             self.diskCache.clear()
@@ -388,7 +390,7 @@ private extension RemoteConfigManager {
             self.isRefreshing = true
             return RefreshRequestContext(
                 epoch: self.epoch,
-                appUserID: self.appUserIDForRefreshes ?? appUserID
+                requestAppUserID: self.identityBoundAppUserID ?? appUserID
             )
         }
     }
@@ -413,7 +415,7 @@ private extension RemoteConfigManager {
             self.isRefreshing = true
             return RefreshRequestContext(
                 epoch: self.epoch,
-                appUserID: self.appUserIDForRefreshes ?? appUserID
+                requestAppUserID: self.identityBoundAppUserID ?? appUserID
             )
         }
     }
@@ -421,7 +423,7 @@ private extension RemoteConfigManager {
     func startRefresh(isAppBackgrounded: Bool, requestContext: RefreshRequestContext) {
         let persisted = self.diskCache.read()
         let request = RemoteConfigRequest(
-            appUserID: requestContext.appUserID,
+            appUserID: requestContext.requestAppUserID,
             domain: persisted?.domain ?? Self.defaultDomain,
             manifest: persisted?.manifest,
             prefetchedBlobs: self.cachedPrefetchedBlobRefs(from: persisted)

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -13,8 +13,8 @@ protocol RemoteConfigManagerType: AnyObject {
 
     /// Whether remote config should be ignored for the current manager lifetime.
     var isDisabled: Bool { get }
-    func refreshRemoteConfig(isAppBackgrounded: Bool, appUserID: String)
-    func refreshRemoteConfigIfStale(isAppBackgrounded: Bool, appUserID: String)
+    func refreshRemoteConfig(isAppBackgrounded: Bool)
+    func refreshRemoteConfigIfStale(isAppBackgrounded: Bool)
 
     /// Returns the committed item index for a known topic.
     ///
@@ -179,9 +179,9 @@ final class NoOpRemoteConfigManager: RemoteConfigManagerType {
 
     let isDisabled = true
 
-    func refreshRemoteConfig(isAppBackgrounded: Bool, appUserID: String) {}
+    func refreshRemoteConfig(isAppBackgrounded: Bool) {}
 
-    func refreshRemoteConfigIfStale(isAppBackgrounded: Bool, appUserID: String) {}
+    func refreshRemoteConfigIfStale(isAppBackgrounded: Bool) {}
 
     func topic(_ topic: RemoteConfigTopic) async -> RemoteConfiguration.ConfigTopic? {
         return nil
@@ -254,10 +254,9 @@ final class RemoteConfigManager: RemoteConfigManagerType {
 
     /// App user ID captured by an identity-bound cache clear.
     ///
-    /// Most refresh callers pass the current user they see at the callsite. During login/switch/logout, `clearCache`
-    /// can bump the epoch before every caller observes the new user from `CurrentUserProvider`. Storing the cleared
-    /// identity under the same lock makes refresh preparation pick `identityBoundAppUserID ?? callerAppUserID` and
-    /// snapshot that with the epoch, so a request is either created for the cleared identity or treated as stale later.
+    /// During login/switch/logout, `clearCache` can bump the epoch before every caller observes the new user from
+    /// `CurrentUserProvider`. Storing the cleared identity under the same lock makes refresh preparation prefer this
+    /// ID over the provider value, so a request is either created for the cleared identity or treated as stale later.
     private var identityBoundAppUserID: String?
 
     /// In-memory staleness marker. Only successful `200` and `204` responses mark the config fresh.
@@ -299,13 +298,15 @@ final class RemoteConfigManager: RemoteConfigManagerType {
         }
     }
 
-    func refreshRemoteConfig(isAppBackgrounded: Bool, appUserID: String) {
+    func refreshRemoteConfig(isAppBackgrounded: Bool) {
+        let appUserID = self.currentUserProvider.currentAppUserID
         guard let requestContext = self.prepareRefreshIfNeeded(appUserID: appUserID) else { return }
 
         self.startRefresh(isAppBackgrounded: isAppBackgrounded, requestContext: requestContext)
     }
 
-    func refreshRemoteConfigIfStale(isAppBackgrounded: Bool, appUserID: String) {
+    func refreshRemoteConfigIfStale(isAppBackgrounded: Bool) {
+        let appUserID = self.currentUserProvider.currentAppUserID
         guard let requestContext = self.prepareRefreshIfStale(
             isAppBackgrounded: isAppBackgrounded,
             appUserID: appUserID
@@ -387,10 +388,12 @@ private extension RemoteConfigManager {
             guard !self.isRefreshing,
                   !self.isDisabledInternal,
                   !self.isClosed else { return nil }
+
+            let requestAppUserID = self.identityBoundAppUserID ?? appUserID
             self.isRefreshing = true
-            return RefreshRequestContext(
+            return .init(
                 epoch: self.epoch,
-                requestAppUserID: self.identityBoundAppUserID ?? appUserID
+                requestAppUserID: requestAppUserID
             )
         }
     }
@@ -412,10 +415,11 @@ private extension RemoteConfigManager {
                     > self.cacheDurationInSeconds(isAppBackgrounded) else { return nil }
             }
 
+            let requestAppUserID = self.identityBoundAppUserID ?? appUserID
             self.isRefreshing = true
-            return RefreshRequestContext(
+            return .init(
                 epoch: self.epoch,
-                requestAppUserID: self.identityBoundAppUserID ?? appUserID
+                requestAppUserID: requestAppUserID
             )
         }
     }
@@ -588,9 +592,10 @@ private extension RemoteConfigManager {
             guard self.canReadCommittedState else { return }
         }
 
+        let appUserID = self.currentUserProvider.currentAppUserID
         if let requestContext = self.prepareRefreshIfStale(
             isAppBackgrounded: false,
-            appUserID: self.currentUserProvider.currentAppUserID,
+            appUserID: appUserID,
             expectedEpoch: expectedEpoch
         ) {
             self.startRefresh(isAppBackgrounded: false, requestContext: requestContext)

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -233,6 +233,12 @@ final class RemoteConfigManager: RemoteConfigManagerType {
         let appUserID: String
     }
 
+    fileprivate struct PendingRefreshRequestContext {
+        let epoch: Int
+        let appUserID: String?
+        let canAdoptReboundAppUserID: Bool
+    }
+
     /// Runs blocking committed-state reads away from the caller's executor.
     private let readQueue = DispatchQueue(label: "com.revenuecat.remote-config.read")
 
@@ -298,17 +304,17 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     }
 
     func refreshRemoteConfig(isAppBackgrounded: Bool) {
-        let fallbackAppUserID = self.currentUserProvider.currentAppUserID
-        guard let requestContext = self.prepareRefreshIfNeeded(fallbackAppUserID: fallbackAppUserID) else { return }
+        guard let requestContext = self.prepareRefreshIfNeeded(
+            fallbackAppUserID: { self.currentUserProvider.currentAppUserID }
+        ) else { return }
 
         self.startRefresh(isAppBackgrounded: isAppBackgrounded, requestContext: requestContext)
     }
 
     func refreshRemoteConfigIfStale(isAppBackgrounded: Bool) {
-        let fallbackAppUserID = self.currentUserProvider.currentAppUserID
         guard let requestContext = self.prepareRefreshIfStale(
             isAppBackgrounded: isAppBackgrounded,
-            fallbackAppUserID: fallbackAppUserID
+            fallbackAppUserID: { self.currentUserProvider.currentAppUserID }
         ) else { return }
 
         self.startRefresh(isAppBackgrounded: isAppBackgrounded, requestContext: requestContext)
@@ -382,25 +388,29 @@ final class RemoteConfigManager: RemoteConfigManagerType {
 
 private extension RemoteConfigManager {
 
-    func prepareRefreshIfNeeded(fallbackAppUserID: String) -> RefreshRequestContext? {
-        return self.lock.perform {
+    func prepareRefreshIfNeeded(fallbackAppUserID: () -> String) -> RefreshRequestContext? {
+        let pendingContext: PendingRefreshRequestContext? = self.lock.perform {
             guard !self.isRefreshing,
                   !self.isDisabledInternal,
                   !self.isClosed else { return nil }
             self.isRefreshing = true
-            return RefreshRequestContext(
+            return PendingRefreshRequestContext(
                 epoch: self.epoch,
-                appUserID: self.appUserIDForRefreshes ?? fallbackAppUserID
+                appUserID: self.appUserIDForRefreshes,
+                canAdoptReboundAppUserID: true
             )
         }
+        guard let pendingContext else { return nil }
+
+        return self.resolveRefreshRequestContext(pendingContext, fallbackAppUserID: fallbackAppUserID)
     }
 
     func prepareRefreshIfStale(
         isAppBackgrounded: Bool,
-        fallbackAppUserID: String,
+        fallbackAppUserID: () -> String,
         expectedEpoch: Int? = nil
     ) -> RefreshRequestContext? {
-        return self.lock.perform {
+        let pendingContext: PendingRefreshRequestContext? = self.lock.perform {
             guard !self.isRefreshing,
                   !self.isDisabledInternal,
                   !self.isClosed else { return nil }
@@ -413,10 +423,41 @@ private extension RemoteConfigManager {
             }
 
             self.isRefreshing = true
-            return RefreshRequestContext(
+            return PendingRefreshRequestContext(
                 epoch: self.epoch,
-                appUserID: self.appUserIDForRefreshes ?? fallbackAppUserID
+                appUserID: self.appUserIDForRefreshes,
+                canAdoptReboundAppUserID: expectedEpoch == nil
             )
+        }
+        guard let pendingContext else { return nil }
+
+        return self.resolveRefreshRequestContext(pendingContext, fallbackAppUserID: fallbackAppUserID)
+    }
+
+    func resolveRefreshRequestContext(
+        _ pendingContext: PendingRefreshRequestContext,
+        fallbackAppUserID: () -> String
+    ) -> RefreshRequestContext? {
+        if let appUserID = pendingContext.appUserID {
+            return RefreshRequestContext(epoch: pendingContext.epoch, appUserID: appUserID)
+        }
+
+        let fallbackAppUserID = fallbackAppUserID()
+        return self.lock.perform {
+            if self.epoch == pendingContext.epoch {
+                return RefreshRequestContext(epoch: pendingContext.epoch, appUserID: fallbackAppUserID)
+            }
+
+            guard pendingContext.canAdoptReboundAppUserID,
+                  !self.isRefreshing,
+                  !self.isDisabledInternal,
+                  !self.isClosed,
+                  let reboundAppUserID = self.appUserIDForRefreshes else {
+                return nil
+            }
+
+            self.isRefreshing = true
+            return RefreshRequestContext(epoch: self.epoch, appUserID: reboundAppUserID)
         }
     }
 
@@ -588,10 +629,9 @@ private extension RemoteConfigManager {
             guard self.canReadCommittedState else { return }
         }
 
-        let fallbackAppUserID = self.currentUserProvider.currentAppUserID
         if let requestContext = self.prepareRefreshIfStale(
             isAppBackgrounded: false,
-            fallbackAppUserID: fallbackAppUserID,
+            fallbackAppUserID: { self.currentUserProvider.currentAppUserID },
             expectedEpoch: expectedEpoch
         ) {
             self.startRefresh(isAppBackgrounded: false, requestContext: requestContext)

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -13,8 +13,8 @@ protocol RemoteConfigManagerType: AnyObject {
 
     /// Whether remote config should be ignored for the current manager lifetime.
     var isDisabled: Bool { get }
-    func refreshRemoteConfig(isAppBackgrounded: Bool)
-    func refreshRemoteConfigIfStale(isAppBackgrounded: Bool)
+    func refreshRemoteConfig(isAppBackgrounded: Bool, appUserID: String)
+    func refreshRemoteConfigIfStale(isAppBackgrounded: Bool, appUserID: String)
 
     /// Returns the committed item index for a known topic.
     ///
@@ -179,9 +179,9 @@ final class NoOpRemoteConfigManager: RemoteConfigManagerType {
 
     let isDisabled = true
 
-    func refreshRemoteConfig(isAppBackgrounded: Bool) {}
+    func refreshRemoteConfig(isAppBackgrounded: Bool, appUserID: String) {}
 
-    func refreshRemoteConfigIfStale(isAppBackgrounded: Bool) {}
+    func refreshRemoteConfigIfStale(isAppBackgrounded: Bool, appUserID: String) {}
 
     func topic(_ topic: RemoteConfigTopic) async -> RemoteConfiguration.ConfigTopic? {
         return nil
@@ -233,12 +233,6 @@ final class RemoteConfigManager: RemoteConfigManagerType {
         let appUserID: String
     }
 
-    fileprivate struct PendingRefreshRequestContext {
-        let epoch: Int
-        let appUserID: String?
-        let canAdoptReboundAppUserID: Bool
-    }
-
     /// Runs blocking committed-state reads away from the caller's executor.
     private let readQueue = DispatchQueue(label: "com.revenuecat.remote-config.read")
 
@@ -259,8 +253,8 @@ final class RemoteConfigManager: RemoteConfigManagerType {
 
     /// User ID to use for refreshes after an identity-bound cache clear.
     ///
-    /// Before the first identity change, refreshes fall back to `currentUserProvider`. During an identity change, this
-    /// is set atomically with the epoch bump so any cold read that races the device-cache user update syncs for the
+    /// Before the first identity change, refreshes use the app user ID passed by the caller. During an identity change,
+    /// this is set atomically with the epoch bump so any refresh that races the device-cache user update syncs for the
     /// incoming user instead of the previous one.
     private var appUserIDForRefreshes: String?
 
@@ -303,18 +297,16 @@ final class RemoteConfigManager: RemoteConfigManagerType {
         }
     }
 
-    func refreshRemoteConfig(isAppBackgrounded: Bool) {
-        guard let requestContext = self.prepareRefreshIfNeeded(
-            fallbackAppUserID: { self.currentUserProvider.currentAppUserID }
-        ) else { return }
+    func refreshRemoteConfig(isAppBackgrounded: Bool, appUserID: String) {
+        guard let requestContext = self.prepareRefreshIfNeeded(appUserID: appUserID) else { return }
 
         self.startRefresh(isAppBackgrounded: isAppBackgrounded, requestContext: requestContext)
     }
 
-    func refreshRemoteConfigIfStale(isAppBackgrounded: Bool) {
+    func refreshRemoteConfigIfStale(isAppBackgrounded: Bool, appUserID: String) {
         guard let requestContext = self.prepareRefreshIfStale(
             isAppBackgrounded: isAppBackgrounded,
-            fallbackAppUserID: { self.currentUserProvider.currentAppUserID }
+            appUserID: appUserID
         ) else { return }
 
         self.startRefresh(isAppBackgrounded: isAppBackgrounded, requestContext: requestContext)
@@ -388,29 +380,25 @@ final class RemoteConfigManager: RemoteConfigManagerType {
 
 private extension RemoteConfigManager {
 
-    func prepareRefreshIfNeeded(fallbackAppUserID: () -> String) -> RefreshRequestContext? {
-        let pendingContext: PendingRefreshRequestContext? = self.lock.perform {
+    func prepareRefreshIfNeeded(appUserID: String) -> RefreshRequestContext? {
+        return self.lock.perform {
             guard !self.isRefreshing,
                   !self.isDisabledInternal,
                   !self.isClosed else { return nil }
             self.isRefreshing = true
-            return PendingRefreshRequestContext(
+            return RefreshRequestContext(
                 epoch: self.epoch,
-                appUserID: self.appUserIDForRefreshes,
-                canAdoptReboundAppUserID: true
+                appUserID: self.appUserIDForRefreshes ?? appUserID
             )
         }
-        guard let pendingContext else { return nil }
-
-        return self.resolveRefreshRequestContext(pendingContext, fallbackAppUserID: fallbackAppUserID)
     }
 
     func prepareRefreshIfStale(
         isAppBackgrounded: Bool,
-        fallbackAppUserID: () -> String,
+        appUserID: String,
         expectedEpoch: Int? = nil
     ) -> RefreshRequestContext? {
-        let pendingContext: PendingRefreshRequestContext? = self.lock.perform {
+        return self.lock.perform {
             guard !self.isRefreshing,
                   !self.isDisabledInternal,
                   !self.isClosed else { return nil }
@@ -423,41 +411,10 @@ private extension RemoteConfigManager {
             }
 
             self.isRefreshing = true
-            return PendingRefreshRequestContext(
+            return RefreshRequestContext(
                 epoch: self.epoch,
-                appUserID: self.appUserIDForRefreshes,
-                canAdoptReboundAppUserID: expectedEpoch == nil
+                appUserID: self.appUserIDForRefreshes ?? appUserID
             )
-        }
-        guard let pendingContext else { return nil }
-
-        return self.resolveRefreshRequestContext(pendingContext, fallbackAppUserID: fallbackAppUserID)
-    }
-
-    func resolveRefreshRequestContext(
-        _ pendingContext: PendingRefreshRequestContext,
-        fallbackAppUserID: () -> String
-    ) -> RefreshRequestContext? {
-        if let appUserID = pendingContext.appUserID {
-            return RefreshRequestContext(epoch: pendingContext.epoch, appUserID: appUserID)
-        }
-
-        let fallbackAppUserID = fallbackAppUserID()
-        return self.lock.perform {
-            if self.epoch == pendingContext.epoch {
-                return RefreshRequestContext(epoch: pendingContext.epoch, appUserID: fallbackAppUserID)
-            }
-
-            guard pendingContext.canAdoptReboundAppUserID,
-                  !self.isRefreshing,
-                  !self.isDisabledInternal,
-                  !self.isClosed,
-                  let reboundAppUserID = self.appUserIDForRefreshes else {
-                return nil
-            }
-
-            self.isRefreshing = true
-            return RefreshRequestContext(epoch: self.epoch, appUserID: reboundAppUserID)
         }
     }
 
@@ -631,7 +588,7 @@ private extension RemoteConfigManager {
 
         if let requestContext = self.prepareRefreshIfStale(
             isAppBackgrounded: false,
-            fallbackAppUserID: { self.currentUserProvider.currentAppUserID },
+            appUserID: self.currentUserProvider.currentAppUserID,
             expectedEpoch: expectedEpoch
         ) {
             self.startRefresh(isAppBackgrounded: false, requestContext: requestContext)

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -228,7 +228,7 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     private let dateProvider: DateProvider
     private let cacheDurationInSeconds: (Bool) -> TimeInterval
 
-    private struct RefreshRequestContext {
+    fileprivate struct RefreshRequestContext {
         let epoch: Int
         let appUserID: String
     }
@@ -352,19 +352,13 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     /// The epoch bump, refresh-guard release, and cache wipe are serialized with response persistence so a late
     /// response for a previous user is either fully persisted before the wipe or dropped after the epoch changes.
     func clearCache() {
-        self.clearCache(boundAppUserID: nil)
+        self.clearCache(forAppUserID: self.currentUserProvider.currentAppUserID)
     }
 
     func clearCache(forAppUserID appUserID: String) {
-        self.clearCache(boundAppUserID: appUserID)
-    }
-
-    private func clearCache(boundAppUserID appUserID: String?) {
         let continuations = self.lock.perform {
             self.epoch += 1
-            if let appUserID {
-                self.appUserIDForRefreshes = appUserID
-            }
+            self.appUserIDForRefreshes = appUserID
             self.isRefreshing = false
             self.lastRefreshedAt = nil
             self.diskCache.clear()
@@ -388,7 +382,7 @@ final class RemoteConfigManager: RemoteConfigManagerType {
 
 private extension RemoteConfigManager {
 
-    private func prepareRefreshIfNeeded(fallbackAppUserID: String) -> RefreshRequestContext? {
+    func prepareRefreshIfNeeded(fallbackAppUserID: String) -> RefreshRequestContext? {
         return self.lock.perform {
             guard !self.isRefreshing,
                   !self.isDisabledInternal,
@@ -401,7 +395,7 @@ private extension RemoteConfigManager {
         }
     }
 
-    private func prepareRefreshIfStale(
+    func prepareRefreshIfStale(
         isAppBackgrounded: Bool,
         fallbackAppUserID: String,
         expectedEpoch: Int? = nil
@@ -426,7 +420,7 @@ private extension RemoteConfigManager {
         }
     }
 
-    private func startRefresh(isAppBackgrounded: Bool, requestContext: RefreshRequestContext) {
+    func startRefresh(isAppBackgrounded: Bool, requestContext: RefreshRequestContext) {
         let persisted = self.diskCache.read()
         let request = RemoteConfigRequest(
             appUserID: requestContext.appUserID,

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -64,6 +64,7 @@ protocol RemoteConfigManagerType: AnyObject {
     func awaitTopicAndPrefetchBlobsReady(_ topic: RemoteConfigTopic) async -> RemoteConfiguration.ConfigTopic?
 
     func clearCache()
+    func clearCache(forAppUserID appUserID: String)
     func close()
 
 }
@@ -204,6 +205,8 @@ final class NoOpRemoteConfigManager: RemoteConfigManagerType {
 
     func clearCache() {}
 
+    func clearCache(forAppUserID appUserID: String) {}
+
     func close() {}
 
 }
@@ -225,6 +228,11 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     private let dateProvider: DateProvider
     private let cacheDurationInSeconds: (Bool) -> TimeInterval
 
+    private struct RefreshRequestContext {
+        let epoch: Int
+        let appUserID: String
+    }
+
     /// Runs blocking committed-state reads away from the caller's executor.
     private let readQueue = DispatchQueue(label: "com.revenuecat.remote-config.read")
 
@@ -242,6 +250,13 @@ final class RemoteConfigManager: RemoteConfigManagerType {
 
     /// Incremented when local state is invalidated so late responses from older users/sessions are dropped.
     private var epoch = 0
+
+    /// User ID to use for refreshes after an identity-bound cache clear.
+    ///
+    /// Before the first identity change, refreshes fall back to `currentUserProvider`. During an identity change, this
+    /// is set atomically with the epoch bump so any cold read that races the device-cache user update syncs for the
+    /// incoming user instead of the previous one.
+    private var appUserIDForRefreshes: String?
 
     /// In-memory staleness marker. Only successful `200` and `204` responses mark the config fresh.
     private var lastRefreshedAt: Date?
@@ -283,15 +298,20 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     }
 
     func refreshRemoteConfig(isAppBackgrounded: Bool) {
-        guard let requestEpoch = self.prepareRefreshIfNeeded() else { return }
+        let fallbackAppUserID = self.currentUserProvider.currentAppUserID
+        guard let requestContext = self.prepareRefreshIfNeeded(fallbackAppUserID: fallbackAppUserID) else { return }
 
-        self.startRefresh(isAppBackgrounded: isAppBackgrounded, requestEpoch: requestEpoch)
+        self.startRefresh(isAppBackgrounded: isAppBackgrounded, requestContext: requestContext)
     }
 
     func refreshRemoteConfigIfStale(isAppBackgrounded: Bool) {
-        guard let requestEpoch = self.prepareRefreshIfStale(isAppBackgrounded: isAppBackgrounded) else { return }
+        let fallbackAppUserID = self.currentUserProvider.currentAppUserID
+        guard let requestContext = self.prepareRefreshIfStale(
+            isAppBackgrounded: isAppBackgrounded,
+            fallbackAppUserID: fallbackAppUserID
+        ) else { return }
 
-        self.startRefresh(isAppBackgrounded: isAppBackgrounded, requestEpoch: requestEpoch)
+        self.startRefresh(isAppBackgrounded: isAppBackgrounded, requestContext: requestContext)
     }
 
     func topic(_ topic: RemoteConfigTopic) async -> RemoteConfiguration.ConfigTopic? {
@@ -332,8 +352,19 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     /// The epoch bump, refresh-guard release, and cache wipe are serialized with response persistence so a late
     /// response for a previous user is either fully persisted before the wipe or dropped after the epoch changes.
     func clearCache() {
+        self.clearCache(boundAppUserID: nil)
+    }
+
+    func clearCache(forAppUserID appUserID: String) {
+        self.clearCache(boundAppUserID: appUserID)
+    }
+
+    private func clearCache(boundAppUserID appUserID: String?) {
         let continuations = self.lock.perform {
             self.epoch += 1
+            if let appUserID {
+                self.appUserIDForRefreshes = appUserID
+            }
             self.isRefreshing = false
             self.lastRefreshedAt = nil
             self.diskCache.clear()
@@ -357,20 +388,24 @@ final class RemoteConfigManager: RemoteConfigManagerType {
 
 private extension RemoteConfigManager {
 
-    func prepareRefreshIfNeeded() -> Int? {
+    private func prepareRefreshIfNeeded(fallbackAppUserID: String) -> RefreshRequestContext? {
         return self.lock.perform {
             guard !self.isRefreshing,
                   !self.isDisabledInternal,
                   !self.isClosed else { return nil }
             self.isRefreshing = true
-            return self.epoch
+            return RefreshRequestContext(
+                epoch: self.epoch,
+                appUserID: self.appUserIDForRefreshes ?? fallbackAppUserID
+            )
         }
     }
 
-    func prepareRefreshIfStale(
+    private func prepareRefreshIfStale(
         isAppBackgrounded: Bool,
+        fallbackAppUserID: String,
         expectedEpoch: Int? = nil
-    ) -> Int? {
+    ) -> RefreshRequestContext? {
         return self.lock.perform {
             guard !self.isRefreshing,
                   !self.isDisabledInternal,
@@ -384,14 +419,17 @@ private extension RemoteConfigManager {
             }
 
             self.isRefreshing = true
-            return self.epoch
+            return RefreshRequestContext(
+                epoch: self.epoch,
+                appUserID: self.appUserIDForRefreshes ?? fallbackAppUserID
+            )
         }
     }
 
-    func startRefresh(isAppBackgrounded: Bool, requestEpoch: Int) {
+    private func startRefresh(isAppBackgrounded: Bool, requestContext: RefreshRequestContext) {
         let persisted = self.diskCache.read()
         let request = RemoteConfigRequest(
-            appUserID: self.currentUserProvider.currentAppUserID,
+            appUserID: requestContext.appUserID,
             domain: persisted?.domain ?? Self.defaultDomain,
             manifest: persisted?.manifest,
             prefetchedBlobs: self.cachedPrefetchedBlobRefs(from: persisted)
@@ -405,7 +443,7 @@ private extension RemoteConfigManager {
             request: request,
             persisted: persisted,
             isAppBackgrounded: isAppBackgrounded,
-            requestEpoch: requestEpoch
+            requestEpoch: requestContext.epoch
         )
     }
 
@@ -556,11 +594,13 @@ private extension RemoteConfigManager {
             guard self.canReadCommittedState else { return }
         }
 
-        if let requestEpoch = self.prepareRefreshIfStale(
+        let fallbackAppUserID = self.currentUserProvider.currentAppUserID
+        if let requestContext = self.prepareRefreshIfStale(
             isAppBackgrounded: false,
+            fallbackAppUserID: fallbackAppUserID,
             expectedEpoch: expectedEpoch
         ) {
-            self.startRefresh(isAppBackgrounded: false, requestEpoch: requestEpoch)
+            self.startRefresh(isAppBackgrounded: false, requestContext: requestContext)
         }
         _ = await self.awaitInFlightRefresh()
     }

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -405,7 +405,7 @@ private extension RemoteConfigManager {
                   !self.isDisabledInternal,
                   !self.isClosed else { return nil }
             if let expectedEpoch {
-                guard self.epoch == expectedEpoch else { return nil }
+                guard self.epoch == expectedEpoch || self.identityBoundAppUserID != nil else { return nil }
             }
             if let lastRefreshedAt = self.lastRefreshedAt {
                 guard self.dateProvider.now().timeIntervalSince(lastRefreshedAt)
@@ -720,9 +720,10 @@ private extension RemoteConfigManager {
 
     /// Performs small blocking cache reads on the manager's read queue.
     func performRead<T>(_ operation: @escaping () -> T) async -> T {
+        let operation = SendableReadOperation(run: operation)
         return await withCheckedContinuation { continuation in
             self.readQueue.async {
-                continuation.resume(returning: operation())
+                continuation.resume(returning: operation.run())
             }
         }
     }
@@ -835,6 +836,12 @@ private extension RemoteConfigManager {
             }
         }
     }
+
+}
+
+private struct SendableReadOperation<T>: @unchecked Sendable {
+
+    let run: () -> T
 
 }
 

--- a/Sources/Networking/UiConfigProvider.swift
+++ b/Sources/Networking/UiConfigProvider.swift
@@ -110,3 +110,5 @@ final class UiConfigProvider {
     }
 
 }
+
+extension UiConfigProvider: @unchecked Sendable {}

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1065,7 +1065,10 @@ public extension Purchases {
 
             self.systemInfo.isApplicationBackgrounded { isAppBackgrounded in
                 self.updateOfferingsCache(isAppBackgrounded: isAppBackgrounded)
-                self.remoteConfigManager.refreshRemoteConfig(isAppBackgrounded: isAppBackgrounded)
+                self.remoteConfigManager.refreshRemoteConfig(
+                    isAppBackgrounded: isAppBackgrounded,
+                    appUserID: appUserID
+                )
             }
         }
     }
@@ -1211,7 +1214,10 @@ extension Purchases {
 
         self.systemInfo.isApplicationBackgrounded { isBackgrounded in
             self.updateOfferingsCache(isAppBackgrounded: isBackgrounded)
-            self.remoteConfigManager.refreshRemoteConfig(isAppBackgrounded: isBackgrounded)
+            self.remoteConfigManager.refreshRemoteConfig(
+                isAppBackgrounded: isBackgrounded,
+                appUserID: newAppUserID
+            )
         }
     }
 
@@ -2754,7 +2760,10 @@ private extension Purchases {
             self.updateOfferingsCache(isAppBackgrounded: isAppBackgrounded)
         }
 
-        self.remoteConfigManager.refreshRemoteConfigIfStale(isAppBackgrounded: isAppBackgrounded)
+        self.remoteConfigManager.refreshRemoteConfigIfStale(
+            isAppBackgrounded: isAppBackgrounded,
+            appUserID: self.appUserID
+        )
     }
 
     func updateAllCaches(completion: ((Result<CustomerInfo, PublicError>) -> Void)?) {
@@ -2789,7 +2798,10 @@ private extension Purchases {
         }
 
         self.updateOfferingsCache(isAppBackgrounded: isAppBackgrounded)
-        self.remoteConfigManager.refreshRemoteConfig(isAppBackgrounded: isAppBackgrounded)
+        self.remoteConfigManager.refreshRemoteConfig(
+            isAppBackgrounded: isAppBackgrounded,
+            appUserID: self.appUserID
+        )
     }
 
     // Used when delegate is being set

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1067,12 +1067,7 @@ public extension Purchases {
 
             self.systemInfo.isApplicationBackgrounded { isAppBackgrounded in
                 self.updateOfferingsCache(isAppBackgrounded: isAppBackgrounded)
-                // Use the same normalized app user ID passed to IdentityManager for this successful login instead
-                // of rereading `self.appUserID`, which can still return the previous cached user here.
-                self.remoteConfigManager.refreshRemoteConfig(
-                    isAppBackgrounded: isAppBackgrounded,
-                    appUserID: normalizedAppUserID
-                )
+                self.remoteConfigManager.refreshRemoteConfig(isAppBackgrounded: isAppBackgrounded)
             }
         }
     }
@@ -1218,12 +1213,7 @@ extension Purchases {
 
         self.systemInfo.isApplicationBackgrounded { isBackgrounded in
             self.updateOfferingsCache(isAppBackgrounded: isBackgrounded)
-            // Use the `newAppUserID` passed to `internalSwitchUser` for this refresh instead of rereading
-            // `self.appUserID` from inside this async background-state callback.
-            self.remoteConfigManager.refreshRemoteConfig(
-                isAppBackgrounded: isBackgrounded,
-                appUserID: newAppUserID
-            )
+            self.remoteConfigManager.refreshRemoteConfig(isAppBackgrounded: isBackgrounded)
         }
     }
 
@@ -2767,10 +2757,7 @@ private extension Purchases {
             self.updateOfferingsCache(isAppBackgrounded: isAppBackgrounded)
         }
 
-        self.remoteConfigManager.refreshRemoteConfigIfStale(
-            isAppBackgrounded: isAppBackgrounded,
-            appUserID: self.appUserID
-        )
+        self.remoteConfigManager.refreshRemoteConfigIfStale(isAppBackgrounded: isAppBackgrounded)
     }
 
     func updateAllCaches(completion: ((Result<CustomerInfo, PublicError>) -> Void)?) {
@@ -2805,10 +2792,7 @@ private extension Purchases {
         }
 
         self.updateOfferingsCache(isAppBackgrounded: isAppBackgrounded)
-        self.remoteConfigManager.refreshRemoteConfig(
-            isAppBackgrounded: isAppBackgrounded,
-            appUserID: self.appUserID
-        )
+        self.remoteConfigManager.refreshRemoteConfig(isAppBackgrounded: isAppBackgrounded)
     }
 
     // Used when delegate is being set

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1525,12 +1525,13 @@ public extension Purchases {
         productID: String,
         completion: @escaping (StoreTransaction?, PublicError?) -> Void
     ) {
+        let completion = SendableRecordPurchaseCompletion(run: completion)
         Task {
             let result = await StoreKit.Transaction.latest(for: productID)
 
             guard let result = result else {
                 OperationDispatcher.dispatchOnMainActor {
-                    completion(nil, NewErrorUtils.storeProblemError(
+                    completion.run(nil, NewErrorUtils.storeProblemError(
                         withMessage: "No transaction found for product ID: \(productID)"
                     ).asPublicError)
                 }
@@ -1540,12 +1541,12 @@ public extension Purchases {
             do {
                 let transaction = try await self.recordPurchase(.success(result))
                 OperationDispatcher.dispatchOnMainActor {
-                    completion(transaction, nil)
+                    completion.run(transaction, nil)
                 }
             } catch {
                 let publicError = NewErrorUtils.purchasesError(withUntypedError: error).asPublicError
                 OperationDispatcher.dispatchOnMainActor {
-                    completion(nil, publicError)
+                    completion.run(nil, publicError)
                 }
             }
         }
@@ -2847,6 +2848,12 @@ private extension Purchases {
             await cache.warmUpPaywallFontsCache(offerings: offerings)
         }
     }
+
+}
+
+private struct SendableRecordPurchaseCompletion: @unchecked Sendable {
+
+    let run: (StoreTransaction?, PublicError?) -> Void
 
 }
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1054,7 +1054,9 @@ public extension Purchases {
     @_disfavoredOverload
     @objc(logIn:completion:)
     func logIn(_ appUserID: String, completion: @escaping (CustomerInfo?, Bool, PublicError?) -> Void) {
-        self.identityManager.logIn(appUserID: appUserID) { result in
+        let normalizedAppUserID = appUserID.trimmingWhitespacesAndNewLines
+
+        self.identityManager.logIn(appUserID: normalizedAppUserID) { result in
             self.operationDispatcher.dispatchOnMainThread {
                 completion(result.value?.info, result.value?.created ?? false, result.error?.asPublicError)
             }
@@ -1065,9 +1067,11 @@ public extension Purchases {
 
             self.systemInfo.isApplicationBackgrounded { isAppBackgrounded in
                 self.updateOfferingsCache(isAppBackgrounded: isAppBackgrounded)
+                // Use the same normalized app user ID passed to IdentityManager for this successful login instead
+                // of rereading `self.appUserID`, which can still return the previous cached user here.
                 self.remoteConfigManager.refreshRemoteConfig(
                     isAppBackgrounded: isAppBackgrounded,
-                    appUserID: appUserID
+                    appUserID: normalizedAppUserID
                 )
             }
         }
@@ -1214,6 +1218,8 @@ extension Purchases {
 
         self.systemInfo.isApplicationBackgrounded { isBackgrounded in
             self.updateOfferingsCache(isAppBackgrounded: isBackgrounded)
+            // Use the `newAppUserID` passed to `internalSwitchUser` for this refresh instead of rereading
+            // `self.appUserID` from inside this async background-state callback.
             self.remoteConfigManager.refreshRemoteConfig(
                 isAppBackgrounded: isBackgrounded,
                 appUserID: newAppUserID

--- a/Tests/UnitTests/Identity/IdentityManagerTests.swift
+++ b/Tests/UnitTests/Identity/IdentityManagerTests.swift
@@ -352,6 +352,7 @@ class IdentityManagerTests: TestCase {
         }
 
         expect(remoteConfigManager.invokedClearCacheCount) == 1
+        expect(remoteConfigManager.invokedClearCacheAppUserIDs) == ["myUser"]
     }
 
     func testLogOutClearsRemoteConfigCache() {
@@ -365,6 +366,8 @@ class IdentityManagerTests: TestCase {
         }
 
         expect(remoteConfigManager.invokedClearCacheCount) == 1
+        expect(remoteConfigManager.invokedClearCacheAppUserIDs.first) == self.mockDeviceCache.clearCachesCalleNewUserID
+        expect(remoteConfigManager.invokedClearCacheAppUserIDs.first) != "myUser"
     }
 
     func testSwitchUserClearsRemoteConfigCache() {
@@ -376,6 +379,7 @@ class IdentityManagerTests: TestCase {
         manager.switchUser(to: "newUser")
 
         expect(remoteConfigManager.invokedClearCacheCount) == 1
+        expect(remoteConfigManager.invokedClearCacheAppUserIDs) == ["newUser"]
     }
 
     func testLogInSyncsAttributes() {

--- a/Tests/UnitTests/Mocks/MockCurrentUserProvider.swift
+++ b/Tests/UnitTests/Mocks/MockCurrentUserProvider.swift
@@ -17,12 +17,14 @@ final class MockCurrentUserProvider: CurrentUserProvider {
 
     var mockIsAnonymous = false
     var mockAppUserID: String
+    var currentAppUserIDRequested: (() -> Void)?
 
     init(mockAppUserID: String) {
         self.mockAppUserID = mockAppUserID
     }
 
     var currentAppUserID: String {
+        self.currentAppUserIDRequested?()
         return self.mockIsAnonymous
             ? self.mockAnonymousID
             : self.mockAppUserID

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -1570,6 +1570,31 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.appUserID) == "new-user"
     }
 
+    func testBlobDataColdReadAfterIdentityClearUsesBoundAppUserIDWhenTriggeringRefresh() async {
+        self.currentUserProvider.mockAppUserID = "old-user"
+        self.manager.clearCache(forAppUserID: "new-user")
+
+        let task = Task {
+            await self.manager.blobData(for: .sources, itemKey: "api")
+        }
+        await self.waitForRemoteConfigRequestCount(1)
+        self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
+        _ = await task.value
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.appUserID) == "new-user"
+    }
+
+    func testRefreshUsesBoundAppUserIDIfIdentityClearRacesRefreshPreparation() {
+        self.currentUserProvider.mockAppUserID = "old-user"
+        self.currentUserProvider.currentAppUserIDRequested = { [weak self] in
+            self?.manager.clearCache(forAppUserID: "new-user")
+        }
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.appUserID) == "new-user"
+    }
+
     func testBlobDataNoContentRefreshCompletesWaitingRead() async {
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -62,54 +62,48 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testRefreshRemoteConfigIfStaleRefreshesWhenNeverRefreshed() {
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
     }
 
     func testNoContentResponseMarksRefreshAsFresh() {
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
 
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
     }
 
-    func testFreshRefreshDoesNotReadCurrentAppUserID() {
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false, appUserID: Self.appUserID)
+    func testFreshRefreshDoesNotStartAnotherRequest() {
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
 
-        var currentAppUserIDReadCount = 0
-        self.currentUserProvider.currentAppUserIDRequested = {
-            currentAppUserIDReadCount += 1
-        }
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
 
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false, appUserID: Self.appUserID)
-
-        expect(currentAppUserIDReadCount) == 0
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
     }
 
     func testFailureDoesNotMarkRefreshAsFresh() {
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1)))))
 
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
     }
 
     func testRefreshRemoteConfigIfStaleUsesForegroundAndBackgroundDurations() {
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
 
         self.dateProvider.advance(by: 6)
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: true, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: true)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
 
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
     }
@@ -117,8 +111,8 @@ final class RemoteConfigManagerTests: TestCase {
     func testClosePreventsNewRefreshes() {
         self.manager.close()
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 0
     }
@@ -167,7 +161,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.manager.close()
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
@@ -181,7 +175,7 @@ final class RemoteConfigManagerTests: TestCase {
     func testFirstRunSendsDefaultAppDomainManifest() throws {
         self.diskCache.stubbedRead = nil
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.appUserID) == Self.appUserID
@@ -199,7 +193,7 @@ final class RemoteConfigManagerTests: TestCase {
             topics: .init()
         )
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.appUserID) == Self.appUserID
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.domain) == "custom"
@@ -209,13 +203,13 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testOverlappingRefreshesAreIgnoredUntilInFlightRefreshCompletes() {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
 
         self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.isAppBackgrounded) == true
@@ -229,7 +223,7 @@ final class RemoteConfigManagerTests: TestCase {
             topics: .init()
         )
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.prefetchedBlobs) == ["cachedBlob"]
         expect(self.blobStore.invokedCachedRefsCount) == 1
@@ -255,7 +249,7 @@ final class RemoteConfigManagerTests: TestCase {
             topics: .init(entries: ["sources": ["api": item]])
         )
         self.diskCache.stubbedRead = persisted
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.diskCache.readHandler = {
             self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
             return persisted
@@ -403,7 +397,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         let task = Task {
             await self.manager.topic(.sources)?["api"]?.content["url"]
         }
@@ -425,7 +419,7 @@ final class RemoteConfigManagerTests: TestCase {
                 "sources": ["api": .init(content: ["url": "https://api.revenuecat.com"])]
             ])
         )
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
 
         let topic = await self.manager.topic(.sources)
@@ -897,7 +891,7 @@ final class RemoteConfigManagerTests: TestCase {
             topics: .init(entries: ["workflows": ["wf1": .init(blobRef: ref)]])
         )
         self.blobStore.stubbedReadDataByRef[ref] = blob
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
 
         let value = try await self.manager.mergeItemsBlobData(
@@ -1113,7 +1107,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
         )
@@ -1141,7 +1135,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.compressedContainer(
                 config: response,
@@ -1174,7 +1168,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
         )
@@ -1245,7 +1239,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
         )
@@ -1275,7 +1269,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
         )
@@ -1296,7 +1290,7 @@ final class RemoteConfigManagerTests: TestCase {
         )
         self.diskCache.stubbedRead = previous
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
 
         expect(self.diskCache.invokedWriteCount) == 0
@@ -1308,7 +1302,7 @@ final class RemoteConfigManagerTests: TestCase {
     func testNoContentResponseWithNoPersistedCacheLeavesCacheUntouched() {
         self.diskCache.stubbedRead = nil
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
 
         expect(self.diskCache.invokedWriteCount) == 0
@@ -1322,7 +1316,7 @@ final class RemoteConfigManagerTests: TestCase {
             manifest: "v1.1710000100.sources:etag1"
         )
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1))))
         )
@@ -1366,10 +1360,10 @@ final class RemoteConfigManagerTests: TestCase {
         )
 
         expect(self.manager.isDisabled) == false
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .invalidRequest)))
         expect(self.manager.isDisabled) == true
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
         expect(self.diskCache.invokedReadCount) == 1
@@ -1381,44 +1375,44 @@ final class RemoteConfigManagerTests: TestCase {
 
     func testTooManyRequestsResponseDisablesRemoteConfig() {
         expect(self.manager.isDisabled) == false
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .tooManyRequests)))
         expect(self.manager.isDisabled) == true
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
         expect(self.diskCache.invokedReadCount) == 1
     }
 
     func testServerErrorDoesNotDisableRemoteConfig() {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
         expect(self.manager.isDisabled) == false
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
         expect(self.diskCache.invokedReadCount) == 2
     }
 
     func testTransportNetworkErrorDoesNotDisableRemoteConfig() {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1))))
         )
         expect(self.manager.isDisabled) == false
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
         expect(self.diskCache.invokedReadCount) == 2
     }
 
     func testClearCacheDoesNotReenableDisabledRemoteConfigRefresh() {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
         expect(self.manager.isDisabled) == true
         self.manager.clearCache(forAppUserID: Self.appUserID)
         expect(self.manager.isDisabled) == true
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
         expect(self.diskCache.invokedClearCount) == 1
@@ -1426,7 +1420,7 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testMalformedConfigPayloadLeavesCacheUntouched() throws {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: "{ not valid json")))
         )
@@ -1452,7 +1446,7 @@ final class RemoteConfigManagerTests: TestCase {
         """
         let invalidContentElement = "{ invalid content element json".asData
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response, contentElements: [invalidContentElement])
@@ -1484,7 +1478,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         let task = Task {
             await self.manager.blobData(for: .workflows, itemKey: "default")
         }
@@ -1616,13 +1610,13 @@ final class RemoteConfigManagerTests: TestCase {
     func testRefreshUsesBoundAppUserIDIfIdentityClearRacesRefreshPreparation() {
         self.manager.clearCache(forAppUserID: "new-user")
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: "old-user")
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.appUserID) == "new-user"
     }
 
     func testBlobDataNoContentRefreshCompletesWaitingRead() async {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
         let task = Task {
             await self.manager.blobData(for: .sources, itemKey: "api")
@@ -1636,7 +1630,7 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testBlobDataFailedRefreshCompletesWaitingRead() async {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
         let task = Task {
             await self.manager.blobData(for: .sources, itemKey: "api")
@@ -1650,7 +1644,7 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testBlobDataMalformedRefreshCompletesWaitingRead() async throws {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
         let task = Task {
             await self.manager.blobData(for: .sources, itemKey: "api")
@@ -1666,7 +1660,7 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testBlobDataClearCacheCompletesWaitingRead() async {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
         let task = Task {
             await self.manager.blobData(for: .sources, itemKey: "api")
@@ -1723,7 +1717,7 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testBlobDataCloseCompletesWaitingRead() async {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
         let task = Task {
             await self.manager.blobData(for: .sources, itemKey: "api")
@@ -1737,7 +1731,7 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testBlobDataDoesNotTriggerRefreshWhenRemoteConfigIsDisabled() async {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
 
         let data = await self.manager.blobData(for: .sources, itemKey: "api")
@@ -1752,7 +1746,7 @@ final class RemoteConfigManagerTests: TestCase {
             manifest: "v1.1710000100.workflows:etag1",
             topics: .init(entries: ["workflows": ["default": .init(blobRef: ref)]])
         )
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
         let readCountAfterDisabling = self.diskCache.invokedReadCount
 
@@ -1780,7 +1774,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response, contentElements: [blob]),
@@ -1812,7 +1806,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response, contentElements: [blob]),
@@ -1833,7 +1827,7 @@ final class RemoteConfigManagerTests: TestCase {
         let workflowBlobRef = RCContainerTestData.blobRef(for: RCContainerTestData.workflowBlob)
         let summerWorkflowBlobRef = RCContainerTestData.blobRef(for: RCContainerTestData.summerWorkflowBlob)
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: container,
@@ -1865,7 +1859,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.compressedContainer(
@@ -1896,7 +1890,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.compressedContainer(
@@ -1927,7 +1921,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try RemoteConfigContainer(
@@ -1963,7 +1957,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response, contentElements: [referencedBlob, unreferencedBlob]),
@@ -1993,7 +1987,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response, contentElements: [prefetchBlob]),
@@ -2032,7 +2026,7 @@ final class RemoteConfigManagerTests: TestCase {
             }
         )
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try RemoteConfigContainer(data: containerData),
@@ -2062,7 +2056,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response),
@@ -2086,7 +2080,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response),
@@ -2109,7 +2103,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response),
@@ -2142,7 +2136,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response, contentElements: [blob]),
@@ -2165,11 +2159,11 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
         )
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
     }
@@ -2196,7 +2190,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.manager.clearCache(forAppUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             at: 0,
@@ -2214,7 +2208,7 @@ final class RemoteConfigManagerTests: TestCase {
             return nil
         }
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 0
         expect(self.diskCache.invokedClearCount) == 1
@@ -2222,17 +2216,17 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testStaleNoContentResponseDoesNotReleaseNewerRefreshGuard() {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.manager.clearCache(forAppUserID: Self.appUserID)
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
 
         self.remoteConfigAPI.complete(at: 0, with: .success(.test(container: nil)))
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
 
         self.remoteConfigAPI.complete(at: 1, with: .success(.test(container: nil)))
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 3
     }
@@ -2251,57 +2245,57 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.manager.clearCache(forAppUserID: Self.appUserID)
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
 
         self.remoteConfigAPI.complete(
             at: 0,
             with: .success(.test(container: try Self.container(config: response)))
         )
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
         expect(self.diskCache.invokedWriteCount) == 0
 
         self.remoteConfigAPI.complete(at: 1, with: .success(.test(container: nil)))
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 3
     }
 
     func testStaleErrorResponseDoesNotReleaseNewerRefreshGuard() {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.manager.clearCache(forAppUserID: Self.appUserID)
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
 
         self.remoteConfigAPI.complete(
             at: 0,
             with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1))))
         )
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
 
         self.remoteConfigAPI.complete(at: 1, with: .success(.test(container: nil)))
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 3
     }
 
     func testStaleFourHundredResponseDoesNotDisableRemoteConfig() {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.manager.clearCache(forAppUserID: Self.appUserID)
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
 
         self.remoteConfigAPI.complete(at: 0, with: .failure(Self.backendError(statusCode: .invalidRequest)))
         expect(self.manager.isDisabled) == false
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
 
         self.remoteConfigAPI.complete(at: 1, with: .success(.test(container: nil)))
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 3
     }
@@ -2322,7 +2316,7 @@ final class RemoteConfigManagerTests: TestCase {
         """
 
         self.manager.clearCache(forAppUserID: Self.appUserID)
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
         )
@@ -2359,7 +2353,7 @@ final class RemoteConfigManagerTests: TestCase {
             clearEntered.signal()
         }
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         DispatchQueue.global().async {
             self.remoteConfigAPI.complete(
                 with: .success(.test(container: container))

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -338,7 +338,7 @@ final class RemoteConfigManagerTests: TestCase {
         """
 
         let task = Task {
-            await self.manager.topic(.sources)
+            await self.manager.topic(.sources)?["api"]?.content["url"] as? String
         }
         await self.waitForRemoteConfigRequestCount(1)
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.isAppBackgrounded) == false
@@ -346,9 +346,7 @@ final class RemoteConfigManagerTests: TestCase {
             with: .success(.test(container: try Self.container(config: response)))
         )
 
-        let maybeTopic = await task.value
-        let topic = try XCTUnwrap(maybeTopic)
-        expect(topic["api"]?.content["url"]) == "https://api.revenuecat.com"
+        expect(await task.value) == "https://api.revenuecat.com"
     }
 
     func testTopicMissingAfterFreshRefreshDoesNotTriggerAnotherRefresh() async throws {
@@ -370,15 +368,14 @@ final class RemoteConfigManagerTests: TestCase {
         """
 
         let firstRead = Task {
-            await self.manager.topic(.workflows)
+            await self.manager.topic(.workflows) == nil
         }
         await self.waitForRemoteConfigRequestCount(1)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
         )
 
-        let firstTopic = await firstRead.value
-        expect(firstTopic).to(beNil())
+        expect(await firstRead.value) == true
 
         let secondRead = await self.manager.topic(.workflows)
 
@@ -406,7 +403,7 @@ final class RemoteConfigManagerTests: TestCase {
 
         self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         let task = Task {
-            await self.manager.topic(.sources)
+            await self.manager.topic(.sources)?["api"]?.content["url"] as? String
         }
         await self.waitForRemoteConfigRequestCount(1)
         await self.waitForDiskCacheReadCount(2)
@@ -414,9 +411,7 @@ final class RemoteConfigManagerTests: TestCase {
             with: .success(.test(container: try Self.container(config: response)))
         )
 
-        let maybeTopic = await task.value
-        let topic = try XCTUnwrap(maybeTopic)
-        expect(topic["api"]?.content["url"]) == "https://api.revenuecat.com"
+        expect(await task.value) == "https://api.revenuecat.com"
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
     }
 
@@ -899,7 +894,7 @@ final class RemoteConfigManagerTests: TestCase {
             topics: .init(entries: ["workflows": ["wf1": .init(blobRef: ref)]])
         )
         self.blobStore.stubbedReadDataByRef[ref] = blob
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
 
         let value = try await self.manager.mergeItemsBlobData(

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -76,6 +76,21 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
     }
 
+    func testFreshRefreshDoesNotReadCurrentAppUserID() {
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
+
+        var currentAppUserIDReadCount = 0
+        self.currentUserProvider.currentAppUserIDRequested = {
+            currentAppUserIDReadCount += 1
+        }
+
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+
+        expect(currentAppUserIDReadCount) == 0
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+    }
+
     func testFailureDoesNotMarkRefreshAsFresh() {
         self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1)))))

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -1599,6 +1599,22 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.appUserID) == "new-user"
     }
 
+    func testBlobDataColdReadUsesBoundAppUserIDIfIdentityClearRacesCurrentUserRead() async {
+        self.currentUserProvider.mockAppUserID = "old-user"
+        self.currentUserProvider.currentAppUserIDRequested = { [manager] in
+            manager?.clearCache(forAppUserID: "new-user")
+        }
+
+        let task = Task {
+            await self.manager.blobData(for: .sources, itemKey: "api")
+        }
+        await self.waitForRemoteConfigRequestCount(1)
+        self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
+        _ = await task.value
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.appUserID) == "new-user"
+    }
+
     func testRefreshUsesBoundAppUserIDIfIdentityClearRacesRefreshPreparation() {
         self.manager.clearCache(forAppUserID: "new-user")
 

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -62,22 +62,22 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testRefreshRemoteConfigIfStaleRefreshesWhenNeverRefreshed() {
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
     }
 
     func testNoContentResponseMarksRefreshAsFresh() {
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
 
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
     }
 
     func testFreshRefreshDoesNotReadCurrentAppUserID() {
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
 
         var currentAppUserIDReadCount = 0
@@ -85,31 +85,31 @@ final class RemoteConfigManagerTests: TestCase {
             currentAppUserIDReadCount += 1
         }
 
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         expect(currentAppUserIDReadCount) == 0
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
     }
 
     func testFailureDoesNotMarkRefreshAsFresh() {
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1)))))
 
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
     }
 
     func testRefreshRemoteConfigIfStaleUsesForegroundAndBackgroundDurations() {
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
 
         self.dateProvider.advance(by: 6)
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: true)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: true, appUserID: Self.appUserID)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
 
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
     }
@@ -117,8 +117,8 @@ final class RemoteConfigManagerTests: TestCase {
     func testClosePreventsNewRefreshes() {
         self.manager.close()
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 0
     }
@@ -167,7 +167,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.manager.close()
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
@@ -181,7 +181,7 @@ final class RemoteConfigManagerTests: TestCase {
     func testFirstRunSendsDefaultAppDomainManifest() throws {
         self.diskCache.stubbedRead = nil
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.appUserID) == Self.appUserID
@@ -199,7 +199,7 @@ final class RemoteConfigManagerTests: TestCase {
             topics: .init()
         )
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: true, appUserID: Self.appUserID)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.appUserID) == Self.appUserID
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.domain) == "custom"
@@ -209,13 +209,13 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testOverlappingRefreshesAreIgnoredUntilInFlightRefreshCompletes() {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: true, appUserID: Self.appUserID)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
 
         self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: true, appUserID: Self.appUserID)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.isAppBackgrounded) == true
@@ -229,7 +229,7 @@ final class RemoteConfigManagerTests: TestCase {
             topics: .init()
         )
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: true, appUserID: Self.appUserID)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.prefetchedBlobs) == ["cachedBlob"]
         expect(self.blobStore.invokedCachedRefsCount) == 1
@@ -255,7 +255,7 @@ final class RemoteConfigManagerTests: TestCase {
             topics: .init(entries: ["sources": ["api": item]])
         )
         self.diskCache.stubbedRead = persisted
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.diskCache.readHandler = {
             self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
             return persisted
@@ -404,7 +404,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         let task = Task {
             await self.manager.topic(.sources)
         }
@@ -427,7 +427,7 @@ final class RemoteConfigManagerTests: TestCase {
                 "sources": ["api": .init(content: ["url": "https://api.revenuecat.com"])]
             ])
         )
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
 
         let topic = await self.manager.topic(.sources)
@@ -1115,7 +1115,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
         )
@@ -1143,7 +1143,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.compressedContainer(
                 config: response,
@@ -1176,7 +1176,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
         )
@@ -1247,7 +1247,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
         )
@@ -1277,7 +1277,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
         )
@@ -1298,7 +1298,7 @@ final class RemoteConfigManagerTests: TestCase {
         )
         self.diskCache.stubbedRead = previous
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
 
         expect(self.diskCache.invokedWriteCount) == 0
@@ -1310,7 +1310,7 @@ final class RemoteConfigManagerTests: TestCase {
     func testNoContentResponseWithNoPersistedCacheLeavesCacheUntouched() {
         self.diskCache.stubbedRead = nil
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
 
         expect(self.diskCache.invokedWriteCount) == 0
@@ -1324,7 +1324,7 @@ final class RemoteConfigManagerTests: TestCase {
             manifest: "v1.1710000100.sources:etag1"
         )
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1))))
         )
@@ -1368,10 +1368,10 @@ final class RemoteConfigManagerTests: TestCase {
         )
 
         expect(self.manager.isDisabled) == false
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .invalidRequest)))
         expect(self.manager.isDisabled) == true
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
         expect(self.diskCache.invokedReadCount) == 1
@@ -1383,44 +1383,44 @@ final class RemoteConfigManagerTests: TestCase {
 
     func testTooManyRequestsResponseDisablesRemoteConfig() {
         expect(self.manager.isDisabled) == false
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .tooManyRequests)))
         expect(self.manager.isDisabled) == true
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
         expect(self.diskCache.invokedReadCount) == 1
     }
 
     func testServerErrorDoesNotDisableRemoteConfig() {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
         expect(self.manager.isDisabled) == false
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
         expect(self.diskCache.invokedReadCount) == 2
     }
 
     func testTransportNetworkErrorDoesNotDisableRemoteConfig() {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1))))
         )
         expect(self.manager.isDisabled) == false
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
         expect(self.diskCache.invokedReadCount) == 2
     }
 
     func testClearCacheDoesNotReenableDisabledRemoteConfigRefresh() {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
         expect(self.manager.isDisabled) == true
         self.manager.clearCache(forAppUserID: Self.appUserID)
         expect(self.manager.isDisabled) == true
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
         expect(self.diskCache.invokedClearCount) == 1
@@ -1428,7 +1428,7 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testMalformedConfigPayloadLeavesCacheUntouched() throws {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: "{ not valid json")))
         )
@@ -1454,7 +1454,7 @@ final class RemoteConfigManagerTests: TestCase {
         """
         let invalidContentElement = "{ invalid content element json".asData
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response, contentElements: [invalidContentElement])
@@ -1486,7 +1486,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         let task = Task {
             await self.manager.blobData(for: .workflows, itemKey: "default")
         }
@@ -1600,18 +1600,15 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testRefreshUsesBoundAppUserIDIfIdentityClearRacesRefreshPreparation() {
-        self.currentUserProvider.mockAppUserID = "old-user"
-        self.currentUserProvider.currentAppUserIDRequested = { [weak self] in
-            self?.manager.clearCache(forAppUserID: "new-user")
-        }
+        self.manager.clearCache(forAppUserID: "new-user")
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: "old-user")
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.appUserID) == "new-user"
     }
 
     func testBlobDataNoContentRefreshCompletesWaitingRead() async {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         let task = Task {
             await self.manager.blobData(for: .sources, itemKey: "api")
@@ -1625,7 +1622,7 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testBlobDataFailedRefreshCompletesWaitingRead() async {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         let task = Task {
             await self.manager.blobData(for: .sources, itemKey: "api")
@@ -1639,7 +1636,7 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testBlobDataMalformedRefreshCompletesWaitingRead() async throws {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         let task = Task {
             await self.manager.blobData(for: .sources, itemKey: "api")
@@ -1655,7 +1652,7 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testBlobDataClearCacheCompletesWaitingRead() async {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         let task = Task {
             await self.manager.blobData(for: .sources, itemKey: "api")
@@ -1712,7 +1709,7 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testBlobDataCloseCompletesWaitingRead() async {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         let task = Task {
             await self.manager.blobData(for: .sources, itemKey: "api")
@@ -1726,7 +1723,7 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testBlobDataDoesNotTriggerRefreshWhenRemoteConfigIsDisabled() async {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
 
         let data = await self.manager.blobData(for: .sources, itemKey: "api")
@@ -1741,7 +1738,7 @@ final class RemoteConfigManagerTests: TestCase {
             manifest: "v1.1710000100.workflows:etag1",
             topics: .init(entries: ["workflows": ["default": .init(blobRef: ref)]])
         )
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
         let readCountAfterDisabling = self.diskCache.invokedReadCount
 
@@ -1769,7 +1766,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response, contentElements: [blob]),
@@ -1801,7 +1798,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response, contentElements: [blob]),
@@ -1822,7 +1819,7 @@ final class RemoteConfigManagerTests: TestCase {
         let workflowBlobRef = RCContainerTestData.blobRef(for: RCContainerTestData.workflowBlob)
         let summerWorkflowBlobRef = RCContainerTestData.blobRef(for: RCContainerTestData.summerWorkflowBlob)
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: container,
@@ -1854,7 +1851,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.compressedContainer(
@@ -1885,7 +1882,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.compressedContainer(
@@ -1916,7 +1913,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try RemoteConfigContainer(
@@ -1952,7 +1949,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response, contentElements: [referencedBlob, unreferencedBlob]),
@@ -1982,7 +1979,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response, contentElements: [prefetchBlob]),
@@ -2021,7 +2018,7 @@ final class RemoteConfigManagerTests: TestCase {
             }
         )
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try RemoteConfigContainer(data: containerData),
@@ -2051,7 +2048,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response),
@@ -2075,7 +2072,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response),
@@ -2098,7 +2095,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response),
@@ -2131,7 +2128,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response, contentElements: [blob]),
@@ -2154,11 +2151,11 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
         )
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
     }
@@ -2185,7 +2182,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.manager.clearCache(forAppUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             at: 0,
@@ -2203,7 +2200,7 @@ final class RemoteConfigManagerTests: TestCase {
             return nil
         }
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 0
         expect(self.diskCache.invokedClearCount) == 1
@@ -2211,17 +2208,17 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testStaleNoContentResponseDoesNotReleaseNewerRefreshGuard() {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.manager.clearCache(forAppUserID: Self.appUserID)
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: true, appUserID: Self.appUserID)
 
         self.remoteConfigAPI.complete(at: 0, with: .success(.test(container: nil)))
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
 
         self.remoteConfigAPI.complete(at: 1, with: .success(.test(container: nil)))
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 3
     }
@@ -2240,57 +2237,57 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.manager.clearCache(forAppUserID: Self.appUserID)
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: true, appUserID: Self.appUserID)
 
         self.remoteConfigAPI.complete(
             at: 0,
             with: .success(.test(container: try Self.container(config: response)))
         )
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
         expect(self.diskCache.invokedWriteCount) == 0
 
         self.remoteConfigAPI.complete(at: 1, with: .success(.test(container: nil)))
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 3
     }
 
     func testStaleErrorResponseDoesNotReleaseNewerRefreshGuard() {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.manager.clearCache(forAppUserID: Self.appUserID)
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: true, appUserID: Self.appUserID)
 
         self.remoteConfigAPI.complete(
             at: 0,
             with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1))))
         )
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
 
         self.remoteConfigAPI.complete(at: 1, with: .success(.test(container: nil)))
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 3
     }
 
     func testStaleFourHundredResponseDoesNotDisableRemoteConfig() {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.manager.clearCache(forAppUserID: Self.appUserID)
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: true, appUserID: Self.appUserID)
 
         self.remoteConfigAPI.complete(at: 0, with: .failure(Self.backendError(statusCode: .invalidRequest)))
         expect(self.manager.isDisabled) == false
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
 
         self.remoteConfigAPI.complete(at: 1, with: .success(.test(container: nil)))
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 3
     }
@@ -2311,7 +2308,7 @@ final class RemoteConfigManagerTests: TestCase {
         """
 
         self.manager.clearCache(forAppUserID: Self.appUserID)
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
         )
@@ -2348,7 +2345,7 @@ final class RemoteConfigManagerTests: TestCase {
             clearEntered.signal()
         }
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         DispatchQueue.global().async {
             self.remoteConfigAPI.complete(
                 with: .success(.test(container: container))

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -1403,7 +1403,7 @@ final class RemoteConfigManagerTests: TestCase {
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
         expect(self.manager.isDisabled) == true
-        self.manager.clearCache()
+        self.manager.clearCache(forAppUserID: Self.appUserID)
         expect(self.manager.isDisabled) == true
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
@@ -1647,7 +1647,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         await self.waitForRemoteConfigRequestCount(1)
         await self.waitForDiskCacheReadCount(2)
-        self.manager.clearCache()
+        self.manager.clearCache(forAppUserID: Self.appUserID)
 
         let data = await task.value
         expect(data).to(beNil())
@@ -1658,7 +1658,7 @@ final class RemoteConfigManagerTests: TestCase {
         self.diskCache.readHandler = {
             if !didClearDuringRead {
                 didClearDuringRead = true
-                self.manager.clearCache()
+                self.manager.clearCache(forAppUserID: Self.appUserID)
             }
 
             return Self.persisted(
@@ -1679,7 +1679,7 @@ final class RemoteConfigManagerTests: TestCase {
         self.diskCache.readHandler = {
             if !didClearDuringRead {
                 didClearDuringRead = true
-                self.manager.clearCache()
+                self.manager.clearCache(forAppUserID: Self.appUserID)
             }
 
             return Self.persisted(
@@ -2149,7 +2149,7 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testClearCacheWipesDiskCacheAndBlobStore() {
-        self.manager.clearCache()
+        self.manager.clearCache(forAppUserID: Self.appUserID)
 
         expect(self.diskCache.invokedClearCount) == 1
         expect(self.blobStore.invokedClearCount) == 1
@@ -2171,7 +2171,7 @@ final class RemoteConfigManagerTests: TestCase {
         """
 
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
-        self.manager.clearCache()
+        self.manager.clearCache(forAppUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             at: 0,
             with: .success(.test(container: try Self.container(config: response)))
@@ -2184,7 +2184,7 @@ final class RemoteConfigManagerTests: TestCase {
 
     func testClearCacheWhileBuildingRequestDoesNotSendStaleRequest() {
         self.diskCache.readHandler = { [manager] in
-            manager?.clearCache()
+            manager?.clearCache(forAppUserID: Self.appUserID)
             return nil
         }
 
@@ -2197,7 +2197,7 @@ final class RemoteConfigManagerTests: TestCase {
 
     func testStaleNoContentResponseDoesNotReleaseNewerRefreshGuard() {
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
-        self.manager.clearCache()
+        self.manager.clearCache(forAppUserID: Self.appUserID)
         self.manager.refreshRemoteConfig(isAppBackgrounded: true)
 
         self.remoteConfigAPI.complete(at: 0, with: .success(.test(container: nil)))
@@ -2226,7 +2226,7 @@ final class RemoteConfigManagerTests: TestCase {
         """
 
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
-        self.manager.clearCache()
+        self.manager.clearCache(forAppUserID: Self.appUserID)
         self.manager.refreshRemoteConfig(isAppBackgrounded: true)
 
         self.remoteConfigAPI.complete(
@@ -2246,7 +2246,7 @@ final class RemoteConfigManagerTests: TestCase {
 
     func testStaleErrorResponseDoesNotReleaseNewerRefreshGuard() {
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
-        self.manager.clearCache()
+        self.manager.clearCache(forAppUserID: Self.appUserID)
         self.manager.refreshRemoteConfig(isAppBackgrounded: true)
 
         self.remoteConfigAPI.complete(
@@ -2265,7 +2265,7 @@ final class RemoteConfigManagerTests: TestCase {
 
     func testStaleFourHundredResponseDoesNotDisableRemoteConfig() {
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
-        self.manager.clearCache()
+        self.manager.clearCache(forAppUserID: Self.appUserID)
         self.manager.refreshRemoteConfig(isAppBackgrounded: true)
 
         self.remoteConfigAPI.complete(at: 0, with: .failure(Self.backendError(statusCode: .invalidRequest)))
@@ -2295,7 +2295,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.clearCache()
+        self.manager.clearCache(forAppUserID: Self.appUserID)
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
@@ -2342,7 +2342,7 @@ final class RemoteConfigManagerTests: TestCase {
         expect(writeStarted.wait(timeout: .now() + .seconds(5))) == .success
 
         DispatchQueue.global().async {
-            self.manager.clearCache()
+            self.manager.clearCache(forAppUserID: Self.appUserID)
         }
 
         expect(clearEntered.wait(timeout: .now() + .milliseconds(200))) == .timedOut

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -338,7 +338,7 @@ final class RemoteConfigManagerTests: TestCase {
         """
 
         let task = Task {
-            await self.manager.topic(.sources)?["api"]?.content["url"] as? String
+            await self.manager.topic(.sources)?["api"]?.content["url"]
         }
         await self.waitForRemoteConfigRequestCount(1)
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.isAppBackgrounded) == false
@@ -346,7 +346,8 @@ final class RemoteConfigManagerTests: TestCase {
             with: .success(.test(container: try Self.container(config: response)))
         )
 
-        expect(await task.value) == "https://api.revenuecat.com"
+        let apiURL = await task.value
+        expect(apiURL) == AnyDecodable.string("https://api.revenuecat.com")
     }
 
     func testTopicMissingAfterFreshRefreshDoesNotTriggerAnotherRefresh() async throws {
@@ -375,7 +376,8 @@ final class RemoteConfigManagerTests: TestCase {
             with: .success(.test(container: try Self.container(config: response)))
         )
 
-        expect(await firstRead.value) == true
+        let didMissTopic = await firstRead.value
+        expect(didMissTopic) == true
 
         let secondRead = await self.manager.topic(.workflows)
 
@@ -403,7 +405,7 @@ final class RemoteConfigManagerTests: TestCase {
 
         self.manager.refreshRemoteConfig(isAppBackgrounded: false, appUserID: Self.appUserID)
         let task = Task {
-            await self.manager.topic(.sources)?["api"]?.content["url"] as? String
+            await self.manager.topic(.sources)?["api"]?.content["url"]
         }
         await self.waitForRemoteConfigRequestCount(1)
         await self.waitForDiskCacheReadCount(2)
@@ -411,7 +413,8 @@ final class RemoteConfigManagerTests: TestCase {
             with: .success(.test(container: try Self.container(config: response)))
         )
 
-        expect(await task.value) == "https://api.revenuecat.com"
+        let apiURL = await task.value
+        expect(apiURL) == AnyDecodable.string("https://api.revenuecat.com")
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
     }
 

--- a/Tests/UnitTests/Networking/UiConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/UiConfigProviderTests.swift
@@ -135,7 +135,7 @@ class UiConfigProviderTests: TestCase {
 
 #else
 
-    func testAssemblesEmptyUiConfigWhenRequiredPartsArePresent() async throws {
+    func testAssemblesUiConfigWhenRequiredPartsArePresent() async throws {
         self.stub(
             app: #"{"colors": {}, "fonts": {}}"#,
             localizations: #"{"en_US": {"day": "Day"}}"#,

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -333,73 +333,128 @@ private final class FakeRemoteConfigAPI: RemoteConfigAPIType {
 
 private final class FakeRemoteConfigDiskCache: RemoteConfigDiskCacheType {
 
-    var stubbedRead: PersistedRemoteConfiguration?
+    private let lock = Lock()
+    private var _stubbedRead: PersistedRemoteConfiguration?
+    var stubbedRead: PersistedRemoteConfiguration? {
+        get {
+            return self.lock.perform {
+                self._stubbedRead
+            }
+        }
+        set {
+            self.lock.perform {
+                self._stubbedRead = newValue
+            }
+        }
+    }
 
     func read() -> PersistedRemoteConfiguration? {
-        return self.stubbedRead
+        return self.lock.perform {
+            self._stubbedRead
+        }
     }
 
     func topic(_ topic: RemoteConfigTopic) -> RemoteConfiguration.ConfigTopic? {
-        return self.stubbedRead?.topics.entries[topic.wireName]
+        return self.lock.perform {
+            self._stubbedRead?.topics.entries[topic.wireName]
+        }
     }
 
     @discardableResult
     func write(_ configuration: PersistedRemoteConfiguration) -> Bool {
-        self.stubbedRead = configuration
+        self.lock.perform {
+            self._stubbedRead = configuration
+        }
         return true
     }
 
     func clear() {
-        self.stubbedRead = nil
+        self.lock.perform {
+            self._stubbedRead = nil
+        }
     }
 
 }
 
 private final class FakeRemoteConfigBlobStore: RemoteConfigBlobStoreType {
 
-    var stubbedData: [String: Data] = [:]
+    private let lock = Lock()
+    private var _stubbedData: [String: Data] = [:]
+    var stubbedData: [String: Data] {
+        get {
+            return self.lock.perform {
+                self._stubbedData
+            }
+        }
+        set {
+            self.lock.perform {
+                self._stubbedData = newValue
+            }
+        }
+    }
 
     func contains(ref: String) -> Bool {
-        return self.stubbedData[ref] != nil
+        return self.lock.perform {
+            self._stubbedData[ref] != nil
+        }
     }
 
     func read(ref: String) -> Data? {
-        return self.stubbedData[ref]
+        return self.lock.perform {
+            self._stubbedData[ref]
+        }
     }
 
     @discardableResult
     func write(ref: String, bytes: UnsafeRawBufferPointer) -> Bool {
         var data = Data()
         data.append(contentsOf: bytes.bindMemory(to: UInt8.self))
-        self.stubbedData[ref] = data
+        self.lock.perform {
+            self._stubbedData[ref] = data
+        }
         return true
     }
 
     func cachedRefs() -> Set<String> {
-        return Set(self.stubbedData.keys)
+        return self.lock.perform {
+            Set(self._stubbedData.keys)
+        }
     }
 
     func retainOnly(_ refs: Set<String>) {
-        self.stubbedData = self.stubbedData.filter { refs.contains($0.key) }
+        self.lock.perform {
+            self._stubbedData = self._stubbedData.filter { refs.contains($0.key) }
+        }
     }
 
     func clear() {
-        self.stubbedData = [:]
+        self.lock.perform {
+            self._stubbedData = [:]
+        }
     }
 
 }
 
 private final class FakeRemoteConfigBlobFetcher: RemoteConfigBlobFetcherType {
 
+    private let lock = Lock()
     private let blobStore: FakeRemoteConfigBlobStore
-    private(set) var invokedEnsureDownloadedRefs: [String] = []
+    private var _invokedEnsureDownloadedRefs: [String] = []
+
+    var invokedEnsureDownloadedRefs: [String] {
+        return self.lock.perform {
+            self._invokedEnsureDownloadedRefs
+        }
+    }
 
     init(blobStore: FakeRemoteConfigBlobStore) {
         self.blobStore = blobStore
     }
 
     func ensureDownloaded(ref: String) async -> Bool {
-        self.invokedEnsureDownloadedRefs.append(ref)
+        self.lock.perform {
+            self._invokedEnsureDownloadedRefs.append(ref)
+        }
         // The store is pre-populated in these tests, so "downloading" is just confirming it's there.
         return self.blobStore.contains(ref: ref)
     }

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -673,24 +673,26 @@ extension BasePurchasesTests.MockOfferingsAPI: @unchecked Sendable {}
 
 final class MockRemoteConfigManager: RemoteConfigManagerType {
 
+    private typealias RefreshParameters = (isAppBackgrounded: Bool, appUserID: String)
+
     var isDisabled = false
 
     private(set) var invokedRefreshRemoteConfigCount = 0
     private(set) var invokedRefreshRemoteConfigIfStaleCount = 0
     private(set) var invokedClearCacheCount = 0
     private(set) var invokedCloseCount = 0
-    private(set) var invokedRefreshRemoteConfigParametersList: [Bool] = []
-    private(set) var invokedRefreshRemoteConfigIfStaleParametersList: [Bool] = []
+    private(set) var invokedRefreshRemoteConfigParametersList: [RefreshParameters] = []
+    private(set) var invokedRefreshRemoteConfigIfStaleParametersList: [RefreshParameters] = []
     private(set) var invokedClearCacheAppUserIDs: [String] = []
 
-    func refreshRemoteConfig(isAppBackgrounded: Bool) {
+    func refreshRemoteConfig(isAppBackgrounded: Bool, appUserID: String) {
         self.invokedRefreshRemoteConfigCount += 1
-        self.invokedRefreshRemoteConfigParametersList.append(isAppBackgrounded)
+        self.invokedRefreshRemoteConfigParametersList.append((isAppBackgrounded, appUserID))
     }
 
-    func refreshRemoteConfigIfStale(isAppBackgrounded: Bool) {
+    func refreshRemoteConfigIfStale(isAppBackgrounded: Bool, appUserID: String) {
         self.invokedRefreshRemoteConfigIfStaleCount += 1
-        self.invokedRefreshRemoteConfigIfStaleParametersList.append(isAppBackgrounded)
+        self.invokedRefreshRemoteConfigIfStaleParametersList.append((isAppBackgrounded, appUserID))
     }
 
     var stubbedTopics: [RemoteConfigTopic: RemoteConfiguration.ConfigTopic] = [:]

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -673,7 +673,7 @@ extension BasePurchasesTests.MockOfferingsAPI: @unchecked Sendable {}
 
 final class MockRemoteConfigManager: RemoteConfigManagerType {
 
-    private typealias RefreshParameters = (isAppBackgrounded: Bool, appUserID: String)
+    typealias RefreshParameters = (isAppBackgrounded: Bool, appUserID: String)
 
     var isDisabled = false
 

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -673,7 +673,9 @@ extension BasePurchasesTests.MockOfferingsAPI: @unchecked Sendable {}
 
 final class MockRemoteConfigManager: RemoteConfigManagerType {
 
-    typealias RefreshParameters = (isAppBackgrounded: Bool, appUserID: String)
+    struct RefreshParameters {
+        let isAppBackgrounded: Bool
+    }
 
     var isDisabled = false
 
@@ -685,14 +687,14 @@ final class MockRemoteConfigManager: RemoteConfigManagerType {
     private(set) var invokedRefreshRemoteConfigIfStaleParametersList: [RefreshParameters] = []
     private(set) var invokedClearCacheAppUserIDs: [String] = []
 
-    func refreshRemoteConfig(isAppBackgrounded: Bool, appUserID: String) {
+    func refreshRemoteConfig(isAppBackgrounded: Bool) {
         self.invokedRefreshRemoteConfigCount += 1
-        self.invokedRefreshRemoteConfigParametersList.append((isAppBackgrounded, appUserID))
+        self.invokedRefreshRemoteConfigParametersList.append(.init(isAppBackgrounded: isAppBackgrounded))
     }
 
-    func refreshRemoteConfigIfStale(isAppBackgrounded: Bool, appUserID: String) {
+    func refreshRemoteConfigIfStale(isAppBackgrounded: Bool) {
         self.invokedRefreshRemoteConfigIfStaleCount += 1
-        self.invokedRefreshRemoteConfigIfStaleParametersList.append((isAppBackgrounded, appUserID))
+        self.invokedRefreshRemoteConfigIfStaleParametersList.append(.init(isAppBackgrounded: isAppBackgrounded))
     }
 
     var stubbedTopics: [RemoteConfigTopic: RemoteConfiguration.ConfigTopic] = [:]

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -593,6 +593,7 @@ extension BasePurchasesTests {
             self.callOrder.append(.postReceipt)
             self.postReceiptDataCalled = true
             self.postReceiptDataCallCount += 1
+            self.userID = appUserID
             self.postedReceiptData = receipt
             self.postedIsRestore = postReceiptSource.isRestore
             self.postedAssociatedTransactionIds.append(associatedTransactionId)

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -681,6 +681,7 @@ final class MockRemoteConfigManager: RemoteConfigManagerType {
     private(set) var invokedCloseCount = 0
     private(set) var invokedRefreshRemoteConfigParametersList: [Bool] = []
     private(set) var invokedRefreshRemoteConfigIfStaleParametersList: [Bool] = []
+    private(set) var invokedClearCacheAppUserIDs: [String] = []
 
     func refreshRemoteConfig(isAppBackgrounded: Bool) {
         self.invokedRefreshRemoteConfigCount += 1
@@ -783,6 +784,11 @@ final class MockRemoteConfigManager: RemoteConfigManagerType {
 
     func clearCache() {
         self.invokedClearCacheCount += 1
+    }
+
+    func clearCache(forAppUserID appUserID: String) {
+        self.invokedClearCacheCount += 1
+        self.invokedClearCacheAppUserIDs.append(appUserID)
     }
 
     func close() {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
@@ -83,7 +83,9 @@ class PurchasesLogInTests: BasePurchasesLogInTests {
         expect(self.backend.getCustomerInfoCallCount) == 2
         expect(self.identityManager.invokedLogOutCount) == 1
         expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigCount) == baselineRemoteConfigRefreshCount + 1
-        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigParametersList.last) == true
+        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigParametersList.last?.isAppBackgrounded) == true
+        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigParametersList.last?.appUserID) ==
+            self.identityManager.currentAppUserID
     }
 
     func testLogOutWithFailure() {
@@ -146,7 +148,8 @@ class PurchasesLogInTests: BasePurchasesLogInTests {
         self.purchases.internalSwitchUser(to: "test-user-id")
 
         expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigCount) == baselineRefreshCount + 1
-        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigParametersList.last) == true
+        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigParametersList.last?.isAppBackgrounded) == true
+        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigParametersList.last?.appUserID) == "test-user-id"
     }
 
     func testSwitchUserNoOpIfAppUserIDIsSameAsCurrent() {
@@ -191,7 +194,9 @@ class PurchasesLogInTests: BasePurchasesLogInTests {
         let parameters = try XCTUnwrap(self.mockOfferingsManager.invokedUpdateOfferingsCacheParameters)
         expect(parameters.appUserID) == Self.mockLoggedInInfo.originalAppUserId
         expect(parameters.isAppBackgrounded) == isAppBackgrounded
-        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigParametersList.last) == isAppBackgrounded
+        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigParametersList.last?.isAppBackgrounded) ==
+            isAppBackgrounded
+        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigParametersList.last?.appUserID) == Self.appUserID
     }
 
     func testLogInFailureDoesNotUpdateOfferingsCache() {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
@@ -44,6 +44,23 @@ class PurchasesLogInTests: BasePurchasesLogInTests {
         expect(self.identityManager.invokedLogInParametersList) == [Self.appUserID]
     }
 
+    func testLogInTrimsAppUserIDForIdentityAndRemoteConfigRefresh() {
+        self.systemInfo.stubbedRemoteConfigEnabled = true
+        Purchases.clearSingleton()
+        self.initializePurchasesInstance(appUserId: nil)
+        self.identityManager.mockLogInResult = .success((Self.mockLoggedInInfo, true))
+
+        waitUntil { completed in
+            self.purchases.logIn("  \(Self.appUserID)  ") { _, _, _ in
+                completed()
+            }
+        }
+
+        expect(self.identityManager.invokedLogInParametersList) == [Self.appUserID]
+        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigParametersList.last?.appUserID) ==
+            Self.appUserID
+    }
+
     func testLogInWithFailure() {
         let error: BackendError = .networkError(.offlineConnection())
         self.identityManager.mockLogInResult = .failure(error)

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
@@ -49,6 +49,7 @@ class PurchasesLogInTests: BasePurchasesLogInTests {
         Purchases.clearSingleton()
         self.initializePurchasesInstance(appUserId: nil)
         self.identityManager.mockLogInResult = .success((Self.mockLoggedInInfo, true))
+        let baselineRefreshCount = self.mockRemoteConfigManager.invokedRefreshRemoteConfigCount
 
         waitUntil { completed in
             self.purchases.logIn("  \(Self.appUserID)  ") { _, _, _ in
@@ -57,8 +58,7 @@ class PurchasesLogInTests: BasePurchasesLogInTests {
         }
 
         expect(self.identityManager.invokedLogInParametersList) == [Self.appUserID]
-        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigParametersList.last?.appUserID) ==
-            Self.appUserID
+        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigCount) == baselineRefreshCount + 1
     }
 
     func testLogInWithFailure() {
@@ -101,8 +101,6 @@ class PurchasesLogInTests: BasePurchasesLogInTests {
         expect(self.identityManager.invokedLogOutCount) == 1
         expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigCount) == baselineRemoteConfigRefreshCount + 1
         expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigParametersList.last?.isAppBackgrounded) == true
-        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigParametersList.last?.appUserID) ==
-            self.identityManager.currentAppUserID
     }
 
     func testLogOutWithFailure() {
@@ -166,7 +164,6 @@ class PurchasesLogInTests: BasePurchasesLogInTests {
 
         expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigCount) == baselineRefreshCount + 1
         expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigParametersList.last?.isAppBackgrounded) == true
-        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigParametersList.last?.appUserID) == "test-user-id"
     }
 
     func testSwitchUserNoOpIfAppUserIDIsSameAsCurrent() {
@@ -213,7 +210,6 @@ class PurchasesLogInTests: BasePurchasesLogInTests {
         expect(parameters.isAppBackgrounded) == isAppBackgrounded
         expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigParametersList.last?.isAppBackgrounded) ==
             isAppBackgrounded
-        expect(self.mockRemoteConfigManager.invokedRefreshRemoteConfigParametersList.last?.appUserID) == Self.appUserID
     }
 
     func testLogInFailureDoesNotUpdateOfferingsCache() {


### PR DESCRIPTION
iOS equivalent of Android PR https://github.com/RevenueCat/purchases-android/pull/3722

Ensures remote config refresh requests are bound to the identity captured during the cache clear / refresh preparation. If the identity changes while a refresh is in progress, the response is discarded instead of being persisted for the new user.

This matters because there can be a race where remote config is cleared for a user ID change, but reading the current user ID back during refresh preparation still returns the old user because the new user has not been written to disk yet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes identity-sensitive remote config refresh timing and request user ID selection; incorrect binding could fetch or persist config for the wrong user, though epoch guards and new tests target the race.
> 
> **Overview**
> Fixes a race during login, switch, and logout where remote config could be cleared for a new user while the next refresh still used the **old** `currentAppUserID` from disk.
> 
> **Remote config:** Adds `clearCache(forAppUserID:)` and stores that ID as `identityBoundAppUserID` when the cache is wiped. Refresh preparation now builds a `RefreshRequestContext` (epoch + `requestAppUserID`) and prefers the bound ID over `CurrentUserProvider`, so cold reads and explicit refreshes after an identity clear hit the correct user. `prepareRefreshIfStale` can still start a refresh when epoch moved but a bound identity is set. `IdentityManager` calls the new API with the **new** user on login/switch/logout and clears remote config **before** device cache updates where ordering changed.
> 
> **Purchases:** `logIn` trims whitespace from the app user ID before identity work (aligned with identity manager trimming).
> 
> **Concurrency:** Small `@unchecked Sendable` wrappers for `OperationQueue`, read closures, and `recordPurchase` completion; `AnyDecodable: Sendable`; `UiConfigProvider: @unchecked Sendable`.
> 
> **Tests:** Identity clear passes expected user IDs; race tests for bound ID during blob reads and refresh; thread-safe fakes; duplicate fresh-refresh test; mock updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a261482602c50f6fb59ba207f3ad46110e484355. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->