### PR TITLE
fix(paywalls): fail decoding a present-but-malformed custom_variables

### DIFF
--- a/Sources/Logging/Strings/OfferingStrings.swift
+++ b/Sources/Logging/Strings/OfferingStrings.swift
@@ -54,7 +54,6 @@ enum OfferingStrings {
     // Custom Variables
     case ui_config_no_custom_variables
     case ui_config_custom_variables_decoded(keys: [String])
-    case ui_config_custom_variables_decode_error(error: Error)
     case ui_config_custom_variables_status(keyPresent: Bool, count: Int, keys: [String])
 
 }
@@ -248,9 +247,6 @@ extension OfferingStrings: LogMessage {
 
         case .ui_config_custom_variables_decoded(let keys):
             return "UIConfig decoded with custom_variables: \(keys)"
-
-        case .ui_config_custom_variables_decode_error(let error):
-            return "Failed to decode custom_variables from UIConfig: \(error.localizedDescription)"
 
         case .ui_config_custom_variables_status(let keyPresent, let count, let keys):
             // swiftlint:disable:next line_length

--- a/Sources/Networking/Responses/RevenueCatUI/UIConfig.swift
+++ b/Sources/Networking/Responses/RevenueCatUI/UIConfig.swift
@@ -173,16 +173,12 @@ import Foundation
             forKey: .variableConfig
         ) ?? VariableConfig(variableCompatibilityMap: [:], functionCompatibilityMap: [:])
 
-        // Try to decode custom_variables with detailed error logging
-        do {
-            self.customVariables = try container.decodeIfPresent(
-                [String: CustomVariableDefinition].self,
-                forKey: .customVariables
-            ) ?? [:]
-        } catch {
-            Logger.error(Strings.offering.ui_config_custom_variables_decode_error(error: error))
-            self.customVariables = [:]
-        }
+        // `custom_variables` was added after the other fields, so the key may be absent from older responses; fall
+        // back to an empty dictionary in that case. If the key is present but malformed, fail like any other field.
+        self.customVariables = try container.decodeIfPresent(
+            [String: CustomVariableDefinition].self,
+            forKey: .customVariables
+        ) ?? [:]
 
         // Debug logging for custom variables
         let hasCustomVariablesKey = container.contains(.customVariables)

--- a/Tests/UnitTests/Networking/Responses/UIConfigDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/UIConfigDecodingTests.swift
@@ -125,6 +125,29 @@ class UIConfigDecodingTests: BaseHTTPResponseTest {
         expect(uiConfig.customVariables).to(beEmpty())
     }
 
+    func testFailsToDecodeMalformedCustomVariables() throws {
+        // When `custom_variables` is present but not the expected object shape, decoding should fail rather than
+        // silently falling back to an empty dictionary (which would hide a malformed response).
+        let json = """
+        {
+            "app": {
+                "colors": {},
+                "fonts": {}
+            },
+            "localizations": {},
+            "variable_config": {
+                "variable_compatibility_map": {},
+                "function_compatibility_map": {}
+            },
+            "custom_variables": "not an object"
+        }
+        """
+
+        expect {
+            try JSONDecoder.default.decode(UIConfig.self, from: json.data(using: .utf8)!)
+        }.to(throwError())
+    }
+
 }
 
 #endif


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests

### Motivation
`UIConfig` decoding fell back to an empty `custom_variables` dictionary even when the key was present but malformed, silently hiding bad responses.

### Description
- Only fall back to an empty dictionary when `custom_variables` is absent (it was added later); a present-but-malformed value now fails to decode like every other required field.
- Removed the now-dead `ui_config_custom_variables_decode_error` log string.
- Added a decoding test asserting a malformed `custom_variables` throws.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow paywall UI config decoding change with clearer failure behavior and test coverage; absent-key backward compatibility is unchanged.
> 
> **Overview**
> **`UIConfig` decoding** no longer swallows errors when `custom_variables` is present but invalid. Missing key still decodes to `{}` for older payloads; malformed values now propagate decode failures like other fields.
> 
> The custom decode `do/catch` and **`ui_config_custom_variables_decode_error`** log case were removed. A unit test asserts that a string-shaped `custom_variables` value throws.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 963f4a6b75d6f02cc98317c8e44f357ec527ba0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->