### PR TITLE
perf(remote-config): give /config its own request lane so it overlaps /offerings

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1312,6 +1312,7 @@
 		E362B0B039CA151D4FEB944F /* ArithmeticOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A71219F92AF8FC83FA7CB /* ArithmeticOperators.swift */; };
 		E5DCF3F2EB33F0C02C79BEEF /* AccessorOperatorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49121C11022272A08D75B4E /* AccessorOperatorsTests.swift */; };
 		E6A54710537E4AA3810E1CB0 /* BackendGetRemoteConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96BC3A5229194DFB9653FC8C /* BackendGetRemoteConfigTests.swift */; };
+		FACE0000000000000000A001 /* BackendRemoteConfigLaneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACE0000000000000000A002 /* BackendRemoteConfigLaneTests.swift */; };
 		E6B064598F674333A29E0781 /* RemoteConfigCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCF81FAC33B948F0947AE312 /* RemoteConfigCallback.swift */; };
 		F2138021CD5445218F7CE984 /* DangerousSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 425B8CF8557E44A4974E502A /* DangerousSettingsTests.swift */; };
 		F516BD29282434070083480B /* StoreKit2StorefrontListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = F516BD28282434070083480B /* StoreKit2StorefrontListener.swift */; };
@@ -2745,6 +2746,7 @@
 		90A1B2C62F96927E00D32EDF /* AdRewardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdRewardTests.swift; sourceTree = "<group>"; };
 		93B46553B99148F3A60B8BFB /* CustomPaywallVariables.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomPaywallVariables.swift; sourceTree = "<group>"; };
 		96BC3A5229194DFB9653FC8C /* BackendGetRemoteConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendGetRemoteConfigTests.swift; sourceTree = "<group>"; };
+		FACE0000000000000000A002 /* BackendRemoteConfigLaneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendRemoteConfigLaneTests.swift; sourceTree = "<group>"; };
 		9A65DFDD258AD60A00DE00B0 /* LogIntent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogIntent.swift; sourceTree = "<group>"; };
 		9A65E03525918B0500DE00B0 /* ConfigureStrings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigureStrings.swift; sourceTree = "<group>"; };
 		9A65E03A25918B0900DE00B0 /* CustomerInfoStrings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomerInfoStrings.swift; sourceTree = "<group>"; };
@@ -5141,6 +5143,7 @@
 				FD5EB26F2DFB19B800DA1974 /* BackendGetVirtualCurrenciesTests.swift */,
 				FD25F3772F33D502007C1A91 /* BackendIsPurchaseAllowedByRestoreBehaviorTests.swift */,
 				96BC3A5229194DFB9653FC8C /* BackendGetRemoteConfigTests.swift */,
+				FACE0000000000000000A002 /* BackendRemoteConfigLaneTests.swift */,
 			);
 			path = Backend;
 			sourceTree = "<group>";
@@ -7611,6 +7614,7 @@
 				5766AA5A283D4CAB00FA6091 /* IgnoreHashableTests.swift in Sources */,
 				0368727A2D9DCF7100506BBB /* DefaultEnumTests.swift in Sources */,
 				E6A54710537E4AA3810E1CB0 /* BackendGetRemoteConfigTests.swift in Sources */,
+				FACE0000000000000000A001 /* BackendRemoteConfigLaneTests.swift in Sources */,
 				03C7305B2D35985900297FEC /* TextComponentTests.swift in Sources */,
 				FDE57B0E2DF8BC1100101CE2 /* VirtualCurrenciesDecodingTests.swift in Sources */,
 				75FCD4CE2E37FBE100036C02 /* SimulatedStoreMockData.swift in Sources */,

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -52,10 +52,31 @@ class Backend {
                                           systemInfo: systemInfo,
                                           offlineCustomerInfoCreator: offlineCustomerInfoCreator,
                                           dateProvider: dateProvider)
-        self.init(backendConfig: config, attributionFetcher: attributionFetcher)
+        // Dedicated remote-config lane: its own HTTPClient (own serial request state + own
+        // connection) and its own queue, so `/config` overlaps `/offerings` instead of
+        // serializing behind it on the shared pipe.
+        let remoteConfigHTTPClient = HTTPClient(systemInfo: systemInfo,
+                                                eTagManager: eTagManager,
+                                                signing: Signing(apiKey: systemInfo.apiKey,
+                                                                 clock: systemInfo.clock),
+                                                diagnosticsTracker: diagnosticsTracker,
+                                                requestTimeout: httpClientTimeout,
+                                                operationDispatcher: OperationDispatcher.default)
+        let remoteConfigConfig = BackendConfiguration(httpClient: remoteConfigHTTPClient,
+                                                      operationDispatcher: operationDispatcher,
+                                                      operationQueue: QueueProvider.createRemoteConfigQueue(),
+                                                      diagnosticsQueue: QueueProvider.createDiagnosticsQueue(),
+                                                      systemInfo: systemInfo,
+                                                      offlineCustomerInfoCreator: offlineCustomerInfoCreator,
+                                                      dateProvider: dateProvider)
+        self.init(backendConfig: config,
+                  remoteConfigBackendConfig: remoteConfigConfig,
+                  attributionFetcher: attributionFetcher)
     }
 
