### PR TITLE
Internal `DangerousSettings.useWorkflows` to enable remote config/workflows programmatically

### DIFF
--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -55,6 +55,7 @@ import Foundation
         let autoSyncPurchases: Bool
         let uiPreviewMode: Bool
         let customEntitlementComputation: Bool
+        let useWorkflows: Bool
     }
 
     internal let storage: Storage
@@ -75,6 +76,11 @@ import Foundation
      * products obtained from StoreKit. This is useful for testing or preview purposes.
      */
     @_spi(Internal) public var uiPreviewMode: Bool { self.storage.uiPreviewMode }
+
+    /**
+     * Enables RevenueCat Workflows (multipage paywalls). Internal RevenueCat use only.
+     */
+    @_spi(Internal) public var useWorkflows: Bool { self.storage.useWorkflows }
 
     /**
      * A property meant for apps that do their own entitlements computation, separated from RevenueCat.
@@ -127,15 +133,30 @@ import Foundation
         self.init(autoSyncPurchases: false, internalSettings: Internal.default, uiPreviewMode: uiPreviewMode)
     }
 
+    /**
+     * Used to enable RevenueCat Workflows (multipage paywalls). Internal RevenueCat use only;
+     * behavior may change without warning.
+     *
+     * - Parameter useWorkflows: if `true`, the SDK wires up the workflows endpoint so multipage
+     * paywalls can be rendered.
+     */
+    @_spi(Internal) public convenience init(useWorkflows: Bool) {
+        self.init(autoSyncPurchases: true,
+                  internalSettings: Internal.default,
+                  useWorkflows: useWorkflows)
+    }
+
     /// Designated initializer
     internal init(autoSyncPurchases: Bool,
                   customEntitlementComputation: Bool = false,
                   internalSettings: InternalDangerousSettingsType,
-                  uiPreviewMode: Bool = false) {
+                  uiPreviewMode: Bool = false,
+                  useWorkflows: Bool = false) {
         self.storage = Storage(
             autoSyncPurchases: autoSyncPurchases,
             uiPreviewMode: uiPreviewMode,
-            customEntitlementComputation: customEntitlementComputation
+            customEntitlementComputation: customEntitlementComputation,
+            useWorkflows: useWorkflows
         )
         self.internalSettings = internalSettings
     }

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -96,8 +96,16 @@ class SystemInfo {
     /// Whether remote config lifecycle wiring is enabled. Temporary gate while remote config is being
     /// rolled out. Paywall workflows read entirely through remote config, so this is also the single
     /// gate for workflows: there's no separate workflows switch, since the two ship together.
+    ///
+    /// Enabled either programmatically via the internal `DangerousSettings.useWorkflows` flag (used by
+    /// hybrid SDKs, which can't set a compilation condition at runtime) or by the `ENABLE_REMOTE_CONFIG`
+    /// compilation condition. Always disabled under custom entitlement computation.
     var remoteConfigEnabled: Bool {
         guard !self.dangerousSettings.customEntitlementComputation else { return false }
+
+        if self.dangerousSettings.useWorkflows {
+            return true
+        }
 
         #if ENABLE_REMOTE_CONFIG
         return true

--- a/Tests/UnitTests/Misc/SystemInfoTests.swift
+++ b/Tests/UnitTests/Misc/SystemInfoTests.swift
@@ -185,6 +185,51 @@ class SystemInfoTests: TestCase {
         expect(SystemInfo.apiBaseURL) == customURL
     }
 
+    func testRemoteConfigEnabledViaDangerousSettings() {
+        let dangerousSettings = DangerousSettings(
+            autoSyncPurchases: true,
+            internalSettings: DangerousSettings.Internal.default,
+            useWorkflows: true
+        )
+        let systemInfo = SystemInfo(platformInfo: nil,
+                                    finishTransactions: true,
+                                    apiKey: "api_key",
+                                    dangerousSettings: dangerousSettings,
+                                    preferredLocalesProvider: .mock())
+        expect(systemInfo.remoteConfigEnabled) == true
+    }
+
+    func testRemoteConfigDisabledUnderCustomEntitlementComputationEvenWithWorkflows() {
+        let dangerousSettings = DangerousSettings(
+            autoSyncPurchases: true,
+            customEntitlementComputation: true,
+            internalSettings: DangerousSettings.Internal.default,
+            useWorkflows: true
+        )
+        let systemInfo = SystemInfo(platformInfo: nil,
+                                    finishTransactions: true,
+                                    apiKey: "api_key",
+                                    dangerousSettings: dangerousSettings,
+                                    preferredLocalesProvider: .mock())
+        expect(systemInfo.remoteConfigEnabled) == false
+    }
+
+    func testDangerousSettingsDifferingOnlyInUseWorkflowsAreNotEqual() {
+        // useWorkflows must participate in equality so reconfiguring with it toggled produces a
+        // new Purchases instance instead of returning the existing (deduped) one.
+        let withWorkflows = DangerousSettings(
+            autoSyncPurchases: true,
+            internalSettings: DangerousSettings.Internal.default,
+            useWorkflows: true
+        )
+        let withoutWorkflows = DangerousSettings(
+            autoSyncPurchases: true,
+            internalSettings: DangerousSettings.Internal.default,
+            useWorkflows: false
+        )
+        expect(withWorkflows) != withoutWorkflows
+    }
+
 }
 
 private extension SystemInfo {


### PR DESCRIPTION
Hybrid SDKs need to enable RevenueCat Workflows (multipage paywalls) programmatically at configure time. Enablement now flows through remote config (`SystemInfo.remoteConfigEnabled`), which is gated by the `ENABLE_REMOTE_CONFIG` compilation condition, and a compile condition can't be set by a hybrid app at runtime.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the gate for remote config and workflow manager wiring at `Purchases` configure time; misconfiguration could enable or skip multipage paywall infrastructure, though the API is internal SPI and CEC still blocks enablement.
> 
> **Overview**
> Adds an internal **`DangerousSettings.useWorkflows`** flag (hashable storage, SPI accessor, and `init(useWorkflows:)`) so hybrid SDKs can turn on multipage paywall / workflows wiring at configure time without the **`ENABLE_REMOTE_CONFIG`** compile flag.
> 
> **`SystemInfo.remoteConfigEnabled`** now returns `true` when `useWorkflows` is set, in addition to the existing compile-time path; **custom entitlement computation** still forces remote config off. Docs on the gate are updated to describe both enablement paths.
> 
> Unit tests cover remote config on via the flag, off when CEC is on even with workflows, and **`DangerousSettings` equality** when only `useWorkflows` differs (so SDK reconfiguration is not incorrectly deduped).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a8397a2c71557472ac6dbf9003f7450076267ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->