### PR TITLE
Temporarily skip iOS 14 CI tests

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1254,9 +1254,13 @@ jobs:
       - run:
           name: Start iOS 14.5 runtime installation (background)
           command: |
-            scripts/install-ios-runtime.sh "iOS 14.5" &
-            disown
-            echo "Started iOS 14.5 runtime installation in background"
+            # Temporarily disabled while waiting for xcodes to handle Apple's
+            # simulator runtime catalog `authentication: none` entries.
+            # https://github.com/XcodesOrg/xcodes/releases
+            # scripts/install-ios-runtime.sh "iOS 14.5" &
+            # disown
+            # echo "Started iOS 14.5 runtime installation in background"
+            echo "Skipping iOS 14.5 runtime installation"
 
       # === iOS 15 tests ===
       # When generating snapshots, skip StoreKit tests on iOS 15.
@@ -1301,39 +1305,59 @@ jobs:
           destination: scan-test-output-ios-15
       - run:
           name: Clean test output before iOS 14 run
-          command: rm -rf fastlane/test_output
+          command: |
+            # rm -rf fastlane/test_output
+            echo "Skipping iOS 14 test output cleanup"
 
       # === iOS 14 tests ===
       - run:
           name: Wait for iOS 14.5 runtime installation
-          command: scripts/wait-for-ios-runtime.sh
+          command: |
+            # scripts/wait-for-ios-runtime.sh
+            echo "Skipping iOS 14.5 runtime installation wait"
           no_output_timeout: 30m
       - run:
           name: Run iOS 14 tests
-          command: bundle exec fastlane test_ios skip_sk_tests:true
+          command: |
+            # bundle exec fastlane test_ios skip_sk_tests:true
+            echo "Skipping iOS 14 tests until xcodes runtime catalog parsing is fixed"
           no_output_timeout: 5m
           environment:
             SCAN_DEVICE: iPhone 12 (14.5)
-      - compress_result_bundle:
-          directory: fastlane/test_output/xctest/ios
-          bundle_name: RevenueCat
+      - run:
+          name: Compress iOS 14 result bundle
+          command: |
+            # - compress_result_bundle:
+            #     directory: fastlane/test_output/xctest/ios
+            #     bundle_name: RevenueCat
+            echo "Skipping iOS 14 result bundle compression"
       - run:
           name: Preserve iOS 14 result bundle
           when: always
           command: |
-            cd fastlane/test_output/xctest/ios 2>/dev/null || exit 0
-            if [ -f RevenueCat.xcresult.tar.gz ]; then
-              mv RevenueCat.xcresult.tar.gz RevenueCat-iOS14.xcresult.tar.gz
-            fi
+            # cd fastlane/test_output/xctest/ios 2>/dev/null || exit 0
+            # if [ -f RevenueCat.xcresult.tar.gz ]; then
+            #   mv RevenueCat.xcresult.tar.gz RevenueCat-iOS14.xcresult.tar.gz
+            # fi
+            echo "Skipping iOS 14 result bundle preservation"
       - create-snapshot-pr-if-needed:
-          condition: << pipeline.parameters.generate_snapshots >>
+          # condition: << pipeline.parameters.generate_snapshots >>
+          condition: false
           job: "create_snapshot_pr"
           version: "ios-14"
-      - store_test_results:
-          path: fastlane/test_output
-      - store_artifacts:
-          path: fastlane/test_output/xctest
-          destination: scan-test-output-ios-14
+      - run:
+          name: Store iOS 14 test results
+          command: |
+            # - store_test_results:
+            #     path: fastlane/test_output
+            echo "Skipping iOS 14 test result storage"
+      - run:
+          name: Store iOS 14 artifacts
+          command: |
+            # - store_artifacts:
+            #     path: fastlane/test_output/xctest
+            #     destination: scan-test-output-ios-14
+            echo "Skipping iOS 14 artifact storage"
       - slack-notify-on-fail
 
   run-test-watchos:


### PR DESCRIPTION
iOS 14 tests started failing because of an issue when downloading the iOS 14 runtime through `xcodes`
```
Error: DecodingError.dataCorrupted: Data was corrupted. Path: downloadables[393].authentication. Debug description: Cannot initialize Authentication from invalid String value none
```

This appears to be due to a server-side change by Apple, which requires client-side changes to `xcodes`. Work appears in progress there, but until a new version with the fix lands we're going to disable the iOS 14 tests in order to unblock our release pipelines.

I've added a comment and will set a reminder to re-enabled this once the fix lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI no longer exercises iOS 14 until reverted, which reduces release-branch coverage for that OS version but avoids false failures from tooling; iOS 15+ jobs are unaffected.
> 
> **Overview**
> **Temporarily disables the iOS 14 portion** of the `run-test-ios-15-and-14` CircleCI job so release pipelines are not blocked while `xcodes` cannot parse Apple’s simulator runtime catalog (`authentication: none`).
> 
> Background iOS 14.5 runtime install via `scripts/install-ios-runtime.sh` is commented out and replaced with a skip message (with a link to upstream `xcodes` fixes). The iOS 15 flow is unchanged.
> 
> All downstream iOS 14 steps are no-ops: no wait for runtime, no `fastlane test_ios`, no result-bundle compress/preserve, no `store_test_results` / `store_artifacts` (those orb steps become echo-only `run` steps). iOS 14 snapshot PR creation is forced off with `condition: false` on `create-snapshot-pr-if-needed`. Pre–iOS 14 cleanup of `fastlane/test_output` is also skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d13ea1a4dd217db231465ffd1ddfb94d96a7f00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->