### PR TITLE
Preserve background audio after videos close

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -424,6 +424,7 @@
 		3DD6C3CC5EC6B69E9DA9571D /* Evaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B78483ACCDD62ABD40AF8827 /* Evaluator.swift */; };
 		424117A427E05CDDE5CAB803 /* LogicOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EF5BB0DF2CED359AB0089B4 /* LogicOperators.swift */; };
 		42F1DF385E3C1F9903A07FBF /* ProductsFetcherSK1.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB3CBAA73855779FE828CE2 /* ProductsFetcherSK1.swift */; };
+		451441F0014BC13272B179CC /* View+ExitOfferPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE8FCE0314FF930204BE4D33 /* View+ExitOfferPresentation.swift */; };
 		49554883F2D5ED48F0907FB9 /* ExitOfferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D26169F24D341F77345716D /* ExitOfferTests.swift */; };
 		49B8016629C29C4691C0774A /* WorkflowsConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C390BBAC430231B23B4B5F8 /* WorkflowsConfigProvider.swift */; };
 		4D21041E2CF548790095D254 /* GradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D21041D2CF548790095D254 /* GradientView.swift */; };
@@ -940,34 +941,6 @@
 		75E61CB62E2F9EF30034B41C /* MockTestStorePurchaseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7581A92C2E2EB27100D0C3DE /* MockTestStorePurchaseHandler.swift */; };
 		75FCD4CE2E37FBE100036C02 /* SimulatedStoreMockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FCD4CC2E37FBE100036C02 /* SimulatedStoreMockData.swift */; };
 		75FCD4CF2E37FBE100036C02 /* SimulatedStoreProductsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FCD4CD2E37FBE100036C02 /* SimulatedStoreProductsManagerTests.swift */; };
-		A1B2C3D42FE1000000000002 /* RCContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE1000000000001 /* RCContainer.swift */; };
-		A1B2C3D42FE1000000000004 /* RCContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE1000000000003 /* RCContainerTests.swift */; };
-		A1B2C3D42FE5000000000002 /* RCContainer+Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE5000000000001 /* RCContainer+Compression.swift */; };
-		A1B2C3D42FE1000000000005 /* RCContainer+Element.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE1000000000006 /* RCContainer+Element.swift */; };
-		A1B2C3D42FE1000000000007 /* RCContainer+Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE1000000000008 /* RCContainer+Parser.swift */; };
-		A1B2C3D42FE1000000000010 /* RemoteConfigSignatureContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE1000000000011 /* RemoteConfigSignatureContextProvider.swift */; };
-		A1B2C3D42FE100000000000D /* RCContainerBackwardsCompatibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE100000000000A /* RCContainerBackwardsCompatibilityTests.swift */; };
-		A1B2C3D42FE100000000000E /* RCContainerTestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE100000000000B /* RCContainerTestData.swift */; };
-		A1B2C3D42FE4000000000002 /* RCContainerCompressionFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE4000000000001 /* RCContainerCompressionFixtureTests.swift */; };
-		A1B2C3D42FE2000000000002 /* RemoteConfigDiskCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE2000000000001 /* RemoteConfigDiskCache.swift */; };
-		A1B2C3D42FE2000000000004 /* RemoteConfigManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE2000000000003 /* RemoteConfigManager.swift */; };
-		A1B2C3D42FE3000000000002 /* RemoteConfigFetchContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE3000000000001 /* RemoteConfigFetchContext.swift */; };
-		A1B2C3D42FE9000000000002 /* GenerationGuardedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE9000000000001 /* GenerationGuardedCache.swift */; };
-		B8EF700CBF25815EC2BF1253 /* UiConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB021C52E3CCC5EB17FFF795 /* UiConfigProvider.swift */; };
-		49B8016629C29C4691C0774A /* WorkflowsConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C390BBAC430231B23B4B5F8 /* WorkflowsConfigProvider.swift */; };
-		A1B2C3D42FE200000000000D /* RemoteConfigBlobStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE200000000000C /* RemoteConfigBlobStore.swift */; };
-		A1B2C3D42FE2000000000006 /* RemoteConfigStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE2000000000005 /* RemoteConfigStrings.swift */; };
-		A1B2C3D42FE7000000000002 /* RemoteConfigTopic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE7000000000001 /* RemoteConfigTopic.swift */; };
-		A1B2C3D42FE6000000000002 /* RemoteConfigBlobRefHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE6000000000001 /* RemoteConfigBlobRefHelpers.swift */; };
-		A1B2C3D42FE6000000000004 /* RemoteConfigBlobDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE6000000000003 /* RemoteConfigBlobDownloader.swift */; };
-		A1B2C3D42FE6000000000006 /* RemoteConfigBlobFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE6000000000005 /* RemoteConfigBlobFetcher.swift */; };
-		A1B2C3D42FE2000000000009 /* RemoteConfigDiskCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE2000000000008 /* RemoteConfigDiskCacheTests.swift */; };
-		A1B2C3D42FE200000000000B /* RemoteConfigManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE200000000000A /* RemoteConfigManagerTests.swift */; };
-		A1B2C3D42FE200000000000F /* RemoteConfigBlobStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE200000000000E /* RemoteConfigBlobStoreTests.swift */; };
-		A1B2C3D42FE6000000000008 /* RemoteConfigBlobFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE6000000000007 /* RemoteConfigBlobFetcherTests.swift */; };
-		A1B2C3D42FE600000000000A /* RemoteConfigBlobDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE6000000000009 /* RemoteConfigBlobDownloaderTests.swift */; };
-		A1B2C3D42FE8000000000002 /* RemoteConfigIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE8000000000001 /* RemoteConfigIntegrationTests.swift */; };
-		A1B2C3D42FE9000000000004 /* GenerationGuardedCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE9000000000003 /* GenerationGuardedCacheTests.swift */; };
 		7648885717DC2DB5009DD01B /* MinMaxOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = C812AE8BAE0546D2F4ACEF35 /* MinMaxOperators.swift */; };
 		7707A94C2CAD93AC006E0313 /* PaywallButtonComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7707A94B2CAD93AC006E0313 /* PaywallButtonComponent.swift */; };
 		7707A94E2CAD94D2006E0313 /* ButtonComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7707A94D2CAD94D2006E0313 /* ButtonComponentViewModel.swift */; };
@@ -1103,7 +1076,6 @@
 		887A60CC2C1D037000E1A461 /* PaywallFontProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A60602C1D037000E1A461 /* PaywallFontProvider.swift */; };
 		887A60CD2C1D037000E1A461 /* PaywallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A60612C1D037000E1A461 /* PaywallView.swift */; };
 		887A60CE2C1D037000E1A461 /* View+PresentPaywall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A60622C1D037000E1A461 /* View+PresentPaywall.swift */; };
-		451441F0014BC13272B179CC /* View+ExitOfferPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE8FCE0314FF930204BE4D33 /* View+ExitOfferPresentation.swift */; };
 		887A60CF2C1D037000E1A461 /* View+PresentPaywallFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A60632C1D037000E1A461 /* View+PresentPaywallFooter.swift */; };
 		887A60D02C1D037000E1A461 /* View+PurchaseRestoreCompleted.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A60642C1D037000E1A461 /* View+PurchaseRestoreCompleted.swift */; };
 		887E7B592C13CD2C002977DE /* PurchasesAreCompletedBy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887E7B582C13CD2C002977DE /* PurchasesAreCompletedBy.swift */; };
