### PR TITLE
other(offerings): gate getOfferings delivery on ui_config and stale-cache paths

### DIFF
--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -91,13 +91,6 @@ class OfferingsManager {
 
             let cacheStatus = self.deviceCache.offeringsCacheStatus(isAppBackgrounded: isAppBackgrounded)
             Logger.debug(Strings.offering.vending_offerings_cache_from_memory)
-            self.trackGetOfferingsResultIfNeeded(trackDiagnostics: trackDiagnostics,
-                                                 startTime: startTime,
-                                                 cacheStatus: cacheStatus,
-                                                 error: nil,
-                                                 requestedProductIds: nil,
-                                                 notFoundProductIds: nil)
-
             if cacheStatus == .stale {
                 // Refresh in the background; the readiness gate below must not delay it.
                 self.updateOfferingsCache(appUserID: appUserID,
@@ -110,6 +103,14 @@ class OfferingsManager {
             // even if the background refresh finished first; that matches the stale-cache
             // model, and the refresh still updates the cache for the next call.
             self.deliverWhenConfigReady {
+                // Tracked inside the gate so the recorded latency includes the readiness
+                // wait this delivery now pays, not just the cache lookup.
+                self.trackGetOfferingsResultIfNeeded(trackDiagnostics: trackDiagnostics,
+                                                     startTime: startTime,
+                                                     cacheStatus: cacheStatus,
+                                                     error: nil,
+                                                     requestedProductIds: nil,
+                                                     notFoundProductIds: nil)
                 self.dispatchCompletionOnMainThreadIfPossible(completion, value: .success(memoryCachedOfferings))
             }
         }

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -102,24 +102,53 @@ class OfferingsManager {
                                                  requestedProductIds: nil,
                                                  notFoundProductIds: nil)
 
-            // When THIS request's stale refresh finishes before the gate opens, deliver its
-            // result instead of the captured snapshot. Recorded through the refresh's own
-            // completion, never by re-reading the shared cache slot after the gate: a
-            // concurrent identity or locale change repopulating that slot must not leak
-            // another request's offerings into this one.
-            let refreshedOfferings: Atomic<Offerings?> = .init(nil)
-            if cacheStatus == .stale {
-                // The readiness gate below must not delay this background refresh.
-                self.updateOfferingsCache(appUserID: appUserID,
-                                          isAppBackgrounded: isAppBackgrounded,
-                                          fetchPolicy: fetchPolicy) { result in
-                    refreshedOfferings.value = result.value?.offerings
-                }
-            }
-            // Cached delivery waits for config readiness (a no-op once config has synced).
-            self.deliverWhenConfigReady {
-                let offerings = refreshedOfferings.value ?? memoryCachedOfferings
-                self.dispatchCompletionOnMainThreadIfPossible(completion, value: .success(offerings))
+            let refreshedOfferings = self.refreshStaleOfferingsInBackground(
+                cacheStatus: cacheStatus,
+                appUserID: appUserID,
+                isAppBackgrounded: isAppBackgrounded,
+                fetchPolicy: fetchPolicy
+            )
+            self.deliverCachedOfferingsWhenConfigReady(memoryCachedOfferings,
+                                                       refreshedOfferings: refreshedOfferings,
+                                                       completion: completion)
+        }
+    }
+
+    /// Kicks the background refresh a stale cache requires (before the readiness gate, which
+    /// must not delay it) and returns where its result lands. Recorded through the refresh's
+    /// own completion, never by re-reading the shared cache slot after the gate: a concurrent
+    /// identity or locale change repopulating that slot must not leak another request's
+    /// offerings into this one.
+    private func refreshStaleOfferingsInBackground(
+        cacheStatus: CacheStatus,
+        appUserID: String,
+        isAppBackgrounded: Bool,
+        fetchPolicy: FetchPolicy
+    ) -> Atomic<Offerings?> {
+        let refreshedOfferings: Atomic<Offerings?> = .init(nil)
+        guard cacheStatus == .stale else { return refreshedOfferings }
+
+        self.updateOfferingsCache(appUserID: appUserID,
+                                  isAppBackgrounded: isAppBackgrounded,
+                                  fetchPolicy: fetchPolicy) { result in
+            refreshedOfferings.value = result.value?.offerings
+        }
+        return refreshedOfferings
+    }
+
+    /// Delivers memory-cached offerings once config is ready (a no-op once config has
+    /// synced), preferring this request's own refresh result when one landed. The recorded
+    /// result is read on the main actor, where the refresh's completion also writes it, so a
+    /// refresh whose completion was enqueued first is always visible to this delivery.
+    private func deliverCachedOfferingsWhenConfigReady(
+        _ memoryCachedOfferings: Offerings,
+        refreshedOfferings: Atomic<Offerings?>,
+        completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?
+    ) {
+        self.deliverWhenConfigReady {
+            guard let completion else { return }
+            self.operationDispatcher.dispatchOnMainActor {
+                completion(.success(refreshedOfferings.value ?? memoryCachedOfferings))
             }
         }
     }

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -102,18 +102,23 @@ class OfferingsManager {
                                                  requestedProductIds: nil,
                                                  notFoundProductIds: nil)
 
+            // When THIS request's stale refresh finishes before the gate opens, deliver its
+            // result instead of the captured snapshot. Recorded through the refresh's own
+            // completion, never by re-reading the shared cache slot after the gate: a
+            // concurrent identity or locale change repopulating that slot must not leak
+            // another request's offerings into this one.
+            let refreshedOfferings: Atomic<Offerings?> = .init(nil)
             if cacheStatus == .stale {
                 // The readiness gate below must not delay this background refresh.
                 self.updateOfferingsCache(appUserID: appUserID,
                                           isAppBackgrounded: isAppBackgrounded,
-                                          fetchPolicy: fetchPolicy,
-                                          completion: nil)
+                                          fetchPolicy: fetchPolicy) { result in
+                    refreshedOfferings.value = result.value?.offerings
+                }
             }
-            // Cached delivery waits for config readiness (a no-op once config has synced),
-            // re-reading the cache afterwards: if the stale path's refresh finished while
-            // waiting, the caller gets the fresh offerings it already paid for.
+            // Cached delivery waits for config readiness (a no-op once config has synced).
             self.deliverWhenConfigReady {
-                let offerings = self.cachedOfferings ?? memoryCachedOfferings
+                let offerings = refreshedOfferings.value ?? memoryCachedOfferings
                 self.dispatchCompletionOnMainThreadIfPossible(completion, value: .success(offerings))
             }
         }

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -28,8 +28,7 @@ class OfferingsManager {
     private let dateProvider: DateProvider
     // Nil when remote config is disabled, in which case offerings delivery is unchanged.
     private let remoteConfigManager: RemoteConfigManagerType?
-    // Derived from `remoteConfigManager`; resolves the `ui_config` body the delivery gate
-    // waits on. Nil exactly when the manager is.
+    // Resolves the `ui_config` body the delivery gate waits on. Nil when the manager is.
     private let uiConfigProvider: UiConfigProvider?
 
     init(deviceCache: DeviceCache,
@@ -114,11 +113,9 @@ class OfferingsManager {
         }
     }
 
-    /// Kicks the background refresh a stale cache requires (before the readiness gate, which
-    /// must not delay it) and returns where its result lands. Recorded through the refresh's
-    /// own completion, never by re-reading the shared cache slot after the gate: a concurrent
-    /// identity or locale change repopulating that slot must not leak another request's
-    /// offerings into this one.
+    /// Starts the background refresh a stale cache needs and returns where its result lands.
+    /// Captured from the refresh's own completion, not the shared cache slot, which a
+    /// concurrent identity/locale change could repopulate with another request's offerings.
     private func refreshStaleOfferingsInBackground(
         cacheStatus: CacheStatus,
         appUserID: String,
@@ -136,10 +133,9 @@ class OfferingsManager {
         return refreshedOfferings
     }
 
-    /// Delivers memory-cached offerings once config is ready (a no-op once config has
-    /// synced), preferring this request's own refresh result when one landed. The recorded
-    /// result is read on the main actor, where the refresh's completion also writes it, so a
-    /// refresh whose completion was enqueued first is always visible to this delivery.
+    /// Delivers cached offerings once config is ready, preferring this request's own refresh
+    /// result. Read on the main actor, where the refresh also writes it, so an earlier refresh
+    /// is visible.
     private func deliverCachedOfferingsWhenConfigReady(
         _ memoryCachedOfferings: Offerings,
         refreshedOfferings: Atomic<Offerings?>,

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -28,6 +28,9 @@ class OfferingsManager {
     private let dateProvider: DateProvider
     // Nil when remote config is disabled, in which case offerings delivery is unchanged.
     private let remoteConfigManager: RemoteConfigManagerType?
+    // Derived from `remoteConfigManager`; resolves the `ui_config` body the delivery gate
+    // waits on. Nil exactly when the manager is.
+    private let uiConfigProvider: UiConfigProvider?
 
     init(deviceCache: DeviceCache,
          operationDispatcher: OperationDispatcher,
@@ -47,6 +50,7 @@ class OfferingsManager {
         self.diagnosticsTracker = diagnosticsTracker
         self.dateProvider = dateProvider
         self.remoteConfigManager = remoteConfigManager
+        self.uiConfigProvider = remoteConfigManager.map { UiConfigProvider(manager: $0) }
     }
 
     func offerings(
@@ -99,23 +103,19 @@ class OfferingsManager {
                                                  notFoundProductIds: nil)
 
             if cacheStatus == .stale {
-                // Serve the cached offerings immediately and refresh in the background, preserving the
-                // existing "return fast, update later" behavior. The background update goes through the
-                // same workflows-aware delivery path, so it refreshes the workflows list too. Gating
-                // here as well would both block delivery and double-fetch the list.
-                self.dispatchCompletionOnMainThreadIfPossible(completion, value: .success(memoryCachedOfferings))
+                // Kick the background refresh before the gated delivery below; the readiness
+                // gate must not delay it.
                 self.updateOfferingsCache(appUserID: appUserID,
                                           isAppBackgrounded: isAppBackgrounded,
                                           fetchPolicy: fetchPolicy,
                                           completion: nil)
-            } else {
-                // Fresh offerings (no background refresh coming): ensure remote config has synced at
-                // least once before delivering, so a caller resolving a workflow right after
-                // `getOfferings` succeeds isn't racing the first config sync. This is a no-op once the
-                // `workflows` topic is already populated, which it normally is on this path.
-                self.deliverWhenConfigReady {
-                    self.dispatchCompletionOnMainThreadIfPossible(completion, value: .success(memoryCachedOfferings))
-                }
+            }
+            // Cached delivery (fresh or stale) goes through the readiness gate: `getOfferings`
+            // returning means the paywall config data is queryable. The gate is a no-op once
+            // config has synced, so the stale path's "return fast, update later" behavior is
+            // preserved everywhere but the very first launch.
+            self.deliverWhenConfigReady {
+                self.dispatchCompletionOnMainThreadIfPossible(completion, value: .success(memoryCachedOfferings))
             }
         }
     }
@@ -391,13 +391,24 @@ private extension OfferingsManager {
     /// `workflows` topic's metadata. The manager's `awaitTopicAndPrefetchBlobsReady()` read no-ops when already synced
     /// and always calls back, so this never hangs. When no manager is wired (workflows disabled),
     /// `deliver` runs immediately, leaving offerings unchanged.
+    /// Invokes `deliver` once the config-endpoint paywall data `getOfferings` depends on is
+    /// ready, resolved concurrently:
+    /// - the `workflows` topic is synced (with its prefetch-flagged blobs downloaded), so
+    ///   workflow resolution right after `getOfferings` doesn't race the first config sync; and
+    /// - the `ui_config` body is resolved, so a paywall render has its styling in hand without
+    ///   a further round trip.
+    ///
+    /// Both steps are best-effort: each returns nil on failure rather than throwing, so
+    /// delivery can never be stranded on either.
     private func deliverWhenConfigReady(deliver: @escaping () -> Void) {
         guard let remoteConfigManager = self.remoteConfigManager else {
             deliver()
             return
         }
         Task {
-            _ = await remoteConfigManager.awaitTopicAndPrefetchBlobsReady(.workflows)
+            async let workflowsReady = remoteConfigManager.awaitTopicAndPrefetchBlobsReady(.workflows)
+            async let uiConfigReady = self.uiConfigProvider?.getUiConfig()
+            _ = await (workflowsReady, uiConfigReady)
             deliver()
         }
     }

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -28,8 +28,6 @@ class OfferingsManager {
     private let dateProvider: DateProvider
     // Nil when remote config is disabled, in which case offerings delivery is unchanged.
     private let remoteConfigManager: RemoteConfigManagerType?
-    // Resolves the `ui_config` body the delivery gate waits on. Nil when the manager is.
-    private let uiConfigProvider: UiConfigProvider?
 
     init(deviceCache: DeviceCache,
          operationDispatcher: OperationDispatcher,
@@ -49,7 +47,6 @@ class OfferingsManager {
         self.diagnosticsTracker = diagnosticsTracker
         self.dateProvider = dateProvider
         self.remoteConfigManager = remoteConfigManager
-        self.uiConfigProvider = remoteConfigManager.map { UiConfigProvider(manager: $0) }
     }
 
     func offerings(
@@ -101,50 +98,19 @@ class OfferingsManager {
                                                  requestedProductIds: nil,
                                                  notFoundProductIds: nil)
 
-            let refreshedOfferings = self.refreshStaleOfferingsInBackground(
-                cacheStatus: cacheStatus,
-                appUserID: appUserID,
-                isAppBackgrounded: isAppBackgrounded,
-                fetchPolicy: fetchPolicy
-            )
-            self.deliverCachedOfferingsWhenConfigReady(memoryCachedOfferings,
-                                                       refreshedOfferings: refreshedOfferings,
-                                                       completion: completion)
-        }
-    }
-
-    /// Starts the background refresh a stale cache needs and returns where its result lands.
-    /// Captured from the refresh's own completion, not the shared cache slot, which a
-    /// concurrent identity/locale change could repopulate with another request's offerings.
-    private func refreshStaleOfferingsInBackground(
-        cacheStatus: CacheStatus,
-        appUserID: String,
-        isAppBackgrounded: Bool,
-        fetchPolicy: FetchPolicy
-    ) -> Atomic<Offerings?> {
-        let refreshedOfferings: Atomic<Offerings?> = .init(nil)
-        guard cacheStatus == .stale else { return refreshedOfferings }
-
-        self.updateOfferingsCache(appUserID: appUserID,
-                                  isAppBackgrounded: isAppBackgrounded,
-                                  fetchPolicy: fetchPolicy) { result in
-            refreshedOfferings.value = result.value?.offerings
-        }
-        return refreshedOfferings
-    }
-
-    /// Delivers cached offerings once config is ready, preferring this request's own refresh
-    /// result. Read on the main actor, where the refresh also writes it, so an earlier refresh
-    /// is visible.
-    private func deliverCachedOfferingsWhenConfigReady(
-        _ memoryCachedOfferings: Offerings,
-        refreshedOfferings: Atomic<Offerings?>,
-        completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?
-    ) {
-        self.deliverWhenConfigReady {
-            guard let completion else { return }
-            self.operationDispatcher.dispatchOnMainActor {
-                completion(.success(refreshedOfferings.value ?? memoryCachedOfferings))
+            if cacheStatus == .stale {
+                // Refresh in the background; the readiness gate below must not delay it.
+                self.updateOfferingsCache(appUserID: appUserID,
+                                          isAppBackgrounded: isAppBackgrounded,
+                                          fetchPolicy: fetchPolicy,
+                                          completion: nil)
+            }
+            // Cached offerings, stale ones included, wait for config readiness before
+            // delivery (a no-op once config has synced). A stale snapshot may be returned
+            // even if the background refresh finished first; that matches the stale-cache
+            // model, and the refresh still updates the cache for the next call.
+            self.deliverWhenConfigReady {
+                self.dispatchCompletionOnMainThreadIfPossible(completion, value: .success(memoryCachedOfferings))
             }
         }
     }
@@ -414,16 +380,10 @@ private extension OfferingsManager {
         }
     }
 
-    /// Runs `deliver` once remote config has synced at least once *and* every workflow flagged for
-    /// prefetch has finished downloading (or failed), when remote config is wired. Matches Android's
-    /// guarantee that offerings delivery waits for every prefetched workflow body, not just the
-    /// `workflows` topic's metadata. The manager's `awaitTopicAndPrefetchBlobsReady()` read no-ops when already synced
-    /// and always calls back, so this never hangs. When no manager is wired (workflows disabled),
-    /// `deliver` runs immediately, leaving offerings unchanged.
     /// Invokes `deliver` once the paywall config data `getOfferings` depends on is ready:
     /// the `workflows` topic (with its prefetch-flagged blobs) and the `ui_config` body,
     /// resolved concurrently. Both are best-effort (nil on failure, never throwing), so
-    /// delivery can never be stranded.
+    /// delivery can never be stranded; when no manager is wired, `deliver` runs immediately.
     private func deliverWhenConfigReady(deliver: @escaping () -> Void) {
         guard let remoteConfigManager = self.remoteConfigManager else {
             deliver()
@@ -431,7 +391,7 @@ private extension OfferingsManager {
         }
         Task {
             async let workflowsReady = remoteConfigManager.awaitTopicAndPrefetchBlobsReady(.workflows)
-            async let uiConfigReady = self.uiConfigProvider?.getUiConfig()
+            async let uiConfigReady = UiConfigProvider(manager: remoteConfigManager).getUiConfig()
             _ = await (workflowsReady, uiConfigReady)
             deliver()
         }

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -323,6 +323,9 @@ private extension OfferingsManager {
                                        preferredLocales: preferredLocales,
                                        appUserID: appUserID)
 
+                // A background refresh (nil completion) only updates the cache; skip the
+                // readiness gate so it doesn't await (and decode) config for a no-op delivery.
+                guard let completion else { return }
                 // Delivers offerings only once remote config has synced at least once, so the
                 // `workflows` topic is available for resolving a workflow right after this call.
                 self.deliverWhenConfigReady {

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -103,19 +103,18 @@ class OfferingsManager {
                                                  notFoundProductIds: nil)
 
             if cacheStatus == .stale {
-                // Kick the background refresh before the gated delivery below; the readiness
-                // gate must not delay it.
+                // The readiness gate below must not delay this background refresh.
                 self.updateOfferingsCache(appUserID: appUserID,
                                           isAppBackgrounded: isAppBackgrounded,
                                           fetchPolicy: fetchPolicy,
                                           completion: nil)
             }
-            // Cached delivery (fresh or stale) goes through the readiness gate: `getOfferings`
-            // returning means the paywall config data is queryable. The gate is a no-op once
-            // config has synced, so the stale path's "return fast, update later" behavior is
-            // preserved everywhere but the very first launch.
+            // Cached delivery waits for config readiness (a no-op once config has synced),
+            // re-reading the cache afterwards: if the stale path's refresh finished while
+            // waiting, the caller gets the fresh offerings it already paid for.
             self.deliverWhenConfigReady {
-                self.dispatchCompletionOnMainThreadIfPossible(completion, value: .success(memoryCachedOfferings))
+                let offerings = self.cachedOfferings ?? memoryCachedOfferings
+                self.dispatchCompletionOnMainThreadIfPossible(completion, value: .success(offerings))
             }
         }
     }
@@ -391,15 +390,10 @@ private extension OfferingsManager {
     /// `workflows` topic's metadata. The manager's `awaitTopicAndPrefetchBlobsReady()` read no-ops when already synced
     /// and always calls back, so this never hangs. When no manager is wired (workflows disabled),
     /// `deliver` runs immediately, leaving offerings unchanged.
-    /// Invokes `deliver` once the config-endpoint paywall data `getOfferings` depends on is
-    /// ready, resolved concurrently:
-    /// - the `workflows` topic is synced (with its prefetch-flagged blobs downloaded), so
-    ///   workflow resolution right after `getOfferings` doesn't race the first config sync; and
-    /// - the `ui_config` body is resolved, so a paywall render has its styling in hand without
-    ///   a further round trip.
-    ///
-    /// Both steps are best-effort: each returns nil on failure rather than throwing, so
-    /// delivery can never be stranded on either.
+    /// Invokes `deliver` once the paywall config data `getOfferings` depends on is ready:
+    /// the `workflows` topic (with its prefetch-flagged blobs) and the `ui_config` body,
+    /// resolved concurrently. Both are best-effort (nil on failure, never throwing), so
+    /// delivery can never be stranded.
     private func deliverWhenConfigReady(deliver: @escaping () -> Void) {
         guard let remoteConfigManager = self.remoteConfigManager else {
             deliver()

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -969,7 +969,12 @@ private extension OfferingsManagerTests {
         static let unexpectedBackendResponseError: BackendError = .unexpectedBackendResponse(
             .customerInfoNil
         )
-        static let sampleOfferings: Offerings = .init(
+        static let sampleOfferings: Offerings = MockData.makeSampleOfferings()
+
+        /// A fresh `Offerings` instance per call, for tests that need two distinguishable snapshots.
+        // swiftlint:disable:next function_body_length
+        static func makeSampleOfferings() -> Offerings {
+            return .init(
             offerings: MockData.anyBackendOfferingsContents.response.offerings
                 .map { offering in
                     Offering(
@@ -996,7 +1001,8 @@ private extension OfferingsManagerTests {
             targeting: nil,
             contents: MockData.anyBackendOfferingsContents,
             loadedFromDiskCache: false
-        )
+            )
+        }
     }
 
 }
@@ -1067,8 +1073,7 @@ extension OfferingsManagerTests {
 
     func testGetOfferingsAwaitsWorkflowsAndUiConfigConcurrently() {
         let mockRemoteConfigManager = MockRemoteConfigManager()
-        // Hold BOTH readiness steps: each must have STARTED before either completes, or one
-        // failing slowly would serialize behind the other.
+        // Hold BOTH readiness steps: each must have started before either completes.
         mockRemoteConfigManager.shouldStoreTopicCompletion = true
         mockRemoteConfigManager.shouldStoreBlobDataCompletion = true
         let manager = self.makeOfferingsManager(remoteConfigManager: mockRemoteConfigManager)
@@ -1133,13 +1138,34 @@ extension OfferingsManagerTests {
 
         // The background refresh starts regardless of the gate...
         expect(self.mockOfferings.invokedGetOfferingsForAppUserID).toEventually(beTrue())
-        // ...but even stale cached offerings must not be delivered before config readiness:
-        // getOfferings returning means the paywall config data is queryable.
+        // ...but delivery, even from a stale cache, waits for config readiness.
         expect(mockRemoteConfigManager.invokedTopicCount).toEventually(beGreaterThan(0))
         expect(delivered.value) == false
 
         mockRemoteConfigManager.completeStoredTopic()
         expect(delivered.value).toEventually(beTrue())
+    }
+
+    func testGetOfferingsFromStaleCacheDeliversRefreshedOfferingsWhenRefreshWinsTheGate() {
+        let mockRemoteConfigManager = MockRemoteConfigManager()
+        mockRemoteConfigManager.shouldStoreTopicCompletion = true
+        let manager = self.makeOfferingsManager(remoteConfigManager: mockRemoteConfigManager)
+        self.mockDeviceCache.stubbedOfferings = MockData.makeSampleOfferings()
+        self.mockDeviceCache.stubbedOfferingCacheStatus = .stale
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsContents)
+
+        let delivered: Atomic<Offerings?> = .init(nil)
+        manager.offerings(appUserID: MockData.anyAppUserID) { result in delivered.value = result.value }
+
+        // While delivery waits on the gate, the background refresh lands fresh offerings.
+        expect(mockRemoteConfigManager.invokedTopicCount).toEventually(beGreaterThan(0))
+        let refreshedOfferings = MockData.makeSampleOfferings()
+        self.mockDeviceCache.stubbedOfferings = refreshedOfferings
+
+        mockRemoteConfigManager.completeStoredTopic()
+        // The caller waited through the refresh; it must get the fresh snapshot, not the
+        // stale one captured before the gate.
+        expect(delivered.value).toEventually(be(refreshedOfferings))
     }
 
     func testGetOfferingsNetworkFetchAwaitsConfigReadyBeforeDelivering() {

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -972,7 +972,6 @@ private extension OfferingsManagerTests {
         static let sampleOfferings: Offerings = MockData.makeSampleOfferings()
 
         /// A fresh `Offerings` instance per call, for tests that need two distinguishable snapshots.
-        // swiftlint:disable:next function_body_length
         static func makeSampleOfferings() -> Offerings {
             return .init(
             offerings: MockData.anyBackendOfferingsContents.response.offerings
@@ -1146,26 +1145,48 @@ extension OfferingsManagerTests {
         expect(delivered.value).toEventually(beTrue())
     }
 
-    func testGetOfferingsFromStaleCacheDeliversRefreshedOfferingsWhenRefreshWinsTheGate() {
+    func testGatedFreshCacheDeliveryNeverReadsTheSharedCacheSlot() {
         let mockRemoteConfigManager = MockRemoteConfigManager()
         mockRemoteConfigManager.shouldStoreTopicCompletion = true
         let manager = self.makeOfferingsManager(remoteConfigManager: mockRemoteConfigManager)
+        let captured = MockData.makeSampleOfferings()
+        self.mockDeviceCache.stubbedOfferings = captured
+        self.mockDeviceCache.stubbedOfferingCacheStatus = .valid
+
+        let delivered: Atomic<Offerings?> = .init(nil)
+        manager.offerings(appUserID: MockData.anyAppUserID) { result in delivered.value = result.value }
+
+        // While delivery waits on the gate, an unrelated write (identity change, another
+        // request) repopulates the shared cache slot. It must not leak into this request.
+        expect(mockRemoteConfigManager.invokedTopicCount).toEventually(beGreaterThan(0))
         self.mockDeviceCache.stubbedOfferings = MockData.makeSampleOfferings()
+
+        mockRemoteConfigManager.completeStoredTopic()
+        expect(delivered.value).toEventually(beIdenticalTo(captured))
+    }
+
+    func testGatedStaleCacheDeliveryNeverDeliversAnUnrelatedCacheWrite() {
+        let mockRemoteConfigManager = MockRemoteConfigManager()
+        mockRemoteConfigManager.shouldStoreTopicCompletion = true
+        let manager = self.makeOfferingsManager(remoteConfigManager: mockRemoteConfigManager)
+        let captured = MockData.makeSampleOfferings()
+        self.mockDeviceCache.stubbedOfferings = captured
         self.mockDeviceCache.stubbedOfferingCacheStatus = .stale
         self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsContents)
 
         let delivered: Atomic<Offerings?> = .init(nil)
         manager.offerings(appUserID: MockData.anyAppUserID) { result in delivered.value = result.value }
 
-        // While delivery waits on the gate, the background refresh lands fresh offerings.
+        // While delivery waits on the gate, an unrelated write repopulates the slot.
         expect(mockRemoteConfigManager.invokedTopicCount).toEventually(beGreaterThan(0))
-        let refreshedOfferings = MockData.makeSampleOfferings()
-        self.mockDeviceCache.stubbedOfferings = refreshedOfferings
+        let unrelated = MockData.makeSampleOfferings()
+        self.mockDeviceCache.stubbedOfferings = unrelated
 
         mockRemoteConfigManager.completeStoredTopic()
-        // The caller waited through the refresh; it must get the fresh snapshot, not the
-        // stale one captured before the gate.
-        expect(delivered.value).toEventually(be(refreshedOfferings))
+        // Delivery is the captured stale snapshot or this request's own refresh result
+        // (whichever the scheduler resolves first); the unrelated slot write, never.
+        expect(delivered.value).toEventuallyNot(beNil())
+        expect(delivered.value).toNot(beIdenticalTo(unrelated))
     }
 
     func testGetOfferingsNetworkFetchAwaitsConfigReadyBeforeDelivering() {

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -1165,7 +1165,7 @@ extension OfferingsManagerTests {
         expect(delivered.value).toEventually(beIdenticalTo(captured))
     }
 
-    func testGatedStaleCacheDeliveryNeverDeliversAnUnrelatedCacheWrite() {
+    func testGatedStaleCacheDeliversTheCapturedSnapshotNotALaterCacheWrite() {
         let mockRemoteConfigManager = MockRemoteConfigManager()
         mockRemoteConfigManager.shouldStoreTopicCompletion = true
         let manager = self.makeOfferingsManager(remoteConfigManager: mockRemoteConfigManager)
@@ -1177,16 +1177,14 @@ extension OfferingsManagerTests {
         let delivered: Atomic<Offerings?> = .init(nil)
         manager.offerings(appUserID: MockData.anyAppUserID) { result in delivered.value = result.value }
 
-        // While delivery waits on the gate, an unrelated write repopulates the slot.
+        // While delivery waits on the gate, the background refresh writes a new slot value.
         expect(mockRemoteConfigManager.invokedTopicCount).toEventually(beGreaterThan(0))
-        let unrelated = MockData.makeSampleOfferings()
-        self.mockDeviceCache.stubbedOfferings = unrelated
+        self.mockDeviceCache.stubbedOfferings = MockData.makeSampleOfferings()
 
         mockRemoteConfigManager.completeStoredTopic()
-        // Delivery is the captured stale snapshot or this request's own refresh result
-        // (whichever the scheduler resolves first); the unrelated slot write, never.
-        expect(delivered.value).toEventuallyNot(beNil())
-        expect(delivered.value).toNot(beIdenticalTo(unrelated))
+        // Stale delivery returns the snapshot captured for this request, never a later
+        // cache write (the refresh's, or another request's).
+        expect(delivered.value).toEventually(beIdenticalTo(captured))
     }
 
     func testGetOfferingsNetworkFetchAwaitsConfigReadyBeforeDelivering() {

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -1059,7 +1059,7 @@ extension OfferingsManagerTests {
 
     func testGetOfferingsDeliversWhenUiConfigResolutionFails() {
         // No ui_config blobs stubbed: resolution fails (nil). Readiness is best-effort, so
-        // delivery must proceed anyway.
+        // delivery must proceed anyway with the real offerings.
         let manager = self.makeOfferingsManager(remoteConfigManager: MockRemoteConfigManager())
         self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsContents)
 
@@ -1068,6 +1068,41 @@ extension OfferingsManagerTests {
         }
 
         expect(result).to(beSuccess())
+        expect(result?.value?["base"]).toNot(beNil())
+        expect(result?.value?["base"]?.monthly?.storeProduct).toNot(beNil())
+    }
+
+    func testGetOfferingsDeliversEvenIfTheGateTaskIsCancelled() {
+        // The gate's two readiness awaits are non-throwing and always awaited before the
+        // callback fires, so no cancellation can strand it. Model that here by resolving both
+        // to their empty/failed states (no workflows topic, no ui_config) and asserting the
+        // completion still runs.
+        let manager = self.makeOfferingsManager(remoteConfigManager: MockRemoteConfigManager())
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsContents)
+
+        let result = waitUntilValue { completed in
+            manager.offerings(appUserID: MockData.anyAppUserID) { completed($0) }
+        }
+
+        expect(result).to(beSuccess())
+    }
+
+    func testBackgroundCacheRefreshCachesWithoutAwaitingTheConfigGate() {
+        // A background refresh passes a nil completion: it has nothing to deliver, so it must
+        // cache the fetched offerings without entering the readiness gate. The held topic
+        // would block the gate forever; asserting the cache still lands (and the gate's topic
+        // read never happens) locks the skip.
+        let mockRemoteConfigManager = MockRemoteConfigManager()
+        mockRemoteConfigManager.shouldStoreTopicCompletion = true
+        let manager = self.makeOfferingsManager(remoteConfigManager: mockRemoteConfigManager)
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsContents)
+
+        manager.updateOfferingsCache(appUserID: MockData.anyAppUserID,
+                                     isAppBackgrounded: false,
+                                     completion: nil)
+
+        expect(self.mockDeviceCache.cacheOfferingsCount).toEventually(equal(1))
+        expect(mockRemoteConfigManager.invokedTopicCount) == 0
     }
 
     func testGetOfferingsAwaitsWorkflowsAndUiConfigConcurrently() {

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -1034,6 +1034,58 @@ extension OfferingsManagerTests {
         expect(delivered.value).toEventually(beTrue())
     }
 
+    func testGetOfferingsDoesNotDeliverUntilUiConfigResolved() {
+        let mockRemoteConfigManager = MockRemoteConfigManager()
+        // The workflows topic resolves immediately; ui_config's blob reads are held.
+        mockRemoteConfigManager.shouldStoreBlobDataCompletion = true
+        let manager = self.makeOfferingsManager(remoteConfigManager: mockRemoteConfigManager)
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsContents)
+
+        let delivered: Atomic<Bool> = false
+        manager.offerings(appUserID: MockData.anyAppUserID) { _ in delivered.value = true }
+
+        // The ui_config read was started but is held, so offerings must wait.
+        expect(mockRemoteConfigManager.invokedBlobDataParameters).toEventuallyNot(beEmpty())
+        expect(delivered.value) == false
+
+        mockRemoteConfigManager.completeStoredBlobReads()
+        expect(delivered.value).toEventually(beTrue())
+    }
+
+    func testGetOfferingsDeliversWhenUiConfigResolutionFails() {
+        // No ui_config blobs stubbed: resolution fails (nil). Readiness is best-effort, so
+        // delivery must proceed anyway.
+        let manager = self.makeOfferingsManager(remoteConfigManager: MockRemoteConfigManager())
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsContents)
+
+        let result = waitUntilValue { completed in
+            manager.offerings(appUserID: MockData.anyAppUserID) { completed($0) }
+        }
+
+        expect(result).to(beSuccess())
+    }
+
+    func testGetOfferingsAwaitsWorkflowsAndUiConfigConcurrently() {
+        let mockRemoteConfigManager = MockRemoteConfigManager()
+        // Hold BOTH readiness steps: each must have STARTED before either completes, or one
+        // failing slowly would serialize behind the other.
+        mockRemoteConfigManager.shouldStoreTopicCompletion = true
+        mockRemoteConfigManager.shouldStoreBlobDataCompletion = true
+        let manager = self.makeOfferingsManager(remoteConfigManager: mockRemoteConfigManager)
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsContents)
+
+        let delivered: Atomic<Bool> = false
+        manager.offerings(appUserID: MockData.anyAppUserID) { _ in delivered.value = true }
+
+        expect(mockRemoteConfigManager.invokedTopicCount).toEventually(beGreaterThan(0))
+        expect(mockRemoteConfigManager.invokedBlobDataParameters).toEventuallyNot(beEmpty())
+        expect(delivered.value) == false
+
+        mockRemoteConfigManager.completeStoredTopic()
+        mockRemoteConfigManager.completeStoredBlobReads()
+        expect(delivered.value).toEventually(beTrue())
+    }
+
     func testGetOfferingsDeliversEvenWhenRemoteConfigHasNoWorkflowsTopic() {
         // A manager with no committed `workflows` topic (e.g. never synced) must still call back, so
         // offerings delivery can never hang.
@@ -1067,9 +1119,8 @@ extension OfferingsManagerTests {
         expect(delivered.value).toEventually(beTrue())
     }
 
-    func testGetOfferingsFromStaleMemoryCacheDeliversImmediately() {
+    func testGetOfferingsFromStaleMemoryCacheGatesDeliveryAndStillRefreshes() {
         let mockRemoteConfigManager = MockRemoteConfigManager()
-        // Hold the topic completion so a foreground wait, if present, would block delivery.
         mockRemoteConfigManager.shouldStoreTopicCompletion = true
         let manager = self.makeOfferingsManager(remoteConfigManager: mockRemoteConfigManager)
         // Cached but stale, so the background refresh runs.
@@ -1080,12 +1131,15 @@ extension OfferingsManagerTests {
         let delivered: Atomic<Bool> = false
         manager.offerings(appUserID: MockData.anyAppUserID) { _ in delivered.value = true }
 
-        // Cached offerings are delivered immediately, not blocked on the held topic completion.
-        expect(delivered.value).toEventually(beTrue())
-
-        // Drain the background refresh's config-ready wait so its `Task` doesn't leak past this test.
+        // The background refresh starts regardless of the gate...
+        expect(self.mockOfferings.invokedGetOfferingsForAppUserID).toEventually(beTrue())
+        // ...but even stale cached offerings must not be delivered before config readiness:
+        // getOfferings returning means the paywall config data is queryable.
         expect(mockRemoteConfigManager.invokedTopicCount).toEventually(beGreaterThan(0))
+        expect(delivered.value) == false
+
         mockRemoteConfigManager.completeStoredTopic()
+        expect(delivered.value).toEventually(beTrue())
     }
 
     func testGetOfferingsNetworkFetchAwaitsConfigReadyBeforeDelivering() {

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -743,9 +743,36 @@ final class MockRemoteConfigManager: RemoteConfigManagerType {
         continuation?.resume(returning: result)
     }
 
+    /// When `true`, `blobData(for:itemKey:)` suspends until `completeStoredBlobReads()` is called,
+    /// so tests can control the timing of a caller awaiting blob-backed resolution (e.g.
+    /// `OfferingsManager`'s config-ready gate resolving `ui_config`).
+    var shouldStoreBlobDataCompletion = false
+    private typealias StoredBlobRead = (
+        topic: RemoteConfigTopic, itemKey: String, continuation: CheckedContinuation<Data?, Never>
+    )
+    private let _storedBlobReads: Atomic<[StoredBlobRead]> = .init([])
+
     func blobData(for topic: RemoteConfigTopic, itemKey: String) async -> Data? {
-        self._invokedBlobDataParameters.modify { $0.append((topic, itemKey)) }
-        return self.stubbedBlobData[topic]?[itemKey]
+        guard self.shouldStoreBlobDataCompletion else {
+            self._invokedBlobDataParameters.modify { $0.append((topic, itemKey)) }
+            return self.stubbedBlobData[topic]?[itemKey]
+        }
+        return await withCheckedContinuation { continuation in
+            // Store before recording the invocation, so a test polling the invocation list can
+            // never observe readiness before `completeStoredBlobReads()` has something to resume.
+            self._storedBlobReads.modify { $0.append((topic, itemKey, continuation)) }
+            self._invokedBlobDataParameters.modify { $0.append((topic, itemKey)) }
+        }
+    }
+
+    /// Resumes every blob read held while `shouldStoreBlobDataCompletion` was `true` with the
+    /// stubbed data for its key, and stops holding subsequent reads, so sequential read chains
+    /// (like `mergeItemsBlobData`'s loop) run to completion.
+    func completeStoredBlobReads() {
+        self.shouldStoreBlobDataCompletion = false
+        for read in self._storedBlobReads.getAndSet([]) {
+            read.continuation.resume(returning: self.stubbedBlobData[read.topic]?[read.itemKey])
+        }
     }
 
     func blobData<T: Decodable>(

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -714,11 +714,11 @@ final class MockRemoteConfigManager: RemoteConfigManagerType {
 
     private let _invokedTopicCount: Atomic<Int> = .init(0)
     var invokedTopicCount: Int { return self._invokedTopicCount.value }
-    /// When `true`, `topic(_:)` suspends until `completeStoredTopic()` is called, so tests can control
-    /// the timing of a caller awaiting it (e.g. `OfferingsManager`'s config-ready gate).
+    /// When `true`, `topic(_:)` suspends until `completeStoredTopic()` resumes every stored
+    /// waiter (there can be several: e.g. a gated delivery plus a background refresh).
     var shouldStoreTopicCompletion = false
-    private let _storedTopicContinuation: Atomic<CheckedContinuation<RemoteConfiguration.ConfigTopic?, Never>?> =
-        .init(nil)
+    private let _storedTopicContinuations: Atomic<[CheckedContinuation<RemoteConfiguration.ConfigTopic?, Never>]> =
+        .init([])
 
     func topic(_ topic: RemoteConfigTopic) async -> RemoteConfiguration.ConfigTopic? {
         guard self.shouldStoreTopicCompletion else {
@@ -726,26 +726,24 @@ final class MockRemoteConfigManager: RemoteConfigManagerType {
             return self.stubbedTopics[topic]
         }
         return await withCheckedContinuation { continuation in
-            // Resume any previously stored continuation so it can't leak if `topic(_:)` is called again
-            // before the prior call's completion is triggered.
-            self._storedTopicContinuation.getAndSet(continuation)?.resume(returning: nil)
-            // Increment only after the continuation is stored, so a test polling `invokedTopicCount`
-            // can never observe readiness before `completeStoredTopic()` has something to resume.
+            // Store before incrementing, so a test polling `invokedTopicCount` can never
+            // observe readiness before `completeStoredTopic()` has something to resume.
+            self._storedTopicContinuations.modify { $0.append(continuation) }
             self._invokedTopicCount.modify { $0 += 1 }
         }
     }
 
-    /// Resumes the continuation captured by a `topic(_:)` call made while `shouldStoreTopicCompletion`
-    /// was `true`. Requires `shouldStoreTopicCompletion == true`.
+    /// Resumes every waiter held while `shouldStoreTopicCompletion` was `true`, and stops
+    /// holding subsequent calls.
     func completeStoredTopic(with result: RemoteConfiguration.ConfigTopic? = nil) {
-        let continuation = self._storedTopicContinuation.value
-        self._storedTopicContinuation.value = nil
-        continuation?.resume(returning: result)
+        self.shouldStoreTopicCompletion = false
+        for continuation in self._storedTopicContinuations.getAndSet([]) {
+            continuation.resume(returning: result)
+        }
     }
 
-    /// When `true`, `blobData(for:itemKey:)` suspends until `completeStoredBlobReads()` is called,
-    /// so tests can control the timing of a caller awaiting blob-backed resolution (e.g.
-    /// `OfferingsManager`'s config-ready gate resolving `ui_config`).
+    /// When `true`, `blobData(for:itemKey:)` suspends until `completeStoredBlobReads()` is
+    /// called, so tests can control the timing of a caller resolving blob-backed data.
     var shouldStoreBlobDataCompletion = false
     private typealias StoredBlobRead = (
         topic: RemoteConfigTopic, itemKey: String, continuation: CheckedContinuation<Data?, Never>
@@ -758,16 +756,14 @@ final class MockRemoteConfigManager: RemoteConfigManagerType {
             return self.stubbedBlobData[topic]?[itemKey]
         }
         return await withCheckedContinuation { continuation in
-            // Store before recording the invocation, so a test polling the invocation list can
-            // never observe readiness before `completeStoredBlobReads()` has something to resume.
+            // Store before recording, so a poller can't observe readiness with nothing to resume.
             self._storedBlobReads.modify { $0.append((topic, itemKey, continuation)) }
             self._invokedBlobDataParameters.modify { $0.append((topic, itemKey)) }
         }
     }
 
-    /// Resumes every blob read held while `shouldStoreBlobDataCompletion` was `true` with the
-    /// stubbed data for its key, and stops holding subsequent reads, so sequential read chains
-    /// (like `mergeItemsBlobData`'s loop) run to completion.
+    /// Resumes every held blob read with its key's stubbed data and stops holding subsequent
+    /// reads, so sequential read chains (like `mergeItemsBlobData`'s loop) run to completion.
     func completeStoredBlobReads() {
         self.shouldStoreBlobDataCompletion = false
         for read in self._storedBlobReads.getAndSet([]) {


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

With remote config on, `getOfferings` shouldn't return until the paywall config data it depends on is queryable: offerings, the workflows topic, and `ui_config` (team-confirmed contract). Android already implements this; iOS was only waiting for the workflows topic, and skipped the gate entirely when serving a stale cache. Aligning also makes the iOS and Android launch measurements comparable: Android's numbers include the `ui_config` round trips, iOS's structurally excluded them.

### Description

`deliverWhenConfigReady` now resolves two things concurrently before delivering: the workflows topic + its prefetch blobs (as before), and the `ui_config` body via the existing `UiConfigProvider`. Both stay best-effort (each resolves nil on failure, so delivery can never be stranded). The stale-memory-cache path now goes through the same gate, with the background refresh kicked first so the gate can't delay it.

Two behavior changes to consciously accept:
1. Cold launches with workflows on get slower: `ui_config`'s blob fetches now happen inside `getOfferings` instead of after it. That's the point — the paywall has its styling in hand when `getOfferings` returns (parity with `WorkflowManager.onPaywallConfigReady` on Android).
2. Stale cache hits before the first config sync now wait for it. The gate is a no-op once config has synced, so stale hits keep returning fast everywhere but the very first launch.


<details>
<summary>On-simulator proof (before/after logs)</summary>

Cold launches of PaywallsTester (Debug, `ENABLE_REMOTE_CONFIG`, live stress project `5f07e7e3` with 3 active topics / 20 referenced blobs), app container erased before each launch, SDK verbose logs captured via `log stream`. The `GATE-PROOF` markers wrap the app's `getOfferings` call.

**BEFORE (`origin/main`)** — `getOfferings` returns without the ui_config blobs ever being fetched (a later paywall render pays those round trips):

```
18:07:42.697  GATE-PROOF: calling getOfferings
18:07:42.758  VERBOSE: Refreshing remote config for domain 'app' (manifestPresent: false, ...)
              [16 inline blobs stored]
18:07:44.090  DEBUG: Persisted remote config for domain 'app' with 3 active topics and 20 referenced blobs.
18:07:44.994  GATE-PROOF: getOfferings RETURNED (offerings: default, error: none)
              [zero "bytes downloaded from" lines in the entire run: ui_config never fetched]
```

**AFTER (this branch)** — delivery completes the same millisecond the last ui_config blob lands; the app is render-ready when `getOfferings` returns:

```
18:06:06.484  GATE-PROOF: calling getOfferings
18:06:06.541  VERBOSE: Refreshing remote config for domain 'app' (manifestPresent: false, ...)
              [16 inline blobs stored]
18:06:07.750  DEBUG: Persisted remote config for domain 'app' with 3 active topics and 20 referenced blobs.
18:06:08.567  VERBOSE: Stored remote config blob 'p0ix...Gf5_' with 4879 bytes downloaded from config.revenuecat-static.com/...
18:06:08.571  VERBOSE: Stored remote config blob 'Jewn...Pwp7' with 53900 bytes downloaded from config.revenuecat-static.com/...
18:06:08.651  VERBOSE: Stored remote config blob 'xXyp...1a1p' with 65 bytes downloaded from config.revenuecat-static.com/...
18:06:08.652  VERBOSE: Stored remote config blob 'jMWA...FWub' with 66 bytes downloaded from config.revenuecat-static.com/...
18:06:08.652  GATE-PROOF: getOfferings RETURNED (offerings: default, error: none)
```

Total cold `getOfferings` in these samples: 2.30s before vs 2.17s after (the four downloads are small and parallel; network variance dominates) — the contract is met at negligible cost for this payload, and the render-time fetches disappear.

</details>

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: this PR
- Branch: `facu/offerings-gate-ui-config`
- Author / human owner: facumenzella
- Agent(s): Claude Code (Fable 5), Codex (plan critique + review loop via codex-companion)
- Session source: current conversation (SDK config benchmark session)
- Generated: 2026-07-09
- Context document version: 2 (refreshed after the stale-delivery simplification)

## Goal

Make `getOfferings` (remote config on) return only when offerings, the workflows topic, and `ui_config` are all queryable, matching Android's contract.

## Initial Prompt

While reconciling why Android's launch benchmark showed ~70% workflows overhead vs iOS's ~20%, the human asked "are you sure on iOS we're waiting for all the blobs to be downloaded, to actually return getOfferings?" — investigation showed iOS gates only on workflows-topic prefetch blobs, while Android additionally awaits the `ui_config` body. The human confirmed with the team: "on the SDK side we can't return getOfferings (when workflows is on) until uiconfig, offerings y workflows are ready", and instructed: check how Android does it and do the same.

## Important Follow-up Prompts

- "What I would do before writing a plan, is check how android does it and do the same" — the plan was written from Android's merged sources (`WorkflowManager.onPaywallConfigReady`, `OfferingsManager` call sites), not from memory.
- Android colleague's confirmation that ui_config blobs are fetched on demand during `getOfferings` (not prefetched during config sync), which is where Android's gate cost lives.

## Agent Contribution

- Verified both platforms' gating in source: iOS `awaitTopicAndPrefetchBlobsReady(.workflows)` only; Android same PLUS `uiConfigProvider.getUiConfig()`, gating cached (incl. stale) and fresh deliveries.
- Wrote the plan (`~/Developer/rc/plans/2026-07-09-ios-getofferings-paywall-config-gate.md`), ran it through a Codex critique (1 finding applied: the mock needed a holdable blob-read hook; 2 accepted-as-is notes), implemented, and proved RED → GREEN.
- Empirical evidence from the benchmark app tier: ui_config's 4 blobs finished downloading ~120ms AFTER `getOfferings` returned on cold config launches (hundreds of samples), confirming the gap this PR closes.

## Human Decisions

- Decision: the contract itself (team sync): `getOfferings` must not return until offerings + workflows + ui_config are ready.
- Decision: mirror Android's implementation shape rather than design an iOS-specific gate.

## Key Implementation Decisions

- Decision: widen `deliverWhenConfigReady` with a concurrent `async let` pair (workflows readiness, `UiConfigProvider.getUiConfig()`); both non-throwing and nil-on-failure, so Android's "best-effort, never strand delivery" semantics fall out of the types with no extra error handling.
- Decision: gate the stale-memory-cache path too (Android gates all cached deliveries), kicking the background refresh BEFORE the gated dispatch so the gate cannot delay the refresh.
  - Rejected: keeping the stale path ungated (violates the confirmed contract on first launch).
- Decision (simplification, after review): stale delivery returns the captured `memoryCachedOfferings` snapshot, matching Android's `vendCachedOfferingsAndMaybeRefresh` (verified in `origin` Android source: it delivers the captured `cachedOfferings` param and does not hand the background refresh's result back to the caller). This replaced an earlier opportunistic "return the refresh result if it beats the gate" variant, deleting the `Atomic<Offerings?>`, the main-actor read-ordering, and the race class those attracted. Tradeoff (accepted, Android-identical): a stale snapshot may be returned even if the refresh already finished; the refresh still updates the cache for the next call.
- Decision: `UiConfigProvider` is created locally inside `deliverWhenConfigReady` (it is stateless), not stored on the manager — one fewer property.
- Decision: background cache refreshes (nil completion) skip the readiness gate entirely, so they don't await or decode config for a no-op delivery.

## Files / Symbols Touched

- `Sources/Purchasing/OfferingsManager.swift` — `deliverWhenConfigReady` (widened to workflows + ui_config, provider created locally), `offerings(appUserID:...)` cached/stale delivery gated on the captured snapshot, `handleOfferingsBackendResult` skips the gate on nil-completion background refreshes.
- `Tests/UnitTests/Purchasing/OfferingsManagerTests.swift` — 3 new tests (ui_config hold, best-effort failure, concurrency of the two waits); `testGetOfferingsFromStaleMemoryCacheDeliversImmediately` rewritten to `...GatesDeliveryAndStillRefreshes` (the old test pinned the behavior this PR removes).
- `Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift` — `MockRemoteConfigManager` gains a holdable blob-read hook (`shouldStoreBlobDataCompletion` / `completeStoredBlobReads()`), mirroring the existing topic hook.

## Validation

- RED → GREEN: the 3 behavior tests failed against the unchanged SDK (hold-based ui_config tests + stale gating), pass after; the best-effort test passes in both states by design.
- `OfferingsManagerTests`: 45/45. Full `UnitTests` suite: no failures introduced (the only failing class, `BackendGetCustomerCenterConfigTests` snapshots, fails identically on pristine `origin/main` in this environment — machine-specific references).
- `swift build` (SPM): green. SwiftLint: clean (the stale-branch edit initially tripped `function_body_length`; resolved by collapsing the duplicated gated dispatch).
- Codex review loop: converged after 4 passes. Applied: a plan-stage mock gap; the stale-refresh capture fix; the shared-slot post-gate read removal (identity-leak hazard) with two pinning tests. Rejected with reasons: "don't gate stale delivery" (contradicts the team-confirmed contract and Android parity) and "guarantee refresh-result delivery on the stale path" (contract requires config readiness, not refresh delivery; a guarantee would chain stale hits to the network round trip — the opportunistic delivery is strictly better than Android parity and never delivers wrong data).
- On-simulator before/after proof captured (see the proof section above): main returns getOfferings with ui_config never fetched; this branch completes delivery the same millisecond the last ui_config blob stores.

## Validation Gaps

- No integration/device test of the end-to-end timing change; the benchmark app tier (PR #7174) will measure it after merge (cold config numbers expected to rise; `last_blob_stored` should no longer exceed `offerings`).
- tvOS path unverified beyond compilation (`getUiConfig()` has a tvOS variant; workflows aren't supported there).

## Review Focus

- Is gating the stale-cache path acceptable UX (first-launch-only wait) given the contract?
- `async let` pair semantics: both children awaited, neither throws — any cancellation path that could strand `deliver()`?
- Should the ui_config wait also cover the `fetchCurrent`/uiPreviewMode path (currently ungated, pre-existing)?

## Risks / Reviewer Notes

- Risk: cold-launch `getOfferings` latency increases by the ui_config fetch cost when its blobs are CDN-delivered; that is the intended contract, and khepri's inline-budget decisions control the size of the cost.
- Risk: `getUiConfig()` has no decoded cache, so the gate's decode work repeats at render; Android pays the same shape of cost (accepted parity).

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes launch-time getOfferings latency and first-launch stale-cache timing when remote config is enabled; behavior is intentional for Android parity but affects paywall readiness contracts.
> 
> **Overview**
> Aligns iOS **getOfferings** (remote config on) with Android: callers don't get offerings until **workflows** (topic + prefetch blobs) and **`ui_config`** are ready to query, not workflows alone.
> 
> **`deliverWhenConfigReady`** now **`async let`**-awaits both **`awaitTopicAndPrefetchBlobsReady(.workflows)`** and **`UiConfigProvider.getUiConfig()`** in parallel; both are best-effort (nil on failure, no stranded completions). **All memory-cache deliveries**—including **stale** hits—use this gate and return the **snapshot captured at request time** (background refresh still runs first for stale; it may finish before the gate but won't change what this call returns). **Diagnostics latency** for cache hits is recorded **inside** the gate. **Background cache updates** with a nil completion **skip** the gate and only write the cache.
> 
> Tests add **holdable `ui_config` blob reads** on **`MockRemoteConfigManager`**, multi-waiter topic completion, and coverage for ui_config wait, concurrent gates, stale gating, snapshot identity, and gate-skipped background refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e66bdf97d55acfb90961651c96895e5d068e0149. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

