### PR TITLE
other(workflows): unify workflows and remote config into a single gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,7 +157,7 @@ The project uses **Tuist** for managing the Xcode workspace. See **`Contributing
 
 Example combining multiple variables:
 ```bash
-TUIST_RC_API_KEY=appl_xxxxx TUIST_LAUNCH_ARGUMENTS="-EnableWorkflowsEndpoint" tuist generate PaywallsTester
+TUIST_RC_API_KEY=appl_xxxxx TUIST_SWIFT_CONDITIONS="ENABLE_REMOTE_CONFIG" tuist generate PaywallsTester
 ```
 
 ### Target Specifications

--- a/RevenueCatUI/Purchasing/MockPurchases.swift
+++ b/RevenueCatUI/Purchasing/MockPurchases.swift
@@ -33,6 +33,7 @@ final class MockPurchases: PaywallPurchasesType, @unchecked Sendable {
     let preferredLocales: [String]
     let preferredLocaleOverride: String?
     var isUIPreviewMode = false
+    var remoteConfigEnabled = false
 
     var purchasesAreCompletedBy: PurchasesAreCompletedBy {
         get { return _purchasesAreCompletedBy }
@@ -173,6 +174,7 @@ extension PaywallPurchasesType {
         mapped.cachedOfferings = self.cachedOfferings
         mapped.offeringsBlock = { try await self.offerings() }
         mapped.isUIPreviewMode = self.isUIPreviewMode
+        mapped.remoteConfigEnabled = self.remoteConfigEnabled
         #if !os(tvOS)
         mapped.workflowBlock = { try await self.workflow(forOfferingIdentifier: $0) }
         mapped.trackWorkflowEventBlock = { await self.track(workflowEvent: $0) }
@@ -202,6 +204,7 @@ extension PaywallPurchasesType {
         mapped.cachedOfferings = self.cachedOfferings
         mapped.offeringsBlock = { try await self.offerings() }
         mapped.isUIPreviewMode = self.isUIPreviewMode
+        mapped.remoteConfigEnabled = self.remoteConfigEnabled
         #if !os(tvOS)
         mapped.workflowBlock = { try await self.workflow(forOfferingIdentifier: $0) }
         mapped.trackWorkflowEventBlock = { await self.track(workflowEvent: $0) }

--- a/RevenueCatUI/Purchasing/PaywallPurchasesType.swift
+++ b/RevenueCatUI/Purchasing/PaywallPurchasesType.swift
@@ -29,6 +29,9 @@ protocol PaywallPurchasesType: Sendable {
     /// property is only useful for reading the override value.
     var preferredLocaleOverride: String? { get }
 
+    /// Whether remote config (and, with it, paywall workflows) is enabled.
+    var remoteConfigEnabled: Bool { get }
+
     /// Returns a tracker of user's subscription history
     var subscriptionHistoryTracker: SubscriptionHistoryTracker { get }
 

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -64,6 +64,12 @@ final class PurchaseHandler: ObservableObject {
         return purchases.preferredLocaleOverride.map(Locale.init)
     }
 
+    /// Whether remote config (and, with it, paywall workflows) is enabled. The single gate for both:
+    /// they ship together, so there's no separate workflows switch.
+    var remoteConfigEnabled: Bool {
+        return purchases.remoteConfigEnabled
+    }
+
     /// Whether a purchase is currently in progress
     @Published
     var packageBeingPurchased: Package?
@@ -292,26 +298,26 @@ extension PurchaseHandler {
 
     func cachedInitialOffering(for content: PaywallViewConfiguration.Content) -> Offering? {
 #if !os(tvOS)
-        let workflowsEndpointEnabled = ProcessInfo.processInfo.workflowsEndpointEnabled
+        let remoteConfigEnabled = self.remoteConfigEnabled
 #else
         // The workflows endpoint isn't available on tvOS, so always fall through to the cached switch.
-        let workflowsEndpointEnabled = false
+        let remoteConfigEnabled = false
 #endif
 
-        return self.cachedInitialOffering(for: content, workflowsEndpointEnabled: workflowsEndpointEnabled)
+        return self.cachedInitialOffering(for: content, remoteConfigEnabled: remoteConfigEnabled)
     }
 
-    // Exposes the workflow flag so tests can cover both states deterministically without relying on the
-    // `-EnableWorkflowsEndpoint` launch argument being present in the scheme.
+    // Exposes the gate so tests can cover both states deterministically without depending on
+    // ENABLE_REMOTE_CONFIG being compiled in for the test target.
     func cachedInitialOffering(
         for content: PaywallViewConfiguration.Content,
-        workflowsEndpointEnabled: Bool
+        remoteConfigEnabled: Bool
     ) -> Offering? {
         // The passed/cached offering alone can't drive a workflow paywall: under workflows the
         // rendered offering is the workflow screen's offering with its workflow-mapped components,
         // and it needs a WorkflowContext the offering doesn't carry. There is no synchronous seed for
         // a workflow paywall, so this overload returns nil and the async resolve path always runs.
-        if workflowsEndpointEnabled {
+        if remoteConfigEnabled {
             return nil
         }
 
@@ -383,13 +389,13 @@ extension PurchaseHandler {
     ) async throws -> ResolvedPaywallViewData {
         return try await self.resolvePaywallViewData(
             for: content,
-            workflowsEndpointEnabled: ProcessInfo.processInfo.workflowsEndpointEnabled
+            remoteConfigEnabled: self.remoteConfigEnabled
         )
     }
 
     func resolvePaywallViewData(
         for content: PaywallViewConfiguration.Content,
-        workflowsEndpointEnabled: Bool
+        remoteConfigEnabled: Bool
     ) async throws -> ResolvedPaywallViewData {
         switch content {
         case let .offering(offering):
@@ -397,7 +403,7 @@ extension PurchaseHandler {
             return try await self.resolvePaywallViewData(
                 for: offering,
                 offerings: nil,
-                workflowsEndpointEnabled: workflowsEndpointEnabled
+                remoteConfigEnabled: remoteConfigEnabled
             )
         case .defaultOffering:
             let offerings = try await self.purchases.offerings()
@@ -405,7 +411,7 @@ extension PurchaseHandler {
             return try await self.resolvePaywallViewData(
                 for: offering,
                 offerings: offerings,
-                workflowsEndpointEnabled: workflowsEndpointEnabled
+                remoteConfigEnabled: remoteConfigEnabled
             )
         case let .offeringIdentifier(identifier, presentedOfferingContext):
             let offerings = try await self.purchases.offerings()
@@ -423,7 +429,7 @@ extension PurchaseHandler {
             return try await self.resolvePaywallViewData(
                 for: resolvedOffering,
                 offerings: offerings,
-                workflowsEndpointEnabled: workflowsEndpointEnabled
+                remoteConfigEnabled: remoteConfigEnabled
             )
         }
     }
@@ -442,9 +448,9 @@ extension PurchaseHandler {
     private func resolvePaywallViewData(
         for offering: Offering,
         offerings: Offerings?,
-        workflowsEndpointEnabled: Bool
+        remoteConfigEnabled: Bool
     ) async throws -> ResolvedPaywallViewData {
-        guard workflowsEndpointEnabled, offering.paywall == nil else {
+        guard remoteConfigEnabled, offering.paywall == nil else {
             return .init(offering: offering, workflowContext: nil)
         }
 
@@ -457,7 +463,7 @@ extension PurchaseHandler {
         return .init(offering: context.initialOffering, workflowContext: context)
     }
 
-    // Callers gate on workflowsEndpointEnabled before reaching this point, so this assumes
+    // Callers gate on remoteConfigEnabled before reaching this point, so this assumes
     // workflows are enabled and always resolves against the workflow endpoint.
     func resolveWorkflowContext(
         identifier: String,
@@ -891,6 +897,8 @@ private final class NotConfiguredPurchases: PaywallPurchasesType {
     var preferredLocaleOverride: String? { nil }
 
     var isUIPreviewMode: Bool { false }
+
+    var remoteConfigEnabled: Bool { false }
 
     var subscriptionHistoryTracker: RevenueCat.SubscriptionHistoryTracker {
         SubscriptionHistoryTracker()

--- a/RevenueCatUI/Purchasing/WorkflowContext.swift
+++ b/RevenueCatUI/Purchasing/WorkflowContext.swift
@@ -277,13 +277,4 @@ struct WorkflowPackageContext {
     }
 }
 
-// Temporary launch-argument gate — remove once workflows are fully released.
-extension ProcessInfo {
-
-    var workflowsEndpointEnabled: Bool {
-        arguments.contains("-EnableWorkflowsEndpoint")
-    }
-
-}
-
 #endif

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -115,8 +115,13 @@ public class PaywallViewController: UIViewController {
 
     // MARK: - Testing Hooks
 
-    /// Settable in tests to simulate workflows being enabled without a scheme launch argument.
-    var workflowsEndpointEnabled: Bool = ProcessInfo.processInfo.workflowsEndpointEnabled
+    /// Settable in tests to simulate remote config being enabled without a build flag.
+    var remoteConfigEnabledForTesting: Bool?
+
+    /// Whether remote config (and, with it, paywall workflows) is enabled.
+    private var remoteConfigEnabled: Bool {
+        return self.remoteConfigEnabledForTesting ?? self.purchaseHandler.remoteConfigEnabled
+    }
 
     var exitOfferOfferingForTesting: Offering? { self.exitOfferOffering }
 
@@ -437,7 +442,7 @@ public class PaywallViewController: UIViewController {
     private func prefetchExitOffer() async {
         // Under workflows the exit offer comes from the embedded paywall (see updateWorkflowExitOffer),
         // so skip this legacy prefetch.
-        guard !self.workflowsEndpointEnabled else { return }
+        guard !self.remoteConfigEnabled else { return }
 
         guard let offering = await self.purchaseHandler.resolveOffering(for: self.configuration.content) else {
             return
@@ -449,7 +454,7 @@ public class PaywallViewController: UIViewController {
     /// surface it. Render-dependent, so verified manually like `prefetchExitOffer`.
     private func updateWorkflowExitOffer(_ offering: Offering?) {
         // The legacy prefetch owns the offer when workflows are off; don't clobber it.
-        guard self.workflowsEndpointEnabled else { return }
+        guard self.remoteConfigEnabled else { return }
 
         // Keep the offer once we're presenting it, even if a late nil arrives mid-dismiss.
         guard offering != nil || !self.isShowingExitOffer else { return }

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -678,9 +678,10 @@ private struct PresentingPaywallModifier: ViewModifier {
             self.handleWorkflowExitOfferPreferenceChange(context)
         }
         .task {
-            // When the workflows endpoint is enabled, exit offers are resolved synchronously
-            // from WorkflowContext.allOfferings via the preference key above — no fetch needed.
-            guard !ProcessInfo.processInfo.workflowsEndpointEnabled else { return }
+            // When remote config (and, with it, workflows) is enabled, exit offers are resolved
+            // synchronously from WorkflowContext.allOfferings via the preference key above — no
+            // fetch needed.
+            guard !self.purchaseHandler.remoteConfigEnabled else { return }
 
             guard let offering = await self.purchaseHandler.resolveOffering(for: self.content) else { return }
             self.exitOfferOffering = await ExitOfferHelper.fetchValidExitOffer(for: offering)
@@ -777,7 +778,7 @@ private struct PresentingPaywallModifier: ViewModifier {
     }
 
     private func handleWorkflowExitOfferPreferenceChange(_ context: WorkflowExitOfferContext?) {
-        guard ProcessInfo.processInfo.workflowsEndpointEnabled else { return }
+        guard self.purchaseHandler.remoteConfigEnabled else { return }
         // Don't nil out exitOfferOffering once an exit offer is already being presented:
         // SwiftUI may fire a final nil preference update during the dismiss animation, after
         // handleMainPaywallDismiss has already copied exitOfferOffering into presentedExitOffer.

--- a/RevenueCatUI/Views/LoadingPaywallView.swift
+++ b/RevenueCatUI/Views/LoadingPaywallView.swift
@@ -163,6 +163,8 @@ private final class LoadingPaywallPurchases: PaywallPurchasesType {
 
     var isUIPreviewMode: Bool { false }
 
+    var remoteConfigEnabled: Bool { false }
+
     var purchasesAreCompletedBy: PurchasesAreCompletedBy {
         get { return .myApp }
         set { _ = newValue }

--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -39,7 +39,6 @@ enum RemoteConfigStrings {
     case uiConfigDecodeFailed(Error)
     case uiConfigMissingRequiredPart
     case uiConfigPartDecodeFailed(itemKey: String, error: Error)
-    case workflowsEnabledWithoutRemoteConfig
 
 }
 
@@ -117,9 +116,6 @@ extension RemoteConfigStrings: LogMessage {
             return "Failed to assemble ui_config: the 'app' or 'localizations' part is unavailable."
         case let .uiConfigPartDecodeFailed(itemKey, error):
             return "Failed to decode ui_config part '\(itemKey)': \(error.localizedDescription)"
-        case .workflowsEnabledWithoutRemoteConfig:
-            return "Workflows are enabled (-EnableWorkflowsEndpoint) but remote config is not " +
-                "(ENABLE_REMOTE_CONFIG is off in this build), so no workflow will ever be found."
         }
     }
 

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -93,13 +93,9 @@ class SystemInfo {
         return self._isSandbox
     }
 
-    /// Whether the paywall workflows endpoint is enabled, driven by the `-EnableWorkflowsEndpoint`
-    /// launch argument. Temporary gate while workflows are being rolled out.
-    var workflowsEndpointEnabled: Bool {
-        return ProcessInfo.processInfo.arguments.contains("-EnableWorkflowsEndpoint")
-    }
-
-    /// Whether remote config lifecycle wiring is enabled. Temporary gate while remote config is being rolled out.
+    /// Whether remote config lifecycle wiring is enabled. Temporary gate while remote config is being
+    /// rolled out. Paywall workflows read entirely through remote config, so this is also the single
+    /// gate for workflows: there's no separate workflows switch, since the two ship together.
     var remoteConfigEnabled: Bool {
         guard !self.dangerousSettings.customEntitlementComputation else { return false }
 
@@ -108,13 +104,6 @@ class SystemInfo {
         #else
         return false
         #endif
-    }
-
-    /// Whether workflows are enabled at runtime but remote config, which workflows now read through,
-    /// is not compiled in. In this state workflows are silently unavailable rather than off: worth its
-    /// own flag so callers can warn instead of quietly failing every workflow lookup.
-    var workflowsEnabledWithoutRemoteConfig: Bool {
-        return self.workflowsEndpointEnabled && !self.remoteConfigEnabled
     }
 
     var isDebugBuild: Bool {

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -26,7 +26,7 @@ class OfferingsManager {
     private let productsManager: ProductsManagerType
     private let diagnosticsTracker: DiagnosticsTrackerType?
     private let dateProvider: DateProvider
-    // Nil when the workflows endpoint is disabled, in which case offerings delivery is unchanged.
+    // Nil when remote config is disabled, in which case offerings delivery is unchanged.
     private let remoteConfigManager: RemoteConfigManagerType?
 
     init(deviceCache: DeviceCache,

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -576,10 +576,6 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             paywallCache = nil
         }
 
-        if systemInfo.workflowsEnabledWithoutRemoteConfig {
-            Logger.warn(Strings.remoteConfig.workflowsEnabledWithoutRemoteConfig)
-        }
-
         let workflowManager = WorkflowManager(
             workflowsConfigProvider: WorkflowsConfigProvider(manager: remoteConfigManager),
             paywallCache: paywallCache,
@@ -593,8 +589,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                                                 offeringsFactory: offeringsFactory,
                                                 productsManager: productsManager,
                                                 diagnosticsTracker: diagnosticsTracker,
-                                                remoteConfigManager: systemInfo.workflowsEndpointEnabled
-                                                && systemInfo.remoteConfigEnabled
+                                                remoteConfigManager: systemInfo.remoteConfigEnabled
                                                 ? remoteConfigManager
                                                 : nil)
         let manageSubsHelper = ManageSubscriptionsHelper(systemInfo: systemInfo,
@@ -2400,6 +2395,13 @@ extension Purchases {
     // swiftlint:disable missing_docs
     @_spi(Internal) public var preferredLocaleOverride: String? {
         return self.systemInfo.preferredLocaleOverride
+    }
+
+    // Exposes the single workflows + remote config gate to RevenueCatUI, which can't see the
+    // ENABLE_REMOTE_CONFIG compile flag directly.
+    // swiftlint:disable missing_docs
+    @_spi(Internal) public var remoteConfigEnabled: Bool {
+        return self.systemInfo.remoteConfigEnabled
     }
 
     // swiftlint:disable missing_docs

--- a/Tests/RevenueCatUITests/Data/PaywallViewConfigurationTests.swift
+++ b/Tests/RevenueCatUITests/Data/PaywallViewConfigurationTests.swift
@@ -19,7 +19,7 @@ import XCTest
 final class PaywallViewConfigurationTests: TestCase {
 
 #if !os(tvOS)
-    func testCachedInitialOfferingReturnsNilForAllContentWhenWorkflowsEndpointEnabled() {
+    func testCachedInitialOfferingReturnsNilForAllContentWhenRemoteConfigEnabled() {
         let cachedOffering = TestData.offeringWithNoIntroOffer
         let purchases = Self.createMockPurchases()
         let handler = Self.createPurchaseHandler(purchases: purchases)
@@ -31,19 +31,19 @@ final class PaywallViewConfigurationTests: TestCase {
 
         expect(handler.cachedInitialOffering(
             for: .offering(cachedOffering),
-            workflowsEndpointEnabled: true
+            remoteConfigEnabled: true
         )).to(beNil())
         expect(handler.cachedInitialOffering(
             for: .defaultOffering,
-            workflowsEndpointEnabled: true
+            remoteConfigEnabled: true
         )).to(beNil())
         expect(handler.cachedInitialOffering(
             for: .offeringIdentifier(cachedOffering.identifier, presentedOfferingContext: nil),
-            workflowsEndpointEnabled: true
+            remoteConfigEnabled: true
         )).to(beNil())
     }
 
-    func testCachedInitialOfferingUsesCachedOfferingsWhenWorkflowsEndpointDisabled() {
+    func testCachedInitialOfferingUsesCachedOfferingsWhenRemoteConfigDisabled() {
         let cachedOffering = TestData.offeringWithNoIntroOffer
         let purchases = Self.createMockPurchases()
         let handler = Self.createPurchaseHandler(purchases: purchases)
@@ -55,19 +55,19 @@ final class PaywallViewConfigurationTests: TestCase {
 
         expect(handler.cachedInitialOffering(
             for: .offering(cachedOffering),
-            workflowsEndpointEnabled: false
+            remoteConfigEnabled: false
         )) === cachedOffering
         expect(handler.cachedInitialOffering(
             for: .defaultOffering,
-            workflowsEndpointEnabled: false
+            remoteConfigEnabled: false
         )?.identifier) == cachedOffering.identifier
         expect(handler.cachedInitialOffering(
             for: .offeringIdentifier(cachedOffering.identifier, presentedOfferingContext: nil),
-            workflowsEndpointEnabled: false
+            remoteConfigEnabled: false
         )?.identifier) == cachedOffering.identifier
     }
 
-    func testResolvePaywallViewDataReturnsNilWorkflowContextWhenWorkflowsEndpointDisabled() async throws {
+    func testResolvePaywallViewDataReturnsNilWorkflowContextWhenRemoteConfigDisabled() async throws {
         let initialOffering = Self.createOffering(identifier: "offering_a")
             .withPresentedOfferingContext(Self.createPresentedOfferingContext(offeringIdentifier: "offering_a"))
         let purchases = Self.createMockPurchases()
@@ -80,21 +80,21 @@ final class PaywallViewConfigurationTests: TestCase {
             )
         }
         purchases.workflowBlock = { _ in
-            XCTFail("Workflow endpoint should not be fetched when workflowsEndpointEnabled is false")
+            XCTFail("Workflow endpoint should not be fetched when remoteConfigEnabled is false")
             throw ErrorCode.configurationError
         }
 
         let offeringResult = try await handler.resolvePaywallViewData(
             for: .offering(initialOffering),
-            workflowsEndpointEnabled: false
+            remoteConfigEnabled: false
         )
         let defaultOfferingResult = try await handler.resolvePaywallViewData(
             for: .defaultOffering,
-            workflowsEndpointEnabled: false
+            remoteConfigEnabled: false
         )
         let offeringIdentifierResult = try await handler.resolvePaywallViewData(
             for: .offeringIdentifier(initialOffering.identifier, presentedOfferingContext: nil),
-            workflowsEndpointEnabled: false
+            remoteConfigEnabled: false
         )
 
         expect(offeringResult.offering.identifier) == initialOffering.identifier
@@ -123,7 +123,7 @@ final class PaywallViewConfigurationTests: TestCase {
 
         let result = try await handler.resolvePaywallViewData(
             for: .offering(initialOffering),
-            workflowsEndpointEnabled: true
+            remoteConfigEnabled: true
         )
 
         expect(result.offering.identifier) == workflowOffering.identifier
@@ -159,7 +159,7 @@ final class PaywallViewConfigurationTests: TestCase {
 
         let result = try await handler.resolvePaywallViewData(
             for: .defaultOffering,
-            workflowsEndpointEnabled: true
+            remoteConfigEnabled: true
         )
 
         expect(result.offering.identifier) == workflowOffering.identifier
@@ -190,7 +190,7 @@ final class PaywallViewConfigurationTests: TestCase {
 
         let result = try await handler.resolvePaywallViewData(
             for: .offeringIdentifier(initialOffering.identifier, presentedOfferingContext: presentedOfferingContext),
-            workflowsEndpointEnabled: true
+            remoteConfigEnabled: true
         )
 
         expect(result.offering.identifier) == workflowOffering.identifier
@@ -221,7 +221,7 @@ final class PaywallViewConfigurationTests: TestCase {
         do {
             _ = try await handler.resolvePaywallViewData(
                 for: .offering(initialOffering),
-                workflowsEndpointEnabled: true
+                remoteConfigEnabled: true
             )
             XCTFail("Expected resolvePaywallViewData to throw")
         } catch let PaywallError.offeringNotFound(identifier) {
@@ -246,7 +246,7 @@ final class PaywallViewConfigurationTests: TestCase {
 
         let result = try await handler.resolvePaywallViewData(
             for: .offering(offering),
-            workflowsEndpointEnabled: true
+            remoteConfigEnabled: true
         )
 
         expect(result.offering.identifier) == offering.identifier
@@ -268,7 +268,7 @@ final class PaywallViewConfigurationTests: TestCase {
 
         let result = try await handler.resolvePaywallViewData(
             for: .defaultOffering,
-            workflowsEndpointEnabled: true
+            remoteConfigEnabled: true
         )
 
         expect(result.offering.identifier) == offering.identifier
@@ -291,7 +291,7 @@ final class PaywallViewConfigurationTests: TestCase {
 
         let result = try await handler.resolvePaywallViewData(
             for: .offeringIdentifier(offering.identifier, presentedOfferingContext: presentedOfferingContext),
-            workflowsEndpointEnabled: true
+            remoteConfigEnabled: true
         )
 
         expect(result.offering.identifier) == offering.identifier

--- a/Tests/RevenueCatUITests/UIKit/PaywallViewControllerExitOfferTests.swift
+++ b/Tests/RevenueCatUITests/UIKit/PaywallViewControllerExitOfferTests.swift
@@ -22,7 +22,7 @@ final class PaywallViewControllerExitOfferTests: TestCase {
 
     func testUpdateDisplayCloseButtonDoesNotClearWorkflowExitOffer() {
         let controller = PaywallViewController(offering: Self.makeOffering(identifier: "main"))
-        controller.workflowsEndpointEnabled = true
+        controller.remoteConfigEnabledForTesting = true
 
         controller.simulateWorkflowExitOfferUpdate(Self.makeOffering(identifier: "exit"))
         expect(controller.exitOfferOfferingForTesting).notTo(beNil(), description: "precondition")
@@ -37,7 +37,7 @@ final class PaywallViewControllerExitOfferTests: TestCase {
 
     func testUpdateFontDoesNotClearWorkflowExitOffer() {
         let controller = PaywallViewController(offering: Self.makeOffering(identifier: "main"))
-        controller.workflowsEndpointEnabled = true
+        controller.remoteConfigEnabledForTesting = true
 
         controller.simulateWorkflowExitOfferUpdate(Self.makeOffering(identifier: "exit"))
         expect(controller.exitOfferOfferingForTesting).notTo(beNil(), description: "precondition")
@@ -54,7 +54,7 @@ final class PaywallViewControllerExitOfferTests: TestCase {
         // Replacing the offering is a legitimate reason to drop the previous exit offer —
         // the new paywall will re-emit one.
         let controller = PaywallViewController(offering: Self.makeOffering(identifier: "original"))
-        controller.workflowsEndpointEnabled = true
+        controller.remoteConfigEnabledForTesting = true
 
         controller.simulateWorkflowExitOfferUpdate(Self.makeOffering(identifier: "exit"))
         expect(controller.exitOfferOfferingForTesting).notTo(beNil(), description: "precondition")

--- a/Tests/UnitTests/Mocks/MockSystemInfo.swift
+++ b/Tests/UnitTests/Mocks/MockSystemInfo.swift
@@ -16,7 +16,6 @@ class MockSystemInfo: SystemInfo {
     var stubbedIsApplicationBackgrounded: Bool?
     var stubbedIsSandbox: Bool?
     var stubbedIsDebugBuild: Bool?
-    var stubbedWorkflowsEndpointEnabled: Bool?
     var stubbedRemoteConfigEnabled: Bool?
     var stubbedStorefront: StorefrontType?
     var stubbedApiKeyValidationResult: Configuration.APIKeyValidationResult?
@@ -101,10 +100,6 @@ class MockSystemInfo: SystemInfo {
 
     override var isSandbox: Bool {
         return self.stubbedIsSandbox ?? super.isSandbox
-    }
-
-    override var workflowsEndpointEnabled: Bool {
-        return self.stubbedWorkflowsEndpointEnabled ?? super.workflowsEndpointEnabled
     }
 
     override var remoteConfigEnabled: Bool {

--- a/Tuist/ProjectDescriptionHelpers/Arguments.swift
+++ b/Tuist/ProjectDescriptionHelpers/Arguments.swift
@@ -7,7 +7,7 @@ extension Arguments {
     ///
     /// Example usage:
     /// ```bash
