### PR TITLE
Pass Tuist Swift conditions to local package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,9 +5,8 @@ import class Foundation.ProcessInfo
 import struct Foundation.URL
 import PackageDescription
 
-/// This looks for a file named `Local.xcconfig` in the root of the purchases-ios[-spm] repo, and reads any compiler
-/// flags defined in it. It does nothing if this file does not exist in this exact folder. This file does not exist on
-/// a clean checkout. It has to be created manually by a developer.
+/// This reads extra Swift compiler conditions from `CI.xcconfig`, `Local.xcconfig`, and
+/// `TUIST_SWIFT_CONDITIONS`.
 var additionalCompilerFlags: [PackageDescription.SwiftSetting] = {
     let ciConfig = try? String(
         contentsOf: URL(fileURLWithPath: #filePath)
@@ -21,19 +20,28 @@ var additionalCompilerFlags: [PackageDescription.SwiftSetting] = {
             .appendingPathComponent("Local.xcconfig")
     )
 
-    guard let config = ciConfig ?? localConfig else {
-        return []
-    }
-
     // We split the capture group by space and remove any special flags, such as $(inherited).
-    return config
+    let configFlags = (ciConfig ?? localConfig)?
         .firstMatch(of: #/^SWIFT_ACTIVE_COMPILATION_CONDITIONS *= *(.*)$/#.anchorsMatchLineEndings())?
         .output
         .1
         .split(whereSeparator: \.isWhitespace)
         .filter { !$0.isEmpty && !$0.hasPrefix("$") }
-        .map { .define(String($0)) }
         ?? []
+
+    let environmentFlags = ProcessInfo.processInfo.environment["TUIST_SWIFT_CONDITIONS"]?
+        .split(whereSeparator: \.isWhitespace)
+        .filter { !$0.isEmpty }
+        ?? []
+
+    var flags: [String] = []
+    for flag in configFlags + environmentFlags {
+        let flag = String(flag)
+        guard !flags.contains(flag) else { continue }
+        flags.append(flag)
+    }
+
+    return flags.map { .define($0) }
 }()
 
 var ciCompilerFlags: [PackageDescription.SwiftSetting] = [


### PR DESCRIPTION
## Motivation
Extra Swift compilation conditions passed through Tuist using `TUIST_SWIFT_CONDITIONS="ENABLE_REMOTE_CONFIG" tuist generate` for example were only available when generating the Tuist project using the RC packages as local xcode projects (through `TUIST_RC_XCODE_PROJECT`). 

When this was not set, the active compilation conditions were only applied to the projects targets, since the RC dependencies were their own independent local SPM package.

## Changes
This PR updates the `Package.swift` file to also look for the `TUIST_SWIFT_CONDITIONS` environment variable and apply them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time compiler flag wiring only; no runtime product behavior changes.
> 
> **Overview**
> **`Package.swift`** now picks up Tuist’s **`TUIST_SWIFT_CONDITIONS`** at SPM resolve/build time, so flags like `ENABLE_REMOTE_CONFIG` apply to the local RevenueCat package—not only to Tuist-generated app targets.
> 
> Compiler defines are merged from **`CI.xcconfig` / `Local.xcconfig`** (`SWIFT_ACTIVE_COMPILATION_CONDITIONS`) and the env var, with **deduplication**. Missing xcconfig no longer blocks env-only flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5396b957fcdf7c0053a4a4f9c5397eb030df7d42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->