### PR TITLE
Fix Paywalls V2 carousel image stuck in size-unknown state on first display

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -180,8 +180,12 @@ struct ImageComponentView: View {
                         }
                     }
                     .onSizeChange { newSize in
-                        let effectiveCurrentSize = self.size ?? self.viewModel.cachedMeasuredSize
-                        guard effectiveCurrentSize != newSize else {
+                        // Compare against local @State only. Looping carousels mount multiple
+                        // copies of a page that share one ImageComponentViewModel (and thus one
+                        // cachedMeasuredSize). If we fell back to the shared cache here, the first
+                        // copy to measure would poison later copies: their local size would stay
+                        // nil and they'd remain stuck in the "size unknown" render path.
+                        guard Self.shouldAcceptMeasuredSize(localSize: self.size, newSize: newSize) else {
                             return
                         }
 
@@ -191,6 +195,15 @@ struct ImageComponentView: View {
                 }
             }
         }
+    }
+
+    /// Whether a newly measured size should be written into this view's local `@State`.
+    ///
+    /// Intentionally ignores any shared `cachedMeasuredSize`: duplicate carousel page copies
+    /// share one view model, so comparing against the cache would let the first copy to measure
+    /// prevent every other copy from ever applying the size to its own state.
+    static func shouldAcceptMeasuredSize(localSize: CGSize?, newSize: CGSize) -> Bool {
+        localSize != newSize
     }
 
     static func renderPlan(

--- a/Tests/RevenueCatUITests/PaywallsV2/ImageComponentViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/ImageComponentViewTests.swift
@@ -102,6 +102,40 @@ final class ImageComponentViewTests: TestCase {
         XCTAssertTrue(plan.showsMeasurementPlaceholder)
     }
 
+    // MARK: - Size-change acceptance (carousel shared-cache race)
+
+    // Regression for looping carousels: multiple page copies share one ImageComponentViewModel
+    // (and thus one cachedMeasuredSize). When local @State is still nil, a measurement must be
+    // accepted even if it equals the shared cache — otherwise the visible copy stays stuck in
+    // the "size unknown" path (image mounted with maxWidth: 0).
+    func testAcceptsMeasurementWhenLocalSizeIsNilEvenIfMatchingSharedCache() {
+        let measured = CGSize(width: 320, height: 200)
+
+        XCTAssertTrue(
+            ImageComponentView.shouldAcceptMeasuredSize(localSize: nil, newSize: measured),
+            "A nil local size must accept the measurement regardless of any shared cached size"
+        )
+    }
+
+    // Once local state already holds this size, reject identical re-measurements to avoid
+    // redraw churn. Init seeds _size from cachedMeasuredSize, so remounted views still short-circuit.
+    func testRejectsMeasurementWhenLocalSizeAlreadyMatches() {
+        let measured = CGSize(width: 320, height: 200)
+
+        XCTAssertFalse(
+            ImageComponentView.shouldAcceptMeasuredSize(localSize: measured, newSize: measured)
+        )
+    }
+
+    func testAcceptsMeasurementWhenLocalSizeDiffers() {
+        let previous = CGSize(width: 100, height: 50)
+        let measured = CGSize(width: 320, height: 200)
+
+        XCTAssertTrue(
+            ImageComponentView.shouldAcceptMeasuredSize(localSize: previous, newSize: measured)
+        )
+    }
+
     // MARK: - maxWidth sizing math (keeps the image within the parent's bounds)
 
     func testCalculateMaxWidthSubtractsBordersPaddingAndMargin() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Carousel images rendered with side margins on their first display per paywall session (SDK 5.80.0+; on ≤5.79.0 the same bug made the image invisible on first display) because duplicate looping-carousel page copies share `cachedMeasuredSize` and the size-change guard prevented the visible copy from ever applying the measured size to its own `@State`.

### Description
In `ImageComponentView`'s `.onSizeChange` handler, compare against local `@State` only (via a small `shouldAcceptMeasuredSize` helper) instead of falling back to the shared view-model cache. Still write both `cachedMeasuredSize` and local `size` when accepting a measurement. Added unit tests covering the nil-local / matching-cache acceptance case.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3f6ece9-c1b9-47da-b439-c610f152e543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3f6ece9-c1b9-47da-b439-c610f152e543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