@@ -1199,6 +1171,8 @@
 		A1B2C3D42FE600000000000A /* RemoteConfigBlobDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE6000000000009 /* RemoteConfigBlobDownloaderTests.swift */; };
 		A1B2C3D42FE7000000000002 /* RemoteConfigTopic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE7000000000001 /* RemoteConfigTopic.swift */; };
 		A1B2C3D42FE8000000000002 /* RemoteConfigIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE8000000000001 /* RemoteConfigIntegrationTests.swift */; };
+		A1B2C3D42FE9000000000002 /* GenerationGuardedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE9000000000001 /* GenerationGuardedCache.swift */; };
+		A1B2C3D42FE9000000000004 /* GenerationGuardedCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE9000000000003 /* GenerationGuardedCacheTests.swift */; };
 		A1B2C3D4E5F60718293A4B5C /* MiscOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E5F60718293A4B5C6D7E8F /* MiscOperators.swift */; };
 		A1E0F0022F297A0100000001 /* EventsManagerStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E0F0012F297A0100000001 /* EventsManagerStrings.swift */; };
 		A524378B284FFF0200E788BD /* AttributionPosterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A524378A284FFF0200E788BD /* AttributionPosterTests.swift */; };
@@ -1327,6 +1301,7 @@
 		DB8C95142F900E2A00FCEE6B /* SafeAreaPreviewShell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8C95132F900E2A00FCEE6B /* SafeAreaPreviewShell.swift */; };
 		DBAA1FBC2F8D45C2000E8C81 /* HeaderTextBodyHeroSafeAreaPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBAA1FBA2F8D45C2000E8C81 /* HeaderTextBodyHeroSafeAreaPreview.swift */; };
 		DBAA1FC22F8D4ED8000E8C81 /* HeaderNestedHeroZLayerSafeAreaPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBAA1FC12F8D4ED8000E8C81 /* HeaderNestedHeroZLayerSafeAreaPreview.swift */; };
+		DBD2A168300E81E20019DB7F /* VideoAudioSessionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD2A167300E81E20019DB7F /* VideoAudioSessionHandler.swift */; };
 		DBE7C6552F02D48900A28663 /* StoreProductDiscount+CustomerCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBE7C6542F02D48900A28663 /* StoreProductDiscount+CustomerCenter.swift */; };
 		DC6FC62BD17B7DB03A096C2A /* Value+JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = B72848B4B4D101F1B94E228E /* Value+JSON.swift */; };
 		DDD45A15A641C0FF0BEF6178 /* PaywallCountdownComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A05E9E1B04B32B832DB194 /* PaywallCountdownComponent.swift */; };
@@ -1373,6 +1348,7 @@
 		F5E5E2EE28479BD000216ECD /* ProductsFetcherSK2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E5E2E82847953000216ECD /* ProductsFetcherSK2Tests.swift */; };
 		F5FCD3EA27DA0D0B003BDC04 /* PriceFormatterProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5FCD3E927DA0D0B003BDC04 /* PriceFormatterProvider.swift */; };
 		F5FCD3FC27DA2034003BDC04 /* PriceFormatterProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5FCD3FB27DA2034003BDC04 /* PriceFormatterProviderTests.swift */; };
+		FA4A2DF41FC434A9401F08CC /* PaywallWebViewAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D0C57ECDF0E7F1A5B4418FF /* PaywallWebViewAPI.swift */; };
 		FA6ABC7C2A81673F00353AF7 /* SystemFontRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6ABC7B2A81673F00353AF8 /* SystemFontRegistryTests.swift */; };
 		FACD000C2F61A1230073D2DE /* PackageVisibilityPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACD000B2F61A1230073D2DE /* PackageVisibilityPreview.swift */; };
 		FACE0000000000000000A001 /* BackendRemoteConfigLaneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACE0000000000000000A002 /* BackendRemoteConfigLaneTests.swift */; };
