### PR TITLE
test(remote-config): add additional regression test coverage

### DIFF
--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -727,7 +727,8 @@ private extension RemoteConfigManager {
     /// Returns the full topic index that should be persisted after this response is applied.
     ///
     /// Changed topics overwrite previous entries, unchanged active topics keep previous entries, and inactive topics
-    /// are removed.
+    /// are removed. Changed topics are full replacements, not item-level patches, so removed items fall out of
+    /// the persisted topic index and blob retention set.
     func postSyncTopics(
         previous: PersistedRemoteConfiguration?,
         response: RemoteConfiguration

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigDiskCacheTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigDiskCacheTests.swift
@@ -224,6 +224,33 @@ final class RemoteConfigDiskCacheTests: TestCase {
         expect(read.topics.entries).to(beEmpty())
     }
 
+    func testReadIgnoresUnknownFields() throws {
+        try FileManager.default.createDirectory(
+            at: self.fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+        try """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.sources:etag1",
+          "active_topics": ["sources"],
+          "prefetch_blobs": [],
+          "topics": {},
+          "future_field": {
+            "value": "ignored"
+          }
+        }
+        """.asData.write(to: self.fileURL)
+
+        let read = try XCTUnwrap(self.cache.read())
+
+        expect(read.domain) == "app"
+        expect(read.manifest) == "v1.1710000100.sources:etag1"
+        expect(read.activeTopics) == ["sources"]
+        expect(read.topics.entries).to(beEmpty())
+    }
+
     func testWriteCreatesDirectoryWhenAbsent() {
         self.cache.write(PersistedRemoteConfiguration(
             domain: "app",

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -1056,6 +1056,43 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.blobStore.invokedRetainOnlyParameters) == Set(["newSources"])
     }
 
+    func testContainerResponsePrunesBlobRefsForItemsDroppedFromChangedTopic() throws {
+        let keptRef = "keptBlob"
+        let removedRef = "removedBlob"
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.workflows:etag1",
+            topics: .init(entries: [
+                "workflows": [
+                    "kept": .init(blobRef: keptRef),
+                    "removed": .init(blobRef: removedRef)
+                ]
+            ])
+        )
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.workflows:etag2",
+          "active_topics": ["workflows"],
+          "topics": {
+            "workflows": {
+              "kept": { "blob_ref": "\(keptRef)" }
+            }
+          }
+        }
+        """
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(
+            with: .success(.test(container: try Self.container(config: response)))
+        )
+
+        let workflows = try XCTUnwrap(self.diskCache.invokedWriteParameter?.topics.entries["workflows"])
+        expect(Set(workflows.keys)) == Set(["kept"])
+        expect(workflows["kept"]?.blobRef) == keptRef
+        expect(workflows["removed"]).to(beNil())
+        expect(self.blobStore.invokedRetainOnlyParameters) == Set([keptRef])
+    }
+
     func testContainerResponseKeepsPreviousEntriesForUnchangedTopicsStillActive() throws {
         let previousProductMapping = RemoteConfiguration.ConfigItem(
             blobRef: "pemBlob",

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -1206,6 +1206,33 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.blobFetcher.invokedPrefetchCount) == 0
     }
 
+    func testMalformedTopicItemLeavesCacheUntouchedAndReleasesRefreshGuard() throws {
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.sources:etag2",
+          "active_topics": ["sources"],
+          "topics": {
+            "sources": {
+              "api": "not-an-object"
+            }
+          }
+        }
+        """
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(
+            with: .success(.test(container: try Self.container(config: response)))
+        )
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
+        expect(self.diskCache.invokedWriteCount) == 0
+        expect(self.blobStore.invokedWriteCount) == 0
+        expect(self.blobStore.invokedRetainOnlyCount) == 0
+        expect(self.blobFetcher.invokedPrefetchCount) == 0
+    }
+
     func testFourHundredResponseDisablesRemoteConfig() {
         self.diskCache.stubbedRead = Self.persisted(
             manifest: "v1.1710000100.sources:etag1"

--- a/Tests/UnitTests/Networking/Responses/RemoteConfigurationDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/RemoteConfigurationDecodingTests.swift
@@ -255,6 +255,23 @@ final class RemoteConfigurationDecodingTests: TestCase {
         XCTAssertThrowsError(try JSONDecoder.default.decode(RemoteConfiguration.self, from: payload))
     }
 
+    func testFailsWhenTopicItemIsNotAnObject() {
+        let payload = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.sources:etag1",
+          "active_topics": ["sources"],
+          "topics": {
+            "sources": {
+              "api": "not-an-object"
+            }
+          }
+        }
+        """.asData
+
+        XCTAssertThrowsError(try JSONDecoder.default.decode(RemoteConfiguration.self, from: payload))
+    }
+
     func testInvalidReservedItemFieldsFallBackWithoutDroppingContent() throws {
         let item = try JSONDecoder.default.decode(
             RemoteConfiguration.ConfigItem.self,


### PR DESCRIPTION
## Description
Adds targeted regression coverage for remote config edge cases.

- `testContainerResponsePrunesBlobRefsForItemsDroppedFromChangedTopic`: verifies changed topics are full replacements, so dropped items are removed from persisted topic metadata and blob retention. Follow-up from https://github.com/RevenueCat/purchases-ios/pull/7134#discussion_r3520883982.
- `testFailsWhenTopicItemIsNotAnObject`: verifies malformed topic items fail decoding instead of being treated as valid config, matching Android PR RevenueCat/purchases-android#3714.
- `testReadIgnoresUnknownFields`: verifies persisted remote config cache remains forward-compatible with unknown fields, matching Android PR RevenueCat/purchases-android#3714.
- `testMalformedTopicItemLeavesCacheUntouchedAndReleasesRefreshGuard`: verifies malformed config does not mutate cache/blob state and does not leave refresh blocked, matching Android PR RevenueCat/purchases-android#3714.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and documentation-only changes; no runtime behavior modifications.
> 
> **Overview**
> Adds **regression tests** for remote config edge cases aligned with Android, plus a short doc note on `postSyncTopics`.
> 
> **Topic sync:** `testContainerResponsePrunesBlobRefsForItemsDroppedFromChangedTopic` locks in that a changed topic **replaces** the whole topic map—dropped items disappear from persisted metadata and `blobStore.retainOnly` only keeps refs still referenced.
> 
> **Malformed / decode failures:** `testFailsWhenTopicItemIsNotAnObject` and `testMalformedTopicItemLeavesCacheUntouchedAndReleasesRefreshGuard` assert non-object topic items fail JSON decode and that a successful container with bad config does not write cache or touch blobs, and that a second refresh can run (refresh guard released).
> 
> **Forward compatibility:** `testReadIgnoresUnknownFields` verifies on-disk cache JSON with extra top-level keys still decodes known fields.
> 
> The only production edit is clarifying in `RemoteConfigManager` that changed topics are full replacements, not per-item patches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 553f4e0a02294fe0977c4fc0ebeb5b003ae7d027. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->