### PR TITLE
Don't switch hosts on device-connectivity errors

### DIFF
--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -871,9 +871,11 @@ extension HTTPClient {
 
 fileprivate extension NetworkError {
     /// A request may be retried against a fallback host only for transient failures (connection-level
-    /// errors and 5xx). See ``NetworkError/isTransient``.
+    /// errors and 5xx) that point at the host rather than the device. A device-connectivity failure
+    /// (see ``NetworkError/isDeviceConnectivityError``) can't be fixed by switching hosts, so it is
+    /// excluded. See ``NetworkError/isTransient``.
     var isAllowedToRetryWithFallbackHost: Bool {
-        return self.isTransient
+        return self.isTransient && !self.isDeviceConnectivityError
     }
 }
 

--- a/Sources/Networking/HTTPClient/NetworkError.swift
+++ b/Sources/Networking/HTTPClient/NetworkError.swift
@@ -275,12 +275,11 @@ extension NetworkError {
     }
 
     /// Whether this error was caused by the *device* lacking connectivity, as opposed to the host being
-    /// unreachable. Switching API sources or fallback hosts cannot help when the device itself is offline,
-    /// so these failures must not trigger a host switch.
+    /// unreachable.
     ///
     /// Only device-side `URLError` codes qualify. Host-side or ambiguous failures — `.cannotConnectToHost`,
-    /// `.cannotFindHost`, `.dnsLookupFailed`, `.timedOut`, and DNS blocking (``NetworkError/dnsError``) —
-    /// stay switch-eligible, since a different host may still succeed.
+    /// `.cannotFindHost`, `.dnsLookupFailed`, `.timedOut`, and DNS blocking (``NetworkError/dnsError``) — are
+    /// not considered device connectivity errors, since a different host may still succeed.
     var isDeviceConnectivityError: Bool {
         switch self {
         case let .networkError(error, _):

--- a/Sources/Networking/HTTPClient/NetworkError.swift
+++ b/Sources/Networking/HTTPClient/NetworkError.swift
@@ -274,6 +274,37 @@ extension NetworkError {
         }
     }
 
+    /// Whether this error was caused by the *device* lacking connectivity, as opposed to the host being
+    /// unreachable. Switching API sources or fallback hosts cannot help when the device itself is offline,
+    /// so these failures must not trigger a host switch.
+    ///
+    /// Only device-side `URLError` codes qualify. Host-side or ambiguous failures — `.cannotConnectToHost`,
+    /// `.cannotFindHost`, `.dnsLookupFailed`, `.timedOut`, and DNS blocking (``NetworkError/dnsError``) —
+    /// stay switch-eligible, since a different host may still succeed.
+    var isDeviceConnectivityError: Bool {
+        switch self {
+        case let .networkError(error, _):
+            return error.domain == NSURLErrorDomain
+                && Self.deviceConnectivityURLErrorCodes.contains(error.code)
+        case .decoding,
+             .dnsError,
+             .unableToCreateRequest,
+             .unexpectedResponse,
+             .errorResponse,
+             .signatureVerificationFailed:
+            return false
+        }
+    }
+
+    /// `URLError` codes that indicate the device has no working connection to any host.
+    private static let deviceConnectivityURLErrorCodes: Set<Int> = [
+        NSURLErrorNotConnectedToInternet,
+        NSURLErrorNetworkConnectionLost,
+        NSURLErrorInternationalRoamingOff,
+        NSURLErrorCallIsActive,
+        NSURLErrorDataNotAllowed
+    ]
+
 }
 
 extension NetworkError {

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -859,6 +859,64 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
         expect(result?.value?.originalSource) == .fallbackUrl
     }
 
+    func testDoesNotRetryWithFallbackHostOnDeviceConnectivityError() throws {
+        let request = HTTPRequest(method: .get, path: .getProductEntitlementMapping)
+        let fallbackURL = try XCTUnwrap(request.path.fallbackUrls.first)
+        // A device-side URLError: switching hosts can't help when the device itself is offline.
+        let deviceError = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
+
+        let fallbackRequestCount: Atomic<Int> = .init(0)
+        stub(condition: isPath(request.path)) { urlRequest in
+            if urlRequest.url?.absoluteString == fallbackURL.absoluteString {
+                fallbackRequestCount.value += 1
+                return HTTPStubsResponse(data: "{\"mapping\": {}}".asData, statusCode: .success, headers: nil)
+            }
+
+            let response = HTTPStubsResponse.emptySuccessResponse()
+            response.error = deviceError
+            return response
+        }
+
+        let result = waitUntilValue { completion in
+            self.client.perform(request) { (response: DataResponse) in
+                completion(response)
+            }
+        }
+
+        expect(result).to(beFailure())
+        expect(fallbackRequestCount.value) == 0
+    }
+
+    func testRetriesWithFallbackHostOnHostConnectivityError() throws {
+        let request = HTTPRequest(method: .get, path: .getProductEntitlementMapping)
+        let responseData = "{\"mapping\": {}}".asData
+        let fallbackURL = try XCTUnwrap(request.path.fallbackUrls.first)
+        // A host-side URLError: a different host may still succeed, so a fallback retry is warranted.
+        let hostError = NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotConnectToHost)
+
+        let fallbackRequestCount: Atomic<Int> = .init(0)
+        stub(condition: isPath(request.path)) { urlRequest in
+            if urlRequest.url?.absoluteString == fallbackURL.absoluteString {
+                fallbackRequestCount.value += 1
+                return HTTPStubsResponse(data: responseData, statusCode: .success, headers: nil)
+            }
+
+            let response = HTTPStubsResponse.emptySuccessResponse()
+            response.error = hostError
+            return response
+        }
+
+        let result = waitUntilValue { completion in
+            self.client.perform(request) { (response: DataResponse) in
+                completion(response)
+            }
+        }
+
+        expect(result).to(beSuccess())
+        expect(result?.value?.originalSource) == .fallbackUrl
+        expect(fallbackRequestCount.value) == 1
+    }
+
     func testResponseOriginalSourceIsNotFallbackUrlWhenNotUsingFallbackHost() throws {
         let request = HTTPRequest(method: .get, path: .getProductEntitlementMapping)
         let responseData = "{\"mapping\": {}}".asData

--- a/Tests/UnitTests/Networking/NetworkErrorTests.swift
+++ b/Tests/UnitTests/Networking/NetworkErrorTests.swift
@@ -359,6 +359,66 @@ class NetworkErrorTests: TestCase {
         }
     }
 