-    convenience init(backendConfig: BackendConfiguration, attributionFetcher: AttributionFetcher) {
+    convenience init(backendConfig: BackendConfiguration,
+                     remoteConfigBackendConfig: BackendConfiguration? = nil,
+                     attributionFetcher: AttributionFetcher) {
         let customer = CustomerAPI(backendConfig: backendConfig, attributionFetcher: attributionFetcher)
         let identity = IdentityAPI(backendConfig: backendConfig)
         let offerings = OfferingsAPI(backendConfig: backendConfig)
@@ -66,7 +87,7 @@ class Backend {
         let redeemWebPurchaseAPI = RedeemWebPurchaseAPI(backendConfig: backendConfig)
         let virtualCurrenciesAPI = VirtualCurrenciesAPI(backendConfig: backendConfig)
         let adsAPI = AdsAPI(backendConfig: backendConfig)
-        let remoteConfigAPI = RemoteConfigAPI(backendConfig: backendConfig)
+        let remoteConfigAPI = RemoteConfigAPI(backendConfig: remoteConfigBackendConfig ?? backendConfig)
 
         self.init(backendConfig: backendConfig,
                   customerAPI: customer,
@@ -260,6 +281,15 @@ extension Backend {
             operationQueue.name = "RC Diagnostics Queue"
             operationQueue.maxConcurrentOperationCount = 1
             operationQueue.qualityOfService = .background
+            return operationQueue
+        }
+
+        /// Dedicated lane for the remote-config request so it runs off the shared serial
+        /// `RC Backend Queue` instead of queuing behind `/offerings`.
+        static func createRemoteConfigQueue() -> OperationQueue {
+            let operationQueue = OperationQueue()
+            operationQueue.name = "RC Remote Config Queue"
+            operationQueue.maxConcurrentOperationCount = 1
             return operationQueue
         }
 

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -52,23 +52,17 @@ class Backend {
                                           systemInfo: systemInfo,
                                           offlineCustomerInfoCreator: offlineCustomerInfoCreator,
                                           dateProvider: dateProvider)
-        // Dedicated remote-config lane: its own HTTPClient (own serial request state + own
-        // connection) and its own queue, so `/config` overlaps `/offerings` instead of
-        // serializing behind it on the shared pipe.
-        let remoteConfigHTTPClient = HTTPClient(systemInfo: systemInfo,
-                                                eTagManager: eTagManager,
-                                                signing: Signing(apiKey: systemInfo.apiKey,
-                                                                 clock: systemInfo.clock),
-                                                diagnosticsTracker: diagnosticsTracker,
-                                                requestTimeout: httpClientTimeout,
-                                                operationDispatcher: OperationDispatcher.default)
-        let remoteConfigConfig = BackendConfiguration(httpClient: remoteConfigHTTPClient,
-                                                      operationDispatcher: operationDispatcher,
-                                                      operationQueue: QueueProvider.createRemoteConfigQueue(),
-                                                      diagnosticsQueue: QueueProvider.createDiagnosticsQueue(),
-                                                      systemInfo: systemInfo,
-                                                      offlineCustomerInfoCreator: offlineCustomerInfoCreator,
-                                                      dateProvider: dateProvider)
+        let remoteConfigConfig = BackendConfiguration(
+            httpClient: .dedicatedRemoteConfig(systemInfo: systemInfo,
+                                               eTagManager: eTagManager,
+                                               diagnosticsTracker: diagnosticsTracker,
+                                               requestTimeout: httpClientTimeout),
+            operationDispatcher: operationDispatcher,
+            operationQueue: QueueProvider.createRemoteConfigQueue(),
+            diagnosticsQueue: QueueProvider.createDiagnosticsQueue(),
+            systemInfo: systemInfo,
+            offlineCustomerInfoCreator: offlineCustomerInfoCreator,
+            dateProvider: dateProvider)
         self.init(backendConfig: config,
                   remoteConfigBackendConfig: remoteConfigConfig,
                   attributionFetcher: attributionFetcher)
@@ -284,8 +278,6 @@ extension Backend {
             return operationQueue
         }
 
-        /// Dedicated lane for the remote-config request so it runs off the shared serial
-        /// `RC Backend Queue` instead of queuing behind `/offerings`.
         static func createRemoteConfigQueue() -> OperationQueue {
             let operationQueue = OperationQueue()
             operationQueue.name = "RC Remote Config Queue"
@@ -293,6 +285,24 @@ extension Backend {
             return operationQueue
         }
 
+    }
+
+}
+
+private extension HTTPClient {
+
+    static func dedicatedRemoteConfig(
+        systemInfo: SystemInfo,
+        eTagManager: ETagManager,
+        diagnosticsTracker: DiagnosticsTrackerType?,
+        requestTimeout: TimeInterval
+    ) -> HTTPClient {
+        HTTPClient(systemInfo: systemInfo,
+                   eTagManager: eTagManager,
+                   signing: Signing(apiKey: systemInfo.apiKey, clock: systemInfo.clock),
+                   diagnosticsTracker: diagnosticsTracker,
+                   requestTimeout: requestTimeout,
+                   operationDispatcher: OperationDispatcher.default)
     }
 
 }

--- a/Tests/UnitTests/Networking/Backend/BackendRemoteConfigLaneTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendRemoteConfigLaneTests.swift
@@ -1,0 +1,102 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  BackendRemoteConfigLaneTests.swift
+//
+//  Verifies the remote-config request runs on its own dedicated HTTPClient lane
+//  instead of the shared client, so `/config` does not serialize behind other
+//  backend requests.
+
+import Foundation
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+final class BackendRemoteConfigLaneTests: BaseBackendTests {
+
+    override func createClient() -> MockHTTPClient {
+        super.createClient(#file)
+    }
+
+    func testRemoteConfigRequestRunsOnDedicatedLaneNotSharedClient() {
+        let laneClient = self.createClient(#file)
+        laneClient.disableSnapshotTesting()
+        self.httpClient.disableSnapshotTesting()
+
+        let backend = Backend(
+            backendConfig: self.makeConfig(client: self.httpClient,
+                                           queue: Backend.QueueProvider.createBackendQueue()),
+            remoteConfigBackendConfig: self.makeConfig(client: laneClient,
+                                                       queue: Backend.QueueProvider.createRemoteConfigQueue()),
+            attributionFetcher: self.makeAttributionFetcher()
+        )
+
+        laneClient.mock(
+            requestPath: HTTPRequest.Path.remoteConfig(domain: "app"),
+            response: .init(statusCode: .noContent, body: Data(), verificationResult: .verified)
+        )
+
+        waitUntil { completed in
+            backend.remoteConfigAPI.getRemoteConfig(
+                request: .init(appUserID: Self.userID),
+                isAppBackgrounded: false
+            ) { _ in completed() }
+        }
+
+        expect(laneClient.calls).to(haveCount(1))
+        expect(self.httpClient.calls).to(beEmpty())
+    }
+
+    func testRemoteConfigFallsBackToSharedClientWhenNoLaneProvided() {
+        self.httpClient.disableSnapshotTesting()
+
+        let backend = Backend(
+            backendConfig: self.makeConfig(client: self.httpClient,
+                                           queue: Backend.QueueProvider.createBackendQueue()),
+            attributionFetcher: self.makeAttributionFetcher()
+        )
+
+        self.httpClient.mock(
+            requestPath: HTTPRequest.Path.remoteConfig(domain: "app"),
+            response: .init(statusCode: .noContent, body: Data(), verificationResult: .verified)
+        )
+
+        waitUntil { completed in
+            backend.remoteConfigAPI.getRemoteConfig(
+                request: .init(appUserID: Self.userID),
+                isAppBackgrounded: false
+            ) { _ in completed() }
+        }
+
+        expect(self.httpClient.calls).to(haveCount(1))
+    }
+
+}
+
+private extension BackendRemoteConfigLaneTests {
+
+    func makeConfig(client: MockHTTPClient, queue: OperationQueue) -> BackendConfiguration {
+        return BackendConfiguration(
+            httpClient: client,
+            operationDispatcher: self.operationDispatcher,
+            operationQueue: queue,
+            diagnosticsQueue: Backend.QueueProvider.createDiagnosticsQueue(),
+            systemInfo: self.systemInfo,
+            offlineCustomerInfoCreator: self.mockOfflineCustomerInfoCreator,
+            dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate)
+        )
+    }
+
+    func makeAttributionFetcher() -> AttributionFetcher {
+        return AttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
+                                  systemInfo: self.systemInfo)
+    }
+
+}

--- a/Tests/UnitTests/Networking/Backend/BackendRemoteConfigLaneTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendRemoteConfigLaneTests.swift
@@ -15,6 +15,8 @@
 
 import Foundation
 import Nimble
+import OHHTTPStubs
+import OHHTTPStubsSwift
 import XCTest
 
 @testable import RevenueCat
@@ -97,6 +99,87 @@ private extension BackendRemoteConfigLaneTests {
     func makeAttributionFetcher() -> AttributionFetcher {
         return AttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
                                   systemInfo: self.systemInfo)
+    }
+
+}
+
+/// Proves the dedicated lane actually runs `/config` in parallel with `/offerings`, using real
+/// `HTTPClient`s (each serial internally) and a stubbed transport: a hung `/offerings` on the
+/// shared client must not block `/config` on the lane.
+final class BackendRemoteConfigLaneParallelTests: TestCase {
+
+    private static let userID = "lane-user"
+
+    override func tearDown() {
+        HTTPStubs.removeAllStubs()
+        super.tearDown()
+    }
+
+    func testConfigCompletesWhileOfferingsHangsOnSeparateLane() throws {
+        #if os(watchOS)
+        throw XCTSkip("OHHTTPStubs does not support watchOS")
+        #endif
+
+        let systemInfo = MockSystemInfo(finishTransactions: true)
+        let eTagManager = MockETagManager()
+
+        func makeClient() -> HTTPClient {
+            return HTTPClient(systemInfo: systemInfo,
+                              eTagManager: eTagManager,
+                              signing: MockSigning(),
+                              diagnosticsTracker: nil,
+                              requestTimeout: 30,
+                              operationDispatcher: OperationDispatcher())
+        }
+
+        func makeConfig(_ client: HTTPClient, _ queue: OperationQueue) -> BackendConfiguration {
+            return BackendConfiguration(httpClient: client,
+                                        operationDispatcher: OperationDispatcher(),
+                                        operationQueue: queue,
+                                        diagnosticsQueue: Backend.QueueProvider.createDiagnosticsQueue(),
+                                        systemInfo: systemInfo,
+                                        offlineCustomerInfoCreator: nil,
+                                        dateProvider: DateProvider())
+        }
+
+        let backend = Backend(
+            backendConfig: makeConfig(makeClient(), Backend.QueueProvider.createBackendQueue()),
+            remoteConfigBackendConfig: makeConfig(makeClient(), Backend.QueueProvider.createRemoteConfigQueue()),
+            attributionFetcher: AttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
+                                                   systemInfo: systemInfo)
+        )
+
+        // `/offerings` stays in flight for the whole test; `/config` returns immediately. If config
+        // shared the offerings client, it would queue behind the hung `/offerings` and time out.
+        let offeringsDispatched: Atomic<Bool> = false
+        let offeringsCompleted: Atomic<Bool> = false
+
+        stub(condition: pathEndsWith("/offerings")) { _ in
+            offeringsDispatched.value = true
+            return HTTPStubsResponse(data: Data("{}".utf8), statusCode: 200, headers: nil)
+                .responseTime(10)
+        }
+        stub(condition: pathEndsWith("/config/app")) { _ in
+            return HTTPStubsResponse(data: Data(), statusCode: 204, headers: nil)
+        }
+
+        backend.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false) { _ in
+            offeringsCompleted.value = true
+        }
+
+        let configResult: Result<RemoteConfigFetchResult, BackendError>? = waitUntilValue(
+            timeout: .seconds(5)
+        ) { completed in
+            backend.remoteConfigAPI.getRemoteConfig(
+                request: .init(appUserID: Self.userID),
+                isAppBackgrounded: false,
+                completion: completed
+            )
+        }
+
+        expect(configResult).to(beSuccess())
+        expect(offeringsDispatched.value).toEventually(beTrue())
+        expect(offeringsCompleted.value) == false
     }
 
 }


