### PR TITLE
feat(remote-config): support json response format

### DIFF
--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -149,7 +149,7 @@ extension HTTPRequest {
         case postCreateTicket
         case isPurchaseAllowedByRestoreBehavior(appUserID: String)
         case rewardVerificationStatus(appUserID: String, clientTransactionID: String)
-        case remoteConfig(domain: String)
+        case remoteConfig(domain: String, responseFormat: RemoteConfigResponseFormat = .rcContainer)
 
     }
 
@@ -196,7 +196,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
             return "/v1/offerings"
         case .getProductEntitlementMapping:
             return "/v1/product_entitlement_mapping"
-        case let .remoteConfig(domain):
+        case let .remoteConfig(domain, _):
             return "/v1/config/\(Self.escape(domain))"
         default:
             return nil
@@ -331,8 +331,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
 
     var responseSignatureContextProvider: ResponseSignatureContextProvider {
         switch self {
-        case .remoteConfig:
-            return RemoteConfigSignatureContextProvider()
+        case let .remoteConfig(_, responseFormat):
+            return RemoteConfigSignatureContextProvider(responseFormat: responseFormat)
         default:
             return DefaultResponseSignatureContextProvider()
         }
@@ -400,7 +400,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
         case let .rewardVerificationStatus(appUserID, clientTransactionID):
             return "subscribers/\(Self.escape(appUserID))/ads/reward_verifications/\(Self.escape(clientTransactionID))"
 
-        case let .remoteConfig(domain):
+        case let .remoteConfig(domain, _):
             return "config/\(Self.escape(domain))"
         }
     }
