### PR TITLE
Use short timeouts for remote config blob downloads

### DIFF
--- a/Sources/Networking/RemoteConfigBlobDownloader.swift
+++ b/Sources/Networking/RemoteConfigBlobDownloader.swift
@@ -24,10 +24,21 @@ final class URLSessionRemoteConfigBlobDownloader: RemoteConfigBlobDownloaderType
         case unexpectedStatusCode(Int)
     }
 
+    static let timeout: TimeInterval = 5
+
     private let session: URLSession
 
-    init(session: URLSession = .shared) {
+    init(session: URLSession = URLSession(
+        configuration: URLSessionRemoteConfigBlobDownloader.defaultSessionConfiguration()
+    )) {
         self.session = session
+    }
+
+    static func defaultSessionConfiguration() -> URLSessionConfiguration {
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = Self.timeout
+        configuration.timeoutIntervalForResource = Self.timeout
+        return configuration
     }
 
     func data(from url: URL) async throws -> Data {

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobFetcherTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigBlobFetcherTests.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 import Nimble
+import OHHTTPStubs
+import OHHTTPStubsSwift
 @testable import RevenueCat
 import XCTest
 
@@ -31,6 +33,7 @@ final class RemoteConfigBlobFetcherTests: TestCase {
     }
 
     override func tearDownWithError() throws {
+        HTTPStubs.removeAllStubs()
         self.downloader.cancelAll()
         self.fetcher = nil
         self.sourceProvider = nil
@@ -214,6 +217,39 @@ final class RemoteConfigBlobFetcherTests: TestCase {
             Self.templateURL.replacingOccurrences(of: Self.placeholder, with: ref),
             Self.backupTemplateURL.replacingOccurrences(of: Self.placeholder, with: ref)
         ]
+        expect(self.blobStore.invokedWriteParameters?.data) == payload
+    }
+
+    func testRealDownloaderUsesFiveSecondTimeoutAndRetriesNextSourceAfterTimeout() async {
+        let payload = "timeout fallback payload".asData
+        let ref = Self.ref(for: payload)
+        let primaryURL = Self.templateURL.replacingOccurrences(of: Self.placeholder, with: ref)
+        let backupURL = Self.backupTemplateURL.replacingOccurrences(of: Self.placeholder, with: ref)
+
+        stub(condition: isAbsoluteURLString(primaryURL)) { _ in
+            return HTTPStubsResponse(error: URLError(.timedOut))
+        }
+        stub(condition: isAbsoluteURLString(backupURL)) { _ in
+            return HTTPStubsResponse(
+                data: payload,
+                statusCode: Int32(HTTPStatusCode.success.rawValue),
+                headers: nil
+            )
+        }
+
+        self.sourceProvider = Self.sourceProvider(urls: [
+            Self.templateURL,
+            Self.backupTemplateURL
+        ])
+        self.fetcher = RemoteConfigBlobFetcher(
+            blobStore: self.blobStore,
+            sourceProvider: self.sourceProvider,
+            downloader: URLSessionRemoteConfigBlobDownloader()
+        )
+
+        let result = await self.fetcher.ensureDownloaded(ref: ref)
+
+        expect(result) == true
         expect(self.blobStore.invokedWriteParameters?.data) == payload
     }
 


### PR DESCRIPTION
We previously used the default session configuration through `URLSessions.shared`, which uses a default timeout of 60s. This is rather high, and Android already uses a shorter 5s timeout, so with this PR we bring this in line. We'll use multiple sources for the blob downloads, so a lower timeout should also ensure we'll fallback to the next source sooner.

In a follow up PR (https://github.com/RevenueCat/purchases-ios/pull/7185) we'll actually implement dynamic timeouts based on the provided sources as well.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow networking tuning for remote config blobs with faster failure on slow hosts; behavior change is intentional alignment with multi-source fallback, not auth or payment paths.
> 
> **Overview**
> Remote config blob downloads no longer use `URLSession.shared` and its ~60s default timeouts. **`URLSessionRemoteConfigBlobDownloader`** now builds a dedicated `URLSession` whose request and resource timeouts are both **5 seconds**, matching Android and speeding failover when multiple blob sources are configured.
> 
> A new integration-style unit test stubs a primary URL with `URLError.timedOut` and a backup with a successful response, asserting **`RemoteConfigBlobFetcher`** still completes and persists the blob via the real downloader.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a45da0f1619473a06d8fe3af9b250b3026db575. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->