### PR TITLE
feat(remote-config): add static fallback config endpoint

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1189,7 +1189,7 @@
 		A5B6CDD8280F3843007629D5 /* AdServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5B6CDD5280F3843007629D5 /* AdServices.framework */; platformFilters = (ios, maccatalyst, macos, ); settings = {ATTRIBUTES = (Weak, ); }; };
 		A5F0104E2717B3150090732D /* BeginRefundRequestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F0104D2717B3150090732D /* BeginRefundRequestHelper.swift */; };
 		A6CC43904EBD4860BFD2BD85 /* GetRemoteConfigOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077FB0E4EC264B2EA08C4521 /* GetRemoteConfigOperation.swift */; };
-		FEDA0000000000000000F0A2 /* GetRemoteConfigStaticFallbackOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA0000000000000000F0A1 /* GetRemoteConfigStaticFallbackOperation.swift */; };
+		FEDA0000000000000000F0A2 /* GetRemoteConfigFallbackOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA0000000000000000F0A1 /* GetRemoteConfigFallbackOperation.swift */; };
 		AA110002AABB0001CCDD0001 /* CustomPaywallEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA110001AABB0001CCDD0001 /* CustomPaywallEvent.swift */; };
 		AA110004AABB0001CCDD0001 /* EventsRequest+CustomPaywallImpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA110003AABB0001CCDD0001 /* EventsRequest+CustomPaywallImpression.swift */; };
 		AA110006AABB0001CCDD0001 /* CustomPaywallEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA110005AABB0001CCDD0001 /* CustomPaywallEventTests.swift */; };
@@ -1581,7 +1581,7 @@
 		043FB8686FEB4A31B9CF48C8 /* PlatformInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformInfoTests.swift; sourceTree = "<group>"; };
 		077AC81FEBE38D1468AE8670 /* VideoAutoplayHandlerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VideoAutoplayHandlerTests.swift; sourceTree = "<group>"; };
 		077FB0E4EC264B2EA08C4521 /* GetRemoteConfigOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetRemoteConfigOperation.swift; sourceTree = "<group>"; };
-		FEDA0000000000000000F0A1 /* GetRemoteConfigStaticFallbackOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetRemoteConfigStaticFallbackOperation.swift; sourceTree = "<group>"; };
+		FEDA0000000000000000F0A1 /* GetRemoteConfigFallbackOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetRemoteConfigFallbackOperation.swift; sourceTree = "<group>"; };
 		0E4CCD8E9E454A2EB3760E06 /* ButtonComponentViewModelMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponentViewModelMappingTests.swift; sourceTree = "<group>"; };
 		13B0EAB50136613F69FAA3BB /* SynchronizedUserDefaultsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SynchronizedUserDefaultsTests.swift; sourceTree = "<group>"; };
 		161627FD2F50987800DEEDEB /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
@@ -6203,7 +6203,7 @@
 				B34605B9279A6E380031CA74 /* PostSubscriberAttributesOperation.swift */,
 				A55D5D65282ECCC100FA7623 /* PostAdServicesTokenOperation.swift */,
 				A56DFDEF286643BF00EF2E32 /* PostAttributionDataOperation.swift */,
-				FEDA0000000000000000F0A1 /* GetRemoteConfigStaticFallbackOperation.swift */,
+				FEDA0000000000000000F0A1 /* GetRemoteConfigFallbackOperation.swift */,
 				077FB0E4EC264B2EA08C4521 /* GetRemoteConfigOperation.swift */,
 			);
 			path = Operations;
@@ -7219,7 +7219,7 @@
 				FEDA000000000000000000B2 /* WeightedSourceSelector.swift in Sources */,
 				FEDA000000000000000000D2 /* RemoteConfigSourceProvider.swift in Sources */,
 				E6B064598F674333A29E0781 /* RemoteConfigCallback.swift in Sources */,
-				FEDA0000000000000000F0A2 /* GetRemoteConfigStaticFallbackOperation.swift in Sources */,
+				FEDA0000000000000000F0A2 /* GetRemoteConfigFallbackOperation.swift in Sources */,
 				A6CC43904EBD4860BFD2BD85 /* GetRemoteConfigOperation.swift in Sources */,
 				D62A9C83BFD14E5FA0452CC7 /* RemoteConfiguration.swift in Sources */,
 				A1B2C3D42FE1000000000002 /* RCContainer.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1189,6 +1189,7 @@
 		A5B6CDD8280F3843007629D5 /* AdServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5B6CDD5280F3843007629D5 /* AdServices.framework */; platformFilters = (ios, maccatalyst, macos, ); settings = {ATTRIBUTES = (Weak, ); }; };
 		A5F0104E2717B3150090732D /* BeginRefundRequestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F0104D2717B3150090732D /* BeginRefundRequestHelper.swift */; };
 		A6CC43904EBD4860BFD2BD85 /* GetRemoteConfigOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077FB0E4EC264B2EA08C4521 /* GetRemoteConfigOperation.swift */; };
+		FEDA0000000000000000F0A2 /* GetFallbackConfigOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA0000000000000000F0A1 /* GetFallbackConfigOperation.swift */; };
 		AA110002AABB0001CCDD0001 /* CustomPaywallEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA110001AABB0001CCDD0001 /* CustomPaywallEvent.swift */; };
 		AA110004AABB0001CCDD0001 /* EventsRequest+CustomPaywallImpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA110003AABB0001CCDD0001 /* EventsRequest+CustomPaywallImpression.swift */; };
 		AA110006AABB0001CCDD0001 /* CustomPaywallEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA110005AABB0001CCDD0001 /* CustomPaywallEventTests.swift */; };
@@ -1580,6 +1581,7 @@
 		043FB8686FEB4A31B9CF48C8 /* PlatformInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformInfoTests.swift; sourceTree = "<group>"; };
 		077AC81FEBE38D1468AE8670 /* VideoAutoplayHandlerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VideoAutoplayHandlerTests.swift; sourceTree = "<group>"; };
 		077FB0E4EC264B2EA08C4521 /* GetRemoteConfigOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetRemoteConfigOperation.swift; sourceTree = "<group>"; };
+		FEDA0000000000000000F0A1 /* GetFallbackConfigOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetFallbackConfigOperation.swift; sourceTree = "<group>"; };
 		0E4CCD8E9E454A2EB3760E06 /* ButtonComponentViewModelMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponentViewModelMappingTests.swift; sourceTree = "<group>"; };
 		13B0EAB50136613F69FAA3BB /* SynchronizedUserDefaultsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SynchronizedUserDefaultsTests.swift; sourceTree = "<group>"; };
 		161627FD2F50987800DEEDEB /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
@@ -6201,6 +6203,7 @@
 				B34605B9279A6E380031CA74 /* PostSubscriberAttributesOperation.swift */,
 				A55D5D65282ECCC100FA7623 /* PostAdServicesTokenOperation.swift */,
 				A56DFDEF286643BF00EF2E32 /* PostAttributionDataOperation.swift */,
+				FEDA0000000000000000F0A1 /* GetFallbackConfigOperation.swift */,
 				077FB0E4EC264B2EA08C4521 /* GetRemoteConfigOperation.swift */,
 			);
 			path = Operations;
@@ -7216,6 +7219,7 @@
 				FEDA000000000000000000B2 /* WeightedSourceSelector.swift in Sources */,
 				FEDA000000000000000000D2 /* RemoteConfigSourceProvider.swift in Sources */,
 				E6B064598F674333A29E0781 /* RemoteConfigCallback.swift in Sources */,
+				FEDA0000000000000000F0A2 /* GetFallbackConfigOperation.swift in Sources */,
 				A6CC43904EBD4860BFD2BD85 /* GetRemoteConfigOperation.swift in Sources */,
 				D62A9C83BFD14E5FA0452CC7 /* RemoteConfiguration.swift in Sources */,
 				A1B2C3D42FE1000000000002 /* RCContainer.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1189,7 +1189,7 @@
 		A5B6CDD8280F3843007629D5 /* AdServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5B6CDD5280F3843007629D5 /* AdServices.framework */; platformFilters = (ios, maccatalyst, macos, ); settings = {ATTRIBUTES = (Weak, ); }; };
 		A5F0104E2717B3150090732D /* BeginRefundRequestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F0104D2717B3150090732D /* BeginRefundRequestHelper.swift */; };
 		A6CC43904EBD4860BFD2BD85 /* GetRemoteConfigOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077FB0E4EC264B2EA08C4521 /* GetRemoteConfigOperation.swift */; };
-		FEDA0000000000000000F0A2 /* GetFallbackConfigOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA0000000000000000F0A1 /* GetFallbackConfigOperation.swift */; };
+		FEDA0000000000000000F0A2 /* GetRemoteConfigStaticFallbackOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA0000000000000000F0A1 /* GetRemoteConfigStaticFallbackOperation.swift */; };
 		AA110002AABB0001CCDD0001 /* CustomPaywallEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA110001AABB0001CCDD0001 /* CustomPaywallEvent.swift */; };
 		AA110004AABB0001CCDD0001 /* EventsRequest+CustomPaywallImpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA110003AABB0001CCDD0001 /* EventsRequest+CustomPaywallImpression.swift */; };
 		AA110006AABB0001CCDD0001 /* CustomPaywallEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA110005AABB0001CCDD0001 /* CustomPaywallEventTests.swift */; };
@@ -1581,7 +1581,7 @@
 		043FB8686FEB4A31B9CF48C8 /* PlatformInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformInfoTests.swift; sourceTree = "<group>"; };
 		077AC81FEBE38D1468AE8670 /* VideoAutoplayHandlerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VideoAutoplayHandlerTests.swift; sourceTree = "<group>"; };
 		077FB0E4EC264B2EA08C4521 /* GetRemoteConfigOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetRemoteConfigOperation.swift; sourceTree = "<group>"; };
-		FEDA0000000000000000F0A1 /* GetFallbackConfigOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetFallbackConfigOperation.swift; sourceTree = "<group>"; };
+		FEDA0000000000000000F0A1 /* GetRemoteConfigStaticFallbackOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetRemoteConfigStaticFallbackOperation.swift; sourceTree = "<group>"; };
 		0E4CCD8E9E454A2EB3760E06 /* ButtonComponentViewModelMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponentViewModelMappingTests.swift; sourceTree = "<group>"; };
 		13B0EAB50136613F69FAA3BB /* SynchronizedUserDefaultsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SynchronizedUserDefaultsTests.swift; sourceTree = "<group>"; };
 		161627FD2F50987800DEEDEB /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
@@ -6203,7 +6203,7 @@
 				B34605B9279A6E380031CA74 /* PostSubscriberAttributesOperation.swift */,
 				A55D5D65282ECCC100FA7623 /* PostAdServicesTokenOperation.swift */,
 				A56DFDEF286643BF00EF2E32 /* PostAttributionDataOperation.swift */,
-				FEDA0000000000000000F0A1 /* GetFallbackConfigOperation.swift */,
+				FEDA0000000000000000F0A1 /* GetRemoteConfigStaticFallbackOperation.swift */,
 				077FB0E4EC264B2EA08C4521 /* GetRemoteConfigOperation.swift */,
 			);
 			path = Operations;
@@ -7219,7 +7219,7 @@
 				FEDA000000000000000000B2 /* WeightedSourceSelector.swift in Sources */,
 				FEDA000000000000000000D2 /* RemoteConfigSourceProvider.swift in Sources */,
 				E6B064598F674333A29E0781 /* RemoteConfigCallback.swift in Sources */,
-				FEDA0000000000000000F0A2 /* GetFallbackConfigOperation.swift in Sources */,
+				FEDA0000000000000000F0A2 /* GetRemoteConfigStaticFallbackOperation.swift in Sources */,
 				A6CC43904EBD4860BFD2BD85 /* GetRemoteConfigOperation.swift in Sources */,
 				D62A9C83BFD14E5FA0452CC7 /* RemoteConfiguration.swift in Sources */,
 				A1B2C3D42FE1000000000002 /* RCContainer.swift in Sources */,

--- a/Sources/Networking/Caching/RemoteConfigCallback.swift
+++ b/Sources/Networking/Caching/RemoteConfigCallback.swift
@@ -14,9 +14,9 @@ struct RemoteConfigCallback: CacheKeyProviding {
 
 }
 
