### PR TITLE
perf(remote-config): memoize decoded UIConfig per ui_config topic

### DIFF
--- a/Sources/Networking/UiConfigProvider.swift
+++ b/Sources/Networking/UiConfigProvider.swift
@@ -13,15 +13,40 @@ import Foundation
 final class UiConfigProvider {
 
     private let manager: RemoteConfigManagerType
+    private let cacheLock = Lock()
+    // Last decoded config and the `ui_config` topic it was built from. Reused while the topic
+    // is unchanged so repeated callers (the offerings gate, workflow render) don't re-read and
+    // re-decode the blobs on every call. Blob refs are content-addressed, so any content change
+    // moves the topic and invalidates this.
+    private var cached: (topic: RemoteConfiguration.ConfigTopic, uiConfig: UIConfig)?
 
     init(manager: RemoteConfigManagerType) {
         self.manager = manager
     }
 
 #if !os(tvOS)
-    /// Assembles a ``UIConfig`` from the `ui_config` topic's parts. Returns `nil` when any part is unavailable
-    /// or fails to decode, so callers never render with a partially assembled configuration.
+    /// Assembles a ``UIConfig`` from the `ui_config` topic's parts. Returns `nil` when any part is
+    /// unavailable or fails to decode, so callers never render with a partially assembled
+    /// configuration. Successful results are memoized per `ui_config` topic; a topic change re-decodes.
     func getUiConfig() async -> UIConfig? {
+        let topic = await self.manager.topic(.uiConfig)
+        if let cached = self.cachedUiConfig(for: topic) {
+            return cached
+        }
+
+        guard let uiConfig = await self.assembleUiConfig() else {
+            return nil
+        }
+        // `mergeItemsBlobData` reads the manager's live topic, so a refresh mid-assembly could
+        // decode a topic other than the key captured above. Only memoize when the topic is
+        // unchanged across the assembly.
+        if await self.manager.topic(.uiConfig) == topic {
+            self.store(uiConfig, for: topic)
+        }
+        return uiConfig
+    }
+
+    private func assembleUiConfig() async -> UIConfig? {
         do {
             guard let uiConfig = try await self.manager.mergeItemsBlobData(
                 for: .uiConfig,
@@ -39,6 +64,20 @@ final class UiConfigProvider {
             Logger.error(Strings.remoteConfig.uiConfigDecodeFailed(error))
             return nil
         }
+    }
+
+    private func cachedUiConfig(for topic: RemoteConfiguration.ConfigTopic?) -> UIConfig? {
+        return self.cacheLock.perform {
+            guard let cached = self.cached, cached.topic == topic else { return nil }
+            return cached.uiConfig
+        }
+    }
+
+    private func store(_ uiConfig: UIConfig, for topic: RemoteConfiguration.ConfigTopic?) {
+        // A successful assembly always has a concrete topic (its items are topic items);
+        // never cache under a nil key.
+        guard let topic else { return }
+        self.cacheLock.perform { self.cached = (topic, uiConfig) }
     }
 #else
     // Paywalls V2 (and therefore workflows) aren't supported on tvOS, where `UIConfig` carries no fields.

--- a/Tests/UnitTests/Networking/UiConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/UiConfigProviderTests.swift
@@ -170,7 +170,9 @@ class UiConfigProviderTests: TestCase {
             customVariables: #"{}"#
         )
         // The cache-key read sees topic A, the post-assembly re-read sees topic B: a refresh
-        // landed mid-decode, so the value must NOT be memoized under A.
+        // landed mid-decode, so the value must NOT be memoized under A. This relies on the mock's
+        // `mergeItemsBlobData` not calling `topic()`; `getUiConfig` makes exactly two topic reads
+        // per call, so the two-element sequence maps to (cache-key read, post-assembly re-read).
         let topicA: RemoteConfiguration.ConfigTopic = ["app": .init(blobRef: "app-a", prefetch: false, content: [:])]
         let topicB: RemoteConfiguration.ConfigTopic = ["app": .init(blobRef: "app-b", prefetch: false, content: [:])]
         self.mockManager.stubbedTopicSequence = [topicA, topicB]

--- a/Tests/UnitTests/Networking/UiConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/UiConfigProviderTests.swift
@@ -142,6 +142,47 @@ class UiConfigProviderTests: TestCase {
         )
     }
 
+    func testCachesDecodedUiConfigAndSkipsDiskWorkOnUnchangedTopic() async throws {
+        self.stub(
+            app: #"{"colors": {}, "fonts": {}}"#,
+            localizations: #"{"en_US": {"day": "Day"}}"#,
+            variableConfig: #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#,
+            customVariables: #"{}"#
+        )
+
+        let first = await self.provider.getUiConfig()
+        let mergesAfterFirst = self.mockManager.invokedMergeItemsBlobDataParameters.count
+        expect(first).toNot(beNil())
+        expect(mergesAfterFirst) == 1
+
+        let second = await self.provider.getUiConfig()
+
+        // The unchanged `ui_config` topic serves the decoded value from memory: no extra decode.
+        expect(second?.localizations["en_US"]?["day"]) == "Day"
+        expect(self.mockManager.invokedMergeItemsBlobDataParameters.count) == mergesAfterFirst
+    }
+
+    func testReDecodesWhenUiConfigTopicChanges() async throws {
+        self.stub(
+            app: #"{"colors": {}, "fonts": {}}"#,
+            localizations: #"{"en_US": {"day": "Day"}}"#,
+            variableConfig: #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#,
+            customVariables: #"{}"#
+        )
+        _ = await self.provider.getUiConfig()
+        expect(self.mockManager.invokedMergeItemsBlobDataParameters.count) == 1
+
+        // A new revision changes the topic (content-addressed blob refs move), which must
+        // invalidate the cached value and force a re-decode.
+        self.mockManager.stubbedTopics[.uiConfig] = [
+            "app": .init(blobRef: "app-v2", prefetch: false, content: [:]),
+            "localizations": .init(blobRef: "localizations-v2", prefetch: false, content: [:])
+        ]
+        _ = await self.provider.getUiConfig()
+
+        expect(self.mockManager.invokedMergeItemsBlobDataParameters.count) == 2
+    }
+
     func testRequestsMergedBlobDataForWireItemKeysNotCamelCased() async throws {
         _ = await self.provider.getUiConfig()
 

--- a/Tests/UnitTests/Networking/UiConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/UiConfigProviderTests.swift
@@ -162,6 +162,49 @@ class UiConfigProviderTests: TestCase {
         expect(self.mockManager.invokedMergeItemsBlobDataParameters.count) == mergesAfterFirst
     }
 
+    func testDoesNotCacheWhenTopicChangesDuringAssembly() async throws {
+        self.stub(
+            app: #"{"colors": {}, "fonts": {}}"#,
+            localizations: #"{"en_US": {"day": "Day"}}"#,
+            variableConfig: #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#,
+            customVariables: #"{}"#
+        )
+        // The cache-key read sees topic A, the post-assembly re-read sees topic B: a refresh
+        // landed mid-decode, so the value must NOT be memoized under A.
+        let topicA: RemoteConfiguration.ConfigTopic = ["app": .init(blobRef: "app-a", prefetch: false, content: [:])]
+        let topicB: RemoteConfiguration.ConfigTopic = ["app": .init(blobRef: "app-b", prefetch: false, content: [:])]
+        self.mockManager.stubbedTopicSequence = [topicA, topicB]
+
+        _ = await self.provider.getUiConfig()
+        expect(self.mockManager.invokedMergeItemsBlobDataParameters.count) == 1
+
+        // Sequence exhausted; topic() now returns the stubbed topic (A). Nothing was cached
+        // under A, so this re-decodes rather than serving a value assembled during the race.
+        self.mockManager.stubbedTopics[.uiConfig] = topicA
+        _ = await self.provider.getUiConfig()
+        expect(self.mockManager.invokedMergeItemsBlobDataParameters.count) == 2
+    }
+
+    func testDoesNotServeStaleUiConfigAfterTopicBecomesNil() async throws {
+        self.stub(
+            app: #"{"colors": {}, "fonts": {}}"#,
+            localizations: #"{"en_US": {"day": "Day"}}"#,
+            variableConfig: #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#,
+            customVariables: #"{}"#
+        )
+        let cached = await self.provider.getUiConfig()
+        expect(cached).toNot(beNil())
+
+        // Simulate an identity-bound clear: the committed topic and its blobs are gone. The
+        // cached value keyed on the old topic must not be served.
+        self.mockManager.stubbedTopics[.uiConfig] = nil
+        self.mockManager.stubbedBlobData[.uiConfig] = [:]
+
+        let afterClear = await self.provider.getUiConfig()
+
+        expect(afterClear).to(beNil())
+    }
+
     func testReDecodesWhenUiConfigTopicChanges() async throws {
         self.stub(
             app: #"{"colors": {}, "fonts": {}}"#,

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -1117,8 +1117,10 @@ extension OfferingsManagerTests {
         let delivered: Atomic<Bool> = false
         manager.offerings(appUserID: MockData.anyAppUserID) { _ in delivered.value = true }
 
-        // Both readiness branches block on their topic read.
-        expect(mockRemoteConfigManager.invokedTopicCount).toEventually(beGreaterThan(0))
+        // Both readiness branches block on their topic read concurrently (workflows readiness
+        // and ui_config resolution), so at least two topic reads are in flight before either
+        // completes; getOfferings must not serialize them.
+        expect(mockRemoteConfigManager.invokedTopicCount).toEventually(beGreaterThanOrEqualTo(2))
         expect(delivered.value) == false
 
         // Topics resolve; ui_config resolution now reaches (and blocks on) its blob reads.

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -1105,9 +1105,10 @@ extension OfferingsManagerTests {
         expect(mockRemoteConfigManager.invokedTopicCount) == 0
     }
 
-    func testGetOfferingsAwaitsWorkflowsAndUiConfigConcurrently() {
+    func testGetOfferingsAwaitsBothWorkflowsTopicAndUiConfigBlobs() {
         let mockRemoteConfigManager = MockRemoteConfigManager()
-        // Hold BOTH readiness steps: each must have started before either completes.
+        // Hold the topic reads first (both the workflows-readiness and ui_config branches
+        // read a topic), then the ui_config blob reads: delivery must clear both to proceed.
         mockRemoteConfigManager.shouldStoreTopicCompletion = true
         mockRemoteConfigManager.shouldStoreBlobDataCompletion = true
         let manager = self.makeOfferingsManager(remoteConfigManager: mockRemoteConfigManager)
@@ -1116,11 +1117,16 @@ extension OfferingsManagerTests {
         let delivered: Atomic<Bool> = false
         manager.offerings(appUserID: MockData.anyAppUserID) { _ in delivered.value = true }
 
+        // Both readiness branches block on their topic read.
         expect(mockRemoteConfigManager.invokedTopicCount).toEventually(beGreaterThan(0))
+        expect(delivered.value) == false
+
+        // Topics resolve; ui_config resolution now reaches (and blocks on) its blob reads.
+        mockRemoteConfigManager.completeStoredTopic()
         expect(mockRemoteConfigManager.invokedBlobDataParameters).toEventuallyNot(beEmpty())
         expect(delivered.value) == false
 
-        mockRemoteConfigManager.completeStoredTopic()
+        // Only once the ui_config blobs resolve too does delivery fire.
         mockRemoteConfigManager.completeStoredBlobReads()
         expect(delivered.value).toEventually(beTrue())
     }

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -720,9 +720,22 @@ final class MockRemoteConfigManager: RemoteConfigManagerType {
     private let _storedTopicContinuations: Atomic<[CheckedContinuation<RemoteConfiguration.ConfigTopic?, Never>]> =
         .init([])
 
+    /// When non-empty, successive `topic(_:)` calls return (and consume) these values in order,
+    /// so a test can model the committed topic changing between reads (e.g. a refresh landing
+    /// mid-assembly). Falls back to `stubbedTopics` once exhausted.
+    private let _topicSequence: Atomic<[RemoteConfiguration.ConfigTopic?]> = .init([])
+    var stubbedTopicSequence: [RemoteConfiguration.ConfigTopic?] {
+        get { self._topicSequence.value }
+        set { self._topicSequence.value = newValue }
+    }
+
     func topic(_ topic: RemoteConfigTopic) async -> RemoteConfiguration.ConfigTopic? {
         guard self.shouldStoreTopicCompletion else {
             self._invokedTopicCount.modify { $0 += 1 }
+            let sequenced: RemoteConfiguration.ConfigTopic?? = self._topicSequence.modify { seq in
+                seq.isEmpty ? nil : .some(seq.removeFirst())
+            }
+            if let sequenced { return sequenced }
             return self.stubbedTopics[topic]
         }
         return await withCheckedContinuation { continuation in


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests

### Motivation

Stacked on #7181. That PR makes `getOfferings` wait on `UiConfigProvider.getUiConfig()`, which reads and JSON-decodes the `ui_config` blobs from disk on every call — and it's also called on the workflow render path. Repeated cache hits (and a subsequent render) re-do the same disk read + decode. A reviewer flagged the avoidable work; this memoizes it.

### Description

`UiConfigProvider` now caches the decoded `UIConfig` keyed on the `ui_config` topic and reuses it while the topic is unchanged. Because blob refs are content-addressed, any content change moves the topic and invalidates the cache automatically — the same invalidation pattern `RemoteConfigSourceProvider.rebuildIfNeeded()` uses for its `sources` topic. `getUiConfig()` now reads the topic first (it's the cache key); on a hit it returns without touching disk.

Not a behavior change: the assembled `UIConfig` is identical, only recomputation is avoided. Benefits every caller — the getOfferings gate and the paywall render path.

> Note for `purchases-android`: Android's `getUiConfig` has the same repeated-decode today; worth a follow-up there.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: this PR (stacked on #7181)
- Branch: `facu/uiconfig-memory-cache` (base: `facu/offerings-gate-ui-config`)
- Author / human owner: facumenzella
- Agent(s): Claude Code (Fable 5), Codex (review loop via codex-companion)
- Generated: 2026-07-10
- Context document version: 1

## Goal

Eliminate the repeated `ui_config` disk-read + JSON-decode that #7181's readiness gate introduced on the hot path, by memoizing the decoded `UIConfig`.

## Initial Prompt

Reviewer on #7181: "we're calling `uiConfigProvider.getUiConfig()` from multiple places and every time we query the disk. Why not have UiConfigProvider cache the UIConfig in memory and only re-query whenever the ui_config topic changes?" — citing `RemoteConfigSourceProvider`'s cache-and-rebuild-on-topic-change pattern as precedent.

## Agent Contribution

- Added a memory cache to `UiConfigProvider`: `(topic, uiConfig)` under a `Lock`, reused while `manager.topic(.uiConfig)` is unchanged, re-decoded otherwise. Mirrors `RemoteConfigSourceProvider.rebuildIfNeeded()`.
- Reordered `getUiConfig()` to read the topic first (cache key), then assemble on a miss.
- Verified topic-equality invalidation is correct: `ConfigTopic` is `[String: ConfigItem]` (Equatable), and content-addressed blob refs guarantee a content change moves the topic.

## Key Implementation Decisions

- Decision: cache key is the `ui_config` `ConfigTopic`, compared by `Equatable` (like the source provider's `sourcesTopic`). Content changes move blob refs → topic changes → cache invalidates. No manual invalidation signal needed.
- Decision: async fill without holding the lock across `await` — check/read under the lock (sync), assemble on a miss without the lock, store under the lock. Two concurrent misses may both assemble (idempotent, last-writer-wins); not coalesced, matching the low call frequency.
- Decision: only successful assemblies are cached (never a nil result), so a transient failure retries next call.

## Files / Symbols Touched

- `Sources/Networking/UiConfigProvider.swift` — `getUiConfig()` split into cache-check + `assembleUiConfig`; new `cached`/`cacheLock`, `cachedUiConfig(for:)`, `store(_:for:)`.
- `Tests/UnitTests/Networking/UiConfigProviderTests.swift` — 2 tests: unchanged topic serves from memory (no extra merge/blob reads); topic change forces a re-decode.
- `Tests/UnitTests/Purchasing/OfferingsManagerTests.swift` — the gate's concurrency test updated for the new topic-first ordering (ui_config now blocks on its topic read before its blob reads).

## Validation

- RED → GREEN: the cache-hit test failed before the change (2 blob merges for 2 calls), passes after (1).
- `UiConfigProviderTests` 11/11, `WorkflowsConfigProviderTests` 11/11, `OfferingsManagerTests` 45/45 (67/67 combined). SwiftLint clean.
- Full `UnitTests` suite is broadly red in this local environment due to snapshot/signature-verification tests that fail identically on pristine `origin/main` (iOS 26 simulator); the classes exercising this change are green in isolation. CI is the authoritative gate.
- On-simulator log check (PaywallsTester, workflows on, live stress project): getOfferings still returns only after the config blobs land — network call pattern unchanged from #7181's verified run.

## Validation Gaps

- The decode-avoidance itself isn't visible in SDK logs (disk decode is silent); it's proven by the unit test's blob-read counts, not the on-device logs.
- Android not yet updated (same repeated-decode there).

## Review Focus

- Is `ConfigTopic` equality the right invalidation key (does every ui_config content change move the topic)?
- Async cache-fill: any correctness issue with two concurrent misses both assembling?

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only memoization with topic-equality invalidation; assembled UIConfig output is unchanged, with explicit guards against stale cache on topic races or nil topics.
> 
> **Overview**
> **`UiConfigProvider.getUiConfig()`** now memoizes the decoded **`UIConfig`** behind a lock, keyed on the current **`ui_config`** `ConfigTopic`. It reads the topic first; on a cache hit it returns without calling **`mergeItemsBlobData`**. Assembly is split into **`assembleUiConfig()`**, and a successful decode is stored only if the topic is unchanged after assembly (avoids caching under a stale key when remote config refreshes mid-decode). Nil/failed assemblies are not cached.
> 
> Unit tests cover cache hits, topic revision invalidation, nil topic after clear, and the mid-assembly topic race. **`MockRemoteConfigManager`** gains **`stubbedTopicSequence`** for ordered topic reads. **`OfferingsManager`** remote-config gate test is tightened to expect concurrent topic reads, then blob reads, before offerings delivery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b7906368b17c029655cad75930b8f923659bd40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->