### PR TITLE
Fix tvOS UI config provider tests

### DIFF
--- a/Tests/UnitTests/Networking/UiConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/UiConfigProviderTests.swift
@@ -29,6 +29,8 @@ class UiConfigProviderTests: TestCase {
         self.provider = UiConfigProvider(manager: self.mockManager)
     }
 
+#if !os(tvOS) // For Paywalls V2
+
     func testAssemblesUiConfigFromItsFourParts() async throws {
         self.stub(
             app: #"{"colors": {}, "fonts": {}}"#,
@@ -105,13 +107,38 @@ class UiConfigProviderTests: TestCase {
     }
 
     func testRequestsWireItemKeysNotCamelCased() async throws {
+        self.stub(
+            app: #"{"colors": {}, "fonts": {}}"#,
+            localizations: #"{"en_US": {"day": "Day"}}"#,
+            variableConfig: #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#,
+            customVariables: #"{"user_name": {"type": "string", "default_value": "Friend"}}"#
+        )
+
         _ = await self.provider.getUiConfig()
 
         let requestedKeys = self.mockManager.invokedBlobDataParameters
             .filter { $0.topic == .uiConfig }
             .map(\.itemKey)
-        expect(requestedKeys).to(contain(["app", "localizations", "variable_config", "custom_variables"]))
+
+        expect(Set(requestedKeys)) == Set(["app", "localizations", "variable_config", "custom_variables"])
     }
+
+#else
+
+    func testAssemblesEmptyUiConfigWhenRequiredPartsArePresent() async throws {
+        self.stub(
+            app: #"{"colors": {}, "fonts": {}}"#,
+            localizations: #"{"en_US": {"day": "Day"}}"#,
+            variableConfig: nil,
+            customVariables: nil
+        )
+
+        let uiConfig = await self.provider.getUiConfig()
+
+        expect(uiConfig) == .empty
+    }
+
+#endif
 
     private func stub(app: String?, localizations: String?, variableConfig: String?, customVariables: String?) {
         var data: [String: Data] = [:]


### PR DESCRIPTION
tvOS tests started failing on main because of the new of `UIConfigProvider` tests. On tvOS the `UIConfig` is an empty struct, so tests failed to compile here without the additional guard. 

I've updated the `UIConfigProvider` tests to define the tvOS specific tests separately and not compile the others for tvOS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with compile-time platform guards; no production UI config behavior is modified.
> 
> **Overview**
> Fixes **tvOS unit test compile failures** by splitting `UiConfigProviderTests` with `#if !os(tvOS)` / `#else`, since tvOS uses an empty `UIConfig` (Paywalls V2) and the existing assertions don’t apply there.
> 
> **Non-tvOS:** Paywalls V2 coverage is unchanged but stays behind the guard. `testRequestsWireItemKeysNotCamelCased` now stubs all four remote-config parts before calling `getUiConfig`, and asserts the requested keys with **set equality** instead of `contain`.
> 
> **tvOS:** Adds `testAssemblesEmptyUiConfigWhenRequiredPartsArePresent`, expecting `uiConfig == .empty` when app/localizations stubs are present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf8ba141e86ace2f4a84ca63c9a6df5475dbf20d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->