### PR TITLE
Fix decode for sheet actions without inline sheet

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
@@ -182,7 +182,7 @@ struct ButtonComponentView: View {
                 )
             )
         case .sheet(let sheet):
-            if let sheetStackViewModel = self.viewModel.sheetStackViewModel {
+            if let sheet, let sheetStackViewModel = self.viewModel.sheetStackViewModel {
                 let sheetViewModel = SheetViewModel(
                     sheet: sheet,
                     sheetStackViewModel: sheetStackViewModel

--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentViewModel.swift
@@ -26,7 +26,7 @@ class ButtonComponentViewModel {
     enum Action {
         case restorePurchases
         case navigateTo(destination: Destination)
-        case sheet(RevenueCat.PaywallComponent.ButtonComponent.Sheet)
+        case sheet(RevenueCat.PaywallComponent.ButtonComponent.Sheet?)
         case navigateBack
         case workflowTrigger
         case closeWorkflow

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
@@ -436,7 +436,7 @@ extension PaywallComponent {
         case .button(let component):
             if component.overrides?.hasUnsupportedCondition() == true { return true }
             if component.stack.containsUnsupportedConditions() { return true }
-            if case let .navigateTo(.sheet(sheet)) = component.action {
+            if case let .navigateTo(.sheet(sheet)) = component.action, let sheet {
                 return sheet.stack.containsUnsupportedConditions()
             }
             return false

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
@@ -170,7 +170,7 @@ struct ViewModelFactory {
 
             var sheetStackViewModel: StackComponentViewModel?
 
-            if case let .navigateTo(.sheet(sheet)) = component.action {
+            if case let .navigateTo(.sheet(sheet)) = component.action, let sheet {
                 sheetStackViewModel = try toStackViewModel(
                     component: sheet.stack,
                     packageValidator: packageValidator,

--- a/Sources/Paywalls/Components/PaywallButtonComponent.swift
+++ b/Sources/Paywalls/Components/PaywallButtonComponent.swift
@@ -246,8 +246,12 @@ import Foundation
                 case "offer_code":
                     self = .offerCode
                 case "sheet":
-                    let sheet = try container.decode(Sheet.self, forKey: .sheet)
-                    self = .sheet(sheet: sheet)
+                    // `sheet` is optional; when absent, fall back to a no-op instead of failing decode.
+                    if let sheet = try container.decodeIfPresent(Sheet.self, forKey: .sheet) {
+                        self = .sheet(sheet: sheet)
+                    } else {
+                        self = .unknown
+                    }
                 case "terms":
                     let urlPayload = try container.decode(URLPayload.self, forKey: .url)
                     self = .terms(urlLid: urlPayload.urlLid, method: urlPayload.method)

--- a/Sources/Paywalls/Components/PaywallButtonComponent.swift
+++ b/Sources/Paywalls/Components/PaywallButtonComponent.swift
@@ -196,7 +196,8 @@ import Foundation
             case customerCenter
             case offerCode
             case privacyPolicy(urlLid: String, method: URLMethod)
-            case sheet(sheet: Sheet)
+            // A nil sheet renders the button with a no-op tap.
+            case sheet(sheet: Sheet?)
             case terms(urlLid: String, method: URLMethod)
             case webPaywallLink(urlLid: String, method: URLMethod)
             case url(urlLid: String, method: URLMethod)
@@ -246,12 +247,7 @@ import Foundation
                 case "offer_code":
                     self = .offerCode
                 case "sheet":
-                    // `sheet` is optional; when absent, fall back to a no-op instead of failing decode.
-                    if let sheet = try container.decodeIfPresent(Sheet.self, forKey: .sheet) {
-                        self = .sheet(sheet: sheet)
-                    } else {
-                        self = .unknown
-                    }
+                    self = .sheet(sheet: try container.decodeIfPresent(Sheet.self, forKey: .sheet))
                 case "terms":
                     let urlPayload = try container.decode(URLPayload.self, forKey: .url)
                     self = .terms(urlLid: urlPayload.urlLid, method: urlPayload.method)

--- a/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
+++ b/Sources/Paywalls/Components/PaywallV2CacheWarming.swift
@@ -130,10 +130,12 @@ extension PaywallComponentsData.PaywallComponentsConfig {
                 case .navigateTo(let destination):
                     switch destination {
                     case .sheet(sheet: let sheet):
-                        urls += self.collectAllImageURLs(
-                            in: sheet.stack,
-                            includeHighResInComponentHeirarchy: includeHighResInComponentHeirarchy
-                        )
+                        if let sheet {
+                            urls += self.collectAllImageURLs(
+                                in: sheet.stack,
+                                includeHighResInComponentHeirarchy: includeHighResInComponentHeirarchy
+                            )
+                        }
                     case .customerCenter, .offerCode, .privacyPolicy, .terms, .webPaywallLink, .url, .unknown:
                         break
                     }

--- a/Tests/UnitTests/Paywalls/Components/ButtonComponentTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/ButtonComponentTests.swift
@@ -356,13 +356,11 @@ class ButtonComponentCodableTests: TestCase {
         guard case .navigateTo(.sheet(let sheet)) = decodedButton.action else {
             return XCTFail("Expected a .navigateTo(.sheet) action, got \(decodedButton.action)")
         }
-        XCTAssertEqual(sheet.id, "sheet-1")
+        XCTAssertEqual(sheet?.id, "sheet-1")
     }
 
-    func testNavigateToSheetWithoutInlineSheetDecodesToUnknown() throws {
-        // A draft paywall can carry a `destination: "sheet"` action whose inline `sheet` payload
-        // hasn't been populated yet. This must NOT fail the whole decode (the web renderer treats
-        // `sheet` as optional); it degrades to an inert `.unknown` destination.
+    func testNavigateToSheetWithoutInlineSheetDecodesToSheetWithNilContent() throws {
+        // A "sheet" destination without its inline sheet must decode (not throw), so the button renders.
         let jsonString = """
         {
             "type": "button",
@@ -376,10 +374,10 @@ class ButtonComponentCodableTests: TestCase {
         let jsonData = jsonString.data(using: .utf8)!
         let decodedButton = try JSONDecoder.default.decode(PaywallComponent.ButtonComponent.self, from: jsonData)
 
-        XCTAssertEqual(decodedButton.action, .navigateTo(destination: .unknown))
+        XCTAssertEqual(decodedButton.action, .navigateTo(destination: .sheet(sheet: nil)))
     }
 
-    func testNavigateToSheetWithNullInlineSheetDecodesToUnknown() throws {
+    func testNavigateToSheetWithNullInlineSheetDecodesToSheetWithNilContent() throws {
         let jsonString = """
         {
             "type": "button",
@@ -394,7 +392,7 @@ class ButtonComponentCodableTests: TestCase {
         let jsonData = jsonString.data(using: .utf8)!
         let decodedButton = try JSONDecoder.default.decode(PaywallComponent.ButtonComponent.self, from: jsonData)
 
-        XCTAssertEqual(decodedButton.action, .navigateTo(destination: .unknown))
+        XCTAssertEqual(decodedButton.action, .navigateTo(destination: .sheet(sheet: nil)))
     }
 
     func testDecodesNameIgnoresExtraIdInJSON() throws {

--- a/Tests/UnitTests/Paywalls/Components/ButtonComponentTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/ButtonComponentTests.swift
@@ -334,6 +334,69 @@ class ButtonComponentCodableTests: TestCase {
         XCTAssertNotEqual(closeWorkflow, navigateBack)
     }
 
+    func testNavigateToSheetWithInlineSheetDecoding() throws {
+        let jsonString = """
+        {
+            "type": "button",
+            "action": {
+                "type": "navigate_to",
+                "destination": "sheet",
+                "sheet": {
+                    "id": "sheet-1",
+                    "background_blur": false,
+                    "stack": \(jsonStringDefaultStack)
+                }
+            },
+            "stack": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedButton = try JSONDecoder.default.decode(PaywallComponent.ButtonComponent.self, from: jsonData)
+
+        guard case .navigateTo(.sheet(let sheet)) = decodedButton.action else {
+            return XCTFail("Expected a .navigateTo(.sheet) action, got \(decodedButton.action)")
+        }
+        XCTAssertEqual(sheet.id, "sheet-1")
+    }
+
+    func testNavigateToSheetWithoutInlineSheetDecodesToUnknown() throws {
+        // A draft paywall can carry a `destination: "sheet"` action whose inline `sheet` payload
+        // hasn't been populated yet. This must NOT fail the whole decode (the web renderer treats
+        // `sheet` as optional); it degrades to an inert `.unknown` destination.
+        let jsonString = """
+        {
+            "type": "button",
+            "action": {
+                "type": "navigate_to",
+                "destination": "sheet"
+            },
+            "stack": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedButton = try JSONDecoder.default.decode(PaywallComponent.ButtonComponent.self, from: jsonData)
+
+        XCTAssertEqual(decodedButton.action, .navigateTo(destination: .unknown))
+    }
+
+    func testNavigateToSheetWithNullInlineSheetDecodesToUnknown() throws {
+        let jsonString = """
+        {
+            "type": "button",
+            "action": {
+                "type": "navigate_to",
+                "destination": "sheet",
+                "sheet": null
+            },
+            "stack": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedButton = try JSONDecoder.default.decode(PaywallComponent.ButtonComponent.self, from: jsonData)
+
+        XCTAssertEqual(decodedButton.action, .navigateTo(destination: .unknown))
+    }
+
     func testDecodesNameIgnoresExtraIdInJSON() throws {
         let jsonString = """
         {


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->
<!-- AI agents: fill in this template, and also follow the "Pull Requests" section in AGENTS.md. -->

### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
While working on bringing Astra to our iOS app, I hit a draft paywall that refused to decode on iOS but rendered fine on the web dashboard. Turned out it's not Astra-specific, it's a gap in how the SDK decodes button sheet
actions.

A `navigate_to` action with `destination: "sheet"` can arrive without an inline `sheet` object (the backend types it as optional and drops null fields), but `ButtonComponent.Destination` decodes that case with a required `decode(Sheet.self, forKey: .sheet)` in the SDK, so it throws `keyNotFound("sheet")`, and since one failing component aborts the whole decode, the paywall won't render. The web SDK types it as `sheet?: SheetProps | null` and treats a missing sheet as a no-op.

### Description
This aligns the SDK with the web contract by making the inline sheet optional (`Destination.sheet(sheet: Sheet?)`) and decoding it with `decodeIfPresent`. A missing or null sheet decodes to `.sheet(nil)`: the button still renders and its tap is a no-op, instead of throwing and taking the whole paywall down. Encoding never serialized the sheet, so this round-trips unchanged. The optional is threaded through the view-model, view, and cache-warming layers, and tests cover a valid inline sheet plus missing and null sheets.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow paywall V2 decoding and UI guard changes with unit tests; no auth, purchases, or data migration impact.
> 
> **Overview**
> Fixes paywall decode failures when a button uses **`navigate_to`** with **`destination: "sheet"`** but the JSON omits **`sheet`** or sends **`sheet: null`** (matching optional backend/web behavior). **`ButtonComponent.Destination`** now decodes **`sheet`** with **`decodeIfPresent`**, models **`sheet(sheet: Sheet?)`**, and documents that a **nil** sheet is a **no-op** tap.
> 
> Downstream paths guard on a non-nil sheet: **`ViewModelFactory`** skips building a sheet stack view model, **`ButtonComponentView`** only calls **`openSheet`** when both sheet content and a stack view model exist, unsupported-condition walks and cache warming skip nil sheet stacks. Unit tests cover inline sheet, missing key, and explicit null.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a41ffe5dd612802a7f9cf6fcda8064199812e0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->