### PR TITLE
[v4] CI fixes and adaptations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -861,42 +861,6 @@ jobs:
           path: fastlane/test_output/xctest
           destination: scan-test-output
 
-  run-test-ios-14:
-    executor:
-      name: macos-executor-for-macos-12_6
-      # Pre-iOS 15 requires macOS 12 which requires Xcode 14.2
-      # See https://circleci.com/docs/using-macos/#supported-xcode-versions
-      xcode_version: "14.2.0"
-    steps:
-      - checkout
-      - install-dependencies:
-          install_xcbeautify: false
-          # Mint 0.17.5 is required here as newer versions of Mint don't support macOS 12.
-          install_mint_0_17_5: true
-          install_swiftlint: false
-      - install-xcbeautify-for-xcode14
-      - update-spm-installation-commit
-      - install-runtime:
-          runtime-name: iOS 14.5
-      - run:
-          name: Run tests
-          command: bundle exec fastlane test_ios skip_sk_tests:true
-          no_output_timeout: 5m
-          environment:
-            SCAN_DEVICE: iPhone 12 (14.5)
-      - compress_result_bundle:
-          directory: fastlane/test_output/xctest/ios
-          bundle_name: RevenueCat
-      - create-snapshot-pr-if-needed:
-          condition: << pipeline.parameters.generate_snapshots >>
-          job: "create_snapshot_pr"
-          version: "ios-14"
-      - store_test_results:
-          path: fastlane/test_output
-      - store_artifacts:
-          path: fastlane/test_output/xctest
-          destination: scan-test-output
-
   run-test-ios-13:
     executor:
       name: macos-executor-for-macos-12_6
@@ -1386,7 +1350,6 @@ workflows:
       - run-test-ios-17
       - run-test-ios-16
       - run-test-ios-15
-      - run-test-ios-14
       - run-test-ios-13
       - run-test-ios-12
       - run-test-macos
@@ -1426,7 +1389,6 @@ workflows:
       - run-test-tvos
       # Pre-iOS 15 requires macOS 12 which requires Xcode 14.2
       # See https://circleci.com/docs/using-macos/#supported-xcode-versions
-      - run-test-ios-14
       - run-test-ios-13:
           <<: *release-branches-and-main
       - run-test-ios-12:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,23 +85,38 @@ commands:
       runtime-name:
         type: string
     steps:
-      # - install-brew-dependency:
-      #     dependency_name: 'xcodes'
-      # - run:
-      #     name: Install simulator
-      #     command: | # Print all available simulators and install required one
-      #         xcodes runtimes
-      #         sudo xcodes runtimes install "<< parameters.runtime-name >>"
-      # Xcodes got broken with latest iOS 18 betas. This is a temporary workaround. https://github.com/XcodesOrg/xcodes/issues/368
+      - restore_cache:
+          keys:
+            - v1-xcodes-2.0.3-{{ arch }}
       - run:
-          name: Install fixed xcodes version
+          name: Install xcodes 2.0.3
           command: |
-              mint install https://github.com/alvar-bolt/xcodes.git@alvar/ios-18-quickfix
+            # Pinned to 2.0.3: it handles Apple's simulator runtime catalog
+            # `authentication: none` entries that break older xcodes versions.
+            # https://github.com/XcodesOrg/xcodes/releases/tag/2.0.3
+            # We install the prebuilt universal binary into /opt/homebrew/bin (on PATH
+            # and reachable under sudo, used by the runtime install step below).
+            # Match on the exact version so a pre-installed/older xcodes is replaced.
+            if xcodes version 2>/dev/null | grep -q "2.0.3"; then
+                echo "xcodes 2.0.3 already installed, skipping."
+                exit 0
+            fi
+            curl -fsSL -o /tmp/xcodes.tar.gz \
+              https://github.com/XcodesOrg/xcodes/releases/download/2.0.3/xcodes-2.0.3.macos.arm64.bottle.tar.gz
+            echo "d0251244b8a02b5af1eb5fa5618c6efff6e387d51f749b631b9c7cceee476fae  /tmp/xcodes.tar.gz" | shasum -a 256 -c -
+            tar -xzf /tmp/xcodes.tar.gz -C /tmp
+            sudo mv /tmp/xcodes/2.0.3/bin/xcodes /opt/homebrew/bin/xcodes
+            sudo chmod +x /opt/homebrew/bin/xcodes
+            xcodes version
+      - save_cache:
+          key: v1-xcodes-2.0.3-{{ arch }}
+          paths:
+            - /opt/homebrew/bin/xcodes
       - run:
           name: Install simulator
           command: | # Print all available simulators and install required one