@@ -2502,6 +2478,7 @@
 		61F92C8B490F4B78AC8B1AAF /* ErrorCode+Conformances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ErrorCode+Conformances.swift"; sourceTree = "<group>"; };
 		645D8E14F3E2F79FAC1C2FA0 /* RulesEngineEvaluateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RulesEngineEvaluateTests.swift; sourceTree = "<group>"; };
 		65279ABC122869A50AEB8A27 /* ExitOffer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExitOffer.swift; sourceTree = "<group>"; };
+		686562C08D953A27986DB276 /* PaywallWebViewValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallWebViewValueTests.swift; sourceTree = "<group>"; };
 		68E47E21986D2C234ADB62E8 /* PredicateFixtureTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PredicateFixtureTests.swift; sourceTree = "<group>"; };
 		6A10AD61D82EB73FC5338DA2 /* WorkflowNavigator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowNavigator.swift; sourceTree = "<group>"; };
 		6E52F908EB90930822406495 /* WorkflowManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowManager.swift; sourceTree = "<group>"; };
@@ -2697,7 +2674,6 @@
 		887A60602C1D037000E1A461 /* PaywallFontProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaywallFontProvider.swift; sourceTree = "<group>"; };
 		887A60612C1D037000E1A461 /* PaywallView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaywallView.swift; sourceTree = "<group>"; };
 		887A60622C1D037000E1A461 /* View+PresentPaywall.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+PresentPaywall.swift"; sourceTree = "<group>"; };
-		FE8FCE0314FF930204BE4D33 /* View+ExitOfferPresentation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+ExitOfferPresentation.swift"; sourceTree = "<group>"; };
 		887A60632C1D037000E1A461 /* View+PresentPaywallFooter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+PresentPaywallFooter.swift"; sourceTree = "<group>"; };
 		887A60642C1D037000E1A461 /* View+PurchaseRestoreCompleted.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+PurchaseRestoreCompleted.swift"; sourceTree = "<group>"; };
 		887A61282C1D168B00E1A461 /* LocalizedAlertErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalizedAlertErrorTests.swift; sourceTree = "<group>"; };
@@ -2714,7 +2690,6 @@
 		887A61342C1D168B00E1A461 /* SnapshotTesting+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SnapshotTesting+Extensions.swift"; sourceTree = "<group>"; };
 		887A61352C1D168B00E1A461 /* TestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestCase.swift; sourceTree = "<group>"; };
 		887A61372C1D168B00E1A461 /* PurchaseHandlerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchaseHandlerTests.swift; sourceTree = "<group>"; };
-		B10A136C03A9FF34FB805EFA /* ExitOfferPresenterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExitOfferPresenterTests.swift; sourceTree = "<group>"; };
 		887A620F2C1D168B00E1A461 /* OtherPaywallViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OtherPaywallViewTests.swift; sourceTree = "<group>"; };
 		887A62102C1D168B00E1A461 /* PaywallViewDynamicTypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaywallViewDynamicTypeTests.swift; sourceTree = "<group>"; };
 		887A62112C1D168B00E1A461 /* PaywallViewLocalizationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaywallViewLocalizationTests.swift; sourceTree = "<group>"; };
@@ -2808,6 +2783,7 @@
 		9D09F3CA2E3A859A0002840E /* sr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sr; path = sr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9D09F3CB2E3A859A0002840F /* sr_Latn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sr_Latn; path = sr_Latn.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9D09F3CC2E3A859A00028410 /* sl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sl; path = sl.lproj/Localizable.strings; sourceTree = "<group>"; };
+		9D0C57ECDF0E7F1A5B4418FF /* PaywallWebViewAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallWebViewAPI.swift; sourceTree = "<group>"; };
 		9E174FCB9B889D4CACED0088 /* Value.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Value.swift; sourceTree = "<group>"; };
 		9F576269BC7130E5B553FB5A /* StringArrayOperatorsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StringArrayOperatorsTests.swift; sourceTree = "<group>"; };
 		9FA3AA2BC4C1B8CE7E9A3B59 /* WorkflowPreview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowPreview.swift; sourceTree = "<group>"; };
@@ -2829,6 +2805,7 @@
 		A1B2C3D42FE200000000000E /* RemoteConfigBlobStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobStoreTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE3000000000001 /* RemoteConfigFetchContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigFetchContext.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE300000000001 /* ProductionRemoteConfigIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductionRemoteConfigIntegrationTests.swift; sourceTree = "<group>"; };
+		A1B2C3D42FE300000000002 /* WorkflowComponentsIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowComponentsIntegrationTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE4000000000001 /* RCContainerCompressionFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RCContainerCompressionFixtureTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE5000000000001 /* RCContainer+Compression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RCContainer+Compression.swift"; sourceTree = "<group>"; };
 		A1B2C3D42FE6000000000001 /* RemoteConfigBlobRefHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobRefHelpers.swift; sourceTree = "<group>"; };
@@ -2838,6 +2815,8 @@
 		A1B2C3D42FE6000000000009 /* RemoteConfigBlobDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobDownloaderTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE7000000000001 /* RemoteConfigTopic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigTopic.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE8000000000001 /* RemoteConfigIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigIntegrationTests.swift; sourceTree = "<group>"; };
+		A1B2C3D42FE9000000000001 /* GenerationGuardedCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationGuardedCache.swift; sourceTree = "<group>"; };
+		A1B2C3D42FE9000000000003 /* GenerationGuardedCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationGuardedCacheTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FEA000000000001 /* RecordingBlobDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingBlobDownloader.swift; sourceTree = "<group>"; };
 		A1B2C3D42FEA000000000002 /* RemoteConfigBlobHealthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobHealthTests.swift; sourceTree = "<group>"; };
 		A1D3F80D2D524F51BA60157C /* ButtonComponentViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponentViewTests.swift; sourceTree = "<group>"; };
@@ -2868,6 +2847,7 @@
 		AD5000000000000000ADAD01 /* AdsStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdsStrings.swift; sourceTree = "<group>"; };
 		AD5000000000000000ADAD03 /* AdRewardEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdRewardEvents.swift; sourceTree = "<group>"; };
 		AD5000000000000000ADAD05 /* AdReward+TestExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AdReward+TestExtensions.swift"; sourceTree = "<group>"; };
+		B10A136C03A9FF34FB805EFA /* ExitOfferPresenterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExitOfferPresenterTests.swift; sourceTree = "<group>"; };
 		B29E428C04E073334CD13B58 /* CarouselStateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CarouselStateTests.swift; sourceTree = "<group>"; };
 		B302206927271BCB008F1A0D /* Decoder+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decoder+Extensions.swift"; sourceTree = "<group>"; };
 		B302206D2728B798008F1A0D /* BackendErrorStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendErrorStrings.swift; sourceTree = "<group>"; };
@@ -2933,7 +2913,6 @@
 		B3F8418E26F3A93400E560FB /* ErrorCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorCodeTests.swift; sourceTree = "<group>"; };
 		B413E59F2F97B3B900B5F0CA /* CarouselTabSwitchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselTabSwitchTests.swift; sourceTree = "<group>"; };
 		B413E5A02F97B3B900B5F0CA /* PaywallsV2ViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallsV2ViewTests.swift; sourceTree = "<group>"; };
-		DBB32F183007CACD00A86DC7 /* BottomSheetSwitchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetSwitchTests.swift; sourceTree = "<group>"; };
 		B49121C11022272A08D75B4E /* AccessorOperatorsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccessorOperatorsTests.swift; sourceTree = "<group>"; };
 		B72848B4B4D101F1B94E228E /* Value+JSON.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Value+JSON.swift"; sourceTree = "<group>"; };
 		B78483ACCDD62ABD40AF8827 /* Evaluator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Evaluator.swift; sourceTree = "<group>"; };
@@ -2974,7 +2953,9 @@
 		DB8C95132F900E2A00FCEE6B /* SafeAreaPreviewShell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeAreaPreviewShell.swift; sourceTree = "<group>"; };
 		DBAA1FBA2F8D45C2000E8C81 /* HeaderTextBodyHeroSafeAreaPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderTextBodyHeroSafeAreaPreview.swift; sourceTree = "<group>"; };
 		DBAA1FC12F8D4ED8000E8C81 /* HeaderNestedHeroZLayerSafeAreaPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderNestedHeroZLayerSafeAreaPreview.swift; sourceTree = "<group>"; };
+		DBB32F183007CACD00A86DC7 /* BottomSheetSwitchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetSwitchTests.swift; sourceTree = "<group>"; };
 		DBD243292EBDF4B80066AC6F /* PromotionalOfferViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionalOfferViewTests.swift; sourceTree = "<group>"; };
+		DBD2A167300E81E20019DB7F /* VideoAudioSessionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAudioSessionHandler.swift; sourceTree = "<group>"; };
 		DBE7C6542F02D48900A28663 /* StoreProductDiscount+CustomerCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoreProductDiscount+CustomerCenter.swift"; sourceTree = "<group>"; };
 		DD6CFFCCD908DC638C42E150 /* RootViewLayoutSnapshotTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RootViewLayoutSnapshotTests.swift; path = Tests/RevenueCatUITests/PaywallsV2/RootViewLayoutSnapshotTests.swift; sourceTree = SOURCE_ROOT; };
 		E1C0A006BEEF0001CCDD0001 /* PaywallHeaderComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallHeaderComponent.swift; sourceTree = "<group>"; };
@@ -2982,39 +2963,6 @@
 		E1C0A008BEEF0001CCDD0001 /* HeaderComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderComponentView.swift; sourceTree = "<group>"; };
 		E1C0A009BEEF0001CCDD0001 /* HeaderComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderComponentTests.swift; sourceTree = "<group>"; };
 		E1C0A00ABEEF0001CCDD0001 /* PaywallComponentsConfigHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallComponentsConfigHeaderTests.swift; sourceTree = "<group>"; };
-		A1B2C3D42FE1000000000001 /* RCContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RCContainer.swift; sourceTree = "<group>"; };
-		A1B2C3D42FE1000000000003 /* RCContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RCContainerTests.swift; sourceTree = "<group>"; };
-		A1B2C3D42FE5000000000001 /* RCContainer+Compression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RCContainer+Compression.swift"; sourceTree = "<group>"; };
-		A1B2C3D42FE1000000000006 /* RCContainer+Element.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RCContainer+Element.swift"; sourceTree = "<group>"; };
-		A1B2C3D42FE1000000000008 /* RCContainer+Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RCContainer+Parser.swift"; sourceTree = "<group>"; };
-		A1B2C3D42FE100000000000A /* RCContainerBackwardsCompatibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RCContainerBackwardsCompatibilityTests.swift; sourceTree = "<group>"; };
-		A1B2C3D42FE100000000000B /* RCContainerTestData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RCContainerTestData.swift; sourceTree = "<group>"; };
-		A1B2C3D42FE100000000000C /* README.md */ = {isa = PBXFileReference; lastKnownFileType = text; path = README.md; sourceTree = "<group>"; };
-		A1B2C3D42FE1000000000011 /* RemoteConfigSignatureContextProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigSignatureContextProvider.swift; sourceTree = "<group>"; };
-		A1B2C3D42FE4000000000001 /* RCContainerCompressionFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RCContainerCompressionFixtureTests.swift; sourceTree = "<group>"; };
-		A1B2C3D42FE2000000000001 /* RemoteConfigDiskCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigDiskCache.swift; sourceTree = "<group>"; };
-		A1B2C3D42FE2000000000003 /* RemoteConfigManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigManager.swift; sourceTree = "<group>"; };
-		A1B2C3D42FE3000000000001 /* RemoteConfigFetchContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigFetchContext.swift; sourceTree = "<group>"; };
-		A1B2C3D42FE9000000000001 /* GenerationGuardedCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationGuardedCache.swift; sourceTree = "<group>"; };
-		DB021C52E3CCC5EB17FFF795 /* UiConfigProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UiConfigProvider.swift; sourceTree = "<group>"; };
-		4C390BBAC430231B23B4B5F8 /* WorkflowsConfigProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowsConfigProvider.swift; sourceTree = "<group>"; };
-		A1B2C3D42FE200000000000C /* RemoteConfigBlobStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobStore.swift; sourceTree = "<group>"; };
-		A1B2C3D42FE2000000000005 /* RemoteConfigStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigStrings.swift; sourceTree = "<group>"; };
-		A1B2C3D42FE7000000000001 /* RemoteConfigTopic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigTopic.swift; sourceTree = "<group>"; };
-		A1B2C3D42FE6000000000001 /* RemoteConfigBlobRefHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobRefHelpers.swift; sourceTree = "<group>"; };
-		A1B2C3D42FE6000000000003 /* RemoteConfigBlobDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobDownloader.swift; sourceTree = "<group>"; };
-		A1B2C3D42FE6000000000005 /* RemoteConfigBlobFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobFetcher.swift; sourceTree = "<group>"; };
-		A1B2C3D42FE2000000000008 /* RemoteConfigDiskCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigDiskCacheTests.swift; sourceTree = "<group>"; };
-		A1B2C3D42FE200000000000A /* RemoteConfigManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigManagerTests.swift; sourceTree = "<group>"; };
-		A1B2C3D42FE200000000000E /* RemoteConfigBlobStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobStoreTests.swift; sourceTree = "<group>"; };
-		A1B2C3D42FE9000000000003 /* GenerationGuardedCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationGuardedCacheTests.swift; sourceTree = "<group>"; };
-		A1B2C3D42FE6000000000007 /* RemoteConfigBlobFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobFetcherTests.swift; sourceTree = "<group>"; };
-		A1B2C3D42FE6000000000009 /* RemoteConfigBlobDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobDownloaderTests.swift; sourceTree = "<group>"; };
-		A1B2C3D42FE8000000000001 /* RemoteConfigIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigIntegrationTests.swift; sourceTree = "<group>"; };
-		A1B2C3D42FE300000000001 /* ProductionRemoteConfigIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductionRemoteConfigIntegrationTests.swift; sourceTree = "<group>"; };
-		A1B2C3D42FE300000000002 /* WorkflowComponentsIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowComponentsIntegrationTests.swift; sourceTree = "<group>"; };
-		A1B2C3D42FEA000000000001 /* RecordingBlobDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingBlobDownloader.swift; sourceTree = "<group>"; };
-		A1B2C3D42FEA000000000002 /* RemoteConfigBlobHealthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobHealthTests.swift; sourceTree = "<group>"; };
 		E31E8A264E9F4375A3B29D78 /* RemoteConfigurationDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigurationDecodingTests.swift; sourceTree = "<group>"; };
 		E35BAD07C46D469D8CC7C396 /* RemoteConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfiguration.swift; sourceTree = "<group>"; };
 		E51CFC7D19BE49D2BA1A79CC /* CapturingLogger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CapturingLogger.swift; sourceTree = "<group>"; };
@@ -3130,6 +3078,7 @@
 		FE5151005B0000000000B002 /* ConfigureStringsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigureStringsTests.swift; sourceTree = "<group>"; };
 		FE5151005C0000000000A002 /* SimulatedStoreTransactionFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatedStoreTransactionFetcher.swift; sourceTree = "<group>"; };
 		FE5151005C0000000000B002 /* SimulatedStoreTransactionFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatedStoreTransactionFetcherTests.swift; sourceTree = "<group>"; };
+		FE8FCE0314FF930204BE4D33 /* View+ExitOfferPresentation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+ExitOfferPresentation.swift"; sourceTree = "<group>"; };
 		FECF627761D375C8431EB866 /* StoreProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreProduct.swift; sourceTree = "<group>"; };
 		FEDA000000000000000000A1 /* WeightedSourceSelectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightedSourceSelectorTests.swift; sourceTree = "<group>"; };
 		FEDA000000000000000000A2 /* WeightedSourceSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightedSourceSelector.swift; sourceTree = "<group>"; };
@@ -3380,6 +3329,7 @@
 				164681CC2E6B577600854AA5 /* VideoPlayerViewUIView.swift */,
 				164681D52E6B577600854AA5 /* VideoPlayerLayerUIView.swift */,
 				36ECF1E76DAADD986E3D0E5A /* VideoAutoplayHandler.swift */,
