### PR TITLE
Align iOS web_view bridge with canonical rc-web-components contract

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -169,6 +169,8 @@
 		2C2AEB3B2CA7209F00A50F38 /* PaywallPackageComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2AEB3A2CA7209F00A50F38 /* PaywallPackageComponent.swift */; };
 		2C2AEB3F2CA7235300A50F38 /* PaywallPurchaseButtonComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2AEB3E2CA7235300A50F38 /* PaywallPurchaseButtonComponent.swift */; };
 		2C3AEEFAE8349B661875E37E /* PaywallWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29FEA8B4082FEAC3D83A4E41 /* PaywallWebViewController.swift */; };
+		A1B2C3D4E5F60718293A4B5C /* WebViewEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F60718293A4B5C6D /* WebViewEnvelope.swift */; };
+		C3D4E5F60718293A4B5C6D7E /* WebViewOrigin.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E5F60718293A4B5C6D7E8F /* WebViewOrigin.swift */; };
 		2C6CC1162B8D2B6900432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6CC1152B8D2B6800432E4D /* PurchasesSyncAttributesAndOfferingsIfNeededTests.swift */; };
 		2C74571F2CE7028E004ACE52 /* ScreenCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C74571E2CE7028A004ACE52 /* ScreenCondition.swift */; };
 		2C7457212CE702BB004ACE52 /* PackageContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7457202CE702BB004ACE52 /* PackageContext.swift */; };
@@ -1699,6 +1701,8 @@
 		1EFA95142CDBAB7500CA5951 /* MockWebPurchaseRedemptionHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWebPurchaseRedemptionHelper.swift; sourceTree = "<group>"; };
 		26AAFBADBA3F4E339D041135 /* WorkflowStepEventCoordinatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowStepEventCoordinatorTests.swift; sourceTree = "<group>"; };
 		29FEA8B4082FEAC3D83A4E41 /* PaywallWebViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaywallWebViewController.swift; sourceTree = "<group>"; };
+		B2C3D4E5F60718293A4B5C6D /* WebViewEnvelope.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewEnvelope.swift; sourceTree = "<group>"; };
+		D4E5F60718293A4B5C6D7E8F /* WebViewOrigin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewOrigin.swift; sourceTree = "<group>"; };
 		2A5E77D02F10B3B500BC5900 /* RevocationReason.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RevocationReason.swift; sourceTree = "<group>"; };
 		2C08B2E82CD40DBF0024857B /* ButtonComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponentTests.swift; sourceTree = "<group>"; };
 		2C08B3062CD55D590024857B /* FlexHStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlexHStack.swift; sourceTree = "<group>"; };
@@ -4773,6 +4777,8 @@
 				8E4F88A43B27C659F48DE31A /* WebViewComponentViewModel.swift */,
 				D3108BDE9CA157DCAA4D5A65 /* PaywallWebViewMessageParser.swift */,
 				29FEA8B4082FEAC3D83A4E41 /* PaywallWebViewController.swift */,
+				B2C3D4E5F60718293A4B5C6D /* WebViewEnvelope.swift */,
+				D4E5F60718293A4B5C6D7E8F /* WebViewOrigin.swift */,
 			);
 			name = WebView;
 			path = WebView;
@@ -8398,6 +8404,8 @@
 				C3B1410F98F1A5B647081D02 /* PaywallWebViewMessage.swift in Sources */,
 				7D4C28B5FDD5D38E1055A107 /* PaywallWebViewMessageParser.swift in Sources */,
 				2C3AEEFAE8349B661875E37E /* PaywallWebViewController.swift in Sources */,
