### PR TITLE
fix(remote-config): align edge-case handling with Android implementation

### DIFF
--- a/RevenueCatUI/Data/Errors/PaywallError.swift
+++ b/RevenueCatUI/Data/Errors/PaywallError.swift
@@ -25,6 +25,9 @@ enum PaywallError: Error {
     /// The selected offering was not found.
     case offeringNotFound(identifier: String)
 
+    /// The workflow was resolved without the UI config required to render it.
+    case workflowUiConfigUnavailable(workflowId: String)
+
     /// The PaywallView must be initialized with ``performPurchase`` and ``performRestore``
     /// when ``purchasesAreCompletedBy`` is ``.myApp``
     case performPurchaseAndRestoreHandlersNotDefined(missingBlocks: String)
@@ -53,6 +56,8 @@ extension PaywallError: CustomNSError, CustomStringConvertible {
 
         case let .offeringNotFound(identifier):
             return "The RevenueCat dashboard does not have an offering with identifier '\(identifier)'."
+        case let .workflowUiConfigUnavailable(workflowId):
+            return "The RevenueCat dashboard workflow '\(workflowId)' is missing its UI configuration."
         case .performPurchaseAndRestoreHandlersNotDefined:
             return "PaywallView has not been correctly initialized. purchasesAreCompletedBy is set to .myApp, and so " +
             "the PaywallView must be initialized with a PerformPurchase and PerformRestore handler."

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -526,9 +526,13 @@ extension PurchaseHandler {
             throw PaywallError.offeringNotFound(identifier: screen.offeringIdentifier ?? triggerOfferingIdentifier)
         }
 
+        guard let uiConfig = workflow.uiConfig else {
+            throw PaywallError.workflowUiConfigUnavailable(workflowId: workflow.id)
+        }
+
         let paywallComponents = WorkflowScreenMapper.toPaywallComponents(
             screen: screen,
-            uiConfig: workflow.uiConfig
+            uiConfig: uiConfig
         )
 
         let initialOffering = baseOffering.withPaywallComponents(paywallComponents)

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -487,20 +487,24 @@ extension PurchaseHandler {
         presentedOfferingContext: PresentedOfferingContext?,
         offerings: Offerings? = nil
     ) async throws -> WorkflowContext {
-        async let fetchResultTask = self.purchases.workflow(forOfferingIdentifier: identifier)
+        do {
+            async let fetchResultTask = self.purchases.workflow(forOfferingIdentifier: identifier)
 
-        // Reuse the caller's snapshot if provided; otherwise fetch concurrently with the workflow above.
-        let allOfferings = try await self.resolveOfferings(offerings)
+            // Reuse the caller's snapshot if provided; otherwise fetch concurrently with the workflow above.
+            let allOfferings = try await self.resolveOfferings(offerings)
 
-        let fetchResult = try await fetchResultTask
+            let fetchResult = try await fetchResultTask
 
-        return try Self.makeWorkflowContext(
-            workflow: fetchResult.workflow,
-            uiConfig: fetchResult.uiConfig,
-            allOfferings: allOfferings,
-            presentedOfferingContext: presentedOfferingContext,
-            triggerOfferingIdentifier: identifier
-        )
+            return try Self.makeWorkflowContext(
+                workflow: fetchResult.workflow,
+                uiConfig: fetchResult.uiConfig,
+                allOfferings: allOfferings,
+                presentedOfferingContext: presentedOfferingContext,
+                triggerOfferingIdentifier: identifier
+            )
+        } catch WorkflowError.uiConfigUnavailable(let workflowId) {
+            throw PaywallError.workflowUiConfigUnavailable(workflowId: workflowId)
+        }
     }
 
     /// Builds a ``WorkflowContext`` from already-resolved `workflow` + `allOfferings`. The context's

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -496,6 +496,7 @@ extension PurchaseHandler {
 
         return try Self.makeWorkflowContext(
             workflow: fetchResult.workflow,
+            uiConfig: fetchResult.uiConfig,
             allOfferings: allOfferings,
             presentedOfferingContext: presentedOfferingContext,
             triggerOfferingIdentifier: identifier
@@ -512,6 +513,7 @@ extension PurchaseHandler {
     /// `allOfferings` (reporting the screen's own offering identifier that was actually missing).
     static func makeWorkflowContext(
         workflow: PublishedWorkflow,
+        uiConfig: UIConfig,
         allOfferings: Offerings,
         presentedOfferingContext: PresentedOfferingContext?,
         triggerOfferingIdentifier: String
@@ -524,10 +526,6 @@ extension PurchaseHandler {
 
         guard let baseOffering = allOfferings.offering(identifier: screen.offeringIdentifier) else {
             throw PaywallError.offeringNotFound(identifier: screen.offeringIdentifier ?? triggerOfferingIdentifier)
-        }
-
-        guard let uiConfig = workflow.uiConfig else {
-            throw PaywallError.workflowUiConfigUnavailable(workflowId: workflow.id)
         }
 
         let paywallComponents = WorkflowScreenMapper.toPaywallComponents(
@@ -546,6 +544,7 @@ extension PurchaseHandler {
 
         return WorkflowContext(
             workflow: workflow,
+            uiConfig: uiConfig,
             allOfferings: allOfferings,
             initialOffering: offering,
             presentedOfferingContext: presentedOfferingContext

--- a/RevenueCatUI/Purchasing/WorkflowContext.swift
+++ b/RevenueCatUI/Purchasing/WorkflowContext.swift
@@ -20,6 +20,7 @@ import Foundation
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @_spi(Internal) public struct WorkflowContext {
     let workflow: PublishedWorkflow
+    let uiConfig: UIConfig
     let allOfferings: Offerings
     let initialOffering: Offering
     /// Preserved so every subsequent step's offering can carry the same placement/targeting metadata.
@@ -29,11 +30,13 @@ import Foundation
 
     init(
         workflow: PublishedWorkflow,
+        uiConfig: UIConfig,
         allOfferings: Offerings,
         initialOffering: Offering,
         presentedOfferingContext: PresentedOfferingContext?
     ) {
         self.workflow = workflow
+        self.uiConfig = uiConfig
         self.allOfferings = allOfferings
         self.initialOffering = initialOffering
         self.presentedOfferingContext = presentedOfferingContext

--- a/RevenueCatUI/Purchasing/WorkflowPreview.swift
+++ b/RevenueCatUI/Purchasing/WorkflowPreview.swift
@@ -25,11 +25,17 @@ import Foundation
     @_spi(Internal) public static func makeContext(
         workflow: PublishedWorkflow,
         offerings: [Offering],
+        uiConfig: UIConfig = UIConfig(
+            app: .init(colors: [:], fonts: [:]),
+            localizations: [:],
+            variableConfig: .init(variableCompatibilityMap: [:], functionCompatibilityMap: [:])
+        ),
         presentedOfferingContext: PresentedOfferingContext? = nil
     ) throws -> WorkflowContext {
         let allOfferings = Offerings.preview(offerings: offerings)
         return try PurchaseHandler.makeWorkflowContext(
             workflow: workflow,
+            uiConfig: uiConfig,
             allOfferings: allOfferings,
             presentedOfferingContext: presentedOfferingContext,
             triggerOfferingIdentifier: workflow.id

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -698,14 +698,13 @@ struct WorkflowPaywallView: View {
         guard let step = context.workflow.steps[stepId],
               let screenId = step.screenId,
               let screen = context.workflow.screens[screenId],
-              let offering = context.offering(for: screen.offeringIdentifier),
-              let uiConfig = context.workflow.uiConfig else {
+              let offering = context.offering(for: screen.offeringIdentifier) else {
             return nil
         }
 
         let paywallComponents = WorkflowScreenMapper.toPaywallComponents(
             screen: screen,
-            uiConfig: uiConfig
+            uiConfig: context.uiConfig
         )
 
         return .init(

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -698,13 +698,14 @@ struct WorkflowPaywallView: View {
         guard let step = context.workflow.steps[stepId],
               let screenId = step.screenId,
               let screen = context.workflow.screens[screenId],
-              let offering = context.offering(for: screen.offeringIdentifier) else {
+              let offering = context.offering(for: screen.offeringIdentifier),
+              let uiConfig = context.workflow.uiConfig else {
             return nil
         }
 
         let paywallComponents = WorkflowScreenMapper.toPaywallComponents(
             screen: screen,
-            uiConfig: context.workflow.uiConfig
+            uiConfig: uiConfig
         )
 
         return .init(

--- a/Sources/Error Handling/BackendError.swift
+++ b/Sources/Error Handling/BackendError.swift
@@ -291,9 +291,6 @@ extension BackendError {
 
         /// A workflow lookup found a matching item, but its body couldn't be decoded.
         case workflowDecodingFailed(workflowId: String, error: NSError)
-
-        /// A workflow resolved, but its `ui_config` couldn't be assembled.
-        case workflowUiConfigUnavailable(workflowId: String)
     }
 
 }
@@ -320,8 +317,6 @@ extension BackendError.UnexpectedBackendResponseError: DescribableError {
             return "Workflow '\(workflowId)' not found in remote config."
         case let .workflowDecodingFailed(workflowId, error):
             return "Workflow '\(workflowId)' could not be decoded from remote config: \(error)."
-        case let .workflowUiConfigUnavailable(workflowId):
-            return "Workflow '\(workflowId)' resolved, but its UI config is unavailable."
         }
     }
 
@@ -353,17 +348,6 @@ extension BackendError {
     ) -> Self {
         return .unexpectedBackendResponse(
             .workflowDecodingFailed(workflowId: workflowId, error: error),
-            extraContext: nil,
-            .init(file: file, function: function, line: line)
-        )
-    }
-
-    static func workflowUiConfigUnavailable(
-        workflowId: String,
-        file: String = #fileID, function: String = #function, line: UInt = #line
-    ) -> Self {
-        return .unexpectedBackendResponse(
-            .workflowUiConfigUnavailable(workflowId: workflowId),
             extraContext: nil,
             .init(file: file, function: function, line: line)
         )

--- a/Sources/FoundationExtensions/Array+Extensions.swift
+++ b/Sources/FoundationExtensions/Array+Extensions.swift
@@ -50,3 +50,14 @@ extension Sequence where Element: AdditiveArithmetic {
     }
 
 }
+
+extension Sequence where Element: Hashable {
+
+    /// Returns the sequence's unique elements, preserving each element's first occurrence.
+    func deduplicated() -> [Element] {
+        var seen: Set<Element> = []
+
+        return self.filter { seen.insert($0).inserted }
+    }
+
+}

--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -113,7 +113,7 @@ extension RemoteConfigStrings: LogMessage {
         case let .uiConfigDecodeFailed(error):
             return "Failed to decode merged ui_config: \(error.localizedDescription)"
         case .uiConfigMissingRequiredPart:
-            return "Failed to assemble ui_config: the 'app' or 'localizations' part is unavailable."
+            return "Failed to assemble ui_config: one or more parts are unavailable."
         case let .uiConfigPartDecodeFailed(itemKey, error):
             return "Failed to decode ui_config part '\(itemKey)': \(error.localizedDescription)"
         }

--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -38,7 +38,6 @@ enum RemoteConfigStrings {
     case storedInlineBlob(String, byteCount: Int)
     case uiConfigDecodeFailed(Error)
     case uiConfigMissingRequiredPart
-    case uiConfigPartDecodeFailed(itemKey: String, error: Error)
 
 }
 
@@ -114,8 +113,6 @@ extension RemoteConfigStrings: LogMessage {
             return "Failed to decode merged ui_config: \(error.localizedDescription)"
         case .uiConfigMissingRequiredPart:
             return "Failed to assemble ui_config: one or more parts are unavailable."
-        case let .uiConfigPartDecodeFailed(itemKey, error):
-            return "Failed to decode ui_config part '\(itemKey)': \(error.localizedDescription)"
         }
     }
 

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -92,7 +92,7 @@ extension RemoteConfigManagerType {
         itemKeys: [String],
         as type: T.Type
     ) async throws -> T? {
-        let uniqueItemKeys = Self.uniqueItemKeys(itemKeys)
+        let uniqueItemKeys = itemKeys.deduplicated()
         guard !self.isDisabled else {
             Logger.warn(Strings.remoteConfig.mergeItemsBlobDataDisabled(topic: topic, itemKeys: uniqueItemKeys))
             return nil
@@ -160,17 +160,6 @@ extension RemoteConfigManagerType {
         }
         envelope.append(contentsOf: "}".utf8)
         return envelope
-    }
-
-    private static func uniqueItemKeys(_ itemKeys: [String]) -> [String] {
-        var seen: Set<String> = []
-        var uniqueItemKeys: [String] = []
-
-        for itemKey in itemKeys where seen.insert(itemKey).inserted {
-            uniqueItemKeys.append(itemKey)
-        }
-
-        return uniqueItemKeys
     }
 
 }
@@ -784,7 +773,7 @@ private extension RemoteConfigManager {
             postSyncTopics: postSyncTopics
         ).filter { !self.blobStore.contains(ref: $0) }
         Logger.verbose(Strings.remoteConfig.prefetchingBlobCount(refsToPrefetch.count))
-        self.blobFetcher.prefetch(refs: Array(refsToPrefetch))
+        self.blobFetcher.prefetch(refs: refsToPrefetch)
 
         return true
     }
@@ -823,14 +812,14 @@ private extension RemoteConfigManager {
     func postSyncPrefetchBlobRefs(
         response: RemoteConfiguration,
         postSyncTopics: RemoteConfiguration.Topics
-    ) -> Set<String> {
+    ) -> [String] {
         let itemPrefetchBlobRefs = postSyncTopics.entries.values.flatMap { topic in
             topic.values
                 .filter(\.prefetch)
                 .compactMap(\.blobRef)
         }
 
-        return Set(response.prefetchBlobs).union(itemPrefetchBlobRefs)
+        return (response.prefetchBlobs + itemPrefetchBlobRefs).deduplicated()
     }
 
     /// Writes valid inline content elements that are referenced by this config response.

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -779,7 +779,10 @@ private extension RemoteConfigManager {
             referencedBlobCount: postSyncReferencedBlobRefs.count
         ))
 
-        let refsToPrefetch = response.prefetchBlobs.filter { !self.blobStore.contains(ref: $0) }
+        let refsToPrefetch = self.postSyncPrefetchBlobRefs(
+            response: response,
+            postSyncTopics: postSyncTopics
+        ).filter { !self.blobStore.contains(ref: $0) }
         Logger.verbose(Strings.remoteConfig.prefetchingBlobCount(refsToPrefetch.count))
         self.blobFetcher.prefetch(refs: refsToPrefetch)
 
@@ -811,6 +814,37 @@ private extension RemoteConfigManager {
         postSyncTopics: RemoteConfiguration.Topics
     ) -> Set<String> {
         return Set(response.prefetchBlobs).union(postSyncTopics.blobRefs)
+    }
+
+    /// Returns the post-sync blob refs the SDK should proactively warm.
+    ///
+    /// This includes server-requested prefetch blobs plus any active-topic item whose metadata has
+    /// `prefetch: true`, matching the refs `awaitTopicAndPrefetchBlobsReady(_:)` waits on before
+    /// vending a topic to consumers that need warmed blobs.
+    func postSyncPrefetchBlobRefs(
+        response: RemoteConfiguration,
+        postSyncTopics: RemoteConfiguration.Topics
+    ) -> [String] {
+        var seen: Set<String> = []
+        var refs: [String] = []
+
+        func appendIfNeeded(_ ref: String) {
+            guard seen.insert(ref).inserted else { return }
+            refs.append(ref)
+        }
+
+        response.prefetchBlobs.forEach(appendIfNeeded)
+
+        for topicName in postSyncTopics.entries.keys.sorted() {
+            guard let topic = postSyncTopics.entries[topicName] else { continue }
+
+            for itemKey in topic.keys.sorted() {
+                guard let item = topic[itemKey], item.prefetch, let ref = item.blobRef else { continue }
+                appendIfNeeded(ref)
+            }
+        }
+
+        return refs
     }
 
     /// Writes valid inline content elements that are referenced by this config response.

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -784,7 +784,7 @@ private extension RemoteConfigManager {
             postSyncTopics: postSyncTopics
         ).filter { !self.blobStore.contains(ref: $0) }
         Logger.verbose(Strings.remoteConfig.prefetchingBlobCount(refsToPrefetch.count))
-        self.blobFetcher.prefetch(refs: refsToPrefetch)
+        self.blobFetcher.prefetch(refs: Array(refsToPrefetch))
 
         return true
     }
@@ -819,32 +819,18 @@ private extension RemoteConfigManager {
     /// Returns the post-sync blob refs the SDK should proactively warm.
     ///
     /// This includes server-requested prefetch blobs plus any active-topic item whose metadata has
-    /// `prefetch: true`, matching the refs `awaitTopicAndPrefetchBlobsReady(_:)` waits on before
-    /// vending a topic to consumers that need warmed blobs.
+    /// `prefetch: true`.
     func postSyncPrefetchBlobRefs(
         response: RemoteConfiguration,
         postSyncTopics: RemoteConfiguration.Topics
-    ) -> [String] {
-        var seen: Set<String> = []
-        var refs: [String] = []
-
-        func appendIfNeeded(_ ref: String) {
-            guard seen.insert(ref).inserted else { return }
-            refs.append(ref)
+    ) -> Set<String> {
+        let itemPrefetchBlobRefs = postSyncTopics.entries.values.flatMap { topic in
+            topic.values
+                .filter(\.prefetch)
+                .compactMap(\.blobRef)
         }
 
-        response.prefetchBlobs.forEach(appendIfNeeded)
-
-        for topicName in postSyncTopics.entries.keys.sorted() {
-            guard let topic = postSyncTopics.entries[topicName] else { continue }
-
-            for itemKey in topic.keys.sorted() {
-                guard let item = topic[itemKey], item.prefetch, let ref = item.blobRef else { continue }
-                appendIfNeeded(ref)
-            }
-        }
-
-        return refs
+        return Set(response.prefetchBlobs).union(itemPrefetchBlobRefs)
     }
 
     /// Writes valid inline content elements that are referenced by this config response.

--- a/Sources/Networking/Responses/RevenueCatUI/UIConfig.swift
+++ b/Sources/Networking/Responses/RevenueCatUI/UIConfig.swift
@@ -168,10 +168,10 @@ import Foundation
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.app = try container.decode(AppConfig.self, forKey: .app)
         self.localizations = try container.decode([String: [String: String]].self, forKey: .localizations)
-        self.variableConfig = try container.decodeIfPresent(
+        self.variableConfig = try container.decode(
             VariableConfig.self,
             forKey: .variableConfig
-        ) ?? VariableConfig(variableCompatibilityMap: [:], functionCompatibilityMap: [:])
+        )
 
         // `custom_variables` was added after the other fields, so the key may be absent from older responses; fall
         // back to an empty dictionary in that case. If the key is present but malformed, fail like any other field.
@@ -193,7 +193,7 @@ import Foundation
 
 extension UIConfig {
 
-    /// An empty configuration used when a workflow's `ui_config` topic parts are not yet available.
+    /// Empty configuration used by tests and platform stubs.
     static let empty = UIConfig(
         app: AppConfig(colors: [:], fonts: [:]),
         localizations: [:],
@@ -210,7 +210,7 @@ extension UIConfig {
 
 extension UIConfig {
 
-    /// An empty configuration used when a workflow's `ui_config` topic parts are not yet available.
+    /// Empty configuration used by tests and platform stubs.
     static let empty = UIConfig()
 
 }

--- a/Sources/Networking/Responses/WorkflowsResponse.swift
+++ b/Sources/Networking/Responses/WorkflowsResponse.swift
@@ -229,6 +229,13 @@ import Foundation
 
 }
 
+@_spi(Internal) public enum WorkflowError: Error, Equatable, Sendable {
+
+    /// The workflow itself resolved, but its `ui_config` couldn't be assembled.
+    case uiConfigUnavailable(workflowId: String)
+
+}
+
 // MARK: - Codable
 
 extension WorkflowTrigger: Codable, Equatable, Sendable {}

--- a/Sources/Networking/Responses/WorkflowsResponse.swift
+++ b/Sources/Networking/Responses/WorkflowsResponse.swift
@@ -175,7 +175,6 @@ import Foundation
     public let singleStepFallbackId: String?
     public let steps: [String: WorkflowStep]
     public let screens: [String: WorkflowScreen]
-    public let uiConfig: UIConfig?
     let contentMaxWidth: Int?
     let metadata: [String: AnyDecodable]?
 
@@ -187,7 +186,6 @@ import Foundation
         singleStepFallbackId: String?,
         steps: [String: WorkflowStep],
         screens: [String: WorkflowScreen],
-        uiConfig: UIConfig?,
         contentMaxWidth: Int? = nil
     ) {
         self.id = id
@@ -196,7 +194,6 @@ import Foundation
         self.singleStepFallbackId = singleStepFallbackId
         self.steps = steps
         self.screens = screens
-        self.uiConfig = uiConfig
         self.contentMaxWidth = contentMaxWidth
         self.metadata = nil
     }
@@ -209,7 +206,6 @@ import Foundation
         singleStepFallbackId: String?,
         steps: [String: WorkflowStep],
         screens: [String: WorkflowScreen],
-        uiConfig: UIConfig?,
         contentMaxWidth: Int?,
         metadata: [String: AnyDecodable]?
     ) {
@@ -219,24 +215,8 @@ import Foundation
         self.singleStepFallbackId = singleStepFallbackId
         self.steps = steps
         self.screens = screens
-        self.uiConfig = uiConfig
         self.contentMaxWidth = contentMaxWidth
         self.metadata = metadata
-    }
-
-    /// Returns a copy with `uiConfig` replaced. Unlike the public initializer, this preserves `metadata`.
-    func withUiConfig(_ uiConfig: UIConfig) -> PublishedWorkflow {
-        return PublishedWorkflow(
-            id: self.id,
-            displayName: self.displayName,
-            initialStepId: self.initialStepId,
-            singleStepFallbackId: self.singleStepFallbackId,
-            steps: self.steps,
-            screens: self.screens,
-            uiConfig: uiConfig,
-            contentMaxWidth: self.contentMaxWidth,
-            metadata: self.metadata
-        )
     }
 
 }
@@ -244,6 +224,7 @@ import Foundation
 @_spi(Internal) public struct WorkflowDataResult {
 
     public let workflow: PublishedWorkflow
+    public let uiConfig: UIConfig
     public let enrolledVariants: [String: String]?
 
 }
@@ -325,8 +306,6 @@ extension PublishedWorkflow: Codable, Equatable, Sendable {
         self.singleStepFallbackId = try container.decodeIfPresent(String.self, forKey: .singleStepFallbackId)
         self.steps = try container.decode([String: WorkflowStep].self, forKey: .steps)
         self.screens = try container.decode([String: WorkflowScreen].self, forKey: .screens)
-        // Ignored in workflow bodies: `ui_config` is resolved from its own remote-config topic.
-        self.uiConfig = nil
         self.contentMaxWidth = try container.decodeIfPresent(Int.self, forKey: .contentMaxWidth)
         self.metadata = try container.decodeIfPresent([String: AnyDecodable].self, forKey: .metadata)
     }

--- a/Sources/Networking/Responses/WorkflowsResponse.swift
+++ b/Sources/Networking/Responses/WorkflowsResponse.swift
@@ -175,7 +175,7 @@ import Foundation
     public let singleStepFallbackId: String?
     public let steps: [String: WorkflowStep]
     public let screens: [String: WorkflowScreen]
-    public let uiConfig: UIConfig
+    public let uiConfig: UIConfig?
     let contentMaxWidth: Int?
     let metadata: [String: AnyDecodable]?
 
@@ -187,7 +187,7 @@ import Foundation
         singleStepFallbackId: String?,
         steps: [String: WorkflowStep],
         screens: [String: WorkflowScreen],
-        uiConfig: UIConfig,
+        uiConfig: UIConfig?,
         contentMaxWidth: Int? = nil
     ) {
         self.id = id
@@ -209,7 +209,7 @@ import Foundation
         singleStepFallbackId: String?,
         steps: [String: WorkflowStep],
         screens: [String: WorkflowScreen],
-        uiConfig: UIConfig,
+        uiConfig: UIConfig?,
         contentMaxWidth: Int?,
         metadata: [String: AnyDecodable]?
     ) {
@@ -313,7 +313,6 @@ extension PublishedWorkflow: Codable, Equatable, Sendable {
         case singleStepFallbackId
         case steps
         case screens
-        case uiConfig
         case contentMaxWidth
         case metadata
     }
@@ -326,8 +325,8 @@ extension PublishedWorkflow: Codable, Equatable, Sendable {
         self.singleStepFallbackId = try container.decodeIfPresent(String.self, forKey: .singleStepFallbackId)
         self.steps = try container.decode([String: WorkflowStep].self, forKey: .steps)
         self.screens = try container.decode([String: WorkflowScreen].self, forKey: .screens)
-        // Absent from the remote-config `workflows` topic body (ui_config is its own topic there).
-        self.uiConfig = try container.decodeIfPresent(UIConfig.self, forKey: .uiConfig) ?? .empty
+        // Ignored in workflow bodies: `ui_config` is resolved from its own remote-config topic.
+        self.uiConfig = nil
         self.contentMaxWidth = try container.decodeIfPresent(Int.self, forKey: .contentMaxWidth)
         self.metadata = try container.decodeIfPresent([String: AnyDecodable].self, forKey: .metadata)
     }
@@ -340,7 +339,6 @@ extension PublishedWorkflow: Codable, Equatable, Sendable {
         try container.encodeIfPresent(self.singleStepFallbackId, forKey: .singleStepFallbackId)
         try container.encode(self.steps, forKey: .steps)
         try container.encode(self.screens, forKey: .screens)
-        try container.encode(self.uiConfig, forKey: .uiConfig)
         try container.encodeIfPresent(self.contentMaxWidth, forKey: .contentMaxWidth)
         try container.encodeIfPresent(self.metadata, forKey: .metadata)
     }

--- a/Sources/Networking/UiConfigProvider.swift
+++ b/Sources/Networking/UiConfigProvider.swift
@@ -19,17 +19,14 @@ final class UiConfigProvider {
     }
 
 #if !os(tvOS)
-    /// Assembles a ``UIConfig`` from the `ui_config` topic's parts. Returns `nil` when a required part
-    /// (`app` or `localizations`) is unavailable or fails to decode.
-    ///
-    /// Optional parts decode independently so missing or malformed optional blobs fall back to the same
-    /// defaults as `UIConfig`'s decoder.
+    /// Assembles a ``UIConfig`` from the `ui_config` topic's parts. Returns `nil` when any part is unavailable
+    /// or fails to decode, so callers never render with a partially assembled configuration.
     func getUiConfig() async -> UIConfig? {
         do {
-            guard let requiredParts = try await self.manager.mergeItemsBlobData(
+            guard let uiConfig = try await self.manager.mergeItemsBlobData(
                 for: .uiConfig,
-                itemKeys: Self.requiredItemKeys,
-                as: RequiredParts.self
+                itemKeys: Self.itemKeys,
+                as: UIConfig.self
             ) else {
                 if !self.manager.isDisabled {
                     Logger.warn(Strings.remoteConfig.uiConfigMissingRequiredPart)
@@ -37,54 +34,12 @@ final class UiConfigProvider {
                 return nil
             }
 
-            let topic = await self.manager.topic(.uiConfig)
-            async let variableConfig = self.decodeOptionalPart(
-                UIConfig.VariableConfig.self,
-                itemKey: Self.variableConfigKey,
-                topic: topic
-            )
-            async let customVariables = self.decodeOptionalPart(
-                [String: UIConfig.CustomVariableDefinition].self,
-                itemKey: Self.customVariablesKey,
-                topic: topic
-            )
-
-            return UIConfig(
-                app: requiredParts.app,
-                localizations: requiredParts.localizations,
-                variableConfig: await variableConfig ?? Self.defaultVariableConfig,
-                customVariables: await customVariables ?? [:]
-            )
+            return uiConfig
         } catch {
             Logger.error(Strings.remoteConfig.uiConfigDecodeFailed(error))
             return nil
         }
     }
-
-    private func decodeOptionalPart<T: Decodable>(
-        _ type: T.Type,
-        itemKey: String,
-        topic: RemoteConfiguration.ConfigTopic?
-    ) async -> T? {
-        guard topic?[itemKey] != nil else { return nil }
-
-        do {
-            return try await self.manager.blobData(for: .uiConfig, itemKey: itemKey, as: type)
-        } catch {
-            Logger.error(Strings.remoteConfig.uiConfigPartDecodeFailed(itemKey: itemKey, error: error))
-            return nil
-        }
-    }
-
-    private struct RequiredParts: Decodable {
-        let app: UIConfig.AppConfig
-        let localizations: [String: [String: String]]
-    }
-
-    private static let defaultVariableConfig = UIConfig.VariableConfig(
-        variableCompatibilityMap: [:],
-        functionCompatibilityMap: [:]
-    )
 #else
     // Paywalls V2 (and therefore workflows) aren't supported on tvOS, where `UIConfig` carries no fields.
     func getUiConfig() async -> UIConfig? {
@@ -102,10 +57,12 @@ final class UiConfigProvider {
     private static let localizationsKey = "localizations"
     private static let variableConfigKey = "variable_config"
     private static let customVariablesKey = "custom_variables"
-    private static var requiredItemKeys: [String] {
+    private static var itemKeys: [String] {
         return [
             Self.appKey,
-            Self.localizationsKey
+            Self.localizationsKey,
+            Self.variableConfigKey,
+            Self.customVariablesKey
         ]
     }
 

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -107,7 +107,7 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         // workflow-body read would still be implicitly awaited (Swift cancels but does not fast-fail an
         // unconsumed `async let` when its scope exits) if the body turns out missing or malformed, so a
         // miss would pay for `ui_config`'s network reads anyway instead of returning immediately.
-        var workflow: PublishedWorkflow
+        let workflow: PublishedWorkflow
         switch await self.fetchWorkflow(workflowId: workflowId) {
         case let .success(fetched):
             workflow = fetched
@@ -118,9 +118,8 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         guard let uiConfig = await self.uiConfigProvider.getUiConfig() else {
             return .failure(.uiConfigUnavailable)
         }
-        workflow = workflow.withUiConfig(uiConfig)
 
-        return .success(WorkflowDataResult(workflow: workflow, enrolledVariants: nil))
+        return .success(WorkflowDataResult(workflow: workflow, uiConfig: uiConfig, enrolledVariants: nil))
     }
 
     private func fetchWorkflow(workflowId: String) async -> Result<PublishedWorkflow, WorkflowResolutionError> {

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -64,8 +64,8 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     }
 
     /// Builds the offeringId → workflowId map in a stable pass over `topic`. A duplicate `offeringId`
-    /// across items signals a backend issue and is logged once per rebuild; the last workflow id wins,
-    /// matching Android's last-wins behavior without relying on Swift dictionary iteration order.
+    /// across items signals a backend issue and is logged once per rebuild; the last workflow id wins
+    /// without relying on Swift dictionary iteration order.
     private func buildOfferingIdMap(from topic: RemoteConfiguration.ConfigTopic) -> [String: String] {
         var map: [String: String] = [:]
         var duplicateOfferingIds: Set<String> = []

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -89,9 +89,8 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
 
     /// Resolves `workflowId` into a ``WorkflowDataResult``, or the specific ``WorkflowResolutionError``
     /// that prevented it: the item is unknown, its body can't be parsed, or `ui_config` isn't available.
-    /// A workflow is only rendered with real styling, never with `PublishedWorkflow`'s decode-time
-    /// `.empty` placeholder, matching Android's `PaywallViewModel` failing the whole render when its
-    /// concurrent `ui_config` fetch fails.
+    /// A workflow is only rendered with styling resolved from the `ui_config` topic, matching Android's
+    /// `PaywallViewModel` failing the whole render when its concurrent `ui_config` fetch fails.
     ///
     /// `enrolled_variants` is not populated here: per-user A/B enrollment doesn't fit this shared,
     /// content-addressed read model and is being designed separately.

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -63,20 +63,19 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         return map[offeringId]
     }
 
-    /// Builds the offeringId → workflowId map in a single pass over `topic`. A duplicate `offeringId`
-    /// across items signals a backend issue and is logged once per rebuild; whichever match the
-    /// dictionary happens to iterate first wins, since there's no principled way to prefer one over
-    /// another.
+    /// Builds the offeringId → workflowId map in a stable pass over `topic`. A duplicate `offeringId`
+    /// across items signals a backend issue and is logged once per rebuild; the last workflow id wins,
+    /// matching Android's last-wins behavior without relying on Swift dictionary iteration order.
     private func buildOfferingIdMap(from topic: RemoteConfiguration.ConfigTopic) -> [String: String] {
         var map: [String: String] = [:]
         var duplicateOfferingIds: Set<String> = []
 
-        for (workflowId, item) in topic {
+        for workflowId in topic.keys.sorted() {
+            guard let item = topic[workflowId] else { continue }
             guard case let .string(offeringId)? = item.content[Self.offeringIdentifierKey] else { continue }
 
             if map[offeringId] != nil {
                 duplicateOfferingIds.insert(offeringId)
-                continue
             }
             map[offeringId] = workflowId
         }

--- a/Sources/Paywalls/PaywallCacheWarming.swift
+++ b/Sources/Paywalls/PaywallCacheWarming.swift
@@ -34,7 +34,7 @@ protocol PaywallCacheWarmingType: Sendable {
     func warmUpPaywallFontsCache(offerings: Offerings) async
 
     @available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *)
-    func warmUpWorkflowCaches(workflow: PublishedWorkflow) async
+    func warmUpWorkflowCaches(workflow: PublishedWorkflow, uiConfig: UIConfig) async
 
 #if !os(tvOS) // For Paywalls
 
@@ -177,7 +177,7 @@ actor PaywallCacheWarming: PaywallCacheWarmingType {
         }
     }
 
-    func warmUpWorkflowCaches(workflow: PublishedWorkflow) async {
+    func warmUpWorkflowCaches(workflow: PublishedWorkflow, uiConfig: UIConfig) async {
         guard !self.warmedWorkflowIDs.contains(workflow.id) else { return }
         self.warmedWorkflowIDs.insert(workflow.id)
 
@@ -194,7 +194,7 @@ actor PaywallCacheWarming: PaywallCacheWarmingType {
         let imageURLs = Set(screens.flatMap(\.allImageURLs))
         let videoURLs = Set(screens.flatMap(\.allLowResVideoUrls))
         #if !os(tvOS)
-        let fonts = workflow.uiConfig?.app.allDownloadableFonts ?? []
+        let fonts = uiConfig.app.allDownloadableFonts
         #endif
 
         await withTaskGroup(of: Void.self) { group in

--- a/Sources/Paywalls/PaywallCacheWarming.swift
+++ b/Sources/Paywalls/PaywallCacheWarming.swift
@@ -194,7 +194,7 @@ actor PaywallCacheWarming: PaywallCacheWarmingType {
         let imageURLs = Set(screens.flatMap(\.allImageURLs))
         let videoURLs = Set(screens.flatMap(\.allLowResVideoUrls))
         #if !os(tvOS)
-        let fonts = workflow.uiConfig.app.allDownloadableFonts
+        let fonts = workflow.uiConfig?.app.allDownloadableFonts ?? []
         #endif
 
         await withTaskGroup(of: Void.self) { group in

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -38,8 +38,8 @@ class WorkflowManager {
         self.operationDispatcher = operationDispatcher
     }
 
-    /// Resolves `workflowId`, or throws the `BackendError` explaining why it couldn't be resolved:
-    /// genuinely missing, malformed, or missing its `ui_config`.
+    /// Resolves `workflowId`, or throws the error explaining why it couldn't be resolved: genuinely
+    /// missing, malformed, or missing its `ui_config`.
     func getWorkflow(workflowId: String) async throws -> WorkflowDataResult {
         switch await self.workflowsConfigProvider.getWorkflow(workflowId: workflowId) {
         case let .success(result):
@@ -50,7 +50,7 @@ class WorkflowManager {
         case let .failure(.decodingFailed(error)):
             throw BackendError.workflowDecodingFailed(workflowId: workflowId, error: error)
         case .failure(.uiConfigUnavailable):
-            throw BackendError.workflowUiConfigUnavailable(workflowId: workflowId)
+            throw WorkflowError.uiConfigUnavailable(workflowId: workflowId)
         }
     }
 

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -79,7 +79,7 @@ private extension WorkflowManager {
         guard #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *), let paywallCache else { return }
 
         self.operationDispatcher.dispatchOnWorkerThread {
-            await paywallCache.warmUpWorkflowCaches(workflow: result.workflow)
+            await paywallCache.warmUpWorkflowCaches(workflow: result.workflow, uiConfig: result.uiConfig)
         }
     }
 

--- a/Tests/RevenueCatUITests/Data/PaywallViewConfigurationTests.swift
+++ b/Tests/RevenueCatUITests/Data/PaywallViewConfigurationTests.swift
@@ -516,6 +516,7 @@ private extension PaywallViewConfigurationTests {
         """
         let data = try XCTUnwrap(json.data(using: .utf8))
         return try JSONDecoder.default.decode(PublishedWorkflow.self, from: data)
+            .withUiConfig(PreviewUIConfig.make())
     }
 
     /// A dashboard-authored V2 paywall independent of any workflow, built from the same screen shape
@@ -523,7 +524,8 @@ private extension PaywallViewConfigurationTests {
     static func createPaywallComponents(offeringIdentifier: String) throws -> Offering.PaywallComponents {
         let workflow = try Self.createWorkflow(offeringIdentifier: offeringIdentifier)
         let screen = try XCTUnwrap(workflow.screens["screen_1"])
-        return WorkflowScreenMapper.toPaywallComponents(screen: screen, uiConfig: workflow.uiConfig)
+        let uiConfig = try XCTUnwrap(workflow.uiConfig)
+        return WorkflowScreenMapper.toPaywallComponents(screen: screen, uiConfig: uiConfig)
     }
 
     /// A non-legacy offering with a fallback paywall already available, wired into a handler whose

--- a/Tests/RevenueCatUITests/Data/PaywallViewConfigurationTests.swift
+++ b/Tests/RevenueCatUITests/Data/PaywallViewConfigurationTests.swift
@@ -466,6 +466,7 @@ private extension PaywallViewConfigurationTests {
     static func createWorkflowDataResult(offeringIdentifier: String) throws -> WorkflowDataResult {
         return .init(
             workflow: try self.createWorkflow(offeringIdentifier: offeringIdentifier),
+            uiConfig: PreviewUIConfig.make(),
             enrolledVariants: nil
         )
     }
@@ -516,7 +517,6 @@ private extension PaywallViewConfigurationTests {
         """
         let data = try XCTUnwrap(json.data(using: .utf8))
         return try JSONDecoder.default.decode(PublishedWorkflow.self, from: data)
-            .withUiConfig(PreviewUIConfig.make())
     }
 
     /// A dashboard-authored V2 paywall independent of any workflow, built from the same screen shape
@@ -524,8 +524,7 @@ private extension PaywallViewConfigurationTests {
     static func createPaywallComponents(offeringIdentifier: String) throws -> Offering.PaywallComponents {
         let workflow = try Self.createWorkflow(offeringIdentifier: offeringIdentifier)
         let screen = try XCTUnwrap(workflow.screens["screen_1"])
-        let uiConfig = try XCTUnwrap(workflow.uiConfig)
-        return WorkflowScreenMapper.toPaywallComponents(screen: screen, uiConfig: uiConfig)
+        return WorkflowScreenMapper.toPaywallComponents(screen: screen, uiConfig: PreviewUIConfig.make())
     }
 
     /// A non-legacy offering with a fallback paywall already available, wired into a handler whose

--- a/Tests/RevenueCatUITests/Data/PaywallViewConfigurationTests.swift
+++ b/Tests/RevenueCatUITests/Data/PaywallViewConfigurationTests.swift
@@ -241,6 +241,23 @@ final class PaywallViewConfigurationTests: TestCase {
         }
     }
 
+    func testResolvePaywallViewDataThrowsWhenWorkflowUiConfigUnavailableEvenWithFallbackAvailable() async throws {
+        let (offering, _, purchases, handler) = try Self.createOfferingWithFallbackFixture()
+        purchases.workflowBlock = { _ in
+            throw WorkflowError.uiConfigUnavailable(workflowId: "wf_test")
+        }
+
+        do {
+            _ = try await handler.resolvePaywallViewData(
+                for: .offering(offering),
+                remoteConfigEnabled: true
+            )
+            XCTFail("Expected resolvePaywallViewData to throw")
+        } catch let PaywallError.workflowUiConfigUnavailable(workflowId) {
+            expect(workflowId) == "wf_test"
+        }
+    }
+
     func testResolvePaywallViewDataThrowsOnCancellationEvenWithFallbackAvailable() async throws {
         // Cancellation must propagate even with a fallback available: mirrors
         // isWorkflowFetchFallbackEligible's CancellationError exclusion.

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
@@ -533,6 +533,7 @@ private extension WorkflowPaywallViewTests {
         )
         return WorkflowContext(
             workflow: workflow,
+            uiConfig: PreviewUIConfig.make(),
             allOfferings: offerings,
             initialOffering: offering,
             presentedOfferingContext: nil
@@ -590,7 +591,6 @@ private extension WorkflowPaywallViewTests {
         """
         let data = try XCTUnwrap(json.data(using: .utf8))
         return try JSONDecoder.default.decode(PublishedWorkflow.self, from: data)
-            .withUiConfig(PreviewUIConfig.make())
     }
 
     static func makeScreenJSON(packages: [PackageSpec], offeringId: String) -> String {
@@ -1182,7 +1182,6 @@ private extension WorkflowPaywallViewTests {
         """
         let data = try XCTUnwrap(workflowJSON.data(using: .utf8))
         let workflow = try JSONDecoder.default.decode(PublishedWorkflow.self, from: data)
-            .withUiConfig(PreviewUIConfig.make())
 
         let packages = [
             makePackage(identifier: TestData.annualPackage.identifier, offeringId: offeringId),
@@ -1215,6 +1214,7 @@ private extension WorkflowPaywallViewTests {
         )
         return WorkflowContext(
             workflow: workflow,
+            uiConfig: PreviewUIConfig.make(),
             allOfferings: offerings,
             initialOffering: offering,
             presentedOfferingContext: nil

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
@@ -590,6 +590,7 @@ private extension WorkflowPaywallViewTests {
         """
         let data = try XCTUnwrap(json.data(using: .utf8))
         return try JSONDecoder.default.decode(PublishedWorkflow.self, from: data)
+            .withUiConfig(PreviewUIConfig.make())
     }
 
     static func makeScreenJSON(packages: [PackageSpec], offeringId: String) -> String {
@@ -1181,6 +1182,7 @@ private extension WorkflowPaywallViewTests {
         """
         let data = try XCTUnwrap(workflowJSON.data(using: .utf8))
         let workflow = try JSONDecoder.default.decode(PublishedWorkflow.self, from: data)
+            .withUiConfig(PreviewUIConfig.make())
 
         let packages = [
             makePackage(identifier: TestData.annualPackage.identifier, offeringId: offeringId),

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowScreenMapperTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowScreenMapperTests.swift
@@ -148,7 +148,11 @@ private extension WorkflowScreenMapperTests {
         let json = """
         {
             "app": { "colors": {}, "fonts": {} },
-            "localizations": {}
+            "localizations": {},
+            "variable_config": {
+                "variable_compatibility_map": {},
+                "function_compatibility_map": {}
+            }
         }
         """
         let data = try XCTUnwrap(json.data(using: .utf8))

--- a/Tests/RevenueCatUITests/Purchasing/WorkflowContextTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/WorkflowContextTests.swift
@@ -1010,3 +1010,26 @@ private extension WorkflowContextTests {
 }
 
 #endif
+
+#if !os(tvOS) // For Paywalls V2
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension WorkflowContext {
+
+    init(
+        workflow: PublishedWorkflow,
+        allOfferings: Offerings,
+        initialOffering: Offering,
+        presentedOfferingContext: PresentedOfferingContext?
+    ) {
+        self.init(
+            workflow: workflow,
+            uiConfig: .empty,
+            allOfferings: allOfferings,
+            initialOffering: initialOffering,
+            presentedOfferingContext: presentedOfferingContext
+        )
+    }
+
+}
+
+#endif

--- a/Tests/RevenueCatUITests/Purchasing/WorkflowPreviewTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/WorkflowPreviewTests.swift
@@ -130,7 +130,11 @@ private extension WorkflowPreviewTests {
         let json = """
         {
           "app": { "colors": {}, "fonts": {} },
-          "localizations": {}
+          "localizations": {},
+          "variable_config": {
+            "variable_compatibility_map": {},
+            "function_compatibility_map": {}
+          }
         }
         """
         let data = try XCTUnwrap(json.data(using: .utf8))

--- a/Tests/RevenueCatUITests/Purchasing/WorkflowPreviewTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/WorkflowPreviewTests.swift
@@ -79,7 +79,7 @@ private extension WorkflowPreviewTests {
     }
 
     /// Builds a single-screen workflow using the `@_spi(Internal)` initializers (C-1), sourcing the
-    /// `componentsConfig`/`uiConfig` sub-objects from JSON since hand-building them is impractical.
+    /// `componentsConfig` sub-object from JSON since hand-building it is impractical.
     static func makeWorkflow(screenOfferingIdentifier: String) throws -> PublishedWorkflow {
         let screen = WorkflowScreen(
             name: nil,
@@ -98,8 +98,7 @@ private extension WorkflowPreviewTests {
             initialStepId: "step_1",
             singleStepFallbackId: nil,
             steps: ["step_1": step],
-            screens: ["screen_1": screen],
-            uiConfig: try Self.makeUIConfig()
+            screens: ["screen_1": screen]
         )
     }
 
@@ -124,21 +123,6 @@ private extension WorkflowPreviewTests {
         """
         let data = try XCTUnwrap(json.data(using: .utf8))
         return try JSONDecoder.default.decode(PaywallComponentsData.ComponentsConfig.self, from: data)
-    }
-
-    static func makeUIConfig() throws -> UIConfig {
-        let json = """
-        {
-          "app": { "colors": {}, "fonts": {} },
-          "localizations": {},
-          "variable_config": {
-            "variable_compatibility_map": {},
-            "function_compatibility_map": {}
-          }
-        }
-        """
-        let data = try XCTUnwrap(json.data(using: .utf8))
-        return try JSONDecoder.default.decode(UIConfig.self, from: data)
     }
 
 }

--- a/Tests/UnitTests/FoundationExtensions/ArrayExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/ArrayExtensionsTests.swift
@@ -89,4 +89,18 @@ class ArrayExtensionsTests: TestCase {
         expect([1, 2, 3].sum()) == 6
     }
 
+    // MARK: - deduplicated
+
+    func testDeduplicatedWithEmptyArray() {
+        expect([Int]().deduplicated()) == []
+    }
+
+    func testDeduplicatedPreservesFirstOccurrenceOrder() {
+        expect([3, 1, 2, 3, 2, 4, 1].deduplicated()) == [3, 1, 2, 4]
+    }
+
+    func testDeduplicatedWithStrings() {
+        expect(["a", "b", "a", "c", "b"].deduplicated()) == ["a", "b", "c"]
+    }
+
 }

--- a/Tests/UnitTests/Mocks/MockPaywallCacheWarming.swift
+++ b/Tests/UnitTests/Mocks/MockPaywallCacheWarming.swift
@@ -113,6 +113,7 @@ final class MockPaywallCacheWarming: PaywallCacheWarmingType {
 
     private let _invokedWarmUpWorkflowCaches: Atomic<Bool> = false
     private let _invokedWarmUpWorkflowCachesWorkflow: Atomic<PublishedWorkflow?> = nil
+    private let _invokedWarmUpWorkflowCachesUiConfig: Atomic<UIConfig?> = nil
 
     var invokedWarmUpWorkflowCaches: Bool {
         get { return self._invokedWarmUpWorkflowCaches.value }
@@ -122,10 +123,15 @@ final class MockPaywallCacheWarming: PaywallCacheWarmingType {
         get { return self._invokedWarmUpWorkflowCachesWorkflow.value }
         set { self._invokedWarmUpWorkflowCachesWorkflow.value = newValue }
     }
+    var invokedWarmUpWorkflowCachesUiConfig: UIConfig? {
+        get { return self._invokedWarmUpWorkflowCachesUiConfig.value }
+        set { self._invokedWarmUpWorkflowCachesUiConfig.value = newValue }
+    }
 
-    func warmUpWorkflowCaches(workflow: PublishedWorkflow) async {
+    func warmUpWorkflowCaches(workflow: PublishedWorkflow, uiConfig: UIConfig) async {
         self.invokedWarmUpWorkflowCaches = true
         self.invokedWarmUpWorkflowCachesWorkflow = workflow
+        self.invokedWarmUpWorkflowCachesUiConfig = uiConfig
     }
 
 #if !os(tvOS)

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
@@ -276,6 +276,9 @@ final class RemoteConfigIntegrationTests: TestCase {
         await self.downloader.setResponse(.success(blob), for: source, ref: ref)
 
         await self.refresh(with: container)
+        await self.waitUntil(file: #filePath, line: #line) {
+            failingBlobStore.writeCount == 1
+        }
 
         expect(failingBlobStore.writeCount) == 1
         expect(self.blobStore.read(ref: ref)).to(beNil())
@@ -711,9 +714,13 @@ private extension RemoteConfigIntegrationTests {
 private final class FailsFirstWriteBlobStore: RemoteConfigBlobStoreType {
 
     private let delegate: RemoteConfigBlobStoreType
+    private let lock = Lock(.nonRecursive)
     private var remainingWriteFailures = 1
+    private var writeCountValue = 0
 
-    private(set) var writeCount = 0
+    var writeCount: Int {
+        return self.lock.perform { self.writeCountValue }
+    }
 
     init(delegate: RemoteConfigBlobStoreType) {
         self.delegate = delegate
@@ -731,9 +738,16 @@ private final class FailsFirstWriteBlobStore: RemoteConfigBlobStoreType {
         ref: String,
         bytes: UnsafeRawBufferPointer
     ) -> Bool {
-        self.writeCount += 1
-        guard self.remainingWriteFailures == 0 else {
-            self.remainingWriteFailures -= 1
+        let shouldFail = self.lock.perform {
+            self.writeCountValue += 1
+            guard self.remainingWriteFailures == 0 else {
+                self.remainingWriteFailures -= 1
+                return true
+            }
+
+            return false
+        }
+        if shouldFail {
             return false
         }
 

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -2145,7 +2145,7 @@ final class RemoteConfigManagerTests: TestCase {
             ))
         )
 
-        expect(self.blobFetcher.invokedPrefetchRefs) == [serverPrefetchRef, itemPrefetchRef]
+        expect(Set(self.blobFetcher.invokedPrefetchRefs)) == Set([serverPrefetchRef, itemPrefetchRef])
     }
 
     func testContainerResponseDoesNotPruneBlobStoreWhenCacheWriteFails() throws {

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -2131,7 +2131,8 @@ final class RemoteConfigManagerTests: TestCase {
               "wf-1": { "blob_ref": "\(itemPrefetchRef)", "prefetch": true },
               "wf-2": { "blob_ref": "\(itemOnDemandRef)", "prefetch": false },
               "wf-3": { "blob_ref": "\(cachedItemPrefetchRef)", "prefetch": true },
-              "wf-4": { "prefetch": true }
+              "wf-4": { "prefetch": true },
+              "wf-5": { "blob_ref": "\(serverPrefetchRef)", "prefetch": true }
             }
           }
         }
@@ -2145,7 +2146,7 @@ final class RemoteConfigManagerTests: TestCase {
             ))
         )
 
-        expect(Set(self.blobFetcher.invokedPrefetchRefs)) == Set([serverPrefetchRef, itemPrefetchRef])
+        expect(self.blobFetcher.invokedPrefetchRefs) == [serverPrefetchRef, itemPrefetchRef]
     }
 
     func testContainerResponseDoesNotPruneBlobStoreWhenCacheWriteFails() throws {

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -2114,6 +2114,40 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.blobFetcher.invokedPrefetchRefs) == [cachedRef, missingRef]
     }
 
+    func testContainerResponsePrefetchesItemLevelPrefetchBlobRefs() throws {
+        let serverPrefetchRef = RCContainerTestData.blobRef(for: "server prefetch".asData)
+        let itemPrefetchRef = RCContainerTestData.blobRef(for: "item prefetch".asData)
+        let itemOnDemandRef = RCContainerTestData.blobRef(for: "item on demand".asData)
+        let cachedItemPrefetchRef = RCContainerTestData.blobRef(for: "cached item prefetch".asData)
+        self.blobStore.stubbedContainsRefs = [cachedItemPrefetchRef]
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.workflows:etag2",
+          "active_topics": ["workflows"],
+          "prefetch_blobs": ["\(serverPrefetchRef)"],
+          "topics": {
+            "workflows": {
+              "wf-1": { "blob_ref": "\(itemPrefetchRef)", "prefetch": true },
+              "wf-2": { "blob_ref": "\(itemOnDemandRef)", "prefetch": false },
+              "wf-3": { "blob_ref": "\(cachedItemPrefetchRef)", "prefetch": true },
+              "wf-4": { "prefetch": true }
+            }
+          }
+        }
+        """
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(
+            with: .success(.test(
+                container: try Self.container(config: response),
+                verificationResult: .verified
+            ))
+        )
+
+        expect(self.blobFetcher.invokedPrefetchRefs) == [serverPrefetchRef, itemPrefetchRef]
+    }
+
     func testContainerResponseDoesNotPruneBlobStoreWhenCacheWriteFails() throws {
         let oldRef = RCContainerTestData.blobRef(for: "old".asData)
         let newRef = RCContainerTestData.blobRef(for: "new".asData)

--- a/Tests/UnitTests/Networking/Responses/PublishedWorkflowCodableTests.swift
+++ b/Tests/UnitTests/Networking/Responses/PublishedWorkflowCodableTests.swift
@@ -21,7 +21,7 @@ import XCTest
 /// mismatch is no longer ruled out for free — these tests catch that.
 class PublishedWorkflowCodableTests: TestCase {
 
-    func testEncodeThenDecodeRoundTripsAllFields() throws {
+    func testEncodeThenDecodeRoundTripsCodableFields() throws {
         let original = PublishedWorkflow(
             id: "wf-1",
             displayName: "Test workflow",
@@ -29,7 +29,7 @@ class PublishedWorkflowCodableTests: TestCase {
             singleStepFallbackId: "step-2",
             steps: [:],
             screens: [:],
-            uiConfig: .empty,
+            uiConfig: nil,
             contentMaxWidth: 400
         )
 
@@ -39,7 +39,28 @@ class PublishedWorkflowCodableTests: TestCase {
         expect(decoded) == original
     }
 
-    func testDecodingWithoutUiConfigDefaultsToEmpty() throws {
+    func testEncodingOmitsUiConfig() throws {
+        let workflow = PublishedWorkflow(
+            id: "wf-1",
+            displayName: "Test workflow",
+            initialStepId: "step-1",
+            singleStepFallbackId: nil,
+            steps: [:],
+            screens: [:],
+            uiConfig: UIConfig(
+                app: .init(colors: [:], fonts: [:]),
+                localizations: ["en_US": ["day": "Day"]],
+                variableConfig: .init(variableCompatibilityMap: [:], functionCompatibilityMap: [:])
+            )
+        )
+
+        let data = try JSONEncoder.default.encode(value: workflow)
+        let json = try XCTUnwrap(String(data: data, encoding: .utf8))
+
+        expect(json).toNot(contain("ui_config"))
+    }
+
+    func testDecodingWithoutUiConfigDefaultsToNil() throws {
         let json = """
         {
           "id": "wf-1",
@@ -54,7 +75,30 @@ class PublishedWorkflowCodableTests: TestCase {
             jsonData: try XCTUnwrap(json.data(using: .utf8))
         )
 
-        expect(decoded.uiConfig) == .empty
+        expect(decoded.uiConfig).to(beNil())
+    }
+
+    func testDecodingIgnoresEmbeddedUiConfig() throws {
+        let json = """
+        {
+          "id": "wf-1",
+          "display_name": "Test",
+          "initial_step_id": "step-1",
+          "steps": {},
+          "screens": {},
+          "ui_config": {
+            "app": { "colors": {}, "fonts": {} },
+            "localizations": { "en_US": { "day": "Day" } },
+            "variable_config": { "variable_compatibility_map": {}, "function_compatibility_map": {} }
+          }
+        }
+        """
+        let decoded = try JSONDecoder.default.decode(
+            PublishedWorkflow.self,
+            jsonData: try XCTUnwrap(json.data(using: .utf8))
+        )
+
+        expect(decoded.uiConfig).to(beNil())
     }
 
     func testDecodingWithMetadataPreservesIt() throws {

--- a/Tests/UnitTests/Networking/Responses/PublishedWorkflowCodableTests.swift
+++ b/Tests/UnitTests/Networking/Responses/PublishedWorkflowCodableTests.swift
@@ -29,7 +29,6 @@ class PublishedWorkflowCodableTests: TestCase {
             singleStepFallbackId: "step-2",
             steps: [:],
             screens: [:],
-            uiConfig: nil,
             contentMaxWidth: 400
         )
 
@@ -46,8 +45,7 @@ class PublishedWorkflowCodableTests: TestCase {
             initialStepId: "step-1",
             singleStepFallbackId: nil,
             steps: [:],
-            screens: [:],
-            uiConfig: .empty
+            screens: [:]
         )
 
         let data = try JSONEncoder.default.encode(value: workflow)
@@ -56,7 +54,7 @@ class PublishedWorkflowCodableTests: TestCase {
         expect(json).toNot(contain("ui_config"))
     }
 
-    func testDecodingWithoutUiConfigDefaultsToNil() throws {
+    func testDecodingWithoutUiConfigSucceeds() throws {
         let json = """
         {
           "id": "wf-1",
@@ -71,7 +69,7 @@ class PublishedWorkflowCodableTests: TestCase {
             jsonData: try XCTUnwrap(json.data(using: .utf8))
         )
 
-        expect(decoded.uiConfig).to(beNil())
+        expect(decoded.id) == "wf-1"
     }
 
     func testDecodingIgnoresEmbeddedUiConfig() throws {
@@ -94,7 +92,7 @@ class PublishedWorkflowCodableTests: TestCase {
             jsonData: try XCTUnwrap(json.data(using: .utf8))
         )
 
-        expect(decoded.uiConfig).to(beNil())
+        expect(decoded.id) == "wf-1"
     }
 
     func testDecodingWithMetadataPreservesIt() throws {

--- a/Tests/UnitTests/Networking/Responses/PublishedWorkflowCodableTests.swift
+++ b/Tests/UnitTests/Networking/Responses/PublishedWorkflowCodableTests.swift
@@ -47,11 +47,7 @@ class PublishedWorkflowCodableTests: TestCase {
             singleStepFallbackId: nil,
             steps: [:],
             screens: [:],
-            uiConfig: UIConfig(
-                app: .init(colors: [:], fonts: [:]),
-                localizations: ["en_US": ["day": "Day"]],
-                variableConfig: .init(variableCompatibilityMap: [:], functionCompatibilityMap: [:])
-            )
+            uiConfig: .empty
         )
 
         let data = try JSONEncoder.default.encode(value: workflow)

--- a/Tests/UnitTests/Networking/Responses/UIConfigDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/UIConfigDecodingTests.swift
@@ -125,9 +125,7 @@ class UIConfigDecodingTests: BaseHTTPResponseTest {
         expect(uiConfig.customVariables).to(beEmpty())
     }
 
-    func testFailsToDecodeMalformedCustomVariables() throws {
-        // When `custom_variables` is present but not the expected object shape, decoding should fail rather than
-        // silently falling back to an empty dictionary (which would hide a malformed response).
+    func testDecodesNullCustomVariablesAsEmpty() throws {
         let json = """
         {
             "app": {
@@ -139,12 +137,61 @@ class UIConfigDecodingTests: BaseHTTPResponseTest {
                 "variable_compatibility_map": {},
                 "function_compatibility_map": {}
             },
-            "custom_variables": "not an object"
+            "custom_variables": null
+        }
+        """
+
+        let uiConfig = try JSONDecoder.default.decode(
+            UIConfig.self,
+            from: json.data(using: .utf8)!
+        )
+
+        expect(uiConfig.customVariables).to(beEmpty())
+    }
+
+    func testThrowsWhenCustomVariablesAreMalformed() throws {
+        let json = """
+        {
+            "app": {
+                "colors": {},
+                "fonts": {}
+            },
+            "localizations": {},
+            "variable_config": {
+                "variable_compatibility_map": {},
+                "function_compatibility_map": {}
+            },
+            "custom_variables": {
+                "player_name": "not-a-definition"
+            }
         }
         """
 
         expect {
-            try JSONDecoder.default.decode(UIConfig.self, from: json.data(using: .utf8)!)
+            try JSONDecoder.default.decode(
+                UIConfig.self,
+                from: json.data(using: .utf8)!
+            )
+        }.to(throwError())
+    }
+
+    func testThrowsWithoutVariableConfig() throws {
+        let json = """
+        {
+            "app": {
+                "colors": {},
+                "fonts": {}
+            },
+            "localizations": {},
+            "custom_variables": {}
+        }
+        """
+
+        expect {
+            try JSONDecoder.default.decode(
+                UIConfig.self,
+                from: json.data(using: .utf8)!
+            )
         }.to(throwError())
     }
 

--- a/Tests/UnitTests/Networking/UiConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/UiConfigProviderTests.swift
@@ -96,6 +96,31 @@ class UiConfigProviderTests: TestCase {
         )
     }
 
+    func testMalformedCustomVariablesReturnsNil() async throws {
+        self.stub(app: #"{"colors": {}, "fonts": {}}"#, localizations: #"{"en_US": {"day": "Day"}}"#,
+                  variableConfig: #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#,
+                  customVariables: #"{"user_name": "not-a-definition"}"#)
+
+        let uiConfig = await self.provider.getUiConfig()
+
+        expect(uiConfig).to(beNil())
+        self.logger.verifyMessageWasLogged(
+            "Failed to decode merged ui_config",
+            level: .error
+        )
+    }
+
+    func testNullCustomVariablesReturnsUiConfigWithEmptyCustomVariables() async throws {
+        self.stub(app: #"{"colors": {}, "fonts": {}}"#, localizations: #"{"en_US": {"day": "Day"}}"#,
+                  variableConfig: #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#,
+                  customVariables: #"null"#)
+
+        let uiConfig = await self.provider.getUiConfig()
+
+        expect(uiConfig).toNot(beNil())
+        expect(uiConfig?.customVariables).to(beEmpty())
+    }
+
     func testLogsWarningWhenARequiredPartIsMissing() async throws {
         self.stub(app: nil, localizations: #"{}"#, variableConfig: nil, customVariables: nil)
 

--- a/Tests/UnitTests/Networking/UiConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/UiConfigProviderTests.swift
@@ -63,40 +63,35 @@ class UiConfigProviderTests: TestCase {
         expect(uiConfig).to(beNil())
     }
 
-    func testUsesDefaultWhenVariableConfigPartIsMissing() async throws {
+    func testReturnsNilWhenVariableConfigPartIsMissing() async throws {
         self.stub(app: #"{"colors": {}, "fonts": {}}"#, localizations: #"{}"#,
                   variableConfig: nil, customVariables: #"{}"#)
 
         let uiConfig = await self.provider.getUiConfig()
 
-        expect(uiConfig).toNot(beNil())
-        expect(uiConfig?.variableConfig.variableCompatibilityMap).to(beEmpty())
-        expect(uiConfig?.variableConfig.functionCompatibilityMap).to(beEmpty())
+        expect(uiConfig).to(beNil())
     }
 
-    func testUsesDefaultWhenCustomVariablesPartIsMissing() async throws {
+    func testReturnsNilWhenCustomVariablesPartIsMissing() async throws {
         self.stub(app: #"{"colors": {}, "fonts": {}}"#, localizations: #"{}"#,
                   variableConfig: #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#,
                   customVariables: nil)
 
         let uiConfig = await self.provider.getUiConfig()
 
-        expect(uiConfig).toNot(beNil())
-        expect(uiConfig?.customVariables).to(beEmpty())
+        expect(uiConfig).to(beNil())
     }
 
-    func testMalformedVariableConfigFallsBackToDefault() async throws {
+    func testMalformedVariableConfigReturnsNil() async throws {
         self.stub(app: #"{"colors": {}, "fonts": {}}"#, localizations: #"{"en_US": {"day": "Day"}}"#,
                   variableConfig: #"{"variable_compatibility_map": "not-a-dictionary"}"#,
                   customVariables: #"{}"#)
 
         let uiConfig = await self.provider.getUiConfig()
 
-        expect(uiConfig).toNot(beNil())
-        expect(uiConfig?.variableConfig.variableCompatibilityMap).to(beEmpty())
-        expect(uiConfig?.variableConfig.functionCompatibilityMap).to(beEmpty())
+        expect(uiConfig).to(beNil())
         self.logger.verifyMessageWasLogged(
-            "Failed to decode ui_config part 'variable_config'",
+            "Failed to decode merged ui_config",
             level: .error
         )
     }
@@ -122,14 +117,16 @@ class UiConfigProviderTests: TestCase {
         )
     }
 
-    func testRequestsMergedBlobDataForRequiredWireItemKeysNotCamelCased() async throws {
+    func testRequestsMergedBlobDataForWireItemKeysNotCamelCased() async throws {
         _ = await self.provider.getUiConfig()
 
         expect(self.mockManager.invokedMergeItemsBlobDataParameters.count) == 1
         expect(self.mockManager.invokedMergeItemsBlobDataParameters.first?.topic) == .uiConfig
         expect(self.mockManager.invokedMergeItemsBlobDataParameters.first?.itemKeys) == [
             "app",
-            "localizations"
+            "localizations",
+            "variable_config",
+            "custom_variables"
         ]
     }
 

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -114,14 +114,13 @@ class WorkflowsConfigProviderTests: TestCase {
         let workflowResult = try XCTUnwrap(result.value)
 
 #if !os(tvOS) // For Paywalls V2
-        XCTAssertEqual(workflowResult.workflow.uiConfig?.localizations["en_US"]?["day"], "Day")
+        XCTAssertEqual(workflowResult.uiConfig.localizations["en_US"]?["day"], "Day")
 #endif
     }
 
-    func testPreservesMetadataWhenSubstitutingUiConfig() async throws {
-        // Regression: the uiConfig substitution used to go through PublishedWorkflow's public
-        // initializer, which always resets `metadata` to nil, silently dropping it whenever ui_config
-        // was available.
+    func testPreservesWorkflowMetadataWhenAssemblingUiConfig() async throws {
+        // Regression: resolving ui_config must not rebuild the workflow through the public
+        // initializer, which always resets `metadata` to nil.
         let workflowJSON = try Self.workflowJSON(id: "wf-1", metadataJSON: #""metadata": { "source": "cdn" }"#)
         self.commit(
             workflows: ["wf-1": .init(blobRef: "wf-1-ref", content: [:])],

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -76,9 +76,8 @@ class WorkflowsConfigProviderTests: TestCase {
     }
 
     func testFailsWithUiConfigUnavailableWhenTheWorkflowResolvesButUiConfigIsUnavailable() async throws {
-        // A workflow is never rendered with PublishedWorkflow's decode-time `.empty` placeholder: if
-        // ui_config can't be assembled, the whole result fails, matching Android's PaywallViewModel
-        // failing the render when its concurrent ui_config fetch fails.
+        // A workflow is never rendered without `ui_config`: if it can't be assembled, the whole result
+        // fails, matching Android's PaywallViewModel failing the render when its concurrent fetch fails.
         let workflowJSON = try Self.workflowJSON(id: "wf-1")
         self.commit(
             workflows: ["wf-1": .init(blobRef: "wf-1-ref", content: [:])],
@@ -115,7 +114,7 @@ class WorkflowsConfigProviderTests: TestCase {
         let workflowResult = try XCTUnwrap(result.value)
 
 #if !os(tvOS) // For Paywalls V2
-        XCTAssertEqual(workflowResult.workflow.uiConfig.localizations["en_US"]?["day"], "Day")
+        XCTAssertEqual(workflowResult.workflow.uiConfig?.localizations["en_US"]?["day"], "Day")
 #endif
     }
 

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -50,12 +50,18 @@ class WorkflowsConfigProviderTests: TestCase {
             workflows: ["wf-1": .init(blobRef: "wf-1-ref", content: ["offeringIdentifier": "premium_annual"])],
             uiConfig: [
                 "app": .init(blobRef: "app-ref", content: [:]),
-                "localizations": .init(blobRef: "loc-ref", content: [:])
+                "localizations": .init(blobRef: "loc-ref", content: [:]),
+                "variable_config": .init(blobRef: "variable-config-ref", content: [:]),
+                "custom_variables": .init(blobRef: "custom-variables-ref", content: [:])
             ],
             blobs: [
                 "wf-1-ref": workflowJSON,
                 "app-ref": Data(#"{"colors": {}, "fonts": {}}"#.utf8),
-                "loc-ref": Data(#"{}"#.utf8)
+                "loc-ref": Data(#"{}"#.utf8),
+                "variable-config-ref": Data(
+                    #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#.utf8
+                ),
+                "custom-variables-ref": Data(#"{}"#.utf8)
             ]
         )
 
@@ -90,12 +96,18 @@ class WorkflowsConfigProviderTests: TestCase {
             workflows: ["wf-1": .init(blobRef: "wf-1-ref", content: [:])],
             uiConfig: [
                 "app": .init(blobRef: "app-ref", content: [:]),
-                "localizations": .init(blobRef: "loc-ref", content: [:])
+                "localizations": .init(blobRef: "loc-ref", content: [:]),
+                "variable_config": .init(blobRef: "variable-config-ref", content: [:]),
+                "custom_variables": .init(blobRef: "custom-variables-ref", content: [:])
             ],
             blobs: [
                 "wf-1-ref": workflowJSON,
                 "app-ref": Data(#"{"colors": {}, "fonts": {}}"#.utf8),
-                "loc-ref": Data(#"{"en_US": {"day": "Day"}}"#.utf8)
+                "loc-ref": Data(#"{"en_US": {"day": "Day"}}"#.utf8),
+                "variable-config-ref": Data(
+                    #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#.utf8
+                ),
+                "custom-variables-ref": Data(#"{}"#.utf8)
             ]
         )
 
@@ -116,12 +128,18 @@ class WorkflowsConfigProviderTests: TestCase {
             workflows: ["wf-1": .init(blobRef: "wf-1-ref", content: [:])],
             uiConfig: [
                 "app": .init(blobRef: "app-ref", content: [:]),
-                "localizations": .init(blobRef: "loc-ref", content: [:])
+                "localizations": .init(blobRef: "loc-ref", content: [:]),
+                "variable_config": .init(blobRef: "variable-config-ref", content: [:]),
+                "custom_variables": .init(blobRef: "custom-variables-ref", content: [:])
             ],
             blobs: [
                 "wf-1-ref": workflowJSON,
                 "app-ref": Data(#"{"colors": {}, "fonts": {}}"#.utf8),
-                "loc-ref": Data(#"{}"#.utf8)
+                "loc-ref": Data(#"{}"#.utf8),
+                "variable-config-ref": Data(
+                    #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#.utf8
+                ),
+                "custom-variables-ref": Data(#"{}"#.utf8)
             ]
         )
 

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -212,16 +212,29 @@ class WorkflowsConfigProviderTests: TestCase {
 
     func testResolvesAndWarnsOnDuplicateOfferingId() async throws {
         let logger = TestLogHandler(testIdentifier: self.name)
-        self.commit(workflows: [
-            "wf-a": .init(blobRef: "a-ref", content: ["offeringIdentifier": "shared"]),
-            "wf-b": .init(blobRef: "b-ref", content: ["offeringIdentifier": "shared"])
-        ])
+        let topicsJSON = """
+        {
+          "workflows": {
+            "wf-a": { "blob_ref": "a-ref", "offering_identifier": "shared" },
+            "wf-b": { "blob_ref": "b-ref", "offering_identifier": "shared" }
+          }
+        }
+        """
+        let topics = try JSONDecoder.default.decode(
+            RemoteConfiguration.Topics.self,
+            jsonData: try XCTUnwrap(topicsJSON.data(using: .utf8))
+        )
+        self.diskCache.stubbedRead = PersistedRemoteConfiguration(
+            manifest: "test-manifest",
+            activeTopics: ["workflows"],
+            topics: topics
+        )
 
         let result = await self.provider.workflowId(forOfferingId: "shared")
         let workflowId = try XCTUnwrap(result)
 
-        // Whichever the dictionary happens to iterate first, but never nil, and always logged.
-        expect(["wf-a", "wf-b"]).to(contain(workflowId))
+        // Matches Android's last-wins duplicate handling, using stable workflow-id ordering on iOS.
+        expect(workflowId) == "wf-b"
         logger.verifyMessageWasLogged("Duplicate offeringId in workflows response: shared",
                                       level: .warn,
                                       expectedCount: 1)

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -776,9 +776,8 @@ final class MockRemoteConfigManager: RemoteConfigManagerType {
         self._invokedMergeItemsBlobDataParameters.modify { $0.append((topic, itemKeys)) }
         guard !self.isDisabled, !itemKeys.isEmpty else { return nil }
 
-        var seen: Set<String> = []
         var mergedBlobValues: [String: AnyDecodable] = [:]
-        for itemKey in itemKeys where seen.insert(itemKey).inserted {
+        for itemKey in itemKeys.deduplicated() {
             guard let data = await self.blobData(for: topic, itemKey: itemKey) else { return nil }
             mergedBlobValues[itemKey] = try JSONDecoder.default.decode(AnyDecodable.self, from: data)
         }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesWorkflowTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesWorkflowTests.swift
@@ -36,7 +36,11 @@ class PurchasesWorkflowTests: BasePurchasesTests {
         self.mockRemoteConfigManager.stubbedBlobData[.workflows] = ["default": try Self.workflowJSON(id: "default")]
         self.mockRemoteConfigManager.stubbedBlobData[.uiConfig] = [
             "app": Data(#"{"colors": {}, "fonts": {}}"#.utf8),
-            "localizations": Data(#"{}"#.utf8)
+            "localizations": Data(#"{}"#.utf8),
+            "variable_config": Data(
+                #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#.utf8
+            ),
+            "custom_variables": Data(#"{}"#.utf8)
         ]
 
         let result = try await self.purchases.workflow(forOfferingIdentifier: "default")

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -62,6 +62,7 @@ class WorkflowManagerTests: TestCase {
 
         expect(self.mockPaywallCache.invokedWarmUpWorkflowCaches) == true
         expect(self.mockPaywallCache.invokedWarmUpWorkflowCachesWorkflow?.id) == "wf_1"
+        expect(self.mockPaywallCache.invokedWarmUpWorkflowCachesUiConfig) == expected.uiConfig
     }
 
     func testGetWorkflowFailsWithWorkflowNotFoundWhenProviderReportsNotFound() async {
@@ -153,7 +154,7 @@ class WorkflowManagerTests: TestCase {
     // MARK: - Helpers
 
     private static func workflowDataResult(id: String) throws -> WorkflowDataResult {
-        return .init(workflow: try self.publishedWorkflow(id: id), enrolledVariants: nil)
+        return .init(workflow: try self.publishedWorkflow(id: id), uiConfig: .empty, enrolledVariants: nil)
     }
 
     private static func publishedWorkflow(id: String) throws -> PublishedWorkflow {

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -100,12 +100,10 @@ class WorkflowManagerTests: TestCase {
         do {
             _ = try await self.manager.getWorkflow(workflowId: "wf_1")
             fail("Expected getWorkflow to throw")
+        } catch WorkflowError.uiConfigUnavailable(let workflowId) {
+            expect(workflowId) == "wf_1"
         } catch {
-            expect(error as? BackendError) == .unexpectedBackendResponse(
-                .workflowUiConfigUnavailable(workflowId: "wf_1"),
-                extraContext: nil,
-                .init(file: "", function: "", line: 0)
-            )
+            fail("Unexpected error: \(error)")
         }
     }
 


### PR DESCRIPTION
## Description

Aligns handling of several edge cases with Android, I found these discrepancies when comparing implementations.

## Changes
- Also prefetch item-level remote-config blobs marked with `prefetch: true`, not just items listed in `prefetch_blobs`. [purchases-android#3683](https://github.com/RevenueCat/purchases-android/pull/3683) / [8ae8f3b892](https://github.com/RevenueCat/purchases-android/commit/8ae8f3b892)
- Also disable the remote config feature if the kill-switch is triggered (4xx) by a response that came in after `clearCache()` [purchases-android#3700](https://github.com/RevenueCat/purchases-android/pull/3700) / [8e31cbfedb](https://github.com/RevenueCat/purchases-android/commit/8e31cbfedb)
- Match Android duplicate workflow offering behavior by having last offering with duplicate ID win [purchases-android#3716](https://github.com/RevenueCat/purchases-android/pull/3716) / [4bd9038e96](https://github.com/RevenueCat/purchases-android/commit/4bd9038e96)
- Update `UIConfigProvider` to require all four parts (blobs) of the `UIConfig` object to be successfully loaded and don't use local defaults if any of them fail [purchases-android#3711](https://github.com/RevenueCat/purchases-android/pull/3711) / [d1da15ff7d](https://github.com/RevenueCat/purchases-android/commit/d1da15ff7d)
- `uiConfig` is now no longer exposed on the `PublishedWorkflow`, but rather passed through the `WorkflowDataResult`. This is done because the `uiConfig` is now fetched separately, and having it as a nullable object on the workflow itself felt a bit confusing throughout the codebase. Now this is clear.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workflow paywall resolution and remote-config ui_config strictness; apps missing any ui_config part or relying on old partial defaults or duplicate-offering behavior may see new failures or different workflow selection.
> 
> **Overview**
> Aligns iOS remote-config and workflow paywall behavior with Android across **ui_config assembly**, **workflow data shape**, and a few **config sync** edge cases.
> 
> **Workflow styling is no longer embedded on `PublishedWorkflow`.** `uiConfig` is resolved from the separate `ui_config` topic and carried on `WorkflowDataResult` and `WorkflowContext`; paywall UI maps screens with `context.uiConfig` instead of `workflow.uiConfig`. Missing assembly surfaces as `WorkflowError.uiConfigUnavailable`, mapped to new `PaywallError.workflowUiConfigUnavailable` (no offerings-paywall fallback for that case).
> 
> **`UiConfigProvider` now requires all four topic parts** (`app`, `localizations`, `variable_config`, `custom_variables`) via a single merged decode—no per-part optional fallbacks or partial configs. `UIConfig` decoding treats `variable_config` as required.
> 
> **Remote config prefetch** after sync now includes server `prefetch_blobs` plus active-topic items with `prefetch: true`, deduplicated via new `Sequence.deduplicated()`.
> 
> **Duplicate workflow `offeringId` mappings** use stable sorted workflow IDs with **last wins** (Android parity), instead of nondeterministic dictionary iteration.
> 
> Related test and mock updates cover stricter ui_config failures, codable shape changes, and cache-warming passing `uiConfig` separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b59584eaf1d2cf348305749e81732106b7b9ebf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->