### PR DESCRIPTION
### Motivation

The remote-config request serializes behind `/offerings` on the shared backend pipe, even though the `getOfferings` readiness gate already asks for them concurrently. The SDK sends one request at a time (`RC Backend Queue` at `maxConcurrentOperationCount = 1`, and a single `HTTPClient` with `currentSerialRequest` + `httpMaximumConnectionsPerHost = 1`), so `/config` can only start once `/offerings` has vacated the pipe.

This gives `RemoteConfigAPI` its own `HTTPClient` (own `URLSession` → own serial-request state → own connection to the host) on its own queue, so `/config` overlaps `/offerings` instead of queuing behind it. Every other request keeps the shared serial pipe untouched, so customer / offerings / purchase ordering is unchanged. The lane client is built via a small `HTTPClient.dedicatedRemoteConfig(...)` factory.

### Measured impact

On device (iPhone 15 Pro, iOS 26, stress project, **test-store** key, 50 iters): config cold `configure + getOfferings` goes from **+32% vs legacy → ~0%** (matches legacy), warm from **+7% → ~2%**. Zero errors/loss/retries.

Important scope note: the measured win is largely a **test-store** effect — with a test-store key, products are fetched over the backend pipe (WebBilling) and were the thing actually queued behind config. **Real App Store apps fetch products via StoreKit, off this pipe, so they see ~0 change** (and no regression). The change still helps test-store/dev apps and makes the config request stop blocking anything on the shared pipe.

