### PR TITLE
test(remote-config): cover getOfferings delivering when a prefetch blob fails

### DIFF
--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -1255,6 +1255,29 @@ extension OfferingsManagerTests {
         expect(mockRemoteConfigManager.invokedEnsureBlobsDownloadedRefs) == [["wf-1-ref"]]
     }
 
+    func testGetOfferingsDeliversEvenWhenPrefetchBlobDownloadFails() {
+        // A permanently failing prefetch blob (dead CDN, 404, checksum mismatch) must not strand
+        // delivery: the gate waits for the download to settle, not to succeed. Blocking or retrying
+        // on failure would turn a transient CDN problem into a total paywall outage.
+        let mockRemoteConfigManager = MockRemoteConfigManager()
+        mockRemoteConfigManager.stubbedTopics[.workflows] = [
+            "wf-1": .init(blobRef: "wf-1-ref", prefetch: true, content: [:])
+        ]
+        mockRemoteConfigManager.stubbedEnsureBlobsDownloadedResult = false
+        let manager = self.makeOfferingsManager(remoteConfigManager: mockRemoteConfigManager)
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsContents)
+
+        let result = waitUntilValue { completed in
+            manager.offerings(appUserID: MockData.anyAppUserID) { completed($0) }
+        }
+
+        // The prefetch blob download was attempted (failure path exercised) and offerings still
+        // delivered, with the real offerings.
+        expect(mockRemoteConfigManager.invokedEnsureBlobsDownloadedRefs) == [["wf-1-ref"]]
+        expect(result).to(beSuccess())
+        expect(result?.value?["base"]).toNot(beNil())
+    }
+
     func testGetOfferingsServedFromDiskOnFailureStillAwaitsConfigReady() throws {
         let mockRemoteConfigManager = MockRemoteConfigManager()
         let manager = self.makeOfferingsManager(remoteConfigManager: mockRemoteConfigManager)


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

The `getOfferings` readiness gate waits for a topic's prefetch blobs before delivering. It is best-effort by design: it waits for the downloads to *settle*, not to *succeed*, so a failing CDN blob still lets offerings through. Nothing tested that failure path, so a well-meaning refactor that retried or blocked on a failed blob would hang cold launch on any CDN blip and CI would stay green.

### Description

Adds one unit test that fails a prefetch blob download (`stubbedEnsureBlobsDownloadedResult = false`) and asserts `getOfferings` still delivers the real offerings, while confirming the download was actually attempted. Pins the "settle, not stored" contract.

Testing (beyond the diff): verified RED to GREEN. Against `main` the test passes in 0.02s. Temporarily breaking the gate extension to retry on failure (`guard allStored else { continue }`) made it hang until the wait timed out (15.16s, `RemoteConfigManager.swift` recompiled so the break really applied); reverting returns it to passing. So the test fails precisely on the paywall-hang regression, not vacuously.

<details>
<summary>AI session context</summary>

**Scope:** this block covers only this PR (the gate-failure test). Other work explored in the same session is unrelated and excluded.

**Metadata**
- Branch: `facu/offerings-gate-delivers-on-blob-failure` (off `origin/main` @ `fbeb89cea`)
- Head: `a2faafa15`
- Change: test-only, +23 lines, one file
- Label: `pr:other` (no behavior change)

**First actionable instruction:** add SDK tests to protect the CDN blob-download path; after auditing existing coverage, the agreed highest-value gap was "the gate must never strand a paywall when a prefetch blob fails."

**What changed and why:** added `OfferingsManagerTests.testGetOfferingsDeliversEvenWhenPrefetchBlobDownloadFails`. The gate's best-effort delivery rests on two easily-edited lines (`_ = await (...)` + unconditional `deliver()` in `OfferingsManager.deliverWhenConfigReady`, and the discarded `await self.ensureBlobsDownloaded(...)` in `RemoteConfigManager.awaitTopicAndPrefetchBlobsReady`). No test guarded it.

**Agent contribution:** audited existing blob-path coverage (found it strong: concurrency cap, checksum rejection, source failover, coalescing, priority upgrade, warm short-circuit, downloading a single blob through the whole path all covered), identified this as the top unguarded invariant, wrote the test, and proved it RED to GREEN.

**Human decisions:** chose to write tests directly against `main`; picked this gap over the others; scoped the PR and this context block to this task only.

**Files / symbols / commands**
- `Tests/UnitTests/Purchasing/OfferingsManagerTests.swift` (new test)
- Exercised (unchanged): `OfferingsManager.deliverWhenConfigReady`, `RemoteConfigManagerType.awaitTopicAndPrefetchBlobsReady`, `MockRemoteConfigManager.stubbedEnsureBlobsDownloadedResult`
- Run: `xcodebuild -workspace RevenueCat-Tuist.xcworkspace -scheme UnitTests -destination 'platform=iOS Simulator,name=iPhone 16 Pro' -only-testing:UnitTests/OfferingsManagerTests/testGetOfferingsDeliversEvenWhenPrefetchBlobDownloadFails test`

**Proof:** GREEN on `main` (0.02s). RED with a deliberately broken gate (retry-on-failure) = 15.16s wait-timeout failure, with `RemoteConfigManager.swift` confirmed recompiled. Reverted to GREEN (0.01s).

**Risks / reviewer notes:** none to the shipping code (test-only). The test asserts settle-not-success semantics; if a future change intentionally makes the gate require successful storage, this test should be updated deliberately, not deleted.

**Not captured / follow-up:** a second gap (downloading several real blobs at once, in `RemoteConfigIntegrationTests`) was identified but is not in this PR.

</details>