+				DBD2A167300E81E20019DB7F /* VideoAudioSessionHandler.swift */,
 			);
 			path = Video;
 			sourceTree = "<group>";
@@ -6460,6 +6410,14 @@
 			path = Generated;
 			sourceTree = "<group>";
 		};
+		EB23E44596DD9714E81840CF /* WebView */ = {
+			isa = PBXGroup;
+			children = (
+				9D0C57ECDF0E7F1A5B4418FF /* PaywallWebViewAPI.swift */,
+			);
+			path = WebView;
+			sourceTree = "<group>";
+		};
 		F5714EA626D7A82E00635477 /* CodableExtensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -8243,6 +8201,7 @@
 				7707A9502CAD9775006E0313 /* ButtonComponentView.swift in Sources */,
 				16A7F4C62E564B97001F9FC8 /* TransitionModifier.swift in Sources */,
 				887A60BE2C1D037000E1A461 /* PaywallFooterViewController.swift in Sources */,
+				DBD2A168300E81E20019DB7F /* VideoAudioSessionHandler.swift in Sources */,
 				887A608A2C1D037000E1A461 /* PurchaseHandler.swift in Sources */,
 				2D2AFE8D2C6A834D00D1B0B4 /* TestData.swift in Sources */,
 				03A98D382D2AC63B009BCA61 /* UIConfigProvider.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -2956,6 +2956,7 @@
 		DBB32F183007CACD00A86DC7 /* BottomSheetSwitchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetSwitchTests.swift; sourceTree = "<group>"; };
 		DBD243292EBDF4B80066AC6F /* PromotionalOfferViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionalOfferViewTests.swift; sourceTree = "<group>"; };
 		DBD2A167300E81E20019DB7F /* VideoAudioSessionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAudioSessionHandler.swift; sourceTree = "<group>"; };
+		DBD2A16E300E833F0019DB7F /* VideoAudioSessionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAudioSessionHandlerTests.swift; sourceTree = "<group>"; };
 		DBE7C6542F02D48900A28663 /* StoreProductDiscount+CustomerCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoreProductDiscount+CustomerCenter.swift"; sourceTree = "<group>"; };
 		DD6CFFCCD908DC638C42E150 /* RootViewLayoutSnapshotTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RootViewLayoutSnapshotTests.swift; path = Tests/RevenueCatUITests/PaywallsV2/RootViewLayoutSnapshotTests.swift; sourceTree = SOURCE_ROOT; };
 		E1C0A006BEEF0001CCDD0001 /* PaywallHeaderComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallHeaderComponent.swift; sourceTree = "<group>"; };
@@ -3201,6 +3202,7 @@
 				C1B939C7DAAFEA1DE2DE2674 /* WebViewEnvelopeTests.swift */,
 				802593842FE07057005AF6DF /* PaywallStateStoreTests.swift */,
 				16A9F7B62FAA22D0008E8A4D /* VideoComponentViewTests.swift */,
