### PR TITLE
fix(remote-config): throttle failed refresh attempts

### DIFF
--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -208,6 +208,7 @@ final class NoOpRemoteConfigManager: RemoteConfigManagerType {
 final class RemoteConfigManager: RemoteConfigManagerType {
 
     private static let defaultDomain = "app"
+    private static let refreshAttemptCooldownInSeconds: TimeInterval = 30
 
     private let remoteConfigAPI: RemoteConfigAPIType
     private let diskCache: RemoteConfigDiskCacheType
@@ -250,6 +251,9 @@ final class RemoteConfigManager: RemoteConfigManagerType {
 
     /// In-memory staleness marker. Only successful `200` and `204` responses mark the config fresh.
     private var lastRefreshedAt: Date?
+
+    /// In-memory attempt marker used to avoid hammering the endpoint when a stale refresh keeps failing.
+    private var lastRefreshAttemptAt: Date?
 
     /// Read callers waiting for the current refresh to finish before rereading committed config state.
     ///
@@ -351,6 +355,7 @@ final class RemoteConfigManager: RemoteConfigManagerType {
             self.identityBoundAppUserID = appUserID
             self.isRefreshing = false
             self.lastRefreshedAt = nil
+            self.lastRefreshAttemptAt = nil
             self.diskCache.clear()
             self.blobStore.clear()
             return self.drainRefreshContinuations()
@@ -396,16 +401,22 @@ private extension RemoteConfigManager {
             guard !self.isRefreshing,
                   !self.isDisabledInternal,
                   !self.isClosed else { return nil }
+            let now = self.dateProvider.now()
             if let expectedEpoch {
                 guard self.epoch == expectedEpoch || self.identityBoundAppUserID != nil else { return nil }
             }
             if let lastRefreshedAt = self.lastRefreshedAt {
-                guard self.dateProvider.now().timeIntervalSince(lastRefreshedAt)
+                guard now.timeIntervalSince(lastRefreshedAt)
                     > self.cacheDurationInSeconds(isAppBackgrounded) else { return nil }
+            }
+            if let lastRefreshAttemptAt = self.lastRefreshAttemptAt {
+                guard now.timeIntervalSince(lastRefreshAttemptAt)
+                    > Self.refreshAttemptCooldownInSeconds else { return nil }
             }
 
             let requestAppUserID = self.identityBoundAppUserID ?? appUserID
             self.isRefreshing = true
+            self.lastRefreshAttemptAt = now
             return .init(
                 epoch: self.epoch,
                 requestAppUserID: requestAppUserID
@@ -652,6 +663,7 @@ private extension RemoteConfigManager {
 
     func markRefreshed() {
         self.lastRefreshedAt = self.dateProvider.now()
+        self.lastRefreshAttemptAt = nil
     }
 
     /// Waits for committed config state to become available for read APIs.

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -663,7 +663,6 @@ private extension RemoteConfigManager {
 
     func markRefreshed() {
         self.lastRefreshedAt = self.dateProvider.now()
-        self.lastRefreshAttemptAt = nil
     }
 
     /// Waits for committed config state to become available for read APIs.

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -208,7 +208,7 @@ final class NoOpRemoteConfigManager: RemoteConfigManagerType {
 final class RemoteConfigManager: RemoteConfigManagerType {
 
     private static let defaultDomain = "app"
-    private static let refreshAttemptCooldownInSeconds: TimeInterval = 30
+    private static let refreshAttemptCooldownInSeconds: TimeInterval = 60
 
     private let remoteConfigAPI: RemoteConfigAPIType
     private let diskCache: RemoteConfigDiskCacheType

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -13,6 +13,7 @@ import XCTest
 final class RemoteConfigManagerTests: TestCase {
 
     private static let appUserID = "app-user-id"
+    private static let refreshAttemptCooldownElapsedInterval: TimeInterval = 61
 
     private var remoteConfigAPI: MockRemoteConfigAPI!
     private var diskCache: MockRemoteConfigDiskCache!
@@ -94,7 +95,7 @@ final class RemoteConfigManagerTests: TestCase {
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
 
-        self.dateProvider.advance(by: 31)
+        self.dateProvider.advance(by: Self.refreshAttemptCooldownElapsedInterval)
         self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
@@ -426,7 +427,7 @@ final class RemoteConfigManagerTests: TestCase {
         expect(secondTopic).to(beNil())
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
 
-        self.dateProvider.advance(by: 31)
+        self.dateProvider.advance(by: Self.refreshAttemptCooldownElapsedInterval)
         let thirdRead = Task {
             await self.manager.topic(.sources)
         }
@@ -1545,7 +1546,7 @@ final class RemoteConfigManagerTests: TestCase {
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
 
-        self.dateProvider.advance(by: 31)
+        self.dateProvider.advance(by: Self.refreshAttemptCooldownElapsedInterval)
         self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
@@ -2365,7 +2366,7 @@ final class RemoteConfigManagerTests: TestCase {
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
 
-        self.dateProvider.advance(by: 31)
+        self.dateProvider.advance(by: Self.refreshAttemptCooldownElapsedInterval)
         self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -92,6 +92,21 @@ final class RemoteConfigManagerTests: TestCase {
 
         self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
 
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+
+        self.dateProvider.advance(by: 31)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
+    }
+
+    func testForcedRefreshBypassesFailureCooldown() {
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1)))))
+        self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
+
+        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
     }
 
@@ -104,6 +119,21 @@ final class RemoteConfigManagerTests: TestCase {
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
 
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
+    }
+
+    func testClearCacheClearsFailureCooldown() {
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1)))))
+        self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
+
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+
+        self.manager.clearCache(forAppUserID: Self.appUserID)
         self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
@@ -378,6 +408,35 @@ final class RemoteConfigManagerTests: TestCase {
 
         expect(secondRead).to(beNil())
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+    }
+
+    func testTopicColdReadFailureUsesFailureCooldown() async {
+        let firstRead = Task {
+            await self.manager.topic(.sources)
+        }
+        await self.waitForRemoteConfigRequestCount(1)
+        self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
+        self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
+
+        let firstTopic = await firstRead.value
+        expect(firstTopic).to(beNil())
+
+        let secondTopic = await self.manager.topic(.sources)
+
+        expect(secondTopic).to(beNil())
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+
+        self.dateProvider.advance(by: 31)
+        let thirdRead = Task {
+            await self.manager.topic(.sources)
+        }
+        await self.waitForRemoteConfigRequestCount(2)
+        self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
+        self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
+
+        let thirdTopic = await thirdRead.value
+        expect(thirdTopic).to(beNil())
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
     }
 
     func testTopicWaitsForInFlightRefreshBeforeReturningMissingTopic() async throws {
@@ -1484,6 +1543,11 @@ final class RemoteConfigManagerTests: TestCase {
 
         self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
 
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+
+        self.dateProvider.advance(by: 31)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
         expect(self.diskCache.invokedWriteCount) == 0
         expect(self.blobStore.invokedWriteCount) == 0
@@ -2297,6 +2361,11 @@ final class RemoteConfigManagerTests: TestCase {
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
         )
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+
+        self.dateProvider.advance(by: 31)
         self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -122,10 +122,15 @@ final class RemoteConfigManagerTests: TestCase {
 
         self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
 
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+
+        self.dateProvider.advance(by: Self.refreshAttemptCooldownElapsedInterval)
+        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
     }
 
-    func testClearCacheClearsFailureCooldown() {
+    func testClearCacheClearsRefreshAttemptCooldown() {
         self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1)))))
         self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))


### PR DESCRIPTION
## Motivation

When locally cached remote-config data is available, a failed request to the remote config endpoint does not fall back. However it also does not update the local cache (which makes sense). However this results in it also bypassing the staleness check, causing every subsequent request to be sent to the backend right away.

Now that we're refreshing the remote config state when fetching offerings, any call to `getOfferings()` (or any app-foreground) will make another call to the remote config API as long as it's degraded.

## Changes
This PR adds the `lastRefreshAttemptAt` and will only allow a new request to be sent after the `rereshAttemptCooldownInSeconds` has passed, which I set to `30s` for now (up for discussion)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to throttling stale refresh scheduling in RemoteConfigManager; forced refresh is unchanged and tests cover the main paths.
> 
> **Overview**
> Stops **hammering the remote config API** when refreshes keep failing while config stays stale (failed responses never update `lastRefreshedAt`, so every `refreshRemoteConfigIfStale` / cold topic read could immediately retry).
> 
> `RemoteConfigManager` now tracks **`lastRefreshAttemptAt`** and, in **`prepareRefreshIfStale` only**, blocks another stale refresh until **`refreshAttemptCooldownInSeconds` (60s)** has passed since the last attempt. **`refreshRemoteConfig`** still uses **`prepareRefreshIfNeeded`** and **does not** apply this cooldown.
> 
> **`clearCache`** resets the attempt marker so identity/cache clears can refresh right away. Unit tests assert cooldown behavior, forced-refresh bypass, cache clear reset, and that repeated stale-if-needed calls no longer double-hit the API until the cooldown elapses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 014e60ddd11b346c3abe386520cf16d13c5b7a19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->