-    /// TUIST_LAUNCH_ARGUMENTS="-EnableWorkflowsEndpoint" tuist generate PaywallsTester
+    /// TUIST_LAUNCH_ARGUMENTS="-MyLaunchFlag" tuist generate PaywallsTester
     /// ```
     public static func appendingTuistLaunchArguments(
         base: Arguments = .arguments()

--- a/Tuist/ProjectDescriptionHelpers/Environment.swift
+++ b/Tuist/ProjectDescriptionHelpers/Environment.swift
@@ -112,10 +112,10 @@ extension Environment {
     /// Example usage:
     /// ```bash
     /// # Single argument
-    /// TUIST_LAUNCH_ARGUMENTS="-EnableWorkflowsEndpoint" tuist generate PaywallsTester
+    /// TUIST_LAUNCH_ARGUMENTS="-MyLaunchFlag" tuist generate PaywallsTester
     ///
     /// # Multiple arguments
-    /// TUIST_LAUNCH_ARGUMENTS="-EnableWorkflowsEndpoint -MyOtherFlag" tuist generate
+    /// TUIST_LAUNCH_ARGUMENTS="-MyLaunchFlag -MyOtherFlag" tuist generate
     /// ```
     public static var extraLaunchArguments: [String] {
         let value = ProcessInfo.processInfo.environment["TUIST_LAUNCH_ARGUMENTS"] ?? ""


### PR DESCRIPTION
### Motivation
Supersedes #6947 (closing that one, it predates most of the remote-config work and went stale/conflicting). Workflows now read entirely through remote config, but they were still gated by two independent flags that could disagree: `-EnableWorkflowsEndpoint` (runtime) and `ENABLE_REMOTE_CONFIG` (compile-time). With the flag on and the compile-time gate off, which is the default everywhere today, every workflow lookup is a guaranteed miss. Since workflows and remote config ship together, there's no reason for two switches.

### Description
Removes `-EnableWorkflowsEndpoint` entirely. Workflows are now on whenever `remoteConfigEnabled` is true.

- Deleted `SystemInfo.workflowsEndpointEnabled` and the now-impossible `workflowsEnabledWithoutRemoteConfig` warning.
- Exposed `remoteConfigEnabled` from `Purchases` (`@_spi(Internal)`) through `PaywallPurchasesType` → `PurchaseHandler`, replacing every `ProcessInfo`-based check in RevenueCatUI.
- `PaywallViewController`'s test-overridable flag became `remoteConfigEnabledForTesting`, since the real value now needs `self.purchaseHandler` and can't be a stored-property default anymore.
- Updated Tuist/AGENTS.md docs that referenced the old launch arg.

Known gap, tracked as a follow-up rather than fixed here: both `View+PresentPaywall.swift` and `PaywallViewController.swift` skip legacy exit-offer prefetch based on the blanket flag rather than whether the specific paywall resolved to a workflow. That's a pre-existing bug (same shape on main today), dormant because almost nobody sets the launch arg in production. This PR turns that same flag into the real production switch, so it becomes reachable for every legacy paywall with a configured exit offer once `ENABLE_REMOTE_CONFIG` ships. Should land before flipping that flag on for real.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which paywall path (workflow vs legacy) and offerings/remote-config wiring run in production once `ENABLE_REMOTE_CONFIG` is on, and the blanket remote-config gate can affect exit-offer prefetch for legacy paywalls until a follow-up fix lands.
> 
> **Overview**
> Replaces the separate **`-EnableWorkflowsEndpoint`** launch-argument gate with **`remoteConfigEnabled`** as the only switch for paywall workflows and remote config lifecycle wiring.
> 
> **Core SDK:** Drops `SystemInfo.workflowsEndpointEnabled`, `workflowsEnabledWithoutRemoteConfig`, and the related startup warning/log string. `OfferingsManager` now wires `remoteConfigManager` when `remoteConfigEnabled` alone is true (no AND with a workflows flag). **`Purchases`** exposes `@_spi(Internal) remoteConfigEnabled` for RevenueCatUI.
> 
> **RevenueCatUI:** Adds `remoteConfigEnabled` on `PaywallPurchasesType` / mocks / `PurchaseHandler` and threads it through paywall resolution (`cachedInitialOffering`, `resolvePaywallViewData`) instead of `ProcessInfo`. Exit-offer and workflow UI paths use `purchaseHandler.remoteConfigEnabled`; **`PaywallViewController`** tests use `remoteConfigEnabledForTesting` instead of overriding the old launch-arg default.
> 
> **Docs/tests:** AGENTS.md and Tuist examples now point at **`TUIST_SWIFT_CONDITIONS="ENABLE_REMOTE_CONFIG"`** instead of the workflows launch arg; unit tests rename parameters and stubs accordingly.
> 
> **Note:** Skipping legacy exit-offer prefetch whenever remote config is on (not only when a workflow actually rendered) is unchanged in shape and becomes production-relevant once `ENABLE_REMOTE_CONFIG` ships—called out in the PR as follow-up work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e3f91396e30b35fbba45c2589a023d986e5a850. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->