-              $HOME/.mint/bin/xcodes runtimes
-              sudo $HOME/.mint/bin/xcodes runtimes install "<< parameters.runtime-name >>"
+              xcodes runtimes
+              sudo xcodes runtimes install "<< parameters.runtime-name >>"
 
   install-bundle-dependencies:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -806,6 +806,41 @@ jobs:
           path: fastlane/test_output/xctest
           destination: scan-test-output
 
+  run-test-ios-14:
+    executor:
+      name: macos-executor
+      # iOS 14 requires Xcode 14, and 14.3.1 is the latest Xcode 14 available on CircleCI.
+      # See https://circleci.com/docs/using-macos/#supported-xcode-versions
+      xcode_version: "14.3.1"
+    steps:
+      - checkout
+      - install-dependencies:
+          install_xcbeautify: false
+          install_mint: true
+          install_swiftlint: false
+      - install-xcbeautify-for-xcode14
+      - update-spm-installation-commit
+      - install-runtime:
+          runtime-name: iOS 14.5
+      - run:
+          name: Run tests
+          command: bundle exec fastlane test_ios skip_sk_tests:true
+          no_output_timeout: 5m
+          environment:
+            SCAN_DEVICE: iPhone 12 (14.5)
+      - compress_result_bundle:
+          directory: fastlane/test_output/xctest/ios
+          bundle_name: RevenueCat
+      - create-snapshot-pr-if-needed:
+          condition: << pipeline.parameters.generate_snapshots >>
+          job: "create_snapshot_pr"
+          version: "ios-14"
+      - store_test_results:
+          path: fastlane/test_output
+      - store_artifacts:
+          path: fastlane/test_output/xctest
+          destination: scan-test-output
+
   run-test-tvos:
     executor:
       name: macos-executor
@@ -1271,6 +1306,7 @@ workflows:
       - run-test-ios-17
       - run-test-ios-16
       - run-test-ios-15
+      - run-test-ios-14
       - run-test-macos
       - run-test-watchos
 
@@ -1304,6 +1340,7 @@ workflows:
       - run-test-ios-17
       - run-test-ios-16
       - run-test-ios-15
+      - run-test-ios-14
       - run-test-watchos
       - run-test-tvos
       - build-tv-watch-and-macos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -610,6 +610,41 @@ jobs:
           path: fastlane/test_output
           destination: scan-test-output
 
+  spm-revenuecat-ui-ios-26:
+    executor:
+      name: macos-executor
+      xcode_version: "26.5"
+    steps:
+      - checkout
+      # xcbeautify not needed: test_revenuecatui uses xcodebuild directly
+      - install-dependencies:
+          install_xcbeautify: false
+      - update-spm-installation-commit
+      - run:
+          name: SPM RevenueCatUI Release Build
+          command: swift build -c release --target RevenueCatUI
+          no_output_timeout: 5m
+      - run:
+          name: SPM RevenueCatUI Tests
+          command: bundle exec fastlane test_revenuecatui
+          no_output_timeout: 15m
+          environment:
+            DEVICE: iPhone 17,OS=26.5
+            # No iOS 26 reference snapshots yet: run unit tests, skip snapshot tests.
+            REVENUECATUI_TEST_PLAN: RevenueCatUI-UnitTests
+      - create-snapshot-pr-if-needed:
+          condition: << pipeline.parameters.generate_revenuecatui_snapshots >>
+          job: "create_snapshots_repo_pr"
+          version: "revenuecatui-26"
+      - compress_result_bundle:
+          directory: fastlane/test_output
+          bundle_name: revenuecatui
+      - store_test_results:
+          path: fastlane/test_output/revenuecatui/tests.xml
+      - store_artifacts:
+          path: fastlane/test_output
+          destination: scan-test-output
+
   spm-revenuecat-ui-watchos:
     executor:
       name: macos-executor
