### PR TITLE
Fix app icon placeholder size

### DIFF
--- a/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/PromotionalOfferView.swift
@@ -124,7 +124,7 @@ struct PromotionalOfferView: View {
             } else {
                 Color.clear
                     // keep a size similar to what the image would have occuppied so layout looks correct
-                    .frame(width: 70, height: 50)
+                    .frame(width: 70, height: 70)
             }
         }
 


### PR DESCRIPTION
### Description
I stumbled across this `AppIconView` while working on some other stuff, and noticed that the placeholder height doesn't match the actual view's height. This PR updates the placeholder height to match the icon's height.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single SwiftUI layout constant in Customer Center UI with no logic or data changes.
> 
> **Overview**
> When `AppIconHelper.getAppIcon()` returns nil in **Customer Center**’s promotional offer screen, the `AppIconView` placeholder no longer uses a shorter frame than the real icon.
> 
> The fallback `Color.clear` placeholder frame height changes from **50** to **70** so it matches the **70×70** frame used when the icon image is shown, keeping vertical spacing consistent above the offer header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5100c21441c6ad1fdcbe84e4083a3f8b4fef88d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->