+				DBD2A16E300E833F0019DB7F /* VideoAudioSessionHandlerTests.swift */,
 				A9D45E4EAFAD4C0385BEDFB3 /* VideoPlayerViewTests.swift */,
 				FACD00012F61A1230073D2DE /* TextComponentLocalizationTests.swift */,
 				FACD00032F61A1230073D2DE /* ViewModelFactoryBadgeTests.swift */,

--- a/RevenueCatUI/Templates/V2/Components/Video/VideoAudioSessionHandler.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoAudioSessionHandler.swift
@@ -43,6 +43,7 @@ final class VideoAudioSessionHandler {
 
     private let audioSession: AudioSessionConfiguring
     private let sessionIdentifier: ObjectIdentifier
+    private var isRegistered = false
 
     init(audioSession: AudioSessionConfiguring = AVAudioSession.sharedInstance()) {
         self.audioSession = audioSession
@@ -53,6 +54,7 @@ final class VideoAudioSessionHandler {
 
         if let state = Self.states[sessionIdentifier] {
             state.handlerCount += 1
+            self.isRegistered = true
             return
         }
 
@@ -73,6 +75,7 @@ final class VideoAudioSessionHandler {
                 previousConfiguration: previousConfiguration,
                 handlerCount: 1
             )
+            self.isRegistered = true
         } catch {
             Logger.warning(Strings.video_failed_to_set_audio_session_category(error))
         }
@@ -82,7 +85,7 @@ final class VideoAudioSessionHandler {
         Self.lock.lock()
         defer { Self.lock.unlock() }
 
-        guard let state = Self.states[sessionIdentifier] else {
+        guard isRegistered, let state = Self.states[sessionIdentifier] else {
             return
         }
 

--- a/RevenueCatUI/Templates/V2/Components/Video/VideoAudioSessionHandler.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoAudioSessionHandler.swift
@@ -37,9 +37,13 @@ extension AVAudioSession: AudioSessionConfiguring {}
 /// The playback category keeps the host app's background audio working, while `mixWithOthers`
 /// prevents the paywall video from interrupting audio played by another app. The initial session
 /// configuration is restored only after the last video is released.
+///
+/// Isolated to the main actor: the SwiftUI video coordinators that own it are created and
+/// dismantled on the main actor, so the shared `states` map is accessed single-threaded and needs
+/// no locking. Registration happens in `init`; the owner must call `release()` from its teardown.
+@MainActor
 final class VideoAudioSessionHandler {
 
-    private static let lock = NSLock()
     private static var states: [ObjectIdentifier: State] = [:]
 
     private let audioSession: AudioSessionConfiguring
@@ -49,9 +53,6 @@ final class VideoAudioSessionHandler {
     init(audioSession: AudioSessionConfiguring = AVAudioSession.sharedInstance()) {
         self.audioSession = audioSession
         self.sessionIdentifier = ObjectIdentifier(audioSession)
-
-        Self.lock.lock()
-        defer { Self.lock.unlock() }
 
         if let state = Self.states[sessionIdentifier] {
             state.handlerCount += 1
@@ -82,13 +83,14 @@ final class VideoAudioSessionHandler {
         }
     }
 
-    deinit {
-        Self.lock.lock()
-        defer { Self.lock.unlock() }
-
+    /// Releases this handler's claim on the shared audio session, restoring the original
+    /// configuration once the last live handler is released. Idempotent, so a coordinator can call
+    /// it from teardown without worrying about being torn down twice.
+    func release() {
         guard isRegistered, let state = Self.states[sessionIdentifier] else {
             return
         }
+        self.isRegistered = false
 
         state.handlerCount -= 1
         guard state.handlerCount == 0 else {

--- a/RevenueCatUI/Templates/V2/Components/Video/VideoAudioSessionHandler.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoAudioSessionHandler.swift
@@ -20,6 +20,7 @@ protocol AudioSessionConfiguring: AnyObject {
     var category: AVAudioSession.Category { get }
     var mode: AVAudioSession.Mode { get }
     var categoryOptions: AVAudioSession.CategoryOptions { get }
+    var secondaryAudioShouldBeSilencedHint: Bool { get }
 
     func setCategory(
         _ category: AVAudioSession.Category,
@@ -101,11 +102,17 @@ final class VideoAudioSessionHandler {
             return
         }
 
+        guard let restorationConfiguration = state.previousConfiguration.restoringMixingIfNeeded(
+            externalAudioIsPlaying: audioSession.secondaryAudioShouldBeSilencedHint
+        ) else {
+            return
+        }
+
         do {
             try audioSession.setCategory(
-                state.previousConfiguration.category,
-                mode: state.previousConfiguration.mode,
-                options: state.previousConfiguration.options
+                restorationConfiguration.category,
+                mode: restorationConfiguration.mode,
+                options: restorationConfiguration.options
             )
         } catch {
             Logger.warning(Strings.video_failed_to_set_audio_session_category(error))
@@ -145,6 +152,20 @@ private extension VideoAudioSessionHandler {
             mode: .default,
             options: [.mixWithOthers]
         )
+
+        /// Returns `nil` when restoring this configuration would interrupt audio from another app.
+        func restoringMixingIfNeeded(externalAudioIsPlaying: Bool) -> Self? {
+            guard externalAudioIsPlaying else {
+                return self
+            }
+
+            switch category {
+            case .playback, .playAndRecord, .multiRoute:
+                return Self(category: category, mode: mode, options: options.union(.mixWithOthers))
+            default:
+                return nil
+            }
+        }
 
         private init(
             category: AVAudioSession.Category,

--- a/RevenueCatUI/Templates/V2/Components/Video/VideoAudioSessionHandler.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoAudioSessionHandler.swift
@@ -1,0 +1,160 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  VideoAudioSessionHandler.swift
+//
+
+import AVFoundation
+@_spi(Internal) import RevenueCat
+
+#if canImport(UIKit) && !os(watchOS)
+
+protocol AudioSessionConfiguring: AnyObject {
+
+    var category: AVAudioSession.Category { get }
+    var mode: AVAudioSession.Mode { get }
+    var categoryOptions: AVAudioSession.CategoryOptions { get }
+
+    func setCategory(
+        _ category: AVAudioSession.Category,
+        mode: AVAudioSession.Mode,
+        options: AVAudioSession.CategoryOptions
+    ) throws
+
+}
+
+extension AVAudioSession: AudioSessionConfiguring {}
+
+/// Configures the app's shared audio session while one or more paywall videos are alive.
+///
+/// The playback category keeps the host app's background audio working, while `mixWithOthers`
+/// prevents the paywall video from interrupting audio played by another app. The initial session
+/// configuration is restored only after the last video is released.
+final class VideoAudioSessionHandler {
+
+    private static let lock = NSLock()
+    private static var states: [ObjectIdentifier: State] = [:]
+
+    private let audioSession: AudioSessionConfiguring
+    private let sessionIdentifier: ObjectIdentifier
+
+    init(audioSession: AudioSessionConfiguring = AVAudioSession.sharedInstance()) {
+        self.audioSession = audioSession
+        self.sessionIdentifier = ObjectIdentifier(audioSession)
+
+        Self.lock.lock()
+        defer { Self.lock.unlock() }
+
+        if let state = Self.states[sessionIdentifier] {
+            state.handlerCount += 1
+            return
+        }
+
+        let previousConfiguration = Configuration(audioSession: audioSession)
+        let playbackConfiguration = Configuration.playbackWithMixing
+
+        guard previousConfiguration != playbackConfiguration else {
+            return
+        }
+
+        do {
+            try audioSession.setCategory(
+                playbackConfiguration.category,
+                mode: playbackConfiguration.mode,
+                options: playbackConfiguration.options
+            )
+            Self.states[sessionIdentifier] = State(
+                previousConfiguration: previousConfiguration,
+                handlerCount: 1
+            )
+        } catch {
+            Logger.warning(Strings.video_failed_to_set_audio_session_category(error))
+        }
+    }
+
+    deinit {
+        Self.lock.lock()
+        defer { Self.lock.unlock() }
+
+        guard let state = Self.states[sessionIdentifier] else {
+            return
+        }
+
+        state.handlerCount -= 1
+        guard state.handlerCount == 0 else {
+            return
+        }
+        Self.states[sessionIdentifier] = nil
+
+        // Do not overwrite an audio session configuration the host app set while the paywall
+        // was being displayed.
+        guard Configuration(audioSession: audioSession) == .playbackWithMixing else {
+            return
+        }
+
+        do {
+            try audioSession.setCategory(
+                state.previousConfiguration.category,
+                mode: state.previousConfiguration.mode,
+                options: state.previousConfiguration.options
+            )
+        } catch {
+            Logger.warning(Strings.video_failed_to_set_audio_session_category(error))
+        }
+    }
+
+}
+
+private extension VideoAudioSessionHandler {
+
+    final class State {
+
+        let previousConfiguration: Configuration
+        var handlerCount: Int
+
+        init(previousConfiguration: Configuration, handlerCount: Int) {
+            self.previousConfiguration = previousConfiguration
+            self.handlerCount = handlerCount
+        }
+
+    }
+
+    struct Configuration: Equatable {
+
+        let category: AVAudioSession.Category
+        let mode: AVAudioSession.Mode
+        let options: AVAudioSession.CategoryOptions
+
+        init(audioSession: AudioSessionConfiguring) {
+            self.category = audioSession.category
+            self.mode = audioSession.mode
+            self.options = audioSession.categoryOptions
+        }
+
+        static let playbackWithMixing = Self(
+            category: .playback,
+            mode: .default,
+            options: [.mixWithOthers]
+        )
+
+        private init(
+            category: AVAudioSession.Category,
+            mode: AVAudioSession.Mode,
+            options: AVAudioSession.CategoryOptions
+        ) {
+            self.category = category
+            self.mode = mode
+            self.options = options
+        }
+
+    }
+
+}
+
+#endif

--- a/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerLayerUIView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerLayerUIView.swift
@@ -96,9 +96,7 @@ struct VideoPlayerLayerView: UIViewRepresentable {
         private let looper: AVPlayerLooper?
         private let autoplayHandler: VideoAutoplayHandler
 
-        private var previousCategory: AVAudioSession.Category?
-        private var previousMode: AVAudioSession.Mode?
-        private var previousOptions: AVAudioSession.CategoryOptions?
+        private let audioSessionHandler: VideoAudioSessionHandler
 
         init(
             videoURL: URL,
@@ -126,20 +124,7 @@ struct VideoPlayerLayerView: UIViewRepresentable {
             #endif
 
             self.player = avPlayer
-
-            let audioSession = AVAudioSession.sharedInstance()
-            self.previousCategory = audioSession.category
-            self.previousMode = audioSession.mode
-            self.previousOptions = audioSession.categoryOptions
-            do {
-                try audioSession.setCategory(
-                    .ambient,
-                    mode: .default,
-                    options: [.mixWithOthers]
-                )
-            } catch {
-                Logger.warning(Strings.video_failed_to_set_audio_session_category(error))
-            }
+            self.audioSessionHandler = VideoAudioSessionHandler()
 
             self.autoplayHandler = VideoAutoplayHandler(
                 playbackController: avPlayer,
@@ -156,24 +141,6 @@ struct VideoPlayerLayerView: UIViewRepresentable {
             // player that's being dismantled.
             autoplayHandler.invalidate()
             player.pause()
-        }
-
-        deinit {
-            guard let category = previousCategory,
-                  let mode = previousMode,
-                  let options = previousOptions else {
-                return
-            }
-
-            do {
-                try AVAudioSession.sharedInstance().setCategory(
-                    category,
-                    mode: mode,
-                    options: options
-                )
-            } catch {
-                Logger.warning(Strings.video_failed_to_set_audio_session_category(error))
-            }
         }
 
     }

--- a/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerLayerUIView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerLayerUIView.swift
@@ -98,6 +98,7 @@ struct VideoPlayerLayerView: UIViewRepresentable {
 
         private let audioSessionHandler: VideoAudioSessionHandler
 
+        @MainActor
         init(
             videoURL: URL,
             shouldAutoPlay: Bool,
@@ -136,11 +137,13 @@ struct VideoPlayerLayerView: UIViewRepresentable {
             }
         }
 
+        @MainActor
         func tearDown() {
             // Stop lifecycle resume before pausing, so a later didBecomeActive can't restart a
             // player that's being dismantled.
             autoplayHandler.invalidate()
             player.pause()
+            audioSessionHandler.release()
         }
 
     }

--- a/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerViewUIView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerViewUIView.swift
@@ -87,7 +87,10 @@ struct VideoPlayerUIView: UIViewControllerRepresentable {
         coordinator.tearDown()
     }
 
-    class Coordinator {
+    // The loop observer is always delivered on the main queue, and this coordinator is only
+    // created and torn down by UIKit on the main actor. `NotificationCenter` nevertheless marks
+    // its observer block as `@Sendable`, so the compiler cannot infer this queue confinement.
+    class Coordinator: @unchecked Sendable {
 
         let player: AVPlayer
 

--- a/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerViewUIView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerViewUIView.swift
@@ -97,6 +97,7 @@ struct VideoPlayerUIView: UIViewControllerRepresentable {
         private var loopObserver: NSObjectProtocol?
         private var isTornDown = false
 
+        @MainActor
         init(
             videoURL: URL,
             shouldAutoPlay: Bool,
@@ -154,6 +155,7 @@ struct VideoPlayerUIView: UIViewControllerRepresentable {
             }
         }
 
+        @MainActor
         func tearDown() {
             isTornDown = true
             autoplayHandler.invalidate()
@@ -162,6 +164,7 @@ struct VideoPlayerUIView: UIViewControllerRepresentable {
                 NotificationCenter.default.removeObserver(loopObserver)
                 self.loopObserver = nil
             }
+            audioSessionHandler.release()
         }
 
         deinit {

--- a/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerViewUIView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoPlayerViewUIView.swift
@@ -91,9 +91,7 @@ struct VideoPlayerUIView: UIViewControllerRepresentable {
 
         let player: AVPlayer
 
-        private var previousCategory: AVAudioSession.Category?
-        private var previousMode: AVAudioSession.Mode?
-        private var previousOptions: AVAudioSession.CategoryOptions?
+        private let audioSessionHandler: VideoAudioSessionHandler
 
         private let autoplayHandler: VideoAutoplayHandler
         private var loopObserver: NSObjectProtocol?
@@ -119,20 +117,7 @@ struct VideoPlayerUIView: UIViewControllerRepresentable {
             #endif
 
             self.player = avPlayer
-
-            let audioSession = AVAudioSession.sharedInstance()
-            self.previousCategory = audioSession.category
-            self.previousMode = audioSession.mode
-            self.previousOptions = audioSession.categoryOptions
-            do {
-                try audioSession.setCategory(
-                    .ambient,
-                    mode: .default,
-                    options: [.mixWithOthers]
-                )
-            } catch {
-                Logger.warning(Strings.video_failed_to_set_audio_session_category(error))
-            }
+            self.audioSessionHandler = VideoAudioSessionHandler()
 
             self.autoplayHandler = VideoAutoplayHandler(
                 playbackController: avPlayer,
@@ -182,22 +167,6 @@ struct VideoPlayerUIView: UIViewControllerRepresentable {
         deinit {
             if let loopObserver = self.loopObserver {
                 NotificationCenter.default.removeObserver(loopObserver)
-            }
-
-            guard let category = previousCategory,
-                  let mode = previousMode,
-                  let options = previousOptions else {
-                return
-            }
-
-            do {
-                try AVAudioSession.sharedInstance().setCategory(
-                    category,
-                    mode: mode,
-                    options: options
-                )
-            } catch {
-                Logger.warning(Strings.video_failed_to_set_audio_session_category(error))
             }
         }
 

--- a/Tests/RevenueCatUITests/PaywallsV2/VideoAudioSessionHandlerTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/VideoAudioSessionHandlerTests.swift
@@ -62,6 +62,40 @@ final class VideoAudioSessionHandlerTests: TestCase {
         XCTAssertEqual(audioSession.setCategoryCalls.count, 2)
     }
 
+    func testUnregisteredHandlerDoesNotRestoreAnotherHandlerConfiguration() {
+        let audioSession = MockAudioSession(configuration: .playbackWithMixing)
+        var unregisteredHandler: VideoAudioSessionHandler? = VideoAudioSessionHandler(audioSession: audioSession)
+        XCTAssertNotNil(unregisteredHandler)
+
+        let previousConfiguration = Configuration(category: .record, mode: .voiceChat, options: [])
+        audioSession.configuration = previousConfiguration
+        var registeredHandler: VideoAudioSessionHandler? = VideoAudioSessionHandler(audioSession: audioSession)
+        XCTAssertNotNil(registeredHandler)
+
+        unregisteredHandler = nil
+
+        XCTAssertEqual(audioSession.configuration, .playbackWithMixing)
+        XCTAssertEqual(audioSession.setCategoryCalls.count, 1)
+
+        registeredHandler = nil
+
+        XCTAssertEqual(audioSession.configuration, previousConfiguration)
+        XCTAssertEqual(audioSession.setCategoryCalls.count, 2)
+    }
+
+    func testPreservesMixingWhenExternalAudioIsPlaying() {
+        let previousConfiguration = Configuration(category: .playback, mode: .default, options: [])
+        let audioSession = MockAudioSession(configuration: previousConfiguration)
+        audioSession.secondaryAudioShouldBeSilencedHint = true
+
+        var handler: VideoAudioSessionHandler? = VideoAudioSessionHandler(audioSession: audioSession)
+        XCTAssertNotNil(handler)
+        handler = nil
+
+        XCTAssertEqual(audioSession.configuration, .playbackWithMixing)
+        XCTAssertEqual(audioSession.setCategoryCalls.count, 2)
+    }
+
     func testDoesNotOverwriteHostConfigurationChangedDuringVideoPlayback() {
         let audioSession = MockAudioSession()
         var handler: VideoAudioSessionHandler? = VideoAudioSessionHandler(audioSession: audioSession)

--- a/Tests/RevenueCatUITests/PaywallsV2/VideoAudioSessionHandlerTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/VideoAudioSessionHandlerTests.swift
@@ -1,0 +1,134 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  VideoAudioSessionHandlerTests.swift
+//
+
+import AVFoundation
+@testable import RevenueCatUI
+import XCTest
+
+#if canImport(UIKit) && !os(watchOS) && !os(tvOS)
+
+final class VideoAudioSessionHandlerTests: TestCase {
+
+    func testSetsPlaybackCategoryWithMixing() {
+        let audioSession = MockAudioSession()
+
+        let handler = VideoAudioSessionHandler(audioSession: audioSession)
+
+        XCTAssertEqual(audioSession.configuration, .playbackWithMixing)
+        XCTAssertNotNil(handler)
+    }
+
+    func testRestoresPreviousConfigurationWhenReleased() {
+        let previousConfiguration = Configuration(
+            category: .record,
+            mode: .voiceChat,
+            options: [.duckOthers]
+        )
+        let audioSession = MockAudioSession(configuration: previousConfiguration)
+
+        var handler: VideoAudioSessionHandler? = VideoAudioSessionHandler(audioSession: audioSession)
+        XCTAssertNotNil(handler)
+        handler = nil
+
+        XCTAssertEqual(audioSession.configuration, previousConfiguration)
+        XCTAssertEqual(audioSession.setCategoryCalls.count, 2)
+    }
+
+    func testRestoresPreviousConfigurationAfterLastHandlerIsReleased() {
+        let previousConfiguration = Configuration(category: .playback, mode: .default, options: [])
+        let audioSession = MockAudioSession(configuration: previousConfiguration)
+
+        var firstHandler: VideoAudioSessionHandler? = VideoAudioSessionHandler(audioSession: audioSession)
+        var secondHandler: VideoAudioSessionHandler? = VideoAudioSessionHandler(audioSession: audioSession)
+        XCTAssertNotNil(firstHandler)
+        XCTAssertNotNil(secondHandler)
+        firstHandler = nil
+
+        XCTAssertEqual(audioSession.configuration, .playbackWithMixing)
+        XCTAssertEqual(audioSession.setCategoryCalls.count, 1)
+
+        secondHandler = nil
+
+        XCTAssertEqual(audioSession.configuration, previousConfiguration)
+        XCTAssertEqual(audioSession.setCategoryCalls.count, 2)
+    }
+
+    func testDoesNotOverwriteHostConfigurationChangedDuringVideoPlayback() {
+        let audioSession = MockAudioSession()
+        var handler: VideoAudioSessionHandler? = VideoAudioSessionHandler(audioSession: audioSession)
+        XCTAssertNotNil(handler)
+        let hostConfiguration = Configuration(category: .playAndRecord, mode: .videoChat, options: [.allowBluetoothHFP])
+        audioSession.configuration = hostConfiguration
+
+        handler = nil
+
+        XCTAssertEqual(audioSession.configuration, hostConfiguration)
+        XCTAssertEqual(audioSession.setCategoryCalls.count, 1)
+    }
+
+    func testDoesNotRestoreWhenConfiguringPlaybackFails() {
+        let audioSession = MockAudioSession()
+        audioSession.shouldThrow = true
+
+        var handler: VideoAudioSessionHandler? = VideoAudioSessionHandler(audioSession: audioSession)
+        XCTAssertNotNil(handler)
+        handler = nil
+
+        XCTAssertEqual(audioSession.setCategoryCalls.count, 1)
+        XCTAssertEqual(audioSession.configuration, .default)
+    }
+
+}
+
+private final class MockAudioSession: AudioSessionConfiguring {
+
+    var configuration: Configuration
+    var shouldThrow = false
+    private(set) var setCategoryCalls: [Configuration] = []
+
+    var category: AVAudioSession.Category { configuration.category }
+    var mode: AVAudioSession.Mode { configuration.mode }
+    var categoryOptions: AVAudioSession.CategoryOptions { configuration.options }
+
+    init(configuration: Configuration = .default) {
+        self.configuration = configuration
+    }
+
+    func setCategory(
+        _ category: AVAudioSession.Category,
+        mode: AVAudioSession.Mode,
+        options: AVAudioSession.CategoryOptions
+    ) throws {
+        let configuration = Configuration(category: category, mode: mode, options: options)
+        setCategoryCalls.append(configuration)
+
+        if shouldThrow {
+            throw NSError(domain: "MockAudioSession", code: 1)
+        }
+
+        self.configuration = configuration
+    }
+
+}
+
+private struct Configuration: Equatable {
+
+    let category: AVAudioSession.Category
+    let mode: AVAudioSession.Mode
+    let options: AVAudioSession.CategoryOptions
+
+    static let `default` = Self(category: .soloAmbient, mode: .default, options: [])
+    static let playbackWithMixing = Self(category: .playback, mode: .default, options: [.mixWithOthers])
+
+}
+
+#endif

--- a/Tests/RevenueCatUITests/PaywallsV2/VideoAudioSessionHandlerTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/VideoAudioSessionHandlerTests.swift
@@ -16,6 +16,7 @@ import XCTest
 
 #if canImport(UIKit) && !os(watchOS) && !os(tvOS)
 
+@MainActor
 final class VideoAudioSessionHandlerTests: TestCase {
 
     func testSetsPlaybackCategoryWithMixing() {
@@ -35,9 +36,8 @@ final class VideoAudioSessionHandlerTests: TestCase {
         )
         let audioSession = MockAudioSession(configuration: previousConfiguration)
 
-        var handler: VideoAudioSessionHandler? = VideoAudioSessionHandler(audioSession: audioSession)
-        XCTAssertNotNil(handler)
-        handler = nil
+        let handler = VideoAudioSessionHandler(audioSession: audioSession)
+        handler.release()
 
         XCTAssertEqual(audioSession.configuration, previousConfiguration)
         XCTAssertEqual(audioSession.setCategoryCalls.count, 2)
@@ -47,16 +47,14 @@ final class VideoAudioSessionHandlerTests: TestCase {
         let previousConfiguration = Configuration(category: .playback, mode: .default, options: [])
         let audioSession = MockAudioSession(configuration: previousConfiguration)
 
-        var firstHandler: VideoAudioSessionHandler? = VideoAudioSessionHandler(audioSession: audioSession)
-        var secondHandler: VideoAudioSessionHandler? = VideoAudioSessionHandler(audioSession: audioSession)
-        XCTAssertNotNil(firstHandler)
-        XCTAssertNotNil(secondHandler)
-        firstHandler = nil
+        let firstHandler = VideoAudioSessionHandler(audioSession: audioSession)
+        let secondHandler = VideoAudioSessionHandler(audioSession: audioSession)
+        firstHandler.release()
 
         XCTAssertEqual(audioSession.configuration, .playbackWithMixing)
         XCTAssertEqual(audioSession.setCategoryCalls.count, 1)
 
-        secondHandler = nil
+        secondHandler.release()
 
         XCTAssertEqual(audioSession.configuration, previousConfiguration)
         XCTAssertEqual(audioSession.setCategoryCalls.count, 2)
@@ -64,20 +62,18 @@ final class VideoAudioSessionHandlerTests: TestCase {
 
     func testUnregisteredHandlerDoesNotRestoreAnotherHandlerConfiguration() {
         let audioSession = MockAudioSession(configuration: .playbackWithMixing)
-        var unregisteredHandler: VideoAudioSessionHandler? = VideoAudioSessionHandler(audioSession: audioSession)
-        XCTAssertNotNil(unregisteredHandler)
+        let unregisteredHandler = VideoAudioSessionHandler(audioSession: audioSession)
 
         let previousConfiguration = Configuration(category: .record, mode: .voiceChat, options: [])
         audioSession.configuration = previousConfiguration
-        var registeredHandler: VideoAudioSessionHandler? = VideoAudioSessionHandler(audioSession: audioSession)
-        XCTAssertNotNil(registeredHandler)
+        let registeredHandler = VideoAudioSessionHandler(audioSession: audioSession)
 
-        unregisteredHandler = nil
+        unregisteredHandler.release()
 
         XCTAssertEqual(audioSession.configuration, .playbackWithMixing)
         XCTAssertEqual(audioSession.setCategoryCalls.count, 1)
 
-        registeredHandler = nil
+        registeredHandler.release()
 
         XCTAssertEqual(audioSession.configuration, previousConfiguration)
         XCTAssertEqual(audioSession.setCategoryCalls.count, 2)
@@ -88,9 +84,8 @@ final class VideoAudioSessionHandlerTests: TestCase {
         let audioSession = MockAudioSession(configuration: previousConfiguration)
         audioSession.secondaryAudioShouldBeSilencedHint = true
 
-        var handler: VideoAudioSessionHandler? = VideoAudioSessionHandler(audioSession: audioSession)
-        XCTAssertNotNil(handler)
-        handler = nil
+        let handler = VideoAudioSessionHandler(audioSession: audioSession)
+        handler.release()
 
         XCTAssertEqual(audioSession.configuration, .playbackWithMixing)
         XCTAssertEqual(audioSession.setCategoryCalls.count, 2)
@@ -98,12 +93,11 @@ final class VideoAudioSessionHandlerTests: TestCase {
 
     func testDoesNotOverwriteHostConfigurationChangedDuringVideoPlayback() {
         let audioSession = MockAudioSession()
-        var handler: VideoAudioSessionHandler? = VideoAudioSessionHandler(audioSession: audioSession)
-        XCTAssertNotNil(handler)
+        let handler = VideoAudioSessionHandler(audioSession: audioSession)
         let hostConfiguration = Configuration(category: .playAndRecord, mode: .videoChat, options: [.allowBluetoothHFP])
         audioSession.configuration = hostConfiguration
 
-        handler = nil
+        handler.release()
 
         XCTAssertEqual(audioSession.configuration, hostConfiguration)
         XCTAssertEqual(audioSession.setCategoryCalls.count, 1)
@@ -113,9 +107,8 @@ final class VideoAudioSessionHandlerTests: TestCase {
         let audioSession = MockAudioSession()
         audioSession.shouldThrow = true
 
-        var handler: VideoAudioSessionHandler? = VideoAudioSessionHandler(audioSession: audioSession)
-        XCTAssertNotNil(handler)
-        handler = nil
+        let handler = VideoAudioSessionHandler(audioSession: audioSession)
+        handler.release()
 
         XCTAssertEqual(audioSession.setCategoryCalls.count, 1)
         XCTAssertEqual(audioSession.configuration, .default)

--- a/Tests/RevenueCatUITests/PaywallsV2/VideoAudioSessionHandlerTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/VideoAudioSessionHandlerTests.swift
@@ -132,6 +132,7 @@ private final class MockAudioSession: AudioSessionConfiguring {
     var category: AVAudioSession.Category { configuration.category }
     var mode: AVAudioSession.Mode { configuration.mode }
     var categoryOptions: AVAudioSession.CategoryOptions { configuration.options }
+    var secondaryAudioShouldBeSilencedHint = false
 
     init(configuration: Configuration = .default) {
         self.configuration = configuration


### PR DESCRIPTION
Addresses [PW-1301](https://linear.app/revenuecat/issue/PW-1301/background-app-audio-stops-when-closing-paywall-on-ios). We mix while the video is shown, then restore the original non-mixing configuration on close. That stops background music.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global `AVAudioSession` behavior for paywall videos; logic is refcounted and guarded but still affects host-app audio in production.
> 
> **Overview**
> Fixes background app audio stopping when an iOS paywall with video is dismissed (PW-1301).
> 
> Paywall video coordinators no longer set `AVAudioSession` to **ambient** inline or restore it from `deinit`. They use a shared **`VideoAudioSessionHandler`** that switches to **playback** with **`mixWithOthers`** while video is active (so other apps’ audio keeps playing), reference-counts multiple videos, and restores the prior category only after the last handler **`release()`** in teardown.
> 
> Restoration is defensive: it skips overwriting a host-changed session, keeps mixing when external audio is playing, and logs failures instead of crashing. Unit tests cover refcounting, restore, and host-override cases via a mock `AudioSessionConfiguring`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1909d215c5f9b12286b3412ab177a70ea39af0b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->