@@ -1380,6 +1415,7 @@ workflows:
       - spm-revenuecat-ui-ios-15
       - spm-revenuecat-ui-ios-16
       - spm-revenuecat-ui-ios-17
+      - spm-revenuecat-ui-ios-26
       - spm-revenuecat-ui-watchos
       - run-test-macos
       - run-test-ios-18

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,15 +34,6 @@ executors:
       CIRCLECI_TESTS_GENERATE_REVENUECAT_UI_SNAPSHOTS: << pipeline.parameters.generate_revenuecatui_snapshots >>
     working_directory: ~/purchases-ios
     shell: /bin/bash --login -o pipefail
-  macos-executor-for-macos-12_6:
-    parameters:
-      xcode_version:
-        type: string
-        default: "16.4"
-    macos:
-      # circleci-lint: disable=unknown-xcode-version
-      xcode: << parameters.xcode_version >>
-    resource_class: macos.m1.medium.gen1
 
 aliases:
   release-branches: &release-branches
@@ -861,76 +852,6 @@ jobs:
           path: fastlane/test_output/xctest
           destination: scan-test-output
 
-  run-test-ios-13:
-    executor:
-      name: macos-executor-for-macos-12_6
-      xcode_version: "14.2.0"
-    steps:
-      - checkout
-      - install-dependencies:
-          install_xcbeautify: false
-          # Mint 0.17.5 is required here as newer versions of Mint don't support macOS 12.
-          install_mint_0_17_5: true
-          install_swiftlint: false
-      - macos/install-rosetta
-      - install-xcbeautify-for-xcode14
-      - update-spm-installation-commit
-      - install-runtime:
-          runtime-name: iOS 13.7
-      - run:
-          name: Run tests
-          command: bundle exec fastlane test_ios
-          no_output_timeout: 5m
-          environment:
-            SCAN_DEVICE: iPhone 11 (13.7)
-      - compress_result_bundle:
-          directory: fastlane/test_output/xctest/ios
-          bundle_name: RevenueCat
-      - create-snapshot-pr-if-needed:
-          condition: << pipeline.parameters.generate_snapshots >>
-          job: "create_snapshot_pr"
-          version: "ios-13"
-      - store_test_results:
-          path: fastlane/test_output
-      - store_artifacts:
-          path: fastlane/test_output/xctest
-          destination: scan-test-output
-
-  run-test-ios-12:
-    executor:
-      name: macos-executor-for-macos-12_6
-      xcode_version: "14.2.0"
-    steps:
-      - checkout
-      - install-dependencies:
-          install_xcbeautify: false
-          # Mint 0.17.5 is required here as newer versions of Mint don't support macOS 12.
-          install_mint_0_17_5: true
-          install_swiftlint: false
-      - macos/install-rosetta
-      - install-xcbeautify-for-xcode14
-      - update-spm-installation-commit
-      - install-runtime:
-          runtime-name: iOS 12.4
-      - run:
-          name: Run tests
-          command: bundle exec fastlane test_ios
-          no_output_timeout: 5m
-          environment:
-            SCAN_DEVICE: iPhone 6 (12.4)
-      - compress_result_bundle:
-          directory: fastlane/test_output/xctest/ios
-          bundle_name: RevenueCat
-      - create-snapshot-pr-if-needed:
-          condition: << pipeline.parameters.generate_snapshots >>
-          job: "create_snapshot_pr"
-          version: "ios-12"
-      - store_test_results:
-          path: fastlane/test_output
-      - store_artifacts:
-          path: fastlane/test_output/xctest
-          destination: scan-test-output
-
   build-tv-watch-and-macos:
     executor:
       name: macos-executor
@@ -1350,8 +1271,6 @@ workflows:
       - run-test-ios-17
       - run-test-ios-16
       - run-test-ios-15
-      - run-test-ios-13
-      - run-test-ios-12
       - run-test-macos
       - run-test-watchos
 
