### PR TITLE
test(remote-config): cover downloading several config blobs at once

### DIFF
--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
@@ -280,6 +280,44 @@ final class RemoteConfigIntegrationTests: TestCase {
         expect(requestedURLs) == [Self.url(source, ref: externalRef)]
     }
 
+    func testMultipleExternalPrefetchBlobsAllDownloadStoreAndReadThroughFacade() async throws {
+        // Production shape: many prefetch-flagged workflow items, each backed by a distinct external
+        // blob. The concurrent prefetch fan-out must download and store every one through the real
+        // store. Count is above the scheduler's concurrency cap (4) so the queue drain past the
+        // first batch is exercised, which a single-blob test can never reach.
+        let count = 5
+        let source = Self.blobSource("primary")
+        let blobs = (0..<count).map { "external-blob-\($0)".asData }
+        let refs = blobs.map { RCContainerTestData.blobRef(for: $0) }
+
+        var items: RemoteConfiguration.ConfigTopic = [:]
+        for index in 0..<count {
+            items["wf-\(index)"] = .init(blobRef: refs[index], prefetch: true)
+            await self.downloader.setResponse(.success(blobs[index]), for: source, ref: refs[index])
+        }
+        let container = try Self.containerData(topics: Self.topics(
+            sources: Self.sourcesTopic(blobSources: [source]),
+            workflows: Self.workflowTopic(items: items)
+        ))
+
+        await self.refresh(with: container)
+        // The gate's exact call: blocks until every prefetch blob has settled.
+        _ = await self.manager.awaitTopicAndPrefetchBlobsReady(.workflows)
+
+        let requestedURLs = await self.downloader.requestedURLStrings()
+        let expectedURLs = refs.map { Self.url(source, ref: $0) }
+
+        // Every distinct external blob was fetched exactly once, stored, and readable via its item.
+        expect(Set(requestedURLs)) == Set(expectedURLs)
+        expect(requestedURLs).to(haveCount(count))
+        for index in 0..<count {
+            expect(self.blobStore.read(ref: refs[index])) == blobs[index]
+            let maybeItemData = await self.manager.blobData(for: .workflows, itemKey: "wf-\(index)")
+            let itemData = try XCTUnwrap(maybeItemData)
+            expect(itemData) == blobs[index]
+        }
+    }
+
     func testInlineBlobWriteFailureFallsBackToExternalBlobDownload() async throws {
         let blob = #"{"workflow":"inline-write-failed"}"#.asData
         let ref = RCContainerTestData.blobRef(for: blob)


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Why

Real projects don't ship one config blob, they ship a pile of them (our stress project pulls ~146). The SDK downloads them a handful at a time and saves them before the paywall is ready. We had solid tests for a single blob going through the whole path, but never for the many-at-once case that actually happens in production. So if the downloading ever broke and only the first few came down, we wouldn't catch it.

### Description

Adds one integration test that downloads 5 real config blobs at once (more than the 4 we download in parallel) through the real downloader and disk store, and checks every one is saved and reads back. It uses more than 4 on purpose, so the case where the later ones get dropped is actually reachable.

Testing (beyond the diff): verified it goes red to green. On `main` it passes in ~0.2s. If I remove the line that starts the next download once one finishes, the 5th blob never starts and the test hangs (killed at the time limit); putting it back makes it pass. A single-blob or 4-blob test could never catch that.

<details>
<summary>AI session context</summary>

**Scope:** this block covers only this PR (the multiple-config-blobs test). Other work explored in the same session is unrelated and excluded.

**Metadata**
- Branch: `facu/remote-config-multi-blob-prefetch-test` (off `origin/main` @ `f39351e7d`)
- Head: `92be97767`
- Change: test-only, +38 lines, one file
- Label: `pr:other` (no behavior change)

**First actionable instruction:** after auditing blob-path coverage, fill the gap for downloading several external CDN blobs against the real store (the production many-blob shape), which was only checked with a mock.

**What changed and why:** added `RemoteConfigIntegrationTests.testMultipleExternalPrefetchBlobsAllDownloadStoreAndReadThroughFacade`. Existing external-blob integration tests download a single blob on demand; downloading several at once through the real fetcher and disk store had no coverage.

**Agent contribution:** audited existing coverage, identified this as the remaining gap, designed the test (5 blobs, above the 4 downloaded in parallel, driven through the real readiness path, order-independent assertions), wrote it, and verified it red to green.

**Human decisions:** write directly against `main`; open a separate draft PR from the gate-failure test; confirmed the design (5 blobs above the parallel limit, order-independent assertions, all-succeed) before implementation; asked for plainer, non-jargon wording.

**Files / symbols / commands**
- `Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift` (new test)
- Exercised (unchanged): `RemoteConfigManager.awaitTopicAndPrefetchBlobsReady`, `RemoteConfigBlobFetchScheduler` (downloads up to 4 at once), `RemoteConfigBlobStore`, `MockIntegrationBlobDownloader`
- Run: `xcodebuild -workspace RevenueCat-Tuist.xcworkspace -scheme UnitTests -destination 'platform=iOS Simulator,name=iPhone 16 Pro' -only-testing:UnitTests/RemoteConfigIntegrationTests/testMultipleExternalPrefetchBlobsAllDownloadStoreAndReadThroughFacade test`

**Proof:** GREEN on `main` (~0.2s, all 5 downloaded/stored/read). RED with the "start the next download once one finishes" line removed = execution-time-allowance timeout (hang), `RemoteConfigBlobFetcher.swift` recompiled. Reverted to GREEN.

**Risks / reviewer notes:** none to shipping code (test-only). One compile fix during development: `await` cannot sit inside `XCTUnwrap`'s non-async autoclosure, so the value is awaited into a local first (matches the file's existing pattern).

**Related:** companion test-only PR (getOfferings still delivers when a blob download fails) is separate; both came from the same coverage audit.

</details>