-struct RemoteConfigStaticFallbackCallback: CacheKeyProviding {
+struct RemoteConfigFallbackCallback: CacheKeyProviding {
 
     let cacheKey: String
-    let completion: (Result<RemoteConfigStaticFallbackFetchResult, BackendError>) -> Void
+    let completion: (Result<RemoteConfigFallbackFetchResult, BackendError>) -> Void
 
 }

--- a/Sources/Networking/Caching/RemoteConfigCallback.swift
+++ b/Sources/Networking/Caching/RemoteConfigCallback.swift
@@ -14,9 +14,9 @@ struct RemoteConfigCallback: CacheKeyProviding {
 
 }
 
-struct RemoteConfigFallbackCallback: CacheKeyProviding {
+struct RemoteConfigStaticFallbackCallback: CacheKeyProviding {
 
     let cacheKey: String
-    let completion: (Result<RemoteConfigFallbackFetchResult, BackendError>) -> Void
+    let completion: (Result<RemoteConfigStaticFallbackFetchResult, BackendError>) -> Void
 
 }

--- a/Sources/Networking/Caching/RemoteConfigCallback.swift
+++ b/Sources/Networking/Caching/RemoteConfigCallback.swift
@@ -13,3 +13,10 @@ struct RemoteConfigCallback: CacheKeyProviding {
     let completion: (Result<RemoteConfigFetchResult, BackendError>) -> Void
 
 }
+
+struct RemoteConfigFallbackCallback: CacheKeyProviding {
+
+    let cacheKey: String
+    let completion: (Result<RemoteConfigFallbackFetchResult, BackendError>) -> Void
+
+}

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -869,16 +869,6 @@ extension HTTPClient {
 
 // MARK: - Extensions
 
-fileprivate extension NetworkError {
-    /// A request may be retried against a fallback host only for transient failures (connection-level
-    /// errors and 5xx) that point at the host rather than the device. A device-connectivity failure
-    /// (see ``NetworkError/isDeviceConnectivityError``) can't be fixed by switching hosts, so it is
-    /// excluded. See ``NetworkError/isTransient``.
-    var isAllowedToRetryWithFallbackHost: Bool {
-        return self.isTransient && !self.isDeviceConnectivityError
-    }
-}
-
 extension HTTPClient {
 
     /// Information from a response to help identify a request.

--- a/Sources/Networking/HTTPClient/HTTPRequest.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequest.swift
@@ -45,6 +45,15 @@ struct HTTPRequest {
 
     init(
         method: Method,
+        path: HTTPRequest.StaticFallbackPath,
+        nonce: Data? = nil,
+        isRetryable: Bool = false
+    ) {
+        self.init(method: method, requestPath: path, nonce: nonce, isRetryable: isRetryable)
+    }
+
+    init(
+        method: Method,
         path: HTTPRequest.DiagnosticsPath,
         nonce: Data? = nil,
         isRetryable: Bool = false

--- a/Sources/Networking/HTTPClient/HTTPRequest.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequest.swift
@@ -45,7 +45,7 @@ struct HTTPRequest {
 
     init(
         method: Method,
-        path: HTTPRequest.StaticFallbackPath,
+        path: HTTPRequest.FallbackPath,
         nonce: Data? = nil,
         isRetryable: Bool = false
     ) {

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -20,6 +20,12 @@ protocol HTTPRequestPath {
     /// The base URL for requests to this path.
     static var serverHostURL: URL { get }
 
+    /// A path-specific base URL override.
+    ///
+    /// Most requests use ``serverHostURL``. A small number of static endpoints are intentionally served
+    /// from a different host without going through HTTPClient's retry-to-fallback-host flow.
+    var serverHostURLOverride: URL? { get }
+
     /// The fallback URLs to use when the main server is down.
     ///
     /// Not all endpoints have a fallback URL, but some do.
@@ -87,6 +93,10 @@ extension HTTPRequestPath {
         return []
     }
 
+    var serverHostURLOverride: URL? {
+        return nil
+    }
+
     var supportsFallbackURLs: Bool {
         !fallbackUrls.isEmpty
     }
@@ -118,7 +128,7 @@ extension HTTPRequestPath {
         } else if let fallbackUrlIndex {
             return self.fallbackUrls[safe: fallbackUrlIndex]
         } else {
-            baseURL = Self.serverHostURL
+            baseURL = self.serverHostURLOverride ?? Self.serverHostURL
         }
         return URL(string: self.relativePath, relativeTo: baseURL)
     }
@@ -150,6 +160,7 @@ extension HTTPRequest {
         case isPurchaseAllowedByRestoreBehavior(appUserID: String)
         case rewardVerificationStatus(appUserID: String, clientTransactionID: String)
         case remoteConfig(domain: String)
+        case fallbackConfig(domain: String)
 
     }
 
@@ -190,14 +201,21 @@ extension HTTPRequest.Path: HTTPRequestPath {
         URL(string: "https://api-production.8-lives-cat.io")
     ]
 
+    var serverHostURLOverride: URL? {
+        switch self {
+        case .fallbackConfig:
+            return Self.fallbackServerHostURLs.first ?? nil
+        default:
+            return nil
+        }
+    }
+
     var fallbackRelativePath: String? {
         switch self {
         case .getOfferings:
             return "/v1/offerings"
         case .getProductEntitlementMapping:
             return "/v1/product_entitlement_mapping"
-        case let .remoteConfig(domain):
-            return "/v1/config/\(Self.escape(domain))"
         default:
             return nil
         }
@@ -239,7 +257,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .postCreateTicket,
                 .isPurchaseAllowedByRestoreBehavior,
                 .rewardVerificationStatus,
-                .remoteConfig:
+                .remoteConfig,
+                .fallbackConfig:
             return true
 
         case .health,
@@ -269,6 +288,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .rewardVerificationStatus:
             return true
         case .remoteConfig,
+             .fallbackConfig,
              .health,
              .appHealthReportAvailability:
             return false
@@ -288,6 +308,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .appHealthReportAvailability,
                 .isPurchaseAllowedByRestoreBehavior,
                 .remoteConfig,
+                .fallbackConfig,
                 .rewardVerificationStatus:
             return true
         case .getIntroEligibility,
@@ -315,6 +336,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .rewardVerificationStatus:
             return true
         case .getOfferings,
+                .fallbackConfig,
                 .getIntroEligibility,
                 .postSubscriberAttributes,
                 .postAttributionData,
@@ -333,6 +355,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
         switch self {
         case .remoteConfig:
             return RemoteConfigSignatureContextProvider()
+        case .fallbackConfig:
+            return FallbackConfigSignatureContextProvider()
         default:
             return DefaultResponseSignatureContextProvider()
         }
@@ -400,7 +424,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
         case let .rewardVerificationStatus(appUserID, clientTransactionID):
             return "subscribers/\(Self.escape(appUserID))/ads/reward_verifications/\(Self.escape(clientTransactionID))"
 
-        case let .remoteConfig(domain):
+        case let .remoteConfig(domain),
+             let .fallbackConfig(domain):
             return "config/\(Self.escape(domain))"
         }
     }
@@ -465,6 +490,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
 
         case .remoteConfig:
             return "remote_config"
+        case .fallbackConfig:
+            return "fallback_config"
         }
     }
 
@@ -475,6 +502,10 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 HTTPClient.RequestHeader.accept.rawValue: HTTPClient.rcContainerFormatAcceptHeaderValue,
                 HTTPClient.RequestHeader.acceptRCElementEncoding.rawValue:
                     HTTPClient.rcContainerFormatElementEncodingHeaderValue
+            ]
+        case .fallbackConfig:
+            return [
+                HTTPClient.RequestHeader.accept.rawValue: "application/json"
             ]
         default:
             return [:]

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -153,7 +153,7 @@ extension HTTPRequest {
 
     }
 
-    enum StaticFallbackPath: Hashable {
+    enum FallbackPath: Hashable {
 
         case remoteConfig(domain: String)
 
@@ -490,7 +490,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
     }
 }
 
-extension HTTPRequest.StaticFallbackPath: HTTPRequestPath {
+extension HTTPRequest.FallbackPath: HTTPRequestPath {
 
     // swiftlint:disable:next force_unwrapping
     static let serverHostURL = URL(string: "https://api-production.8-lives-cat.io")!
@@ -526,7 +526,7 @@ extension HTTPRequest.StaticFallbackPath: HTTPRequestPath {
     var responseSignatureContextProvider: ResponseSignatureContextProvider {
         switch self {
         case .remoteConfig:
-            return StaticFallbackSignatureContextProvider()
+            return FallbackSignatureContextProvider()
         }
     }
 
@@ -540,7 +540,7 @@ extension HTTPRequest.StaticFallbackPath: HTTPRequestPath {
     var name: String {
         switch self {
         case .remoteConfig:
-            return "remote_config_static_fallback"
+            return "remote_config_fallback"
         }
     }
 

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -547,9 +547,7 @@ extension HTTPRequest.StaticFallbackPath: HTTPRequestPath {
     var additionalHeaders: HTTPRequest.Headers {
         switch self {
         case .remoteConfig:
-            return [
-                HTTPClient.RequestHeader.accept.rawValue: "application/json"
-            ]
+            return [:]
         }
     }
 

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -356,7 +356,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
         case .remoteConfig:
             return RemoteConfigSignatureContextProvider()
         case .remoteConfigStaticFallback:
-            return FallbackConfigSignatureContextProvider()
+            return StaticFallbackSignatureContextProvider()
         default:
             return DefaultResponseSignatureContextProvider()
         }

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -160,7 +160,7 @@ extension HTTPRequest {
         case isPurchaseAllowedByRestoreBehavior(appUserID: String)
         case rewardVerificationStatus(appUserID: String, clientTransactionID: String)
         case remoteConfig(domain: String)
-        case fallbackConfig(domain: String)
+        case remoteConfigStaticFallback(domain: String)
 
     }
 
@@ -203,7 +203,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
 
     var serverHostURLOverride: URL? {
         switch self {
-        case .fallbackConfig:
+        case .remoteConfigStaticFallback:
             return Self.fallbackServerHostURLs.first ?? nil
         default:
             return nil
@@ -258,7 +258,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .isPurchaseAllowedByRestoreBehavior,
                 .rewardVerificationStatus,
                 .remoteConfig,
-                .fallbackConfig:
+                .remoteConfigStaticFallback:
             return true
 
         case .health,
@@ -288,7 +288,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .rewardVerificationStatus:
             return true
         case .remoteConfig,
-             .fallbackConfig,
+             .remoteConfigStaticFallback,
              .health,
              .appHealthReportAvailability:
             return false
@@ -308,7 +308,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .appHealthReportAvailability,
                 .isPurchaseAllowedByRestoreBehavior,
                 .remoteConfig,
-                .fallbackConfig,
+                .remoteConfigStaticFallback,
                 .rewardVerificationStatus:
             return true
         case .getIntroEligibility,
@@ -336,7 +336,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .rewardVerificationStatus:
             return true
         case .getOfferings,
-                .fallbackConfig,
+                .remoteConfigStaticFallback,
                 .getIntroEligibility,
                 .postSubscriberAttributes,
                 .postAttributionData,
@@ -355,7 +355,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
         switch self {
         case .remoteConfig:
             return RemoteConfigSignatureContextProvider()
-        case .fallbackConfig:
+        case .remoteConfigStaticFallback:
             return FallbackConfigSignatureContextProvider()
         default:
             return DefaultResponseSignatureContextProvider()
@@ -425,7 +425,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
             return "subscribers/\(Self.escape(appUserID))/ads/reward_verifications/\(Self.escape(clientTransactionID))"
 
         case let .remoteConfig(domain),
-             let .fallbackConfig(domain):
+             let .remoteConfigStaticFallback(domain):
             return "config/\(Self.escape(domain))"
         }
     }
@@ -490,8 +490,8 @@ extension HTTPRequest.Path: HTTPRequestPath {
 
         case .remoteConfig:
             return "remote_config"
-        case .fallbackConfig:
-            return "fallback_config"
+        case .remoteConfigStaticFallback:
+            return "remote_config_static_fallback"
         }
     }
 
@@ -503,7 +503,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 HTTPClient.RequestHeader.acceptRCElementEncoding.rawValue:
                     HTTPClient.rcContainerFormatElementEncodingHeaderValue
             ]
-        case .fallbackConfig:
+        case .remoteConfigStaticFallback:
             return [
                 HTTPClient.RequestHeader.accept.rawValue: "application/json"
             ]

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -505,7 +505,7 @@ extension HTTPRequest.FallbackPath: HTTPRequestPath {
     var shouldSendEtag: Bool {
         switch self {
         case .remoteConfig:
-            return false
+            return true
         }
     }
 

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -20,12 +20,6 @@ protocol HTTPRequestPath {
     /// The base URL for requests to this path.
     static var serverHostURL: URL { get }
 
-    /// A path-specific base URL override.
-    ///
-    /// Most requests use ``serverHostURL``. A small number of static endpoints are intentionally served
-    /// from a different host without going through HTTPClient's retry-to-fallback-host flow.
-    var serverHostURLOverride: URL? { get }
-
     /// The fallback URLs to use when the main server is down.
     ///
     /// Not all endpoints have a fallback URL, but some do.
@@ -93,10 +87,6 @@ extension HTTPRequestPath {
         return []
     }
 
-    var serverHostURLOverride: URL? {
-        return nil
-    }
-
     var supportsFallbackURLs: Bool {
         !fallbackUrls.isEmpty
     }
@@ -128,7 +118,7 @@ extension HTTPRequestPath {
         } else if let fallbackUrlIndex {
             return self.fallbackUrls[safe: fallbackUrlIndex]
         } else {
-            baseURL = self.serverHostURLOverride ?? Self.serverHostURL
+            baseURL = Self.serverHostURL
         }
         return URL(string: self.relativePath, relativeTo: baseURL)
     }
@@ -160,7 +150,12 @@ extension HTTPRequest {
         case isPurchaseAllowedByRestoreBehavior(appUserID: String)
         case rewardVerificationStatus(appUserID: String, clientTransactionID: String)
         case remoteConfig(domain: String)
-        case remoteConfigStaticFallback(domain: String)
+
+    }
+
+    enum StaticFallbackPath: Hashable {
+
+        case remoteConfig(domain: String)
 
     }
 
@@ -200,15 +195,6 @@ extension HTTPRequest.Path: HTTPRequestPath {
     private static let fallbackServerHostURLs = [
         URL(string: "https://api-production.8-lives-cat.io")
     ]
-
-    var serverHostURLOverride: URL? {
-        switch self {
-        case .remoteConfigStaticFallback:
-            return Self.fallbackServerHostURLs.first ?? nil
-        default:
-            return nil
-        }
-    }
 
     var fallbackRelativePath: String? {
         switch self {
@@ -257,8 +243,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .postCreateTicket,
                 .isPurchaseAllowedByRestoreBehavior,
                 .rewardVerificationStatus,
-                .remoteConfig,
-                .remoteConfigStaticFallback:
+                .remoteConfig:
             return true
 
         case .health,
@@ -288,7 +273,6 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .rewardVerificationStatus:
             return true
         case .remoteConfig,
-             .remoteConfigStaticFallback,
              .health,
              .appHealthReportAvailability:
             return false
@@ -308,7 +292,6 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .appHealthReportAvailability,
                 .isPurchaseAllowedByRestoreBehavior,
                 .remoteConfig,
-                .remoteConfigStaticFallback,
                 .rewardVerificationStatus:
             return true
         case .getIntroEligibility,
@@ -336,7 +319,6 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .rewardVerificationStatus:
             return true
         case .getOfferings,
-                .remoteConfigStaticFallback,
                 .getIntroEligibility,
                 .postSubscriberAttributes,
                 .postAttributionData,
@@ -355,8 +337,6 @@ extension HTTPRequest.Path: HTTPRequestPath {
         switch self {
         case .remoteConfig:
             return RemoteConfigSignatureContextProvider()
-        case .remoteConfigStaticFallback:
-            return StaticFallbackSignatureContextProvider()
         default:
             return DefaultResponseSignatureContextProvider()
         }
@@ -424,8 +404,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
         case let .rewardVerificationStatus(appUserID, clientTransactionID):
             return "subscribers/\(Self.escape(appUserID))/ads/reward_verifications/\(Self.escape(clientTransactionID))"
 
-        case let .remoteConfig(domain),
-             let .remoteConfigStaticFallback(domain):
+        case let .remoteConfig(domain):
             return "config/\(Self.escape(domain))"
         }
     }
@@ -490,8 +469,6 @@ extension HTTPRequest.Path: HTTPRequestPath {
 
         case .remoteConfig:
             return "remote_config"
-        case .remoteConfigStaticFallback:
-            return "remote_config_static_fallback"
         }
     }
 
@@ -503,10 +480,6 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 HTTPClient.RequestHeader.acceptRCElementEncoding.rawValue:
                     HTTPClient.rcContainerFormatElementEncodingHeaderValue
             ]
-        case .remoteConfigStaticFallback:
-            return [
-                HTTPClient.RequestHeader.accept.rawValue: "application/json"
-            ]
         default:
             return [:]
         }
@@ -515,4 +488,69 @@ extension HTTPRequest.Path: HTTPRequestPath {
     private static func escape(_ appUserID: String) -> String {
         return appUserID.trimmedAndEscaped
     }
+}
+
+extension HTTPRequest.StaticFallbackPath: HTTPRequestPath {
+
+    // swiftlint:disable:next force_unwrapping
+    static let serverHostURL = URL(string: "https://api-production.8-lives-cat.io")!
+
+    var authenticated: Bool {
+        switch self {
+        case .remoteConfig:
+            return true
+        }
+    }
+
+    var shouldSendEtag: Bool {
+        switch self {
+        case .remoteConfig:
+            return false
+        }
+    }
+
+    var supportsSignatureVerification: Bool {
+        switch self {
+        case .remoteConfig:
+            return true
+        }
+    }
+
+    var needsNonceForSigning: Bool {
+        switch self {
+        case .remoteConfig:
+            return false
+        }
+    }
+
+    var responseSignatureContextProvider: ResponseSignatureContextProvider {
+        switch self {
+        case .remoteConfig:
+            return StaticFallbackSignatureContextProvider()
+        }
+    }
+
+    var relativePath: String {
+        switch self {
+        case let .remoteConfig(domain):
+            return "/v1/config/\(domain.trimmedAndEscaped)"
+        }
+    }
+
+    var name: String {
+        switch self {
+        case .remoteConfig:
+            return "remote_config_static_fallback"
+        }
+    }
+
+    var additionalHeaders: HTTPRequest.Headers {
+        switch self {
+        case .remoteConfig:
+            return [
+                HTTPClient.RequestHeader.accept.rawValue: "application/json"
+            ]
+        }
+    }
+
 }

--- a/Sources/Networking/HTTPClient/NetworkError.swift
+++ b/Sources/Networking/HTTPClient/NetworkError.swift
@@ -304,6 +304,14 @@ extension NetworkError {
         NSURLErrorDataNotAllowed
     ]
 
+    /// A request may be retried against a fallback host only for transient failures (connection-level
+    /// errors and 5xx) that point at the host rather than the device. A device-connectivity failure
+    /// (see ``NetworkError/isDeviceConnectivityError``) can't be fixed by switching hosts, so it is
+    /// excluded. See ``NetworkError/isTransient``.
+    var isAllowedToRetryWithFallbackHost: Bool {
+        return self.isTransient && !self.isDeviceConnectivityError
+    }
+
 }
 
 extension NetworkError {

--- a/Sources/Networking/Operations/GetFallbackConfigOperation.swift
+++ b/Sources/Networking/Operations/GetFallbackConfigOperation.swift
@@ -1,0 +1,72 @@
+//
+//  GetFallbackConfigOperation.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden on 09/07/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+//
+
+import Foundation
+
+final class GetFallbackConfigOperation: CacheableNetworkOperation {
+
+    private let callbackCache: CallbackCache<RemoteConfigFallbackCallback>
+    private let domain: String
+
+    static func createFactory(
+        configuration: NetworkConfiguration,
+        callbackCache: CallbackCache<RemoteConfigFallbackCallback>,
+        domain: String
+    ) -> CacheableNetworkOperationFactory<GetFallbackConfigOperation> {
+        return .init({ cacheKey in
+                .init(
+                    configuration: configuration,
+                    callbackCache: callbackCache,
+                    domain: domain,
+                    cacheKey: cacheKey
+                )
+        },
+                     individualizedCacheKeyPart: "domain=\(domain)")
+    }
+
+    private init(
+        configuration: NetworkConfiguration,
+        callbackCache: CallbackCache<RemoteConfigFallbackCallback>,
+        domain: String,
+        cacheKey: String
+    ) {
+        self.callbackCache = callbackCache
+        self.domain = domain
+        super.init(configuration: configuration, cacheKey: cacheKey)
+    }
+
+    override func begin(completion: @escaping () -> Void) {
+        self.getFallbackConfig(completion: completion)
+    }
+
+}
+
+// Restating inherited @unchecked Sendable from Foundation's Operation
+extension GetFallbackConfigOperation: @unchecked Sendable {}
+
+private extension GetFallbackConfigOperation {
+
+    func getFallbackConfig(completion: @escaping () -> Void) {
+        let request = HTTPRequest(method: .get, path: .fallbackConfig(domain: self.domain))
+
+        self.httpClient.perform(request) { (response: VerifiedHTTPResponse<RemoteConfiguration?>.Result) in
+            defer {
+                completion()
+            }
+
+            self.callbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
+                callback.completion(
+                    response
+                        .map(RemoteConfigFallbackFetchResult.init(response:))
+                        .mapError(BackendError.networkError)
+                )
+            }
+        }
+    }
+
+}

--- a/Sources/Networking/Operations/GetFallbackConfigOperation.swift
+++ b/Sources/Networking/Operations/GetFallbackConfigOperation.swift
@@ -52,7 +52,7 @@ extension GetFallbackConfigOperation: @unchecked Sendable {}
 private extension GetFallbackConfigOperation {
 
     func getFallbackConfig(completion: @escaping () -> Void) {
-        let request = HTTPRequest(method: .get, path: .fallbackConfig(domain: self.domain))
+        let request = HTTPRequest(method: .get, path: .remoteConfigStaticFallback(domain: self.domain))
 
         self.httpClient.perform(request) { (response: VerifiedHTTPResponse<RemoteConfiguration?>.Result) in
             defer {

--- a/Sources/Networking/Operations/GetRemoteConfigFallbackOperation.swift
+++ b/Sources/Networking/Operations/GetRemoteConfigFallbackOperation.swift
@@ -54,7 +54,7 @@ private extension GetRemoteConfigFallbackOperation {
     func getRemoteConfigFallback(completion: @escaping () -> Void) {
         let request = HTTPRequest(method: .get, path: HTTPRequest.FallbackPath.remoteConfig(domain: self.domain))
 
-        self.httpClient.perform(request) { (response: VerifiedHTTPResponse<RemoteConfiguration?>.Result) in
+        self.httpClient.perform(request) { (response: VerifiedHTTPResponse<RemoteConfiguration>.Result) in
             defer {
                 completion()
             }

--- a/Sources/Networking/Operations/GetRemoteConfigFallbackOperation.swift
+++ b/Sources/Networking/Operations/GetRemoteConfigFallbackOperation.swift
@@ -1,5 +1,5 @@
 //
-//  GetRemoteConfigStaticFallbackOperation.swift
+//  GetRemoteConfigFallbackOperation.swift
 //  RevenueCat
 //
 //  Created by Rick van der Linden on 09/07/2026.
@@ -8,16 +8,16 @@
 
 import Foundation
 
-final class GetRemoteConfigStaticFallbackOperation: CacheableNetworkOperation {
+final class GetRemoteConfigFallbackOperation: CacheableNetworkOperation {
 
-    private let callbackCache: CallbackCache<RemoteConfigStaticFallbackCallback>
+    private let callbackCache: CallbackCache<RemoteConfigFallbackCallback>
     private let domain: String
 
     static func createFactory(
         configuration: NetworkConfiguration,
-        callbackCache: CallbackCache<RemoteConfigStaticFallbackCallback>,
+        callbackCache: CallbackCache<RemoteConfigFallbackCallback>,
         domain: String
-    ) -> CacheableNetworkOperationFactory<GetRemoteConfigStaticFallbackOperation> {
+    ) -> CacheableNetworkOperationFactory<GetRemoteConfigFallbackOperation> {
         return .init({ cacheKey in
                 .init(
                     configuration: configuration,
@@ -31,7 +31,7 @@ final class GetRemoteConfigStaticFallbackOperation: CacheableNetworkOperation {
 
     private init(
         configuration: NetworkConfiguration,
-        callbackCache: CallbackCache<RemoteConfigStaticFallbackCallback>,
+        callbackCache: CallbackCache<RemoteConfigFallbackCallback>,
         domain: String,
         cacheKey: String
     ) {
@@ -41,18 +41,18 @@ final class GetRemoteConfigStaticFallbackOperation: CacheableNetworkOperation {
     }
 
     override func begin(completion: @escaping () -> Void) {
-        self.getRemoteConfigStaticFallback(completion: completion)
+        self.getRemoteConfigFallback(completion: completion)
     }
 
 }
 
 // Restating inherited @unchecked Sendable from Foundation's Operation
-extension GetRemoteConfigStaticFallbackOperation: @unchecked Sendable {}
+extension GetRemoteConfigFallbackOperation: @unchecked Sendable {}
 
-private extension GetRemoteConfigStaticFallbackOperation {
+private extension GetRemoteConfigFallbackOperation {
 
-    func getRemoteConfigStaticFallback(completion: @escaping () -> Void) {
-        let request = HTTPRequest(method: .get, path: HTTPRequest.StaticFallbackPath.remoteConfig(domain: self.domain))
+    func getRemoteConfigFallback(completion: @escaping () -> Void) {
+        let request = HTTPRequest(method: .get, path: HTTPRequest.FallbackPath.remoteConfig(domain: self.domain))
 
         self.httpClient.perform(request) { (response: VerifiedHTTPResponse<RemoteConfiguration?>.Result) in
             defer {
@@ -62,7 +62,7 @@ private extension GetRemoteConfigStaticFallbackOperation {
             self.callbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
                 callback.completion(
                     response
-                        .map(RemoteConfigStaticFallbackFetchResult.init(response:))
+                        .map(RemoteConfigFallbackFetchResult.init(response:))
                         .mapError(BackendError.networkError)
                 )
             }

--- a/Sources/Networking/Operations/GetRemoteConfigOperation.swift
+++ b/Sources/Networking/Operations/GetRemoteConfigOperation.swift
@@ -103,7 +103,10 @@ extension GetRemoteConfigOperation: @unchecked Sendable {}
 private extension GetRemoteConfigOperation {
 
     func getRemoteConfig(completion: @escaping () -> Void) {
-        let request = HTTPRequest(method: .post(self.request), path: .remoteConfig(domain: self.request.domain))
+        let request = HTTPRequest(
+            method: .post(self.request),
+            path: HTTPRequest.Path.remoteConfig(domain: self.request.domain)
+        )
 
         self.httpClient.perform(request) { (response: VerifiedHTTPResponse<RemoteConfigContainer?>.Result) in
             defer {

--- a/Sources/Networking/Operations/GetRemoteConfigStaticFallbackOperation.swift
+++ b/Sources/Networking/Operations/GetRemoteConfigStaticFallbackOperation.swift
@@ -52,7 +52,7 @@ extension GetRemoteConfigStaticFallbackOperation: @unchecked Sendable {}
 private extension GetRemoteConfigStaticFallbackOperation {
 
     func getRemoteConfigStaticFallback(completion: @escaping () -> Void) {
-        let request = HTTPRequest(method: .get, path: .remoteConfigStaticFallback(domain: self.domain))
+        let request = HTTPRequest(method: .get, path: HTTPRequest.StaticFallbackPath.remoteConfig(domain: self.domain))
 
         self.httpClient.perform(request) { (response: VerifiedHTTPResponse<RemoteConfiguration?>.Result) in
             defer {

--- a/Sources/Networking/Operations/GetRemoteConfigStaticFallbackOperation.swift
+++ b/Sources/Networking/Operations/GetRemoteConfigStaticFallbackOperation.swift
@@ -1,5 +1,5 @@
 //
-//  GetFallbackConfigOperation.swift
+//  GetRemoteConfigStaticFallbackOperation.swift
 //  RevenueCat
 //
 //  Created by Rick van der Linden on 09/07/2026.
@@ -8,16 +8,16 @@
 
 import Foundation
 
-final class GetFallbackConfigOperation: CacheableNetworkOperation {
+final class GetRemoteConfigStaticFallbackOperation: CacheableNetworkOperation {
 
-    private let callbackCache: CallbackCache<RemoteConfigFallbackCallback>
+    private let callbackCache: CallbackCache<RemoteConfigStaticFallbackCallback>
     private let domain: String
 
     static func createFactory(
         configuration: NetworkConfiguration,
-        callbackCache: CallbackCache<RemoteConfigFallbackCallback>,
+        callbackCache: CallbackCache<RemoteConfigStaticFallbackCallback>,
         domain: String
-    ) -> CacheableNetworkOperationFactory<GetFallbackConfigOperation> {
+    ) -> CacheableNetworkOperationFactory<GetRemoteConfigStaticFallbackOperation> {
         return .init({ cacheKey in
                 .init(
                     configuration: configuration,
@@ -31,7 +31,7 @@ final class GetFallbackConfigOperation: CacheableNetworkOperation {
 
     private init(
         configuration: NetworkConfiguration,
-        callbackCache: CallbackCache<RemoteConfigFallbackCallback>,
+        callbackCache: CallbackCache<RemoteConfigStaticFallbackCallback>,
         domain: String,
         cacheKey: String
     ) {
@@ -41,17 +41,17 @@ final class GetFallbackConfigOperation: CacheableNetworkOperation {
     }
 
     override func begin(completion: @escaping () -> Void) {
-        self.getFallbackConfig(completion: completion)
+        self.getRemoteConfigStaticFallback(completion: completion)
     }
 
 }
 
 // Restating inherited @unchecked Sendable from Foundation's Operation
-extension GetFallbackConfigOperation: @unchecked Sendable {}
+extension GetRemoteConfigStaticFallbackOperation: @unchecked Sendable {}
 
-private extension GetFallbackConfigOperation {
+private extension GetRemoteConfigStaticFallbackOperation {
 
-    func getFallbackConfig(completion: @escaping () -> Void) {
+    func getRemoteConfigStaticFallback(completion: @escaping () -> Void) {
         let request = HTTPRequest(method: .get, path: .remoteConfigStaticFallback(domain: self.domain))
 
         self.httpClient.perform(request) { (response: VerifiedHTTPResponse<RemoteConfiguration?>.Result) in
@@ -62,7 +62,7 @@ private extension GetFallbackConfigOperation {
             self.callbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
                 callback.completion(
                     response
-                        .map(RemoteConfigFallbackFetchResult.init(response:))
+                        .map(RemoteConfigStaticFallbackFetchResult.init(response:))
                         .mapError(BackendError.networkError)
                 )
             }

--- a/Sources/Networking/RemoteConfigAPI.swift
+++ b/Sources/Networking/RemoteConfigAPI.swift
@@ -101,11 +101,10 @@ struct RemoteConfigFetchResult {
 
 struct RemoteConfigFallbackFetchResult {
 
-    /// `nil` represents a successful `204 No Content` response.
-    let configuration: RemoteConfiguration?
+    let configuration: RemoteConfiguration
     let verificationResult: VerificationResult
 
-    init(response: VerifiedHTTPResponse<RemoteConfiguration?>) {
+    init(response: VerifiedHTTPResponse<RemoteConfiguration>) {
         self.configuration = response.body
         self.verificationResult = response.verificationResult
     }

--- a/Sources/Networking/RemoteConfigAPI.swift
+++ b/Sources/Networking/RemoteConfigAPI.swift
@@ -10,7 +10,7 @@ import Foundation
 protocol RemoteConfigAPIType: AnyObject {
 
     typealias RemoteConfigResponseHandler = Backend.ResponseHandler<RemoteConfigFetchResult>
-    typealias RemoteConfigFallbackResponseHandler = Backend.ResponseHandler<RemoteConfigFallbackFetchResult>
+    typealias StaticFallbackResponseHandler = Backend.ResponseHandler<RemoteConfigStaticFallbackFetchResult>
 
     func getRemoteConfig(
         request: RemoteConfigRequest,
@@ -18,10 +18,10 @@ protocol RemoteConfigAPIType: AnyObject {
         completion: @escaping RemoteConfigResponseHandler
     )
 
-    func getFallbackConfig(
+    func getRemoteConfigStaticFallback(
         domain: String,
         isAppBackgrounded: Bool,
-        completion: @escaping RemoteConfigFallbackResponseHandler
+        completion: @escaping StaticFallbackResponseHandler
     )
 
 }
@@ -29,16 +29,16 @@ protocol RemoteConfigAPIType: AnyObject {
 class RemoteConfigAPI: RemoteConfigAPIType {
 
     typealias RemoteConfigResponseHandler = Backend.ResponseHandler<RemoteConfigFetchResult>
-    typealias RemoteConfigFallbackResponseHandler = Backend.ResponseHandler<RemoteConfigFallbackFetchResult>
+    typealias StaticFallbackResponseHandler = Backend.ResponseHandler<RemoteConfigStaticFallbackFetchResult>
 
     private let callbackCache: CallbackCache<RemoteConfigCallback>
-    private let fallbackCallbackCache: CallbackCache<RemoteConfigFallbackCallback>
+    private let staticFallbackCallbackCache: CallbackCache<RemoteConfigStaticFallbackCallback>
     private let backendConfig: BackendConfiguration
 
     init(backendConfig: BackendConfiguration) {
         self.backendConfig = backendConfig
         self.callbackCache = .init()
-        self.fallbackCallbackCache = .init()
+        self.staticFallbackCallbackCache = .init()
     }
 
     func getRemoteConfig(
@@ -62,19 +62,19 @@ class RemoteConfigAPI: RemoteConfigAPIType {
         )
     }
 
-    func getFallbackConfig(
+    func getRemoteConfigStaticFallback(
         domain: String,
         isAppBackgrounded: Bool,
-        completion: @escaping RemoteConfigFallbackResponseHandler
+        completion: @escaping StaticFallbackResponseHandler
     ) {
-        let factory = GetFallbackConfigOperation.createFactory(
+        let factory = GetRemoteConfigStaticFallbackOperation.createFactory(
             configuration: self.backendConfig,
-            callbackCache: self.fallbackCallbackCache,
+            callbackCache: self.staticFallbackCallbackCache,
             domain: domain
         )
 
-        let callback = RemoteConfigFallbackCallback(cacheKey: factory.cacheKey, completion: completion)
-        let cacheStatus = self.fallbackCallbackCache.add(callback)
+        let callback = RemoteConfigStaticFallbackCallback(cacheKey: factory.cacheKey, completion: completion)
+        let cacheStatus = self.staticFallbackCallbackCache.add(callback)
 
         self.backendConfig.addCacheableOperation(
             with: factory,
@@ -99,7 +99,7 @@ struct RemoteConfigFetchResult {
 
 }
 
-struct RemoteConfigFallbackFetchResult {
+struct RemoteConfigStaticFallbackFetchResult {
 
     /// `nil` represents a successful `204 No Content` response.
     let configuration: RemoteConfiguration?

--- a/Sources/Networking/RemoteConfigAPI.swift
+++ b/Sources/Networking/RemoteConfigAPI.swift
@@ -10,6 +10,7 @@ import Foundation
 protocol RemoteConfigAPIType: AnyObject {
 
     typealias RemoteConfigResponseHandler = Backend.ResponseHandler<RemoteConfigFetchResult>
+    typealias RemoteConfigFallbackResponseHandler = Backend.ResponseHandler<RemoteConfigFallbackFetchResult>
 
     func getRemoteConfig(
         request: RemoteConfigRequest,
@@ -17,18 +18,27 @@ protocol RemoteConfigAPIType: AnyObject {
         completion: @escaping RemoteConfigResponseHandler
     )
 
+    func getFallbackConfig(
+        domain: String,
+        isAppBackgrounded: Bool,
+        completion: @escaping RemoteConfigFallbackResponseHandler
+    )
+
 }
 
 class RemoteConfigAPI: RemoteConfigAPIType {
 
     typealias RemoteConfigResponseHandler = Backend.ResponseHandler<RemoteConfigFetchResult>
+    typealias RemoteConfigFallbackResponseHandler = Backend.ResponseHandler<RemoteConfigFallbackFetchResult>
 
     private let callbackCache: CallbackCache<RemoteConfigCallback>
+    private let fallbackCallbackCache: CallbackCache<RemoteConfigFallbackCallback>
     private let backendConfig: BackendConfiguration
 
     init(backendConfig: BackendConfiguration) {
         self.backendConfig = backendConfig
         self.callbackCache = .init()
+        self.fallbackCallbackCache = .init()
     }
 
     func getRemoteConfig(
@@ -52,6 +62,27 @@ class RemoteConfigAPI: RemoteConfigAPIType {
         )
     }
 
+    func getFallbackConfig(
+        domain: String,
+        isAppBackgrounded: Bool,
+        completion: @escaping RemoteConfigFallbackResponseHandler
+    ) {
+        let factory = GetFallbackConfigOperation.createFactory(
+            configuration: self.backendConfig,
+            callbackCache: self.fallbackCallbackCache,
+            domain: domain
+        )
+
+        let callback = RemoteConfigFallbackCallback(cacheKey: factory.cacheKey, completion: completion)
+        let cacheStatus = self.fallbackCallbackCache.add(callback)
+
+        self.backendConfig.addCacheableOperation(
+            with: factory,
+            delay: .default(forBackgroundedApp: isAppBackgrounded),
+            cacheStatus: cacheStatus
+        )
+    }
+
 }
 
 struct RemoteConfigFetchResult {
@@ -63,6 +94,19 @@ struct RemoteConfigFetchResult {
 
     init(response: VerifiedHTTPResponse<RemoteConfigContainer?>) {
         self.container = response.body
+        self.verificationResult = response.verificationResult
+    }
+
+}
+
+struct RemoteConfigFallbackFetchResult {
+
+    /// `nil` represents a successful `204 No Content` response.
+    let configuration: RemoteConfiguration?
+    let verificationResult: VerificationResult
+
+    init(response: VerifiedHTTPResponse<RemoteConfiguration?>) {
+        self.configuration = response.body
         self.verificationResult = response.verificationResult
     }
 

--- a/Sources/Networking/RemoteConfigAPI.swift
+++ b/Sources/Networking/RemoteConfigAPI.swift
@@ -10,7 +10,7 @@ import Foundation
 protocol RemoteConfigAPIType: AnyObject {
 
     typealias RemoteConfigResponseHandler = Backend.ResponseHandler<RemoteConfigFetchResult>
-    typealias StaticFallbackResponseHandler = Backend.ResponseHandler<RemoteConfigStaticFallbackFetchResult>
+    typealias FallbackResponseHandler = Backend.ResponseHandler<RemoteConfigFallbackFetchResult>
 
     func getRemoteConfig(
         request: RemoteConfigRequest,
@@ -18,10 +18,10 @@ protocol RemoteConfigAPIType: AnyObject {
         completion: @escaping RemoteConfigResponseHandler
     )
 
-    func getRemoteConfigStaticFallback(
+    func getRemoteConfigFallback(
         domain: String,
         isAppBackgrounded: Bool,
-        completion: @escaping StaticFallbackResponseHandler
+        completion: @escaping FallbackResponseHandler
     )
 
 }
@@ -29,16 +29,16 @@ protocol RemoteConfigAPIType: AnyObject {
 class RemoteConfigAPI: RemoteConfigAPIType {
 
     typealias RemoteConfigResponseHandler = Backend.ResponseHandler<RemoteConfigFetchResult>
-    typealias StaticFallbackResponseHandler = Backend.ResponseHandler<RemoteConfigStaticFallbackFetchResult>
+    typealias FallbackResponseHandler = Backend.ResponseHandler<RemoteConfigFallbackFetchResult>
 
     private let callbackCache: CallbackCache<RemoteConfigCallback>
-    private let staticFallbackCallbackCache: CallbackCache<RemoteConfigStaticFallbackCallback>
+    private let fallbackCallbackCache: CallbackCache<RemoteConfigFallbackCallback>
     private let backendConfig: BackendConfiguration
 
     init(backendConfig: BackendConfiguration) {
         self.backendConfig = backendConfig
         self.callbackCache = .init()
-        self.staticFallbackCallbackCache = .init()
+        self.fallbackCallbackCache = .init()
     }
 
     func getRemoteConfig(
@@ -62,19 +62,19 @@ class RemoteConfigAPI: RemoteConfigAPIType {
         )
     }
 
-    func getRemoteConfigStaticFallback(
+    func getRemoteConfigFallback(
         domain: String,
         isAppBackgrounded: Bool,
-        completion: @escaping StaticFallbackResponseHandler
+        completion: @escaping FallbackResponseHandler
     ) {
-        let factory = GetRemoteConfigStaticFallbackOperation.createFactory(
+        let factory = GetRemoteConfigFallbackOperation.createFactory(
             configuration: self.backendConfig,
-            callbackCache: self.staticFallbackCallbackCache,
+            callbackCache: self.fallbackCallbackCache,
             domain: domain
         )
 
-        let callback = RemoteConfigStaticFallbackCallback(cacheKey: factory.cacheKey, completion: completion)
-        let cacheStatus = self.staticFallbackCallbackCache.add(callback)
+        let callback = RemoteConfigFallbackCallback(cacheKey: factory.cacheKey, completion: completion)
+        let cacheStatus = self.fallbackCallbackCache.add(callback)
 
         self.backendConfig.addCacheableOperation(
             with: factory,
@@ -99,7 +99,7 @@ struct RemoteConfigFetchResult {
 
 }
 
-struct RemoteConfigStaticFallbackFetchResult {
+struct RemoteConfigFallbackFetchResult {
 
     /// `nil` represents a successful `204 No Content` response.
     let configuration: RemoteConfiguration?

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -536,7 +536,7 @@ private extension RemoteConfigManager {
             return
         }
 
-        self.enqueueFallbackConfigIfCurrent(
+        self.enqueueRemoteConfigStaticFallbackIfCurrent(
             domain: request.domain,
             previous: previous,
             isAppBackgrounded: isAppBackgrounded,
@@ -552,7 +552,7 @@ private extension RemoteConfigManager {
         return previous?.domain == domain
     }
 
-    func enqueueFallbackConfigIfCurrent(
+    func enqueueRemoteConfigStaticFallbackIfCurrent(
         domain: String,
         previous: PersistedRemoteConfiguration?,
         isAppBackgrounded: Bool,
@@ -562,7 +562,7 @@ private extension RemoteConfigManager {
         self.lock.perform {
             guard self.epoch == requestEpoch else { return }
 
-            self.remoteConfigAPI.getFallbackConfig(
+            self.remoteConfigAPI.getRemoteConfigStaticFallback(
                 domain: domain,
                 isAppBackgrounded: isAppBackgrounded
             ) { [weak self] result in
@@ -570,7 +570,7 @@ private extension RemoteConfigManager {
 
                 switch result {
                 case let .success(fallbackResult):
-                    self.handleFallbackSuccess(
+                    self.handleRemoteConfigStaticFallbackSuccess(
                         fallbackResult,
                         previous: previous,
                         requestEpoch: requestEpoch
@@ -582,8 +582,8 @@ private extension RemoteConfigManager {
         }
     }
 
-    func handleFallbackSuccess(
-        _ fallbackResult: RemoteConfigFallbackFetchResult,
+    func handleRemoteConfigStaticFallbackSuccess(
+        _ fallbackResult: RemoteConfigStaticFallbackFetchResult,
         previous: PersistedRemoteConfiguration?,
         requestEpoch: Int
     ) {

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -592,6 +592,7 @@ private extension RemoteConfigManager {
 
         guard let configuration = fallbackResult.configuration else {
             Logger.debug(Strings.remoteConfig.notModified)
+            self.markRefreshedIfCurrent(requestEpoch)
             return
         }
 

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -595,18 +595,12 @@ private extension RemoteConfigManager {
         guard self.isCurrent(requestEpoch) else { return }
         defer { self.releaseGuardIfOwned(requestEpoch: requestEpoch) }
 
-        guard let configuration = fallbackResult.configuration else {
-            Logger.debug(Strings.remoteConfig.notModified)
-            self.markRefreshedIfCurrent(requestEpoch)
-            return
-        }
-
         self.lock.perform {
             guard self.epoch == requestEpoch else { return }
             let didPersist = self.persist(
                 container: nil,
                 previous: previous,
-                response: configuration
+                response: fallbackResult.configuration
             )
             if didPersist {
                 self.markRefreshed()

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -459,7 +459,13 @@ private extension RemoteConfigManager {
                         requestEpoch: requestEpoch
                     )
                 case let .failure(error):
-                    self.handleFailure(error, requestEpoch: requestEpoch)
+                    self.handleFailure(
+                        error,
+                        request: request,
+                        previous: persisted,
+                        isAppBackgrounded: isAppBackgrounded,
+                        requestEpoch: requestEpoch
+                    )
                 }
             }
         }
@@ -519,12 +525,92 @@ private extension RemoteConfigManager {
 
     func handleFailure(
         _ error: BackendError,
+        request: RemoteConfigRequest,
+        previous: PersistedRemoteConfiguration?,
+        isAppBackgrounded: Bool,
         requestEpoch: Int
+    ) {
+        guard error.isRemoteConfigFallbackEligible else {
+            self.handleFinalFailure(error, requestEpoch: requestEpoch, shouldDisableRefresh: true)
+            return
+        }
+
+        self.enqueueFallbackConfigIfCurrent(
+            domain: request.domain,
+            previous: previous,
+            isAppBackgrounded: isAppBackgrounded,
+            requestEpoch: requestEpoch,
+            originalError: error
+        )
+    }
+
+    func enqueueFallbackConfigIfCurrent(
+        domain: String,
+        previous: PersistedRemoteConfiguration?,
+        isAppBackgrounded: Bool,
+        requestEpoch: Int,
+        originalError: BackendError
+    ) {
+        self.lock.perform {
+            guard self.epoch == requestEpoch else { return }
+
+            self.remoteConfigAPI.getFallbackConfig(
+                domain: domain,
+                isAppBackgrounded: isAppBackgrounded
+            ) { [weak self] result in
+                guard let self else { return }
+
+                switch result {
+                case let .success(fallbackResult):
+                    self.handleFallbackSuccess(
+                        fallbackResult,
+                        previous: previous,
+                        requestEpoch: requestEpoch
+                    )
+                case .failure:
+                    self.handleFinalFailure(originalError, requestEpoch: requestEpoch, shouldDisableRefresh: false)
+                }
+            }
+        }
+    }
+
+    func handleFallbackSuccess(
+        _ fallbackResult: RemoteConfigFallbackFetchResult,
+        previous: PersistedRemoteConfiguration?,
+        requestEpoch: Int
+    ) {
+        guard self.isCurrent(requestEpoch) else { return }
+        defer { self.releaseGuardIfOwned(requestEpoch: requestEpoch) }
+
+        guard let configuration = fallbackResult.configuration else {
+            Logger.debug(Strings.remoteConfig.notModified)
+            return
+        }
+
+        self.lock.perform {
+            guard self.epoch == requestEpoch else { return }
+            let didPersist = self.persist(
+                container: nil,
+                previous: previous,
+                response: configuration
+            )
+            if didPersist {
+                self.markRefreshed()
+            }
+        }
+    }
+
+    func handleFinalFailure(
+        _ error: BackendError,
+        requestEpoch: Int,
+        shouldDisableRefresh: Bool
     ) {
         let continuations = self.lock.perform {
             guard self.epoch == requestEpoch else { return nil as [CheckedContinuation<Void, Never>]? }
 
-            self.disableRefreshIfNeeded(for: error)
+            if shouldDisableRefresh {
+                self.disableRefreshIfNeeded(for: error)
+            }
             self.isRefreshing = false
 
             return self.drainRefreshContinuations()
@@ -732,7 +818,7 @@ private extension RemoteConfigManager {
 
     /// Persists the config sync state and any valid inline blobs from a successful container response.
     func persist(
-        container: RemoteConfigContainer,
+        container: RemoteConfigContainer?,
         previous: PersistedRemoteConfiguration?,
         response: RemoteConfiguration
     ) -> Bool {
@@ -759,7 +845,9 @@ private extension RemoteConfigManager {
 
         guard self.diskCache.write(persistedConfiguration) else { return false }
 
-        self.extractInlineBlobs(from: container, keepingOnly: postSyncReferencedBlobRefs)
+        if let container {
+            self.extractInlineBlobs(from: container, keepingOnly: postSyncReferencedBlobRefs)
+        }
         self.blobStore.retainOnly(postSyncReferencedBlobRefs)
 
         Logger.debug(Strings.remoteConfig.persistedConfiguration(
@@ -868,6 +956,15 @@ private extension BackendError {
         }
 
         return 400...499 ~= statusCode.rawValue
+    }
+
+    /// Transient failures are eligible for the static JSON fallback config request.
+    var isRemoteConfigFallbackEligible: Bool {
+        guard case let .networkError(networkError) = self else {
+            return false
+        }
+
+        return networkError.isTransient
     }
 
 }

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -580,8 +580,8 @@ private extension RemoteConfigManager {
                         previous: previous,
                         requestEpoch: requestEpoch
                     )
-                case .failure:
-                    self.handleFinalFailure(originalError, requestEpoch: requestEpoch, shouldDisableRefresh: false)
+                case let .failure(fallbackError):
+                    self.handleFinalFailure(fallbackError, requestEpoch: requestEpoch, shouldDisableRefresh: true)
                 }
             }
         }

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -536,6 +536,11 @@ private extension RemoteConfigManager {
             return
         }
 
+        guard SystemInfo.proxyURL == nil else {
+            self.handleFinalFailure(error, requestEpoch: requestEpoch, shouldDisableRefresh: false)
+            return
+        }
+
         self.enqueueRemoteConfigFallbackIfCurrent(
             domain: request.domain,
             previous: previous,

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -530,7 +530,8 @@ private extension RemoteConfigManager {
         isAppBackgrounded: Bool,
         requestEpoch: Int
     ) {
-        guard error.isRemoteConfigFallbackEligible else {
+        guard error.isRemoteConfigFallbackEligible,
+              !self.hasUsableCachedConfig(previous, for: request.domain) else {
             self.handleFinalFailure(error, requestEpoch: requestEpoch, shouldDisableRefresh: true)
             return
         }
@@ -542,6 +543,13 @@ private extension RemoteConfigManager {
             requestEpoch: requestEpoch,
             originalError: error
         )
+    }
+
+    func hasUsableCachedConfig(
+        _ previous: PersistedRemoteConfiguration?,
+        for domain: String
+    ) -> Bool {
+        return previous?.domain == domain
     }
 
     func enqueueFallbackConfigIfCurrent(

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -536,7 +536,7 @@ private extension RemoteConfigManager {
             return
         }
 
-        self.enqueueRemoteConfigStaticFallbackIfCurrent(
+        self.enqueueRemoteConfigFallbackIfCurrent(
             domain: request.domain,
             previous: previous,
             isAppBackgrounded: isAppBackgrounded,
@@ -552,7 +552,7 @@ private extension RemoteConfigManager {
         return previous?.domain == domain
     }
 
-    func enqueueRemoteConfigStaticFallbackIfCurrent(
+    func enqueueRemoteConfigFallbackIfCurrent(
         domain: String,
         previous: PersistedRemoteConfiguration?,
         isAppBackgrounded: Bool,
@@ -562,7 +562,7 @@ private extension RemoteConfigManager {
         self.lock.perform {
             guard self.epoch == requestEpoch else { return }
 
-            self.remoteConfigAPI.getRemoteConfigStaticFallback(
+            self.remoteConfigAPI.getRemoteConfigFallback(
                 domain: domain,
                 isAppBackgrounded: isAppBackgrounded
             ) { [weak self] result in
@@ -570,7 +570,7 @@ private extension RemoteConfigManager {
 
                 switch result {
                 case let .success(fallbackResult):
-                    self.handleRemoteConfigStaticFallbackSuccess(
+                    self.handleRemoteConfigFallbackSuccess(
                         fallbackResult,
                         previous: previous,
                         requestEpoch: requestEpoch
@@ -582,8 +582,8 @@ private extension RemoteConfigManager {
         }
     }
 
-    func handleRemoteConfigStaticFallbackSuccess(
-        _ fallbackResult: RemoteConfigStaticFallbackFetchResult,
+    func handleRemoteConfigFallbackSuccess(
+        _ fallbackResult: RemoteConfigFallbackFetchResult,
         previous: PersistedRemoteConfiguration?,
         requestEpoch: Int
     ) {

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -966,13 +966,13 @@ private extension BackendError {
         return 400...499 ~= statusCode.rawValue
     }
 
-    /// Transient failures are eligible for the static JSON fallback config request.
+    /// Failures that can retry against a fallback host are eligible for the JSON fallback config request.
     var isRemoteConfigFallbackEligible: Bool {
         guard case let .networkError(networkError) = self else {
             return false
         }
 
-        return networkError.isTransient
+        return networkError.isAllowedToRetryWithFallbackHost
     }
 
 }

--- a/Sources/Networking/RemoteConfigSignatureContextProvider.swift
+++ b/Sources/Networking/RemoteConfigSignatureContextProvider.swift
@@ -31,7 +31,7 @@ struct RemoteConfigSignatureContextProvider: ResponseSignatureContextProvider {
 ///
 /// Static fallback config signs the JSON response body directly. It does not include request body
 /// parameters because the fallback endpoint is a static-style `GET`.
-struct FallbackConfigSignatureContextProvider: ResponseSignatureContextProvider {
+struct StaticFallbackSignatureContextProvider: ResponseSignatureContextProvider {
 
     func responsePayloadForSignature(from body: Data?, statusCode: HTTPStatusCode) throws -> Data? {
         guard statusCode != .noContent else {

--- a/Sources/Networking/RemoteConfigSignatureContextProvider.swift
+++ b/Sources/Networking/RemoteConfigSignatureContextProvider.swift
@@ -27,6 +27,30 @@ struct RemoteConfigSignatureContextProvider: ResponseSignatureContextProvider {
 
 }
 
+/// Provides signature inputs for static JSON remote config fallback responses.
+///
+/// Static fallback config signs the JSON response body directly. It does not include request body
+/// parameters because the fallback endpoint is a static-style `GET`.
+struct FallbackConfigSignatureContextProvider: ResponseSignatureContextProvider {
+
+    func responsePayloadForSignature(from body: Data?, statusCode: HTTPStatusCode) throws -> Data? {
+        guard statusCode != .noContent else {
+            return Data()
+        }
+
+        guard let body else {
+            throw RCContainer.Parser.FormatError.missingBody
+        }
+
+        return body
+    }
+
+    func requestBodyForSignature(for request: HTTPRequest) -> HTTPRequestBody? {
+        return nil
+    }
+
+}
+
 private extension RemoteConfigSignatureContextProvider {
 
     /// Extracts the signed payload from a remote config RC Container response.

--- a/Sources/Networking/RemoteConfigSignatureContextProvider.swift
+++ b/Sources/Networking/RemoteConfigSignatureContextProvider.swift
@@ -29,9 +29,9 @@ struct RemoteConfigSignatureContextProvider: ResponseSignatureContextProvider {
 
 /// Provides signature inputs for static JSON remote config fallback responses.
 ///
-/// Static fallback config signs the JSON response body directly. It does not include request body
-/// parameters because the fallback endpoint is a static-style `GET`.
-struct StaticFallbackSignatureContextProvider: ResponseSignatureContextProvider {
+/// Fallback config signs the JSON response body directly. It does not include request body
+/// parameters because the fallback endpoint is a fallback `GET`.
+struct FallbackSignatureContextProvider: ResponseSignatureContextProvider {
 
     func responsePayloadForSignature(from body: Data?, statusCode: HTTPStatusCode) throws -> Data? {
         guard statusCode != .noContent else {

--- a/Sources/Networking/RemoteConfigSignatureContextProvider.swift
+++ b/Sources/Networking/RemoteConfigSignatureContextProvider.swift
@@ -34,10 +34,6 @@ struct RemoteConfigSignatureContextProvider: ResponseSignatureContextProvider {
 struct FallbackSignatureContextProvider: ResponseSignatureContextProvider {
 
     func responsePayloadForSignature(from body: Data?, statusCode: HTTPStatusCode) throws -> Data? {
-        guard statusCode != .noContent else {
-            return Data()
-        }
-
         guard let body else {
             throw RCContainer.Parser.FormatError.missingBody
         }

--- a/Sources/Networking/Responses/RemoteConfiguration.swift
+++ b/Sources/Networking/Responses/RemoteConfiguration.swift
@@ -147,6 +147,8 @@ extension RemoteConfiguration: Codable {
 
 }
 
+extension RemoteConfiguration: HTTPResponseBody {}
+
 extension RemoteConfiguration.Topics: Codable {
 
     init(from decoder: Decoder) throws {

--- a/Tests/BackendIntegrationTests/ProductionRemoteConfigIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/ProductionRemoteConfigIntegrationTests.swift
@@ -41,9 +41,9 @@ class BaseProductionRemoteConfigIntegrationTests: BaseBackendIntegrationTests {
         }
     }
 
-    func fetchRemoteConfigStaticFallback() async throws -> RemoteConfigStaticFallbackFetchResult {
+    func fetchRemoteConfigFallback() async throws -> RemoteConfigFallbackFetchResult {
         return try await withCheckedThrowingContinuation { continuation in
-            self.remoteConfigAPI.getRemoteConfigStaticFallback(
+            self.remoteConfigAPI.getRemoteConfigFallback(
                 domain: Self.domain,
                 isAppBackgrounded: false
             ) { result in
@@ -81,7 +81,7 @@ class BaseProductionRemoteConfigIntegrationTests: BaseBackendIntegrationTests {
         expect(result.container).to(beNil())
     }
 
-    func verifyRemoteConfigStaticFallbackResponse(_ result: RemoteConfigStaticFallbackFetchResult) throws {
+    func verifyRemoteConfigFallbackResponse(_ result: RemoteConfigFallbackFetchResult) throws {
         expect(result.verificationResult) == .verified
 
         let configuration = try XCTUnwrap(result.configuration)
@@ -152,10 +152,10 @@ final class ProductionRemoteConfigIntegrationTests: BaseProductionRemoteConfigIn
         self.verifyNoContentResponse(result)
     }
 
-    func testCanFetchRemoteConfigFromStaticFallbackURL() async throws {
-        let result = try await self.fetchRemoteConfigStaticFallback()
+    func testCanFetchRemoteConfigFromFallbackURL() async throws {
+        let result = try await self.fetchRemoteConfigFallback()
 
-        try self.verifyRemoteConfigStaticFallbackResponse(result)
+        try self.verifyRemoteConfigFallbackResponse(result)
     }
 
 }
@@ -182,10 +182,10 @@ final class EnforcedProductionRemoteConfigIntegrationTests: BaseProductionRemote
         self.verifyNoContentResponse(result)
     }
 
-    func testVerifiesStaticFallbackResponseWhenVerificationIsEnforced() async throws {
-        let result = try await self.fetchRemoteConfigStaticFallback()
+    func testVerifiesFallbackResponseWhenVerificationIsEnforced() async throws {
+        let result = try await self.fetchRemoteConfigFallback()
 
-        try self.verifyRemoteConfigStaticFallbackResponse(result)
+        try self.verifyRemoteConfigFallbackResponse(result)
     }
 
 }

--- a/Tests/BackendIntegrationTests/ProductionRemoteConfigIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/ProductionRemoteConfigIntegrationTests.swift
@@ -41,9 +41,9 @@ class BaseProductionRemoteConfigIntegrationTests: BaseBackendIntegrationTests {
         }
     }
 
-    func fetchFallbackConfig() async throws -> RemoteConfigFallbackFetchResult {
+    func fetchRemoteConfigStaticFallback() async throws -> RemoteConfigStaticFallbackFetchResult {
         return try await withCheckedThrowingContinuation { continuation in
-            self.remoteConfigAPI.getFallbackConfig(
+            self.remoteConfigAPI.getRemoteConfigStaticFallback(
                 domain: Self.domain,
                 isAppBackgrounded: false
             ) { result in
@@ -81,7 +81,7 @@ class BaseProductionRemoteConfigIntegrationTests: BaseBackendIntegrationTests {
         expect(result.container).to(beNil())
     }
 
-    func verifyFallbackConfigResponse(_ result: RemoteConfigFallbackFetchResult) throws {
+    func verifyRemoteConfigStaticFallbackResponse(_ result: RemoteConfigStaticFallbackFetchResult) throws {
         expect(result.verificationResult) == .verified
 
         let configuration = try XCTUnwrap(result.configuration)
@@ -153,9 +153,9 @@ final class ProductionRemoteConfigIntegrationTests: BaseProductionRemoteConfigIn
     }
 
     func testCanFetchRemoteConfigFromStaticFallbackURL() async throws {
-        let result = try await self.fetchFallbackConfig()
+        let result = try await self.fetchRemoteConfigStaticFallback()
 
-        try self.verifyFallbackConfigResponse(result)
+        try self.verifyRemoteConfigStaticFallbackResponse(result)
     }
 
 }
@@ -183,9 +183,9 @@ final class EnforcedProductionRemoteConfigIntegrationTests: BaseProductionRemote
     }
 
     func testVerifiesStaticFallbackResponseWhenVerificationIsEnforced() async throws {
-        let result = try await self.fetchFallbackConfig()
+        let result = try await self.fetchRemoteConfigStaticFallback()
 
-        try self.verifyFallbackConfigResponse(result)
+        try self.verifyRemoteConfigStaticFallbackResponse(result)
     }
 
 }

--- a/Tests/BackendIntegrationTests/ProductionRemoteConfigIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/ProductionRemoteConfigIntegrationTests.swift
@@ -41,6 +41,17 @@ class BaseProductionRemoteConfigIntegrationTests: BaseBackendIntegrationTests {
         }
     }
 
+    func fetchFallbackConfig() async throws -> RemoteConfigFallbackFetchResult {
+        return try await withCheckedThrowingContinuation { continuation in
+            self.remoteConfigAPI.getFallbackConfig(
+                domain: Self.domain,
+                isAppBackgrounded: false
+            ) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
+
     func remoteConfiguration(from container: RemoteConfigContainer) throws -> RemoteConfiguration {
         return try container.configElement.withDecodedPayloadBytes { bytes in
             try JSONDecoder.default.decode(
@@ -68,6 +79,13 @@ class BaseProductionRemoteConfigIntegrationTests: BaseBackendIntegrationTests {
     func verifyNoContentResponse(_ result: RemoteConfigFetchResult) {
         expect(result.verificationResult) == .verified
         expect(result.container).to(beNil())
+    }
+
+    func verifyFallbackConfigResponse(_ result: RemoteConfigFallbackFetchResult) throws {
+        expect(result.verificationResult) == .verified
+
+        let configuration = try XCTUnwrap(result.configuration)
+        self.verifyRemoteConfiguration(configuration)
     }
 
 }
@@ -134,6 +152,12 @@ final class ProductionRemoteConfigIntegrationTests: BaseProductionRemoteConfigIn
         self.verifyNoContentResponse(result)
     }
 
+    func testCanFetchRemoteConfigFromStaticFallbackURL() async throws {
+        let result = try await self.fetchFallbackConfig()
+
+        try self.verifyFallbackConfigResponse(result)
+    }
+
 }
 
 final class EnforcedProductionRemoteConfigIntegrationTests: BaseProductionRemoteConfigIntegrationTests {
@@ -156,6 +180,12 @@ final class EnforcedProductionRemoteConfigIntegrationTests: BaseProductionRemote
         let result = try await self.fetchRemoteConfig(manifest: configuration.manifest)
 
         self.verifyNoContentResponse(result)
+    }
+
+    func testVerifiesStaticFallbackResponseWhenVerificationIsEnforced() async throws {
+        let result = try await self.fetchFallbackConfig()
+
+        try self.verifyFallbackConfigResponse(result)
     }
 
 }

--- a/Tests/BackendIntegrationTests/ProductionRemoteConfigIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/ProductionRemoteConfigIntegrationTests.swift
@@ -84,8 +84,7 @@ class BaseProductionRemoteConfigIntegrationTests: BaseBackendIntegrationTests {
     func verifyRemoteConfigFallbackResponse(_ result: RemoteConfigFallbackFetchResult) throws {
         expect(result.verificationResult) == .verified
 
-        let configuration = try XCTUnwrap(result.configuration)
-        self.verifyRemoteConfiguration(configuration)
+        self.verifyRemoteConfiguration(result.configuration)
     }
 
 }

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -157,6 +157,10 @@ class MockHTTPClient: HTTPClient {
         self.mock(path: requestPath, response: response)
     }
 
+    func mock(requestPath: HTTPRequest.StaticFallbackPath, response: Response) {
+        self.mock(path: requestPath, response: response)
+    }
+
     func mock(requestPath: HTTPRequest.WebBillingPath, response: Response) {
         self.mock(path: requestPath, response: response)
     }

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -157,7 +157,7 @@ class MockHTTPClient: HTTPClient {
         self.mock(path: requestPath, response: response)
     }
 
-    func mock(requestPath: HTTPRequest.StaticFallbackPath, response: Response) {
+    func mock(requestPath: HTTPRequest.FallbackPath, response: Response) {
         self.mock(path: requestPath, response: response)
     }
 

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -118,6 +118,42 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(self.httpClient.calls.first?.headers["Accept-Encoding"]).to(beNil())
     }
 
+    func testGetFallbackConfigUsesGetMethodAndFallbackPath() {
+        self.mockSuccessfulFallbackResponse()
+
+        let result = waitUntilValue { completed in
+            self.remoteConfigAPI.getFallbackConfig(
+                domain: "app",
+                isAppBackgrounded: false,
+                completion: completed
+            )
+        }
+
+        expect(result).to(beSuccess())
+        expect(self.httpClient.calls).to(haveCount(1))
+        expect(self.httpClient.calls.first?.request.method.httpMethod) == "GET"
+        expect(self.httpClient.calls.first?.request.path as? HTTPRequest.Path) == .fallbackConfig(domain: "app")
+        expect(self.httpClient.calls.first?.request.path.url?.absoluteString)
+            == "https://api-production.8-lives-cat.io/v1/config/app"
+        expect(self.httpClient.calls.first?.request.requestBody).to(beNil())
+    }
+
+    func testGetFallbackConfigRequestsJSONFormat() {
+        self.mockSuccessfulFallbackResponse()
+
+        waitUntil { completed in
+            self.remoteConfigAPI.getFallbackConfig(
+                domain: "app",
+                isAppBackgrounded: false
+            ) { _ in completed() }
+        }
+
+        expect(self.httpClient.calls.first?.headers[HTTPClient.RequestHeader.accept.rawValue]) == "application/json"
+        expect(self.httpClient.calls.first?.headers[HTTPClient.RequestHeader.acceptRCElementEncoding.rawValue])
+            .to(beNil())
+        expect(self.httpClient.calls.first?.headers["Accept-Encoding"]).to(beNil())
+    }
+
     func testGetRemoteConfigDoesNotSendETagHeaders() {
         self.mockSuccessfulResponse()
 
@@ -130,6 +166,24 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
         expect(self.httpClient.calls.first?.headers[ETagManager.eTagRequestHeader.rawValue]).to(beNil())
         expect(self.httpClient.calls.first?.headers[ETagManager.eTagValidationTimeRequestHeader.rawValue]).to(beNil())
+    }
+
+    func testGetFallbackConfigDoesNotSendETagHeadersOrSignatureRequestHeaders() {
+        self.mockSuccessfulFallbackResponse()
+
+        waitUntil { completed in
+            self.remoteConfigAPI.getFallbackConfig(
+                domain: "app",
+                isAppBackgrounded: false
+            ) { _ in completed() }
+        }
+
+        let headers = self.httpClient.calls.first?.headers
+        expect(headers?[ETagManager.eTagRequestHeader.rawValue]).to(beNil())
+        expect(headers?[ETagManager.eTagValidationTimeRequestHeader.rawValue]).to(beNil())
+        expect(headers?[HTTPClient.RequestHeader.nonce.rawValue]).to(beNil())
+        expect(headers?[HTTPClient.RequestHeader.headerParametersForSignature.rawValue]).to(beNil())
+        expect(headers?[HTTPClient.RequestHeader.postParameters.rawValue]).to(beNil())
     }
 
     func testGetRemoteConfigDoesNotSendSignatureVerificationHeaders() {
@@ -556,12 +610,94 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(error.domain) == String(reflecting: RCContainer.Parser.FormatError.self)
     }
 
+    func testGetFallbackConfigParsesJSONResponse() throws {
+        self.mockSuccessfulFallbackResponse(verificationResult: .verified)
+
+        let result: Result<RemoteConfigFallbackFetchResult, BackendError>? = waitUntilValue { completed in
+            self.remoteConfigAPI.getFallbackConfig(
+                domain: "app",
+                isAppBackgrounded: false,
+                completion: completed
+            )
+        }
+
+        let fetchResult = try XCTUnwrap(result?.value)
+        let configuration = try XCTUnwrap(fetchResult.configuration)
+
+        expect(configuration.domain) == "app"
+        expect(configuration.manifest) == "v1.test"
+        expect(configuration.activeTopics) == ["sources"]
+        expect(fetchResult.verificationResult) == .verified
+    }
+
+    func testGetFallbackConfigNoContentResponseSucceedsWithNoConfiguration() throws {
+        self.httpClient.mock(
+            requestPath: .fallbackConfig(domain: "app"),
+            response: .init(statusCode: .noContent, body: Data(), verificationResult: .verified)
+        )
+
+        let result: Result<RemoteConfigFallbackFetchResult, BackendError>? = waitUntilValue { completed in
+            self.remoteConfigAPI.getFallbackConfig(
+                domain: "app",
+                isAppBackgrounded: false,
+                completion: completed
+            )
+        }
+
+        expect(result).to(beSuccess())
+        let fetchResult = try XCTUnwrap(result?.value)
+
+        expect(fetchResult.configuration).to(beNil())
+        expect(fetchResult.verificationResult) == .verified
+    }
+
+    func testGetFallbackConfigInvalidJSONSendsDecodingError() {
+        self.httpClient.mock(
+            requestPath: .fallbackConfig(domain: "app"),
+            response: .init(statusCode: .success, body: "not json".asData)
+        )
+
+        let result = waitUntilValue { completed in
+            self.remoteConfigAPI.getFallbackConfig(
+                domain: "app",
+                isAppBackgrounded: false,
+                completion: completed
+            )
+        }
+
+        guard case .networkError(.decoding) = result?.error else {
+            fail("Expected decoding error, got \(String(describing: result?.error))")
+            return
+        }
+    }
+
 }
 
 private extension BackendGetRemoteConfigTests {
 
     static let config = #"{"manifest":{}}"#.asData
     static let content = #"{"products":[]}"#.asData
+    static let fallbackConfig = """
+    {
+      "domain": "app",
+      "manifest": "v1.test",
+      "active_topics": ["sources"],
+      "topics": {
+        "sources": {
+          "api": {
+            "sources": [
+              {
+                "id": "primary",
+                "url": "https://api.revenuecat.com/",
+                "priority": 0,
+                "weight": 100
+              }
+            ]
+          }
+        }
+      }
+    }
+    """.asData
     static let appUserID = "app-user-id"
 
     static var defaultRequest: RemoteConfigRequest {
@@ -584,6 +720,20 @@ private extension BackendGetRemoteConfigTests {
                 body: Self.containerData,
                 verificationResult: verificationResult,
                 delay: delay
+            )
+        )
+    }
+
+    func mockSuccessfulFallbackResponse(
+        domain: String = "app",
+        verificationResult: VerificationResult = .defaultValue
+    ) {
+        self.httpClient.mock(
+            requestPath: .fallbackConfig(domain: domain),
+            response: .init(
+                statusCode: .success,
+                body: Self.fallbackConfig,
+                verificationResult: verificationResult
             )
         )
     }

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -621,32 +621,11 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         }
 
         let fetchResult = try XCTUnwrap(result?.value)
-        let configuration = try XCTUnwrap(fetchResult.configuration)
+        let configuration = fetchResult.configuration
 
         expect(configuration.domain) == "app"
         expect(configuration.manifest) == "v1.test"
         expect(configuration.activeTopics) == ["sources"]
-        expect(fetchResult.verificationResult) == .verified
-    }
-
-    func testGetRemoteConfigFallbackNoContentResponseSucceedsWithNoConfiguration() throws {
-        self.httpClient.mock(
-            requestPath: HTTPRequest.FallbackPath.remoteConfig(domain: "app"),
-            response: .init(statusCode: .noContent, body: Data(), verificationResult: .verified)
-        )
-
-        let result: Result<RemoteConfigFallbackFetchResult, BackendError>? = waitUntilValue { completed in
-            self.remoteConfigAPI.getRemoteConfigFallback(
-                domain: "app",
-                isAppBackgrounded: false,
-                completion: completed
-            )
-        }
-
-        expect(result).to(beSuccess())
-        let fetchResult = try XCTUnwrap(result?.value)
-
-        expect(fetchResult.configuration).to(beNil())
         expect(fetchResult.verificationResult) == .verified
     }
 

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -118,11 +118,11 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(self.httpClient.calls.first?.headers["Accept-Encoding"]).to(beNil())
     }
 
-    func testGetRemoteConfigStaticFallbackUsesGetMethodAndFallbackPath() {
+    func testGetRemoteConfigFallbackUsesGetMethodAndFallbackPath() {
         self.mockSuccessfulFallbackResponse()
 
         let result = waitUntilValue { completed in
-            self.remoteConfigAPI.getRemoteConfigStaticFallback(
+            self.remoteConfigAPI.getRemoteConfigFallback(
                 domain: "app",
                 isAppBackgrounded: false,
                 completion: completed
@@ -132,18 +132,18 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(result).to(beSuccess())
         expect(self.httpClient.calls).to(haveCount(1))
         expect(self.httpClient.calls.first?.request.method.httpMethod) == "GET"
-        expect(self.httpClient.calls.first?.request.path as? HTTPRequest.StaticFallbackPath)
-            == HTTPRequest.StaticFallbackPath.remoteConfig(domain: "app")
+        expect(self.httpClient.calls.first?.request.path as? HTTPRequest.FallbackPath)
+            == HTTPRequest.FallbackPath.remoteConfig(domain: "app")
         expect(self.httpClient.calls.first?.request.path.url?.absoluteString)
             == "https://api-production.8-lives-cat.io/v1/config/app"
         expect(self.httpClient.calls.first?.request.requestBody).to(beNil())
     }
 
-    func testGetRemoteConfigStaticFallbackDoesNotRequestRCContainerFormat() {
+    func testGetRemoteConfigFallbackDoesNotRequestRCContainerFormat() {
         self.mockSuccessfulFallbackResponse()
 
         waitUntil { completed in
-            self.remoteConfigAPI.getRemoteConfigStaticFallback(
+            self.remoteConfigAPI.getRemoteConfigFallback(
                 domain: "app",
                 isAppBackgrounded: false
             ) { _ in completed() }
@@ -169,11 +169,11 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(self.httpClient.calls.first?.headers[ETagManager.eTagValidationTimeRequestHeader.rawValue]).to(beNil())
     }
 
-    func testGetRemoteConfigStaticFallbackDoesNotSendETagHeadersOrSignatureRequestHeaders() {
+    func testGetRemoteConfigFallbackDoesNotSendETagHeadersOrSignatureRequestHeaders() {
         self.mockSuccessfulFallbackResponse()
 
         waitUntil { completed in
-            self.remoteConfigAPI.getRemoteConfigStaticFallback(
+            self.remoteConfigAPI.getRemoteConfigFallback(
                 domain: "app",
                 isAppBackgrounded: false
             ) { _ in completed() }
@@ -611,11 +611,11 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(error.domain) == String(reflecting: RCContainer.Parser.FormatError.self)
     }
 
-    func testGetRemoteConfigStaticFallbackParsesJSONResponse() throws {
+    func testGetRemoteConfigFallbackParsesJSONResponse() throws {
         self.mockSuccessfulFallbackResponse(verificationResult: .verified)
 
-        let result: Result<RemoteConfigStaticFallbackFetchResult, BackendError>? = waitUntilValue { completed in
-            self.remoteConfigAPI.getRemoteConfigStaticFallback(
+        let result: Result<RemoteConfigFallbackFetchResult, BackendError>? = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfigFallback(
                 domain: "app",
                 isAppBackgrounded: false,
                 completion: completed
@@ -631,14 +631,14 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(fetchResult.verificationResult) == .verified
     }
 
-    func testGetRemoteConfigStaticFallbackNoContentResponseSucceedsWithNoConfiguration() throws {
+    func testGetRemoteConfigFallbackNoContentResponseSucceedsWithNoConfiguration() throws {
         self.httpClient.mock(
-            requestPath: HTTPRequest.StaticFallbackPath.remoteConfig(domain: "app"),
+            requestPath: HTTPRequest.FallbackPath.remoteConfig(domain: "app"),
             response: .init(statusCode: .noContent, body: Data(), verificationResult: .verified)
         )
 
-        let result: Result<RemoteConfigStaticFallbackFetchResult, BackendError>? = waitUntilValue { completed in
-            self.remoteConfigAPI.getRemoteConfigStaticFallback(
+        let result: Result<RemoteConfigFallbackFetchResult, BackendError>? = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfigFallback(
                 domain: "app",
                 isAppBackgrounded: false,
                 completion: completed
@@ -652,14 +652,14 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(fetchResult.verificationResult) == .verified
     }
 
-    func testGetRemoteConfigStaticFallbackInvalidJSONSendsDecodingError() {
+    func testGetRemoteConfigFallbackInvalidJSONSendsDecodingError() {
         self.httpClient.mock(
-            requestPath: HTTPRequest.StaticFallbackPath.remoteConfig(domain: "app"),
+            requestPath: HTTPRequest.FallbackPath.remoteConfig(domain: "app"),
             response: .init(statusCode: .success, body: "not json".asData)
         )
 
         let result = waitUntilValue { completed in
-            self.remoteConfigAPI.getRemoteConfigStaticFallback(
+            self.remoteConfigAPI.getRemoteConfigFallback(
                 domain: "app",
                 isAppBackgrounded: false,
                 completion: completed
@@ -678,7 +678,7 @@ private extension BackendGetRemoteConfigTests {
 
     static let config = #"{"manifest":{}}"#.asData
     static let content = #"{"products":[]}"#.asData
-    static let remoteConfigStaticFallback = """
+    static let remoteConfigFallback = """
     {
       "domain": "app",
       "manifest": "v1.test",
@@ -730,10 +730,10 @@ private extension BackendGetRemoteConfigTests {
         verificationResult: VerificationResult = .defaultValue
     ) {
         self.httpClient.mock(
-            requestPath: HTTPRequest.StaticFallbackPath.remoteConfig(domain: domain),
+            requestPath: HTTPRequest.FallbackPath.remoteConfig(domain: domain),
             response: .init(
                 statusCode: .success,
-                body: Self.remoteConfigStaticFallback,
+                body: Self.remoteConfigFallback,
                 verificationResult: verificationResult
             )
         )

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -132,7 +132,8 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(result).to(beSuccess())
         expect(self.httpClient.calls).to(haveCount(1))
         expect(self.httpClient.calls.first?.request.method.httpMethod) == "GET"
-        expect(self.httpClient.calls.first?.request.path as? HTTPRequest.Path) == .fallbackConfig(domain: "app")
+        expect(self.httpClient.calls.first?.request.path as? HTTPRequest.Path)
+            == .remoteConfigStaticFallback(domain: "app")
         expect(self.httpClient.calls.first?.request.path.url?.absoluteString)
             == "https://api-production.8-lives-cat.io/v1/config/app"
         expect(self.httpClient.calls.first?.request.requestBody).to(beNil())
@@ -632,7 +633,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
     func testGetFallbackConfigNoContentResponseSucceedsWithNoConfiguration() throws {
         self.httpClient.mock(
-            requestPath: .fallbackConfig(domain: "app"),
+            requestPath: .remoteConfigStaticFallback(domain: "app"),
             response: .init(statusCode: .noContent, body: Data(), verificationResult: .verified)
         )
 
@@ -653,7 +654,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
     func testGetFallbackConfigInvalidJSONSendsDecodingError() {
         self.httpClient.mock(
-            requestPath: .fallbackConfig(domain: "app"),
+            requestPath: .remoteConfigStaticFallback(domain: "app"),
             response: .init(statusCode: .success, body: "not json".asData)
         )
 
@@ -677,7 +678,7 @@ private extension BackendGetRemoteConfigTests {
 
     static let config = #"{"manifest":{}}"#.asData
     static let content = #"{"products":[]}"#.asData
-    static let fallbackConfig = """
+    static let remoteConfigStaticFallback = """
     {
       "domain": "app",
       "manifest": "v1.test",
@@ -729,10 +730,10 @@ private extension BackendGetRemoteConfigTests {
         verificationResult: VerificationResult = .defaultValue
     ) {
         self.httpClient.mock(
-            requestPath: .fallbackConfig(domain: domain),
+            requestPath: .remoteConfigStaticFallback(domain: domain),
             response: .init(
                 statusCode: .success,
-                body: Self.fallbackConfig,
+                body: Self.remoteConfigStaticFallback,
                 verificationResult: verificationResult
             )
         )

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -139,7 +139,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(self.httpClient.calls.first?.request.requestBody).to(beNil())
     }
 
-    func testGetRemoteConfigStaticFallbackRequestsJSONFormat() {
+    func testGetRemoteConfigStaticFallbackDoesNotRequestRCContainerFormat() {
         self.mockSuccessfulFallbackResponse()
 
         waitUntil { completed in
@@ -149,7 +149,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
             ) { _ in completed() }
         }
 
-        expect(self.httpClient.calls.first?.headers[HTTPClient.RequestHeader.accept.rawValue]) == "application/json"
+        expect(self.httpClient.calls.first?.headers[HTTPClient.RequestHeader.accept.rawValue]).to(beNil())
         expect(self.httpClient.calls.first?.headers[HTTPClient.RequestHeader.acceptRCElementEncoding.rawValue])
             .to(beNil())
         expect(self.httpClient.calls.first?.headers["Accept-Encoding"]).to(beNil())

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -169,7 +169,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(self.httpClient.calls.first?.headers[ETagManager.eTagValidationTimeRequestHeader.rawValue]).to(beNil())
     }
 
-    func testGetRemoteConfigFallbackDoesNotSendETagHeadersOrSignatureRequestHeaders() {
+    func testGetRemoteConfigFallbackDoesNotSendSignatureRequestHeaders() {
         self.mockSuccessfulFallbackResponse()
 
         waitUntil { completed in
@@ -180,8 +180,6 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         }
 
         let headers = self.httpClient.calls.first?.headers
-        expect(headers?[ETagManager.eTagRequestHeader.rawValue]).to(beNil())
-        expect(headers?[ETagManager.eTagValidationTimeRequestHeader.rawValue]).to(beNil())
         expect(headers?[HTTPClient.RequestHeader.nonce.rawValue]).to(beNil())
         expect(headers?[HTTPClient.RequestHeader.headerParametersForSignature.rawValue]).to(beNil())
         expect(headers?[HTTPClient.RequestHeader.postParameters.rawValue]).to(beNil())

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -132,8 +132,8 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(result).to(beSuccess())
         expect(self.httpClient.calls).to(haveCount(1))
         expect(self.httpClient.calls.first?.request.method.httpMethod) == "GET"
-        expect(self.httpClient.calls.first?.request.path as? HTTPRequest.Path)
-            == .remoteConfigStaticFallback(domain: "app")
+        expect(self.httpClient.calls.first?.request.path as? HTTPRequest.StaticFallbackPath)
+            == HTTPRequest.StaticFallbackPath.remoteConfig(domain: "app")
         expect(self.httpClient.calls.first?.request.path.url?.absoluteString)
             == "https://api-production.8-lives-cat.io/v1/config/app"
         expect(self.httpClient.calls.first?.request.requestBody).to(beNil())
@@ -402,7 +402,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
             }
         )
         self.httpClient.mock(
-            requestPath: .remoteConfig(domain: "app"),
+            requestPath: HTTPRequest.Path.remoteConfig(domain: "app"),
             response: .init(statusCode: .success, body: data)
         )
 
@@ -429,7 +429,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
             checksumOverride: { _, _ in Array(repeating: 0, count: RCContainerTestData.checksumSize) }
         )
         self.httpClient.mock(
-            requestPath: .remoteConfig(domain: "app"),
+            requestPath: HTTPRequest.Path.remoteConfig(domain: "app"),
             response: .init(statusCode: .success, body: data)
         )
 
@@ -466,7 +466,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
     func testGetRemoteConfigNoContentResponseSucceedsWithNoContainer() throws {
         self.httpClient.mock(
-            requestPath: .remoteConfig(domain: "app"),
+            requestPath: HTTPRequest.Path.remoteConfig(domain: "app"),
             response: .init(statusCode: .noContent, body: Data(), verificationResult: .verified)
         )
 
@@ -489,7 +489,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
     func testGetRemoteConfigFailSendsError() {
         self.httpClient.mock(
-            requestPath: .remoteConfig(domain: "app"),
+            requestPath: HTTPRequest.Path.remoteConfig(domain: "app"),
             response: .init(error: .unexpectedResponse(nil))
         )
 
@@ -508,7 +508,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         let mockedError: NetworkError = .unexpectedResponse(nil)
 
         self.httpClient.mock(
-            requestPath: .remoteConfig(domain: "app"),
+            requestPath: HTTPRequest.Path.remoteConfig(domain: "app"),
             response: .init(error: mockedError)
         )
 
@@ -529,7 +529,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         let mockedError: NetworkError = .errorResponse(errorResponse, .internalServerError)
 
         self.httpClient.mock(
-            requestPath: .remoteConfig(domain: "app"),
+            requestPath: HTTPRequest.Path.remoteConfig(domain: "app"),
             response: .init(error: mockedError)
         )
 
@@ -547,7 +547,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
     func testGetRemoteConfigInvalidRCContainerSendsDecodingError() {
         self.httpClient.mock(
-            requestPath: .remoteConfig(domain: "app"),
+            requestPath: HTTPRequest.Path.remoteConfig(domain: "app"),
             response: .init(statusCode: .success, body: "not an rc container".asData)
         )
 
@@ -569,7 +569,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
     func testGetRemoteConfigSuccessfulEmptyResponseSendsDecodingError() {
         self.httpClient.mock(
-            requestPath: .remoteConfig(domain: "app"),
+            requestPath: HTTPRequest.Path.remoteConfig(domain: "app"),
             response: .init(statusCode: .success, body: Data())
         )
 
@@ -591,7 +591,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
     func testGetRemoteConfigSuccessfulJSONResponseSendsDecodingError() {
         self.httpClient.mock(
-            requestPath: .remoteConfig(domain: "app"),
+            requestPath: HTTPRequest.Path.remoteConfig(domain: "app"),
             response: .init(statusCode: .success, body: #"{"api_sources":[]}"#.asData)
         )
 
@@ -633,7 +633,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
     func testGetRemoteConfigStaticFallbackNoContentResponseSucceedsWithNoConfiguration() throws {
         self.httpClient.mock(
-            requestPath: .remoteConfigStaticFallback(domain: "app"),
+            requestPath: HTTPRequest.StaticFallbackPath.remoteConfig(domain: "app"),
             response: .init(statusCode: .noContent, body: Data(), verificationResult: .verified)
         )
 
@@ -654,7 +654,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
     func testGetRemoteConfigStaticFallbackInvalidJSONSendsDecodingError() {
         self.httpClient.mock(
-            requestPath: .remoteConfigStaticFallback(domain: "app"),
+            requestPath: HTTPRequest.StaticFallbackPath.remoteConfig(domain: "app"),
             response: .init(statusCode: .success, body: "not json".asData)
         )
 
@@ -715,7 +715,7 @@ private extension BackendGetRemoteConfigTests {
         delay: DispatchTimeInterval = .never
     ) {
         self.httpClient.mock(
-            requestPath: .remoteConfig(domain: domain),
+            requestPath: HTTPRequest.Path.remoteConfig(domain: domain),
             response: .init(
                 statusCode: .success,
                 body: Self.containerData,
@@ -730,7 +730,7 @@ private extension BackendGetRemoteConfigTests {
         verificationResult: VerificationResult = .defaultValue
     ) {
         self.httpClient.mock(
-            requestPath: .remoteConfigStaticFallback(domain: domain),
+            requestPath: HTTPRequest.StaticFallbackPath.remoteConfig(domain: domain),
             response: .init(
                 statusCode: .success,
                 body: Self.remoteConfigStaticFallback,

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -118,11 +118,11 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(self.httpClient.calls.first?.headers["Accept-Encoding"]).to(beNil())
     }
 
-    func testGetFallbackConfigUsesGetMethodAndFallbackPath() {
+    func testGetRemoteConfigStaticFallbackUsesGetMethodAndFallbackPath() {
         self.mockSuccessfulFallbackResponse()
 
         let result = waitUntilValue { completed in
-            self.remoteConfigAPI.getFallbackConfig(
+            self.remoteConfigAPI.getRemoteConfigStaticFallback(
                 domain: "app",
                 isAppBackgrounded: false,
                 completion: completed
@@ -139,11 +139,11 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(self.httpClient.calls.first?.request.requestBody).to(beNil())
     }
 
-    func testGetFallbackConfigRequestsJSONFormat() {
+    func testGetRemoteConfigStaticFallbackRequestsJSONFormat() {
         self.mockSuccessfulFallbackResponse()
 
         waitUntil { completed in
-            self.remoteConfigAPI.getFallbackConfig(
+            self.remoteConfigAPI.getRemoteConfigStaticFallback(
                 domain: "app",
                 isAppBackgrounded: false
             ) { _ in completed() }
@@ -169,11 +169,11 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(self.httpClient.calls.first?.headers[ETagManager.eTagValidationTimeRequestHeader.rawValue]).to(beNil())
     }
 
-    func testGetFallbackConfigDoesNotSendETagHeadersOrSignatureRequestHeaders() {
+    func testGetRemoteConfigStaticFallbackDoesNotSendETagHeadersOrSignatureRequestHeaders() {
         self.mockSuccessfulFallbackResponse()
 
         waitUntil { completed in
-            self.remoteConfigAPI.getFallbackConfig(
+            self.remoteConfigAPI.getRemoteConfigStaticFallback(
                 domain: "app",
                 isAppBackgrounded: false
             ) { _ in completed() }
@@ -611,11 +611,11 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(error.domain) == String(reflecting: RCContainer.Parser.FormatError.self)
     }
 
-    func testGetFallbackConfigParsesJSONResponse() throws {
+    func testGetRemoteConfigStaticFallbackParsesJSONResponse() throws {
         self.mockSuccessfulFallbackResponse(verificationResult: .verified)
 
-        let result: Result<RemoteConfigFallbackFetchResult, BackendError>? = waitUntilValue { completed in
-            self.remoteConfigAPI.getFallbackConfig(
+        let result: Result<RemoteConfigStaticFallbackFetchResult, BackendError>? = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfigStaticFallback(
                 domain: "app",
                 isAppBackgrounded: false,
                 completion: completed
@@ -631,14 +631,14 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(fetchResult.verificationResult) == .verified
     }
 
-    func testGetFallbackConfigNoContentResponseSucceedsWithNoConfiguration() throws {
+    func testGetRemoteConfigStaticFallbackNoContentResponseSucceedsWithNoConfiguration() throws {
         self.httpClient.mock(
             requestPath: .remoteConfigStaticFallback(domain: "app"),
             response: .init(statusCode: .noContent, body: Data(), verificationResult: .verified)
         )
 
-        let result: Result<RemoteConfigFallbackFetchResult, BackendError>? = waitUntilValue { completed in
-            self.remoteConfigAPI.getFallbackConfig(
+        let result: Result<RemoteConfigStaticFallbackFetchResult, BackendError>? = waitUntilValue { completed in
+            self.remoteConfigAPI.getRemoteConfigStaticFallback(
                 domain: "app",
                 isAppBackgrounded: false,
                 completion: completed
@@ -652,14 +652,14 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(fetchResult.verificationResult) == .verified
     }
 
-    func testGetFallbackConfigInvalidJSONSendsDecodingError() {
+    func testGetRemoteConfigStaticFallbackInvalidJSONSendsDecodingError() {
         self.httpClient.mock(
             requestPath: .remoteConfigStaticFallback(domain: "app"),
             response: .init(statusCode: .success, body: "not json".asData)
         )
 
         let result = waitUntilValue { completed in
-            self.remoteConfigAPI.getFallbackConfig(
+            self.remoteConfigAPI.getRemoteConfigStaticFallback(
                 domain: "app",
                 isAppBackgrounded: false,
                 completion: completed

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1087,7 +1087,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
     func testRemoteConfigDoesNotUseETagCacheEvenIfResponseIncludesETagHeader() {
         let request = HTTPRequest(
             method: .post(RemoteConfigRequest(appUserID: "app-user-id")),
-            path: .remoteConfig(domain: "app")
+            path: HTTPRequest.Path.remoteConfig(domain: "app")
         )
         let headerPresent: Atomic<Bool?> = nil
 

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -749,6 +749,41 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
         expect(self.eTagManager.invokedHTTPResultFromCacheOrBackendCount) == 1
     }
 
+    func testRemoteConfigFallbackSendsETagHeaders() {
+        let path = HTTPRequest.FallbackPath.remoteConfig(domain: "app")
+        let request = HTTPRequest(method: .get, path: path)
+        let responseData = "{\"domain\":\"app\",\"manifest\":\"test\",\"active_topics\":[],\"topics\":{}}".asData
+        let eTag = "fallback-etag"
+        let eTagValidationTime = Date(timeIntervalSince1970: 1234567)
+
+        self.eTagManager.stubResponseEtag(eTag, validationTime: eTagValidationTime)
+
+        stub(condition: isPath(path)) { request in
+            expect(request.allHTTPHeaderFields?[ETagManager.eTagRequestHeader.rawValue]) == eTag
+            expect(request.allHTTPHeaderFields?[ETagManager.eTagValidationTimeRequestHeader.rawValue])
+            == eTagValidationTime.millisecondsSince1970.description
+
+            return HTTPStubsResponse(
+                data: responseData,
+                statusCode: .success,
+                headers: nil
+            )
+        }
+
+        let result = waitUntilValue { completion in
+            self.client.perform(request) { (response: DataResponse) in
+                completion(response)
+            }
+        }
+
+        expect(result).toNot(beNil())
+        expect(result).to(beSuccess())
+        expect(result?.value?.body) == responseData
+
+        expect(self.eTagManager.invokedETagHeader).to(beTrue())
+        expect(self.eTagManager.invokedHTTPResultFromCacheOrBackend) == true
+    }
+
     func testResponseOriginalSourceIsLoadShedderWhenHeaderIsTrue() throws {
         let request = HTTPRequest(method: .get, path: .mockPath)
         let responseData = "{\"message\": \"something is great up in the cloud\"}".asData

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -784,6 +784,48 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
         expect(self.eTagManager.invokedHTTPResultFromCacheOrBackend) == true
     }
 
+    func testRemoteConfigFallbackGetsCachedResponseWhenStatusCodeIsNotModified() {
+        let path = HTTPRequest.FallbackPath.remoteConfig(domain: "app")
+        let request = HTTPRequest(method: .get, path: path)
+        let cachedResponseData = """
+        {"domain":"app","manifest":"cached","active_topics":[],"topics":{}}
+        """.asData
+        let eTag = "fallback-etag"
+
+        self.eTagManager.stubResponseEtag(eTag)
+        self.eTagManager.shouldReturnResultFromBackend = false
+        self.eTagManager.stubbedHTTPResultFromCacheOrBackendResult = .init(
+            httpStatusCode: .success,
+            responseHeaders: [:],
+            body: cachedResponseData,
+            verificationResult: .verified,
+            isLoadShedderResponse: false,
+            isFallbackUrlResponse: false
+        )
+
+        stub(condition: isPath(path)) { request in
+            expect(request.allHTTPHeaderFields?[ETagManager.eTagRequestHeader.rawValue]) == eTag
+
+            return HTTPStubsResponse(
+                data: Data(),
+                statusCode: .notModified,
+                headers: nil
+            )
+        }
+
+        let response: VerifiedHTTPResponse<RemoteConfiguration>.Result? = waitUntilValue { completion in
+            self.client.perform(request) { (response: VerifiedHTTPResponse<RemoteConfiguration>.Result) in
+                completion(response)
+            }
+        }
+
+        expect(response).to(beSuccess())
+        expect(response?.value?.httpStatusCode) == .success
+        expect(response?.value?.body.domain) == "app"
+        expect(response?.value?.body.manifest) == "cached"
+        expect(self.eTagManager.invokedHTTPResultFromCacheOrBackend) == true
+    }
+
     func testResponseOriginalSourceIsLoadShedderWhenHeaderIsTrue() throws {
         let request = HTTPRequest(method: .get, path: .mockPath)
         let responseData = "{\"message\": \"something is great up in the cloud\"}".asData

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -37,14 +37,16 @@ class HTTPRequestTests: TestCase {
         .health,
         .getProductEntitlementMapping,
         .rewardVerificationStatus(appUserID: userID, clientTransactionID: clientTransactionID),
-        .remoteConfig(domain: "app")
+        .remoteConfig(domain: "app"),
+        .fallbackConfig(domain: "app")
     ]
     private static let unauthenticatedPaths: Set<HTTPRequest.Path> = [
         .health
     ]
     private static let pathsWithoutETags: Set<HTTPRequest.Path> = [
         .health,
-        .remoteConfig(domain: "app")
+        .remoteConfig(domain: "app"),
+        .fallbackConfig(domain: "app")
     ]
     private static let pathsWithSignatureVerification: Set<HTTPRequest.Path> = [
         .getCustomerInfo(appUserID: userID),
@@ -54,7 +56,8 @@ class HTTPRequestTests: TestCase {
         .getOfferings(appUserID: userID),
         .getProductEntitlementMapping,
         .rewardVerificationStatus(appUserID: userID, clientTransactionID: clientTransactionID),
-        .remoteConfig(domain: "app")
+        .remoteConfig(domain: "app"),
+        .fallbackConfig(domain: "app")
     ]
     private static let pathsThatRequireNonce: Set<HTTPRequest.Path> = [
         .getCustomerInfo(appUserID: userID),
@@ -172,7 +175,8 @@ class HTTPRequestTests: TestCase {
 
         expect(staticEndpoints) == [
             .getOfferings(appUserID: Self.userID),
-            .getProductEntitlementMapping
+            .getProductEntitlementMapping,
+            .fallbackConfig(domain: "app")
         ]
     }
 
@@ -199,9 +203,6 @@ class HTTPRequestTests: TestCase {
             case .getOfferings:
                 XCTAssertEqual(fallbackUrlsPaths,
                                ["https://api-production.8-lives-cat.io/v1/offerings"])
-            case .remoteConfig:
-                XCTAssertEqual(fallbackUrlsPaths,
-                               ["https://api-production.8-lives-cat.io/v1/config/app"])
             default:
                 XCTAssertTrue(fallbackUrlsPaths.isEmpty)
             }
@@ -212,8 +213,16 @@ class HTTPRequestTests: TestCase {
         let path = HTTPRequest.Path.remoteConfig(domain: "app workflows/project")
 
         expect(path.relativePath) == "/v1/config/app%20workflows%2Fproject"
-        expect(path.fallbackUrls.map { $0.absoluteString })
-            == ["https://api-production.8-lives-cat.io/v1/config/app%20workflows%2Fproject"]
+        expect(path.fallbackUrls).to(beEmpty())
+    }
+
+    func testFallbackConfigPathUsesFallbackHostAndEscapesDomain() {
+        let path = HTTPRequest.Path.fallbackConfig(domain: "app workflows/project")
+
+        expect(path.relativePath) == "/v1/config/app%20workflows%2Fproject"
+        expect(path.url?.absoluteString)
+            == "https://api-production.8-lives-cat.io/v1/config/app%20workflows%2Fproject"
+        expect(path.fallbackUrls).to(beEmpty())
     }
 
     func testUserIDEscaping() {
@@ -310,6 +319,23 @@ class HTTPRequestTests: TestCase {
         expect(headers[HTTPClient.RequestHeader.accept.rawValue]) == HTTPClient.rcContainerFormatAcceptHeaderValue
         expect(headers[HTTPClient.RequestHeader.acceptRCElementEncoding.rawValue])
             == HTTPClient.rcContainerFormatElementEncodingHeaderValue
+        expect(headers["Accept-Encoding"]).to(beNil())
+    }
+
+    func testFallbackConfigUsesJSONAcceptHeaders() {
+        let request: HTTPRequest = .init(
+            method: .get,
+            path: .fallbackConfig(domain: "app")
+        )
+        let headers = request.headers(
+            with: [:],
+            defaultHeaders: [:],
+            verificationMode: .disabled,
+            internalSettings: DangerousSettings.Internal.default
+        )
+
+        expect(headers[HTTPClient.RequestHeader.accept.rawValue]) == "application/json"
+        expect(headers[HTTPClient.RequestHeader.acceptRCElementEncoding.rawValue]).to(beNil())
         expect(headers["Accept-Encoding"]).to(beNil())
     }
 }

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -37,16 +37,14 @@ class HTTPRequestTests: TestCase {
         .health,
         .getProductEntitlementMapping,
         .rewardVerificationStatus(appUserID: userID, clientTransactionID: clientTransactionID),
-        .remoteConfig(domain: "app"),
-        .remoteConfigStaticFallback(domain: "app")
+        .remoteConfig(domain: "app")
     ]
     private static let unauthenticatedPaths: Set<HTTPRequest.Path> = [
         .health
     ]
     private static let pathsWithoutETags: Set<HTTPRequest.Path> = [
         .health,
-        .remoteConfig(domain: "app"),
-        .remoteConfigStaticFallback(domain: "app")
+        .remoteConfig(domain: "app")
     ]
     private static let pathsWithSignatureVerification: Set<HTTPRequest.Path> = [
         .getCustomerInfo(appUserID: userID),
@@ -56,8 +54,7 @@ class HTTPRequestTests: TestCase {
         .getOfferings(appUserID: userID),
         .getProductEntitlementMapping,
         .rewardVerificationStatus(appUserID: userID, clientTransactionID: clientTransactionID),
-        .remoteConfig(domain: "app"),
-        .remoteConfigStaticFallback(domain: "app")
+        .remoteConfig(domain: "app")
     ]
     private static let pathsThatRequireNonce: Set<HTTPRequest.Path> = [
         .getCustomerInfo(appUserID: userID),
@@ -175,8 +172,7 @@ class HTTPRequestTests: TestCase {
 
         expect(staticEndpoints) == [
             .getOfferings(appUserID: Self.userID),
-            .getProductEntitlementMapping,
-            .remoteConfigStaticFallback(domain: "app")
+            .getProductEntitlementMapping
         ]
     }
 
@@ -217,12 +213,17 @@ class HTTPRequestTests: TestCase {
     }
 
     func testFallbackConfigPathUsesFallbackHostAndEscapesDomain() {
-        let path = HTTPRequest.Path.remoteConfigStaticFallback(domain: "app workflows/project")
+        let path = HTTPRequest.StaticFallbackPath.remoteConfig(domain: "app workflows/project")
 
         expect(path.relativePath) == "/v1/config/app%20workflows%2Fproject"
         expect(path.url?.absoluteString)
             == "https://api-production.8-lives-cat.io/v1/config/app%20workflows%2Fproject"
         expect(path.fallbackUrls).to(beEmpty())
+        expect(path.authenticated).to(beTrue())
+        expect(path.shouldSendEtag).to(beFalse())
+        expect(path.supportsSignatureVerification).to(beTrue())
+        expect(path.needsNonceForSigning).to(beFalse())
+        expect(path.name) == "remote_config_static_fallback"
     }
 
     func testUserIDEscaping() {
@@ -307,7 +308,7 @@ class HTTPRequestTests: TestCase {
     func testRemoteConfigUsesRCContainerAcceptHeaders() {
         let request: HTTPRequest = .init(
             method: .post(RemoteConfigRequest(appUserID: "app-user-id")),
-            path: .remoteConfig(domain: "app")
+            path: HTTPRequest.Path.remoteConfig(domain: "app")
         )
         let headers = request.headers(
             with: [:],
@@ -325,7 +326,7 @@ class HTTPRequestTests: TestCase {
     func testFallbackConfigUsesJSONAcceptHeaders() {
         let request: HTTPRequest = .init(
             method: .get,
-            path: .remoteConfigStaticFallback(domain: "app")
+            path: HTTPRequest.StaticFallbackPath.remoteConfig(domain: "app")
         )
         let headers = request.headers(
             with: [:],

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -38,7 +38,7 @@ class HTTPRequestTests: TestCase {
         .getProductEntitlementMapping,
         .rewardVerificationStatus(appUserID: userID, clientTransactionID: clientTransactionID),
         .remoteConfig(domain: "app"),
-        .fallbackConfig(domain: "app")
+        .remoteConfigStaticFallback(domain: "app")
     ]
     private static let unauthenticatedPaths: Set<HTTPRequest.Path> = [
         .health
@@ -46,7 +46,7 @@ class HTTPRequestTests: TestCase {
     private static let pathsWithoutETags: Set<HTTPRequest.Path> = [
         .health,
         .remoteConfig(domain: "app"),
-        .fallbackConfig(domain: "app")
+        .remoteConfigStaticFallback(domain: "app")
     ]
     private static let pathsWithSignatureVerification: Set<HTTPRequest.Path> = [
         .getCustomerInfo(appUserID: userID),
@@ -57,7 +57,7 @@ class HTTPRequestTests: TestCase {
         .getProductEntitlementMapping,
         .rewardVerificationStatus(appUserID: userID, clientTransactionID: clientTransactionID),
         .remoteConfig(domain: "app"),
-        .fallbackConfig(domain: "app")
+        .remoteConfigStaticFallback(domain: "app")
     ]
     private static let pathsThatRequireNonce: Set<HTTPRequest.Path> = [
         .getCustomerInfo(appUserID: userID),
@@ -176,7 +176,7 @@ class HTTPRequestTests: TestCase {
         expect(staticEndpoints) == [
             .getOfferings(appUserID: Self.userID),
             .getProductEntitlementMapping,
-            .fallbackConfig(domain: "app")
+            .remoteConfigStaticFallback(domain: "app")
         ]
     }
 
@@ -217,7 +217,7 @@ class HTTPRequestTests: TestCase {
     }
 
     func testFallbackConfigPathUsesFallbackHostAndEscapesDomain() {
-        let path = HTTPRequest.Path.fallbackConfig(domain: "app workflows/project")
+        let path = HTTPRequest.Path.remoteConfigStaticFallback(domain: "app workflows/project")
 
         expect(path.relativePath) == "/v1/config/app%20workflows%2Fproject"
         expect(path.url?.absoluteString)
@@ -325,7 +325,7 @@ class HTTPRequestTests: TestCase {
     func testFallbackConfigUsesJSONAcceptHeaders() {
         let request: HTTPRequest = .init(
             method: .get,
-            path: .fallbackConfig(domain: "app")
+            path: .remoteConfigStaticFallback(domain: "app")
         )
         let headers = request.headers(
             with: [:],

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -220,7 +220,7 @@ class HTTPRequestTests: TestCase {
             == "https://api-production.8-lives-cat.io/v1/config/app%20workflows%2Fproject"
         expect(path.fallbackUrls).to(beEmpty())
         expect(path.authenticated).to(beTrue())
-        expect(path.shouldSendEtag).to(beFalse())
+        expect(path.shouldSendEtag).to(beTrue())
         expect(path.supportsSignatureVerification).to(beTrue())
         expect(path.needsNonceForSigning).to(beFalse())
         expect(path.name) == "remote_config_fallback"

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -213,7 +213,7 @@ class HTTPRequestTests: TestCase {
     }
 
     func testFallbackConfigPathUsesFallbackHostAndEscapesDomain() {
-        let path = HTTPRequest.StaticFallbackPath.remoteConfig(domain: "app workflows/project")
+        let path = HTTPRequest.FallbackPath.remoteConfig(domain: "app workflows/project")
 
         expect(path.relativePath) == "/v1/config/app%20workflows%2Fproject"
         expect(path.url?.absoluteString)
@@ -223,7 +223,7 @@ class HTTPRequestTests: TestCase {
         expect(path.shouldSendEtag).to(beFalse())
         expect(path.supportsSignatureVerification).to(beTrue())
         expect(path.needsNonceForSigning).to(beFalse())
-        expect(path.name) == "remote_config_static_fallback"
+        expect(path.name) == "remote_config_fallback"
     }
 
     func testUserIDEscaping() {
@@ -326,7 +326,7 @@ class HTTPRequestTests: TestCase {
     func testFallbackConfigDoesNotRequestRCContainerFormat() {
         let request: HTTPRequest = .init(
             method: .get,
-            path: HTTPRequest.StaticFallbackPath.remoteConfig(domain: "app")
+            path: HTTPRequest.FallbackPath.remoteConfig(domain: "app")
         )
         let headers = request.headers(
             with: [:],

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -323,7 +323,7 @@ class HTTPRequestTests: TestCase {
         expect(headers["Accept-Encoding"]).to(beNil())
     }
 
-    func testFallbackConfigUsesJSONAcceptHeaders() {
+    func testFallbackConfigDoesNotRequestRCContainerFormat() {
         let request: HTTPRequest = .init(
             method: .get,
             path: HTTPRequest.StaticFallbackPath.remoteConfig(domain: "app")
@@ -335,7 +335,7 @@ class HTTPRequestTests: TestCase {
             internalSettings: DangerousSettings.Internal.default
         )
 
-        expect(headers[HTTPClient.RequestHeader.accept.rawValue]) == "application/json"
+        expect(headers[HTTPClient.RequestHeader.accept.rawValue]).to(beNil())
         expect(headers[HTTPClient.RequestHeader.acceptRCElementEncoding.rawValue]).to(beNil())
         expect(headers["Accept-Encoding"]).to(beNil())
     }

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
@@ -582,7 +582,7 @@ private extension RemoteConfigIntegrationTests {
         verificationResult: VerificationResult = .verified
     ) {
         self.httpClient.mock(
-            requestPath: .remoteConfig(domain: RemoteConfiguration.defaultDomain),
+            requestPath: HTTPRequest.Path.remoteConfig(domain: RemoteConfiguration.defaultDomain),
             response: .init(statusCode: statusCode, body: body, verificationResult: verificationResult)
         )
     }
@@ -593,14 +593,14 @@ private extension RemoteConfigIntegrationTests {
         verificationResult: VerificationResult = .verified
     ) {
         self.httpClient.mock(
-            requestPath: .remoteConfigStaticFallback(domain: RemoteConfiguration.defaultDomain),
+            requestPath: HTTPRequest.StaticFallbackPath.remoteConfig(domain: RemoteConfiguration.defaultDomain),
             response: .init(statusCode: statusCode, body: body, verificationResult: verificationResult)
         )
     }
 
     func mockRemoteConfigError(_ error: NetworkError) {
         self.httpClient.mock(
-            requestPath: .remoteConfig(domain: RemoteConfiguration.defaultDomain),
+            requestPath: HTTPRequest.Path.remoteConfig(domain: RemoteConfiguration.defaultDomain),
             response: .init(error: error)
         )
     }
@@ -614,7 +614,7 @@ private extension RemoteConfigIntegrationTests {
     var remoteConfigStaticFallbackRequestCount: Int {
         return self.httpClient.calls.filter {
             $0.request.path.url
-                == HTTPRequest.Path.remoteConfigStaticFallback(domain: RemoteConfiguration.defaultDomain).url
+                == HTTPRequest.StaticFallbackPath.remoteConfig(domain: RemoteConfiguration.defaultDomain).url
         }.count
     }
 

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
@@ -229,6 +229,27 @@ final class RemoteConfigIntegrationTests: TestCase {
         expect(self.blobStore.read(ref: ref)) == blob
     }
 
+    func testStaticFallbackConfigDownloadsExternalBlobThroughFacade() async throws {
+        let blob = #"{"workflow":"static-fallback"}"#.asData
+        let ref = RCContainerTestData.blobRef(for: blob)
+        let source = Self.blobSource("primary")
+        let topics = Self.topics(
+            sources: Self.sourcesTopic(blobSources: [source]),
+            workflows: Self.workflowTopic(ref: ref)
+        )
+        await self.downloader.setResponse(.success(blob), for: source, ref: ref)
+
+        await self.refreshFromStaticFallback(with: try Self.configData(topics: topics))
+
+        let maybeData = await self.manager.blobData(for: .workflows, itemKey: "default")
+        let data = try XCTUnwrap(maybeData)
+        let requestedURLs = await self.downloader.requestedURLStrings()
+
+        expect(data) == blob
+        expect(requestedURLs) == [Self.url(source, ref: ref)]
+        expect(self.blobStore.read(ref: ref)) == blob
+    }
+
     func testMixedInlineAndExternalBlobsOnlyDownloadsExternalBlob() async throws {
         let inlineBlob = #"{"workflow":"inline"}"#.asData
         let externalBlob = #"{"workflow":"external"}"#.asData
@@ -539,6 +560,22 @@ private extension RemoteConfigIntegrationTests {
         await self.waitForPersistedManifest(Self.manifest)
     }
 
+    func refreshFromStaticFallback(
+        with body: Data,
+        verificationResult: VerificationResult = .verified
+    ) async {
+        self.mockRemoteConfigError(.errorResponse(
+            .init(code: .unknownError, originalCode: BackendErrorCode.unknownError.rawValue),
+            .internalServerError
+        ))
+        self.mockRemoteConfigStaticFallbackResponse(body: body, verificationResult: verificationResult)
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        await self.waitForRemoteConfigRequestCount(1)
+        await self.waitForRemoteConfigStaticFallbackRequestCount(1)
+        await self.waitForPersistedManifest(Self.manifest)
+    }
+
     func mockRemoteConfigResponse(
         statusCode: HTTPStatusCode = .success,
         body: Data,
@@ -546,6 +583,17 @@ private extension RemoteConfigIntegrationTests {
     ) {
         self.httpClient.mock(
             requestPath: .remoteConfig(domain: RemoteConfiguration.defaultDomain),
+            response: .init(statusCode: statusCode, body: body, verificationResult: verificationResult)
+        )
+    }
+
+    func mockRemoteConfigStaticFallbackResponse(
+        statusCode: HTTPStatusCode = .success,
+        body: Data,
+        verificationResult: VerificationResult = .verified
+    ) {
+        self.httpClient.mock(
+            requestPath: .remoteConfigStaticFallback(domain: RemoteConfiguration.defaultDomain),
             response: .init(statusCode: statusCode, body: body, verificationResult: verificationResult)
         )
     }
@@ -563,6 +611,13 @@ private extension RemoteConfigIntegrationTests {
         }.count
     }
 
+    var remoteConfigStaticFallbackRequestCount: Int {
+        return self.httpClient.calls.filter {
+            $0.request.path.url
+                == HTTPRequest.Path.remoteConfigStaticFallback(domain: RemoteConfiguration.defaultDomain).url
+        }.count
+    }
+
     func waitForRemoteConfigRequestCount(
         _ count: Int,
         file: StaticString = #filePath,
@@ -570,6 +625,16 @@ private extension RemoteConfigIntegrationTests {
     ) async {
         await self.waitUntil(file: file, line: line) {
             self.remoteConfigRequestCount >= count
+        }
+    }
+
+    func waitForRemoteConfigStaticFallbackRequestCount(
+        _ count: Int,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        await self.waitUntil(file: file, line: line) {
+            self.remoteConfigStaticFallbackRequestCount >= count
         }
     }
 

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
@@ -229,8 +229,8 @@ final class RemoteConfigIntegrationTests: TestCase {
         expect(self.blobStore.read(ref: ref)) == blob
     }
 
-    func testStaticFallbackConfigDownloadsExternalBlobThroughFacade() async throws {
-        let blob = #"{"workflow":"static-fallback"}"#.asData
+    func testFallbackConfigDownloadsExternalBlobThroughFacade() async throws {
+        let blob = #"{"workflow":"fallback"}"#.asData
         let ref = RCContainerTestData.blobRef(for: blob)
         let source = Self.blobSource("primary")
         let topics = Self.topics(
@@ -239,7 +239,7 @@ final class RemoteConfigIntegrationTests: TestCase {
         )
         await self.downloader.setResponse(.success(blob), for: source, ref: ref)
 
-        await self.refreshFromStaticFallback(with: try Self.configData(topics: topics))
+        await self.refreshFromFallback(with: try Self.configData(topics: topics))
 
         let maybeData = await self.manager.blobData(for: .workflows, itemKey: "default")
         let data = try XCTUnwrap(maybeData)
@@ -560,7 +560,7 @@ private extension RemoteConfigIntegrationTests {
         await self.waitForPersistedManifest(Self.manifest)
     }
 
-    func refreshFromStaticFallback(
+    func refreshFromFallback(
         with body: Data,
         verificationResult: VerificationResult = .verified
     ) async {
@@ -568,11 +568,11 @@ private extension RemoteConfigIntegrationTests {
             .init(code: .unknownError, originalCode: BackendErrorCode.unknownError.rawValue),
             .internalServerError
         ))
-        self.mockRemoteConfigStaticFallbackResponse(body: body, verificationResult: verificationResult)
+        self.mockRemoteConfigFallbackResponse(body: body, verificationResult: verificationResult)
 
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         await self.waitForRemoteConfigRequestCount(1)
-        await self.waitForRemoteConfigStaticFallbackRequestCount(1)
+        await self.waitForRemoteConfigFallbackRequestCount(1)
         await self.waitForPersistedManifest(Self.manifest)
     }
 
@@ -587,13 +587,13 @@ private extension RemoteConfigIntegrationTests {
         )
     }
 
-    func mockRemoteConfigStaticFallbackResponse(
+    func mockRemoteConfigFallbackResponse(
         statusCode: HTTPStatusCode = .success,
         body: Data,
         verificationResult: VerificationResult = .verified
     ) {
         self.httpClient.mock(
-            requestPath: HTTPRequest.StaticFallbackPath.remoteConfig(domain: RemoteConfiguration.defaultDomain),
+            requestPath: HTTPRequest.FallbackPath.remoteConfig(domain: RemoteConfiguration.defaultDomain),
             response: .init(statusCode: statusCode, body: body, verificationResult: verificationResult)
         )
     }
@@ -611,10 +611,10 @@ private extension RemoteConfigIntegrationTests {
         }.count
     }
 
-    var remoteConfigStaticFallbackRequestCount: Int {
+    var remoteConfigFallbackRequestCount: Int {
         return self.httpClient.calls.filter {
             $0.request.path.url
-                == HTTPRequest.StaticFallbackPath.remoteConfig(domain: RemoteConfiguration.defaultDomain).url
+                == HTTPRequest.FallbackPath.remoteConfig(domain: RemoteConfiguration.defaultDomain).url
         }.count
     }
 
@@ -628,13 +628,13 @@ private extension RemoteConfigIntegrationTests {
         }
     }
 
-    func waitForRemoteConfigStaticFallbackRequestCount(
+    func waitForRemoteConfigFallbackRequestCount(
         _ count: Int,
         file: StaticString = #filePath,
         line: UInt = #line
     ) async {
         await self.waitUntil(file: file, line: line) {
-            self.remoteConfigStaticFallbackRequestCount >= count
+            self.remoteConfigFallbackRequestCount >= count
         }
     }
 

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -88,7 +88,7 @@ final class RemoteConfigManagerTests: TestCase {
     func testFailureDoesNotMarkRefreshAsFresh() {
         self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1)))))
-        self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
+        self.remoteConfigAPI.completeStaticFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
 
         self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
 
@@ -1321,7 +1321,7 @@ final class RemoteConfigManagerTests: TestCase {
         self.remoteConfigAPI.complete(
             with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1))))
         )
-        self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
+        self.remoteConfigAPI.completeStaticFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
 
         expect(self.diskCache.invokedWriteCount) == 0
         expect(self.blobStore.invokedWriteCount) == 0
@@ -1389,7 +1389,7 @@ final class RemoteConfigManagerTests: TestCase {
     func testServerErrorDoesNotDisableRemoteConfig() {
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
-        self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
+        self.remoteConfigAPI.completeStaticFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
         expect(self.manager.isDisabled) == false
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
@@ -1401,9 +1401,9 @@ final class RemoteConfigManagerTests: TestCase {
         self.manager.refreshRemoteConfig(isAppBackgrounded: true)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
 
-        expect(self.remoteConfigAPI.invokedGetFallbackConfigCount) == 1
-        expect(self.remoteConfigAPI.invokedGetFallbackConfigParameters?.domain) == "app"
-        expect(self.remoteConfigAPI.invokedGetFallbackConfigParameters?.isAppBackgrounded) == true
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigStaticFallbackCount) == 1
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigStaticFallbackParameters?.domain) == "app"
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigStaticFallbackParameters?.isAppBackgrounded) == true
     }
 
     func testPrimaryServerErrorWithPersistedCacheDoesNotTriggerFallbackConfigRequest() {
@@ -1413,7 +1413,7 @@ final class RemoteConfigManagerTests: TestCase {
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
 
         expect(self.manager.isDisabled) == false
-        expect(self.remoteConfigAPI.invokedGetFallbackConfigCount) == 0
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigStaticFallbackCount) == 0
         expect(self.diskCache.invokedWriteCount) == 0
     }
 
@@ -1422,7 +1422,7 @@ final class RemoteConfigManagerTests: TestCase {
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
 
         expect(self.manager.isDisabled) == true
-        expect(self.remoteConfigAPI.invokedGetFallbackConfigCount) == 0
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigStaticFallbackCount) == 0
     }
 
     func testFallbackConfigSuccessPersistsConfigurationWithoutInlineBlobExtraction() {
@@ -1440,7 +1440,7 @@ final class RemoteConfigManagerTests: TestCase {
 
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
-        self.remoteConfigAPI.completeFallback(with: .success(.test(configuration: configuration)))
+        self.remoteConfigAPI.completeStaticFallback(with: .success(.test(configuration: configuration)))
 
         expect(self.diskCache.invokedWriteCount) == 1
         expect(self.diskCache.invokedWriteParameter?.manifest) == "v1.1710000100.workflows:etag2"
@@ -1455,7 +1455,7 @@ final class RemoteConfigManagerTests: TestCase {
     func testFallbackConfigFailureLeavesCacheUntouchedAndDoesNotMarkRefreshFresh() {
         self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
-        self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
+        self.remoteConfigAPI.completeStaticFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
 
         self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
 
@@ -1471,7 +1471,7 @@ final class RemoteConfigManagerTests: TestCase {
         self.remoteConfigAPI.complete(
             with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1))))
         )
-        self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
+        self.remoteConfigAPI.completeStaticFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
         expect(self.manager.isDisabled) == false
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
@@ -1711,7 +1711,7 @@ final class RemoteConfigManagerTests: TestCase {
         await self.waitForRemoteConfigRequestCount(1)
         await self.waitForDiskCacheReadCount(2)
         self.remoteConfigAPI.complete(with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1)))))
-        self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
+        self.remoteConfigAPI.completeStaticFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
 
         let data = await task.value
         expect(data).to(beNil())
@@ -2685,15 +2685,15 @@ private extension RemoteConfigFetchResult {
 
 }
 
-private extension RemoteConfigFallbackFetchResult {
+private extension RemoteConfigStaticFallbackFetchResult {
 
     /// Builds a fallback fetch result through the production initializer. A `nil` configuration
     /// represents a `204 No Content` response.
     static func test(
         configuration: RemoteConfiguration?,
         verificationResult: VerificationResult = .verified
-    ) -> RemoteConfigFallbackFetchResult {
-        return RemoteConfigFallbackFetchResult(response: .init(
+    ) -> RemoteConfigStaticFallbackFetchResult {
+        return RemoteConfigStaticFallbackFetchResult(response: .init(
             httpStatusCode: configuration == nil ? .noContent : .success,
             responseHeaders: [:],
             body: configuration,
@@ -2716,18 +2716,18 @@ private final class MockRemoteConfigAPI: RemoteConfigAPIType {
         request: RemoteConfigRequest,
         isAppBackgrounded: Bool
     )] = []
-    private(set) var invokedGetFallbackConfigCount = 0
-    private(set) var invokedGetFallbackConfigParameters: (
+    private(set) var invokedGetRemoteConfigStaticFallbackCount = 0
+    private(set) var invokedGetRemoteConfigStaticFallbackParameters: (
         domain: String,
         isAppBackgrounded: Bool
     )?
-    private(set) var invokedGetFallbackConfigParametersList: [(
+    private(set) var invokedGetRemoteConfigStaticFallbackParametersList: [(
         domain: String,
         isAppBackgrounded: Bool
     )] = []
 
     private var completions: [Backend.ResponseHandler<RemoteConfigFetchResult>] = []
-    private var fallbackCompletions: [Backend.ResponseHandler<RemoteConfigFallbackFetchResult>] = []
+    private var staticFallbackCompletions: [Backend.ResponseHandler<RemoteConfigStaticFallbackFetchResult>] = []
 
     func getRemoteConfig(
         request: RemoteConfigRequest,
@@ -2740,23 +2740,23 @@ private final class MockRemoteConfigAPI: RemoteConfigAPIType {
         self.completions.append(completion)
     }
 
-    func getFallbackConfig(
+    func getRemoteConfigStaticFallback(
         domain: String,
         isAppBackgrounded: Bool,
-        completion: @escaping Backend.ResponseHandler<RemoteConfigFallbackFetchResult>
+        completion: @escaping Backend.ResponseHandler<RemoteConfigStaticFallbackFetchResult>
     ) {
-        self.invokedGetFallbackConfigCount += 1
-        self.invokedGetFallbackConfigParameters = (domain, isAppBackgrounded)
-        self.invokedGetFallbackConfigParametersList.append((domain, isAppBackgrounded))
-        self.fallbackCompletions.append(completion)
+        self.invokedGetRemoteConfigStaticFallbackCount += 1
+        self.invokedGetRemoteConfigStaticFallbackParameters = (domain, isAppBackgrounded)
+        self.invokedGetRemoteConfigStaticFallbackParametersList.append((domain, isAppBackgrounded))
+        self.staticFallbackCompletions.append(completion)
     }
 
     func complete(with result: Result<RemoteConfigFetchResult, BackendError>) {
         self.completions.last?(result)
     }
 
-    func completeFallback(with result: Result<RemoteConfigFallbackFetchResult, BackendError>) {
-        self.fallbackCompletions.last?(result)
+    func completeStaticFallback(with result: Result<RemoteConfigStaticFallbackFetchResult, BackendError>) {
+        self.staticFallbackCompletions.last?(result)
     }
 
     func complete(

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -85,17 +85,6 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
     }
 
-    func testFallbackNoContentResponseMarksRefreshAsFresh() {
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
-        self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
-        self.remoteConfigAPI.completeFallback(with: .success(.test(configuration: nil)))
-
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
-
-        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
-        expect(self.remoteConfigAPI.invokedGetRemoteConfigFallbackCount) == 1
-    }
-
     func testFailureDoesNotMarkRefreshAsFresh() {
         self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1)))))
@@ -2710,14 +2699,12 @@ private extension RemoteConfigFetchResult {
 
 private extension RemoteConfigFallbackFetchResult {
 
-    /// Builds a fallback fetch result through the production initializer. A `nil` configuration
-    /// represents a `204 No Content` response.
     static func test(
-        configuration: RemoteConfiguration?,
+        configuration: RemoteConfiguration,
         verificationResult: VerificationResult = .verified
     ) -> RemoteConfigFallbackFetchResult {
         return RemoteConfigFallbackFetchResult(response: .init(
-            httpStatusCode: configuration == nil ? .noContent : .success,
+            httpStatusCode: .success,
             responseHeaders: [:],
             body: configuration,
             verificationResult: verificationResult,

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -1428,6 +1428,18 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.diskCache.invokedWriteCount) == 0
     }
 
+    func testPrimaryServerErrorWithProxyURLDoesNotTriggerFallbackConfigRequest() throws {
+        SystemInfo.proxyURL = try XCTUnwrap(URL(string: "https://proxy.revenuecat.com"))
+        defer { SystemInfo.proxyURL = nil }
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+        self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
+
+        expect(self.manager.isDisabled) == false
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigFallbackCount) == 0
+        expect(self.diskCache.invokedWriteCount) == 0
+    }
+
     func testPrimaryClientErrorDisablesRemoteConfigAndDoesNotTriggerFallbackConfigRequest() {
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -85,21 +85,21 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
     }
 
-    func testStaticFallbackNoContentResponseMarksRefreshAsFresh() {
+    func testFallbackNoContentResponseMarksRefreshAsFresh() {
         self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
-        self.remoteConfigAPI.completeStaticFallback(with: .success(.test(configuration: nil)))
+        self.remoteConfigAPI.completeFallback(with: .success(.test(configuration: nil)))
 
         self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
-        expect(self.remoteConfigAPI.invokedGetRemoteConfigStaticFallbackCount) == 1
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigFallbackCount) == 1
     }
 
     func testFailureDoesNotMarkRefreshAsFresh() {
         self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1)))))
-        self.remoteConfigAPI.completeStaticFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
+        self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
 
         self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
 
@@ -1332,7 +1332,7 @@ final class RemoteConfigManagerTests: TestCase {
         self.remoteConfigAPI.complete(
             with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1))))
         )
-        self.remoteConfigAPI.completeStaticFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
+        self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
 
         expect(self.diskCache.invokedWriteCount) == 0
         expect(self.blobStore.invokedWriteCount) == 0
@@ -1400,7 +1400,7 @@ final class RemoteConfigManagerTests: TestCase {
     func testServerErrorDoesNotDisableRemoteConfig() {
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
-        self.remoteConfigAPI.completeStaticFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
+        self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
         expect(self.manager.isDisabled) == false
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
@@ -1412,9 +1412,9 @@ final class RemoteConfigManagerTests: TestCase {
         self.manager.refreshRemoteConfig(isAppBackgrounded: true)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
 
-        expect(self.remoteConfigAPI.invokedGetRemoteConfigStaticFallbackCount) == 1
-        expect(self.remoteConfigAPI.invokedGetRemoteConfigStaticFallbackParameters?.domain) == "app"
-        expect(self.remoteConfigAPI.invokedGetRemoteConfigStaticFallbackParameters?.isAppBackgrounded) == true
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigFallbackCount) == 1
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigFallbackParameters?.domain) == "app"
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigFallbackParameters?.isAppBackgrounded) == true
     }
 
     func testPrimaryServerErrorWithPersistedCacheDoesNotTriggerFallbackConfigRequest() {
@@ -1424,7 +1424,7 @@ final class RemoteConfigManagerTests: TestCase {
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
 
         expect(self.manager.isDisabled) == false
-        expect(self.remoteConfigAPI.invokedGetRemoteConfigStaticFallbackCount) == 0
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigFallbackCount) == 0
         expect(self.diskCache.invokedWriteCount) == 0
     }
 
@@ -1433,7 +1433,7 @@ final class RemoteConfigManagerTests: TestCase {
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
 
         expect(self.manager.isDisabled) == true
-        expect(self.remoteConfigAPI.invokedGetRemoteConfigStaticFallbackCount) == 0
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigFallbackCount) == 0
     }
 
     func testFallbackConfigSuccessPersistsConfigurationWithoutInlineBlobExtraction() {
@@ -1451,7 +1451,7 @@ final class RemoteConfigManagerTests: TestCase {
 
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
-        self.remoteConfigAPI.completeStaticFallback(with: .success(.test(configuration: configuration)))
+        self.remoteConfigAPI.completeFallback(with: .success(.test(configuration: configuration)))
 
         expect(self.diskCache.invokedWriteCount) == 1
         expect(self.diskCache.invokedWriteParameter?.manifest) == "v1.1710000100.workflows:etag2"
@@ -1466,7 +1466,7 @@ final class RemoteConfigManagerTests: TestCase {
     func testFallbackConfigFailureLeavesCacheUntouchedAndDoesNotMarkRefreshFresh() {
         self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
-        self.remoteConfigAPI.completeStaticFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
+        self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
 
         self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
 
@@ -1482,7 +1482,7 @@ final class RemoteConfigManagerTests: TestCase {
         self.remoteConfigAPI.complete(
             with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1))))
         )
-        self.remoteConfigAPI.completeStaticFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
+        self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
         expect(self.manager.isDisabled) == false
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
@@ -1722,7 +1722,7 @@ final class RemoteConfigManagerTests: TestCase {
         await self.waitForRemoteConfigRequestCount(1)
         await self.waitForDiskCacheReadCount(2)
         self.remoteConfigAPI.complete(with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1)))))
-        self.remoteConfigAPI.completeStaticFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
+        self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
 
         let data = await task.value
         expect(data).to(beNil())
@@ -2696,15 +2696,15 @@ private extension RemoteConfigFetchResult {
 
 }
 
-private extension RemoteConfigStaticFallbackFetchResult {
+private extension RemoteConfigFallbackFetchResult {
 
     /// Builds a fallback fetch result through the production initializer. A `nil` configuration
     /// represents a `204 No Content` response.
     static func test(
         configuration: RemoteConfiguration?,
         verificationResult: VerificationResult = .verified
-    ) -> RemoteConfigStaticFallbackFetchResult {
-        return RemoteConfigStaticFallbackFetchResult(response: .init(
+    ) -> RemoteConfigFallbackFetchResult {
+        return RemoteConfigFallbackFetchResult(response: .init(
             httpStatusCode: configuration == nil ? .noContent : .success,
             responseHeaders: [:],
             body: configuration,
@@ -2727,18 +2727,18 @@ private final class MockRemoteConfigAPI: RemoteConfigAPIType {
         request: RemoteConfigRequest,
         isAppBackgrounded: Bool
     )] = []
-    private(set) var invokedGetRemoteConfigStaticFallbackCount = 0
-    private(set) var invokedGetRemoteConfigStaticFallbackParameters: (
+    private(set) var invokedGetRemoteConfigFallbackCount = 0
+    private(set) var invokedGetRemoteConfigFallbackParameters: (
         domain: String,
         isAppBackgrounded: Bool
     )?
-    private(set) var invokedGetRemoteConfigStaticFallbackParametersList: [(
+    private(set) var invokedGetRemoteConfigFallbackParametersList: [(
         domain: String,
         isAppBackgrounded: Bool
     )] = []
 
     private var completions: [Backend.ResponseHandler<RemoteConfigFetchResult>] = []
-    private var staticFallbackCompletions: [Backend.ResponseHandler<RemoteConfigStaticFallbackFetchResult>] = []
+    private var fallbackCompletions: [Backend.ResponseHandler<RemoteConfigFallbackFetchResult>] = []
 
     func getRemoteConfig(
         request: RemoteConfigRequest,
@@ -2751,23 +2751,23 @@ private final class MockRemoteConfigAPI: RemoteConfigAPIType {
         self.completions.append(completion)
     }
 
-    func getRemoteConfigStaticFallback(
+    func getRemoteConfigFallback(
         domain: String,
         isAppBackgrounded: Bool,
-        completion: @escaping Backend.ResponseHandler<RemoteConfigStaticFallbackFetchResult>
+        completion: @escaping Backend.ResponseHandler<RemoteConfigFallbackFetchResult>
     ) {
-        self.invokedGetRemoteConfigStaticFallbackCount += 1
-        self.invokedGetRemoteConfigStaticFallbackParameters = (domain, isAppBackgrounded)
-        self.invokedGetRemoteConfigStaticFallbackParametersList.append((domain, isAppBackgrounded))
-        self.staticFallbackCompletions.append(completion)
+        self.invokedGetRemoteConfigFallbackCount += 1
+        self.invokedGetRemoteConfigFallbackParameters = (domain, isAppBackgrounded)
+        self.invokedGetRemoteConfigFallbackParametersList.append((domain, isAppBackgrounded))
+        self.fallbackCompletions.append(completion)
     }
 
     func complete(with result: Result<RemoteConfigFetchResult, BackendError>) {
         self.completions.last?(result)
     }
 
-    func completeStaticFallback(with result: Result<RemoteConfigStaticFallbackFetchResult, BackendError>) {
-        self.staticFallbackCompletions.last?(result)
+    func completeFallback(with result: Result<RemoteConfigFallbackFetchResult, BackendError>) {
+        self.fallbackCompletions.last?(result)
     }
 
     func complete(

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -1397,6 +1397,19 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.diskCache.invokedReadCount) == 2
     }
 
+    func testFallbackClientErrorDisablesRemoteConfig() {
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
+        self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .invalidRequest)))
+        expect(self.manager.isDisabled) == true
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigFallbackCount) == 1
+        expect(self.diskCache.invokedReadCount) == 1
+    }
+
     func testPrimaryServerErrorTriggersFallbackConfigRequest() {
         self.manager.refreshRemoteConfig(isAppBackgrounded: true)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -88,6 +88,7 @@ final class RemoteConfigManagerTests: TestCase {
     func testFailureDoesNotMarkRefreshAsFresh() {
         self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1)))))
+        self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
 
         self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
 
@@ -1320,6 +1321,7 @@ final class RemoteConfigManagerTests: TestCase {
         self.remoteConfigAPI.complete(
             with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1))))
         )
+        self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
 
         expect(self.diskCache.invokedWriteCount) == 0
         expect(self.blobStore.invokedWriteCount) == 0
@@ -1387,6 +1389,7 @@ final class RemoteConfigManagerTests: TestCase {
     func testServerErrorDoesNotDisableRemoteConfig() {
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
+        self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
         expect(self.manager.isDisabled) == false
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
@@ -1394,11 +1397,102 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.diskCache.invokedReadCount) == 2
     }
 
+    func testPrimaryServerErrorTriggersFallbackConfigRequest() {
+        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+        self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
+
+        expect(self.remoteConfigAPI.invokedGetFallbackConfigCount) == 1
+        expect(self.remoteConfigAPI.invokedGetFallbackConfigParameters?.domain) == "app"
+        expect(self.remoteConfigAPI.invokedGetFallbackConfigParameters?.isAppBackgrounded) == true
+    }
+
+    func testPrimaryClientErrorDisablesRemoteConfigAndDoesNotTriggerFallbackConfigRequest() {
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
+
+        expect(self.manager.isDisabled) == true
+        expect(self.remoteConfigAPI.invokedGetFallbackConfigCount) == 0
+    }
+
+    func testFallbackConfigSuccessPersistsConfigurationWithoutInlineBlobExtraction() {
+        let prefetchedRef = RCContainerTestData.blobRef(for: #"{"id":"prefetched"}"#.asData)
+        let retainedRef = RCContainerTestData.blobRef(for: #"{"id":"retained"}"#.asData)
+        let configuration = RemoteConfiguration(
+            domain: "app",
+            manifest: "v1.1710000100.workflows:etag2",
+            activeTopics: ["workflows"],
+            prefetchBlobs: [prefetchedRef],
+            topics: .init(entries: [
+                "workflows": ["default": .init(blobRef: retainedRef)]
+            ])
+        )
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
+        self.remoteConfigAPI.completeFallback(with: .success(.test(configuration: configuration)))
+
+        expect(self.diskCache.invokedWriteCount) == 1
+        expect(self.diskCache.invokedWriteParameter?.manifest) == "v1.1710000100.workflows:etag2"
+        expect(Self.blobRefsByTopic(from: self.diskCache.invokedWriteParameter?.topics)) == [
+            "workflows": [retainedRef]
+        ]
+        expect(self.blobStore.invokedWriteCount) == 0
+        expect(self.blobStore.invokedRetainOnlyParameters) == Set([prefetchedRef, retainedRef])
+        expect(self.blobFetcher.invokedPrefetchRefs) == [prefetchedRef]
+    }
+
+    func testFallbackConfigSuccessMergesUnchangedTopicsAndPrunesDroppedTopics() {
+        let keptRef = RCContainerTestData.blobRef(for: #"{"id":"kept"}"#.asData)
+        let prunedRef = RCContainerTestData.blobRef(for: #"{"id":"pruned"}"#.asData)
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.sources:etag1,workflows:etag1",
+            activeTopics: ["sources", "workflows"],
+            topics: .init(entries: [
+                "sources": ["api": .init(blobRef: keptRef)],
+                "workflows": ["removed": .init(blobRef: prunedRef)]
+            ])
+        )
+        let configuration = RemoteConfiguration(
+            domain: "app",
+            manifest: "v1.1710000100.sources:etag1,ui_config:etag2",
+            activeTopics: ["sources", "ui_config"],
+            topics: .init(entries: [
+                "ui_config": ["app": .init(content: ["enabled": true])]
+            ])
+        )
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
+        self.remoteConfigAPI.completeFallback(with: .success(.test(configuration: configuration)))
+
+        expect(self.diskCache.invokedWriteParameter?.activeTopics) == ["sources", "ui_config"]
+        expect(Self.blobRefsByTopic(from: self.diskCache.invokedWriteParameter?.topics)) == [
+            "sources": [keptRef],
+            "ui_config": []
+        ]
+        expect(self.blobStore.invokedRetainOnlyParameters) == Set([keptRef])
+    }
+
+    func testFallbackConfigFailureLeavesCacheUntouchedAndDoesNotMarkRefreshFresh() {
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
+        self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
+
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
+        expect(self.diskCache.invokedWriteCount) == 0
+        expect(self.blobStore.invokedWriteCount) == 0
+        expect(self.blobStore.invokedRetainOnlyCount) == 0
+        expect(self.blobFetcher.invokedPrefetchCount) == 0
+    }
+
     func testTransportNetworkErrorDoesNotDisableRemoteConfig() {
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1))))
         )
+        self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
         expect(self.manager.isDisabled) == false
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
 
@@ -1638,6 +1732,7 @@ final class RemoteConfigManagerTests: TestCase {
         await self.waitForRemoteConfigRequestCount(1)
         await self.waitForDiskCacheReadCount(2)
         self.remoteConfigAPI.complete(with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1)))))
+        self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
 
         let data = await task.value
         expect(data).to(beNil())
@@ -2611,6 +2706,26 @@ private extension RemoteConfigFetchResult {
 
 }
 
+private extension RemoteConfigFallbackFetchResult {
+
+    /// Builds a fallback fetch result through the production initializer. A `nil` configuration
+    /// represents a `204 No Content` response.
+    static func test(
+        configuration: RemoteConfiguration?,
+        verificationResult: VerificationResult = .verified
+    ) -> RemoteConfigFallbackFetchResult {
+        return RemoteConfigFallbackFetchResult(response: .init(
+            httpStatusCode: configuration == nil ? .noContent : .success,
+            responseHeaders: [:],
+            body: configuration,
+            verificationResult: verificationResult,
+            isLoadShedderResponse: false,
+            isFallbackUrlResponse: false
+        ))
+    }
+
+}
+
 private final class MockRemoteConfigAPI: RemoteConfigAPIType {
 
     private(set) var invokedGetRemoteConfigCount = 0
@@ -2622,8 +2737,18 @@ private final class MockRemoteConfigAPI: RemoteConfigAPIType {
         request: RemoteConfigRequest,
         isAppBackgrounded: Bool
     )] = []
+    private(set) var invokedGetFallbackConfigCount = 0
+    private(set) var invokedGetFallbackConfigParameters: (
+        domain: String,
+        isAppBackgrounded: Bool
+    )?
+    private(set) var invokedGetFallbackConfigParametersList: [(
+        domain: String,
+        isAppBackgrounded: Bool
+    )] = []
 
     private var completions: [Backend.ResponseHandler<RemoteConfigFetchResult>] = []
+    private var fallbackCompletions: [Backend.ResponseHandler<RemoteConfigFallbackFetchResult>] = []
 
     func getRemoteConfig(
         request: RemoteConfigRequest,
@@ -2636,8 +2761,23 @@ private final class MockRemoteConfigAPI: RemoteConfigAPIType {
         self.completions.append(completion)
     }
 
+    func getFallbackConfig(
+        domain: String,
+        isAppBackgrounded: Bool,
+        completion: @escaping Backend.ResponseHandler<RemoteConfigFallbackFetchResult>
+    ) {
+        self.invokedGetFallbackConfigCount += 1
+        self.invokedGetFallbackConfigParameters = (domain, isAppBackgrounded)
+        self.invokedGetFallbackConfigParametersList.append((domain, isAppBackgrounded))
+        self.fallbackCompletions.append(completion)
+    }
+
     func complete(with result: Result<RemoteConfigFetchResult, BackendError>) {
         self.completions.last?(result)
+    }
+
+    func completeFallback(with result: Result<RemoteConfigFallbackFetchResult, BackendError>) {
+        self.fallbackCompletions.last?(result)
     }
 
     func complete(

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -85,6 +85,17 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
     }
 
+    func testStaticFallbackNoContentResponseMarksRefreshAsFresh() {
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
+        self.remoteConfigAPI.completeStaticFallback(with: .success(.test(configuration: nil)))
+
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigStaticFallbackCount) == 1
+    }
+
     func testFailureDoesNotMarkRefreshAsFresh() {
         self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1)))))

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -1406,6 +1406,17 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.remoteConfigAPI.invokedGetFallbackConfigParameters?.isAppBackgrounded) == true
     }
 
+    func testPrimaryServerErrorWithPersistedCacheDoesNotTriggerFallbackConfigRequest() {
+        self.diskCache.stubbedRead = Self.persisted(domain: "app", manifest: "cached-manifest")
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+        self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
+
+        expect(self.manager.isDisabled) == false
+        expect(self.remoteConfigAPI.invokedGetFallbackConfigCount) == 0
+        expect(self.diskCache.invokedWriteCount) == 0
+    }
+
     func testPrimaryClientErrorDisablesRemoteConfigAndDoesNotTriggerFallbackConfigRequest() {
         self.manager.refreshRemoteConfig(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
@@ -1439,38 +1450,6 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.blobStore.invokedWriteCount) == 0
         expect(self.blobStore.invokedRetainOnlyParameters) == Set([prefetchedRef, retainedRef])
         expect(self.blobFetcher.invokedPrefetchRefs) == [prefetchedRef]
-    }
-
-    func testFallbackConfigSuccessMergesUnchangedTopicsAndPrunesDroppedTopics() {
-        let keptRef = RCContainerTestData.blobRef(for: #"{"id":"kept"}"#.asData)
-        let prunedRef = RCContainerTestData.blobRef(for: #"{"id":"pruned"}"#.asData)
-        self.diskCache.stubbedRead = Self.persisted(
-            manifest: "v1.1710000100.sources:etag1,workflows:etag1",
-            activeTopics: ["sources", "workflows"],
-            topics: .init(entries: [
-                "sources": ["api": .init(blobRef: keptRef)],
-                "workflows": ["removed": .init(blobRef: prunedRef)]
-            ])
-        )
-        let configuration = RemoteConfiguration(
-            domain: "app",
-            manifest: "v1.1710000100.sources:etag1,ui_config:etag2",
-            activeTopics: ["sources", "ui_config"],
-            topics: .init(entries: [
-                "ui_config": ["app": .init(content: ["enabled": true])]
-            ])
-        )
-
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
-        self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
-        self.remoteConfigAPI.completeFallback(with: .success(.test(configuration: configuration)))
-
-        expect(self.diskCache.invokedWriteParameter?.activeTopics) == ["sources", "ui_config"]
-        expect(Self.blobRefsByTopic(from: self.diskCache.invokedWriteParameter?.topics)) == [
-            "sources": [keptRef],
-            "ui_config": []
-        ]
-        expect(self.blobStore.invokedRetainOnlyParameters) == Set([keptRef])
     }
 
     func testFallbackConfigFailureLeavesCacheUntouchedAndDoesNotMarkRefreshFresh() {

--- a/Tests/UnitTests/Networking/Responses/RemoteConfigurationDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/RemoteConfigurationDecodingTests.swift
@@ -37,6 +37,52 @@ final class RemoteConfigurationDecodingTests: TestCase {
         try self.expectFullPayloadSources(in: response)
     }
 
+    func testDeserializesFallbackConfigResponseShape() throws {
+        let payload = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.sources:sources-etag,ui_config:ui-etag,workflows:workflows-etag",
+          "active_topics": ["sources", "ui_config", "workflows"],
+          "prefetch_blobs": ["AAECAwQFBgcICQoLDA0ODxAREhMUFRYX"],
+          "topics": {
+            "sources": {
+              "blob": {
+                "sources": [
+                  {
+                    "id": "assets",
+                    "url_format": "https://assets.revenuecat.com/app/{blob_ref}",
+                    "priority": 0,
+                    "weight": 100
+                  }
+                ]
+              }
+            },
+            "ui_config": {
+              "app": {
+                "blob_ref": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYX",
+                "prefetch": true
+              }
+            },
+            "workflows": {
+              "default": {
+                "blob_ref": "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY"
+              }
+            }
+          }
+        }
+        """.asData
+
+        let response = try JSONDecoder.default.decode(RemoteConfiguration.self, from: payload)
+
+        expect(response.domain) == "app"
+        expect(response.activeTopics) == ["sources", "ui_config", "workflows"]
+        expect(response.prefetchBlobs) == ["AAECAwQFBgcICQoLDA0ODxAREhMUFRYX"]
+        expect(response.topics.entries["sources"]?["blob"]?.content["sources"]).toNot(beNil())
+        expect(response.topics.entries["ui_config"]?["app"]?.blobRef) == "AAECAwQFBgcICQoLDA0ODxAREhMUFRYX"
+        expect(response.topics.entries["ui_config"]?["app"]?.prefetch) == true
+        expect(response.topics.entries["workflows"]?["default"]?.blobRef) == "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcY"
+    }
+
     private func expectFullPayloadSources(in response: RemoteConfiguration) throws {
         let sourcesTopic = try XCTUnwrap(response.topics.entries["sources"])
 

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -554,15 +554,15 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
     }
 
     func testFallbackConfigSignatureUsesRawJSONPayloadWithoutNonceOrRequestBody() throws {
-        let body = Self.remoteConfigStaticFallbackBody
-        self.mockResponse(path: HTTPRequest.StaticFallbackPath.remoteConfig(domain: "app"),
+        let body = Self.remoteConfigFallbackBody
+        self.mockResponse(path: HTTPRequest.FallbackPath.remoteConfig(domain: "app"),
                           signature: Self.sampleSignature,
                           requestDate: Self.date2,
                           body: body)
         self.signing.stubbedVerificationResult = true
 
         let response: VerifiedHTTPResponse<RemoteConfiguration?>.Result? = waitUntilValue { completion in
-            self.client.perform(Self.remoteConfigStaticFallbackRequest, completionHandler: completion)
+            self.client.perform(Self.remoteConfigFallbackRequest, completionHandler: completion)
         }
 
         expect(response).to(beSuccess())
@@ -579,15 +579,15 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
     }
 
     func testFallbackConfigSignatureIncludesETagIfBackendSendsIt() throws {
-        self.mockResponse(path: HTTPRequest.StaticFallbackPath.remoteConfig(domain: "app"),
+        self.mockResponse(path: HTTPRequest.FallbackPath.remoteConfig(domain: "app"),
                           signature: Self.sampleSignature,
                           requestDate: Self.date2,
                           eTag: Self.eTag,
-                          body: Self.remoteConfigStaticFallbackBody)
+                          body: Self.remoteConfigFallbackBody)
         self.signing.stubbedVerificationResult = true
 
         let response: VerifiedHTTPResponse<RemoteConfiguration?>.Result? = waitUntilValue { completion in
-            self.client.perform(Self.remoteConfigStaticFallbackRequest, completionHandler: completion)
+            self.client.perform(Self.remoteConfigFallbackRequest, completionHandler: completion)
         }
 
         expect(response).to(beSuccess())
@@ -595,7 +595,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
     }
 
     func testFallbackConfigNoContentResponseUsesEmptySignaturePayloadWithoutNonce() throws {
-        self.mockResponse(path: HTTPRequest.StaticFallbackPath.remoteConfig(domain: "app"),
+        self.mockResponse(path: HTTPRequest.FallbackPath.remoteConfig(domain: "app"),
                           signature: Self.sampleSignature,
                           requestDate: Self.date2,
                           body: "not json".asData,
@@ -603,7 +603,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
         self.signing.stubbedVerificationResult = true
 
         let response: VerifiedHTTPResponse<RemoteConfiguration?>.Result? = waitUntilValue { completion in
-            self.client.perform(Self.remoteConfigStaticFallbackRequest, completionHandler: completion)
+            self.client.perform(Self.remoteConfigFallbackRequest, completionHandler: completion)
         }
 
         expect(response).to(beSuccess())
@@ -616,15 +616,15 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
     }
 
     func testFallbackConfigInvalidSignatureReturnsFailedVerification() throws {
-        let body = Self.remoteConfigStaticFallbackBody
-        self.mockResponse(path: HTTPRequest.StaticFallbackPath.remoteConfig(domain: "app"),
+        let body = Self.remoteConfigFallbackBody
+        self.mockResponse(path: HTTPRequest.FallbackPath.remoteConfig(domain: "app"),
                           signature: Self.sampleSignature,
                           requestDate: Self.date2,
                           body: body)
         self.signing.stubbedVerificationResult = false
 
         let response: VerifiedHTTPResponse<RemoteConfiguration?>.Result? = waitUntilValue { completion in
-            self.client.perform(Self.remoteConfigStaticFallbackRequest, completionHandler: completion)
+            self.client.perform(Self.remoteConfigFallbackRequest, completionHandler: completion)
         }
 
         expect(response).to(beSuccess())
@@ -637,20 +637,20 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
 
     func testFallbackConfigInvalidSignatureFailsInEnforcedMode() throws {
         self.changeClientToEnforced()
-        self.mockResponse(path: HTTPRequest.StaticFallbackPath.remoteConfig(domain: "app"),
+        self.mockResponse(path: HTTPRequest.FallbackPath.remoteConfig(domain: "app"),
                           signature: Self.sampleSignature,
                           requestDate: Self.date2,
-                          body: Self.remoteConfigStaticFallbackBody)
+                          body: Self.remoteConfigFallbackBody)
         self.signing.stubbedVerificationResult = false
 
         let response: VerifiedHTTPResponse<RemoteConfiguration?>.Result? = waitUntilValue { completion in
-            self.client.perform(Self.remoteConfigStaticFallbackRequest, completionHandler: completion)
+            self.client.perform(Self.remoteConfigFallbackRequest, completionHandler: completion)
         }
 
         expect(response).to(beFailure())
         expect(response?.error)
             .to(matchError(NetworkError.signatureVerificationFailed(
-                path: HTTPRequest.StaticFallbackPath.remoteConfig(domain: "app"),
+                path: HTTPRequest.FallbackPath.remoteConfig(domain: "app"),
                 code: .success
             )))
         expect(self.signing.requests).to(haveCount(1))
@@ -1328,14 +1328,14 @@ private extension BaseSignatureVerificationHTTPClientTests {
         )
     }
 
-    static var remoteConfigStaticFallbackRequest: HTTPRequest {
+    static var remoteConfigFallbackRequest: HTTPRequest {
         return .init(
             method: .get,
-            path: HTTPRequest.StaticFallbackPath.remoteConfig(domain: "app")
+            path: HTTPRequest.FallbackPath.remoteConfig(domain: "app")
         )
     }
 
-    static var remoteConfigStaticFallbackBody: Data {
+    static var remoteConfigFallbackBody: Data {
         return """
         {
           "domain": "app",

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -578,6 +578,22 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
         expect(signingRequest.signature) == Self.sampleSignature
     }
 
+    func testFallbackConfigSignatureIncludesETagIfBackendSendsIt() throws {
+        self.mockResponse(path: HTTPRequest.Path.remoteConfigStaticFallback(domain: "app"),
+                          signature: Self.sampleSignature,
+                          requestDate: Self.date2,
+                          eTag: Self.eTag,
+                          body: Self.remoteConfigStaticFallbackBody)
+        self.signing.stubbedVerificationResult = true
+
+        let response: VerifiedHTTPResponse<RemoteConfiguration?>.Result? = waitUntilValue { completion in
+            self.client.perform(Self.remoteConfigStaticFallbackRequest, completionHandler: completion)
+        }
+
+        expect(response).to(beSuccess())
+        expect(self.signing.requests.onlyElement?.parameters.etag) == Self.eTag
+    }
+
     func testFallbackConfigNoContentResponseUsesEmptySignaturePayloadWithoutNonce() throws {
         self.mockResponse(path: HTTPRequest.Path.remoteConfigStaticFallback(domain: "app"),
                           signature: Self.sampleSignature,

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -554,14 +554,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
     }
 
     func testFallbackConfigSignatureUsesRawJSONPayloadWithoutNonceOrRequestBody() throws {
-        let body = """
-        {
-          "domain": "app",
-          "manifest": "v1.test",
-          "active_topics": [],
-          "topics": {}
-        }
-        """.asData
+        let body = Self.remoteConfigStaticFallbackBody
         self.mockResponse(path: HTTPRequest.Path.remoteConfigStaticFallback(domain: "app"),
                           signature: Self.sampleSignature,
                           requestDate: Self.date2,
@@ -604,6 +597,47 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
         expect(self.signing.requests.onlyElement?.parameters.message) == Data()
         expect(self.signing.requests.onlyElement?.parameters.nonce).to(beNil())
         expect(self.signing.requests.onlyElement?.parameters.requestBody).to(beNil())
+    }
+
+    func testFallbackConfigInvalidSignatureReturnsFailedVerification() throws {
+        let body = Self.remoteConfigStaticFallbackBody
+        self.mockResponse(path: HTTPRequest.Path.remoteConfigStaticFallback(domain: "app"),
+                          signature: Self.sampleSignature,
+                          requestDate: Self.date2,
+                          body: body)
+        self.signing.stubbedVerificationResult = false
+
+        let response: VerifiedHTTPResponse<RemoteConfiguration?>.Result? = waitUntilValue { completion in
+            self.client.perform(Self.remoteConfigStaticFallbackRequest, completionHandler: completion)
+        }
+
+        expect(response).to(beSuccess())
+        expect(response?.value?.verificationResult) == .failed
+        expect(self.signing.requests).to(haveCount(1))
+        expect(self.signing.requests.onlyElement?.parameters.message) == body
+        expect(self.signing.requests.onlyElement?.parameters.nonce).to(beNil())
+        expect(self.signing.requests.onlyElement?.parameters.requestBody).to(beNil())
+    }
+
+    func testFallbackConfigInvalidSignatureFailsInEnforcedMode() throws {
+        self.changeClientToEnforced()
+        self.mockResponse(path: HTTPRequest.Path.remoteConfigStaticFallback(domain: "app"),
+                          signature: Self.sampleSignature,
+                          requestDate: Self.date2,
+                          body: Self.remoteConfigStaticFallbackBody)
+        self.signing.stubbedVerificationResult = false
+
+        let response: VerifiedHTTPResponse<RemoteConfiguration?>.Result? = waitUntilValue { completion in
+            self.client.perform(Self.remoteConfigStaticFallbackRequest, completionHandler: completion)
+        }
+
+        expect(response).to(beFailure())
+        expect(response?.error)
+            .to(matchError(NetworkError.signatureVerificationFailed(
+                path: HTTPRequest.Path.remoteConfigStaticFallback(domain: "app"),
+                code: .success
+            )))
+        expect(self.signing.requests).to(haveCount(1))
     }
 
     func testRemoteConfigSignaturePayloadMissingBodyThrowsMissingBodyError() {
@@ -1283,6 +1317,17 @@ private extension BaseSignatureVerificationHTTPClientTests {
             method: .get,
             path: HTTPRequest.Path.remoteConfigStaticFallback(domain: "app")
         )
+    }
+
+    static var remoteConfigStaticFallbackBody: Data {
+        return """
+        {
+          "domain": "app",
+          "manifest": "v1.test",
+          "active_topics": [],
+          "topics": {}
+        }
+        """.asData
     }
 
     static func rcContainer(

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -561,7 +561,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
                           body: body)
         self.signing.stubbedVerificationResult = true
 
-        let response: VerifiedHTTPResponse<RemoteConfiguration?>.Result? = waitUntilValue { completion in
+        let response: VerifiedHTTPResponse<RemoteConfiguration>.Result? = waitUntilValue { completion in
             self.client.perform(Self.remoteConfigFallbackRequest, completionHandler: completion)
         }
 
@@ -586,33 +586,12 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
                           body: Self.remoteConfigFallbackBody)
         self.signing.stubbedVerificationResult = true
 
-        let response: VerifiedHTTPResponse<RemoteConfiguration?>.Result? = waitUntilValue { completion in
+        let response: VerifiedHTTPResponse<RemoteConfiguration>.Result? = waitUntilValue { completion in
             self.client.perform(Self.remoteConfigFallbackRequest, completionHandler: completion)
         }
 
         expect(response).to(beSuccess())
         expect(self.signing.requests.onlyElement?.parameters.etag) == Self.eTag
-    }
-
-    func testFallbackConfigNoContentResponseUsesEmptySignaturePayloadWithoutNonce() throws {
-        self.mockResponse(path: HTTPRequest.FallbackPath.remoteConfig(domain: "app"),
-                          signature: Self.sampleSignature,
-                          requestDate: Self.date2,
-                          body: "not json".asData,
-                          statusCode: .noContent)
-        self.signing.stubbedVerificationResult = true
-
-        let response: VerifiedHTTPResponse<RemoteConfiguration?>.Result? = waitUntilValue { completion in
-            self.client.perform(Self.remoteConfigFallbackRequest, completionHandler: completion)
-        }
-
-        expect(response).to(beSuccess())
-        expect(response?.value?.body).to(beNil())
-        expect(response?.value?.verificationResult) == .verified
-        expect(self.signing.requests).to(haveCount(1))
-        expect(self.signing.requests.onlyElement?.parameters.message) == Data()
-        expect(self.signing.requests.onlyElement?.parameters.nonce).to(beNil())
-        expect(self.signing.requests.onlyElement?.parameters.requestBody).to(beNil())
     }
 
     func testFallbackConfigInvalidSignatureReturnsFailedVerification() throws {
@@ -623,7 +602,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
                           body: body)
         self.signing.stubbedVerificationResult = false
 
-        let response: VerifiedHTTPResponse<RemoteConfiguration?>.Result? = waitUntilValue { completion in
+        let response: VerifiedHTTPResponse<RemoteConfiguration>.Result? = waitUntilValue { completion in
             self.client.perform(Self.remoteConfigFallbackRequest, completionHandler: completion)
         }
 
@@ -643,7 +622,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
                           body: Self.remoteConfigFallbackBody)
         self.signing.stubbedVerificationResult = false
 
-        let response: VerifiedHTTPResponse<RemoteConfiguration?>.Result? = waitUntilValue { completion in
+        let response: VerifiedHTTPResponse<RemoteConfiguration>.Result? = waitUntilValue { completion in
             self.client.perform(Self.remoteConfigFallbackRequest, completionHandler: completion)
         }
 

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -555,7 +555,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
 
     func testFallbackConfigSignatureUsesRawJSONPayloadWithoutNonceOrRequestBody() throws {
         let body = Self.remoteConfigStaticFallbackBody
-        self.mockResponse(path: HTTPRequest.Path.remoteConfigStaticFallback(domain: "app"),
+        self.mockResponse(path: HTTPRequest.StaticFallbackPath.remoteConfig(domain: "app"),
                           signature: Self.sampleSignature,
                           requestDate: Self.date2,
                           body: body)
@@ -579,7 +579,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
     }
 
     func testFallbackConfigSignatureIncludesETagIfBackendSendsIt() throws {
-        self.mockResponse(path: HTTPRequest.Path.remoteConfigStaticFallback(domain: "app"),
+        self.mockResponse(path: HTTPRequest.StaticFallbackPath.remoteConfig(domain: "app"),
                           signature: Self.sampleSignature,
                           requestDate: Self.date2,
                           eTag: Self.eTag,
@@ -595,7 +595,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
     }
 
     func testFallbackConfigNoContentResponseUsesEmptySignaturePayloadWithoutNonce() throws {
-        self.mockResponse(path: HTTPRequest.Path.remoteConfigStaticFallback(domain: "app"),
+        self.mockResponse(path: HTTPRequest.StaticFallbackPath.remoteConfig(domain: "app"),
                           signature: Self.sampleSignature,
                           requestDate: Self.date2,
                           body: "not json".asData,
@@ -617,7 +617,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
 
     func testFallbackConfigInvalidSignatureReturnsFailedVerification() throws {
         let body = Self.remoteConfigStaticFallbackBody
-        self.mockResponse(path: HTTPRequest.Path.remoteConfigStaticFallback(domain: "app"),
+        self.mockResponse(path: HTTPRequest.StaticFallbackPath.remoteConfig(domain: "app"),
                           signature: Self.sampleSignature,
                           requestDate: Self.date2,
                           body: body)
@@ -637,7 +637,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
 
     func testFallbackConfigInvalidSignatureFailsInEnforcedMode() throws {
         self.changeClientToEnforced()
-        self.mockResponse(path: HTTPRequest.Path.remoteConfigStaticFallback(domain: "app"),
+        self.mockResponse(path: HTTPRequest.StaticFallbackPath.remoteConfig(domain: "app"),
                           signature: Self.sampleSignature,
                           requestDate: Self.date2,
                           body: Self.remoteConfigStaticFallbackBody)
@@ -650,7 +650,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
         expect(response).to(beFailure())
         expect(response?.error)
             .to(matchError(NetworkError.signatureVerificationFailed(
-                path: HTTPRequest.Path.remoteConfigStaticFallback(domain: "app"),
+                path: HTTPRequest.StaticFallbackPath.remoteConfig(domain: "app"),
                 code: .success
             )))
         expect(self.signing.requests).to(haveCount(1))
@@ -1331,7 +1331,7 @@ private extension BaseSignatureVerificationHTTPClientTests {
     static var remoteConfigStaticFallbackRequest: HTTPRequest {
         return .init(
             method: .get,
-            path: HTTPRequest.Path.remoteConfigStaticFallback(domain: "app")
+            path: HTTPRequest.StaticFallbackPath.remoteConfig(domain: "app")
         )
     }
 

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -553,6 +553,59 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
         expect(self.signing.requests.onlyElement?.parameters.nonce).toNot(beNil())
     }
 
+    func testFallbackConfigSignatureUsesRawJSONPayloadWithoutNonceOrRequestBody() throws {
+        let body = """
+        {
+          "domain": "app",
+          "manifest": "v1.test",
+          "active_topics": [],
+          "topics": {}
+        }
+        """.asData
+        self.mockResponse(path: HTTPRequest.Path.fallbackConfig(domain: "app"),
+                          signature: Self.sampleSignature,
+                          requestDate: Self.date2,
+                          body: body)
+        self.signing.stubbedVerificationResult = true
+
+        let response: VerifiedHTTPResponse<RemoteConfiguration?>.Result? = waitUntilValue { completion in
+            self.client.perform(Self.fallbackConfigRequest, completionHandler: completion)
+        }
+
+        expect(response).to(beSuccess())
+        expect(response?.value?.verificationResult) == .verified
+
+        expect(self.signing.requests).to(haveCount(1))
+        let signingRequest = try XCTUnwrap(self.signing.requests.onlyElement)
+
+        expect(signingRequest.parameters.message) == body
+        expect(signingRequest.parameters.nonce).to(beNil())
+        expect(signingRequest.parameters.requestBody).to(beNil())
+        expect(signingRequest.parameters.requestDate) == Self.date2.millisecondsSince1970
+        expect(signingRequest.signature) == Self.sampleSignature
+    }
+
+    func testFallbackConfigNoContentResponseUsesEmptySignaturePayloadWithoutNonce() throws {
+        self.mockResponse(path: HTTPRequest.Path.fallbackConfig(domain: "app"),
+                          signature: Self.sampleSignature,
+                          requestDate: Self.date2,
+                          body: "not json".asData,
+                          statusCode: .noContent)
+        self.signing.stubbedVerificationResult = true
+
+        let response: VerifiedHTTPResponse<RemoteConfiguration?>.Result? = waitUntilValue { completion in
+            self.client.perform(Self.fallbackConfigRequest, completionHandler: completion)
+        }
+
+        expect(response).to(beSuccess())
+        expect(response?.value?.body).to(beNil())
+        expect(response?.value?.verificationResult) == .verified
+        expect(self.signing.requests).to(haveCount(1))
+        expect(self.signing.requests.onlyElement?.parameters.message) == Data()
+        expect(self.signing.requests.onlyElement?.parameters.nonce).to(beNil())
+        expect(self.signing.requests.onlyElement?.parameters.requestBody).to(beNil())
+    }
+
     func testRemoteConfigSignaturePayloadMissingBodyThrowsMissingBodyError() {
         let provider = RemoteConfigSignatureContextProvider()
 
@@ -1222,6 +1275,13 @@ private extension BaseSignatureVerificationHTTPClientTests {
         return .init(
             method: .post(RemoteConfigRequest(appUserID: "app-user-id")),
             path: HTTPRequest.Path.remoteConfig(domain: "app")
+        )
+    }
+
+    static var fallbackConfigRequest: HTTPRequest {
+        return .init(
+            method: .get,
+            path: HTTPRequest.Path.fallbackConfig(domain: "app")
         )
     }
 

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -562,14 +562,14 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
           "topics": {}
         }
         """.asData
-        self.mockResponse(path: HTTPRequest.Path.fallbackConfig(domain: "app"),
+        self.mockResponse(path: HTTPRequest.Path.remoteConfigStaticFallback(domain: "app"),
                           signature: Self.sampleSignature,
                           requestDate: Self.date2,
                           body: body)
         self.signing.stubbedVerificationResult = true
 
         let response: VerifiedHTTPResponse<RemoteConfiguration?>.Result? = waitUntilValue { completion in
-            self.client.perform(Self.fallbackConfigRequest, completionHandler: completion)
+            self.client.perform(Self.remoteConfigStaticFallbackRequest, completionHandler: completion)
         }
 
         expect(response).to(beSuccess())
@@ -586,7 +586,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
     }
 
     func testFallbackConfigNoContentResponseUsesEmptySignaturePayloadWithoutNonce() throws {
-        self.mockResponse(path: HTTPRequest.Path.fallbackConfig(domain: "app"),
+        self.mockResponse(path: HTTPRequest.Path.remoteConfigStaticFallback(domain: "app"),
                           signature: Self.sampleSignature,
                           requestDate: Self.date2,
                           body: "not json".asData,
@@ -594,7 +594,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
         self.signing.stubbedVerificationResult = true
 
         let response: VerifiedHTTPResponse<RemoteConfiguration?>.Result? = waitUntilValue { completion in
-            self.client.perform(Self.fallbackConfigRequest, completionHandler: completion)
+            self.client.perform(Self.remoteConfigStaticFallbackRequest, completionHandler: completion)
         }
 
         expect(response).to(beSuccess())
@@ -1278,10 +1278,10 @@ private extension BaseSignatureVerificationHTTPClientTests {
         )
     }
 
-    static var fallbackConfigRequest: HTTPRequest {
+    static var remoteConfigStaticFallbackRequest: HTTPRequest {
         return .init(
             method: .get,
-            path: HTTPRequest.Path.fallbackConfig(domain: "app")
+            path: HTTPRequest.Path.remoteConfigStaticFallback(domain: "app")
         )
     }
 

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -358,6 +358,24 @@ private final class FakeRemoteConfigAPI: RemoteConfigAPIType {
         }
     }
 
+    func getFallbackConfig(
+        domain: String,
+        isAppBackgrounded: Bool,
+        completion: @escaping Backend.ResponseHandler<RemoteConfigFallbackFetchResult>
+    ) {
+        DispatchQueue.global().async {
+            let result = RemoteConfigFallbackFetchResult(response: VerifiedHTTPResponse(
+                httpStatusCode: .noContent,
+                responseHeaders: [:],
+                body: nil,
+                verificationResult: .verified,
+                isLoadShedderResponse: false,
+                isFallbackUrlResponse: false
+            ))
+            completion(.success(result))
+        }
+    }
+
 }
 
 private final class FakeRemoteConfigDiskCache: RemoteConfigDiskCacheType {

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -364,15 +364,7 @@ private final class FakeRemoteConfigAPI: RemoteConfigAPIType {
         completion: @escaping Backend.ResponseHandler<RemoteConfigFallbackFetchResult>
     ) {
         DispatchQueue.global().async {
-            let result = RemoteConfigFallbackFetchResult(response: VerifiedHTTPResponse(
-                httpStatusCode: .noContent,
-                responseHeaders: [:],
-                body: nil,
-                verificationResult: .verified,
-                isLoadShedderResponse: false,
-                isFallbackUrlResponse: false
-            ))
-            completion(.success(result))
+            completion(.failure(.networkError(.unexpectedResponse(nil))))
         }
     }
 

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -358,13 +358,13 @@ private final class FakeRemoteConfigAPI: RemoteConfigAPIType {
         }
     }
 
-    func getRemoteConfigStaticFallback(
+    func getRemoteConfigFallback(
         domain: String,
         isAppBackgrounded: Bool,
-        completion: @escaping Backend.ResponseHandler<RemoteConfigStaticFallbackFetchResult>
+        completion: @escaping Backend.ResponseHandler<RemoteConfigFallbackFetchResult>
     ) {
         DispatchQueue.global().async {
-            let result = RemoteConfigStaticFallbackFetchResult(response: VerifiedHTTPResponse(
+            let result = RemoteConfigFallbackFetchResult(response: VerifiedHTTPResponse(
                 httpStatusCode: .noContent,
                 responseHeaders: [:],
                 body: nil,

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -358,13 +358,13 @@ private final class FakeRemoteConfigAPI: RemoteConfigAPIType {
         }
     }
 
-    func getFallbackConfig(
+    func getRemoteConfigStaticFallback(
         domain: String,
         isAppBackgrounded: Bool,
-        completion: @escaping Backend.ResponseHandler<RemoteConfigFallbackFetchResult>
+        completion: @escaping Backend.ResponseHandler<RemoteConfigStaticFallbackFetchResult>
     ) {
         DispatchQueue.global().async {
-            let result = RemoteConfigFallbackFetchResult(response: VerifiedHTTPResponse(
+            let result = RemoteConfigStaticFallbackFetchResult(response: VerifiedHTTPResponse(
                 httpStatusCode: .noContent,
                 responseHeaders: [:],
                 body: nil,


### PR DESCRIPTION
## Description
Since the fallback endpoint handling of the remote-config API is quite different from the main backend API we've decided to split this up into its own request. 

This PR introduces the `fallbackConfig` request path, which handles the request differently in a couple of ways;
- Sends a `GET` instead of `POST` request
- Does not send any `POST` body data
- Does not send a `nonce` for signature verification, and only verifies the signature against the response
- Expects an `application/json` response rather than `RCContainer`, and does not expect inlined blobs
- **Only** reach for the fallback endpoint if we don't have a useable local cache.

## Todo

- [x] Decide if we really only going to use the fallback if we have no cache at all. Or if we should introduce a staleness check with a max-age on the cache for this fallback mechanism to trigger.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote config fetch, persistence, and signature paths when the primary API is down; mistakes could leave apps without config or with wrong verification behavior, but scope is limited to fallback eligibility and a separate GET endpoint.
> 
> **Overview**
> Adds a **dedicated remote config fallback flow** when the primary `POST` RC Container request fails with transient host errors and there is **no persisted config for the domain** (skipped when a proxy URL is set or usable cache exists).
> 
> The fallback uses a new **`HTTPRequest.FallbackPath`** on the production fallback host: **`GET` `/v1/config/<domain>`**, plain **`application/json`** (`RemoteConfiguration`), **ETag caching**, and signature verification over the **raw response body** (no nonce or POST signing headers). Primary `remoteConfig` is **no longer** wired into generic per-path fallback URL retries.
> 
> **`RemoteConfigManager`** chains into **`getRemoteConfigFallback`** on eligible failures, persists the JSON config **without inline blob extraction**, and only disables refresh on final failure when appropriate. **`GetRemoteConfigFallbackOperation`**, API types, and broad unit/integration coverage accompany the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a7a69c07f3239f261c904789b8de89a1cfd867f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->