### Testing

- `BackendRemoteConfigLaneTests` (new): asserts `/config` routes to the dedicated lane client and not the shared client, and that it falls back to the shared client when no lane is provided. Passing via the `UnitTests` scheme (2 cases, 0 failures).
- Still worth a look: an explicit concurrency-safety assertion for the now-parallel config request against the shared `ETagManager` / `Signing` (keyed per-path/per-request, expected safe; the device runs showed zero request failures).

<details>
<summary>AI session context</summary>

**Metadata**
- Branch: `facu/config-dedicated-lane` (2 commits off `origin/main`)
- Scope: `Sources/Networking/Backend.swift` + `Tests/UnitTests/Networking/Backend/BackendRemoteConfigLaneTests.swift`
- Author-driven; AI implemented + measured under direction.

**What changed & why**
- Added `QueueProvider.createRemoteConfigQueue()` and an `HTTPClient.dedicatedRemoteConfig(...)` factory; `RemoteConfigAPI` now runs on that dedicated `HTTPClient` + queue via a new optional `remoteConfigBackendConfig` param on `Backend` (defaults to the shared config, so other `Backend` construction is unaffected).

**How we got here (decision log)**
- `Decision:` profiled the app-launch benchmark; the config penalty was **not** the readiness gate (~10 ms), decode (~4 ms), or config being on the critical path (it finishes with 590–890 ms of slack before the gate consumes it).
- `Decision:` root cause is the single serial HTTPClient — `/config` and (test-store) product fetch queue behind `/offerings`. Two serialization layers: `RC Backend Queue` + `HTTPClient.currentSerialRequest` / `httpMaximumConnectionsPerHost = 1`.
- `Rejected:` dedicated OperationQueue only, decode-off-queue, UIConfig memory cache (#7186, closed) — all missed the HTTPClient serializer and moved no numbers.
- `Proof:` with the lane, `config_req_start` moves 879 → 72 ms (overlaps offerings); cold product fetch returns to 339 ms == legacy's 341 ms; config cold penalty +32% → ~0 (device, 30 + 50 iters agree within ~3%). Verified independently by advisor + a codex review.

**Risks / reviewer notes**
- `Risk:` two concurrent connections to the same host; `ETagManager`/`Signing` must be safe under the now-parallel config request (no shared-nonce race). Benchmark run showed zero request failures; no explicit concurrency test yet.
- `Risk:` blob prefetch/download still rides the shared pipe; CDN-blob projects (unlike this inline project) may want the lane extended to blob downloads — separate change.

**Validation**
- `Proof:` `BackendRemoteConfigLaneTests` passes via the `UnitTests` Tuist scheme (2 cases). `swift build` + swiftlint clean.
- `Validation gap:` full CI / API tests not yet run on this branch; concurrency-safety test pending.
</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a second concurrent connection to the host while still sharing `ETagManager` and signing setup; ordering for non-config traffic is unchanged but parallel config traffic is new surface area.
> 
> **Overview**
> Remote config (`/config`) no longer shares the single serial backend `HTTPClient` and `RC Backend Queue` with offerings and other APIs. Production `Backend` init now builds a second `BackendConfiguration` with `HTTPClient.dedicatedRemoteConfig(...)`, `QueueProvider.createRemoteConfigQueue()`, and wires `RemoteConfigAPI` to that lane; other APIs stay on the existing config.
> 
> `Backend(backendConfig:remoteConfigBackendConfig:attributionFetcher:)` gains an optional `remoteConfigBackendConfig` (defaults to the shared config when omitted). Tests assert `/config` hits the lane client only, fallback to the shared client works, and `/config` can finish while a slow `/offerings` is still in flight on the shared pipe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de441b1bd58a27bd208be4955aa33de625eb4b00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->