### PR TITLE
feat(remote-config): use merged blobs helper for ui config

### DIFF
--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -36,8 +36,8 @@ enum RemoteConfigStrings {
     case sourceUnhealthy(ref: String, hasNextSource: Bool)
     case storedBlob(String, byteCount: Int, URL)
     case storedInlineBlob(String, byteCount: Int)
+    case uiConfigDecodeFailed(Error)
     case uiConfigMissingRequiredPart
-    case uiConfigPartDecodeFailed(itemKey: String, error: Error)
     case workflowsEnabledWithoutRemoteConfig
 
 }
@@ -110,10 +110,10 @@ extension RemoteConfigStrings: LogMessage {
             return "Stored remote config blob '\(ref)' with \(byteCount) bytes downloaded from \(url.absoluteString)."
         case let .storedInlineBlob(ref, byteCount):
             return "Stored inline remote config blob '\(ref)' with \(byteCount) bytes."
+        case let .uiConfigDecodeFailed(error):
+            return "Failed to decode merged ui_config: \(error.localizedDescription)"
         case .uiConfigMissingRequiredPart:
-            return "Failed to assemble ui_config: the 'app' or 'localizations' part is unavailable."
-        case let .uiConfigPartDecodeFailed(itemKey, error):
-            return "Failed to decode ui_config part '\(itemKey)': \(error.localizedDescription)"
+            return "Failed to assemble ui_config: one or more blob parts are unavailable."
         case .workflowsEnabledWithoutRemoteConfig:
             return "Workflows are enabled (-EnableWorkflowsEndpoint) but remote config is not " +
                 "(ENABLE_REMOTE_CONFIG is off in this build), so no workflow will ever be found."

--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -38,6 +38,7 @@ enum RemoteConfigStrings {
     case storedInlineBlob(String, byteCount: Int)
     case uiConfigDecodeFailed(Error)
     case uiConfigMissingRequiredPart
+    case uiConfigPartDecodeFailed(itemKey: String, error: Error)
     case workflowsEnabledWithoutRemoteConfig
 
 }
@@ -113,7 +114,9 @@ extension RemoteConfigStrings: LogMessage {
         case let .uiConfigDecodeFailed(error):
             return "Failed to decode merged ui_config: \(error.localizedDescription)"
         case .uiConfigMissingRequiredPart:
-            return "Failed to assemble ui_config: one or more blob parts are unavailable."
+            return "Failed to assemble ui_config: the 'app' or 'localizations' part is unavailable."
+        case let .uiConfigPartDecodeFailed(itemKey, error):
+            return "Failed to decode ui_config part '\(itemKey)': \(error.localizedDescription)"
         case .workflowsEnabledWithoutRemoteConfig:
             return "Workflows are enabled (-EnableWorkflowsEndpoint) but remote config is not " +
                 "(ENABLE_REMOTE_CONFIG is off in this build), so no workflow will ever be found."

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -92,12 +92,12 @@ extension RemoteConfigManagerType {
         as type: T.Type
     ) async throws -> T? {
         let uniqueItemKeys = Self.uniqueItemKeys(itemKeys)
-        guard !uniqueItemKeys.isEmpty else {
-            Logger.warn(Strings.remoteConfig.mergeItemsBlobDataEmpty(topic: topic))
-            return nil
-        }
         guard !self.isDisabled else {
             Logger.warn(Strings.remoteConfig.mergeItemsBlobDataDisabled(topic: topic, itemKeys: uniqueItemKeys))
+            return nil
+        }
+        guard !uniqueItemKeys.isEmpty else {
+            Logger.warn(Strings.remoteConfig.mergeItemsBlobDataEmpty(topic: topic))
             return nil
         }
 

--- a/Sources/Networking/UiConfigProvider.swift
+++ b/Sources/Networking/UiConfigProvider.swift
@@ -19,24 +19,72 @@ final class UiConfigProvider {
     }
 
 #if !os(tvOS)
-    /// Assembles a ``UIConfig`` from the `ui_config` topic's parts. Returns `nil` when any part is
-    /// unavailable or when the merged config fails to decode.
+    /// Assembles a ``UIConfig`` from the `ui_config` topic's parts. Returns `nil` when a required part
+    /// (`app` or `localizations`) is unavailable or fails to decode.
+    ///
+    /// Optional parts decode independently so missing or malformed optional blobs fall back to the same
+    /// defaults as `UIConfig`'s decoder.
     func getUiConfig() async -> UIConfig? {
         do {
-            let uiConfig = try await self.manager.mergeItemsBlobData(
+            guard let requiredParts = try await self.manager.mergeItemsBlobData(
                 for: .uiConfig,
-                itemKeys: Self.itemKeys,
-                as: UIConfig.self
-            )
-            if uiConfig == nil, !self.manager.isDisabled {
-                Logger.warn(Strings.remoteConfig.uiConfigMissingRequiredPart)
+                itemKeys: Self.requiredItemKeys,
+                as: RequiredParts.self
+            ) else {
+                if !self.manager.isDisabled {
+                    Logger.warn(Strings.remoteConfig.uiConfigMissingRequiredPart)
+                }
+                return nil
             }
-            return uiConfig
+
+            let topic = await self.manager.topic(.uiConfig)
+            async let variableConfig = self.decodeOptionalPart(
+                UIConfig.VariableConfig.self,
+                itemKey: Self.variableConfigKey,
+                topic: topic
+            )
+            async let customVariables = self.decodeOptionalPart(
+                [String: UIConfig.CustomVariableDefinition].self,
+                itemKey: Self.customVariablesKey,
+                topic: topic
+            )
+
+            return UIConfig(
+                app: requiredParts.app,
+                localizations: requiredParts.localizations,
+                variableConfig: await variableConfig ?? Self.defaultVariableConfig,
+                customVariables: await customVariables ?? [:]
+            )
         } catch {
             Logger.error(Strings.remoteConfig.uiConfigDecodeFailed(error))
             return nil
         }
     }
+
+    private func decodeOptionalPart<T: Decodable>(
+        _ type: T.Type,
+        itemKey: String,
+        topic: RemoteConfiguration.ConfigTopic?
+    ) async -> T? {
+        guard topic?[itemKey] != nil else { return nil }
+
+        do {
+            return try await self.manager.blobData(for: .uiConfig, itemKey: itemKey, as: type)
+        } catch {
+            Logger.error(Strings.remoteConfig.uiConfigPartDecodeFailed(itemKey: itemKey, error: error))
+            return nil
+        }
+    }
+
+    private struct RequiredParts: Decodable {
+        let app: UIConfig.AppConfig
+        let localizations: [String: [String: String]]
+    }
+
+    private static let defaultVariableConfig = UIConfig.VariableConfig(
+        variableCompatibilityMap: [:],
+        functionCompatibilityMap: [:]
+    )
 #else
     // Paywalls V2 (and therefore workflows) aren't supported on tvOS, where `UIConfig` carries no fields.
     func getUiConfig() async -> UIConfig? {
@@ -54,12 +102,10 @@ final class UiConfigProvider {
     private static let localizationsKey = "localizations"
     private static let variableConfigKey = "variable_config"
     private static let customVariablesKey = "custom_variables"
-    private static var itemKeys: [String] {
+    private static var requiredItemKeys: [String] {
         return [
             Self.appKey,
-            Self.localizationsKey,
-            Self.variableConfigKey,
-            Self.customVariablesKey
+            Self.localizationsKey
         ]
     }
 

--- a/Sources/Networking/UiConfigProvider.swift
+++ b/Sources/Networking/UiConfigProvider.swift
@@ -28,7 +28,7 @@ final class UiConfigProvider {
                 itemKeys: Self.itemKeys,
                 as: UIConfig.self
             )
-            if uiConfig == nil {
+            if uiConfig == nil, !self.manager.isDisabled {
                 Logger.warn(Strings.remoteConfig.uiConfigMissingRequiredPart)
             }
             return uiConfig
@@ -40,6 +40,7 @@ final class UiConfigProvider {
 #else
     // Paywalls V2 (and therefore workflows) aren't supported on tvOS, where `UIConfig` carries no fields.
     func getUiConfig() async -> UIConfig? {
+        guard !self.manager.isDisabled else { return nil }
         guard await self.manager.blobData(for: .uiConfig, itemKey: Self.appKey) != nil,
               await self.manager.blobData(for: .uiConfig, itemKey: Self.localizationsKey) != nil else {
             Logger.warn(Strings.remoteConfig.uiConfigMissingRequiredPart)

--- a/Sources/Networking/UiConfigProvider.swift
+++ b/Sources/Networking/UiConfigProvider.swift
@@ -19,47 +19,24 @@ final class UiConfigProvider {
     }
 
 #if !os(tvOS)
-    /// Assembles a ``UIConfig`` from the `ui_config` topic's parts. Returns `nil` when a required part
-    /// (`app` or `localizations`) is unavailable or fails to decode.
-    ///
-    /// Each part decodes independently: a malformed `variable_config` or `custom_variables` blob falls
-    /// back to its own default instead of invalidating the whole result, since those parts already have
-    /// defaults `UIConfig` can use elsewhere.
+    /// Assembles a ``UIConfig`` from the `ui_config` topic's parts. Returns `nil` when any part is
+    /// unavailable or when the merged config fails to decode.
     func getUiConfig() async -> UIConfig? {
-        async let app = self.decodePart(UIConfig.AppConfig.self, itemKey: Self.appKey)
-        async let localizations = self.decodePart([String: [String: String]].self, itemKey: Self.localizationsKey)
-        async let variableConfig = self.decodePart(UIConfig.VariableConfig.self, itemKey: Self.variableConfigKey)
-        async let customVariables = self.decodePart(
-            [String: UIConfig.CustomVariableDefinition].self,
-            itemKey: Self.customVariablesKey
-        )
-
-        guard let app = await app, let localizations = await localizations else {
-            Logger.warn(Strings.remoteConfig.uiConfigMissingRequiredPart)
-            return nil
-        }
-
-        return UIConfig(
-            app: app,
-            localizations: localizations,
-            variableConfig: await variableConfig ?? Self.defaultVariableConfig,
-            customVariables: await customVariables ?? [:]
-        )
-    }
-
-    private func decodePart<T: Decodable>(_ type: T.Type, itemKey: String) async -> T? {
         do {
-            return try await self.manager.blobData(for: .uiConfig, itemKey: itemKey, as: type)
+            let uiConfig = try await self.manager.mergeItemsBlobData(
+                for: .uiConfig,
+                itemKeys: Self.itemKeys,
+                as: UIConfig.self
+            )
+            if uiConfig == nil {
+                Logger.warn(Strings.remoteConfig.uiConfigMissingRequiredPart)
+            }
+            return uiConfig
         } catch {
-            Logger.error(Strings.remoteConfig.uiConfigPartDecodeFailed(itemKey: itemKey, error: error))
+            Logger.error(Strings.remoteConfig.uiConfigDecodeFailed(error))
             return nil
         }
     }
-
-    private static let defaultVariableConfig = UIConfig.VariableConfig(
-        variableCompatibilityMap: [:],
-        functionCompatibilityMap: [:]
-    )
 #else
     // Paywalls V2 (and therefore workflows) aren't supported on tvOS, where `UIConfig` carries no fields.
     func getUiConfig() async -> UIConfig? {
@@ -76,5 +53,13 @@ final class UiConfigProvider {
     private static let localizationsKey = "localizations"
     private static let variableConfigKey = "variable_config"
     private static let customVariablesKey = "custom_variables"
+    private static var itemKeys: [String] {
+        return [
+            Self.appKey,
+            Self.localizationsKey,
+            Self.variableConfigKey,
+            Self.customVariablesKey
+        ]
+    }
 
 }

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -702,6 +702,30 @@ final class RemoteConfigManagerTests: TestCase {
         )
     }
 
+    func testMergeItemsBlobDataReturnsNilForEmptyItemKeysWhenRemoteConfigIsDisabledWithoutReadingBlobs() async throws {
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
+
+        let value = try await self.manager.mergeItemsBlobData(
+            for: .workflows,
+            itemKeys: [],
+            as: SingleMergedWorkflowPayload.self
+        )
+
+        expect(value).to(beNil())
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+        expect(self.blobFetcher.invokedEnsureDownloadedRefs).to(beEmpty())
+        expect(self.blobStore.invokedReadRefs).to(beEmpty())
+        self.logger.verifyMessageWasLogged(
+            Strings.remoteConfig.mergeItemsBlobDataDisabled(topic: .workflows, itemKeys: []),
+            level: .warn
+        )
+        self.logger.verifyMessageWasNotLogged(
+            Strings.remoteConfig.mergeItemsBlobDataEmpty(topic: .workflows),
+            allowNoMessages: false
+        )
+    }
+
     func testMergeItemsBlobDataReturnsNilWhenItemIsMissingAfterRefresh() async throws {
         self.diskCache.writeHandler = { configuration in
             self.diskCache.stubbedRead = configuration

--- a/Tests/UnitTests/Networking/UiConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/UiConfigProviderTests.swift
@@ -101,6 +101,19 @@ class UiConfigProviderTests: TestCase {
         self.logger.verifyMessageWasLogged(Strings.remoteConfig.uiConfigMissingRequiredPart, level: .warn)
     }
 
+    func testDoesNotLogMissingPartsWarningWhenRemoteConfigIsDisabled() async throws {
+        self.mockManager.isDisabled = true
+
+        let uiConfig = await self.provider.getUiConfig()
+
+        expect(uiConfig).to(beNil())
+        self.logger.verifyMessageWasNotLogged(
+            Strings.remoteConfig.uiConfigMissingRequiredPart,
+            level: .warn,
+            allowNoMessages: true
+        )
+    }
+
     func testRequestsMergedBlobDataWithWireItemKeysNotCamelCased() async throws {
         _ = await self.provider.getUiConfig()
 
@@ -127,6 +140,19 @@ class UiConfigProviderTests: TestCase {
         let uiConfig = await self.provider.getUiConfig()
 
         expect(uiConfig) == .empty
+    }
+
+    func testDoesNotLogMissingPartsWarningWhenRemoteConfigIsDisabled() async throws {
+        self.mockManager.isDisabled = true
+
+        let uiConfig = await self.provider.getUiConfig()
+
+        expect(uiConfig).to(beNil())
+        self.logger.verifyMessageWasNotLogged(
+            Strings.remoteConfig.uiConfigMissingRequiredPart,
+            level: .warn,
+            allowNoMessages: true
+        )
     }
 
 #endif

--- a/Tests/UnitTests/Networking/UiConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/UiConfigProviderTests.swift
@@ -101,21 +101,17 @@ class UiConfigProviderTests: TestCase {
         self.logger.verifyMessageWasLogged(Strings.remoteConfig.uiConfigMissingRequiredPart, level: .warn)
     }
 
-    func testRequestsWireItemKeysNotCamelCased() async throws {
-        self.stub(
-            app: #"{"colors": {}, "fonts": {}}"#,
-            localizations: #"{"en_US": {"day": "Day"}}"#,
-            variableConfig: #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#,
-            customVariables: #"{"user_name": {"type": "string", "default_value": "Friend"}}"#
-        )
-
+    func testRequestsMergedBlobDataWithWireItemKeysNotCamelCased() async throws {
         _ = await self.provider.getUiConfig()
 
-        let requestedKeys = self.mockManager.invokedBlobDataParameters
-            .filter { $0.topic == .uiConfig }
-            .map(\.itemKey)
-
-        expect(Set(requestedKeys)) == Set(["app", "localizations", "variable_config", "custom_variables"])
+        expect(self.mockManager.invokedMergeItemsBlobDataParameters.count) == 1
+        expect(self.mockManager.invokedMergeItemsBlobDataParameters.first?.topic) == .uiConfig
+        expect(self.mockManager.invokedMergeItemsBlobDataParameters.first?.itemKeys) == [
+            "app",
+            "localizations",
+            "variable_config",
+            "custom_variables"
+        ]
     }
 
 #else

--- a/Tests/UnitTests/Networking/UiConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/UiConfigProviderTests.swift
@@ -63,34 +63,42 @@ class UiConfigProviderTests: TestCase {
         expect(uiConfig).to(beNil())
     }
 
-    func testReturnsNilWhenVariableConfigPartIsMissing() async throws {
+    func testUsesDefaultWhenVariableConfigPartIsMissing() async throws {
         self.stub(app: #"{"colors": {}, "fonts": {}}"#, localizations: #"{}"#,
                   variableConfig: nil, customVariables: #"{}"#)
 
         let uiConfig = await self.provider.getUiConfig()
 
-        expect(uiConfig).to(beNil())
+        expect(uiConfig).toNot(beNil())
+        expect(uiConfig?.variableConfig.variableCompatibilityMap).to(beEmpty())
+        expect(uiConfig?.variableConfig.functionCompatibilityMap).to(beEmpty())
     }
 
-    func testReturnsNilWhenCustomVariablesPartIsMissing() async throws {
+    func testUsesDefaultWhenCustomVariablesPartIsMissing() async throws {
         self.stub(app: #"{"colors": {}, "fonts": {}}"#, localizations: #"{}"#,
                   variableConfig: #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#,
                   customVariables: nil)
 
         let uiConfig = await self.provider.getUiConfig()
 
-        expect(uiConfig).to(beNil())
+        expect(uiConfig).toNot(beNil())
+        expect(uiConfig?.customVariables).to(beEmpty())
     }
 
-    func testMalformedVariableConfigFailsMergedAssembly() async throws {
+    func testMalformedVariableConfigFallsBackToDefault() async throws {
         self.stub(app: #"{"colors": {}, "fonts": {}}"#, localizations: #"{"en_US": {"day": "Day"}}"#,
                   variableConfig: #"{"variable_compatibility_map": "not-a-dictionary"}"#,
                   customVariables: #"{}"#)
 
         let uiConfig = await self.provider.getUiConfig()
 
-        expect(uiConfig).to(beNil())
-        self.logger.verifyMessageWasLogged("Failed to decode merged ui_config", level: .error)
+        expect(uiConfig).toNot(beNil())
+        expect(uiConfig?.variableConfig.variableCompatibilityMap).to(beEmpty())
+        expect(uiConfig?.variableConfig.functionCompatibilityMap).to(beEmpty())
+        self.logger.verifyMessageWasLogged(
+            "Failed to decode ui_config part 'variable_config'",
+            level: .error
+        )
     }
 
     func testLogsWarningWhenARequiredPartIsMissing() async throws {
@@ -114,16 +122,14 @@ class UiConfigProviderTests: TestCase {
         )
     }
 
-    func testRequestsMergedBlobDataWithWireItemKeysNotCamelCased() async throws {
+    func testRequestsMergedBlobDataForRequiredWireItemKeysNotCamelCased() async throws {
         _ = await self.provider.getUiConfig()
 
         expect(self.mockManager.invokedMergeItemsBlobDataParameters.count) == 1
         expect(self.mockManager.invokedMergeItemsBlobDataParameters.first?.topic) == .uiConfig
         expect(self.mockManager.invokedMergeItemsBlobDataParameters.first?.itemKeys) == [
             "app",
-            "localizations",
-            "variable_config",
-            "custom_variables"
+            "localizations"
         ]
     }
 
@@ -164,6 +170,9 @@ class UiConfigProviderTests: TestCase {
         if let variableConfig { data["variable_config"] = Data(variableConfig.utf8) }
         if let customVariables { data["custom_variables"] = Data(customVariables.utf8) }
         self.mockManager.stubbedBlobData[.uiConfig] = data
+        self.mockManager.stubbedTopics[.uiConfig] = data.keys.reduce(into: [:]) { topic, key in
+            topic[key] = RemoteConfiguration.ConfigItem()
+        }
     }
 
 }

--- a/Tests/UnitTests/Networking/UiConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/UiConfigProviderTests.swift
@@ -63,39 +63,34 @@ class UiConfigProviderTests: TestCase {
         expect(uiConfig).to(beNil())
     }
 
-    func testAssemblesUiConfigWhenVariableConfigPartIsMissing() async throws {
-        // variableConfig has decode-time defaults, so omitting it entirely must not fail assembly.
+    func testReturnsNilWhenVariableConfigPartIsMissing() async throws {
         self.stub(app: #"{"colors": {}, "fonts": {}}"#, localizations: #"{}"#,
-                  variableConfig: nil, customVariables: nil)
+                  variableConfig: nil, customVariables: #"{}"#)
 
         let uiConfig = await self.provider.getUiConfig()
 
-        expect(uiConfig).toNot(beNil())
+        expect(uiConfig).to(beNil())
     }
 
-    func testAssemblesUiConfigWhenCustomVariablesPartIsMissing() async throws {
-        // customVariables has decode-time defaults, so omitting it entirely must not fail assembly.
+    func testReturnsNilWhenCustomVariablesPartIsMissing() async throws {
         self.stub(app: #"{"colors": {}, "fonts": {}}"#, localizations: #"{}"#,
-                  variableConfig: nil, customVariables: nil)
+                  variableConfig: #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#,
+                  customVariables: nil)
 
         let uiConfig = await self.provider.getUiConfig()
 
-        expect(uiConfig).toNot(beNil())
-        expect(uiConfig?.customVariables).to(beEmpty())
+        expect(uiConfig).to(beNil())
     }
 
-    func testMalformedVariableConfigFallsBackToDefaultInsteadOfFailingTheWholeAssembly() async throws {
-        // variable_config is syntactically valid JSON but the wrong shape for VariableConfig, which used
-        // to fail the single merged decode of the whole UIConfig, discarding good app/localizations data.
+    func testMalformedVariableConfigFailsMergedAssembly() async throws {
         self.stub(app: #"{"colors": {}, "fonts": {}}"#, localizations: #"{"en_US": {"day": "Day"}}"#,
-                  variableConfig: #"{"variable_compatibility_map": "not-a-dictionary"}"#, customVariables: nil)
+                  variableConfig: #"{"variable_compatibility_map": "not-a-dictionary"}"#,
+                  customVariables: #"{}"#)
 
         let uiConfig = await self.provider.getUiConfig()
 
-        expect(uiConfig).toNot(beNil())
-        expect(uiConfig?.localizations["en_US"]?["day"]) == "Day"
-        expect(uiConfig?.variableConfig.variableCompatibilityMap).to(beEmpty())
-        self.logger.verifyMessageWasLogged("Failed to decode ui_config part 'variable_config'", level: .error)
+        expect(uiConfig).to(beNil())
+        self.logger.verifyMessageWasLogged("Failed to decode merged ui_config", level: .error)
     }
 
     func testLogsWarningWhenARequiredPartIsMissing() async throws {

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -102,7 +102,9 @@ class WorkflowsConfigProviderTests: TestCase {
         let result = await self.provider.getWorkflow(workflowId: "wf-1")
         let workflowResult = try XCTUnwrap(result.value)
 
-        expect(workflowResult.workflow.uiConfig.localizations["en_US"]?["day"]) == "Day"
+#if !os(tvOS) // For Paywalls V2
+        XCTAssertEqual(workflowResult.workflow.uiConfig.localizations["en_US"]?["day"], "Day")
+#endif
     }
 
     func testPreservesMetadataWhenSubstitutingUiConfig() async throws {

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -703,6 +703,11 @@ final class MockRemoteConfigManager: RemoteConfigManagerType {
     var invokedBlobDataParameters: [(topic: RemoteConfigTopic, itemKey: String)] {
         return self._invokedBlobDataParameters.value
     }
+    private let _invokedMergeItemsBlobDataParameters: Atomic<[(topic: RemoteConfigTopic, itemKeys: [String])]> =
+        .init([])
+    var invokedMergeItemsBlobDataParameters: [(topic: RemoteConfigTopic, itemKeys: [String])] {
+        return self._invokedMergeItemsBlobDataParameters.value
+    }
 
     private let _invokedTopicCount: Atomic<Int> = .init(0)
     var invokedTopicCount: Int { return self._invokedTopicCount.value }
@@ -758,6 +763,25 @@ final class MockRemoteConfigManager: RemoteConfigManagerType {
     func ensureBlobsDownloaded(_ refs: [String]) async -> Bool {
         self._invokedEnsureBlobsDownloadedRefs.modify { $0.append(refs) }
         return self.stubbedEnsureBlobsDownloadedResult
+    }
+
+    func mergeItemsBlobData<T: Decodable>(
+        for topic: RemoteConfigTopic,
+        itemKeys: [String],
+        as type: T.Type
+    ) async throws -> T? {
+        self._invokedMergeItemsBlobDataParameters.modify { $0.append((topic, itemKeys)) }
+        guard !self.isDisabled, !itemKeys.isEmpty else { return nil }
+
+        var seen: Set<String> = []
+        var mergedBlobValues: [String: AnyDecodable] = [:]
+        for itemKey in itemKeys where seen.insert(itemKey).inserted {
+            guard let data = await self.blobData(for: topic, itemKey: itemKey) else { return nil }
+            mergedBlobValues[itemKey] = try JSONDecoder.default.decode(AnyDecodable.self, from: data)
+        }
+
+        let mergedData = try JSONEncoder.default.encode(mergedBlobValues)
+        return try JSONDecoder.default.decode(type, from: mergedData)
     }
 
     func clearCache() {


### PR DESCRIPTION
## Description
Implements the `mergeItemsBlobData` helper introduced in https://github.com/RevenueCat/purchases-ios/pull/7149 into the `UIConfigProvider`, greatly simplifying the implementation and relying on the helper to combine the different blobs into the single `UIConfig` type.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Paywalls V2 / workflow UI config is assembled from remote config blobs; behavior shifts around disabled remote config and required vs optional parts, though tests cover the main paths.
> 
> **Overview**
> **`UiConfigProvider`** now loads **`app`** and **`localizations`** through **`RemoteConfigManager.mergeItemsBlobData`** (into a small **`RequiredParts`** type) instead of decoding each blob on its own. **`variable_config`** and **`custom_variables`** stay optional: they are fetched only when present in the topic and still fall back to defaults on missing or bad data.
> 
> When required parts are missing, a warning is logged only if remote config is **not** disabled; merged decode failures log a new **`uiConfigDecodeFailed`** message. On tvOS, **`getUiConfig()`** returns **`nil`** immediately when remote config is disabled.
> 
> **`mergeItemsBlobData`** checks the disabled guard **before** the empty item-keys guard so disabled callers get **`mergeItemsBlobDataDisabled`** instead of **`mergeItemsBlobDataEmpty`**. Tests and **`MockRemoteConfigManager`** were updated for merge invocation and the new logging behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7609d722885d94ab0591200397e0afe2ded35ab2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->