+				A1B2C3D4E5F60718293A4B5C /* WebViewEnvelope.swift in Sources */,
+				C3D4E5F60718293A4B5C6D7E /* WebViewOrigin.swift in Sources */,
 				58DEBF0E38BFD23227FEE8CA /* View+PaywallWebViewMessage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/RevenueCatUI/Data/PaywallWebViewValue.swift
+++ b/RevenueCatUI/Data/PaywallWebViewValue.swift
@@ -114,7 +114,7 @@ extension PaywallWebViewValue {
 
     /// The maximum nesting depth allowed when converting a JSON object tree. Mirrors the limit
     /// enforced by the message parser so that conversion and validation agree.
-    static let maxDepth = 32
+    static let maxDepth = 16
 
     /// Creates a value from a Foundation JSON object (as produced by `WKScriptMessage.body` or
     /// `JSONSerialization`). Returns `nil` if the object contains any non-JSON value or exceeds

--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -115,6 +115,7 @@ enum Strings {
     case paywall_web_view_message_rejected(reason: String)
     case paywall_web_view_post_message_failed(Error)
     case paywall_web_view_post_message_skipped
+    case paywall_web_view_reserved_locale_stripped
 
     // Exit Offers
     case errorFetchingOfferings(Error)
@@ -372,7 +373,7 @@ extension Strings: CustomStringConvertible {
 
         case .paywall_web_view_content_rules_failed(let error):
             return "Failed to compile content-blocking rules for a web_view component; the page " +
-            "remains isolated to its uploaded bundle: \(error)"
+            "will not load: \(error)"
         case .paywall_web_view_missing_id:
             return "web_view component has no id; the postMessage bridge is disabled for it. " +
             "Assign an id to the component to enable bidirectional communication."
@@ -383,6 +384,8 @@ extension Strings: CustomStringConvertible {
         case .paywall_web_view_post_message_skipped:
             return "Skipped delivering a message to a web_view component because its web view is no " +
             "longer available or is showing different content."
+        case .paywall_web_view_reserved_locale_stripped:
+            return "Stripped the reserved 'locale' key from app-provided web_view variables."
 
         case .errorFetchingOfferings(let error):
             return "Error fetching offerings: \(error)"

--- a/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewController.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewController.swift
@@ -23,7 +23,7 @@ import WebKit
 ///
 /// Use it to reply to a `"rc:request-variables"` message with additional variables, or to send any
 /// message that follows the web view protocol envelope. Messages are delivered to the web content
-/// via `window.__revenueCatReceiveMessage(...)`.
+/// via `window.__rcWebComponentsReceive(...)`.
 ///
 /// Modeled as a concrete `struct` (rather than a protocol) following the SDK convention for
 /// callback-supplied action handles, so methods can be added without a source-breaking change.
@@ -37,17 +37,34 @@ public struct PaywallWebViewController {
 
     private let componentID: String
     private let expectedLoadedURL: URL?
+    private let protocolVersion: Int
+    private let channelOpen: () -> Bool
 
     #if canImport(WebKit)
-    init(webView: WKWebView?, componentID: String, expectedLoadedURL: URL?) {
+    init(
+        webView: WKWebView?,
+        componentID: String,
+        expectedLoadedURL: URL?,
+        protocolVersion: Int,
+        channelOpen: @escaping () -> Bool
+    ) {
         self.webView = webView
         self.componentID = componentID
         self.expectedLoadedURL = expectedLoadedURL
+        self.protocolVersion = protocolVersion
+        self.channelOpen = channelOpen
     }
     #else
-    init(componentID: String, expectedLoadedURL: URL?) {
+    init(
+        componentID: String,
+        expectedLoadedURL: URL?,
+        protocolVersion: Int,
+        channelOpen: @escaping () -> Bool
+    ) {
         self.componentID = componentID
         self.expectedLoadedURL = expectedLoadedURL
+        self.protocolVersion = protocolVersion
+        self.channelOpen = channelOpen
     }
     #endif
 
@@ -65,66 +82,89 @@ public struct PaywallWebViewController {
         self.postMessage(
             componentID: componentID,
             type: PaywallWebViewMessageType.variables,
-            variables: variables
+            variables: Self.sanitizeAppProvidedVariables(variables)
         )
     }
 
-    /// Sends a message to the web content following the web view protocol envelope
-    /// `{ "type", "component_id", "variables" }`.
+    /// Sends a message to the web content using the canonical transport envelope.
     ///
     /// - Parameters:
     ///   - componentID: The component to address.
     ///   - type: The message type, e.g. `"rc:variables"`.
-    ///   - variables: The message payload, delivered under the `"variables"` key.
+    ///   - variables: The message payload, delivered flat in the envelope `payload` field.
     public func postMessage(
         componentID: String,
         type: String,
         variables: [String: PaywallWebViewValue]
     ) {
-        guard let script = Self.receiveMessageScript(
+        guard self.channelOpen() else {
+            return
+        }
+
+        let envelope = WebViewEnvelope.build(
+            kind: WebViewEnvelope.kindMessage,
+            protocolVersion: self.protocolVersion,
             componentID: componentID,
             type: type,
-            variables: variables
-        ) else {
+            payload: variables
+        )
+
+        guard let script = Self.receiveEnvelopeScript(envelope: envelope) else {
             return
         }
 
         self.evaluate(script: script)
     }
 
-    /// Builds the envelope `{ "type", "component_id", "variables" }` and wraps it in a guarded call
-    /// to `window.__revenueCatReceiveMessage`. The JSON is produced by `JSONSerialization`, never
-    /// string-interpolated from raw values, so app- or web-supplied strings cannot break out of the
-    /// call. Internal for testability.
-    static func receiveMessageScript(
-        componentID: String,
-        type: String,
-        variables: [String: PaywallWebViewValue]
-    ) -> String? {
-        let envelope: [String: PaywallWebViewValue] = [
-            "type": .string(type),
-            "component_id": .string(componentID),
-            "variables": .object(variables)
-        ]
-
+    /// Builds a guarded call to `window.__rcWebComponentsReceive` for the given transport envelope.
+    /// Internal for testability.
+    static func receiveEnvelopeScript(envelope: [String: PaywallWebViewValue]) -> String? {
         let jsonObject = PaywallWebViewValue.object(envelope).jsonObject
         guard let data = try? JSONSerialization.data(withJSONObject: jsonObject),
               let json = String(data: data, encoding: .utf8) else {
             return nil
         }
 
+        let escaped = Self.escapeForJavaScript(json)
         return """
-        (function(){var m=\(json);if(typeof window.__revenueCatReceiveMessage==='function'){\
-        window.__revenueCatReceiveMessage(m);}})();
+        (function(){var m=\(escaped);if(typeof window.\(WebViewEnvelope.receiveFunction)==='function'){\
+        window.\(WebViewEnvelope.receiveFunction)(m);}})();
         """
+    }
+
+    /// Strips SDK-managed keys from app-provided variable maps.
+    static func sanitizeAppProvidedVariables(
+        _ variables: [String: PaywallWebViewValue]
+    ) -> [String: PaywallWebViewValue] {
+        guard variables.keys.contains("locale") else {
+            return variables
+        }
+
+        Logger.debug(Strings.paywall_web_view_reserved_locale_stripped)
+        return variables.filter { $0.key != "locale" }
+    }
+
+    /// Delivers a pre-built transport envelope to the web content.
+    func deliverEnvelope(_ envelope: [String: PaywallWebViewValue]) {
+        guard self.channelOpen() else {
+            return
+        }
+
+        guard let script = Self.receiveEnvelopeScript(envelope: envelope) else {
+            return
+        }
+
+        self.evaluate(script: script)
     }
 
     private func evaluate(script: String) {
         #if canImport(WebKit)
         guard let webView = self.webView,
-              self.expectedLoadedURL == nil || webView.url == self.expectedLoadedURL else {
-            // The web view was deallocated or navigated elsewhere — don't post into
-            // unrelated content.
+              WebViewOrigin.matches(
+                currentURL: webView.url,
+                expectedURL: self.expectedLoadedURL,
+                allowBeforeNavigation: false
+              ) else {
             Logger.debug(Strings.paywall_web_view_post_message_skipped)
             return
         }
@@ -134,7 +174,17 @@ public struct PaywallWebViewController {
                 Logger.debug(Strings.paywall_web_view_post_message_failed(error))
             }
         }
+        #else
+        _ = script
         #endif
+    }
+
+    /// JSON is a subset of JS object-literal syntax, but U+2028/U+2029 are valid in JSON strings
+    /// yet terminate JS statements. Escape them so the payload is safe to embed.
+    private static func escapeForJavaScript(_ json: String) -> String {
+        json
+            .replacingOccurrences(of: "\u{2028}", with: "\\u2028")
+            .replacingOccurrences(of: "\u{2029}", with: "\\u2029")
     }
 
 }

--- a/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewController.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewController.swift
@@ -39,6 +39,7 @@ public struct PaywallWebViewController {
     private let expectedLoadedURL: URL?
     private let protocolVersion: Int
     private let channelOpen: () -> Bool
+    internal var envelopeDeliveryHandler: (([String: PaywallWebViewValue]) -> Void)?
 
     #if canImport(WebKit)
     init(
@@ -154,6 +155,7 @@ public struct PaywallWebViewController {
             return
         }
 
+        self.envelopeDeliveryHandler?(envelope)
         self.evaluate(script: script)
     }
 

--- a/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewMessageParser.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewMessageParser.swift
@@ -23,100 +23,145 @@ enum PaywallWebViewMessageType {
     static let stepComplete = "rc:step-complete"
     static let requestVariables = "rc:request-variables"
     static let error = "rc:error"
+    static let resize = "resize"
 
     /// Native → web messages.
     static let variables = "rc:variables"
 
 }
 
-/// Validates and parses raw `web_view` message bodies into typed ``PaywallWebViewMessage`` values.
+/// Validates and parses transport envelopes into typed ``PaywallWebViewMessage`` values.
 ///
-/// Deliberately `WebKit`-free: it accepts the already-extracted `WKScriptMessage.body` as `Any`
-/// so the full validation surface is unit-testable without a live `WKWebView`.
+/// Deliberately `WebKit`-free so the full validation surface is unit-testable without a live
+/// `WKWebView`.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct PaywallWebViewMessageParser {
 
-    /// Maximum size (in bytes of the serialized JSON) accepted for a single inbound message.
+    /// Maximum size (in bytes of the serialized JSON) accepted for a single inbound frame.
     static let maxPayloadBytes = 64 * 1024
 
     enum ParseError: Error, Equatable {
         case notAnObject
+        case invalidEnvelope
         case missingType
-        case missingComponentID
         case componentIDMismatch(expected: String, received: String)
         case oversizedPayload(bytes: Int)
         case invalidResponses
         case missingError
         case invalidValue
+        case missingRequestID
         /// Known-but-unsupported or entirely unknown message type — dropped per v1 policy.
         case unsupportedType(String)
     }
 
-    private enum Keys {
-        static let type = "type"
-        static let componentID = "component_id"
-        static let responses = "responses"
-        static let error = "error"
+    struct ParsedAppMessage {
+        let message: PaywallWebViewMessage
+        /// Set when the inbound frame is a transport `request` that expects a `response`.
+        let requestID: String?
+        let requestType: String?
     }
+
+    private static let stepCompleteReservedPayloadKeys: Set<String> = [
+        WebViewEnvelope.Field.channel,
+        WebViewEnvelope.Field.protocolVersion,
+        WebViewEnvelope.Field.kind,
+        WebViewEnvelope.Field.type,
+        WebViewEnvelope.Field.componentID,
+        WebViewEnvelope.Field.id,
+        WebViewEnvelope.Field.error,
+        WebViewEnvelope.Field.variables
+    ]
 
     /// The identifier of the `web_view` component this parser accepts messages for.
     let expectedComponentID: String
 
-    func parse(_ body: Any) -> Result<PaywallWebViewMessage, ParseError> {
-        guard let dictionary = body as? [String: Any] else {
+    func parseEnvelope(_ body: Any) -> Result<ParsedAppMessage, ParseError> {
+        guard let dictionary = Self.dictionary(from: body) else {
             return .failure(.notAnObject)
         }
 
-        // Reject non-JSON-serializable bodies up front. `isValidJSONObject` is used before
-        // `data(withJSONObject:)` because the latter raises an (uncatchable) `NSException` rather
-        // than throwing a Swift error for invalid types such as `Date`.
         guard JSONSerialization.isValidJSONObject(dictionary) else {
             return .failure(.invalidValue)
         }
 
-        // Enforce the payload size limit before allocating typed values.
         if let serialized = try? JSONSerialization.data(withJSONObject: dictionary) {
             guard serialized.count <= Self.maxPayloadBytes else {
                 return .failure(.oversizedPayload(bytes: serialized.count))
             }
         }
 
-        guard let type = dictionary[Keys.type] as? String else {
+        guard let envelope = WebViewEnvelope.parse(dictionary) else {
+            return .failure(.invalidEnvelope)
+        }
+
+        switch envelope.kind {
+        case WebViewEnvelope.kindMessage, WebViewEnvelope.kindRequest:
+            return self.parseAppMessage(envelope: envelope)
+
+        default:
+            return .failure(.invalidEnvelope)
+        }
+    }
+
+    private func parseAppMessage(
+        envelope: WebViewEnvelope.Parsed
+    ) -> Result<ParsedAppMessage, ParseError> {
+        guard envelope.componentID == self.expectedComponentID else {
+            return .failure(.componentIDMismatch(
+                expected: self.expectedComponentID,
+                received: envelope.componentID
+            ))
+        }
+
+        guard let type = envelope.type, !type.isEmpty else {
             return .failure(.missingType)
         }
 
-        guard let componentID = dictionary[Keys.componentID] as? String else {
-            return .failure(.missingComponentID)
+        if envelope.kind == WebViewEnvelope.kindRequest, envelope.id == nil {
+            return .failure(.missingRequestID)
         }
 
-        guard componentID == self.expectedComponentID else {
-            return .failure(.componentIDMismatch(expected: self.expectedComponentID, received: componentID))
-        }
+        let messageResult = self.message(
+            type: type,
+            componentID: envelope.componentID,
+            envelope: envelope
+        )
 
-        return self.message(type: type, componentID: componentID, dictionary: dictionary)
+        switch messageResult {
+        case .success(let message):
+            let requestID = envelope.kind == WebViewEnvelope.kindRequest ? envelope.id : nil
+            return .success(ParsedAppMessage(
+                message: message,
+                requestID: requestID,
+                requestType: type
+            ))
+
+        case .failure(let error):
+            return .failure(error)
+        }
     }
 
     private func message(
         type: String,
         componentID: String,
-        dictionary: [String: Any]
+        envelope: WebViewEnvelope.Parsed
     ) -> Result<PaywallWebViewMessage, ParseError> {
         switch type {
         case PaywallWebViewMessageType.stepLoaded,
-             PaywallWebViewMessageType.requestVariables:
+             PaywallWebViewMessageType.requestVariables,
+             PaywallWebViewMessageType.resize:
             return .success(.init(componentID: componentID, type: type))
 
         case PaywallWebViewMessageType.stepComplete:
-            return Self.stepComplete(type: type, componentID: componentID, dictionary: dictionary)
+            return Self.stepComplete(type: type, componentID: componentID, envelope: envelope)
 
         case PaywallWebViewMessageType.error:
-            guard let errorMessage = dictionary[Keys.error] as? String else {
+            guard let errorMessage = Self.errorMessage(from: envelope) else {
                 return .failure(.missingError)
             }
             return .success(.init(componentID: componentID, type: type, error: errorMessage))
 
         default:
-            // Unknown message types are dropped in v1.
             return .failure(.unsupportedType(type))
         }
     }
@@ -124,28 +169,42 @@ struct PaywallWebViewMessageParser {
     private static func stepComplete(
         type: String,
         componentID: String,
-        dictionary: [String: Any]
+        envelope: WebViewEnvelope.Parsed
     ) -> Result<PaywallWebViewMessage, ParseError> {
-        guard let rawResponses = dictionary[Keys.responses] else {
+        guard let payload = envelope.payload, !payload.isEmpty else {
             return .success(.init(componentID: componentID, type: type))
         }
-        guard let object = rawResponses as? [String: Any],
-              let converted = Self.convert(object: object) else {
+
+        if let responsesObject = payload[WebViewEnvelope.Field.responses]?.objectValue {
+            return .success(.init(componentID: componentID, type: type, responses: responsesObject))
+        }
+
+        if payload.keys.contains(where: { Self.stepCompleteReservedPayloadKeys.contains($0) }) {
             return .failure(.invalidResponses)
         }
-        return .success(.init(componentID: componentID, type: type, responses: converted))
+
+        return .success(.init(componentID: componentID, type: type, responses: payload))
     }
 
-    private static func convert(object: [String: Any]) -> [String: PaywallWebViewValue]? {
-        var result: [String: PaywallWebViewValue] = [:]
-        result.reserveCapacity(object.count)
-        for (key, value) in object {
-            guard let converted = PaywallWebViewValue(jsonObject: value) else {
-                return nil
-            }
-            result[key] = converted
+    private static func errorMessage(from envelope: WebViewEnvelope.Parsed) -> String? {
+        if let payloadError = envelope.payload?[WebViewEnvelope.Field.error]?.stringValue {
+            return payloadError
         }
-        return result
+        return envelope.error
+    }
+
+    private static func dictionary(from body: Any) -> [String: Any]? {
+        if let dictionary = body as? [String: Any] {
+            return dictionary
+        }
+
+        if let jsonString = body as? String,
+           let data = jsonString.data(using: .utf8),
+           let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            return object
+        }
+
+        return nil
     }
 
 }

--- a/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewMessageParser.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewMessageParser.swift
@@ -27,6 +27,8 @@ enum PaywallWebViewMessageType {
 
     /// Native → web messages.
     static let variables = "rc:variables"
+    /// Host → content: which axes the native host sizes to the content (`fit`).
+    static let fit = "fit"
 
 }
 
@@ -103,9 +105,16 @@ struct PaywallWebViewMessageParser {
         }
     }
 
-    private func parseAppMessage(
+    func parseAppMessage(
         envelope: WebViewEnvelope.Parsed
     ) -> Result<ParsedAppMessage, ParseError> {
+        switch envelope.kind {
+        case WebViewEnvelope.kindMessage, WebViewEnvelope.kindRequest:
+            break
+        default:
+            return .failure(.invalidEnvelope)
+        }
+
         guard envelope.componentID == self.expectedComponentID else {
             return .failure(.componentIDMismatch(
                 expected: self.expectedComponentID,

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewCapabilitiesConfiguration.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewCapabilitiesConfiguration.swift
@@ -20,21 +20,16 @@ import WebKit
 /// WebKit-free content-blocking policy for `web_view` components. Kept separate from the WKWebView
 /// rendering code so it can be unit-tested without instantiating a web view.
 ///
-/// For the initial version every `web_view` is isolated from external sources: customers must
-/// upload everything in a single bundle. The fixed policy blocks remote (third-party) images,
-/// scripts and fonts while allowing same-origin assets, blocks `data:` images and fonts, and
-/// blocks XHR (`raw`) loads entirely.
+/// Same-origin subresources and same-origin fetch/XHR are allowed; `data:` images and fonts are
+/// allowed; cross-origin third-party subresource loads are blocked.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 enum WebViewCapabilitiesConfiguration {
 
     /// Stable identifier used to cache the compiled `WKContentRuleList` for the fixed isolation
-    /// policy. The policy never varies, so a single identifier is enough.
-    static let contentRuleListIdentifier = "rc-webview-v1-isolation"
+    /// policy. Bump when the policy changes.
+    static let contentRuleListIdentifier = "rc-webview-v2-isolation"
 
-    /// The fixed content-blocking rules (as a JSON string) enforcing full isolation from external
-    /// sources. `raw` is used for XHR (rather than the newer `fetch`/`websocket` resource types) so
-    /// the list compiles on older OS versions; an unknown resource-type would fail the whole list
-    /// closed.
+    /// The fixed content-blocking rules (as a JSON string) enforcing bundle isolation.
     static var contentBlockingRules: String? {
         let rules: [[String: Any]] = [
             // Block remote (third-party) images, scripts and fonts; same-origin assets still load.
@@ -46,19 +41,12 @@ enum WebViewCapabilitiesConfiguration {
                 ],
                 "action": ["type": "block"]
             ],
-            // Block inline `data:` images and fonts.
-            [
-                "trigger": [
-                    "url-filter": "^data:",
-                    "resource-type": ["image", "font"]
-                ],
-                "action": ["type": "block"]
-            ],
-            // Block XHR.
+            // Block third-party XHR/fetch.
             [
                 "trigger": [
                     "url-filter": ".*",
-                    "resource-type": ["raw"]
+                    "resource-type": ["raw"],
+                    "load-type": ["third-party"]
                 ],
                 "action": ["type": "block"]
             ]
@@ -82,17 +70,16 @@ enum WebViewCapabilitiesConfiguration {
 ///
 /// Accessed on the main thread only (`compileContentRuleList`'s completion handler is invoked there).
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-final class WebViewContentRuleListStore {
+class WebViewContentRuleListStore {
 
-    static let shared = WebViewContentRuleListStore()
+    static var shared = WebViewContentRuleListStore()
 
     private var cache: [String: WKContentRuleList] = [:]
 
     private init() {}
 
     /// Returns the compiled rule list for `identifier`, compiling `json` if it isn't cached yet.
-    /// Completes on the main thread; `nil` indicates compilation failed (the caller should fail
-    /// closed by blocking all requests).
+    /// Completes on the main thread; `nil` indicates compilation failed.
     func ruleList(
         forIdentifier identifier: String,
         json: String,

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewCapabilitiesConfiguration.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewCapabilitiesConfiguration.swift
@@ -70,13 +70,19 @@ enum WebViewCapabilitiesConfiguration {
 ///
 /// Accessed on the main thread only (`compileContentRuleList`'s completion handler is invoked there).
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-class WebViewContentRuleListStore {
+final class WebViewContentRuleListStore {
 
-    static var shared = WebViewContentRuleListStore()
+    static let shared = WebViewContentRuleListStore()
 
     private var cache: [String: WKContentRuleList] = [:]
+    private let compile: (String, String, @escaping (WKContentRuleList?) -> Void) -> Void
 
-    private init() {}
+    init(
+        compile: @escaping (String, String, @escaping (WKContentRuleList?) -> Void) -> Void
+            = WebViewContentRuleListStore.defaultCompile
+    ) {
+        self.compile = compile
+    }
 
     /// Returns the compiled rule list for `identifier`, compiling `json` if it isn't cached yet.
     /// Completes on the main thread; `nil` indicates compilation failed.
@@ -90,6 +96,19 @@ class WebViewContentRuleListStore {
             return
         }
 
+        self.compile(identifier, json) { [weak self] ruleList in
+            if let ruleList {
+                self?.cache[identifier] = ruleList
+            }
+            completion(ruleList)
+        }
+    }
+
+    private static func defaultCompile(
+        identifier: String,
+        json: String,
+        completion: @escaping (WKContentRuleList?) -> Void
+    ) {
         guard let store = WKContentRuleListStore.default() else {
             completion(nil)
             return
@@ -98,12 +117,9 @@ class WebViewContentRuleListStore {
         store.compileContentRuleList(
             forIdentifier: identifier,
             encodedContentRuleList: json
-        ) { [weak self] ruleList, error in
+        ) { ruleList, error in
             if let error {
                 Logger.debug(Strings.paywall_web_view_content_rules_failed(error))
-            }
-            if let ruleList {
-                self?.cache[identifier] = ruleList
             }
             completion(ruleList)
         }

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
@@ -51,8 +51,19 @@ struct WebViewComponentView: View {
     private var bridge: WebViewBridgeConfiguration {
         WebViewBridgeConfiguration(
             componentID: viewModel.componentID,
+            protocolVersion: viewModel.protocolVersion,
+            expectedURL: viewModel.url,
             messageAction: webViewMessageAction,
-            baseVariables: PaywallWebViewVariables.base(locale: viewModel.locale)
+            baseVariables: PaywallWebViewVariables.base(locale: viewModel.locale),
+            size: viewModel.size,
+            onContentResize: { width, height in
+                if case .fit = viewModel.size.height, let height {
+                    dynamicHeight = height
+                }
+                if case .fit = viewModel.size.width, let width {
+                    _ = width
+                }
+            }
         )
     }
 
@@ -91,10 +102,15 @@ struct WebViewBridgeConfiguration {
     /// The canonical `component_id`. When `nil` (legacy/partial config without an `id`) the message
     /// bridge is not installed.
     let componentID: String?
+    let protocolVersion: Int
+    let expectedURL: URL?
     let messageAction: PaywallWebViewMessageAction?
 
-    /// SDK-managed + paywall custom variables sent automatically in response to `rc:request-variables`.
+    /// SDK-managed variables sent automatically in response to `rc:request-variables`.
     let baseVariables: [String: PaywallWebViewValue]
+
+    let size: PaywallComponent.Size
+    let onContentResize: (CGFloat?, CGFloat?) -> Void
 
 }
 
@@ -118,37 +134,120 @@ enum PaywallWebViewVariables {
 
 }
 
-/// Dispatches a validated inbound `web_view` message. `WebKit`-free (takes the extracted body and
-/// frame flag) so it's unit-testable without a live `WKWebView`.
+/// Dispatches validated inbound `web_view` transport frames. `WebKit`-free so it's unit-testable.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 enum PaywallWebViewMessageDispatcher {
 
+    private static let maxResizeDimension: CGFloat = 10_000
+
     @MainActor
     static func handle(
-        body: Any,
-        isMainFrame: Bool,
+        envelope: WebViewEnvelope.Parsed,
         componentID: String,
+        protocolVersion: Int,
         controller: PaywallWebViewController,
         bridge: WebViewBridgeConfiguration
     ) {
-        guard isMainFrame else {
-            Logger.debug(Strings.paywall_web_view_message_rejected(reason: "message not from the main frame"))
+        switch envelope.kind {
+        case WebViewEnvelope.kindMessage, WebViewEnvelope.kindRequest:
+            break
+        default:
+            return
+        }
+
+        if envelope.kind == WebViewEnvelope.kindMessage,
+           envelope.type == PaywallWebViewMessageType.resize {
+            Self.handleResize(envelope: envelope, bridge: bridge)
             return
         }
 
         let parser = PaywallWebViewMessageParser(expectedComponentID: componentID)
-        switch parser.parse(body) {
-        case .success(let message):
-            // The SDK always replies to a variables request with the canonical SDK-managed +
-            // custom variables, even when the app installs no handler.
-            if message.type == PaywallWebViewMessageType.requestVariables {
-                controller.postVariables(componentID: message.componentID, variables: bridge.baseVariables)
+        switch parser.parseEnvelope(Self.envelopeDictionary(envelope)) {
+        case .success(let parsed):
+            if parsed.message.type == PaywallWebViewMessageType.requestVariables {
+                Self.replyToVariablesRequest(
+                    parsed: parsed,
+                    controller: controller,
+                    bridge: bridge,
+                    protocolVersion: protocolVersion,
+                    componentID: componentID
+                )
             }
-            bridge.messageAction?(message, controller)
+            bridge.messageAction?(parsed.message, controller)
 
         case .failure(let error):
             Logger.debug(Strings.paywall_web_view_message_rejected(reason: "\(error)"))
         }
+    }
+
+    @MainActor
+    private static func replyToVariablesRequest(
+        parsed: PaywallWebViewMessageParser.ParsedAppMessage,
+        controller: PaywallWebViewController,
+        bridge: WebViewBridgeConfiguration,
+        protocolVersion: Int,
+        componentID: String
+    ) {
+        if let requestID = parsed.requestID, let requestType = parsed.requestType {
+            controller.deliverEnvelope(
+                WebViewEnvelope.build(
+                    kind: WebViewEnvelope.kindResponse,
+                    protocolVersion: protocolVersion,
+                    componentID: componentID,
+                    type: requestType,
+                    id: requestID,
+                    payload: bridge.baseVariables
+                )
+            )
+        } else {
+            controller.postVariables(componentID: componentID, variables: bridge.baseVariables)
+        }
+    }
+
+    @MainActor
+    private static func handleResize(
+        envelope: WebViewEnvelope.Parsed,
+        bridge: WebViewBridgeConfiguration
+    ) {
+        guard let payload = envelope.payload else {
+            return
+        }
+
+        let width = Self.validatedDimension(payload["width"]?.numberValue)
+        let height = Self.validatedDimension(payload["height"]?.numberValue)
+        bridge.onContentResize(width, height)
+    }
+
+    private static func validatedDimension(_ value: Double?) -> CGFloat? {
+        guard let value, value.isFinite, value > 0 else {
+            return nil
+        }
+
+        return min(CGFloat(value), Self.maxResizeDimension)
+    }
+
+    private static func envelopeDictionary(_ envelope: WebViewEnvelope.Parsed) -> [String: Any] {
+        var dictionary: [String: Any] = [
+            WebViewEnvelope.Field.channel: WebViewEnvelope.channel,
+            WebViewEnvelope.Field.protocolVersion: envelope.protocolVersion,
+            WebViewEnvelope.Field.kind: envelope.kind,
+            WebViewEnvelope.Field.componentID: envelope.componentID
+        ]
+
+        if let type = envelope.type {
+            dictionary[WebViewEnvelope.Field.type] = type
+        }
+        if let id = envelope.id {
+            dictionary[WebViewEnvelope.Field.id] = id
+        }
+        if let error = envelope.error {
+            dictionary[WebViewEnvelope.Field.error] = error
+        }
+        if let payload = envelope.payload {
+            dictionary[WebViewEnvelope.Field.payload] = PaywallWebViewValue.object(payload).jsonObject
+        }
+
+        return dictionary
     }
 
 }
@@ -193,7 +292,6 @@ private extension View {
     func applyWebViewHeight(_ constraint: PaywallComponent.SizeConstraint, measuredHeight: CGFloat?) -> some View {
         switch constraint {
         case .fit, .relative:
-            // Web content has no intrinsic height, so use the dynamically-measured height.
             self.frame(height: measuredHeight)
         case .fill:
             self.frame(maxHeight: .infinity)
@@ -220,77 +318,6 @@ private extension WebViewComponentView {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 enum PaywallWebViewScripts {
 
-    static let measureHeightJavaScript = "window.__rcMeasureHeight && window.__rcMeasureHeight()"
-
-    static let heightReportingJavaScriptSource = """
-    (function() {
-      function measureHeight() {
-        var body = document.body;
-        var html = document.documentElement;
-        var bodyRect = body.getBoundingClientRect();
-        var height = Math.max(bodyRect.height, html.getBoundingClientRect().height);
-
-        var children = body.children;
-        for (var i = 0; i < children.length; i++) {
-          var child = children[i];
-          var style = window.getComputedStyle(child);
-          if (style.display === 'none' || style.visibility === 'hidden') { continue; }
-          var rect = child.getBoundingClientRect();
-          if (rect.height > 0) {
-            height = Math.max(height, rect.bottom - bodyRect.top);
-          }
-        }
-
-        return Math.ceil(height);
-      }
-
-      window.__rcMeasureHeight = measureHeight;
-
-      function reportHeight() {
-        var height = measureHeight();
-        if (window.webkit && window.webkit.messageHandlers.rcWebViewHeight) {
-          window.webkit.messageHandlers.rcWebViewHeight.postMessage(height);
-        }
-      }
-
-      window.__rcReportHeight = reportHeight;
-
-      if (!window.__rcHeightObserverInstalled) {
-        window.__rcHeightObserverInstalled = true;
-
-        if (window.ResizeObserver) {
-          var resizeObserver = new ResizeObserver(reportHeight);
-          resizeObserver.observe(document.documentElement);
-          if (document.body) { resizeObserver.observe(document.body); }
-        }
-
-        new MutationObserver(reportHeight).observe(document.documentElement, {
-          subtree: true,
-          childList: true,
-          attributes: true,
-          characterData: true
-        });
-
-        document.addEventListener('click', function() {
-          reportHeight();
-          setTimeout(reportHeight, 50);
-          setTimeout(reportHeight, 150);
-          setTimeout(reportHeight, 350);
-        }, true);
-
-        document.addEventListener('transitionend', reportHeight, true);
-        document.addEventListener('animationend', reportHeight, true);
-        window.addEventListener('load', reportHeight);
-      }
-
-      if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', reportHeight, { once: true });
-      } else {
-        reportHeight();
-      }
-    })();
-    """
-
     static let disableZoomUserScript: WKUserScript = {
         let source = """
         (function() {
@@ -308,45 +335,9 @@ enum PaywallWebViewScripts {
         return WKUserScript(source: source, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
     }()
 
-    static let heightReportingUserScript = WKUserScript(
-        source: PaywallWebViewScripts.heightReportingJavaScriptSource,
-        injectionTime: .atDocumentEnd,
-        forMainFrameOnly: true
-    )
-
-    /// The native handler name the message bridge posts to. Independent of height reporting.
-    static let messageHandlerName = "rcWebViewMessage"
-
-    /// Injected at document start so the web bundle can call `window.RevenueCatWebView.postMessage`
-    /// before its own scripts run. Native → web messages arrive via `window.__revenueCatReceiveMessage`,
-    /// which the web bundle defines. The bridge exposes no other native surface.
-    static let messageBridgeJavaScriptSource = """
-    (function() {
-      if (window.__rcBridgeInstalled) { return; }
-      window.__rcBridgeInstalled = true;
-
-      window.RevenueCatWebView = window.RevenueCatWebView || {
-        postMessage: function(message) {
-          if (window.webkit &&
-              window.webkit.messageHandlers &&
-              window.webkit.messageHandlers.\(messageHandlerName)) {
-            window.webkit.messageHandlers.\(messageHandlerName).postMessage(message);
-          }
-        }
-      };
-    })();
-    """
-
-    static let messageBridgeUserScript = WKUserScript(
-        source: PaywallWebViewScripts.messageBridgeJavaScriptSource,
-        injectionTime: .atDocumentStart,
-        forMainFrameOnly: true
-    )
-
     /// Attaches the content-blocking rule list (compiling it if necessary), then loads `url`. The
     /// load is deferred until the rules are in place so no request is issued before isolation
-    /// applies. Fails closed: if compilation fails the page still loads, already isolated to its
-    /// uploaded bundle.
+    /// applies. Fails closed: if compilation fails the page is not loaded.
     static func loadIsolated(url: URL, on webView: WKWebView) {
         guard let json = WebViewCapabilitiesConfiguration.contentBlockingRules else {
             webView.load(URLRequest(url: url))
@@ -358,9 +349,10 @@ enum PaywallWebViewScripts {
             json: json
         ) { [weak webView] ruleList in
             guard let webView else { return }
-            if let ruleList {
-                webView.configuration.userContentController.add(ruleList)
+            guard let ruleList else {
+                return
             }
+            webView.configuration.userContentController.add(ruleList)
             webView.load(URLRequest(url: url))
         }
     }
@@ -387,107 +379,6 @@ final class WeakScriptMessageHandler: NSObject, WKScriptMessageHandler {
 
 }
 
-/// Measures a web view's rendered content height and reports changes via `onHeight`. Shared by the
-/// iOS and macOS coordinators so the (otherwise identical) measurement logic lives in one place.
-/// Registers itself as the `rcWebViewHeight` script-message handler and also measures on demand
-/// after navigation finishes.
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-final class WebViewHeightReporter: NSObject, WKScriptMessageHandler {
-
-    static let handlerName = "rcWebViewHeight"
-
-    /// Invoked with each newly measured content height (raw; callers apply their own change
-    /// threshold and main-thread dispatch).
-    private let onHeight: (CGFloat, WKWebView) -> Void
-    private var messageHandler: WeakScriptMessageHandler?
-    private var measurementGeneration = 0
-
-    init(onHeight: @escaping (CGFloat, WKWebView) -> Void) {
-        self.onHeight = onHeight
-    }
-
-    func register(on webView: WKWebView) {
-        let handler = WeakScriptMessageHandler(delegate: self)
-        self.messageHandler = handler
-        webView.configuration.userContentController.removeScriptMessageHandler(forName: Self.handlerName)
-        webView.configuration.userContentController.add(handler, name: Self.handlerName)
-    }
-
-    func unregister(from webView: WKWebView) {
-        webView.configuration.userContentController.removeScriptMessageHandler(forName: Self.handlerName)
-        self.messageHandler = nil
-    }
-
-    func reportIfNeeded(in webView: WKWebView) {
-        webView.evaluateJavaScript("window.__rcReportHeight && window.__rcReportHeight()")
-    }
-
-    /// Re-injects the height-reporting script and measures, both immediately and once all resources
-    /// finish loading. Call from the navigation delegate's `didFinish`.
-    func handleNavigationFinished(in webView: WKWebView) {
-        webView.evaluateJavaScript(PaywallWebViewScripts.heightReportingJavaScriptSource)
-        self.measure(in: webView)
-        let javaScript = """
-        new Promise(r => {
-          if (document.readyState === 'complete') { r(); return; }
-          window.addEventListener('load', () => r(), { once: true });
-        }).then(() => 0);
-        """
-        webView.evaluateJavaScript(javaScript) { [weak self, weak webView] _, _ in
-            guard let self, let webView else { return }
-            webView.evaluateJavaScript(PaywallWebViewScripts.heightReportingJavaScriptSource)
-            self.measure(in: webView)
-            self.scheduleDelayedMeasurements(in: webView)
-        }
-    }
-
-    func userContentController(
-        _ userContentController: WKUserContentController,
-        didReceive message: WKScriptMessage
-    ) {
-        guard message.name == Self.handlerName, let webView = message.webView else { return }
-        if let height = Self.height(from: message.body) {
-            self.onHeight(height, webView)
-        }
-    }
-
-    private func measure(in webView: WKWebView) {
-        // Skip until the view has a width, otherwise the measurement collapses to zero.
-        guard webView.bounds.width > 0 else { return }
-
-        self.measurementGeneration += 1
-        let generation = self.measurementGeneration
-
-        let measureJS = PaywallWebViewScripts.measureHeightJavaScript
-        webView.evaluateJavaScript(measureJS) { [weak self, weak webView] result, _ in
-            guard let self, let webView, generation == self.measurementGeneration else { return }
-            if let height = Self.height(from: result) {
-                self.onHeight(height, webView)
-            }
-        }
-    }
-
-    private func scheduleDelayedMeasurements(in webView: WKWebView) {
-        let delays: [TimeInterval] = [0.05, 0.15, 0.35]
-        for delay in delays {
-            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self, weak webView] in
-                guard let self, let webView else { return }
-                self.measure(in: webView)
-            }
-        }
-    }
-
-    private static func height(from value: Any?) -> CGFloat? {
-        if let number = value as? NSNumber {
-            return CGFloat(number.doubleValue)
-        } else if let double = value as? Double {
-            return CGFloat(double)
-        }
-        return nil
-    }
-
-}
-
 /// Source of the per-render bridge state a ``WebViewMessageBridge`` needs when a message arrives.
 /// Implemented by the platform coordinators so the bridge can read the current configuration and
 /// loaded URL without duplicating that state.
@@ -495,18 +386,19 @@ final class WebViewHeightReporter: NSObject, WKScriptMessageHandler {
 protocol WebViewBridgeHost: AnyObject {
     var bridge: WebViewBridgeConfiguration? { get }
     var currentURL: URL? { get }
+    func resetMeasuredContentSize()
 }
 
-/// Bridges inbound `web_view` postMessage calls to ``PaywallWebViewMessageDispatcher``. Shared by
-/// the iOS and macOS coordinators so the (otherwise identical) registration and dispatch live in
-/// one place. The handler is installed only when the component has a stable `id`.
+/// Bridges inbound `web_view` transport frames to ``PaywallWebViewMessageDispatcher``. Shared by
+/// the iOS and macOS coordinators. The handler is installed only when the component has a stable `id`.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 final class WebViewMessageBridge: NSObject, WKScriptMessageHandler {
 
-    static let handlerName = PaywallWebViewScripts.messageHandlerName
+    static let handlerName = WebViewEnvelope.messageHandlerName
 
     private weak var host: WebViewBridgeHost?
     private var messageHandler: WeakScriptMessageHandler?
+    private var channelOpen = false
 
     init(host: WebViewBridgeHost) {
         self.host = host
@@ -526,6 +418,11 @@ final class WebViewMessageBridge: NSObject, WKScriptMessageHandler {
     func unregister(from webView: WKWebView) {
         webView.configuration.userContentController.removeScriptMessageHandler(forName: Self.handlerName)
         self.messageHandler = nil
+        self.channelOpen = false
+    }
+
+    func resetChannel() {
+        self.channelOpen = false
     }
 
     func userContentController(
@@ -535,23 +432,148 @@ final class WebViewMessageBridge: NSObject, WKScriptMessageHandler {
         guard message.name == Self.handlerName,
               let host = self.host,
               let bridge = host.bridge,
-              let componentID = bridge.componentID else {
+              let componentID = bridge.componentID,
+              let webView = message.webView else {
+            return
+        }
+
+        guard message.frameInfo.isMainFrame else {
+            Logger.debug(Strings.paywall_web_view_message_rejected(reason: "message not from the main frame"))
+            return
+        }
+
+        guard let dictionary = Self.dictionary(from: message.body) else {
+            Logger.debug(Strings.paywall_web_view_message_rejected(reason: "invalid envelope"))
+            return
+        }
+
+        guard JSONSerialization.isValidJSONObject(dictionary),
+              let serialized = try? JSONSerialization.data(withJSONObject: dictionary),
+              serialized.count <= PaywallWebViewMessageParser.maxPayloadBytes else {
+            Logger.debug(Strings.paywall_web_view_message_rejected(reason: "oversized or invalid payload"))
+            return
+        }
+
+        guard let envelope = WebViewEnvelope.parse(dictionary) else {
+            Logger.debug(Strings.paywall_web_view_message_rejected(reason: "invalid envelope"))
+            return
+        }
+
+        let expectedURL = bridge.expectedURL ?? host.currentURL
+        let allowBeforeNavigation = envelope.kind == WebViewEnvelope.kindConnect
+        guard WebViewOrigin.matches(
+            currentURL: webView.url,
+            expectedURL: expectedURL,
+            allowBeforeNavigation: allowBeforeNavigation
+        ) else {
+            Logger.debug(Strings.paywall_web_view_message_rejected(reason: "origin mismatch"))
+            return
+        }
+
+        if envelope.kind == WebViewEnvelope.kindConnect {
+            self.handleConnect(envelope: envelope, webView: webView, bridge: bridge, componentID: componentID)
+            return
+        }
+
+        guard self.channelOpen else {
+            Logger.debug(Strings.paywall_web_view_message_rejected(reason: "channel not open"))
+            return
+        }
+
+        if envelope.componentID != componentID {
+            Logger.debug(Strings.paywall_web_view_message_rejected(reason: "component_id mismatch"))
             return
         }
 
         let controller = PaywallWebViewController(
-            webView: message.webView,
+            webView: webView,
             componentID: componentID,
-            expectedLoadedURL: host.currentURL
+            expectedLoadedURL: expectedURL,
+            protocolVersion: bridge.protocolVersion,
+            channelOpen: { self.channelOpen }
         )
 
         PaywallWebViewMessageDispatcher.handle(
-            body: message.body,
-            isMainFrame: message.frameInfo.isMainFrame,
+            envelope: envelope,
             componentID: componentID,
+            protocolVersion: bridge.protocolVersion,
             controller: controller,
             bridge: bridge
         )
+    }
+
+    private func handleConnect(
+        envelope: WebViewEnvelope.Parsed,
+        webView: WKWebView,
+        bridge: WebViewBridgeConfiguration,
+        componentID: String
+    ) {
+        guard !self.channelOpen else {
+            return
+        }
+
+        if envelope.protocolVersion != bridge.protocolVersion {
+            self.deliver(
+                WebViewEnvelope.build(
+                    kind: WebViewEnvelope.kindReject,
+                    protocolVersion: bridge.protocolVersion,
+                    componentID: "",
+                    error: "Unsupported protocol_version \(envelope.protocolVersion); " +
+                        "native host supports \(bridge.protocolVersion)"
+                ),
+                to: webView,
+                expectedURL: bridge.expectedURL,
+                allowBeforeNavigation: true
+            )
+            return
+        }
+
+        self.channelOpen = true
+        self.deliver(
+            WebViewEnvelope.build(
+                kind: WebViewEnvelope.kindInit,
+                protocolVersion: bridge.protocolVersion,
+                componentID: componentID
+            ),
+            to: webView,
+            expectedURL: bridge.expectedURL,
+            allowBeforeNavigation: true
+        )
+    }
+
+    private func deliver(
+        _ envelope: [String: PaywallWebViewValue],
+        to webView: WKWebView,
+        expectedURL: URL?,
+        allowBeforeNavigation: Bool
+    ) {
+        guard WebViewOrigin.matches(
+            currentURL: webView.url,
+            expectedURL: expectedURL,
+            allowBeforeNavigation: allowBeforeNavigation
+        ) else {
+            return
+        }
+
+        guard let script = PaywallWebViewController.receiveEnvelopeScript(envelope: envelope) else {
+            return
+        }
+
+        webView.evaluateJavaScript(script)
+    }
+
+    private static func dictionary(from body: Any) -> [String: Any]? {
+        if let dictionary = body as? [String: Any] {
+            return dictionary
+        }
+
+        if let jsonString = body as? String,
+           let data = jsonString.data(using: .utf8),
+           let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            return object
+        }
+
+        return nil
     }
 
 }
@@ -586,32 +608,31 @@ private struct WebViewRepresentable: UIViewRepresentable {
         webView.scrollView.delegate = context.coordinator
 
         context.coordinator.bridge = bridge
-        context.coordinator.registerHeightReporting(on: webView)
         context.coordinator.registerMessageBridgeIfNeeded(on: webView)
         context.coordinator.currentURL = url
+        if height == nil, case .fit = bridge.size.height {
+            height = WebViewComponentView.initialHeight
+        }
         PaywallWebViewScripts.loadIsolated(url: url, on: webView)
         return webView
     }
 
     func updateUIView(_ uiView: WKWebView, context: Context) {
-        // Refresh the bridge config so SDK-managed variables (color scheme) and the app handler
-        // stay current; do not reload the web view on these changes.
         context.coordinator.bridge = bridge
 
         if context.coordinator.currentURL != url {
             context.coordinator.currentURL = url
+            context.coordinator.resetMeasuredContentSize()
+            context.coordinator.messageBridge.resetChannel()
             uiView.load(URLRequest(url: url))
         }
 
         if let height, let autoSizingWebView = uiView as? AutoSizingWebView {
             autoSizingWebView.setContentHeight(height)
         }
-
-        context.coordinator.reportHeightIfNeeded(in: uiView)
     }
 
     static func dismantleUIView(_ uiView: WKWebView, coordinator: Coordinator) {
-        coordinator.unregisterHeightReporting(from: uiView)
         coordinator.unregisterMessageBridge(from: uiView)
         uiView.navigationDelegate = nil
         uiView.scrollView.delegate = nil
@@ -628,30 +649,14 @@ private struct WebViewRepresentable: UIViewRepresentable {
         var currentURL: URL?
         var bridge: WebViewBridgeConfiguration?
 
-        private lazy var heightReporter = WebViewHeightReporter { [weak self] newHeight, webView in
-            guard let self, newHeight >= 0, abs(newHeight - (self.height ?? 0)) > 0.5 else { return }
-            DispatchQueue.main.async {
-                self.height = newHeight
-                (webView as? AutoSizingWebView)?.setContentHeight(newHeight)
-            }
-        }
-
-        private lazy var messageBridge = WebViewMessageBridge(host: self)
+        fileprivate lazy var messageBridge = WebViewMessageBridge(host: self)
 
         init(height: Binding<CGFloat?>) {
             _height = height
         }
 
-        func registerHeightReporting(on webView: WKWebView) {
-            self.heightReporter.register(on: webView)
-        }
-
-        func unregisterHeightReporting(from webView: WKWebView) {
-            self.heightReporter.unregister(from: webView)
-        }
-
-        func reportHeightIfNeeded(in webView: WKWebView) {
-            self.heightReporter.reportIfNeeded(in: webView)
+        func resetMeasuredContentSize() {
+            self.height = nil
         }
 
         func registerMessageBridgeIfNeeded(on webView: WKWebView) {
@@ -660,10 +665,6 @@ private struct WebViewRepresentable: UIViewRepresentable {
 
         func unregisterMessageBridge(from webView: WKWebView) {
             self.messageBridge.unregister(from: webView)
-        }
-
-        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-            self.heightReporter.handleNavigationFinished(in: webView)
         }
 
         func viewForZooming(in scrollView: UIScrollView) -> UIView? {
@@ -698,8 +699,6 @@ final class AutoSizingWebView: WKWebView {
         config.websiteDataStore = .nonPersistent()
         config.allowsInlineMediaPlayback = true
         config.userContentController.addUserScript(PaywallWebViewScripts.disableZoomUserScript)
-        config.userContentController.addUserScript(PaywallWebViewScripts.heightReportingUserScript)
-        config.userContentController.addUserScript(PaywallWebViewScripts.messageBridgeUserScript)
         super.init(frame: .zero, configuration: config)
         isOpaque = false
         backgroundColor = .clear
@@ -728,9 +727,11 @@ private struct MacWebViewRepresentable: NSViewRepresentable {
         let webView = WKWebView(frame: .zero, configuration: Self.makeConfiguration())
         webView.navigationDelegate = context.coordinator
         context.coordinator.bridge = bridge
-        context.coordinator.registerHeightReporting(on: webView)
         context.coordinator.registerMessageBridgeIfNeeded(on: webView)
         context.coordinator.currentURL = url
+        if height == nil, case .fit = bridge.size.height {
+            height = WebViewComponentView.initialHeight
+        }
         PaywallWebViewScripts.loadIsolated(url: url, on: webView)
 
         return webView
@@ -741,14 +742,13 @@ private struct MacWebViewRepresentable: NSViewRepresentable {
 
         if context.coordinator.currentURL != url {
             context.coordinator.currentURL = url
+            context.coordinator.resetMeasuredContentSize()
+            context.coordinator.messageBridge.resetChannel()
             nsView.load(URLRequest(url: url))
         }
-
-        context.coordinator.reportHeightIfNeeded(in: nsView)
     }
 
     static func dismantleNSView(_ nsView: WKWebView, coordinator: Coordinator) {
-        coordinator.unregisterHeightReporting(from: nsView)
         coordinator.unregisterMessageBridge(from: nsView)
         nsView.navigationDelegate = nil
         nsView.stopLoading()
@@ -765,8 +765,9 @@ private struct MacWebViewRepresentable: NSViewRepresentable {
     private static func makeConfiguration() -> WKWebViewConfiguration {
         let config = WKWebViewConfiguration()
         config.websiteDataStore = .nonPersistent()
-        config.userContentController.addUserScript(PaywallWebViewScripts.heightReportingUserScript)
-        config.userContentController.addUserScript(PaywallWebViewScripts.messageBridgeUserScript)
+        // macOS WKWebView does not support pinch-zoom on scroll views the way iOS does; viewport
+        // meta injection is unnecessary for zoom parity.
+        config.userContentController.addUserScript(PaywallWebViewScripts.disableZoomUserScript)
 
         return config
     }
@@ -777,29 +778,14 @@ private struct MacWebViewRepresentable: NSViewRepresentable {
         var currentURL: URL?
         var bridge: WebViewBridgeConfiguration?
 
-        private lazy var heightReporter = WebViewHeightReporter { [weak self] newHeight, _ in
-            guard let self, newHeight >= 0, abs(newHeight - (self.height ?? 0)) > 0.5 else { return }
-            DispatchQueue.main.async {
-                self.height = newHeight
-            }
-        }
-
-        private lazy var messageBridge = WebViewMessageBridge(host: self)
+        fileprivate lazy var messageBridge = WebViewMessageBridge(host: self)
 
         init(height: Binding<CGFloat?>) {
             _height = height
         }
 
-        func registerHeightReporting(on webView: WKWebView) {
-            self.heightReporter.register(on: webView)
-        }
-
-        func unregisterHeightReporting(from webView: WKWebView) {
-            self.heightReporter.unregister(from: webView)
-        }
-
-        func reportHeightIfNeeded(in webView: WKWebView) {
-            self.heightReporter.reportIfNeeded(in: webView)
+        func resetMeasuredContentSize() {
+            self.height = nil
         }
 
         func registerMessageBridgeIfNeeded(on webView: WKWebView) {
@@ -808,10 +794,6 @@ private struct MacWebViewRepresentable: NSViewRepresentable {
 
         func unregisterMessageBridge(from webView: WKWebView) {
             self.messageBridge.unregister(from: webView)
-        }
-
-        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-            self.heightReporter.handleNavigationFinished(in: webView)
         }
 
     }

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
@@ -36,9 +36,6 @@ struct WebViewComponentView: View {
     @State private var dynamicHeight: CGFloat?
     #endif
 
-    @Environment(\.customPaywallVariables)
-    private var customVariables
-
     @Environment(\.paywallWebViewMessageAction)
     private var webViewMessageAction
 
@@ -62,14 +59,14 @@ struct WebViewComponentView: View {
     @ViewBuilder
     private var content: some View {
         #if canImport(UIKit) && canImport(WebKit)
-        if let resolvedURL = viewModel.resolvedURL(customVariables: customVariables) {
+        if let resolvedURL = viewModel.url {
             WebViewRepresentable(url: resolvedURL, height: $dynamicHeight, bridge: bridge)
                 .modifier(WebViewSizeModifier(size: viewModel.size, measuredHeight: dynamicHeight))
                 .clipped()
                 .background(Color.clear)
         }
         #elseif os(macOS)
-        if let resolvedURL = viewModel.resolvedURL(customVariables: customVariables) {
+        if let resolvedURL = viewModel.url {
             let macHeight = dynamicHeight ?? Self.initialHeight
             MacWebViewRepresentable(url: resolvedURL, height: $dynamicHeight, bridge: bridge)
                 .modifier(WebViewSizeModifier(size: viewModel.size, measuredHeight: macHeight))

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
@@ -200,7 +200,15 @@ enum PaywallWebViewMessageDispatcher {
                 )
             )
         } else {
-            controller.postVariables(componentID: componentID, variables: bridge.baseVariables)
+            controller.deliverEnvelope(
+                WebViewEnvelope.build(
+                    kind: WebViewEnvelope.kindMessage,
+                    protocolVersion: protocolVersion,
+                    componentID: componentID,
+                    type: PaywallWebViewMessageType.variables,
+                    payload: bridge.baseVariables
+                )
+            )
         }
     }
 

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
@@ -56,15 +56,22 @@ struct WebViewComponentView: View {
             messageAction: webViewMessageAction,
             baseVariables: PaywallWebViewVariables.base(locale: viewModel.locale),
             size: viewModel.size,
-            onContentResize: { width, height in
+            onContentResize: { _, height in
                 if case .fit = viewModel.size.height, let height {
                     dynamicHeight = height
                 }
-                if case .fit = viewModel.size.width, let width {
-                    _ = width
-                }
             }
         )
+    }
+
+    private var measuredHeight: CGFloat? {
+        if let dynamicHeight {
+            return dynamicHeight
+        }
+        if case .fit = viewModel.size.height {
+            return Self.initialHeight
+        }
+        return nil
     }
 
     @ViewBuilder
@@ -72,15 +79,14 @@ struct WebViewComponentView: View {
         #if canImport(UIKit) && canImport(WebKit)
         if let resolvedURL = viewModel.url {
             WebViewRepresentable(url: resolvedURL, height: $dynamicHeight, bridge: bridge)
-                .modifier(WebViewSizeModifier(size: viewModel.size, measuredHeight: dynamicHeight))
+                .modifier(WebViewSizeModifier(size: viewModel.size, measuredHeight: self.measuredHeight))
                 .clipped()
                 .background(Color.clear)
         }
         #elseif os(macOS)
         if let resolvedURL = viewModel.url {
-            let macHeight = dynamicHeight ?? Self.initialHeight
             MacWebViewRepresentable(url: resolvedURL, height: $dynamicHeight, bridge: bridge)
-                .modifier(WebViewSizeModifier(size: viewModel.size, measuredHeight: macHeight))
+                .modifier(WebViewSizeModifier(size: viewModel.size, measuredHeight: self.measuredHeight))
                 .clipped()
                 .background(Color.clear)
         }
@@ -155,14 +161,13 @@ enum PaywallWebViewMessageDispatcher {
             return
         }
 
-        if envelope.kind == WebViewEnvelope.kindMessage,
-           envelope.type == PaywallWebViewMessageType.resize {
+        if envelope.type == PaywallWebViewMessageType.resize {
             Self.handleResize(envelope: envelope, bridge: bridge)
             return
         }
 
         let parser = PaywallWebViewMessageParser(expectedComponentID: componentID)
-        switch parser.parseEnvelope(Self.envelopeDictionary(envelope)) {
+        switch parser.parseAppMessage(envelope: envelope) {
         case .success(let parsed):
             if parsed.message.type == PaywallWebViewMessageType.requestVariables {
                 Self.replyToVariablesRequest(
@@ -234,30 +239,6 @@ enum PaywallWebViewMessageDispatcher {
         return min(CGFloat(value), Self.maxResizeDimension)
     }
 
-    private static func envelopeDictionary(_ envelope: WebViewEnvelope.Parsed) -> [String: Any] {
-        var dictionary: [String: Any] = [
-            WebViewEnvelope.Field.channel: WebViewEnvelope.channel,
-            WebViewEnvelope.Field.protocolVersion: envelope.protocolVersion,
-            WebViewEnvelope.Field.kind: envelope.kind,
-            WebViewEnvelope.Field.componentID: envelope.componentID
-        ]
-
-        if let type = envelope.type {
-            dictionary[WebViewEnvelope.Field.type] = type
-        }
-        if let id = envelope.id {
-            dictionary[WebViewEnvelope.Field.id] = id
-        }
-        if let error = envelope.error {
-            dictionary[WebViewEnvelope.Field.error] = error
-        }
-        if let payload = envelope.payload {
-            dictionary[WebViewEnvelope.Field.payload] = PaywallWebViewValue.object(payload).jsonObject
-        }
-
-        return dictionary
-    }
-
 }
 
 /// Applies the component's ``PaywallComponent/Size`` to the web view. For a `fit` height the
@@ -317,6 +298,13 @@ private extension WebViewComponentView {
 
     static let initialHeight: CGFloat = 100
 
+    static func effectiveFitHeight(for height: PaywallComponent.SizeConstraint) -> CGFloat? {
+        if case .fit = height {
+            return Self.initialHeight
+        }
+        return nil
+    }
+
 }
 
 #endif
@@ -346,13 +334,17 @@ enum PaywallWebViewScripts {
     /// Attaches the content-blocking rule list (compiling it if necessary), then loads `url`. The
     /// load is deferred until the rules are in place so no request is issued before isolation
     /// applies. Fails closed: if compilation fails the page is not loaded.
-    static func loadIsolated(url: URL, on webView: WKWebView) {
+    static func loadIsolated(
+        url: URL,
+        on webView: WKWebView,
+        ruleListStore: WebViewContentRuleListStore = .shared
+    ) {
         guard let json = WebViewCapabilitiesConfiguration.contentBlockingRules else {
             webView.load(URLRequest(url: url))
             return
         }
 
-        WebViewContentRuleListStore.shared.ruleList(
+        ruleListStore.ruleList(
             forIdentifier: WebViewCapabilitiesConfiguration.contentRuleListIdentifier,
             json: json
         ) { [weak webView] ruleList in
@@ -547,6 +539,71 @@ final class WebViewMessageBridge: NSObject, WKScriptMessageHandler {
             expectedURL: bridge.expectedURL,
             allowBeforeNavigation: true
         )
+        self.sendFitIfNeeded(to: webView, bridge: bridge, componentID: componentID)
+    }
+
+    private func sendFitIfNeeded(
+        to webView: WKWebView,
+        bridge: WebViewBridgeConfiguration,
+        componentID: String
+    ) {
+        guard let envelope = Self.fitEnvelope(
+            protocolVersion: bridge.protocolVersion,
+            componentID: componentID,
+            size: bridge.size
+        ) else {
+            return
+        }
+
+        self.deliver(
+            envelope,
+            to: webView,
+            expectedURL: bridge.expectedURL,
+            allowBeforeNavigation: true
+        )
+    }
+
+    static func fitEnvelope(
+        protocolVersion: Int,
+        componentID: String,
+        size: PaywallComponent.Size
+    ) -> [String: PaywallWebViewValue]? {
+        let sizeToContentWidth: Bool
+        let sizeToContentHeight: Bool
+
+        switch size.width {
+        case .fit:
+            sizeToContentWidth = true
+        default:
+            sizeToContentWidth = false
+        }
+
+        switch size.height {
+        case .fit:
+            sizeToContentHeight = true
+        default:
+            sizeToContentHeight = false
+        }
+
+        guard sizeToContentWidth || sizeToContentHeight else {
+            return nil
+        }
+
+        var payload: [String: PaywallWebViewValue] = [:]
+        if sizeToContentWidth {
+            payload["width"] = .bool(true)
+        }
+        if sizeToContentHeight {
+            payload["height"] = .bool(true)
+        }
+
+        return WebViewEnvelope.build(
+            kind: WebViewEnvelope.kindMessage,
+            protocolVersion: protocolVersion,
+            componentID: componentID,
+            type: PaywallWebViewMessageType.fit,
+            payload: payload
+        )
     }
 
     private func deliver(
@@ -618,9 +675,6 @@ private struct WebViewRepresentable: UIViewRepresentable {
         context.coordinator.bridge = bridge
         context.coordinator.registerMessageBridgeIfNeeded(on: webView)
         context.coordinator.currentURL = url
-        if height == nil, case .fit = bridge.size.height {
-            height = WebViewComponentView.initialHeight
-        }
         PaywallWebViewScripts.loadIsolated(url: url, on: webView)
         return webView
     }
@@ -635,8 +689,11 @@ private struct WebViewRepresentable: UIViewRepresentable {
             uiView.load(URLRequest(url: url))
         }
 
-        if let height, let autoSizingWebView = uiView as? AutoSizingWebView {
-            autoSizingWebView.setContentHeight(height)
+        if let autoSizingWebView = uiView as? AutoSizingWebView {
+            let effectiveHeight = height ?? WebViewComponentView.effectiveFitHeight(for: bridge.size.height)
+            if let effectiveHeight {
+                autoSizingWebView.setContentHeight(effectiveHeight)
+            }
         }
     }
 
@@ -737,9 +794,6 @@ private struct MacWebViewRepresentable: NSViewRepresentable {
         context.coordinator.bridge = bridge
         context.coordinator.registerMessageBridgeIfNeeded(on: webView)
         context.coordinator.currentURL = url
-        if height == nil, case .fit = bridge.size.height {
-            height = WebViewComponentView.initialHeight
-        }
         PaywallWebViewScripts.loadIsolated(url: url, on: webView)
 
         return webView

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentViewModel.swift
@@ -17,9 +17,8 @@ import Foundation
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 class WebViewComponentViewModel {
 
-    private let urlTemplate: String
+    private let urlString: String
     private let localizationProvider: LocalizationProvider
-    private let uiConfigProvider: UIConfigProvider
 
     let size: PaywallComponent.Size
     let visible: Bool
@@ -28,9 +27,22 @@ class WebViewComponentViewModel {
     /// bridge. `nil` for legacy/partial configs that omit `id`, in which case the bridge is disabled.
     let componentID: String?
 
+    /// The schema-declared `protocol_version`. Defaults to `1` when omitted.
+    let protocolVersion: Int
+
     /// The locale resolved for this paywall, exposed as an SDK-managed `locale` variable.
     var locale: Locale {
         self.localizationProvider.locale
+    }
+
+    /// The static HTTPS URL to load. Variables never touch the URL.
+    var url: URL? {
+        guard let url = URL(string: self.urlString),
+              url.isValidPaywallWebViewURL else {
+            return nil
+        }
+
+        return url
     }
 
     init(
@@ -38,39 +50,12 @@ class WebViewComponentViewModel {
         localizationProvider: LocalizationProvider,
         uiConfigProvider: UIConfigProvider
     ) {
-        self.urlTemplate = component.url
+        self.urlString = component.url
         self.size = component.size
         self.visible = component.visible ?? true
         self.componentID = component.id
+        self.protocolVersion = component.protocolVersion
         self.localizationProvider = localizationProvider
-        self.uiConfigProvider = uiConfigProvider
-    }
-
-    /// Resolves `{{ custom.* }}` template tokens in the URL using the provided custom variables,
-    /// falling back to dashboard-configured defaults. Returns `nil` if the resolved string is
-    /// not a valid URL.
-    func resolvedURL(customVariables: [String: CustomVariableValue]) -> URL? {
-        let handler = VariableHandlerV2(
-            variableCompatibilityMap: uiConfigProvider.variableConfig.variableCompatibilityMap,
-            functionCompatibilityMap: uiConfigProvider.variableConfig.functionCompatibilityMap,
-            discountRelativeToMostExpensivePerMonth: nil,
-            showZeroDecimalPlacePrices: false,
-            customVariables: customVariables,
-            defaultCustomVariables: uiConfigProvider.defaultCustomVariables
-        )
-        let resolved = handler.processVariables(
-            in: urlTemplate,
-            with: nil,
-            locale: localizationProvider.locale,
-            localizations: [:],
-            isEligibleForIntroOffer: false
-        )
-        guard let url = URL(string: resolved),
-              url.isValidPaywallWebViewURL else {
-            return nil
-        }
-
-        return url
     }
 
 }
@@ -79,11 +64,12 @@ class WebViewComponentViewModel {
 extension WebViewComponentViewModel: Hashable {
 
     func hash(into hasher: inout Hasher) {
-        hasher.combine(urlTemplate)
+        hasher.combine(self.urlString)
+        hasher.combine(self.componentID)
     }
 
     static func == (lhs: WebViewComponentViewModel, rhs: WebViewComponentViewModel) -> Bool {
-        lhs.urlTemplate == rhs.urlTemplate
+        lhs.urlString == rhs.urlString && lhs.componentID == rhs.componentID
     }
 
 }

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewEnvelope.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewEnvelope.swift
@@ -1,0 +1,166 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WebViewEnvelope.swift
+
+import Foundation
+
+#if !os(tvOS) // For Paywalls V2
+
+/// Wire-format envelopes for the `workflow-web-components-sdk` transport layer.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+enum WebViewEnvelope {
+
+    static let channel = "rc-web-components"
+    static let messageHandlerName = "rcWebComponents"
+    static let receiveFunction = "__rcWebComponentsReceive"
+    static let defaultProtocolVersion = 1
+
+    static let kindConnect = "connect"
+    static let kindInit = "init"
+    static let kindReject = "reject"
+    static let kindMessage = "message"
+    static let kindRequest = "request"
+    static let kindResponse = "response"
+    static let kindError = "error"
+
+    private static let envelopeKinds: Set<String> = [
+        kindConnect, kindInit, kindReject, kindMessage, kindRequest, kindResponse, kindError
+    ]
+
+    enum Field {
+        static let channel = "channel"
+        static let protocolVersion = "protocol_version"
+        static let kind = "kind"
+        static let componentID = "component_id"
+        static let type = "type"
+        static let id = "id"
+        static let payload = "payload"
+        static let error = "error"
+        static let responses = "responses"
+        static let variables = "variables"
+    }
+
+    struct Parsed: Equatable {
+        let kind: String
+        let protocolVersion: Int
+        let componentID: String
+        let type: String?
+        let id: String?
+        let payload: [String: PaywallWebViewValue]?
+        let error: String?
+    }
+
+    static func parse(_ dictionary: [String: Any]) -> Parsed? {
+        guard dictionary[Field.channel] as? String == Self.channel else {
+            return nil
+        }
+
+        guard let protocolVersionNumber = dictionary[Field.protocolVersion] as? NSNumber,
+              protocolVersionNumber.doubleValue.isFinite else {
+            return nil
+        }
+        let protocolVersion = protocolVersionNumber.intValue
+
+        guard let kind = dictionary[Field.kind] as? String,
+              Self.envelopeKinds.contains(kind) else {
+            return nil
+        }
+
+        guard let componentID = dictionary[Field.componentID] as? String else {
+            return nil
+        }
+
+        if dictionary.keys.contains(Field.type),
+           dictionary[Field.type] as? String == nil {
+            return nil
+        }
+        let type = dictionary[Field.type] as? String
+
+        if dictionary.keys.contains(Field.id),
+           dictionary[Field.id] as? String == nil {
+            return nil
+        }
+        let id = dictionary[Field.id] as? String
+
+        if dictionary.keys.contains(Field.error),
+           dictionary[Field.error] as? String == nil {
+            return nil
+        }
+        let error = dictionary[Field.error] as? String
+
+        let payload: [String: PaywallWebViewValue]?
+        if let rawPayload = dictionary[Field.payload] {
+            guard let object = rawPayload as? [String: Any],
+                  let converted = Self.convert(object: object) else {
+                return nil
+            }
+            payload = converted
+        } else {
+            payload = nil
+        }
+
+        return Parsed(
+            kind: kind,
+            protocolVersion: protocolVersion,
+            componentID: componentID,
+            type: type,
+            id: id,
+            payload: payload,
+            error: error
+        )
+    }
+
+    static func build(
+        kind: String,
+        protocolVersion: Int,
+        componentID: String,
+        type: String? = nil,
+        id: String? = nil,
+        payload: [String: PaywallWebViewValue]? = nil,
+        error: String? = nil
+    ) -> [String: PaywallWebViewValue] {
+        var envelope: [String: PaywallWebViewValue] = [
+            Field.channel: .string(Self.channel),
+            Field.protocolVersion: .number(Double(protocolVersion)),
+            Field.kind: .string(kind),
+            Field.componentID: .string(componentID)
+        ]
+
+        if let type {
+            envelope[Field.type] = .string(type)
+        }
+        if let id {
+            envelope[Field.id] = .string(id)
+        }
+        if let payload {
+            envelope[Field.payload] = .object(payload)
+        }
+        if let error {
+            envelope[Field.error] = .string(error)
+        }
+
+        return envelope
+    }
+
+    private static func convert(object: [String: Any]) -> [String: PaywallWebViewValue]? {
+        var result: [String: PaywallWebViewValue] = [:]
+        result.reserveCapacity(object.count)
+        for (key, value) in object {
+            guard let converted = PaywallWebViewValue(jsonObject: value) else {
+                return nil
+            }
+            result[key] = converted
+        }
+        return result
+    }
+
+}
+
+#endif

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewOrigin.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewOrigin.swift
@@ -1,0 +1,83 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WebViewOrigin.swift
+
+import Foundation
+
+#if !os(tvOS) // For Paywalls V2
+
+/// Origin comparison helpers for `web_view` messaging (`scheme://host[:port]`).
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+enum WebViewOrigin {
+
+    /// Returns the origin of `url` as `scheme://host[:port]`, or `nil` when the URL has no host.
+    static func origin(of url: URL) -> String? {
+        guard let host = url.host?.lowercased(), !host.isEmpty else {
+            return nil
+        }
+
+        let scheme = (url.scheme ?? "").lowercased()
+        let port = Self.effectivePort(for: url)
+        let portSuffix: String
+        if let port, !Self.isDefaultPort(port, scheme: scheme) {
+            portSuffix = ":\(port)"
+        } else {
+            portSuffix = ""
+        }
+
+        return "\(scheme)://\(host)\(portSuffix)"
+    }
+
+    /// Whether `currentURL` shares the same origin as `expectedURL`.
+    static func matches(currentURL: URL?, expectedURL: URL?, allowBeforeNavigation: Bool) -> Bool {
+        guard let expectedOrigin = expectedURL.flatMap({ Self.origin(of: $0) }) else {
+            return false
+        }
+
+        guard let currentURL else {
+            return allowBeforeNavigation
+        }
+
+        guard let currentOrigin = Self.origin(of: currentURL) else {
+            return allowBeforeNavigation
+        }
+
+        return currentOrigin == expectedOrigin
+    }
+
+    private static func effectivePort(for url: URL) -> Int? {
+        if let port = url.port {
+            return port
+        }
+
+        switch url.scheme?.lowercased() {
+        case "https":
+            return 443
+        case "http":
+            return 80
+        default:
+            return nil
+        }
+    }
+
+    private static func isDefaultPort(_ port: Int, scheme: String) -> Bool {
+        switch scheme {
+        case "https":
+            return port == 443
+        case "http":
+            return port == 80
+        default:
+            return false
+        }
+    }
+
+}
+
+#endif

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
@@ -516,8 +516,7 @@ struct ViewModelFactory {
         case .webView(let component):
             return .webView(WebViewComponentViewModel(
                 component: component,
-                localizationProvider: localizationProvider,
-                uiConfigProvider: uiConfigProvider
+                localizationProvider: localizationProvider
             ))
         case .fallbackHeader:
             // fallbackHeader is filtered out in toStackViewModel and should never reach here.

--- a/Sources/Paywalls/Components/PaywallWebViewComponent.swift
+++ b/Sources/Paywalls/Components/PaywallWebViewComponent.swift
@@ -26,9 +26,7 @@ import Foundation
         /// Decoded and preserved; no protocol-version-specific behavior is implemented yet.
         public let protocolVersion: Int
 
-        /// The URL (or URL template) of the web bundle entrypoint to load.
-        /// May contain `{{ custom.variable }}` tokens that are resolved at display time.
-        /// After variable substitution it must resolve to a valid HTTPS URL with a host.
+        /// The static HTTPS URL of the web bundle entrypoint to load.
         public let url: String
 
         public let size: Size

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewBridgeTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewBridgeTests.swift
@@ -117,9 +117,7 @@ final class PaywallWebViewBridgeTests: TestCase {
 
     func testDispatcherHandlesResizeBeforeAppHandler() {
         var reportedHeight: CGFloat?
-        let bridge = self.bridge(onContentResize: { _, height in
-            reportedHeight = height
-        })
+        var handled = false
 
         let envelope = WebViewEnvelope.Parsed(
             kind: WebViewEnvelope.kindMessage,
@@ -131,7 +129,6 @@ final class PaywallWebViewBridgeTests: TestCase {
             error: nil
         )
 
-        var handled = false
         PaywallWebViewMessageDispatcher.handle(
             envelope: envelope,
             componentID: Self.componentID,
@@ -147,33 +144,92 @@ final class PaywallWebViewBridgeTests: TestCase {
         XCTAssertFalse(handled)
     }
 
-    func testDispatcherAutoRepliesToRequestVariablesMessageForm() throws {
-        let envelope = WebViewEnvelope.build(
-            kind: WebViewEnvelope.kindMessage,
+    func testDispatcherHandlesResizeRequestWithoutForwardingToAppHandler() {
+        var handled = false
+        let envelope = WebViewEnvelope.Parsed(
+            kind: WebViewEnvelope.kindRequest,
             protocolVersion: 1,
             componentID: Self.componentID,
-            type: PaywallWebViewMessageType.variables,
-            payload: ["locale": .string("en-US")]
+            type: PaywallWebViewMessageType.resize,
+            id: "resize-req",
+            payload: ["height": .number(180)],
+            error: nil
         )
-        let script = try XCTUnwrap(PaywallWebViewController.receiveEnvelopeScript(envelope: envelope))
-        XCTAssertTrue(script.contains("\"rc:variables\""))
-        XCTAssertTrue(script.contains("\"locale\":\"en-US\""))
-        XCTAssertFalse(script.contains("\"variables\""))
+
+        PaywallWebViewMessageDispatcher.handle(
+            envelope: envelope,
+            componentID: Self.componentID,
+            protocolVersion: 1,
+            controller: self.makeController(channelOpen: true),
+            bridge: self.bridge(messageAction: { _, _ in handled = true })
+        )
+
+        XCTAssertFalse(handled)
     }
 
-    func testDispatcherAutoRepliesToRequestVariablesRequestForm() throws {
-        let envelope = WebViewEnvelope.build(
-            kind: WebViewEnvelope.kindResponse,
+    func testDispatcherAutoRepliesToRequestVariablesMessageForm() {
+        var delivered: [[String: PaywallWebViewValue]] = []
+        let controller = self.makeController(channelOpen: true) { delivered.append($0) }
+
+        PaywallWebViewMessageDispatcher.handle(
+            envelope: WebViewEnvelope.Parsed(
+                kind: WebViewEnvelope.kindMessage,
+                protocolVersion: 1,
+                componentID: Self.componentID,
+                type: PaywallWebViewMessageType.requestVariables,
+                id: nil,
+                payload: nil,
+                error: nil
+            ),
+            componentID: Self.componentID,
+            protocolVersion: 1,
+            controller: controller,
+            bridge: self.bridge(baseVariables: ["locale": .string("en-US")])
+        )
+
+        XCTAssertEqual(delivered.count, 1)
+        XCTAssertEqual(delivered[0][WebViewEnvelope.Field.kind], .string(WebViewEnvelope.kindMessage))
+        XCTAssertEqual(delivered[0][WebViewEnvelope.Field.type], .string(PaywallWebViewMessageType.variables))
+        XCTAssertEqual(delivered[0][WebViewEnvelope.Field.payload]?.objectValue?["locale"], .string("en-US"))
+    }
+
+    func testDispatcherAutoRepliesToRequestVariablesRequestForm() {
+        var delivered: [[String: PaywallWebViewValue]] = []
+        let controller = self.makeController(channelOpen: true) { delivered.append($0) }
+
+        PaywallWebViewMessageDispatcher.handle(
+            envelope: WebViewEnvelope.Parsed(
+                kind: WebViewEnvelope.kindRequest,
+                protocolVersion: 1,
+                componentID: Self.componentID,
+                type: PaywallWebViewMessageType.requestVariables,
+                id: "req-1",
+                payload: nil,
+                error: nil
+            ),
+            componentID: Self.componentID,
+            protocolVersion: 1,
+            controller: controller,
+            bridge: self.bridge(baseVariables: ["locale": .string("fr-FR")])
+        )
+
+        XCTAssertEqual(delivered.count, 1)
+        XCTAssertEqual(delivered[0][WebViewEnvelope.Field.kind], .string(WebViewEnvelope.kindResponse))
+        XCTAssertEqual(delivered[0][WebViewEnvelope.Field.id], .string("req-1"))
+        XCTAssertEqual(delivered[0][WebViewEnvelope.Field.type], .string(PaywallWebViewMessageType.requestVariables))
+        XCTAssertEqual(delivered[0][WebViewEnvelope.Field.payload]?.objectValue?["locale"], .string("fr-FR"))
+    }
+
+    func testFitEnvelopeDeclaresHostManagedAxes() throws {
+        let envelope = try XCTUnwrap(WebViewMessageBridge.fitEnvelope(
             protocolVersion: 1,
             componentID: Self.componentID,
-            type: PaywallWebViewMessageType.requestVariables,
-            id: "req-1",
-            payload: ["locale": .string("fr-FR")]
-        )
-        let script = try XCTUnwrap(PaywallWebViewController.receiveEnvelopeScript(envelope: envelope))
-        XCTAssertTrue(script.contains("\"kind\":\"response\""))
-        XCTAssertTrue(script.contains("\"id\":\"req-1\""))
-        XCTAssertTrue(script.contains("\"locale\":\"fr-FR\""))
+            size: .init(width: .fill, height: .fit)
+        ))
+
+        XCTAssertEqual(envelope[WebViewEnvelope.Field.type], .string(PaywallWebViewMessageType.fit))
+        XCTAssertEqual(envelope[WebViewEnvelope.Field.payload]?.objectValue?["height"], .bool(true))
+        XCTAssertNil(envelope[WebViewEnvelope.Field.payload]?.objectValue?["width"])
     }
 
     func testRejectEnvelopeFormatForUnsupportedProtocolVersion() throws {
@@ -283,9 +339,12 @@ final class PaywallWebViewBridgeTests: TestCase {
         )
     }
 
-    private func makeController(channelOpen: Bool) -> PaywallWebViewController {
+    private func makeController(
+        channelOpen: Bool,
+        onDeliverEnvelope: (([String: PaywallWebViewValue]) -> Void)? = nil
+    ) -> PaywallWebViewController {
         #if canImport(WebKit)
-        return PaywallWebViewController(
+        let controller = PaywallWebViewController(
             webView: nil,
             componentID: Self.componentID,
             expectedLoadedURL: Self.expectedURL,
@@ -293,13 +352,15 @@ final class PaywallWebViewBridgeTests: TestCase {
             channelOpen: { channelOpen }
         )
         #else
-        return PaywallWebViewController(
+        let controller = PaywallWebViewController(
             componentID: Self.componentID,
             expectedLoadedURL: Self.expectedURL,
             protocolVersion: 1,
             channelOpen: { channelOpen }
         )
         #endif
+        controller.envelopeDeliveryHandler = onDeliverEnvelope
+        return controller
     }
 
     private func embeddedJSON(in script: String) -> String? {

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewBridgeTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewBridgeTests.swift
@@ -24,258 +24,243 @@ import WebKit
 final class PaywallWebViewBridgeTests: TestCase {
 
     private static let componentID = "promo_web_view"
+    private static let expectedURL = URL(string: "https://assets.example.com/promo/index.html")!
+
+    // MARK: - Envelope model
+
+    func testEnvelopeParseRejectsWrongChannel() {
+        let parsed = WebViewEnvelope.parse([
+            WebViewEnvelope.Field.channel: "wrong",
+            WebViewEnvelope.Field.protocolVersion: 1,
+            WebViewEnvelope.Field.kind: WebViewEnvelope.kindConnect,
+            WebViewEnvelope.Field.componentID: ""
+        ])
+        XCTAssertNil(parsed)
+    }
+
+    func testEnvelopeParseAcceptsConnect() {
+        let parsed = WebViewEnvelope.parse([
+            WebViewEnvelope.Field.channel: WebViewEnvelope.channel,
+            WebViewEnvelope.Field.protocolVersion: 1,
+            WebViewEnvelope.Field.kind: WebViewEnvelope.kindConnect,
+            WebViewEnvelope.Field.componentID: ""
+        ])
+        XCTAssertEqual(parsed?.kind, WebViewEnvelope.kindConnect)
+    }
 
     // MARK: - SDK-managed variables
 
     func testBaseVariablesIncludeLocale() {
         let variables = PaywallWebViewVariables.base(locale: Locale(identifier: "en_US"))
-
         XCTAssertEqual(variables["locale"], .string("en-US"))
     }
 
-    // MARK: - Controller envelope / outbound JS
+    // MARK: - Controller outbound JS
 
-    func testReceiveMessageScriptProducesRFCEnvelope() throws {
-        let script = try XCTUnwrap(PaywallWebViewController.receiveMessageScript(
+    func testReceiveEnvelopeScriptUsesCanonicalReceiveFunction() throws {
+        let envelope = WebViewEnvelope.build(
+            kind: WebViewEnvelope.kindMessage,
+            protocolVersion: 1,
             componentID: Self.componentID,
-            type: "rc:variables",
-            variables: [
+            type: PaywallWebViewMessageType.variables,
+            payload: [
                 "locale": .string("en-US"),
                 "custom": .object(["plan": .string("annual")])
             ]
-        ))
-
-        XCTAssertTrue(script.contains("window.__revenueCatReceiveMessage"))
-        XCTAssertTrue(script.contains("typeof window.__revenueCatReceiveMessage==='function'"))
-
-        // The embedded payload must be valid JSON matching the RFC envelope.
-        let json = try XCTUnwrap(self.embeddedJSON(in: script))
-        let object = try XCTUnwrap(
-            JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any]
-        )
-        XCTAssertEqual(object["type"] as? String, "rc:variables")
-        XCTAssertEqual(object["component_id"] as? String, Self.componentID)
-        let variables = try XCTUnwrap(object["variables"] as? [String: Any])
-        XCTAssertEqual(variables["locale"] as? String, "en-US")
-    }
-
-    // MARK: - Dispatcher routing
-
-    func testDispatcherRejectsNonMainFrameMessages() {
-        var handled = false
-        PaywallWebViewMessageDispatcher.handle(
-            body: ["type": "rc:step-loaded", "component_id": Self.componentID],
-            isMainFrame: false,
-            componentID: Self.componentID,
-            controller: self.makeController(),
-            bridge: self.bridge { _, _ in handled = true }
         )
 
-        XCTAssertFalse(handled, "Messages from non-main frames must be dropped")
-    }
+        let script = try XCTUnwrap(PaywallWebViewController.receiveEnvelopeScript(envelope: envelope))
 
-    func testDispatcherForwardsValidMessageToHandler() {
-        var received: PaywallWebViewMessage?
-        PaywallWebViewMessageDispatcher.handle(
-            body: [
-                "type": "rc:step-complete",
-                "component_id": Self.componentID,
-                "responses": ["selected_plan": "annual"]
-            ],
-            isMainFrame: true,
-            componentID: Self.componentID,
-            controller: self.makeController(),
-            bridge: self.bridge { message, _ in received = message }
-        )
-
-        XCTAssertEqual(received?.type, "rc:step-complete")
-        XCTAssertEqual(received?.componentID, Self.componentID)
-        XCTAssertEqual(received?.responses?["selected_plan"], .string("annual"))
-    }
-
-    func testDispatcherDropsMismatchedComponentID() {
-        var handled = false
-        PaywallWebViewMessageDispatcher.handle(
-            body: ["type": "rc:step-loaded", "component_id": "other"],
-            isMainFrame: true,
-            componentID: Self.componentID,
-            controller: self.makeController(),
-            bridge: self.bridge { _, _ in handled = true }
-        )
-
-        XCTAssertFalse(handled, "Messages for a different component must be rejected")
-    }
-
-    func testDispatcherStillInvokesHandlerForRequestVariables() {
-        var received: PaywallWebViewMessage?
-        PaywallWebViewMessageDispatcher.handle(
-            body: ["type": "rc:request-variables", "component_id": Self.componentID],
-            isMainFrame: true,
-            componentID: Self.componentID,
-            controller: self.makeController(),
-            bridge: self.bridge(baseVariables: ["locale": .string("en-US")]) { message, _ in received = message }
-        )
-
-        XCTAssertEqual(received?.type, "rc:request-variables")
-    }
-
-    // MARK: - JavaScript injection
-
-    func testBridgeScriptExposesPostMessageAndHandlerName() {
-        let source = PaywallWebViewScripts.messageBridgeJavaScriptSource
-        XCTAssertTrue(source.contains("window.RevenueCatWebView"))
-        XCTAssertTrue(source.contains("postMessage"))
-        XCTAssertTrue(source.contains("window.webkit.messageHandlers.rcWebViewMessage"))
-        XCTAssertTrue(source.contains("__rcBridgeInstalled"))
-    }
-
-    func testBridgeUsesDedicatedHandlerNameSeparateFromHeight() {
-        XCTAssertEqual(PaywallWebViewScripts.messageHandlerName, "rcWebViewMessage")
-        XCTAssertNotEqual(PaywallWebViewScripts.messageHandlerName, "rcWebViewHeight")
-    }
-
-    // MARK: - Outbound JS escaping (security)
-
-    func testReceiveMessageScriptEscapesHostileStringValues() throws {
-        // Quotes, backslashes, newlines, and a literal closing-script sequence must all be confined
-        // to the JSON payload and survive a round-trip exactly — never breaking out of the call.
-        let hostile = "annual\" }); alert('xss'); //\n</script>\\ end\u{2028}\u{2029}"
-        let script = try XCTUnwrap(PaywallWebViewController.receiveMessageScript(
-            componentID: Self.componentID,
-            type: "rc:variables",
-            variables: ["custom": .object(["evil": .string(hostile)])]
-        ))
+        XCTAssertTrue(script.contains("window.__rcWebComponentsReceive"))
+        XCTAssertTrue(script.contains("typeof window.__rcWebComponentsReceive==='function'"))
 
         let json = try XCTUnwrap(self.embeddedJSON(in: script))
         let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
-        let variables = try XCTUnwrap(object["variables"] as? [String: Any])
-        let custom = try XCTUnwrap(variables["custom"] as? [String: Any])
-        XCTAssertEqual(custom["evil"] as? String, hostile)
+        XCTAssertEqual(object[WebViewEnvelope.Field.channel] as? String, WebViewEnvelope.channel)
+        XCTAssertEqual(object[WebViewEnvelope.Field.kind] as? String, WebViewEnvelope.kindMessage)
+        XCTAssertEqual(object[WebViewEnvelope.Field.type] as? String, "rc:variables")
+        let payload = try XCTUnwrap(object[WebViewEnvelope.Field.payload] as? [String: Any])
+        XCTAssertEqual(payload["locale"] as? String, "en-US")
+        XCTAssertNil(payload["variables"])
+    }
 
-        // A raw newline would make the `var m=...` statement a syntax error; it must be escaped.
+    func testPostVariablesStripsReservedLocaleKey() throws {
+        let sanitized = PaywallWebViewController.sanitizeAppProvidedVariables([
+            "locale": .string("zz-ZZ"),
+            "custom": .object(["k": .string("v")])
+        ])
+
+        XCTAssertNil(sanitized["locale"])
+        XCTAssertEqual(sanitized["custom"], .object(["k": .string("v")]))
+    }
+
+    func testReceiveEnvelopeScriptEscapesHostileStringValues() throws {
+        let hostile = "annual\" }); alert('xss'); //\n</script>\\ end\u{2028}\u{2029}"
+        let envelope = WebViewEnvelope.build(
+            kind: WebViewEnvelope.kindMessage,
+            protocolVersion: 1,
+            componentID: Self.componentID,
+            type: PaywallWebViewMessageType.variables,
+            payload: ["custom": .object(["evil": .string(hostile)])]
+        )
+
+        let script = try XCTUnwrap(PaywallWebViewController.receiveEnvelopeScript(envelope: envelope))
+        let json = try XCTUnwrap(self.embeddedJSON(in: script))
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+        let payload = try XCTUnwrap(object[WebViewEnvelope.Field.payload] as? [String: Any])
+        let custom = try XCTUnwrap(payload["custom"] as? [String: Any])
+        XCTAssertEqual(custom["evil"] as? String, hostile)
         XCTAssertFalse(json.contains("\n"))
     }
 
-    func testReceiveMessageScriptSerializesAllValueTypes() throws {
-        let script = try XCTUnwrap(PaywallWebViewController.receiveMessageScript(
+    // MARK: - Dispatcher
+
+    func testDispatcherHandlesResizeBeforeAppHandler() {
+        var reportedHeight: CGFloat?
+        let bridge = self.bridge(onContentResize: { _, height in
+            reportedHeight = height
+        })
+
+        let envelope = WebViewEnvelope.Parsed(
+            kind: WebViewEnvelope.kindMessage,
+            protocolVersion: 1,
             componentID: Self.componentID,
-            type: "rc:variables",
-            variables: [
-                "string": .string("s"),
-                "number": .number(3.5),
-                "bool": .bool(false),
-                "null": .null,
-                "array": .array([.number(1), .string("two")]),
-                "object": .object(["nested": .bool(true)])
-            ]
+            type: PaywallWebViewMessageType.resize,
+            id: nil,
+            payload: ["height": .number(240)],
+            error: nil
+        )
+
+        var handled = false
+        PaywallWebViewMessageDispatcher.handle(
+            envelope: envelope,
+            componentID: Self.componentID,
+            protocolVersion: 1,
+            controller: self.makeController(channelOpen: true),
+            bridge: self.bridge(
+                onContentResize: { _, height in reportedHeight = height },
+                messageAction: { _, _ in handled = true }
+            )
+        )
+
+        XCTAssertEqual(reportedHeight, 240)
+        XCTAssertFalse(handled)
+    }
+
+    func testDispatcherAutoRepliesToRequestVariablesMessageForm() throws {
+        let envelope = WebViewEnvelope.build(
+            kind: WebViewEnvelope.kindMessage,
+            protocolVersion: 1,
+            componentID: Self.componentID,
+            type: PaywallWebViewMessageType.variables,
+            payload: ["locale": .string("en-US")]
+        )
+        let script = try XCTUnwrap(PaywallWebViewController.receiveEnvelopeScript(envelope: envelope))
+        XCTAssertTrue(script.contains("\"rc:variables\""))
+        XCTAssertTrue(script.contains("\"locale\":\"en-US\""))
+        XCTAssertFalse(script.contains("\"variables\""))
+    }
+
+    func testDispatcherAutoRepliesToRequestVariablesRequestForm() throws {
+        let envelope = WebViewEnvelope.build(
+            kind: WebViewEnvelope.kindResponse,
+            protocolVersion: 1,
+            componentID: Self.componentID,
+            type: PaywallWebViewMessageType.requestVariables,
+            id: "req-1",
+            payload: ["locale": .string("fr-FR")]
+        )
+        let script = try XCTUnwrap(PaywallWebViewController.receiveEnvelopeScript(envelope: envelope))
+        XCTAssertTrue(script.contains("\"kind\":\"response\""))
+        XCTAssertTrue(script.contains("\"id\":\"req-1\""))
+        XCTAssertTrue(script.contains("\"locale\":\"fr-FR\""))
+    }
+
+    func testRejectEnvelopeFormatForUnsupportedProtocolVersion() throws {
+        let envelope = WebViewEnvelope.build(
+            kind: WebViewEnvelope.kindReject,
+            protocolVersion: 1,
+            componentID: "",
+            error: "Unsupported protocol_version 2; native host supports 1"
+        )
+
+        let script = try XCTUnwrap(PaywallWebViewController.receiveEnvelopeScript(envelope: envelope))
+        XCTAssertTrue(script.contains("\"kind\":\"reject\""))
+        XCTAssertTrue(script.contains("Unsupported protocol_version 2"))
+    }
+
+    // MARK: - Origin gating
+
+    func testOriginMatchesDefaultHTTPSPort() {
+        XCTAssertTrue(WebViewOrigin.matches(
+            currentURL: URL(string: "https://assets.example.com:443/promo/step-two.html"),
+            expectedURL: Self.expectedURL,
+            allowBeforeNavigation: false
         ))
-
-        let json = try XCTUnwrap(self.embeddedJSON(in: script))
-        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
-        let variables = try XCTUnwrap(object["variables"] as? [String: Any])
-        XCTAssertEqual(variables["string"] as? String, "s")
-        XCTAssertEqual(variables["number"] as? Double, 3.5)
-        XCTAssertEqual(variables["bool"] as? Bool, false)
-        XCTAssertTrue(variables["null"] is NSNull)
-        let array = try XCTUnwrap(variables["array"] as? [Any])
-        XCTAssertEqual(array.count, 2)
-        XCTAssertEqual(array.first as? Double, 1)
-        XCTAssertEqual(array.last as? String, "two")
-        XCTAssertEqual((variables["object"] as? [String: Any])?["nested"] as? Bool, true)
     }
 
-    // MARK: - Variables: locale formatting
-
-    func testBaseVariablesFormatsLanguageOnlyLocale() {
-        let variables = PaywallWebViewVariables.base(locale: Locale(identifier: "fr"))
-
-        XCTAssertEqual(variables["locale"], .string("fr"))
+    func testOriginRejectsCrossOriginNavigation() {
+        XCTAssertFalse(WebViewOrigin.matches(
+            currentURL: URL(string: "https://evil.example.org/phish.html"),
+            expectedURL: Self.expectedURL,
+            allowBeforeNavigation: false
+        ))
     }
 
-    func testBaseVariablesFormatsScriptAndRegionLocaleAsBCP47() {
-        let variables = PaywallWebViewVariables.base(locale: Locale(identifier: "zh_Hans_CN"))
+    func testOriginAllowsHandshakeBeforeNavigation() {
+        XCTAssertTrue(WebViewOrigin.matches(
+            currentURL: nil,
+            expectedURL: Self.expectedURL,
+            allowBeforeNavigation: true
+        ))
+    }
 
-        // Must use hyphen separators (BCP-47), never the underscore form.
-        let locale = variables["locale"]?.stringValue
-        XCTAssertEqual(locale?.contains("_"), false)
-        XCTAssertEqual(locale?.contains("zh"), true)
+    func testOriginComparisonIsCaseInsensitiveForHost() {
+        XCTAssertTrue(WebViewOrigin.matches(
+            currentURL: URL(string: "https://ASSETS.EXAMPLE.COM/promo/index.html"),
+            expectedURL: Self.expectedURL,
+            allowBeforeNavigation: false
+        ))
     }
 
 #if canImport(WebKit)
 
-    // MARK: - WebKit round-trip integration
-
-    func testWebContentPostMessageReachesNativeHandler() {
-        let handlerCalled = self.expectation(description: "native handler invoked")
-        var receivedBody: Any?
-        let handler = TestScriptMessageHandler { message in
-            receivedBody = message.body
-            handlerCalled.fulfill()
-        }
+    func testWebContentMessageReachesAppHandlerAfterHandshake() {
+        var received: PaywallWebViewMessage?
+        let host = TestWebViewBridgeHost(expectedURL: Self.expectedURL)
+        host.currentURL = Self.expectedURL
+        host.bridge = self.bridge { message, _ in received = message }
+        let messageBridge = WebViewMessageBridge(host: host)
 
         let config = WKWebViewConfiguration()
-        config.userContentController.addUserScript(PaywallWebViewScripts.messageBridgeUserScript)
-        config.userContentController.add(handler, name: PaywallWebViewScripts.messageHandlerName)
-
         let webView = self.loadedWebView(html: "<html><body>hi</body></html>", configuration: config)
+        messageBridge.registerIfNeeded(on: webView)
 
         webView.evaluateJavaScript(
-            "window.RevenueCatWebView.postMessage("
-            + "{type:'rc:step-complete',component_id:'\(Self.componentID)',responses:{selected_plan:'annual'}}); true"
+            """
+            window.webkit.messageHandlers.\(WebViewEnvelope.messageHandlerName).postMessage(
+            '{"channel":"rc-web-components","protocol_version":1,"kind":"connect","component_id":""}'
+            ); true
+            """
         )
 
-        self.wait(for: [handlerCalled], timeout: 10)
-        config.userContentController.removeScriptMessageHandler(forName: PaywallWebViewScripts.messageHandlerName)
-
-        let body = receivedBody as? [String: Any]
-        XCTAssertEqual(body?["type"] as? String, "rc:step-complete")
-        XCTAssertEqual(body?["component_id"] as? String, Self.componentID)
-        XCTAssertEqual((body?["responses"] as? [String: Any])?["selected_plan"] as? String, "annual")
-    }
-
-    func testControllerDeliversVariablesToWebContentIntact() throws {
-        let webView = self.loadedWebView(html: Self.receiverHTML)
-
-        let controller = PaywallWebViewController(
-            webView: webView,
-            componentID: Self.componentID,
-            expectedLoadedURL: webView.url
+        webView.evaluateJavaScript(
+            """
+            window.webkit.messageHandlers.\(WebViewEnvelope.messageHandlerName).postMessage(
+            '{"channel":"rc-web-components","protocol_version":1,"kind":"message",\
+            "component_id":"\(Self.componentID)","type":"rc:step-loaded"}'
+            ); true
+            """
         )
 
-        // Include hostile characters to prove escaping survives the real evaluateJavaScript path.
-        let hostile = "annual\" }); //\n</script>\\ end"
-        controller.postVariables(
-            componentID: Self.componentID,
-            variables: ["locale": .string("en-US"), "custom": .object(["plan": .string(hostile)])]
-        )
+        let delivered = self.expectation(description: "message delivered")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            if received != nil { delivered.fulfill() }
+        }
+        self.wait(for: [delivered], timeout: 2)
 
-        let received = try XCTUnwrap(self.pollString(in: webView, script: "window.__rcReceived"))
-        let object = try XCTUnwrap(
-            JSONSerialization.jsonObject(with: Data(received.utf8)) as? [String: Any]
-        )
-        XCTAssertEqual(object["type"] as? String, "rc:variables")
-        XCTAssertEqual(object["component_id"] as? String, Self.componentID)
-        let variables = try XCTUnwrap(object["variables"] as? [String: Any])
-        XCTAssertEqual(variables["locale"] as? String, "en-US")
-        XCTAssertEqual((variables["custom"] as? [String: Any])?["plan"] as? String, hostile)
-    }
-
-    func testControllerSkipsDeliveryWhenURLMismatches() throws {
-        let webView = self.loadedWebView(html: Self.receiverHTML)
-
-        let controller = PaywallWebViewController(
-            webView: webView,
-            componentID: Self.componentID,
-            expectedLoadedURL: URL(string: "https://different.example.com/elsewhere")!
-        )
-        controller.postVariables(componentID: Self.componentID, variables: ["locale": .string("en-US")])
-
-        // The receive hook must never fire for a mismatched expected URL.
-        let state = try XCTUnwrap(self.pollString(
-            in: webView,
-            script: "window.__rcReceived === null ? 'NULL' : 'GOT'"
-        ))
-        XCTAssertEqual(state, "NULL")
+        XCTAssertEqual(received?.type, "rc:step-loaded")
+        messageBridge.unregister(from: webView)
     }
 
 #endif
@@ -284,25 +269,39 @@ final class PaywallWebViewBridgeTests: TestCase {
 
     private func bridge(
         baseVariables: [String: PaywallWebViewValue] = [:],
-        messageAction: @escaping @MainActor (PaywallWebViewMessage, PaywallWebViewController) -> Void
+        onContentResize: @escaping (CGFloat?, CGFloat?) -> Void = { _, _ in },
+        messageAction: @escaping @MainActor (PaywallWebViewMessage, PaywallWebViewController) -> Void = { _, _ in }
     ) -> WebViewBridgeConfiguration {
         WebViewBridgeConfiguration(
             componentID: Self.componentID,
+            protocolVersion: 1,
+            expectedURL: Self.expectedURL,
             messageAction: PaywallWebViewMessageAction(messageAction),
-            baseVariables: baseVariables
+            baseVariables: baseVariables,
+            size: .init(width: .fill, height: .fit),
+            onContentResize: onContentResize
         )
     }
 
-    private func makeController() -> PaywallWebViewController {
+    private func makeController(channelOpen: Bool) -> PaywallWebViewController {
         #if canImport(WebKit)
-        return PaywallWebViewController(webView: nil, componentID: Self.componentID, expectedLoadedURL: nil)
+        return PaywallWebViewController(
+            webView: nil,
+            componentID: Self.componentID,
+            expectedLoadedURL: Self.expectedURL,
+            protocolVersion: 1,
+            channelOpen: { channelOpen }
+        )
         #else
-        return PaywallWebViewController(componentID: Self.componentID, expectedLoadedURL: nil)
+        return PaywallWebViewController(
+            componentID: Self.componentID,
+            expectedLoadedURL: Self.expectedURL,
+            protocolVersion: 1,
+            channelOpen: { channelOpen }
+        )
         #endif
     }
 
-    /// Extracts the JSON object literal embedded between `var m=` and `;if(typeof` in the receive
-    /// script, for assertion purposes.
     private func embeddedJSON(in script: String) -> String? {
         guard let start = script.range(of: "var m="),
               let end = script.range(of: ";if(typeof") else {
@@ -313,80 +312,44 @@ final class PaywallWebViewBridgeTests: TestCase {
 
 #if canImport(WebKit)
 
-    /// HTML whose receive hook stores the last message it gets as a JSON string on `window.__rcReceived`.
-    private static let receiverHTML = """
-    <html><body><script>
-    window.__rcReceived = null;
-    window.__revenueCatReceiveMessage = function(m) { window.__rcReceived = JSON.stringify(m); };
-    </script></body></html>
-    """
-
-    /// Keeps navigation delegates alive for the duration of a test (`WKWebView.navigationDelegate` is weak).
     private var retainedDelegates: [AnyObject] = []
 
     private func loadedWebView(
         html: String,
         configuration: WKWebViewConfiguration = WKWebViewConfiguration()
     ) -> WKWebView {
-        if configuration.userContentController.userScripts.isEmpty {
-            configuration.userContentController.addUserScript(PaywallWebViewScripts.messageBridgeUserScript)
-        }
         let webView = WKWebView(frame: .zero, configuration: configuration)
 
         let loaded = self.expectation(description: "web view finished loading")
         let delegate = TestNavigationDelegate { loaded.fulfill() }
         self.retainedDelegates.append(delegate)
         webView.navigationDelegate = delegate
-        webView.loadHTMLString(html, baseURL: URL(string: "https://example.com"))
+        webView.loadHTMLString(html, baseURL: Self.expectedURL)
         self.wait(for: [loaded], timeout: 10)
 
         return webView
-    }
-
-    /// Repeatedly evaluates `script` until it returns a non-nil string or the timeout elapses.
-    private func pollString(in webView: WKWebView, script: String, timeout: TimeInterval = 5) -> String? {
-        let deadline = Date().addingTimeInterval(timeout)
-        var result: String?
-
-        while result == nil && Date() < deadline {
-            let evaluated = self.expectation(description: "evaluate \(script)")
-            webView.evaluateJavaScript(script) { value, _ in
-                result = value as? String
-                evaluated.fulfill()
-            }
-            self.wait(for: [evaluated], timeout: 2)
-
-            if result == nil {
-                RunLoop.current.run(until: Date().addingTimeInterval(0.1))
-            }
-        }
-
-        return result
     }
 
 #endif
 
 }
 
-#if canImport(WebKit)
-
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-private final class TestScriptMessageHandler: NSObject, WKScriptMessageHandler {
+@MainActor
+private final class TestWebViewBridgeHost: WebViewBridgeHost {
+    var bridge: WebViewBridgeConfiguration?
+    var currentURL: URL?
 
-    private let onMessage: (WKScriptMessage) -> Void
+    let expectedURL: URL
 
-    init(onMessage: @escaping (WKScriptMessage) -> Void) {
-        self.onMessage = onMessage
+    init(expectedURL: URL) {
+        self.expectedURL = expectedURL
     }
 
-    func userContentController(
-        _ userContentController: WKUserContentController,
-        didReceive message: WKScriptMessage
-    ) {
-        self.onMessage(message)
-    }
-
+    func resetMeasuredContentSize() {}
 }
+
+#if canImport(WebKit)
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private final class TestNavigationDelegate: NSObject, WKNavigationDelegate {

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewMessageParserTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewMessageParserTests.swift
@@ -24,127 +24,127 @@ final class PaywallWebViewMessageParserTests: TestCase {
         PaywallWebViewMessageParser(expectedComponentID: componentID)
     }
 
-    // MARK: - Message parsing: valid
-
-    func testParsesStepLoaded() throws {
-        let result = self.parser().parse([
-            "type": "rc:step-loaded",
-            "component_id": Self.componentID
-        ])
-
-        let message = try result.get()
-        XCTAssertEqual(message.type, "rc:step-loaded")
-        XCTAssertEqual(message.componentID, Self.componentID)
-        XCTAssertNil(message.responses)
-        XCTAssertNil(message.error)
+    private func envelope(
+        kind: String = WebViewEnvelope.kindMessage,
+        type: String,
+        payload: [String: Any]? = nil,
+        id: String? = nil,
+        componentID: String = componentID
+    ) -> [String: Any] {
+        var dictionary: [String: Any] = [
+            WebViewEnvelope.Field.channel: WebViewEnvelope.channel,
+            WebViewEnvelope.Field.protocolVersion: 1,
+            WebViewEnvelope.Field.kind: kind,
+            WebViewEnvelope.Field.componentID: componentID,
+            WebViewEnvelope.Field.type: type
+        ]
+        if let payload {
+            dictionary[WebViewEnvelope.Field.payload] = payload
+        }
+        if let id {
+            dictionary[WebViewEnvelope.Field.id] = id
+        }
+        return dictionary
     }
 
-    func testParsesStepCompleteWithResponses() throws {
-        let result = self.parser().parse([
-            "type": "rc:step-complete",
-            "component_id": Self.componentID,
-            "responses": [
-                "selected_plan": "annual",
-                "accepted_terms": true
-            ]
-        ])
+    // MARK: - Envelope parsing
 
-        let message = try result.get()
-        XCTAssertEqual(message.type, "rc:step-complete")
+    func testParsesStepLoaded() throws {
+        let result = self.parser().parseEnvelope(self.envelope(type: PaywallWebViewMessageType.stepLoaded))
+
+        let message = try result.get().message
+        XCTAssertEqual(message.type, "rc:step-loaded")
+        XCTAssertEqual(message.componentID, Self.componentID)
+    }
+
+    func testParsesStepCompleteWithResponsesInPayload() throws {
+        let result = self.parser().parseEnvelope(self.envelope(
+            type: PaywallWebViewMessageType.stepComplete,
+            payload: [
+                WebViewEnvelope.Field.responses: [
+                    "selected_plan": "annual",
+                    "accepted_terms": true
+                ]
+            ]
+        ))
+
+        let message = try result.get().message
         XCTAssertEqual(message.responses?["selected_plan"], .string("annual"))
         XCTAssertEqual(message.responses?["accepted_terms"], .bool(true))
     }
 
-    func testParsesStepCompleteWithoutResponses() throws {
-        let result = self.parser().parse([
-            "type": "rc:step-complete",
-            "component_id": Self.componentID
-        ])
+    func testParsesStepCompleteWithFlatPayload() throws {
+        let result = self.parser().parseEnvelope(self.envelope(
+            type: PaywallWebViewMessageType.stepComplete,
+            payload: ["selected_plan": "annual"]
+        ))
 
-        let message = try result.get()
-        XCTAssertNil(message.responses)
+        XCTAssertEqual(try result.get().message.responses?["selected_plan"], .string("annual"))
     }
 
-    func testParsesRequestVariables() throws {
-        let result = self.parser().parse([
-            "type": "rc:request-variables",
-            "component_id": Self.componentID
-        ])
+    func testParsesRequestVariablesAsTransportRequest() throws {
+        let result = self.parser().parseEnvelope(self.envelope(
+            kind: WebViewEnvelope.kindRequest,
+            type: PaywallWebViewMessageType.requestVariables,
+            id: "req-1"
+        ))
 
-        XCTAssertEqual(try result.get().type, "rc:request-variables")
+        let parsed = try result.get()
+        XCTAssertEqual(parsed.message.type, "rc:request-variables")
+        XCTAssertEqual(parsed.requestID, "req-1")
     }
 
-    func testParsesError() throws {
-        let result = self.parser().parse([
-            "type": "rc:error",
-            "component_id": Self.componentID,
-            "error": "Something went wrong"
-        ])
+    func testParsesErrorFromPayload() throws {
+        let result = self.parser().parseEnvelope(self.envelope(
+            type: PaywallWebViewMessageType.error,
+            payload: [WebViewEnvelope.Field.error: "Something went wrong"]
+        ))
 
-        let message = try result.get()
-        XCTAssertEqual(message.type, "rc:error")
-        XCTAssertEqual(message.error, "Something went wrong")
+        XCTAssertEqual(try result.get().message.error, "Something went wrong")
     }
 
-    // MARK: - Message parsing: invalid
-
-    func testRejectsNonObjectBody() {
-        XCTAssertEqual(self.parser().parse("not an object").failure, .notAnObject)
+    func testRejectsWrongChannel() {
+        var body = self.envelope(type: PaywallWebViewMessageType.stepLoaded)
+        body[WebViewEnvelope.Field.channel] = "wrong"
+        XCTAssertEqual(self.parser().parseEnvelope(body).failure, .invalidEnvelope)
     }
 
-    func testRejectsMissingType() {
-        let result = self.parser().parse(["component_id": Self.componentID])
-        XCTAssertEqual(result.failure, .missingType)
-    }
-
-    func testRejectsMissingComponentID() {
-        let result = self.parser().parse(["type": "rc:step-loaded"])
-        XCTAssertEqual(result.failure, .missingComponentID)
+    func testRejectsMissingKind() {
+        var body = self.envelope(type: PaywallWebViewMessageType.stepLoaded)
+        body.removeValue(forKey: WebViewEnvelope.Field.kind)
+        XCTAssertEqual(self.parser().parseEnvelope(body).failure, .invalidEnvelope)
     }
 
     func testRejectsMismatchedComponentID() {
-        let result = self.parser().parse([
-            "type": "rc:step-loaded",
-            "component_id": "a_different_component"
-        ])
+        let result = self.parser().parseEnvelope(self.envelope(
+            type: PaywallWebViewMessageType.stepLoaded,
+            componentID: "other"
+        ))
         XCTAssertEqual(
             result.failure,
-            .componentIDMismatch(expected: Self.componentID, received: "a_different_component")
+            .componentIDMismatch(expected: Self.componentID, received: "other")
         )
     }
 
-    func testRejectsInvalidResponsesShape() {
-        let result = self.parser().parse([
-            "type": "rc:step-complete",
-            "component_id": Self.componentID,
-            "responses": "not an object"
-        ])
-        XCTAssertEqual(result.failure, .invalidResponses)
-    }
-
-    func testRejectsErrorWithoutErrorField() {
-        let result = self.parser().parse([
-            "type": "rc:error",
-            "component_id": Self.componentID
-        ])
-        XCTAssertEqual(result.failure, .missingError)
+    func testRejectsTransportRequestWithoutID() {
+        let result = self.parser().parseEnvelope(self.envelope(
+            kind: WebViewEnvelope.kindRequest,
+            type: PaywallWebViewMessageType.requestVariables
+        ))
+        XCTAssertEqual(result.failure, .missingRequestID)
     }
 
     func testDropsUnknownType() {
-        let result = self.parser().parse([
-            "type": "rc:totally-unknown",
-            "component_id": Self.componentID
-        ])
+        let result = self.parser().parseEnvelope(self.envelope(type: "rc:totally-unknown"))
         XCTAssertEqual(result.failure, .unsupportedType("rc:totally-unknown"))
     }
 
     func testRejectsOversizedPayload() {
         let huge = String(repeating: "a", count: PaywallWebViewMessageParser.maxPayloadBytes + 1)
-        let result = self.parser().parse([
-            "type": "rc:step-complete",
-            "component_id": Self.componentID,
-            "responses": ["blob": huge]
-        ])
+        let result = self.parser().parseEnvelope(self.envelope(
+            type: PaywallWebViewMessageType.stepComplete,
+            payload: [WebViewEnvelope.Field.responses: ["blob": huge]]
+        ))
 
         guard case .oversizedPayload = result.failure else {
             return XCTFail("Expected .oversizedPayload, got \(String(describing: result.failure))")
@@ -152,30 +152,23 @@ final class PaywallWebViewMessageParserTests: TestCase {
     }
 
     func testRejectsExcessivelyNestedResponses() {
-        // Build an array nested deeper than the allowed depth.
         var nested: Any = "leaf"
         for _ in 0...(PaywallWebViewValue.maxDepth + 2) {
             nested = [nested]
         }
-        let result = self.parser().parse([
-            "type": "rc:step-complete",
-            "component_id": Self.componentID,
-            "responses": ["deep": nested]
-        ])
+        let result = self.parser().parseEnvelope(self.envelope(
+            type: PaywallWebViewMessageType.stepComplete,
+            payload: [WebViewEnvelope.Field.responses: ["deep": nested]]
+        ))
         XCTAssertEqual(result.failure, .invalidResponses)
     }
 
-    func testRejectsNonJSONValueInResponses() {
-        let result = self.parser().parse([
-            "type": "rc:step-complete",
-            "component_id": Self.componentID,
-            "responses": ["when": Date()]
-        ])
-        // A `Date` is not JSON-serializable, so the body fails the up-front size/JSON check.
-        XCTAssertEqual(result.failure, .invalidValue)
+    func testParsesJSONStringBody() throws {
+        let data = try JSONSerialization.data(withJSONObject: self.envelope(type: PaywallWebViewMessageType.stepLoaded))
+        let json = String(data: data, encoding: .utf8)!
+        let result = self.parser().parseEnvelope(json)
+        XCTAssertEqual(try result.get().message.type, "rc:step-loaded")
     }
-
-    // MARK: - Protocol message-type constants
 
     func testMessageTypeConstantsMatchProtocol() {
         XCTAssertEqual(PaywallWebViewMessageType.stepLoaded, "rc:step-loaded")
@@ -183,52 +176,7 @@ final class PaywallWebViewMessageParserTests: TestCase {
         XCTAssertEqual(PaywallWebViewMessageType.requestVariables, "rc:request-variables")
         XCTAssertEqual(PaywallWebViewMessageType.error, "rc:error")
         XCTAssertEqual(PaywallWebViewMessageType.variables, "rc:variables")
-    }
-
-    // MARK: - Size limit & richer responses
-
-    func testParserAcceptsLargePayloadUnderLimit() throws {
-        let blob = String(repeating: "a", count: PaywallWebViewMessageParser.maxPayloadBytes / 2)
-        let result = self.parser().parse([
-            "type": "rc:step-complete",
-            "component_id": Self.componentID,
-            "responses": ["blob": blob]
-        ])
-
-        XCTAssertEqual(try result.get().responses?["blob"], .string(blob))
-    }
-
-    func testParserAcceptsResponsesWithNestedJSONValues() throws {
-        let result = self.parser().parse([
-            "type": "rc:step-complete",
-            "component_id": Self.componentID,
-            "responses": [
-                "selected_plan": "annual",
-                "quantity": 3,
-                "accepted_terms": true,
-                "coupon": NSNull(),
-                "addons": ["a", "b"],
-                "meta": ["source": "onboarding"]
-            ]
-        ])
-
-        let responses = try XCTUnwrap(result.get().responses)
-        XCTAssertEqual(responses["selected_plan"], .string("annual"))
-        XCTAssertEqual(responses["quantity"], .number(3))
-        XCTAssertEqual(responses["accepted_terms"], .bool(true))
-        XCTAssertEqual(responses["coupon"], .null)
-        XCTAssertEqual(responses["addons"], .array([.string("a"), .string("b")]))
-        XCTAssertEqual(responses["meta"], .object(["source": .string("onboarding")]))
-    }
-
-    func testParserAcceptsEmptyResponsesObject() throws {
-        let result = self.parser().parse([
-            "type": "rc:step-complete",
-            "component_id": Self.componentID,
-            "responses": [String: Any]()
-        ])
-
-        XCTAssertEqual(try result.get().responses, [:])
+        XCTAssertEqual(PaywallWebViewMessageType.resize, "resize")
     }
 
 }

--- a/Tests/RevenueCatUITests/PaywallsV2/WebViewCapabilitiesTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WebViewCapabilitiesTests.swift
@@ -23,7 +23,7 @@ final class WebViewCapabilitiesTests: TestCase {
     // MARK: - Content-blocking rules
 
     func testContentRuleListIdentifierIsStableConstant() {
-        XCTAssertEqual(WebViewCapabilitiesConfiguration.contentRuleListIdentifier, "rc-webview-v1-isolation")
+        XCTAssertEqual(WebViewCapabilitiesConfiguration.contentRuleListIdentifier, "rc-webview-v2-isolation")
     }
 
     func testContentBlockingRulesAreValidJSON() throws {
@@ -31,9 +31,9 @@ final class WebViewCapabilitiesTests: TestCase {
         XCTAssertNoThrow(try JSONSerialization.jsonObject(with: Data(rules.utf8)))
     }
 
-    func testContentBlockingRulesHaveThreeBlockRules() throws {
+    func testContentBlockingRulesHaveTwoBlockRules() throws {
         let parsed = try Self.parseRules()
-        XCTAssertEqual(parsed.count, 3)
+        XCTAssertEqual(parsed.count, 2)
         for rule in parsed {
             let action = try XCTUnwrap(rule["action"] as? [String: Any])
             XCTAssertEqual(action["type"] as? String, "block")
@@ -44,23 +44,32 @@ final class WebViewCapabilitiesTests: TestCase {
         let trigger = try Self.trigger(matchingResourceTypes: ["image", "script", "font"])
 
         XCTAssertEqual(trigger["url-filter"] as? String, ".*")
-        // Only third-party (remote) loads are blocked, so same-origin assets still load.
         XCTAssertEqual(trigger["load-type"] as? [String], ["third-party"])
     }
 
-    func testDataImagesAndFontsAreBlocked() throws {
-        let trigger = try Self.trigger(matchingResourceTypes: ["image", "font"])
-
-        XCTAssertEqual(trigger["url-filter"] as? String, "^data:")
-        // Block regardless of load type — there is no same-origin carve-out for `data:`.
-        XCTAssertNil(trigger["load-type"])
-    }
-
-    func testXHRIsBlocked() throws {
+    func testThirdPartyXHRIsBlocked() throws {
         let trigger = try Self.trigger(matchingResourceTypes: ["raw"])
 
         XCTAssertEqual(trigger["url-filter"] as? String, ".*")
-        XCTAssertNil(trigger["load-type"])
+        XCTAssertEqual(trigger["load-type"] as? [String], ["third-party"])
+    }
+
+    func testLoadIsolatedDoesNotLoadWhenRuleListCompilationFails() {
+        let webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let originalStore = WebViewContentRuleListStore.shared
+        defer { WebViewContentRuleListStore.shared = originalStore }
+        WebViewContentRuleListStore.shared = FailingWebViewContentRuleListStore()
+
+        let url = URL(string: "https://example.com/bundle.html")!
+        PaywallWebViewScripts.loadIsolated(url: url, on: webView)
+
+        let expectation = self.expectation(description: "rule list callback")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            expectation.fulfill()
+        }
+        self.wait(for: [expectation], timeout: 1)
+
+        XCTAssertNil(webView.url)
     }
 
     // MARK: - Helpers
@@ -71,13 +80,25 @@ final class WebViewCapabilitiesTests: TestCase {
         return try XCTUnwrap(object as? [[String: Any]])
     }
 
-    /// Returns the `trigger` of the single rule whose `resource-type` exactly matches `resourceTypes`.
-    private static func trigger(matchingResourceTypes resourceTypes: [String]) throws -> [String: Any] {
+  private static func trigger(matchingResourceTypes resourceTypes: [String]) throws -> [String: Any] {
         let triggers = try Self.parseRules().compactMap { $0["trigger"] as? [String: Any] }
         let match = triggers.first { trigger in
             (trigger["resource-type"] as? [String]).map(Set.init) == Set(resourceTypes)
         }
         return try XCTUnwrap(match, "No rule blocking resource types \(resourceTypes)")
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private final class FailingWebViewContentRuleListStore: WebViewContentRuleListStore {
+
+    override func ruleList(
+        forIdentifier identifier: String,
+        json: String,
+        completion: @escaping (WKContentRuleList?) -> Void
+    ) {
+        completion(nil)
     }
 
 }

--- a/Tests/RevenueCatUITests/PaywallsV2/WebViewCapabilitiesTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WebViewCapabilitiesTests.swift
@@ -56,12 +56,12 @@ final class WebViewCapabilitiesTests: TestCase {
 
     func testLoadIsolatedDoesNotLoadWhenRuleListCompilationFails() {
         let webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
-        let originalStore = WebViewContentRuleListStore.shared
-        defer { WebViewContentRuleListStore.shared = originalStore }
-        WebViewContentRuleListStore.shared = FailingWebViewContentRuleListStore()
+        let failingStore = WebViewContentRuleListStore { _, _, completion in
+            completion(nil)
+        }
 
         let url = URL(string: "https://example.com/bundle.html")!
-        PaywallWebViewScripts.loadIsolated(url: url, on: webView)
+        PaywallWebViewScripts.loadIsolated(url: url, on: webView, ruleListStore: failingStore)
 
         let expectation = self.expectation(description: "rule list callback")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
@@ -80,25 +80,12 @@ final class WebViewCapabilitiesTests: TestCase {
         return try XCTUnwrap(object as? [[String: Any]])
     }
 
-  private static func trigger(matchingResourceTypes resourceTypes: [String]) throws -> [String: Any] {
+    private static func trigger(matchingResourceTypes resourceTypes: [String]) throws -> [String: Any] {
         let triggers = try Self.parseRules().compactMap { $0["trigger"] as? [String: Any] }
         let match = triggers.first { trigger in
             (trigger["resource-type"] as? [String]).map(Set.init) == Set(resourceTypes)
         }
         return try XCTUnwrap(match, "No rule blocking resource types \(resourceTypes)")
-    }
-
-}
-
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-private final class FailingWebViewContentRuleListStore: WebViewContentRuleListStore {
-
-    override func ruleList(
-        forIdentifier identifier: String,
-        json: String,
-        completion: @escaping (WKContentRuleList?) -> Void
-    ) {
-        completion(nil)
     }
 
 }

--- a/Tests/RevenueCatUITests/PaywallsV2/WebViewComponentTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WebViewComponentTests.swift
@@ -123,126 +123,45 @@ final class WebViewComponentTests: TestCase {
         XCTAssertFalse(viewModel.visible)
     }
 
-    func testDecodeWebViewComponentWithTemplateURL() throws {
-        let json = """
-        {
-          "type": "web_view",
-          "url": "https://example.com/{{ custom.animal }}.html",
-          "size": { "width": { "type": "fill" }, "height": { "type": "fit" } }
-        }
-        """.data(using: .utf8)!
+    // MARK: - URL validation
 
-        let component = try JSONDecoder.default.decode(PaywallComponent.self, from: json)
+    func testURLReturnsValidHTTPSURL() {
+        let viewModel = Self.makeViewModel(url: "https://example.com/page.html")
 
-        guard case .webView(let webView) = component else {
-            XCTFail("Expected .webView component, got \(component)")
-            return
-        }
-
-        XCTAssertEqual(webView.url, "https://example.com/{{ custom.animal }}.html")
+        XCTAssertEqual(viewModel.url?.absoluteString, "https://example.com/page.html")
     }
 
-    // MARK: - Variable resolution
+    func testURLRejectsHTTPURL() {
+        let viewModel = Self.makeViewModel(url: "http://example.com/page.html")
 
-    func testResolvedURLWithNoTemplateReturnsSameURL() {
-        let viewModel = Self.makeViewModel(urlTemplate: "https://example.com/page.html")
-
-        let result = viewModel.resolvedURL(customVariables: [:])
-
-        XCTAssertEqual(result?.absoluteString, "https://example.com/page.html")
+        XCTAssertNil(viewModel.url)
     }
 
-    func testResolvedURLSubstitutesRuntimeCustomVariable() {
-        let viewModel = Self.makeViewModel(
-            urlTemplate: "https://example.com/{{ custom.animal }}.html",
-            customVariableDefinitions: ["animal": .init(type: "string", defaultValue: "cat")]
-        )
+    func testURLRejectsFileURL() {
+        let viewModel = Self.makeViewModel(url: "file:///tmp/page.html")
 
-        let result = viewModel.resolvedURL(customVariables: ["animal": .string("dog")])
-
-        XCTAssertEqual(result?.absoluteString, "https://example.com/dog.html")
+        XCTAssertNil(viewModel.url)
     }
 
-    func testResolvedURLFallsBackToDashboardDefaultCustomVariable() {
-        let viewModel = Self.makeViewModel(
-            urlTemplate: "https://example.com/{{ custom.animal }}.html",
-            customVariableDefinitions: ["animal": .init(type: "string", defaultValue: "cat")]
-        )
+    func testURLRejectsCustomSchemeURL() {
+        let viewModel = Self.makeViewModel(url: "custom-scheme://example.com/page.html")
 
-        // No runtime variables supplied — should use dashboard default "cat"
-        let result = viewModel.resolvedURL(customVariables: [:])
-
-        XCTAssertEqual(result?.absoluteString, "https://example.com/cat.html")
+        XCTAssertNil(viewModel.url)
     }
 
-    func testResolvedURLRuntimeVariableOverridesDashboardDefault() {
-        let viewModel = Self.makeViewModel(
-            urlTemplate: "https://example.com/{{ custom.animal }}.html",
-            customVariableDefinitions: ["animal": .init(type: "string", defaultValue: "cat")]
-        )
+    func testURLRejectsURLWithoutHost() {
+        let viewModel = Self.makeViewModel(url: "https:/page.html")
 
-        let result = viewModel.resolvedURL(customVariables: ["animal": .string("bird")])
-
-        XCTAssertEqual(result?.absoluteString, "https://example.com/bird.html")
+        XCTAssertNil(viewModel.url)
     }
 
-    func testResolvedURLRejectsHTTPURL() {
-        let viewModel = Self.makeViewModel(urlTemplate: "http://example.com/page.html")
+    func testURLRejectsTemplateURLContainingBraces() {
+        let viewModel = Self.makeViewModel(url: "https://example.com/{{ custom.animal }}.html")
 
-        let result = viewModel.resolvedURL(customVariables: [:])
-
-        XCTAssertNil(result)
+        XCTAssertNil(viewModel.url)
     }
 
-    func testResolvedURLRejectsFileURL() {
-        let viewModel = Self.makeViewModel(urlTemplate: "file:///tmp/page.html")
-
-        let result = viewModel.resolvedURL(customVariables: [:])
-
-        XCTAssertNil(result)
-    }
-
-    func testResolvedURLRejectsCustomSchemeURL() {
-        let viewModel = Self.makeViewModel(urlTemplate: "custom-scheme://example.com/page.html")
-
-        let result = viewModel.resolvedURL(customVariables: [:])
-
-        XCTAssertNil(result)
-    }
-
-    func testResolvedURLRejectsURLWithoutHost() {
-        let viewModel = Self.makeViewModel(urlTemplate: "https:/page.html")
-
-        let result = viewModel.resolvedURL(customVariables: [:])
-
-        XCTAssertNil(result)
-    }
-
-    func testResolvedURLRejectsCustomVariableSubstitutedHTTPURL() {
-        let viewModel = Self.makeViewModel(
-            urlTemplate: "{{ custom.url }}",
-            customVariableDefinitions: ["url": .init(type: "string", defaultValue: "https://example.com/page.html")]
-        )
-
-        let result = viewModel.resolvedURL(customVariables: ["url": .string("http://example.com/page.html")])
-
-        XCTAssertNil(result)
-    }
-
-    func testResolvedURLReturnsNilForUnresolvableTemplate() {
-        // Missing variable with no default → resolves to empty string → invalid URL
-        let viewModel = Self.makeViewModel(
-            urlTemplate: "https://example.com/{{ custom.missing }}.html"
-        )
-
-        // Empty string substituted for unknown variable produces an invalid URL
-        let result = viewModel.resolvedURL(customVariables: [:])
-
-        // "https://example.com/.html" is technically valid, so we just check it ran
-        XCTAssertNotNil(result)
-    }
-
-    // MARK: - Component ID & locale
+    // MARK: - Component ID, locale, protocol version
 
     func testViewModelExposesSchemaComponentID() {
         let viewModel = Self.makeViewModel(
@@ -259,9 +178,23 @@ final class WebViewComponentTests: TestCase {
     }
 
     func testViewModelExposesLocale() {
-        let viewModel = Self.makeViewModel(urlTemplate: "https://example.com")
+        let viewModel = Self.makeViewModel(url: "https://example.com")
 
         XCTAssertEqual(viewModel.locale, Locale(identifier: "en_US"))
+    }
+
+    func testViewModelDefaultsProtocolVersionToOne() {
+        let viewModel = Self.makeViewModel(component: .init(url: "https://example.com"))
+
+        XCTAssertEqual(viewModel.protocolVersion, 1)
+    }
+
+    func testViewModelExposesDecodedProtocolVersion() {
+        let viewModel = Self.makeViewModel(
+            component: .init(protocolVersion: 2, url: "https://example.com")
+        )
+
+        XCTAssertEqual(viewModel.protocolVersion, 2)
     }
 
 }
@@ -271,30 +204,16 @@ final class WebViewComponentTests: TestCase {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private extension WebViewComponentTests {
 
-    static func makeViewModel(
-        urlTemplate: String,
-        customVariableDefinitions: [String: UIConfig.CustomVariableDefinition] = [:]
-    ) -> WebViewComponentViewModel {
-        return makeViewModel(
-            component: .init(url: urlTemplate),
-            customVariableDefinitions: customVariableDefinitions
-        )
+    static func makeViewModel(url: String) -> WebViewComponentViewModel {
+        return makeViewModel(component: .init(url: url))
     }
 
     static func makeViewModel(
-        component: PaywallComponent.WebViewComponent,
-        customVariableDefinitions: [String: UIConfig.CustomVariableDefinition] = [:]
+        component: PaywallComponent.WebViewComponent
     ) -> WebViewComponentViewModel {
-        let uiConfig = UIConfig(
-            app: .init(colors: [:], fonts: [:]),
-            localizations: [:],
-            variableConfig: .init(variableCompatibilityMap: [:], functionCompatibilityMap: [:]),
-            customVariables: customVariableDefinitions
-        )
         return WebViewComponentViewModel(
             component: component,
-            localizationProvider: .init(locale: Locale(identifier: "en_US"), localizedStrings: [:]),
-            uiConfigProvider: UIConfigProvider(uiConfig: uiConfig)
+            localizationProvider: .init(locale: Locale(identifier: "en_US"), localizedStrings: [:])
         )
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

The existing `web-view-bridge-wiring` stack implements an outdated flat postMessage protocol, URL template substitution, a custom height channel, and fail-open content-rule loading. This PR aligns iOS with the `workflow-web-components-sdk` wire contract (matching Android PR #3655) while keeping the public `PaywallWebView*` API unchanged.

## Summary of changes

1. **URL model** — `web_view.url` is a literal static HTTPS URL; custom-variable substitution removed.
2. **Transport** — `rcWebComponents` handler + `__rcWebComponentsReceive`; canonical envelope + handshake; flat `payload` variables map; `fit` message after `init` declares host-managed axes.
3. **Autosizing** — `resize` app messages only; removed `rcWebViewHeight` / injected measurement JS.
4. **Content isolation** — `rc-webview-v2-isolation` policy (allow `data:`, block third-party only); fail-closed when rule-list compilation fails.
5. **protocol_version** — defaults to `1`; unsupported versions get `reject` during handshake.

**payload = flat variables map** (matches `Bridge.send(type, payload)` semantics of `workflow-web-components-sdk`).

## Wire contract

Handler name: `rcWebComponents`. Native→JS: `window.__rcWebComponentsReceive(<json>)` guarded by `typeof`.

Every frame in both directions is a JSON object:

```json
{
  "channel": "rc-web-components",
  "protocol_version": 1,
  "kind": "connect | init | reject | message | request | response | error",
  "component_id": "<string, '' allowed only on connect>",
  "type": "<app message name, on message/request/response>",
  "id": "<correlation id, on request/response/error>",
  "payload": { },
  "error": "<string, on error/reject>"
}
```

**Handshake:** content sends `kind:"connect"`; native replies `init` (matching `protocol_version`) or `reject`. App frames before open are dropped.

**Origin gating:** `scheme://host[:port]` with default ports normalized; case-insensitive hosts. Cross-origin navigation stops messaging both ways (connect/init/reject allowed before first navigation).

**Validation:** main frame only; ≤ 64 KiB; max depth 16; `component_id` must match schema id once open.

## Testing

Updated/added unit tests for envelope parsing, handshake reject, `rc:request-variables` auto-reply through `PaywallWebViewMessageDispatcher` (observing `deliverEnvelope`), `fit` envelope, resize handling (message + request forms), origin gating, escaping, content-rule JSON, and fail-closed load.

**Could not verify locally:** Xcode/`xcodebuild` is unavailable in this environment, so `RevenueCatUI` unit tests were not run here — relying on CI.

**API baselines (`api/revenuecatui-api-*.swiftinterface`):** intentionally unchanged. This branch adds no new public API beyond what the stack already introduced (controller init/envelope helpers are internal). The stack's existing `check-api-changes-revenuecatui` failure predates these transport changes and remains for the stack owner to resolve via `fastlane update_swiftinterface_baselines` on a Mac with Xcode.

**Duplicate connect while open:** matches Android (`guard !channelOpen`); not changed here. If `rc-host.js` re-sends `init` on repeated connects, both native hosts currently ignore it — worth a shared follow-up if web behavior differs.

## Task checklist → commits

| Task | Commit |
|------|--------|
| 1 — Remove URL variable substitution | `c7d302fa6` |
| 2 — Canonical transport + handshake | `4b593e528` |
| 3 — Resize-based autosizing | `4b593e528` |
| 4 — Content isolation v2 + fail-closed | `db0dad8a1` |
| 5 — protocol_version handling + reject test | `4b593e528` (+ view-model tests in `c7d302fa6`) |
| 6 — Hygiene (macOS zoom comment, schema docs) | `4f5225a84` |
| Review fixes (fit send, binding mutation, dispatcher tests, resize leak) | latest |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f96f14e8-e017-4dd9-959f-7250ae236044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f96f14e8-e017-4dd9-959f-7250ae236044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