@@ -470,12 +470,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
 
     var additionalHeaders: HTTPRequest.Headers {
         switch self {
-        case .remoteConfig:
-            return [
-                HTTPClient.RequestHeader.accept.rawValue: HTTPClient.rcContainerFormatAcceptHeaderValue,
-                HTTPClient.RequestHeader.acceptRCElementEncoding.rawValue:
-                    HTTPClient.rcContainerFormatElementEncodingHeaderValue
-            ]
+        case let .remoteConfig(_, responseFormat):
+            return responseFormat.additionalHeaders
         default:
             return [:]
         }
@@ -484,4 +480,23 @@ extension HTTPRequest.Path: HTTPRequestPath {
     private static func escape(_ appUserID: String) -> String {
         return appUserID.trimmedAndEscaped
     }
+}
+
+private extension RemoteConfigResponseFormat {
+
+    var additionalHeaders: HTTPRequest.Headers {
+        switch self {
+        case .rcContainer:
+            return [
+                HTTPClient.RequestHeader.accept.rawValue: HTTPClient.rcContainerFormatAcceptHeaderValue,
+                HTTPClient.RequestHeader.acceptRCElementEncoding.rawValue:
+                    HTTPClient.rcContainerFormatElementEncodingHeaderValue
+            ]
+        case .json:
+            return [
+                HTTPClient.RequestHeader.accept.rawValue: "application/json"
+            ]
+        }
+    }
+
 }

--- a/Sources/Networking/Operations/GetRemoteConfigOperation.swift
+++ b/Sources/Networking/Operations/GetRemoteConfigOperation.swift
@@ -117,6 +117,8 @@ private extension GetRemoteConfigOperation {
         case .rcContainer:
             self.perform(request, completion: completion) { (response: VerifiedHTTPResponse<RemoteConfigContainer?>) in
                 try RemoteConfigFetchResult(containerResponse: response)
+            } diagnosticData: { responseBody in
+                responseBody?.configPayloadDataForDiagnostics() ?? Data()
             }
         case .json:
             self.perform(request, completion: completion) { (response: VerifiedHTTPResponse<RemoteConfiguration?>) in
@@ -128,7 +130,8 @@ private extension GetRemoteConfigOperation {
     func perform<ResponseBody: HTTPResponseBody>(
         _ request: HTTPRequest,
         completion: @escaping () -> Void,
-        mapResponse: @escaping (VerifiedHTTPResponse<ResponseBody>) throws -> RemoteConfigFetchResult
+        mapResponse: @escaping (VerifiedHTTPResponse<ResponseBody>) throws -> RemoteConfigFetchResult,
+        diagnosticData: @escaping (ResponseBody) -> Data = { _ in Data() }
     ) {
         self.httpClient.perform(request) { (response: VerifiedHTTPResponse<ResponseBody>.Result) in
             defer {
@@ -139,7 +142,9 @@ private extension GetRemoteConfigOperation {
                 callback.completion(
                     response
                         .flatMap { response in
-                            Result { try mapResponse(response) }.mapError { NetworkError.decoding($0, Data()) }
+                            Result { try mapResponse(response) }.mapError {
+                                NetworkError.decoding($0, diagnosticData(response.body))
+                            }
                         }
                         .mapError(BackendError.networkError)
                 )

--- a/Sources/Networking/Operations/GetRemoteConfigOperation.swift
+++ b/Sources/Networking/Operations/GetRemoteConfigOperation.swift
@@ -51,6 +51,7 @@ struct RemoteConfigRequest: Codable, Equatable, HTTPRequestBody {
     let domain: String
     let manifest: String?
     let prefetchedBlobs: [String]
+    let responseFormat: RemoteConfigResponseFormat
 
     private enum CodingKeys: String, CodingKey {
         case appUserID = "appUserId"
@@ -62,18 +63,21 @@ struct RemoteConfigRequest: Codable, Equatable, HTTPRequestBody {
         appUserID: String,
         domain: String = RemoteConfiguration.defaultDomain,
         manifest: String? = nil,
-        prefetchedBlobs: [String] = []
+        prefetchedBlobs: [String] = [],
+        responseFormat: RemoteConfigResponseFormat = .rcContainer
     ) {
         self.appUserID = appUserID
         self.domain = domain
         self.manifest = manifest
         self.prefetchedBlobs = prefetchedBlobs
+        self.responseFormat = responseFormat
     }
 
     var cacheKey: String {
         [
             "app_user_id=\(self.appUserID)",
             "domain=\(self.domain)",
+            "response_format=\(self.responseFormat.rawValue)",
             "manifest=\(self.manifest ?? "")",
             "prefetched_blobs=\(self.prefetchedBlobs.sorted().joined(separator: ","))"
         ].joined(separator: "|")
@@ -93,6 +97,7 @@ struct RemoteConfigRequest: Codable, Equatable, HTTPRequestBody {
         self.domain = RemoteConfiguration.defaultDomain
         self.manifest = try container.decodeIfPresent(String.self, forKey: .manifest)
         self.prefetchedBlobs = try container.decodeIfPresent([String].self, forKey: .prefetchedBlobs) ?? []
+        self.responseFormat = .rcContainer
     }
 
 }
@@ -103,9 +108,29 @@ extension GetRemoteConfigOperation: @unchecked Sendable {}
 private extension GetRemoteConfigOperation {
 
     func getRemoteConfig(completion: @escaping () -> Void) {
-        let request = HTTPRequest(method: .post(self.request), path: .remoteConfig(domain: self.request.domain))
+        let request = HTTPRequest(
+            method: .post(self.request),
+            path: .remoteConfig(domain: self.request.domain, responseFormat: self.request.responseFormat)
+        )
 
-        self.httpClient.perform(request) { (response: VerifiedHTTPResponse<RemoteConfigContainer?>.Result) in
+        switch self.request.responseFormat {
+        case .rcContainer:
+            self.perform(request, completion: completion) { (response: VerifiedHTTPResponse<RemoteConfigContainer?>) in
+                try RemoteConfigFetchResult(containerResponse: response)
+            }
+        case .json:
+            self.perform(request, completion: completion) { (response: VerifiedHTTPResponse<RemoteConfiguration?>) in
+                RemoteConfigFetchResult(configurationResponse: response)
+            }
+        }
+    }
+
+    func perform<ResponseBody: HTTPResponseBody>(
+        _ request: HTTPRequest,
+        completion: @escaping () -> Void,
+        mapResponse: @escaping (VerifiedHTTPResponse<ResponseBody>) throws -> RemoteConfigFetchResult
+    ) {
+        self.httpClient.perform(request) { (response: VerifiedHTTPResponse<ResponseBody>.Result) in
             defer {
                 completion()
             }
@@ -113,7 +138,9 @@ private extension GetRemoteConfigOperation {
             self.callbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
                 callback.completion(
                     response
-                        .map(RemoteConfigFetchResult.init(response:))
+                        .flatMap { response in
+                            Result { try mapResponse(response) }.mapError { NetworkError.decoding($0, Data()) }
+                        }
                         .mapError(BackendError.networkError)
                 )
             }

--- a/Sources/Networking/RemoteConfigAPI.swift
+++ b/Sources/Networking/RemoteConfigAPI.swift
@@ -68,10 +68,6 @@ struct RemoteConfigFetchResult {
     let response: RemoteConfigResponse?
     let verificationResult: VerificationResult
 
-    var container: RemoteConfigContainer? {
-        return self.response?.container
-    }
-
     init(containerResponse response: VerifiedHTTPResponse<RemoteConfigContainer?>) throws {
         self.response = try response.body.map(RemoteConfigResponse.init(container:))
         self.verificationResult = response.verificationResult
@@ -112,15 +108,6 @@ enum RemoteConfigResponse {
         }
     }
 
-    fileprivate var container: RemoteConfigContainer? {
-        switch self {
-        case let .rcContainer(container, _):
-            return container
-        case .json:
-            return nil
-        }
-    }
-
     init(configuration: RemoteConfiguration) {
         self = .json(configuration)
     }
@@ -143,6 +130,10 @@ struct RemoteConfigContainer {
     /// Underlying generic RC Container parsed from the remote config response.
     let rcContainer: RCContainer
 
+    /// Original RC Container bytes, retained for diagnostics if config decoding fails after
+    /// structural container parsing succeeds.
+    let rawData: Data?
+
     /// The first RC Container element, interpreted as the remote config payload for `/v1/config/<domain>`.
     let configElement: RCContainer.Element
 
@@ -156,13 +147,14 @@ struct RemoteConfigContainer {
     /// to the blob store.
     init(data: Data) throws {
         let container = try RCContainer(data: data)
-        try self.init(rcContainer: container)
+        try self.init(rcContainer: container, rawData: data)
     }
 
-    init(rcContainer container: RCContainer) throws {
+    init(rcContainer container: RCContainer, rawData: Data? = nil) throws {
         let configElement = try Self.configElement(in: container)
 
         self.rcContainer = container
+        self.rawData = rawData
         self.configElement = configElement
         self.inlineContentElements = Dictionary(
             container.elements.dropFirst().map { ($0.checksum, $0) },
@@ -202,6 +194,10 @@ extension RemoteConfigContainer {
         }
 
         return configElement
+    }
+
+    func configPayloadDataForDiagnostics() -> Data {
+        return (try? self.configElement.withDecodedPayloadBytes { Data($0) }) ?? self.rawData ?? Data()
     }
 
 }

--- a/Sources/Networking/RemoteConfigAPI.swift
+++ b/Sources/Networking/RemoteConfigAPI.swift
@@ -89,25 +89,40 @@ struct RemoteConfigFetchResult {
 
 }
 
-struct RemoteConfigResponse {
+enum RemoteConfigResponse {
 
-    let configuration: RemoteConfiguration
-    let inlineContentElements: [String: RCContainer.Element]
+    case rcContainer(RemoteConfigContainer, configuration: RemoteConfiguration)
+    case json(RemoteConfiguration)
 
-    fileprivate let container: RemoteConfigContainer?
+    var configuration: RemoteConfiguration {
+        switch self {
+        case let .rcContainer(_, configuration):
+            return configuration
+        case let .json(configuration):
+            return configuration
+        }
+    }
 
-    init(
-        configuration: RemoteConfiguration,
-        inlineContentElements: [String: RCContainer.Element] = [:],
-        container: RemoteConfigContainer? = nil
-    ) {
-        self.configuration = configuration
-        self.inlineContentElements = inlineContentElements
-        self.container = container
+    var inlineContentElements: [String: RCContainer.Element] {
+        switch self {
+        case let .rcContainer(container, _):
+            return container.inlineContentElements
+        case .json:
+            return [:]
+        }
+    }
+
+    fileprivate var container: RemoteConfigContainer? {
+        switch self {
+        case let .rcContainer(container, _):
+            return container
+        case .json:
+            return nil
+        }
     }
 
     init(configuration: RemoteConfiguration) {
-        self.init(configuration: configuration, inlineContentElements: [:], container: nil)
+        self = .json(configuration)
     }
 
     init(container: RemoteConfigContainer) throws {
@@ -118,11 +133,7 @@ struct RemoteConfigResponse {
             )
         }
 
-        self.init(
-            configuration: configuration,
-            inlineContentElements: container.inlineContentElements,
-            container: container
-        )
+        self = .rcContainer(container, configuration: configuration)
     }
 
 }

--- a/Sources/Networking/RemoteConfigAPI.swift
+++ b/Sources/Networking/RemoteConfigAPI.swift
@@ -54,16 +54,75 @@ class RemoteConfigAPI: RemoteConfigAPIType {
 
 }
 
+enum RemoteConfigResponseFormat: String, Codable {
+
+    case rcContainer
+    case json
+
+}
+
 struct RemoteConfigFetchResult {
 
     /// `nil` represents a successful `204 No Content` response. Malformed or undecodable
-    /// container bytes should fail before this result is created.
-    let container: RemoteConfigContainer?
+    /// response bodies should fail before this result is created.
+    let response: RemoteConfigResponse?
     let verificationResult: VerificationResult
 
-    init(response: VerifiedHTTPResponse<RemoteConfigContainer?>) {
-        self.container = response.body
+    var container: RemoteConfigContainer? {
+        return self.response?.container
+    }
+
+    init(containerResponse response: VerifiedHTTPResponse<RemoteConfigContainer?>) throws {
+        self.response = try response.body.map(RemoteConfigResponse.init(container:))
         self.verificationResult = response.verificationResult
+    }
+
+    init(noContentResponse response: VerifiedHTTPResponse<RemoteConfigContainer?>) {
+        self.response = nil
+        self.verificationResult = response.verificationResult
+    }
+
+    init(configurationResponse response: VerifiedHTTPResponse<RemoteConfiguration?>) {
+        self.response = response.body.map(RemoteConfigResponse.init(configuration:))
+        self.verificationResult = response.verificationResult
+    }
+
+}
+
+struct RemoteConfigResponse {
+
+    let configuration: RemoteConfiguration
+    let inlineContentElements: [String: RCContainer.Element]
+
+    fileprivate let container: RemoteConfigContainer?
+
+    init(
+        configuration: RemoteConfiguration,
+        inlineContentElements: [String: RCContainer.Element] = [:],
+        container: RemoteConfigContainer? = nil
+    ) {
+        self.configuration = configuration
+        self.inlineContentElements = inlineContentElements
+        self.container = container
+    }
+
+    init(configuration: RemoteConfiguration) {
+        self.init(configuration: configuration, inlineContentElements: [:], container: nil)
+    }
+
+    init(container: RemoteConfigContainer) throws {
+        let configuration = try container.configElement.withDecodedPayloadBytes { bytes in
+            try JSONDecoder.default.decode(
+                RemoteConfiguration.self,
+                from: Data(bytes)
+            )
+        }
+
+        self.init(
+            configuration: configuration,
+            inlineContentElements: container.inlineContentElements,
+            container: container
+        )
     }
 
 }

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -497,35 +497,22 @@ private extension RemoteConfigManager {
         guard self.isCurrent(requestEpoch) else { return }
         defer { self.releaseGuardIfOwned(requestEpoch: requestEpoch) }
 
-        guard let container = fetchResult.container else {
+        guard let response = fetchResult.response else {
             Logger.debug(Strings.remoteConfig.notModified)
             self.markRefreshedIfCurrent(requestEpoch)
             return
         }
 
-        do {
-            let response = try container.configElement.withDecodedPayloadBytes { bytes in
-                try JSONDecoder.default.decode(
-                    RemoteConfiguration.self,
-                    from: Data(bytes)
-                )
+        self.lock.perform {
+            guard self.epoch == requestEpoch else { return }
+            let didPersist = self.persist(
+                remoteConfigResponse: response,
+                previous: previous
+            )
+            if didPersist {
+                self.markRefreshed()
             }
-
-            self.lock.perform {
-                guard self.epoch == requestEpoch else { return }
-                let didPersist = self.persist(
-                    container: container,
-                    previous: previous,
-                    response: response
-                )
-                if didPersist {
-                    self.markRefreshed()
-                }
-            }
-        } catch {
-            Logger.error(Strings.remoteConfig.failedToParseResponse(error))
         }
-
     }
 
     func handleFailure(
@@ -741,12 +728,13 @@ private extension RemoteConfigManager {
         return persisted.prefetchBlobs.filter { cachedRefs.contains($0) }
     }
 
-    /// Persists the config sync state and any valid inline blobs from a successful container response.
+    /// Persists the config sync state and any valid inline blobs from a successful response.
     func persist(
-        container: RemoteConfigContainer,
-        previous: PersistedRemoteConfiguration?,
-        response: RemoteConfiguration
+        remoteConfigResponse: RemoteConfigResponse,
+        previous: PersistedRemoteConfiguration?
     ) -> Bool {
+        let response = remoteConfigResponse.configuration
+
         Logger.debug(Strings.remoteConfig.receivedConfiguration(
             activeTopics: response.activeTopics, changedTopics: Array(response.topics.entries.keys)
         ))
@@ -770,7 +758,10 @@ private extension RemoteConfigManager {
 
         guard self.diskCache.write(persistedConfiguration) else { return false }
 
-        self.extractInlineBlobs(from: container, keepingOnly: postSyncReferencedBlobRefs)
+        self.extractInlineBlobs(
+            remoteConfigResponse.inlineContentElements,
+            keepingOnly: postSyncReferencedBlobRefs
+        )
         self.blobStore.retainOnly(postSyncReferencedBlobRefs)
 
         Logger.debug(Strings.remoteConfig.persistedConfiguration(
@@ -817,10 +808,10 @@ private extension RemoteConfigManager {
     ///
     /// Invalid or unreferenced content elements are skipped because inline blobs are opportunistic cache entries.
     func extractInlineBlobs(
-        from container: RemoteConfigContainer,
+        _ inlineContentElements: [String: RCContainer.Element],
         keepingOnly referencedBlobRefs: Set<String>
     ) {
-        for (ref, element) in container.inlineContentElements {
+        for (ref, element) in inlineContentElements {
             guard referencedBlobRefs.contains(ref) else { continue }
 
             do {

--- a/Sources/Networking/RemoteConfigSignatureContextProvider.swift
+++ b/Sources/Networking/RemoteConfigSignatureContextProvider.swift
@@ -7,18 +7,29 @@
 
 import Foundation
 
-/// Provides the signature inputs for remote config RC Container responses.
+/// Provides the signature inputs for remote config responses.
 ///
-/// The response signature covers the config element's decoded payload bytes. A `204 No Content`
-/// response verifies the request context with an empty payload.
+/// RC Container responses sign the config element's decoded payload bytes. JSON responses sign
+/// the raw response body. A `204 No Content` response verifies the request context with an empty payload.
 struct RemoteConfigSignatureContextProvider: ResponseSignatureContextProvider {
+
+    private let responseFormat: RemoteConfigResponseFormat
+
+    init(responseFormat: RemoteConfigResponseFormat = .rcContainer) {
+        self.responseFormat = responseFormat
+    }
 
     func responsePayloadForSignature(from body: Data?, statusCode: HTTPStatusCode) throws -> Data? {
         guard statusCode != .noContent else {
             return Data()
         }
 
-        return try Self.configPayload(from: body)
+        switch self.responseFormat {
+        case .rcContainer:
+            return try Self.configPayload(from: body)
+        case .json:
+            return try Self.jsonPayload(from: body)
+        }
     }
 
     func requestBodyForSignature(for request: HTTPRequest) -> HTTPRequestBody? {
@@ -44,6 +55,14 @@ private extension RemoteConfigSignatureContextProvider {
         return try configElement.withDecodedPayloadBytes { bytes in
             Data(bytes)
         }
+    }
+
+    static func jsonPayload(from data: Data?) throws -> Data {
+        guard let data = data else {
+            throw RCContainer.Parser.FormatError.missingBody
+        }
+
+        return data
     }
 
 }

--- a/Sources/Networking/Responses/RemoteConfiguration.swift
+++ b/Sources/Networking/Responses/RemoteConfiguration.swift
@@ -147,6 +147,8 @@ extension RemoteConfiguration: Codable {
 
 }
 
+extension RemoteConfiguration: HTTPResponseBody {}
+
 extension RemoteConfiguration.Topics: Codable {
 
     init(from decoder: Decoder) throws {

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -347,7 +347,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         }
 
         let fetchResult = try XCTUnwrap(result?.value)
-        let container = try XCTUnwrap(fetchResult.container)
+        let container = try XCTUnwrap(fetchResult.response?.rcContainer)
 
         let contentElementsByChecksum = container.inlineContentElements
 
@@ -373,7 +373,6 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         let fetchResult = try XCTUnwrap(result?.value)
         let response = try XCTUnwrap(fetchResult.response)
 
-        expect(fetchResult.container).to(beNil())
         expect(response.configuration.domain) == "app"
         expect(response.configuration.manifest) == "v1.test"
         expect(response.inlineContentElements).to(beEmpty())
@@ -393,7 +392,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
         let fetchResult = try XCTUnwrap(result?.value)
 
-        expect(fetchResult.container).toNot(beNil())
+        expect(fetchResult.response?.rcContainer).toNot(beNil())
         expect(fetchResult.verificationResult) == .verified
     }
 
@@ -421,7 +420,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         }
 
         let fetchResult = try XCTUnwrap(result?.value)
-        let container = try XCTUnwrap(fetchResult.container)
+        let container = try XCTUnwrap(fetchResult.response?.rcContainer)
 
         let contentElementsByChecksum = container.inlineContentElements
 
@@ -448,7 +447,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         }
 
         let fetchResult = try XCTUnwrap(result?.value)
-        let container = try XCTUnwrap(fetchResult.container)
+        let container = try XCTUnwrap(fetchResult.response?.rcContainer)
 
         expect(RCContainerTestData.data(from: container.configElement)) == Self.config
     }
@@ -466,7 +465,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
         let fetchResult = try XCTUnwrap(result?.value)
 
-        expect(fetchResult.container).toNot(beNil())
+        expect(fetchResult.response?.rcContainer).toNot(beNil())
         expect(fetchResult.verificationResult) == .failed
     }
 
@@ -487,7 +486,6 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(result).to(beSuccess())
         let fetchResult = try XCTUnwrap(result?.value)
 
-        expect(fetchResult.container).to(beNil())
         expect(fetchResult.response).to(beNil())
         expect(fetchResult.verificationResult) == .verified
     }
@@ -639,6 +637,33 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(error.domain) == String(reflecting: RCContainer.Parser.FormatError.self)
     }
 
+    func testGetRemoteConfigInvalidConfigPayloadInRCContainerSendsDecodingErrorWithResponseBody() {
+        let malformedConfig = #"{"domain":"app","manifest":}"#
+        let data = RCContainerTestData.container(config: malformedConfig.asData)
+        self.httpClient.mock(
+            requestPath: .remoteConfig(domain: "app"),
+            response: .init(statusCode: .success, body: data)
+        )
+
+        let result = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfig(
+                request: Self.defaultRequest,
+                isAppBackgrounded: false,
+                completion: completed
+            )
+        }
+
+        guard case .networkError(.decoding) = result?.error else {
+            fail("Expected decoding error, got \(String(describing: result?.error))")
+            return
+        }
+
+        self.logger.verifyMessageWasLogged(
+            Strings.network.json_data_received(dataString: malformedConfig),
+            level: .error
+        )
+    }
+
     func testGetRemoteConfigInvalidJSONResponseSendsDecodingErrorInJSONMode() {
         self.httpClient.mock(
             requestPath: .remoteConfig(domain: "app", responseFormat: .json),
@@ -699,6 +724,18 @@ private extension BackendGetRemoteConfigTests {
                 delay: delay
             )
         )
+    }
+
+}
+
+private extension RemoteConfigResponse {
+
+    var rcContainer: RemoteConfigContainer? {
+        guard case let .rcContainer(container, _) = self else {
+            return nil
+        }
+
+        return container
     }
 
 }

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -71,6 +71,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
         expect(body["app_user_id"] as? String) == Self.appUserID
         expect(body["domain"]).to(beNil())
+        expect(body["response_format"]).to(beNil())
         expect(body["manifest"]).to(beNil())
         expect(body["prefetched_blobs"] as? [String]).to(beEmpty())
     }
@@ -97,6 +98,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(self.httpClient.calls.first?.request.path.relativePath) == "/v1/config/project"
         expect(body["app_user_id"] as? String) == Self.appUserID
         expect(body["domain"]).to(beNil())
+        expect(body["response_format"]).to(beNil())
         expect(body["manifest"] as? String) == "v1.123.paywalls:etag-paywalls,product_entitlement_mapping:etag-pem"
         expect(body["prefetched_blobs"] as? [String]) == ["blob-b"]
     }
@@ -115,6 +117,24 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
             == HTTPClient.rcContainerFormatAcceptHeaderValue
         expect(self.httpClient.calls.first?.headers[HTTPClient.RequestHeader.acceptRCElementEncoding.rawValue])
             == HTTPClient.rcContainerFormatElementEncodingHeaderValue
+        expect(self.httpClient.calls.first?.headers["Accept-Encoding"]).to(beNil())
+    }
+
+    func testGetRemoteConfigRequestsJSONFormatWhenConfigured() {
+        self.mockSuccessfulResponse(responseFormat: .json)
+
+        waitUntil { completed in
+            self.remoteConfigAPI.getRemoteConfig(
+                request: .init(appUserID: Self.appUserID, responseFormat: .json),
+                isAppBackgrounded: false
+            ) { _ in completed() }
+        }
+
+        expect(self.httpClient.calls.first?.request.path as? HTTPRequest.Path)
+            == HTTPRequest.Path.remoteConfig(domain: "app", responseFormat: .json)
+        expect(self.httpClient.calls.first?.headers[HTTPClient.RequestHeader.accept.rawValue]) == "application/json"
+        expect(self.httpClient.calls.first?.headers[HTTPClient.RequestHeader.acceptRCElementEncoding.rawValue])
+            .to(beNil())
         expect(self.httpClient.calls.first?.headers["Accept-Encoding"]).to(beNil())
     }
 
@@ -278,6 +298,26 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(self.httpClient.calls).to(haveCount(2))
     }
 
+    func testGetRemoteConfigDoesNotCoalesceSimultaneousRequestsWithDifferentResponseFormats() {
+        self.mockSuccessfulResponse(delay: .milliseconds(10))
+        self.mockSuccessfulResponse(responseFormat: .json, delay: .milliseconds(10))
+
+        let responses: Atomic<Int> = .init(0)
+
+        self.remoteConfigAPI.getRemoteConfig(
+            request: .init(appUserID: Self.appUserID, manifest: "v1.10.paywalls:etag-a"),
+            isAppBackgrounded: false
+        ) { _ in responses.value += 1 }
+
+        self.remoteConfigAPI.getRemoteConfig(
+            request: .init(appUserID: Self.appUserID, manifest: "v1.10.paywalls:etag-a", responseFormat: .json),
+            isAppBackgrounded: false
+        ) { _ in responses.value += 1 }
+
+        expect(responses.value).toEventually(equal(2))
+        expect(self.httpClient.calls).to(haveCount(2))
+    }
+
     func testCoalescedRequestsLogDebugMessage() {
         self.mockSuccessfulResponse(delay: .milliseconds(10))
 
@@ -317,6 +357,27 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
             from: try XCTUnwrap(contentElementsByChecksum[RCContainerTestData.blobRef(for: Self.content)])
         )) == Self.content
         expect(fetchResult.verificationResult) == .notRequested
+    }
+
+    func testGetRemoteConfigParsesJSONResponse() throws {
+        self.mockSuccessfulResponse(responseFormat: .json, verificationResult: .verified)
+
+        let result: Result<RemoteConfigFetchResult, BackendError>? = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfig(
+                request: .init(appUserID: Self.appUserID, responseFormat: .json),
+                isAppBackgrounded: false,
+                completion: completed
+            )
+        }
+
+        let fetchResult = try XCTUnwrap(result?.value)
+        let response = try XCTUnwrap(fetchResult.response)
+
+        expect(fetchResult.container).to(beNil())
+        expect(response.configuration.domain) == "app"
+        expect(response.configuration.manifest) == "v1.test"
+        expect(response.inlineContentElements).to(beEmpty())
+        expect(fetchResult.verificationResult) == .verified
     }
 
     func testGetRemoteConfigReturnsVerificationResultFromHTTPClient() throws {
@@ -427,6 +488,28 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         let fetchResult = try XCTUnwrap(result?.value)
 
         expect(fetchResult.container).to(beNil())
+        expect(fetchResult.response).to(beNil())
+        expect(fetchResult.verificationResult) == .verified
+    }
+
+    func testGetRemoteConfigJSONNoContentResponseSucceedsWithNoResponse() throws {
+        self.httpClient.mock(
+            requestPath: .remoteConfig(domain: "app", responseFormat: .json),
+            response: .init(statusCode: .noContent, body: Data(), verificationResult: .verified)
+        )
+
+        let result: Result<RemoteConfigFetchResult, BackendError>? = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfig(
+                request: .init(appUserID: Self.appUserID, responseFormat: .json),
+                isAppBackgrounded: false,
+                completion: completed
+            )
+        }
+
+        expect(result).to(beSuccess())
+        let fetchResult = try XCTUnwrap(result?.value)
+
+        expect(fetchResult.response).to(beNil())
         expect(fetchResult.verificationResult) == .verified
     }
 
@@ -556,11 +639,40 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(error.domain) == String(reflecting: RCContainer.Parser.FormatError.self)
     }
 
+    func testGetRemoteConfigInvalidJSONResponseSendsDecodingErrorInJSONMode() {
+        self.httpClient.mock(
+            requestPath: .remoteConfig(domain: "app", responseFormat: .json),
+            response: .init(statusCode: .success, body: #"{"api_sources":[]}"#.asData)
+        )
+
+        let result = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfig(
+                request: .init(appUserID: Self.appUserID, responseFormat: .json),
+                isAppBackgrounded: false,
+                completion: completed
+            )
+        }
+
+        guard case .networkError(.decoding) = result?.error else {
+            fail("Expected decoding error, got \(String(describing: result?.error))")
+            return
+        }
+    }
+
 }
 
 private extension BackendGetRemoteConfigTests {
 
-    static let config = #"{"manifest":{}}"#.asData
+    static let config = """
+    {
+      "domain": "app",
+      "manifest": "v1.test",
+      "active_topics": ["workflows"],
+      "topics": {
+        "workflows": {}
+      }
+    }
+    """.asData
     static let content = #"{"products":[]}"#.asData
     static let appUserID = "app-user-id"
 
@@ -574,14 +686,15 @@ private extension BackendGetRemoteConfigTests {
 
     func mockSuccessfulResponse(
         domain: String = "app",
+        responseFormat: RemoteConfigResponseFormat = .rcContainer,
         verificationResult: VerificationResult = .defaultValue,
         delay: DispatchTimeInterval = .never
     ) {
         self.httpClient.mock(
-            requestPath: .remoteConfig(domain: domain),
+            requestPath: .remoteConfig(domain: domain, responseFormat: responseFormat),
             response: .init(
                 statusCode: .success,
-                body: Self.containerData,
+                body: responseFormat == .rcContainer ? Self.containerData : Self.config,
                 verificationResult: verificationResult,
                 delay: delay
             )

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -312,4 +312,21 @@ class HTTPRequestTests: TestCase {
             == HTTPClient.rcContainerFormatElementEncodingHeaderValue
         expect(headers["Accept-Encoding"]).to(beNil())
     }
+
+    func testRemoteConfigUsesJSONAcceptHeaderWhenRequested() {
+        let request: HTTPRequest = .init(
+            method: .post(RemoteConfigRequest(appUserID: "app-user-id", responseFormat: .json)),
+            path: .remoteConfig(domain: "app", responseFormat: .json)
+        )
+        let headers = request.headers(
+            with: [:],
+            defaultHeaders: [:],
+            verificationMode: .disabled,
+            internalSettings: DangerousSettings.Internal.default
+        )
+
+        expect(headers[HTTPClient.RequestHeader.accept.rawValue]) == "application/json"
+        expect(headers[HTTPClient.RequestHeader.acceptRCElementEncoding.rawValue]).to(beNil())
+        expect(headers["Accept-Encoding"]).to(beNil())
+    }
 }

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -1328,22 +1328,9 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testMalformedTopicItemLeavesCacheUntouchedAndReleasesRefreshGuard() throws {
-        let response = """
-        {
-          "domain": "app",
-          "manifest": "v1.1710000100.sources:etag2",
-          "active_topics": ["sources"],
-          "topics": {
-            "sources": {
-              "api": "not-an-object"
-            }
-          }
-        }
-        """
-
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
-            with: .success(.test(container: try Self.container(config: response)))
+            with: .failure(Self.configDecodingError())
         )
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
@@ -1422,7 +1409,7 @@ final class RemoteConfigManagerTests: TestCase {
     func testMalformedConfigPayloadLeavesCacheUntouched() throws {
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
-            with: .success(.test(container: try Self.container(config: "{ not valid json")))
+            with: .failure(Self.configDecodingError())
         )
 
         expect(self.diskCache.invokedWriteCount) == 0
@@ -1652,7 +1639,7 @@ final class RemoteConfigManagerTests: TestCase {
         await self.waitForRemoteConfigRequestCount(1)
         await self.waitForDiskCacheReadCount(2)
         self.remoteConfigAPI.complete(
-            with: .success(.test(container: try Self.container(config: "{ not valid json")))
+            with: .failure(Self.configDecodingError())
         )
 
         let data = await task.value
@@ -1784,6 +1771,35 @@ final class RemoteConfigManagerTests: TestCase {
 
         expect(self.blobStore.invokedWriteParameters?.ref) == blobRef
         expect(self.blobStore.invokedWriteParameters?.data) == blob
+    }
+
+    func testJSONResponsePersistsConfigurationWithoutInlineBlobExtraction() throws {
+        let blobRef = RCContainerTestData.blobRef(for: "external blob".asData)
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.workflows:etag2",
+          "active_topics": ["workflows"],
+          "topics": {
+            "workflows": {
+              "default": { "blob_ref": "\(blobRef)" }
+            }
+          }
+        }
+        """
+        let configuration = try JSONDecoder.default.decode(RemoteConfiguration.self, from: response.asData)
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(
+            with: .success(.test(configuration: configuration, verificationResult: .verified))
+        )
+
+        expect(self.diskCache.invokedWriteParameter?.manifest) == "v1.1710000100.workflows:etag2"
+        expect(Self.blobRefsByTopic(from: self.diskCache.invokedWriteParameter?.topics)) == [
+            "workflows": [blobRef]
+        ]
+        expect(self.blobStore.invokedWriteCount) == 0
+        expect(self.blobStore.invokedRetainOnlyParameters) == Set([blobRef])
     }
 
     func testBlobDataReadsContainerInlineBlobAfterItIsStored() async throws {
@@ -2409,6 +2425,13 @@ private extension RemoteConfigManagerTests {
         ))
     }
 
+    static func configDecodingError() -> BackendError {
+        return .networkError(.decoding(
+            NSError(domain: "RemoteConfigManagerTests", code: 1),
+            Data()
+        ))
+    }
+
     static func container(
         config: String,
         contentElements: [Data] = []
@@ -2564,10 +2587,34 @@ private extension RemoteConfigFetchResult {
         container: RemoteConfigContainer?,
         verificationResult: VerificationResult = .verified
     ) -> RemoteConfigFetchResult {
-        return RemoteConfigFetchResult(response: .init(
+        let response = VerifiedHTTPResponse(
             httpStatusCode: container == nil ? .noContent : .success,
             responseHeaders: [:],
             body: container,
+            verificationResult: verificationResult,
+            isLoadShedderResponse: false,
+            isFallbackUrlResponse: false
+        )
+
+        guard container != nil else {
+            return RemoteConfigFetchResult(noContentResponse: response)
+        }
+
+        do {
+            return try RemoteConfigFetchResult(containerResponse: response)
+        } catch {
+            preconditionFailure("Unexpected invalid remote config test container: \(error)")
+        }
+    }
+
+    static func test(
+        configuration: RemoteConfiguration,
+        verificationResult: VerificationResult = .verified
+    ) -> RemoteConfigFetchResult {
+        return RemoteConfigFetchResult(configurationResponse: .init(
+            httpStatusCode: .success,
+            responseHeaders: [:],
+            body: configuration,
             verificationResult: verificationResult,
             isLoadShedderResponse: false,
             isFallbackUrlResponse: false

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -372,6 +372,54 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
         expect(signingRequest.signature) == Self.sampleSignature
     }
 
+    func testValidRemoteConfigJSONSignatureUsesRawBodyAsSignedMessage() throws {
+        let body = Self.remoteConfigJSON
+        self.mockResponse(path: HTTPRequest.Path.remoteConfig(domain: "app", responseFormat: .json),
+                          signature: Self.sampleSignature,
+                          requestDate: Self.date2,
+                          body: body)
+        self.signing.stubbedVerificationResult = true
+
+        let response: VerifiedHTTPResponse<Data?>.Result? = waitUntilValue { completion in
+            self.client.perform(Self.remoteConfigJSONRequest, completionHandler: completion)
+        }
+
+        expect(response).to(beSuccess())
+        expect(response?.value?.verificationResult) == .verified
+
+        expect(self.signing.requests).to(haveCount(1))
+        let signingRequest = try XCTUnwrap(self.signing.requests.onlyElement)
+
+        expect(signingRequest.parameters.message) == body
+        expect(signingRequest.parameters.nonce).toNot(beNil())
+        expect(signingRequest.parameters.requestBody).to(beNil())
+        expect(signingRequest.parameters.requestDate) == Self.date2.millisecondsSince1970
+        expect(signingRequest.signature) == Self.sampleSignature
+    }
+
+    func testRemoteConfigJSONNoContentSignatureUsesEmptyPayload() throws {
+        self.mockResponse(path: HTTPRequest.Path.remoteConfig(domain: "app", responseFormat: .json),
+                          signature: Self.sampleSignature,
+                          requestDate: Self.date2,
+                          body: Data(),
+                          statusCode: .noContent)
+        self.signing.stubbedVerificationResult = true
+
+        let response: VerifiedHTTPResponse<Data?>.Result? = waitUntilValue { completion in
+            self.client.perform(Self.remoteConfigJSONRequest, completionHandler: completion)
+        }
+
+        expect(response).to(beSuccess())
+        expect(response?.value?.verificationResult) == .verified
+
+        expect(self.signing.requests).to(haveCount(1))
+        let signingRequest = try XCTUnwrap(self.signing.requests.onlyElement)
+
+        expect(signingRequest.parameters.message) == Data()
+        expect(signingRequest.parameters.requestBody).to(beNil())
+        expect(signingRequest.signature) == Self.sampleSignature
+    }
+
     func testValidRemoteConfigSignatureUsesDecodedConfigPayloadAsSignedMessage() throws {
         let config = Data(repeating: UInt8(ascii: "c"), count: 2048)
         let body = try RCContainerTestData.compressedContainer(
@@ -1223,6 +1271,24 @@ private extension BaseSignatureVerificationHTTPClientTests {
             method: .post(RemoteConfigRequest(appUserID: "app-user-id")),
             path: HTTPRequest.Path.remoteConfig(domain: "app")
         )
+    }
+
+    static var remoteConfigJSONRequest: HTTPRequest {
+        return .init(
+            method: .post(RemoteConfigRequest(appUserID: "app-user-id", responseFormat: .json)),
+            path: HTTPRequest.Path.remoteConfig(domain: "app", responseFormat: .json)
+        )
+    }
+
+    static var remoteConfigJSON: Data {
+        return """
+        {
+          "domain": "app",
+          "manifest": "v1.test",
+          "active_topics": [],
+          "topics": {}
+        }
+        """.asData
     }
 
     static func rcContainer(

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -317,7 +317,7 @@ private final class FakeRemoteConfigAPI: RemoteConfigAPIType {
         // `RemoteConfigManager` calls this from inside a lock and documents that it assumes the
         // completion is never invoked synchronously, so this must dispatch asynchronously.
         DispatchQueue.global().async {
-            let result = RemoteConfigFetchResult(response: VerifiedHTTPResponse(
+            let result = RemoteConfigFetchResult(noContentResponse: VerifiedHTTPResponse(
                 httpStatusCode: .noContent,
                 responseHeaders: [:],
                 body: nil,


### PR DESCRIPTION
## Description

The fallback config endpoint is just a static file hosted on a CDN. It will not contain any user-specific data, will not accept any post body and will not contain an `RCContainer` response with inlined blobs. This means that the response will be JSON instead.

This PR adds support for receiving JSON instead of `RCContainer` responses for the config endpoint. A follow up PR will actually wire this into fallback handling.