@@ -1387,12 +1306,6 @@ workflows:
       - run-test-ios-15
       - run-test-watchos
       - run-test-tvos
-      # Pre-iOS 15 requires macOS 12 which requires Xcode 14.2
-      # See https://circleci.com/docs/using-macos/#supported-xcode-versions
-      - run-test-ios-13:
-          <<: *release-branches-and-main
-      - run-test-ios-12:
-          <<: *release-branches-and-main
       - build-tv-watch-and-macos
       - build-visionos
       - backend-integration-tests-SK1:

--- a/Tests/RevenueCatUITests/BaseSnapshotTest.swift
+++ b/Tests/RevenueCatUITests/BaseSnapshotTest.swift
@@ -150,6 +150,9 @@ extension View {
 
         window.makeKeyAndVisible()
 
+        // Wait for views to render
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+
         return {
             controller.beginAppearanceTransition(false, animated: false)
             controller.view.removeFromSuperview()
@@ -157,6 +160,7 @@ extension View {
             controller.endAppearanceTransition()
             window.rootViewController = nil
             window.resignKey()
+            RunLoop.main.run(until: Date().addingTimeInterval(0.1))
         }
     }
 

--- a/Tests/RevenueCatUITests/PaywallViewEventsTests.swift
+++ b/Tests/RevenueCatUITests/PaywallViewEventsTests.swift
@@ -11,6 +11,8 @@
 //
 //  Created by Nacho Soto on 9/7/23.
 
+// swiftlint:disable type_name
+
 import Nimble
 import RevenueCat
 @testable import RevenueCatUI
@@ -20,14 +22,38 @@ import XCTest
 #if !os(watchOS) && !os(macOS)
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+final class PaywallViewEventsFullscreenLightModeTests: BasePaywallViewEventsTests {
+    override var mode: PaywallViewMode { .fullScreen }
+    override var scheme: ColorScheme { .light }
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+final class PaywallViewEventsFooterDarkModeTests: BasePaywallViewEventsTests {
+    override var mode: PaywallViewMode { .footer }
+    override var scheme: ColorScheme { .dark }
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @MainActor
-class PaywallViewEventsTests: TestCase {
+class BasePaywallViewEventsTests: TestCase {
+
+    // To be overridden by subclasses
+    var mode: PaywallViewMode { fatalError("Must override") }
+    var scheme: ColorScheme { fatalError("Must override") }
 
     private var events: [PaywallEvent] = []
     private var handler: PurchaseHandler!
 
-    private let mode: PaywallViewMode = .random
-    private let scheme: ColorScheme = Bool.random() ? .dark : .light
+    /// Prevents XCTest from running this base class directly.
+    /// This class is intended to be subclassed for concrete test cases,
+    /// each providing their own `mode` and `scheme` configurations.
+    /// By returning an empty test suite for the base class,
+    /// we ensure that shared test logic is only executed through subclasses.
+    override class var defaultTestSuite: XCTestSuite {
+        return self == BasePaywallViewEventsTests.self
+            ? XCTestSuite(name: "BasePaywallViewEventsTests")
+            : super.defaultTestSuite
+    }
 
     private var impressionEventExpectation: XCTestExpectation!
     private var closeEventExpectation: XCTestExpectation!
@@ -126,7 +152,7 @@ class PaywallViewEventsTests: TestCase {
 // MARK: -
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-private extension PaywallViewEventsTests {
+private extension BasePaywallViewEventsTests {
 
     /// Invokes `createView` and runs the given `closure` during the lifetime of the view.
     /// Returns after the view has been completly removed from the hierarchy.

--- a/Tests/RevenueCatUITests/PaywallViewEventsTests.swift
+++ b/Tests/RevenueCatUITests/PaywallViewEventsTests.swift
@@ -114,7 +114,7 @@ class PaywallViewEventsTests: TestCase {
 
         await self.waitForCloseEvent()
 
-        expect(self.events).to(haveCount(4))
+        await expect(self.events).toEventually(haveCount(4))
         expect(self.events.map(\.eventType)) == [.impression, .close, .impression, .close]
         expect(Set(self.events.map(\.data.sessionIdentifier))).to(haveCount(2))
     }
@@ -137,6 +137,9 @@ private extension PaywallViewEventsTests {
         try await Task {
             let dispose = try self.createView()
                 .addToHierarchy()
+
+            try await Task.sleep(nanoseconds: 3 * 1_000_000)
+
             try await closure()
             dispose()
         }.value
@@ -174,7 +177,7 @@ private extension PaywallViewEventsTests {
     }
 
     func waitForCloseEvent() async {
-        await self.fulfillment(of: [self.closeEventExpectation], timeout: 1)
+        await self.fulfillment(of: [self.closeEventExpectation], timeout: 3)
     }
 
 }

--- a/Tests/RevenueCatUITests/PaywallViewEventsTests.swift
+++ b/Tests/RevenueCatUITests/PaywallViewEventsTests.swift
@@ -140,9 +140,6 @@ class BasePaywallViewEventsTests: TestCase {
 
         await self.waitForCloseEvent()
 
-        // `waitForCloseEvent` already waits for both close events (expectedFulfillmentCount = 2),
-        // so all four events are present here. A synchronous check is used because v4 ships
-        // Nimble 10, whose async `await ... toEventually` (main uses it via Nimble 13) is unreliable.
         expect(self.events).to(haveCount(4))
         expect(self.events.map(\.eventType)) == [.impression, .close, .impression, .close]
         expect(Set(self.events.map(\.data.sessionIdentifier))).to(haveCount(2))

--- a/Tests/RevenueCatUITests/PaywallViewEventsTests.swift
+++ b/Tests/RevenueCatUITests/PaywallViewEventsTests.swift
@@ -140,7 +140,10 @@ class BasePaywallViewEventsTests: TestCase {
 
         await self.waitForCloseEvent()
 
-        await expect(self.events).toEventually(haveCount(4))
+        // `waitForCloseEvent` already waits for both close events (expectedFulfillmentCount = 2),
+        // so all four events are present here. A synchronous check is used because v4 ships
+        // Nimble 10, whose async `await ... toEventually` (main uses it via Nimble 13) is unreliable.
+        expect(self.events).to(haveCount(4))
         expect(self.events.map(\.eventType)) == [.impression, .close, .impression, .close]
         expect(Set(self.events.map(\.data.sessionIdentifier))).to(haveCount(2))
     }

--- a/Tests/RevenueCatUITests/PresentIfNeededTests.swift
+++ b/Tests/RevenueCatUITests/PresentIfNeededTests.swift
@@ -129,7 +129,9 @@ class PresentIfNeededTests: TestCase {
             dispose()
         }
 
-        expect(started).toEventually(beTrue())
+        // Newer simulators (iOS 26+) can be slower to present the paywall and wire up
+        // the restore handler, so allow more time than Nimble's 1s default.
+        expect(started).toEventually(beTrue(), timeout: .seconds(5))
         task.cancel()
     }
 

--- a/Tests/RevenueCatUITests/TestPlans/RevenueCatUI-UnitTests.xctestplan
+++ b/Tests/RevenueCatUITests/TestPlans/RevenueCatUI-UnitTests.xctestplan
@@ -17,6 +17,8 @@
       }
     ],
     "maximumTestExecutionTimeAllowance" : 180,
+    "maximumTestRepetitions" : 3,
+    "testRepetitionMode" : "retryOnFailure",
     "testTimeoutsEnabled" : true
   },
   "testTargets" : [

--- a/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
@@ -187,6 +187,10 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
 
         _ = try await sk2Product.purchase()
 
+        // Delay added to reduce flakiness on iOS 26, where eligibility may be checked too soon after purchase.
+        // Allows StoreKit time to register the purchase before checking eligibility.
+        try await Task.sleep(nanoseconds: 100_000_000)
+
         let postPurchaseStatus: IntroEligibilityStatus = await withCheckedContinuation { continuation in
             self.trialOrIntroPriceEligibilityChecker.checkEligibility(product: storeProduct) { status in
                 continuation.resume(returning: status)

--- a/Tests/UnitTests/TestHelpers/SnapshotTesting+Extensions.swift
+++ b/Tests/UnitTests/TestHelpers/SnapshotTesting+Extensions.swift
@@ -34,6 +34,11 @@ func assertSnapshot<Value, Format>(
   testName: String = #function,
   line: UInt = #line
 ) {
+    // Skip snapshot comparisons when there are no reference snapshots for the
+    // current OS (e.g. new iOS versions). Image snapshots are skipped in
+    // `BaseSnapshotTest`; this covers JSON/text snapshots too.
+    guard ProcessInfo.processInfo.environment["RC_SKIP_SNAPSHOT_TESTS"] != "1" else { return }
+
     let failure = verifySnapshot(
         matching: try value(),
         as: snapshotting,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -212,6 +212,9 @@ platform :ios do
     platform = ENV['PLATFORM'] || 'iOS Simulator'
     destination = ENV['DEVICE'] || "iPhone 14,OS=16.4"
     sdk = ENV['BUILD_SDK'] || 'iphonesimulator'
+    # Allow overriding the test plan (e.g. RevenueCatUI-UnitTests to skip snapshot
+    # tests on OS versions that don't have reference snapshots yet).
+    test_plan = ENV['REVENUECATUI_TEST_PLAN'] || (generate_snapshots ? "CI-Snapshots" : "CI-RevenueCatUI")
 
     fetch_snapshots
 
@@ -227,7 +230,7 @@ platform :ios do
         report_formats: [:junit],
         report_path: 'fastlane/test_output/revenuecatui/tests.xml',
         test: true,
-        xcargs: generate_snapshots ? "-testPlan CI-Snapshots" : "-testPlan CI-RevenueCatUI"
+        xcargs: "-testPlan #{test_plan}"
       )
     rescue => e
       # Equivalent to `fail_build: !generate_snapshots`


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
First slice of Xcode 27 support for v4: CI fixes and test/CI adaptations only, no library source changes. Pinning xcodes 2.0.3 unblocks the legacy iOS simulator-install step (older xcodes can't parse Apple's `authentication: none` runtime catalog).

### Description
- Pin xcodes to 2.0.3 in `install-runtime`.
- Add `spm-revenuecat-ui-ios-26` CI job (Xcode 26.5), skipping RevenueCatUI snapshot tests where no reference snapshots exist yet.
- Legacy iOS matrix: drop `run-test-ios-12`/`run-test-ios-13` (they require the retired Xcode 14.2 / macOS 12.6, no longer available on CircleCI) and re-add `run-test-ios-14` on Xcode 14.3.1 with the iOS 14.5 runtime.

### Backported PRs
- #7162 (Pin xcodes to 2.0.3)
- #5552 (`TrialOrIntroPriceEligibilityCheckerSK2Tests` flake)
- #5008, #5573 (`PaywallViewEventsTests` flakes)

Xcode 27 support (and the iOS 27 job) follows in stacked PR #7194.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CircleCI, Fastlane, and test code; production SDK behavior is unchanged.
> 
> **Overview**
> **CI and test-only** changes for newer Xcode/iOS simulators; no SDK library source updates.
> 
> CircleCI drops the retired **macOS 12.6 / Xcode 14.2** executor and **iOS 12/13** test jobs, keeps **iOS 14** on **Xcode 14.3.1** with the pinned **xcodes 2.0.3** simulator-runtime install (cached binary + checksum). Adds **`spm-revenuecat-ui-ios-26`** (Xcode 26.5) and wires **`REVENUECATUI_TEST_PLAN`** in Fastlane so that job runs **RevenueCatUI-UnitTests** (snapshots skipped via `RC_SKIP_SNAPSHOT_TESTS`).
> 
> Test hardening: **`assertSnapshot`** respects the same skip env as image snapshots; paywall event tests use **fixed mode/scheme subclasses** instead of random config, with longer async timeouts and brief **RunLoop** waits in hierarchy setup; StoreKit intro-eligibility test waits after purchase; RevenueCatUI unit test plan **retries on failure** (up to 3).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6672219665321ee65f5561fe6ccc04c6a8e025f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->