### PR TITLE
fix(ci): stop mirroring main to purchases-ios-spm, tags only

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -2156,13 +2156,12 @@ jobs:
       - revenuecat/setup-git-credentials
       - revenuecat/trust-github-key
       - run:
-          name: Clone purchases-ios and push to purchases-ios-spm
+          name: Mirror purchases-ios tags to purchases-ios-spm (main not mirrored)
           command: |
             git clone git@github.com:RevenueCat/purchases-ios.git
             cd purchases-ios
             git fetch --tags
             git remote set-url origin git@github.com:RevenueCat/purchases-ios-spm.git
-            git push origin
             git push --tags
 
   deploy-to-purchases-ios-admob:


### PR DESCRIPTION
Stop pushing `main` to the SPM mirror so we can disable automations there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing what gets mirrored affects how the public SPM repo tracks releases; tag-only is the usual consumption path, but anything depending on an up-to-date `main` on the mirror would stop working.
> 
> **Overview**
> The **`deploy-to-spm`** release job no longer runs **`git push origin`** after retargeting the clone to **`purchases-ios-spm`**, so **`main` (and other branch refs) are not updated** on the SPM mirror—only **`git push --tags`** still runs.
> 
> The CircleCI step name was updated to state explicitly that tags are mirrored and **`main` is not**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc69e2b37752a9392cd44c7c326b96510307ad50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->