+    func testIsDeviceConnectivityErrorTrueForDeviceSideURLErrorCodes() {
+        for code in Self.deviceConnectivityURLErrorCodes {
+            expect(Self.urlError(code).isDeviceConnectivityError)
+                .to(beTrue(), description: "URLError code \(code) should be a device connectivity error")
+        }
+    }
+
+    func testIsDeviceConnectivityErrorFalseForHostSideURLErrorCodes() {
+        // Host-side or ambiguous failures must stay switch-eligible: a different host may still succeed.
+        let hostSideCodes = [
+            NSURLErrorCannotConnectToHost,
+            NSURLErrorCannotFindHost,
+            NSURLErrorDNSLookupFailed,
+            NSURLErrorTimedOut
+        ]
+
+        for code in hostSideCodes {
+            expect(Self.urlError(code).isDeviceConnectivityError)
+                .to(beFalse(), description: "URLError code \(code) should not be a device connectivity error")
+        }
+    }
+
+    func testIsDeviceConnectivityErrorFalseForNonNetworkErrors() {
+        let errors = [
+            error(NetworkError.decodingError()),
+            error(Self.dnsError),
+            error(Self.unableToCreateRequestError),
+            error(Self.unexpectedResponseError),
+            error(Self.responseError(.internalServerError)),
+            error(Self.responseError(.invalidRequest)),
+            error(Self.signatureVerificationFailed)
+        ]
+
+        for error in errors {
+            check(error.0.isDeviceConnectivityError,
+                  condition: beFalse(),
+                  descrition: "Expected error to not be a device connectivity error",
+                  file: error.1,
+                  line: error.2)
+        }
+    }
+
+    func testIsDeviceConnectivityErrorFalseWhenNotInURLErrorDomain() {
+        // A device-side code in a different error domain is not a URLError and must not qualify.
+        let error: NetworkError = .networkError(
+            NSError(domain: "com.some.other.domain", code: NSURLErrorNotConnectedToInternet)
+        )
+
+        expect(error.isDeviceConnectivityError) == false
+    }
+
+    /// `isTransient` must stay `true` for device-connectivity errors: it also feeds cache fallback and
+    /// generic retry, which should keep working. Only host switching is gated separately.
+    func testDeviceConnectivityErrorsRemainTransient() {
+        for code in Self.deviceConnectivityURLErrorCodes {
+            expect(Self.urlError(code).isTransient)
+                .to(beTrue(), description: "URLError code \(code) should remain transient")
+        }
+    }
+
     // MARK: - Helpers
 
     /// Stores the file/line information so expectation failures can point to the line creating the error.
@@ -404,6 +464,19 @@ class NetworkErrorTests: TestCase {
                           message: nil),
             statusCode
         )
+    }
+
+    /// `URLError` codes that indicate the *device* has no working connection to any host.
+    fileprivate static let deviceConnectivityURLErrorCodes = [
+        NSURLErrorNotConnectedToInternet,
+        NSURLErrorNetworkConnectionLost,
+        NSURLErrorInternationalRoamingOff,
+        NSURLErrorCallIsActive,
+        NSURLErrorDataNotAllowed
+    ]
+
+    private static func urlError(_ code: Int) -> NetworkError {
+        return .networkError(NSError(domain: NSURLErrorDomain, code: code))
     }
 }
 


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Retrying against a fallback host when the device itself is offline is pointless and wastes time. We should only switch hosts when the failure points at the host.

### Description
- Adds `NetworkError.isDeviceConnectivityError`, true only for device-side `URLError` codes (`.notConnectedToInternet`, `.networkConnectionLost`, `.internationalRoamingOff`, `.callIsActive`, `.dataNotAllowed`).
- Narrows the fallback-host retry gate to `isTransient && !isDeviceConnectivityError`. Host-side/ambiguous failures (`.cannotConnectToHost`, `.cannotFindHost`, `.dnsLookupFailed`, `.timedOut`, DNS blocking) stay eligible for a fallback-host retry.
- `isTransient` is unchanged, so cache fallback and generic retry are unaffected.

Android "counterpart": RevenueCat/purchases-android#3740.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to fallback-host retry gating in HTTPClient with broad unit test coverage; generic retry and cache fallback paths are explicitly unchanged.
> 
> **Overview**
> **Fallback host switching** no longer runs when the failure indicates the **device** has no usable network (e.g. not connected to the internet), since another API host cannot help in that case.
> 
> Adds **`NetworkError.isDeviceConnectivityError`**, true only for a fixed set of `NSURLError` codes (offline, connection lost, roaming off, active call, cellular data disallowed). Host- or path-oriented failures (cannot connect/find host, DNS, timeout, `dnsError`) are **not** treated as device errors and **still** qualify for fallback retry.
> 
> The fallback gate in **`HTTPClient`** changes from **`isTransient`** alone to **`isTransient && !isDeviceConnectivityError`**. **`isTransient`** is unchanged, so cache fallback and backoff retries behave as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ff008da3a529d4afdfb5ed4284095c61a1b4228. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->