### PR TITLE
fix(remote-config): Cache remote config workflows in-memory to avoid loading flash

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -950,6 +950,7 @@
 		A1B2C3D42FE2000000000002 /* RemoteConfigDiskCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE2000000000001 /* RemoteConfigDiskCache.swift */; };
 		A1B2C3D42FE2000000000004 /* RemoteConfigManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE2000000000003 /* RemoteConfigManager.swift */; };
 		A1B2C3D42FE3000000000002 /* RemoteConfigFetchContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE3000000000001 /* RemoteConfigFetchContext.swift */; };
+		A1B2C3D42FE9000000000002 /* GenerationGuardedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE9000000000001 /* GenerationGuardedCache.swift */; };
 		B8EF700CBF25815EC2BF1253 /* UiConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB021C52E3CCC5EB17FFF795 /* UiConfigProvider.swift */; };
 		49B8016629C29C4691C0774A /* WorkflowsConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C390BBAC430231B23B4B5F8 /* WorkflowsConfigProvider.swift */; };
 		A1B2C3D42FE200000000000D /* RemoteConfigBlobStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE200000000000C /* RemoteConfigBlobStore.swift */; };
@@ -964,6 +965,7 @@
 		A1B2C3D42FE6000000000008 /* RemoteConfigBlobFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE6000000000007 /* RemoteConfigBlobFetcherTests.swift */; };
 		A1B2C3D42FE600000000000A /* RemoteConfigBlobDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE6000000000009 /* RemoteConfigBlobDownloaderTests.swift */; };
 		A1B2C3D42FE8000000000002 /* RemoteConfigIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE8000000000001 /* RemoteConfigIntegrationTests.swift */; };
+		A1B2C3D42FE9000000000004 /* GenerationGuardedCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE9000000000003 /* GenerationGuardedCacheTests.swift */; };
 		7648885717DC2DB5009DD01B /* MinMaxOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = C812AE8BAE0546D2F4ACEF35 /* MinMaxOperators.swift */; };
 		7707A94C2CAD93AC006E0313 /* PaywallButtonComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7707A94B2CAD93AC006E0313 /* PaywallButtonComponent.swift */; };
 		7707A94E2CAD94D2006E0313 /* ButtonComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7707A94D2CAD94D2006E0313 /* ButtonComponentViewModel.swift */; };
@@ -2919,6 +2921,7 @@
 		A1B2C3D42FE2000000000001 /* RemoteConfigDiskCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigDiskCache.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE2000000000003 /* RemoteConfigManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigManager.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE3000000000001 /* RemoteConfigFetchContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigFetchContext.swift; sourceTree = "<group>"; };
+		A1B2C3D42FE9000000000001 /* GenerationGuardedCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationGuardedCache.swift; sourceTree = "<group>"; };
 		DB021C52E3CCC5EB17FFF795 /* UiConfigProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UiConfigProvider.swift; sourceTree = "<group>"; };
 		4C390BBAC430231B23B4B5F8 /* WorkflowsConfigProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowsConfigProvider.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE200000000000C /* RemoteConfigBlobStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobStore.swift; sourceTree = "<group>"; };
@@ -2930,6 +2933,7 @@
 		A1B2C3D42FE2000000000008 /* RemoteConfigDiskCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigDiskCacheTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE200000000000A /* RemoteConfigManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigManagerTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE200000000000E /* RemoteConfigBlobStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobStoreTests.swift; sourceTree = "<group>"; };
+		A1B2C3D42FE9000000000003 /* GenerationGuardedCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationGuardedCacheTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE6000000000007 /* RemoteConfigBlobFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobFetcherTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE6000000000009 /* RemoteConfigBlobDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobDownloaderTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE8000000000001 /* RemoteConfigIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigIntegrationTests.swift; sourceTree = "<group>"; };
@@ -4592,6 +4596,7 @@
 				A1B2C3D42FE2000000000001 /* RemoteConfigDiskCache.swift */,
 				A1B2C3D42FE2000000000003 /* RemoteConfigManager.swift */,
 				A1B2C3D42FE3000000000001 /* RemoteConfigFetchContext.swift */,
+				A1B2C3D42FE9000000000001 /* GenerationGuardedCache.swift */,
 				DB021C52E3CCC5EB17FFF795 /* UiConfigProvider.swift */,
 				4C390BBAC430231B23B4B5F8 /* WorkflowsConfigProvider.swift */,
 				A1B2C3D42FE7000000000001 /* RemoteConfigTopic.swift */,
@@ -4620,6 +4625,7 @@
 				A1B2C3D42FE2000000000007 /* RemoteConfig */,
 				5733B1A327FF9F8300EC2045 /* NetworkErrorTests.swift */,
 				5733B1A727FFBCC800EC2045 /* BackendErrorTests.swift */,
+				A1B2C3D42FE9000000000003 /* GenerationGuardedCacheTests.swift */,
 				371E0615EDF883698273BC59 /* UiConfigProviderTests.swift */,
 				FFB683A085B695768EAB9AA5 /* WorkflowsConfigProviderTests.swift */,
 				5733B1A927FFBCF900EC2045 /* BaseErrorTests.swift */,
@@ -7251,6 +7257,7 @@
 				A1B2C3D42FE2000000000002 /* RemoteConfigDiskCache.swift in Sources */,
 				A1B2C3D42FE2000000000004 /* RemoteConfigManager.swift in Sources */,
 				A1B2C3D42FE3000000000002 /* RemoteConfigFetchContext.swift in Sources */,
+				A1B2C3D42FE9000000000002 /* GenerationGuardedCache.swift in Sources */,
 				B8EF700CBF25815EC2BF1253 /* UiConfigProvider.swift in Sources */,
 				49B8016629C29C4691C0774A /* WorkflowsConfigProvider.swift in Sources */,
 				A1B2C3D42FE2000000000006 /* RemoteConfigStrings.swift in Sources */,
@@ -7853,6 +7860,7 @@
 				5796A3C027D7D64500653165 /* ResultExtensionsTests.swift in Sources */,
 				351B51A726D450D400BD2BD7 /* SystemInfoTests.swift in Sources */,
 				5733B1A827FFBCC800EC2045 /* BackendErrorTests.swift in Sources */,
+				A1B2C3D42FE9000000000004 /* GenerationGuardedCacheTests.swift in Sources */,
 				AD787D4FC44F9C3638DCDEF9 /* UiConfigProviderTests.swift in Sources */,
 				E48EFFFF5FF27ECC25F4E308 /* WorkflowsConfigProviderTests.swift in Sources */,
 				03A98D362D244329009BCA61 /* UIConfigDecodingTests.swift in Sources */,

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -212,7 +212,6 @@ public struct PaywallView: View {
         self._offering = .init(
             initialValue: seededWorkflowContext?.initialOffering
                 ?? cachedPaywallViewData?.offering
-                ?? configuration.purchaseHandler.cachedInitialOffering(for: configuration.content)
         )
         self._customerInfo = .init(
             initialValue: configuration.customerInfo ?? Self.loadCachedCustomerInfoIfPossible()

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -202,16 +202,17 @@ public struct PaywallView: View {
 
         self._introEligibility = .init(wrappedValue: configuration.introEligibility ?? .default())
 
-        // An injected workflow context (preview/injection path) is used directly; there is no
-        // synchronous cache seed for a workflow paywall, so otherwise the seed is nil and the async
-        // resolve path always takes over, falling back to the cached offering in the meantime.
         let seededWorkflowContext = configuration.injectedWorkflowContext
-        self._workflowContext = .init(initialValue: seededWorkflowContext)
+        let cachedPaywallViewData = seededWorkflowContext == nil
+            ? configuration.purchaseHandler.cachedInitialPaywallViewData(for: configuration.content)
+            : nil
+        self._workflowContext = .init(
+            initialValue: seededWorkflowContext ?? cachedPaywallViewData?.workflowContext
+        )
         self._offering = .init(
             initialValue: seededWorkflowContext?.initialOffering
-                ?? configuration.purchaseHandler.cachedInitialOffering(
-                    for: configuration.content
-                )
+                ?? cachedPaywallViewData?.offering
+                ?? configuration.purchaseHandler.cachedInitialOffering(for: configuration.content)
         )
         self._customerInfo = .init(
             initialValue: configuration.customerInfo ?? Self.loadCachedCustomerInfoIfPossible()

--- a/RevenueCatUI/Purchasing/MockPurchases.swift
+++ b/RevenueCatUI/Purchasing/MockPurchases.swift
@@ -44,10 +44,15 @@ final class MockPurchases: PaywallPurchasesType, @unchecked Sendable {
 
 #if !os(tvOS)
     var workflowBlock: ((String) async throws -> WorkflowDataResult)?
+    var cachedWorkflowBlock: ((String) -> WorkflowDataResult?)?
 
     func workflow(forOfferingIdentifier offeringID: String) async throws -> WorkflowDataResult {
         guard let block = workflowBlock else { throw ErrorCode.configurationError }
         return try await block(offeringID)
+    }
+
+    func cachedWorkflow(forOfferingIdentifier offeringID: String) -> WorkflowDataResult? {
+        return self.cachedWorkflowBlock?(offeringID)
     }
 #endif
 
@@ -177,6 +182,7 @@ extension PaywallPurchasesType {
         mapped.remoteConfigEnabled = self.remoteConfigEnabled
         #if !os(tvOS)
         mapped.workflowBlock = { try await self.workflow(forOfferingIdentifier: $0) }
+        mapped.cachedWorkflowBlock = { self.cachedWorkflow(forOfferingIdentifier: $0) }
         mapped.trackWorkflowEventBlock = { await self.track(workflowEvent: $0) }
         #endif
 
@@ -207,6 +213,7 @@ extension PaywallPurchasesType {
         mapped.remoteConfigEnabled = self.remoteConfigEnabled
         #if !os(tvOS)
         mapped.workflowBlock = { try await self.workflow(forOfferingIdentifier: $0) }
+        mapped.cachedWorkflowBlock = { self.cachedWorkflow(forOfferingIdentifier: $0) }
         mapped.trackWorkflowEventBlock = { await self.track(workflowEvent: $0) }
         #endif
 

--- a/RevenueCatUI/Purchasing/PaywallPurchasesType.swift
+++ b/RevenueCatUI/Purchasing/PaywallPurchasesType.swift
@@ -43,6 +43,8 @@ protocol PaywallPurchasesType: Sendable {
 #if !os(tvOS)
     @Sendable
     func workflow(forOfferingIdentifier offeringID: String) async throws -> WorkflowDataResult
+
+    func cachedWorkflow(forOfferingIdentifier offeringID: String) -> WorkflowDataResult?
 #endif
 
     @Sendable

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -307,6 +307,54 @@ extension PurchaseHandler {
         return self.cachedInitialOffering(for: content, remoteConfigEnabled: remoteConfigEnabled)
     }
 
+#if !os(tvOS)
+    func cachedInitialPaywallViewData(
+        for content: PaywallViewConfiguration.Content
+    ) -> ResolvedPaywallViewData? {
+        return self.cachedInitialPaywallViewData(
+            for: content,
+            remoteConfigEnabled: self.remoteConfigEnabled
+        )
+    }
+
+    func cachedInitialPaywallViewData(
+        for content: PaywallViewConfiguration.Content,
+        remoteConfigEnabled: Bool
+    ) -> ResolvedPaywallViewData? {
+        if !remoteConfigEnabled {
+            return self.cachedInitialOffering(
+                for: content,
+                remoteConfigEnabled: remoteConfigEnabled
+            ).map { .init(offering: $0, workflowContext: nil) }
+        }
+
+        guard let cachedOfferings = self.purchases.cachedOfferings,
+              let offering = self.initialOffering(
+                content: content,
+                from: cachedOfferings
+              ) else {
+            return nil
+        }
+
+        guard offering.paywall == nil else {
+            return .init(offering: offering, workflowContext: nil)
+        }
+
+        guard let fetchResult = self.purchases.cachedWorkflow(forOfferingIdentifier: offering.identifier),
+              let context = try? Self.makeWorkflowContext(
+                workflow: fetchResult.workflow,
+                uiConfig: fetchResult.uiConfig,
+                allOfferings: cachedOfferings,
+                presentedOfferingContext: offering.presentedOfferingContext,
+                triggerOfferingIdentifier: offering.identifier
+              ) else {
+            return nil
+        }
+
+        return .init(offering: context.initialOffering, workflowContext: context)
+    }
+#endif
+
     // Exposes the gate so tests can cover both states deterministically without depending on
     // ENABLE_REMOTE_CONFIG being compiled in for the test target.
     func cachedInitialOffering(
@@ -315,24 +363,38 @@ extension PurchaseHandler {
     ) -> Offering? {
         // The passed/cached offering alone can't drive a workflow paywall: under workflows the
         // rendered offering is the workflow screen's offering with its workflow-mapped components,
-        // and it needs a WorkflowContext the offering doesn't carry. There is no synchronous seed for
-        // a workflow paywall, so this overload returns nil and the async resolve path always runs.
+        // and it needs a WorkflowContext the offering doesn't carry.
         if remoteConfigEnabled {
+#if !os(tvOS)
+            return self.cachedInitialPaywallViewData(
+                for: content,
+                remoteConfigEnabled: remoteConfigEnabled
+            )?.offering
+#else
             return nil
+#endif
         }
 
+        return self.initialOffering(
+            content: content,
+            from: self.purchases.cachedOfferings
+        )
+    }
+
+    private func initialOffering(
+        content: PaywallViewConfiguration.Content,
+        from cachedOfferings: Offerings?
+    ) -> Offering? {
         switch content {
         case let .offering(offering):
             return offering
         case .defaultOffering:
-            return self.purchases.cachedOfferings?.current
+            return cachedOfferings?.current
         case let .offeringIdentifier(identifier, presentedOfferingContext):
-            let offering = self.purchases.cachedOfferings?.offering(identifier: identifier)
-
+            let offering = cachedOfferings?.offering(identifier: identifier)
             if let presentedOfferingContext {
                 return offering?.withPresentedOfferingContext(presentedOfferingContext)
             }
-
             return offering
         }
     }
@@ -961,6 +1023,10 @@ private final class NotConfiguredPurchases: PaywallPurchasesType {
 #if !os(tvOS)
     func workflow(forOfferingIdentifier offeringID: String) async throws -> WorkflowDataResult {
         throw ErrorCode.configurationError
+    }
+
+    func cachedWorkflow(forOfferingIdentifier offeringID: String) -> WorkflowDataResult? {
+        return nil
     }
 #endif
 

--- a/RevenueCatUI/Views/LoadingPaywallView.swift
+++ b/RevenueCatUI/Views/LoadingPaywallView.swift
@@ -182,6 +182,10 @@ private final class LoadingPaywallPurchases: PaywallPurchasesType {
     func workflow(forOfferingIdentifier offeringID: String) async throws -> WorkflowDataResult {
         throw ErrorCode.configurationError
     }
+
+    func cachedWorkflow(forOfferingIdentifier offeringID: String) -> WorkflowDataResult? {
+        return nil
+    }
 #endif
 
     func customerInfo() async throws -> RevenueCat.CustomerInfo {

--- a/Sources/Networking/GenerationGuardedCache.swift
+++ b/Sources/Networking/GenerationGuardedCache.swift
@@ -1,0 +1,78 @@
+//
+//  GenerationGuardedCache.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+
+/// Small in-memory cache for remote-config-derived values.
+///
+/// Values are tagged with the remote config generation and a provider-owned key. Reads only return when
+/// the generation is still current, and stale lower-generation stores cannot overwrite newer cache state.
+final class GenerationGuardedCache<Key: Equatable, Value> {
+
+    private let lock = Lock()
+    private var cached: CachedValue?
+
+    func value(currentGeneration: Int) -> Value? {
+        return self.lock.perform {
+            guard let cached = self.cached else { return nil }
+            guard cached.generation == currentGeneration else {
+                if cached.generation < currentGeneration {
+                    self.cached = nil
+                }
+                return nil
+            }
+            return cached.value
+        }
+    }
+
+    func value(for snapshot: GenerationGuardedCacheSnapshot<Key>) -> Value? {
+        return self.lock.perform {
+            guard let cached = self.cached else { return nil }
+            guard cached.generation == snapshot.generation,
+                  cached.key == snapshot.key else {
+                if cached.generation <= snapshot.generation {
+                    self.cached = nil
+                }
+                return nil
+            }
+            return cached.value
+        }
+    }
+
+    func store(_ value: Value, for snapshot: GenerationGuardedCacheSnapshot<Key>) {
+        self.lock.perform {
+            guard snapshot.generation >= (self.cached?.generation ?? Int.min) else { return }
+            self.cached = .init(generation: snapshot.generation, key: snapshot.key, value: value)
+        }
+    }
+
+    func clearIfStale(currentGeneration: Int) {
+        self.lock.perform {
+            guard let cached = self.cached,
+                  cached.generation < currentGeneration else { return }
+            self.cached = nil
+        }
+    }
+
+}
+
+struct GenerationGuardedCacheSnapshot<Key: Equatable> {
+    let generation: Int
+    let key: Key
+}
+
+private extension GenerationGuardedCache {
+
+    struct CachedValue {
+        let generation: Int
+        let key: Key
+        let value: Value
+    }
+
+}
+
+extension GenerationGuardedCache: @unchecked Sendable {}

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -75,6 +75,16 @@ protocol RemoteConfigManagerType: AnyObject {
 
 extension RemoteConfigManagerType {
 
+    func withCurrentConfigGeneration<T>(_ operation: (Int) -> T?) -> T? {
+        let generation = self.configGeneration
+        guard let value = operation(generation),
+              self.configGeneration == generation else {
+            return nil
+        }
+
+        return value
+    }
+
     func topicCacheSnapshot(_ topic: RemoteConfigTopic) async
     -> GenerationGuardedCacheSnapshot<RemoteConfiguration.ConfigTopic>? {
         guard let configTopic = await self.topic(topic) else { return nil }

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -13,6 +13,10 @@ protocol RemoteConfigManagerType: AnyObject {
 
     /// Whether remote config should be ignored for the current manager lifetime.
     var isDisabled: Bool { get }
+
+    /// Monotonically increases whenever committed remote config state is replaced or invalidated.
+    var configGeneration: Int { get }
+
     func refreshRemoteConfig(fetchContext: RemoteConfigFetchContext, isAppBackgrounded: Bool)
     func refreshRemoteConfigIfStale(fetchContext: RemoteConfigFetchContext, isAppBackgrounded: Bool)
 
@@ -70,6 +74,24 @@ protocol RemoteConfigManagerType: AnyObject {
 }
 
 extension RemoteConfigManagerType {
+
+    func topicCacheSnapshot(_ topic: RemoteConfigTopic) async
+    -> GenerationGuardedCacheSnapshot<RemoteConfiguration.ConfigTopic>? {
+        guard let configTopic = await self.topic(topic) else { return nil }
+        return .init(generation: self.configGeneration, key: configTopic)
+    }
+
+    func isCurrent(
+        _ snapshot: GenerationGuardedCacheSnapshot<RemoteConfiguration.ConfigTopic>,
+        for topic: RemoteConfigTopic
+    ) async -> Bool {
+        guard self.configGeneration == snapshot.generation,
+              await self.topic(topic) == snapshot.key else {
+            return false
+        }
+
+        return true
+    }
 
     func awaitTopicAndPrefetchBlobsReady(_ topic: RemoteConfigTopic) async -> RemoteConfiguration.ConfigTopic? {
         guard var committed = await self.topic(topic) else { return nil }
@@ -167,6 +189,7 @@ extension RemoteConfigManagerType {
 final class NoOpRemoteConfigManager: RemoteConfigManagerType {
 
     let isDisabled = true
+    let configGeneration = 0
 
     func refreshRemoteConfig(fetchContext: RemoteConfigFetchContext, isAppBackgrounded: Bool) {}
 
@@ -248,6 +271,10 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     /// Incremented when local state is invalidated so late responses from older users/sessions are dropped.
     private var epoch = 0
 
+    /// Incremented whenever committed config changes or becomes invalid. Async cache warmers use this
+    /// as a stale-write guard so older work cannot repopulate memory after a newer config is active.
+    private var generation = 0
+
     /// App user ID captured by an identity-bound cache clear.
     ///
     /// During login/switch/logout, `clearCache` can bump the epoch before every caller observes the new user from
@@ -285,6 +312,12 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     var isDisabled: Bool {
         return self.lock.perform {
             self.isDisabledInternal
+        }
+    }
+
+    var configGeneration: Int {
+        return self.lock.perform {
+            self.generation
         }
     }
 
@@ -359,6 +392,7 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     func clearCache(forAppUserID appUserID: String) {
         let continuations = self.lock.perform {
             self.epoch += 1
+            self.generation += 1
             self.identityBoundAppUserID = appUserID
             self.isRefreshing = false
             self.lastRefreshedAt = nil
@@ -372,6 +406,7 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     func close() {
         let continuations = self.lock.perform {
             self.epoch += 1
+            self.generation += 1
             self.isClosed = true
             self.isRefreshing = false
             return self.drainRefreshContinuations()
@@ -538,6 +573,7 @@ private extension RemoteConfigManager {
                     response: response
                 )
                 if didPersist {
+                    self.generation += 1
                     self.markRefreshed()
                 }
             }
@@ -627,6 +663,7 @@ private extension RemoteConfigManager {
                 response: fallbackResult.configuration
             )
             if didPersist {
+                self.generation += 1
                 self.markRefreshed()
             }
         }
@@ -658,6 +695,7 @@ private extension RemoteConfigManager {
         guard error.isRemoteConfigDisablingClientError else { return }
 
         self.isDisabledInternal = true
+        self.generation += 1
     }
 
     func isCurrent(_ requestEpoch: Int) -> Bool {

--- a/Sources/Networking/UiConfigProvider.swift
+++ b/Sources/Networking/UiConfigProvider.swift
@@ -13,6 +13,7 @@ import Foundation
 final class UiConfigProvider {
 
     private let manager: RemoteConfigManagerType
+    private let cache = GenerationGuardedCache<RemoteConfiguration.ConfigTopic, UIConfig>()
 
     init(manager: RemoteConfigManagerType) {
         self.manager = manager
@@ -22,6 +23,34 @@ final class UiConfigProvider {
     /// Assembles a ``UIConfig`` from the `ui_config` topic's parts. Returns `nil` when any part is unavailable
     /// or fails to decode, so callers never render with a partially assembled configuration.
     func getUiConfig() async -> UIConfig? {
+        guard let snapshot = await self.manager.topicCacheSnapshot(.uiConfig) else {
+            return nil
+        }
+
+        if let cached = self.cache.value(for: snapshot) {
+            return cached
+        }
+
+        guard let uiConfig = await self.assembleUiConfig() else {
+            return nil
+        }
+
+        guard await self.manager.isCurrent(snapshot, for: .uiConfig) else {
+            self.cache.clearIfStale(currentGeneration: self.manager.configGeneration)
+            return nil
+        }
+
+        self.cache.store(uiConfig, for: snapshot)
+        return uiConfig
+    }
+
+    /// Returns the in-memory config without awaiting remote-config state. This is used only to seed
+    /// first-frame workflow rendering after the offerings readiness gate has already warmed config.
+    func cachedUiConfig() -> UIConfig? {
+        return self.cache.value(currentGeneration: self.manager.configGeneration)
+    }
+
+    private func assembleUiConfig() async -> UIConfig? {
         do {
             guard let uiConfig = try await self.manager.mergeItemsBlobData(
                 for: .uiConfig,
@@ -40,16 +69,36 @@ final class UiConfigProvider {
             return nil
         }
     }
+
 #else
     // Paywalls V2 (and therefore workflows) aren't supported on tvOS, where `UIConfig` carries no fields.
     func getUiConfig() async -> UIConfig? {
+        guard let snapshot = await self.manager.topicCacheSnapshot(.uiConfig) else {
+            return nil
+        }
+
+        if let cached = self.cache.value(for: snapshot) {
+            return cached
+        }
+
         guard !self.manager.isDisabled else { return nil }
         guard await self.manager.blobData(for: .uiConfig, itemKey: Self.appKey) != nil,
               await self.manager.blobData(for: .uiConfig, itemKey: Self.localizationsKey) != nil else {
             Logger.warn(Strings.remoteConfig.uiConfigMissingRequiredPart)
             return nil
         }
+
+        guard await self.manager.isCurrent(snapshot, for: .uiConfig) else {
+            self.cache.clearIfStale(currentGeneration: self.manager.configGeneration)
+            return nil
+        }
+
+        self.cache.store(.empty, for: snapshot)
         return .empty
+    }
+
+    func cachedUiConfig() -> UIConfig? {
+        return self.cache.value(currentGeneration: self.manager.configGeneration)
     }
 #endif
 

--- a/Sources/Networking/UiConfigProvider.swift
+++ b/Sources/Networking/UiConfigProvider.swift
@@ -47,7 +47,13 @@ final class UiConfigProvider {
     /// Returns the in-memory config without awaiting remote-config state. This is used only to seed
     /// first-frame workflow rendering after the offerings readiness gate has already warmed config.
     func cachedUiConfig() -> UIConfig? {
-        return self.cache.value(currentGeneration: self.manager.configGeneration)
+        return self.manager.withCurrentConfigGeneration { generation in
+            self.cachedUiConfig(currentGeneration: generation)
+        }
+    }
+
+    func cachedUiConfig(currentGeneration: Int) -> UIConfig? {
+        return self.cache.value(currentGeneration: currentGeneration)
     }
 
     private func assembleUiConfig() async -> UIConfig? {
@@ -98,7 +104,13 @@ final class UiConfigProvider {
     }
 
     func cachedUiConfig() -> UIConfig? {
-        return self.cache.value(currentGeneration: self.manager.configGeneration)
+        return self.manager.withCurrentConfigGeneration { generation in
+            self.cachedUiConfig(currentGeneration: generation)
+        }
+    }
+
+    func cachedUiConfig(currentGeneration: Int) -> UIConfig? {
+        return self.cache.value(currentGeneration: currentGeneration)
     }
 #endif
 

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -39,6 +39,7 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
 
     private let manager: RemoteConfigManagerType
     private let uiConfigProvider: UiConfigProvider
+    private let paywallCache: PaywallCacheWarmingType?
 
     /// The offeringId → workflowId map built from the last topic snapshot seen, keyed by that snapshot
     /// so a repeat call with an unchanged topic reuses it instead of rescanning every item's content.
@@ -49,9 +50,14 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         PrefetchedWorkflowCache
     >()
 
-    init(manager: RemoteConfigManagerType, uiConfigProvider: UiConfigProvider? = nil) {
+    init(
+        manager: RemoteConfigManagerType,
+        uiConfigProvider: UiConfigProvider? = nil,
+        paywallCache: PaywallCacheWarmingType? = nil
+    ) {
         self.manager = manager
         self.uiConfigProvider = uiConfigProvider ?? UiConfigProvider(manager: manager)
+        self.paywallCache = paywallCache
     }
 
     /// Resolves `offeringId` to its workflow id via an offeringId → workflowId map built from the
@@ -161,6 +167,8 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
             .init(offeringIdMap: offeringIdMap, workflows: workflows),
             for: snapshot
         )
+
+        await self.warmPrefetchedWorkflowAssets(workflows)
     }
 
     func cachedWorkflow(forOfferingId offeringId: String) -> WorkflowDataResult? {
@@ -235,6 +243,19 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
                 }
             }
             return workflows
+        }
+    }
+
+    private func warmPrefetchedWorkflowAssets(_ workflows: [String: PublishedWorkflow]) async {
+        guard #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *),
+              let paywallCache,
+              let uiConfig = await self.uiConfigProvider.getUiConfig() else {
+            return
+        }
+
+        for workflowId in workflows.keys.sorted() {
+            guard let workflow = workflows[workflowId] else { continue }
+            await paywallCache.warmUpWorkflowCaches(workflow: workflow, uiConfig: uiConfig)
         }
     }
 

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -175,14 +175,16 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     }
 
     func cachedWorkflow(forOfferingId offeringId: String) -> WorkflowDataResult? {
-        guard let cache = self.currentWorkflowCache() else { return nil }
-        let workflowId = cache.offeringIdMap[offeringId] ?? offeringId
-        guard let workflow = cache.workflows[workflowId],
-              let uiConfig = self.uiConfigProvider.cachedUiConfig() else {
-            return nil
-        }
+        return self.manager.withCurrentConfigGeneration { generation in
+            guard let cache = self.currentWorkflowCache(currentGeneration: generation) else { return nil }
+            let workflowId = cache.offeringIdMap[offeringId] ?? offeringId
+            guard let workflow = cache.workflows[workflowId],
+                  let uiConfig = self.uiConfigProvider.cachedUiConfig(currentGeneration: generation) else {
+                return nil
+            }
 
-        return WorkflowDataResult(workflow: workflow, uiConfig: uiConfig, enrolledVariants: nil)
+            return WorkflowDataResult(workflow: workflow, uiConfig: uiConfig, enrolledVariants: nil)
+        }
     }
 
     private func fetchWorkflow(workflowId: String) async -> Result<PublishedWorkflow, WorkflowResolutionError> {
@@ -200,17 +202,25 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     }
 
     private func cachedWorkflow(workflowId: String) -> WorkflowDataResult? {
-        guard let cache = self.currentWorkflowCache(),
-              let workflow = cache.workflows[workflowId],
-              let uiConfig = self.uiConfigProvider.cachedUiConfig() else {
-            return nil
-        }
+        return self.manager.withCurrentConfigGeneration { generation in
+            guard let cache = self.currentWorkflowCache(currentGeneration: generation),
+                  let workflow = cache.workflows[workflowId],
+                  let uiConfig = self.uiConfigProvider.cachedUiConfig(currentGeneration: generation) else {
+                return nil
+            }
 
-        return WorkflowDataResult(workflow: workflow, uiConfig: uiConfig, enrolledVariants: nil)
+            return WorkflowDataResult(workflow: workflow, uiConfig: uiConfig, enrolledVariants: nil)
+        }
     }
 
     private func currentWorkflowCache() -> PrefetchedWorkflowCache? {
-        return self.prefetchedWorkflowsCache.value(currentGeneration: self.manager.configGeneration)
+        return self.manager.withCurrentConfigGeneration { generation in
+            self.currentWorkflowCache(currentGeneration: generation)
+        }
+    }
+
+    private func currentWorkflowCache(currentGeneration: Int) -> PrefetchedWorkflowCache? {
+        return self.prefetchedWorkflowsCache.value(currentGeneration: currentGeneration)
     }
 
     private func decodePrefetchedWorkflows(

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -152,7 +152,10 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     }
 
     private func warmPrefetchedWorkflowsOnBackgroundExecutor() async {
+        guard self.currentWorkflowCache() == nil else { return }
         guard let topic = await self.manager.awaitTopicAndPrefetchBlobsReady(.workflows) else { return }
+        guard self.currentWorkflowCache() == nil else { return }
+
         let snapshot = GenerationGuardedCacheSnapshot(
             generation: self.manager.configGeneration,
             key: topic

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -180,7 +180,7 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     func cachedWorkflow(forOfferingId offeringId: String) -> WorkflowDataResult? {
         return self.manager.withCurrentConfigGeneration { generation in
             guard let cache = self.currentWorkflowCache(currentGeneration: generation) else { return nil }
-            let workflowId = cache.offeringIdMap[offeringId] ?? offeringId
+            let workflowId = self.resolvedWorkflowId(forOfferingId: offeringId, in: cache)
             guard let workflow = cache.workflows[workflowId],
                   let uiConfig = self.uiConfigProvider.cachedUiConfig(currentGeneration: generation) else {
                 return nil
@@ -188,6 +188,11 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
 
             return WorkflowDataResult(workflow: workflow, uiConfig: uiConfig, enrolledVariants: nil)
         }
+    }
+
+    private func resolvedWorkflowId(forOfferingId offeringId: String, in cache: PrefetchedWorkflowCache) -> String {
+        // Fall back to treating the input as a workflow id, matching the async resolution path.
+        return cache.offeringIdMap[offeringId] ?? offeringId
     }
 
     private func fetchWorkflow(workflowId: String) async -> Result<PublishedWorkflow, WorkflowResolutionError> {
@@ -230,9 +235,6 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         from topic: RemoteConfiguration.ConfigTopic
     ) async -> [String: PublishedWorkflow] {
         await withTaskGroup(of: (String, PublishedWorkflow?).self) { group in
-            // swiftlint:disable:next todo
-            // TODO: Measure warmup performance with large remote configs and cap this fan-out into batches
-            // if decoding many prefetched workflows at once creates CPU or memory pressure.
             for workflowId in topic.keys.sorted() {
                 guard topic[workflowId]?.prefetch == true else { continue }
                 group.addTask {

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -152,17 +152,22 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     }
 
     private func warmPrefetchedWorkflowsOnBackgroundExecutor() async {
-        guard self.currentWorkflowCache() == nil else { return }
+        guard self.currentWorkflowCache()?.isComplete != true else { return }
         guard let topic = await self.manager.awaitTopicAndPrefetchBlobsReady(.workflows) else { return }
-        guard self.currentWorkflowCache() == nil else { return }
 
         let snapshot = GenerationGuardedCacheSnapshot(
             generation: self.manager.configGeneration,
             key: topic
         )
+        let cachedWorkflows = self.prefetchedWorkflowsCache.value(for: snapshot)?.workflows ?? [:]
+        let expectedWorkflowIds = Set(topic.compactMap { workflowId, item in
+            item.prefetch ? workflowId : nil
+        })
+        guard !expectedWorkflowIds.isSubset(of: cachedWorkflows.keys) else { return }
 
         let offeringIdMap = self.buildOfferingIdMap(from: topic)
-        let workflows = await self.decodePrefetchedWorkflows(from: topic)
+        let decodedWorkflows = await self.decodePrefetchedWorkflows(from: topic)
+        let workflows = cachedWorkflows.merging(decodedWorkflows) { _, decoded in decoded }
 
         guard await self.manager.isCurrent(snapshot, for: .workflows) else {
             self.prefetchedWorkflowsCache.clearIfStale(currentGeneration: self.manager.configGeneration)
@@ -170,11 +175,15 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         }
 
         self.prefetchedWorkflowsCache.store(
-            .init(offeringIdMap: offeringIdMap, workflows: workflows),
+            .init(
+                offeringIdMap: offeringIdMap,
+                workflows: workflows,
+                isComplete: expectedWorkflowIds.isSubset(of: workflows.keys)
+            ),
             for: snapshot
         )
 
-        self.warmPrefetchedWorkflowAssetsInBackground(workflows)
+        self.warmPrefetchedWorkflowAssetsInBackground(decodedWorkflows)
     }
 
     func cachedWorkflow(forOfferingId offeringId: String) -> WorkflowDataResult? {
@@ -290,4 +299,5 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
 private struct PrefetchedWorkflowCache {
     let offeringIdMap: [String: String]
     let workflows: [String: PublishedWorkflow]
+    let isComplete: Bool
 }

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -11,6 +11,8 @@ protocol WorkflowsConfigProviderType {
 
     func workflowId(forOfferingId offeringId: String) async -> String?
     func getWorkflow(workflowId: String) async -> Result<WorkflowDataResult, WorkflowResolutionError>
+    func warmPrefetchedWorkflows() async
+    func cachedWorkflow(forOfferingId offeringId: String) -> WorkflowDataResult?
 
 }
 
@@ -42,9 +44,14 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     /// so a repeat call with an unchanged topic reuses it instead of rescanning every item's content.
     private let cachedOfferingIdMap: Atomic<(topic: RemoteConfiguration.ConfigTopic, map: [String: String])?> = nil
 
-    init(manager: RemoteConfigManagerType) {
+    private let prefetchedWorkflowsCache = GenerationGuardedCache<
+        RemoteConfiguration.ConfigTopic,
+        PrefetchedWorkflowCache
+    >()
+
+    init(manager: RemoteConfigManagerType, uiConfigProvider: UiConfigProvider? = nil) {
         self.manager = manager
-        self.uiConfigProvider = UiConfigProvider(manager: manager)
+        self.uiConfigProvider = uiConfigProvider ?? UiConfigProvider(manager: manager)
     }
 
     /// Resolves `offeringId` to its workflow id via an offeringId → workflowId map built from the
@@ -95,14 +102,18 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     /// `enrolled_variants` is not populated here: per-user A/B enrollment doesn't fit this shared,
     /// content-addressed read model and is being designed separately.
     ///
-    /// Known limitation: the workflow body and `ui_config` are two independent reads through
-    /// `RemoteConfigManager`. If an identity change (`clearCache()`) lands between them, the result can
-    /// combine a workflow body from the config committed before the clear with `ui_config` from the one
-    /// committed after. This is a narrow window (a config-committing identity change racing an in-flight
-    /// workflow render) and `ui_config` is app/domain-level presentation data, not per-user; a stricter
-    /// fix would need `RemoteConfigManager` to expose a way to validate both reads landed in the same
-    /// sync generation.
+    /// Cache misses validate the workflow topic's generation after `ui_config` resolves, so an in-flight
+    /// config change fails the resolution instead of returning a mixed-generation workflow/config pair.
     func getWorkflow(workflowId: String) async -> Result<WorkflowDataResult, WorkflowResolutionError> {
+        if let cached = self.cachedWorkflow(workflowId: workflowId) {
+            return .success(cached)
+        }
+
+        guard let snapshot = await self.manager.topicCacheSnapshot(.workflows),
+              snapshot.key[workflowId] != nil else {
+            return .failure(.notFound)
+        }
+
         // Deliberately sequential, not `async let`: an `async let` for `ui_config` started alongside the
         // workflow-body read would still be implicitly awaited (Swift cancels but does not fast-fail an
         // unconsumed `async let` when its scope exits) if the body turns out missing or malformed, so a
@@ -118,8 +129,49 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         guard let uiConfig = await self.uiConfigProvider.getUiConfig() else {
             return .failure(.uiConfigUnavailable)
         }
+        guard await self.manager.isCurrent(snapshot, for: .workflows) else {
+            return .failure(.notFound)
+        }
 
         return .success(WorkflowDataResult(workflow: workflow, uiConfig: uiConfig, enrolledVariants: nil))
+    }
+
+    func warmPrefetchedWorkflows() async {
+        await Task.detached(priority: .utility) {
+            await self.warmPrefetchedWorkflowsOnBackgroundExecutor()
+        }.value
+    }
+
+    private func warmPrefetchedWorkflowsOnBackgroundExecutor() async {
+        guard let topic = await self.manager.awaitTopicAndPrefetchBlobsReady(.workflows) else { return }
+        let snapshot = GenerationGuardedCacheSnapshot(
+            generation: self.manager.configGeneration,
+            key: topic
+        )
+
+        let offeringIdMap = self.buildOfferingIdMap(from: topic)
+        let workflows = await self.decodePrefetchedWorkflows(from: topic)
+
+        guard await self.manager.isCurrent(snapshot, for: .workflows) else {
+            self.prefetchedWorkflowsCache.clearIfStale(currentGeneration: self.manager.configGeneration)
+            return
+        }
+
+        self.prefetchedWorkflowsCache.store(
+            .init(offeringIdMap: offeringIdMap, workflows: workflows),
+            for: snapshot
+        )
+    }
+
+    func cachedWorkflow(forOfferingId offeringId: String) -> WorkflowDataResult? {
+        guard let cache = self.currentWorkflowCache() else { return nil }
+        let workflowId = cache.offeringIdMap[offeringId] ?? offeringId
+        guard let workflow = cache.workflows[workflowId],
+              let uiConfig = self.uiConfigProvider.cachedUiConfig() else {
+            return nil
+        }
+
+        return WorkflowDataResult(workflow: workflow, uiConfig: uiConfig, enrolledVariants: nil)
     }
 
     private func fetchWorkflow(workflowId: String) async -> Result<PublishedWorkflow, WorkflowResolutionError> {
@@ -136,6 +188,61 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         }
     }
 
+    private func cachedWorkflow(workflowId: String) -> WorkflowDataResult? {
+        guard let cache = self.currentWorkflowCache(),
+              let workflow = cache.workflows[workflowId],
+              let uiConfig = self.uiConfigProvider.cachedUiConfig() else {
+            return nil
+        }
+
+        return WorkflowDataResult(workflow: workflow, uiConfig: uiConfig, enrolledVariants: nil)
+    }
+
+    private func currentWorkflowCache() -> PrefetchedWorkflowCache? {
+        return self.prefetchedWorkflowsCache.value(currentGeneration: self.manager.configGeneration)
+    }
+
+    private func decodePrefetchedWorkflows(
+        from topic: RemoteConfiguration.ConfigTopic
+    ) async -> [String: PublishedWorkflow] {
+        await withTaskGroup(of: (String, PublishedWorkflow?).self) { group in
+            // swiftlint:disable:next todo
+            // TODO: Measure warmup performance with large remote configs and cap this fan-out into batches
+            // if decoding many prefetched workflows at once creates CPU or memory pressure.
+            for workflowId in topic.keys.sorted() {
+                guard topic[workflowId]?.prefetch == true else { continue }
+                group.addTask {
+                    do {
+                        return (
+                            workflowId,
+                            try await self.manager.blobData(
+                                for: .workflows,
+                                itemKey: workflowId,
+                                as: PublishedWorkflow.self
+                            )
+                        )
+                    } catch {
+                        Logger.error(Strings.codable.decoding_error(error, PublishedWorkflow.self))
+                        return (workflowId, nil)
+                    }
+                }
+            }
+
+            var workflows: [String: PublishedWorkflow] = [:]
+            for await (workflowId, workflow) in group {
+                if let workflow {
+                    workflows[workflowId] = workflow
+                }
+            }
+            return workflows
+        }
+    }
+
     private static let offeringIdentifierKey = "offeringIdentifier"
 
+}
+
+private struct PrefetchedWorkflowCache {
+    let offeringIdMap: [String: String]
+    let workflows: [String: PublishedWorkflow]
 }

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -40,6 +40,7 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     private let manager: RemoteConfigManagerType
     private let uiConfigProvider: UiConfigProvider
     private let paywallCache: PaywallCacheWarmingType?
+    private let operationDispatcher: OperationDispatcher
 
     /// The offeringId → workflowId map built from the last topic snapshot seen, keyed by that snapshot
     /// so a repeat call with an unchanged topic reuses it instead of rescanning every item's content.
@@ -53,11 +54,13 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     init(
         manager: RemoteConfigManagerType,
         uiConfigProvider: UiConfigProvider? = nil,
-        paywallCache: PaywallCacheWarmingType? = nil
+        paywallCache: PaywallCacheWarmingType? = nil,
+        operationDispatcher: OperationDispatcher = .default
     ) {
         self.manager = manager
         self.uiConfigProvider = uiConfigProvider ?? UiConfigProvider(manager: manager)
         self.paywallCache = paywallCache
+        self.operationDispatcher = operationDispatcher
     }
 
     /// Resolves `offeringId` to its workflow id via an offeringId → workflowId map built from the
@@ -168,7 +171,7 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
             for: snapshot
         )
 
-        await self.warmPrefetchedWorkflowAssets(workflows)
+        self.warmPrefetchedWorkflowAssetsInBackground(workflows)
     }
 
     func cachedWorkflow(forOfferingId offeringId: String) -> WorkflowDataResult? {
@@ -243,6 +246,12 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
                 }
             }
             return workflows
+        }
+    }
+
+    private func warmPrefetchedWorkflowAssetsInBackground(_ workflows: [String: PublishedWorkflow]) {
+        self.operationDispatcher.dispatchOnWorkerThread {
+            await self.warmPrefetchedWorkflowAssets(workflows)
         }
     }
 

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -28,6 +28,8 @@ class OfferingsManager {
     private let dateProvider: DateProvider
     // Nil when remote config is disabled, in which case offerings delivery is unchanged.
     private let remoteConfigManager: RemoteConfigManagerType?
+    private let uiConfigProvider: UiConfigProvider?
+    private let workflowsConfigProvider: WorkflowsConfigProviderType?
 
     init(deviceCache: DeviceCache,
          operationDispatcher: OperationDispatcher,
@@ -37,7 +39,9 @@ class OfferingsManager {
          productsManager: ProductsManagerType,
          diagnosticsTracker: DiagnosticsTrackerType?,
          dateProvider: DateProvider = DateProvider(),
-         remoteConfigManager: RemoteConfigManagerType? = nil) {
+         remoteConfigManager: RemoteConfigManagerType? = nil,
+         uiConfigProvider: UiConfigProvider? = nil,
+         workflowsConfigProvider: WorkflowsConfigProviderType? = nil) {
         self.deviceCache = deviceCache
         self.operationDispatcher = operationDispatcher
         self.systemInfo = systemInfo
@@ -47,6 +51,8 @@ class OfferingsManager {
         self.diagnosticsTracker = diagnosticsTracker
         self.dateProvider = dateProvider
         self.remoteConfigManager = remoteConfigManager
+        self.uiConfigProvider = uiConfigProvider
+        self.workflowsConfigProvider = workflowsConfigProvider
     }
 
     func offerings(
@@ -394,10 +400,19 @@ private extension OfferingsManager {
             return
         }
         Task {
-            async let workflowsReady = remoteConfigManager.awaitTopicAndPrefetchBlobsReady(.workflows)
-            async let uiConfigReady = UiConfigProvider(manager: remoteConfigManager).getUiConfig()
+            let uiConfigProvider = self.uiConfigProvider ?? UiConfigProvider(manager: remoteConfigManager)
+            async let workflowsReady: Void = self.warmWorkflowConfigIfNeeded(remoteConfigManager: remoteConfigManager)
+            async let uiConfigReady = uiConfigProvider.getUiConfig()
             _ = await (workflowsReady, uiConfigReady)
             deliver()
+        }
+    }
+
+    private func warmWorkflowConfigIfNeeded(remoteConfigManager: RemoteConfigManagerType) async {
+        if let workflowsConfigProvider = self.workflowsConfigProvider {
+            await workflowsConfigProvider.warmPrefetchedWorkflows()
+        } else {
+            _ = await remoteConfigManager.awaitTopicAndPrefetchBlobsReady(.workflows)
         }
     }
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -581,7 +581,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         let workflowsConfigProvider = WorkflowsConfigProvider(
             manager: remoteConfigManager,
             uiConfigProvider: uiConfigProvider,
-            paywallCache: paywallCache
+            paywallCache: paywallCache,
+            operationDispatcher: operationDispatcher
         )
 
         let workflowManager = WorkflowManager(

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -580,7 +580,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         let uiConfigProvider = UiConfigProvider(manager: remoteConfigManager)
         let workflowsConfigProvider = WorkflowsConfigProvider(
             manager: remoteConfigManager,
-            uiConfigProvider: uiConfigProvider
+            uiConfigProvider: uiConfigProvider,
+            paywallCache: paywallCache
         )
 
         let workflowManager = WorkflowManager(

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -577,8 +577,14 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             paywallCache = nil
         }
 
+        let uiConfigProvider = UiConfigProvider(manager: remoteConfigManager)
+        let workflowsConfigProvider = WorkflowsConfigProvider(
+            manager: remoteConfigManager,
+            uiConfigProvider: uiConfigProvider
+        )
+
         let workflowManager = WorkflowManager(
-            workflowsConfigProvider: WorkflowsConfigProvider(manager: remoteConfigManager),
+            workflowsConfigProvider: workflowsConfigProvider,
             paywallCache: paywallCache,
             operationDispatcher: operationDispatcher
         )
@@ -592,6 +598,12 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                                                 diagnosticsTracker: diagnosticsTracker,
                                                 remoteConfigManager: systemInfo.remoteConfigEnabled
                                                 ? remoteConfigManager
+                                                : nil,
+                                                uiConfigProvider: systemInfo.remoteConfigEnabled
+                                                ? uiConfigProvider
+                                                : nil,
+                                                workflowsConfigProvider: systemInfo.remoteConfigEnabled
+                                                ? workflowsConfigProvider
                                                 : nil)
         let manageSubsHelper = ManageSubscriptionsHelper(systemInfo: systemInfo,
                                                          customerInfoManager: customerInfoManager,
@@ -1025,6 +1037,11 @@ public extension Purchases {
     @_spi(Internal)
     func workflow(forOfferingIdentifier offeringID: String) async throws -> WorkflowDataResult {
         return try await self.workflowManager.getWorkflow(forOfferingId: offeringID)
+    }
+
+    @_spi(Internal)
+    func cachedWorkflow(forOfferingIdentifier offeringID: String) -> WorkflowDataResult? {
+        return self.workflowManager.cachedWorkflow(forOfferingId: offeringID)
     }
 
     internal func offerings(fetchPolicy: OfferingsManager.FetchPolicy) async throws -> Offerings {

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -58,6 +58,10 @@ class WorkflowManager {
         return await self.workflowsConfigProvider.workflowId(forOfferingId: offeringId)
     }
 
+    func cachedWorkflow(forOfferingId offeringId: String) -> WorkflowDataResult? {
+        return self.workflowsConfigProvider.cachedWorkflow(forOfferingId: offeringId)
+    }
+
     /// Resolves `offeringId` to its workflow for `Purchases.workflow(forOfferingIdentifier:)`. Fails
     /// fast when the offering has no mapped workflow: the config path has no lazy offering→workflow
     /// conversion, so a missing mapping means the offering simply has no workflow attached. It surfaces

--- a/Tests/RevenueCatUITests/Data/PaywallViewConfigurationTests.swift
+++ b/Tests/RevenueCatUITests/Data/PaywallViewConfigurationTests.swift
@@ -19,8 +19,8 @@ import XCTest
 final class PaywallViewConfigurationTests: TestCase {
 
 #if !os(tvOS)
-    func testCachedInitialOfferingReturnsNilForAllContentWhenRemoteConfigEnabled() {
-        let cachedOffering = TestData.offeringWithNoIntroOffer
+    func testCachedInitialOfferingReturnsNilForWorkflowContentWhenRemoteConfigEnabledWithoutCachedWorkflow() {
+        let cachedOffering = Self.createOffering(identifier: "offering_a", paywall: nil)
         let purchases = Self.createMockPurchases()
         let handler = Self.createPurchaseHandler(purchases: purchases)
 
@@ -136,6 +136,35 @@ final class PaywallViewConfigurationTests: TestCase {
         expect(packageContext.placementIdentifier) == "placement_offering_a"
         expect(packageContext.targetingContext?.revision) == 7
         expect(packageContext.targetingContext?.ruleId) == "targeting_rule_offering_a"
+    }
+
+    func testCachedInitialPaywallViewDataReturnsWorkflowContextForCachedWorkflow() throws {
+        let initialOffering = Self.createOffering(identifier: "offering_a", paywall: nil)
+            .withPresentedOfferingContext(Self.createPresentedOfferingContext(offeringIdentifier: "offering_a"))
+        let workflowOffering = Self.createOffering(identifier: "offering_b")
+        let purchases = Self.createMockPurchases()
+        let handler = Self.createPurchaseHandler(purchases: purchases)
+        let cachedWorkflow = try Self.createWorkflowDataResult(offeringIdentifier: workflowOffering.identifier)
+
+        purchases.cachedOfferings = Self.createOfferings([initialOffering, workflowOffering])
+        purchases.cachedWorkflowBlock = { offeringIdentifier in
+            expect(offeringIdentifier) == initialOffering.identifier
+            return cachedWorkflow
+        }
+        purchases.workflowBlock = { _ in
+            XCTFail("Cached initial data must not use the async workflow path")
+            throw ErrorCode.configurationError
+        }
+
+        let result = handler.cachedInitialPaywallViewData(
+            for: .offering(initialOffering),
+            remoteConfigEnabled: true
+        )
+
+        expect(result?.offering.identifier) == workflowOffering.identifier
+        expect(result?.offering.paywallComponents).toNot(beNil())
+        expect(result?.workflowContext?.initialOffering.identifier) == workflowOffering.identifier
+        expect(result?.workflowContext?.presentedOfferingContext?.offeringIdentifier) == initialOffering.identifier
     }
 
     func testResolvePaywallViewDataReturnsWorkflowContextForWorkflowDefaultOffering() async throws {

--- a/Tests/UnitTests/Caching/FileRepositoryTests.swift
+++ b/Tests/UnitTests/Caching/FileRepositoryTests.swift
@@ -128,9 +128,9 @@ class FileRepositoryTests: TestCase {
         let url = try await sut.fileRepository
             .generateOrGetCachedFileURL(for: someURL, withChecksum: Checksum.generate(from: data, with: .md5))
 
-        await expect(sut.networkService.invocations.count).toEventually(equal(1))
+        XCTAssertEqual(sut.networkService.invocations.count, 1)
         XCTAssertEqual(sut.cache.saveDataInvocations.count, 1)
-
+        XCTAssertEqual(url, sut.cache.saveDataInvocations.first?.url)
     }
 
     func test_whenChecksumMismatch_throwsChecksumMismatch() async throws {

--- a/Tests/UnitTests/Mocks/MockPaywallCacheWarming.swift
+++ b/Tests/UnitTests/Mocks/MockPaywallCacheWarming.swift
@@ -112,12 +112,17 @@ final class MockPaywallCacheWarming: PaywallCacheWarmingType {
     // MARK: -
 
     private let _invokedWarmUpWorkflowCaches: Atomic<Bool> = false
+    private let _invokedWarmUpWorkflowCachesCount: Atomic<Int> = .init(0)
     private let _invokedWarmUpWorkflowCachesWorkflow: Atomic<PublishedWorkflow?> = nil
     private let _invokedWarmUpWorkflowCachesUiConfig: Atomic<UIConfig?> = nil
 
     var invokedWarmUpWorkflowCaches: Bool {
         get { return self._invokedWarmUpWorkflowCaches.value }
         set { self._invokedWarmUpWorkflowCaches.value = newValue }
+    }
+    var invokedWarmUpWorkflowCachesCount: Int {
+        get { return self._invokedWarmUpWorkflowCachesCount.value }
+        set { self._invokedWarmUpWorkflowCachesCount.value = newValue }
     }
     var invokedWarmUpWorkflowCachesWorkflow: PublishedWorkflow? {
         get { return self._invokedWarmUpWorkflowCachesWorkflow.value }
@@ -130,6 +135,7 @@ final class MockPaywallCacheWarming: PaywallCacheWarmingType {
 
     func warmUpWorkflowCaches(workflow: PublishedWorkflow, uiConfig: UIConfig) async {
         self.invokedWarmUpWorkflowCaches = true
+        self._invokedWarmUpWorkflowCachesCount.modify { $0 += 1 }
         self.invokedWarmUpWorkflowCachesWorkflow = workflow
         self.invokedWarmUpWorkflowCachesUiConfig = uiConfig
     }

--- a/Tests/UnitTests/Mocks/MockWorkflowsConfigProvider.swift
+++ b/Tests/UnitTests/Mocks/MockWorkflowsConfigProvider.swift
@@ -39,4 +39,18 @@ final class MockWorkflowsConfigProvider: WorkflowsConfigProviderType, @unchecked
         return .failure(.notFound)
     }
 
+    private(set) var invokedWarmPrefetchedWorkflowsCount = 0
+
+    func warmPrefetchedWorkflows() async {
+        self.invokedWarmPrefetchedWorkflowsCount += 1
+    }
+
+    var stubbedCachedWorkflowResult: [String: WorkflowDataResult] = [:]
+    private(set) var invokedCachedWorkflowParameters: [String] = []
+
+    func cachedWorkflow(forOfferingId offeringId: String) -> WorkflowDataResult? {
+        self.invokedCachedWorkflowParameters.append(offeringId)
+        return self.stubbedCachedWorkflowResult[offeringId]
+    }
+
 }

--- a/Tests/UnitTests/Networking/GenerationGuardedCacheTests.swift
+++ b/Tests/UnitTests/Networking/GenerationGuardedCacheTests.swift
@@ -1,0 +1,95 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  GenerationGuardedCacheTests.swift
+//
+//  Created by Rick van der Linden.
+
+import Nimble
+import XCTest
+
+@_spi(Internal) @testable import RevenueCat
+
+class GenerationGuardedCacheTests: TestCase {
+
+    func testStartsCold() {
+        let cache = GenerationGuardedCache<String, String>()
+
+        expect(cache.value(currentGeneration: 0)).to(beNil())
+        expect(cache.value(for: .init(generation: 0, key: "key"))).to(beNil())
+    }
+
+    func testReturnsStoredValueForMatchingGenerationAndKey() {
+        let cache = GenerationGuardedCache<String, String>()
+
+        cache.store("value", for: .init(generation: 2, key: "key"))
+
+        expect(cache.value(currentGeneration: 2)) == "value"
+        expect(cache.value(for: .init(generation: 2, key: "key"))) == "value"
+    }
+
+    func testCurrentGenerationReadClearsOlderValue() {
+        let cache = GenerationGuardedCache<String, String>()
+
+        cache.store("value", for: .init(generation: 2, key: "key"))
+
+        expect(cache.value(currentGeneration: 3)).to(beNil())
+        expect(cache.value(currentGeneration: 2)).to(beNil())
+    }
+
+    func testSnapshotReadClearsOlderOrSameGenerationMismatch() {
+        let cache = GenerationGuardedCache<String, String>()
+
+        cache.store("value", for: .init(generation: 2, key: "old"))
+
+        expect(cache.value(for: .init(generation: 2, key: "new"))).to(beNil())
+        expect(cache.value(currentGeneration: 2)).to(beNil())
+    }
+
+    func testStaleSnapshotReadDoesNotClearNewerValue() {
+        let cache = GenerationGuardedCache<String, String>()
+
+        cache.store("new", for: .init(generation: 3, key: "new"))
+
+        expect(cache.value(for: .init(generation: 2, key: "old"))).to(beNil())
+        expect(cache.value(currentGeneration: 3)) == "new"
+    }
+
+    func testLowerGenerationStoreDoesNotOverwriteNewerValue() {
+        let cache = GenerationGuardedCache<String, String>()
+
+        cache.store("new", for: .init(generation: 3, key: "key"))
+        cache.store("old", for: .init(generation: 2, key: "key"))
+
+        expect(cache.value(currentGeneration: 3)) == "new"
+    }
+
+    func testClearIfStaleDoesNotClearSameOrNewerGeneration() {
+        let cache = GenerationGuardedCache<String, String>()
+
+        cache.store("new", for: .init(generation: 3, key: "key"))
+
+        cache.clearIfStale(currentGeneration: 2)
+        expect(cache.value(currentGeneration: 3)) == "new"
+
+        cache.clearIfStale(currentGeneration: 3)
+        expect(cache.value(currentGeneration: 3)) == "new"
+    }
+
+    func testClearIfStaleClearsOlderGeneration() {
+        let cache = GenerationGuardedCache<String, String>()
+
+        cache.store("old", for: .init(generation: 2, key: "key"))
+
+        cache.clearIfStale(currentGeneration: 3)
+
+        expect(cache.value(currentGeneration: 2)).to(beNil())
+    }
+
+}

--- a/Tests/UnitTests/Networking/UiConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/UiConfigProviderTests.swift
@@ -121,6 +121,109 @@ class UiConfigProviderTests: TestCase {
         expect(uiConfig?.customVariables).to(beEmpty())
     }
 
+    func testCachesDecodedUiConfigAndSkipsBlobMergeOnUnchangedGenerationAndTopic() async throws {
+        self.stub(
+            app: #"{"colors": {}, "fonts": {}}"#,
+            localizations: #"{"en_US": {"day": "Day"}}"#,
+            variableConfig: #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#,
+            customVariables: #"{}"#
+        )
+
+        let first = await self.provider.getUiConfig()
+        let mergesAfterFirst = self.mockManager.invokedMergeItemsBlobDataParameters.count
+        let second = await self.provider.getUiConfig()
+
+        expect(first).toNot(beNil())
+        expect(second?.localizations["en_US"]?["day"]) == "Day"
+        expect(mergesAfterFirst) == 1
+        expect(self.mockManager.invokedMergeItemsBlobDataParameters.count) == mergesAfterFirst
+        expect(self.provider.cachedUiConfig()?.localizations["en_US"]?["day"]) == "Day"
+    }
+
+    func testReDecodesWhenUiConfigGenerationChanges() async throws {
+        self.stub(
+            app: #"{"colors": {}, "fonts": {}}"#,
+            localizations: #"{"en_US": {"day": "Day"}}"#,
+            variableConfig: #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#,
+            customVariables: #"{}"#
+        )
+        _ = await self.provider.getUiConfig()
+        self.mockManager.configGeneration += 1
+
+        _ = await self.provider.getUiConfig()
+
+        expect(self.mockManager.invokedMergeItemsBlobDataParameters.count) == 2
+        expect(self.provider.cachedUiConfig()).toNot(beNil())
+    }
+
+    func testStoresUiConfigWhenGenerationChangesDuringInitialTopicRead() async throws {
+        self.stub(
+            app: #"{"colors": {}, "fonts": {}}"#,
+            localizations: #"{"en_US": {"day": "Day"}}"#,
+            variableConfig: #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#,
+            customVariables: #"{}"#
+        )
+        self.mockManager.shouldStoreTopicCompletion = true
+        let topic = try XCTUnwrap(self.mockManager.stubbedTopics[.uiConfig])
+
+        async let uiConfig = self.provider.getUiConfig()
+        await self.waitUntilTopicRequested()
+        self.mockManager.configGeneration += 1
+        self.mockManager.completeStoredTopic(with: topic)
+
+        let resolvedUiConfig = await uiConfig
+        expect(resolvedUiConfig).toNot(beNil())
+        expect(self.provider.cachedUiConfig()).toNot(beNil())
+    }
+
+    func testReturnsNilAndDoesNotCacheUiConfigWhenGenerationChangesDuringDecode() async throws {
+        self.stub(
+            app: #"{"colors": {}, "fonts": {}}"#,
+            localizations: #"{"en_US": {"day": "Day"}}"#,
+            variableConfig: #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#,
+            customVariables: #"{}"#
+        )
+        self.mockManager.shouldStoreBlobDataCompletion = true
+
+        async let uiConfig = self.provider.getUiConfig()
+        await self.waitUntilBlobDataRequested()
+        self.mockManager.configGeneration += 1
+        self.mockManager.completeStoredBlobReads()
+
+        let resolvedUiConfig = await uiConfig
+        expect(resolvedUiConfig).to(beNil())
+        expect(self.provider.cachedUiConfig()).to(beNil())
+    }
+
+    func testCachedUiConfigReturnsNilWhenGenerationChangesWithoutRewarming() async throws {
+        self.stub(
+            app: #"{"colors": {}, "fonts": {}}"#,
+            localizations: #"{"en_US": {"day": "Day"}}"#,
+            variableConfig: #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#,
+            customVariables: #"{}"#
+        )
+        _ = await self.provider.getUiConfig()
+
+        self.mockManager.configGeneration += 1
+
+        expect(self.provider.cachedUiConfig()).to(beNil())
+    }
+
+    func testReDecodesWhenUiConfigTopicChanges() async throws {
+        self.stub(
+            app: #"{"colors": {}, "fonts": {}}"#,
+            localizations: #"{"en_US": {"day": "Day"}}"#,
+            variableConfig: #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#,
+            customVariables: #"{}"#
+        )
+        _ = await self.provider.getUiConfig()
+        self.mockManager.stubbedTopics[.uiConfig]?["app"] = .init(blobRef: "app-v2")
+
+        _ = await self.provider.getUiConfig()
+
+        expect(self.mockManager.invokedMergeItemsBlobDataParameters.count) == 2
+    }
+
     func testLogsWarningWhenARequiredPartIsMissing() async throws {
         self.stub(app: nil, localizations: #"{}"#, variableConfig: nil, customVariables: nil)
 
@@ -143,6 +246,13 @@ class UiConfigProviderTests: TestCase {
     }
 
     func testRequestsMergedBlobDataForWireItemKeysNotCamelCased() async throws {
+        self.mockManager.stubbedTopics[.uiConfig] = [
+            "app": .init(),
+            "localizations": .init(),
+            "variable_config": .init(),
+            "custom_variables": .init()
+        ]
+
         _ = await self.provider.getUiConfig()
 
         expect(self.mockManager.invokedMergeItemsBlobDataParameters.count) == 1
@@ -194,6 +304,18 @@ class UiConfigProviderTests: TestCase {
         self.mockManager.stubbedBlobData[.uiConfig] = data
         self.mockManager.stubbedTopics[.uiConfig] = data.keys.reduce(into: [:]) { topic, key in
             topic[key] = RemoteConfiguration.ConfigItem()
+        }
+    }
+
+    private func waitUntilTopicRequested() async {
+        while self.mockManager.invokedTopicCount == 0 {
+            await Task.yield()
+        }
+    }
+
+    private func waitUntilBlobDataRequested() async {
+        while self.mockManager.invokedBlobDataParameters.isEmpty {
+            await Task.yield()
         }
     }
 

--- a/Tests/UnitTests/Networking/UiConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/UiConfigProviderTests.swift
@@ -209,6 +209,29 @@ class UiConfigProviderTests: TestCase {
         expect(self.provider.cachedUiConfig()).to(beNil())
     }
 
+    func testCachedUiConfigReturnsNilWhenGenerationChangesBetweenGenerationReadAndCacheLookup() async throws {
+        self.stub(
+            app: #"{"colors": {}, "fonts": {}}"#,
+            localizations: #"{"en_US": {"day": "Day"}}"#,
+            variableConfig: #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#,
+            customVariables: #"{}"#
+        )
+        _ = await self.provider.getUiConfig()
+
+        var didAdvanceGeneration = false
+        let mockManager = try XCTUnwrap(self.mockManager)
+        self.mockManager.onConfigGenerationRead = { [mockManager] in
+            guard !didAdvanceGeneration else { return }
+
+            didAdvanceGeneration = true
+            mockManager.onConfigGenerationRead = nil
+            mockManager.configGeneration += 1
+        }
+
+        expect(self.provider.cachedUiConfig()).to(beNil())
+        expect(didAdvanceGeneration) == true
+    }
+
     func testReDecodesWhenUiConfigTopicChanges() async throws {
         self.stub(
             app: #"{"colors": {}, "fonts": {}}"#,

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -313,6 +313,32 @@ class WorkflowsConfigProviderTests: TestCase {
         expect(self.blobFetcher.invokedEnsureDownloadedRefs).toNot(contain("wf-on-demand-ref"))
     }
 
+    func testWarmPrefetchedWorkflowsReturnsEarlyWhenCacheAlreadyWarmForGeneration() async throws {
+        self.commit(
+            workflows: [
+                "wf-prefetch": .init(
+                    blobRef: "wf-prefetch-ref",
+                    prefetch: true,
+                    content: ["offeringIdentifier": "premium"]
+                )
+            ],
+            uiConfig: Self.uiConfigTopic,
+            blobs: Self.uiConfigBlobs.merging([
+                "wf-prefetch-ref": try Self.workflowJSON(id: "wf-prefetch")
+            ]) { current, _ in current }
+        )
+
+        async let workflowsWarm: Void = self.provider.warmPrefetchedWorkflows()
+        async let uiConfigWarm = self.uiConfigProvider.getUiConfig()
+        _ = await (workflowsWarm, uiConfigWarm)
+        let ensureAllDownloadedCountAfterFirstWarm = self.blobFetcher.invokedEnsureAllDownloadedRefs.count
+
+        await self.provider.warmPrefetchedWorkflows()
+
+        expect(self.provider.cachedWorkflow(forOfferingId: "premium")?.workflow.id) == "wf-prefetch"
+        expect(self.blobFetcher.invokedEnsureAllDownloadedRefs.count) == ensureAllDownloadedCountAfterFirstWarm
+    }
+
     func testWarmPrefetchedWorkflowsWarmsAssetsForPrefetchTrueBodies() async throws {
         let paywallCache = MockPaywallCacheWarming()
         let operationDispatcher = MockOperationDispatcher()
@@ -677,10 +703,17 @@ private final class FakeRemoteConfigBlobFetcher: RemoteConfigBlobFetcherType {
     private let lock = Lock()
     private let blobStore: FakeRemoteConfigBlobStore
     private var _invokedEnsureDownloadedRefs: [String] = []
+    private var _invokedEnsureAllDownloadedRefs: [[String]] = []
 
     var invokedEnsureDownloadedRefs: [String] {
         return self.lock.perform {
             self._invokedEnsureDownloadedRefs
+        }
+    }
+
+    var invokedEnsureAllDownloadedRefs: [[String]] {
+        return self.lock.perform {
+            self._invokedEnsureAllDownloadedRefs
         }
     }
 
@@ -697,6 +730,9 @@ private final class FakeRemoteConfigBlobFetcher: RemoteConfigBlobFetcherType {
     }
 
     func ensureAllDownloaded(refs: [String]) async -> Bool {
+        self.lock.perform {
+            self._invokedEnsureAllDownloadedRefs.append(refs)
+        }
         return refs.allSatisfy { self.blobStore.contains(ref: $0) }
     }
 

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -26,6 +26,7 @@ class WorkflowsConfigProviderTests: TestCase {
     private var blobStore: FakeRemoteConfigBlobStore!
     private var blobFetcher: FakeRemoteConfigBlobFetcher!
     private var manager: RemoteConfigManager!
+    private var uiConfigProvider: UiConfigProvider!
     private var provider: WorkflowsConfigProvider!
 
     override func setUpWithError() throws {
@@ -41,7 +42,11 @@ class WorkflowsConfigProviderTests: TestCase {
             blobFetcher: self.blobFetcher,
             currentUserProvider: FakeCurrentUserProvider()
         )
-        self.provider = WorkflowsConfigProvider(manager: self.manager)
+        self.uiConfigProvider = UiConfigProvider(manager: self.manager)
+        self.provider = WorkflowsConfigProvider(
+            manager: self.manager,
+            uiConfigProvider: self.uiConfigProvider
+        )
     }
 
     func testResolvesAWorkflowAlreadyCommittedToTheWorkflowsTopic() async throws {
@@ -270,6 +275,98 @@ class WorkflowsConfigProviderTests: TestCase {
         expect(secondWorkflowId) == "wf-2"
     }
 
+    func testWarmPrefetchedWorkflowsCachesOnlyPrefetchTrueBodiesAndAllOfferingMappings() async throws {
+        let prefetchedWorkflow = try Self.workflowJSON(id: "wf-prefetch")
+        let onDemandWorkflow = try Self.workflowJSON(id: "wf-on-demand")
+        self.commit(
+            workflows: [
+                "wf-prefetch": .init(
+                    blobRef: "wf-prefetch-ref",
+                    prefetch: true,
+                    content: ["offeringIdentifier": "premium"]
+                ),
+                "wf-on-demand": .init(
+                    blobRef: "wf-on-demand-ref",
+                    prefetch: false,
+                    content: ["offeringIdentifier": "basic"]
+                )
+            ],
+            uiConfig: Self.uiConfigTopic,
+            blobs: Self.uiConfigBlobs.merging([
+                "wf-prefetch-ref": prefetchedWorkflow,
+                "wf-on-demand-ref": onDemandWorkflow
+            ]) { current, _ in current }
+        )
+
+        async let workflowsWarm: Void = self.provider.warmPrefetchedWorkflows()
+        async let uiConfigWarm = self.uiConfigProvider.getUiConfig()
+        _ = await (workflowsWarm, uiConfigWarm)
+
+        let cachedPrefetched = self.provider.cachedWorkflow(forOfferingId: "premium")
+        let cachedOnDemand = self.provider.cachedWorkflow(forOfferingId: "basic")
+        let mappedOnDemand = await self.provider.workflowId(forOfferingId: "basic")
+
+        expect(cachedPrefetched?.workflow.id) == "wf-prefetch"
+        expect(cachedOnDemand).to(beNil())
+        expect(mappedOnDemand) == "wf-on-demand"
+        expect(self.blobFetcher.invokedEnsureDownloadedRefs).to(contain("wf-prefetch-ref"))
+        expect(self.blobFetcher.invokedEnsureDownloadedRefs).toNot(contain("wf-on-demand-ref"))
+    }
+
+    func testCachedPrefetchedWorkflowMissesAfterGenerationInvalidates() async throws {
+        self.commit(
+            workflows: [
+                "wf-prefetch": .init(
+                    blobRef: "wf-prefetch-ref",
+                    prefetch: true,
+                    content: ["offeringIdentifier": "premium"]
+                )
+            ],
+            uiConfig: Self.uiConfigTopic,
+            blobs: Self.uiConfigBlobs.merging([
+                "wf-prefetch-ref": try Self.workflowJSON(id: "wf-prefetch")
+            ]) { current, _ in current }
+        )
+        async let workflowsWarm: Void = self.provider.warmPrefetchedWorkflows()
+        async let uiConfigWarm = self.uiConfigProvider.getUiConfig()
+        _ = await (workflowsWarm, uiConfigWarm)
+        expect(self.provider.cachedWorkflow(forOfferingId: "premium")).toNot(beNil())
+
+        self.manager.clearCache()
+
+        expect(self.provider.cachedWorkflow(forOfferingId: "premium")).to(beNil())
+    }
+
+    func testWarmPrefetchedWorkflowsStoresCacheWhenGenerationChangesDuringInitialTopicRead() async throws {
+        let mockManager = MockRemoteConfigManager()
+        let uiConfigProvider = UiConfigProvider(manager: mockManager)
+        let provider = WorkflowsConfigProvider(manager: mockManager, uiConfigProvider: uiConfigProvider)
+        let workflowsTopic: RemoteConfiguration.ConfigTopic = [
+            "wf-prefetch": .init(
+                blobRef: "wf-prefetch-ref",
+                prefetch: true,
+                content: ["offeringIdentifier": "premium"]
+            )
+        ]
+        mockManager.stubbedTopics[.workflows] = workflowsTopic
+        mockManager.stubbedBlobData[.workflows] = [
+            "wf-prefetch": try Self.workflowJSON(id: "wf-prefetch")
+        ]
+        mockManager.stubbedTopics[.uiConfig] = Self.uiConfigTopic
+        mockManager.stubbedBlobData[.uiConfig] = Self.uiConfigBlobsByItemKey
+        mockManager.shouldStoreTopicCompletion = true
+
+        async let workflowsWarm: Void = provider.warmPrefetchedWorkflows()
+        await self.waitUntilTopicRequested(on: mockManager)
+        mockManager.configGeneration += 1
+        mockManager.completeStoredTopic(with: workflowsTopic)
+
+        await workflowsWarm
+        _ = await uiConfigProvider.getUiConfig()
+
+        expect(provider.cachedWorkflow(forOfferingId: "premium")?.workflow.id) == "wf-prefetch"
+    }
+
     // MARK: - Helpers
 
     private func commit(
@@ -327,6 +424,37 @@ class WorkflowsConfigProviderTests: TestCase {
         }
         """
         return try XCTUnwrap(json.data(using: .utf8))
+    }
+
+    private static let uiConfigTopic: [String: RemoteConfiguration.ConfigItem] = [
+        "app": .init(blobRef: "app-ref", content: [:]),
+        "localizations": .init(blobRef: "loc-ref", content: [:]),
+        "variable_config": .init(blobRef: "variable-config-ref", content: [:]),
+        "custom_variables": .init(blobRef: "custom-variables-ref", content: [:])
+    ]
+
+    private static let uiConfigBlobs: [String: Data] = [
+        "app-ref": Data(#"{"colors": {}, "fonts": {}}"#.utf8),
+        "loc-ref": Data(#"{}"#.utf8),
+        "variable-config-ref": Data(
+            #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#.utf8
+        ),
+        "custom-variables-ref": Data(#"{}"#.utf8)
+    ]
+
+    private static let uiConfigBlobsByItemKey: [String: Data] = [
+        "app": Data(#"{"colors": {}, "fonts": {}}"#.utf8),
+        "localizations": Data(#"{}"#.utf8),
+        "variable_config": Data(
+            #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#.utf8
+        ),
+        "custom_variables": Data(#"{}"#.utf8)
+    ]
+
+    private func waitUntilTopicRequested(on manager: MockRemoteConfigManager) async {
+        while manager.invokedTopicCount == 0 {
+            await Task.yield()
+        }
     }
 
 }

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -340,6 +340,10 @@ class WorkflowsConfigProviderTests: TestCase {
     }
 
     func testWarmPrefetchedWorkflowsWarmsAssetsForPrefetchTrueBodies() async throws {
+        guard #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *) else {
+            throw XCTSkip("warmUpWorkflowCaches requires iOS 15+")
+        }
+
         let paywallCache = MockPaywallCacheWarming()
         let operationDispatcher = MockOperationDispatcher()
         self.provider = WorkflowsConfigProvider(

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -339,6 +339,41 @@ class WorkflowsConfigProviderTests: TestCase {
         expect(self.blobFetcher.invokedEnsureAllDownloadedRefs.count) == ensureAllDownloadedCountAfterFirstWarm
     }
 
+    func testWarmPrefetchedWorkflowsRetriesIncompleteCache() async throws {
+        self.commit(
+            workflows: [
+                "wf-first": .init(
+                    blobRef: "wf-first-ref",
+                    prefetch: true,
+                    content: ["offeringIdentifier": "first"]
+                ),
+                "wf-second": .init(
+                    blobRef: "wf-second-ref",
+                    prefetch: true,
+                    content: ["offeringIdentifier": "second"]
+                )
+            ],
+            uiConfig: Self.uiConfigTopic,
+            blobs: Self.uiConfigBlobs.merging([
+                "wf-first-ref": try Self.workflowJSON(id: "wf-first"),
+                "wf-second-ref": Data("invalid".utf8)
+            ]) { current, _ in current }
+        )
+
+        async let workflowsWarm: Void = self.provider.warmPrefetchedWorkflows()
+        async let uiConfigWarm = self.uiConfigProvider.getUiConfig()
+        _ = await (workflowsWarm, uiConfigWarm)
+
+        expect(self.provider.cachedWorkflow(forOfferingId: "first")?.workflow.id) == "wf-first"
+        expect(self.provider.cachedWorkflow(forOfferingId: "second")).to(beNil())
+
+        self.blobStore.stubbedData["wf-second-ref"] = try Self.workflowJSON(id: "wf-second")
+        await self.provider.warmPrefetchedWorkflows()
+
+        expect(self.provider.cachedWorkflow(forOfferingId: "first")?.workflow.id) == "wf-first"
+        expect(self.provider.cachedWorkflow(forOfferingId: "second")?.workflow.id) == "wf-second"
+    }
+
     func testWarmPrefetchedWorkflowsWarmsAssetsForPrefetchTrueBodies() async throws {
         guard #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *) else {
             throw XCTSkip("warmUpWorkflowCaches requires iOS 15+")

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -315,10 +315,12 @@ class WorkflowsConfigProviderTests: TestCase {
 
     func testWarmPrefetchedWorkflowsWarmsAssetsForPrefetchTrueBodies() async throws {
         let paywallCache = MockPaywallCacheWarming()
+        let operationDispatcher = MockOperationDispatcher()
         self.provider = WorkflowsConfigProvider(
             manager: self.manager,
             uiConfigProvider: self.uiConfigProvider,
-            paywallCache: paywallCache
+            paywallCache: paywallCache,
+            operationDispatcher: operationDispatcher
         )
         self.commit(
             workflows: [
@@ -342,9 +344,43 @@ class WorkflowsConfigProviderTests: TestCase {
 
         await self.provider.warmPrefetchedWorkflows()
 
+        expect(operationDispatcher.invokedDispatchAsyncOnWorkerThread) == true
         expect(paywallCache.invokedWarmUpWorkflowCachesCount) == 1
         expect(paywallCache.invokedWarmUpWorkflowCachesWorkflow?.id) == "wf-prefetch"
         expect(paywallCache.invokedWarmUpWorkflowCachesUiConfig) == self.uiConfigProvider.cachedUiConfig()
+    }
+
+    func testWarmPrefetchedWorkflowsDoesNotWaitForAssetWarming() async throws {
+        let paywallCache = MockPaywallCacheWarming()
+        let operationDispatcher = MockOperationDispatcher()
+        operationDispatcher.shouldInvokeDispatchOnWorkerThreadBlock = false
+        self.provider = WorkflowsConfigProvider(
+            manager: self.manager,
+            uiConfigProvider: self.uiConfigProvider,
+            paywallCache: paywallCache,
+            operationDispatcher: operationDispatcher
+        )
+        self.commit(
+            workflows: [
+                "wf-prefetch": .init(
+                    blobRef: "wf-prefetch-ref",
+                    prefetch: true,
+                    content: ["offeringIdentifier": "premium"]
+                )
+            ],
+            uiConfig: Self.uiConfigTopic,
+            blobs: Self.uiConfigBlobs.merging([
+                "wf-prefetch-ref": try Self.workflowJSON(id: "wf-prefetch")
+            ]) { current, _ in current }
+        )
+
+        async let workflowsWarm: Void = self.provider.warmPrefetchedWorkflows()
+        async let uiConfigWarm = self.uiConfigProvider.getUiConfig()
+        _ = await (workflowsWarm, uiConfigWarm)
+
+        expect(operationDispatcher.invokedDispatchAsyncOnWorkerThread) == true
+        expect(paywallCache.invokedWarmUpWorkflowCachesCount) == 0
+        expect(self.provider.cachedWorkflow(forOfferingId: "premium")?.workflow.id) == "wf-prefetch"
     }
 
     func testCachedPrefetchedWorkflowMissesAfterGenerationInvalidates() async throws {

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -313,6 +313,40 @@ class WorkflowsConfigProviderTests: TestCase {
         expect(self.blobFetcher.invokedEnsureDownloadedRefs).toNot(contain("wf-on-demand-ref"))
     }
 
+    func testWarmPrefetchedWorkflowsWarmsAssetsForPrefetchTrueBodies() async throws {
+        let paywallCache = MockPaywallCacheWarming()
+        self.provider = WorkflowsConfigProvider(
+            manager: self.manager,
+            uiConfigProvider: self.uiConfigProvider,
+            paywallCache: paywallCache
+        )
+        self.commit(
+            workflows: [
+                "wf-prefetch": .init(
+                    blobRef: "wf-prefetch-ref",
+                    prefetch: true,
+                    content: ["offeringIdentifier": "premium"]
+                ),
+                "wf-on-demand": .init(
+                    blobRef: "wf-on-demand-ref",
+                    prefetch: false,
+                    content: ["offeringIdentifier": "basic"]
+                )
+            ],
+            uiConfig: Self.uiConfigTopic,
+            blobs: Self.uiConfigBlobs.merging([
+                "wf-prefetch-ref": try Self.workflowJSON(id: "wf-prefetch"),
+                "wf-on-demand-ref": try Self.workflowJSON(id: "wf-on-demand")
+            ]) { current, _ in current }
+        )
+
+        await self.provider.warmPrefetchedWorkflows()
+
+        expect(paywallCache.invokedWarmUpWorkflowCachesCount) == 1
+        expect(paywallCache.invokedWarmUpWorkflowCachesWorkflow?.id) == "wf-prefetch"
+        expect(paywallCache.invokedWarmUpWorkflowCachesUiConfig) == self.uiConfigProvider.cachedUiConfig()
+    }
+
     func testCachedPrefetchedWorkflowMissesAfterGenerationInvalidates() async throws {
         self.commit(
             workflows: [

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -1042,6 +1042,8 @@ extension OfferingsManagerTests {
     func testGetOfferingsDoesNotDeliverUntilUiConfigResolved() {
         let mockRemoteConfigManager = MockRemoteConfigManager()
         // The workflows topic resolves immediately; ui_config's blob reads are held.
+        mockRemoteConfigManager.stubbedTopics[.uiConfig] = Self.uiConfigTopic
+        mockRemoteConfigManager.stubbedBlobData[.uiConfig] = Self.uiConfigBlobs
         mockRemoteConfigManager.shouldStoreBlobDataCompletion = true
         let manager = self.makeOfferingsManager(remoteConfigManager: mockRemoteConfigManager)
         self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsContents)
@@ -1108,7 +1110,10 @@ extension OfferingsManagerTests {
     func testGetOfferingsAwaitsWorkflowsAndUiConfigConcurrently() {
         let mockRemoteConfigManager = MockRemoteConfigManager()
         // Hold BOTH readiness steps: each must have started before either completes.
+        mockRemoteConfigManager.stubbedTopics[.uiConfig] = Self.uiConfigTopic
+        mockRemoteConfigManager.stubbedBlobData[.uiConfig] = Self.uiConfigBlobs
         mockRemoteConfigManager.shouldStoreTopicCompletion = true
+        mockRemoteConfigManager.storedTopicCompletionTopics = [.workflows]
         mockRemoteConfigManager.shouldStoreBlobDataCompletion = true
         let manager = self.makeOfferingsManager(remoteConfigManager: mockRemoteConfigManager)
         self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsContents)
@@ -1307,5 +1312,21 @@ extension OfferingsManagerTests {
                                 diagnosticsTracker: self.mockDiagnosticsTracker,
                                 remoteConfigManager: remoteConfigManager)
     }
+
+    private static let uiConfigTopic: [String: RemoteConfiguration.ConfigItem] = [
+        "app": .init(blobRef: "app-ref", content: [:]),
+        "localizations": .init(blobRef: "localizations-ref", content: [:]),
+        "variable_config": .init(blobRef: "variable-config-ref", content: [:]),
+        "custom_variables": .init(blobRef: "custom-variables-ref", content: [:])
+    ]
+
+    private static let uiConfigBlobs: [String: Data] = [
+        "app": Data(#"{"colors": {}, "fonts": {}}"#.utf8),
+        "localizations": Data(#"{}"#.utf8),
+        "variable_config": Data(
+            #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#.utf8
+        ),
+        "custom_variables": Data(#"{}"#.utf8)
+    ]
 
 }

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -680,6 +680,7 @@ final class MockRemoteConfigManager: RemoteConfigManagerType {
     }
 
     var isDisabled = false
+    var configGeneration = 0
 
     private(set) var invokedRefreshRemoteConfigCount = 0
     private(set) var invokedRefreshRemoteConfigIfStaleCount = 0
@@ -722,11 +723,15 @@ final class MockRemoteConfigManager: RemoteConfigManagerType {
     /// When `true`, `topic(_:)` suspends until `completeStoredTopic()` resumes every stored
     /// waiter (there can be several: e.g. a gated delivery plus a background refresh).
     var shouldStoreTopicCompletion = false
+    /// Restricts held topic reads when `shouldStoreTopicCompletion` is true. `nil` preserves the
+    /// default behavior of holding every topic.
+    var storedTopicCompletionTopics: Set<RemoteConfigTopic>?
     private let _storedTopicContinuations: Atomic<[CheckedContinuation<RemoteConfiguration.ConfigTopic?, Never>]> =
         .init([])
 
     func topic(_ topic: RemoteConfigTopic) async -> RemoteConfiguration.ConfigTopic? {
-        guard self.shouldStoreTopicCompletion else {
+        guard self.shouldStoreTopicCompletion,
+              self.storedTopicCompletionTopics?.contains(topic) ?? true else {
             self._invokedTopicCount.modify { $0 += 1 }
             return self.stubbedTopics[topic]
         }
@@ -815,10 +820,12 @@ final class MockRemoteConfigManager: RemoteConfigManagerType {
     }
 
     func clearCache() {
+        self.configGeneration += 1
         self.invokedClearCacheCount += 1
     }
 
     func clearCache(forAppUserID appUserID: String) {
+        self.configGeneration += 1
         self.invokedClearCacheCount += 1
         self.invokedClearCacheAppUserIDs.append(appUserID)
     }

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -680,7 +680,17 @@ final class MockRemoteConfigManager: RemoteConfigManagerType {
     }
 
     var isDisabled = false
-    var configGeneration = 0
+    var onConfigGenerationRead: (() -> Void)?
+    var configGeneration: Int {
+        get {
+            defer { self.onConfigGenerationRead?() }
+            return self.configGenerationStorage
+        }
+        set {
+            self.configGenerationStorage = newValue
+        }
+    }
+    private var configGenerationStorage = 0
 
     private(set) var invokedRefreshRemoteConfigCount = 0
     private(set) var invokedRefreshRemoteConfigIfStaleCount = 0

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesWorkflowTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesWorkflowTests.swift
@@ -54,6 +54,22 @@ class PurchasesWorkflowTests: BasePurchasesTests {
 
     // MARK: - Helpers
 
+    private static let uiConfigTopic: [String: RemoteConfiguration.ConfigItem] = [
+        "app": .init(blobRef: "app-ref", content: [:]),
+        "localizations": .init(blobRef: "localizations-ref", content: [:]),
+        "variable_config": .init(blobRef: "variable-config-ref", content: [:]),
+        "custom_variables": .init(blobRef: "custom-variables-ref", content: [:])
+    ]
+
+    private static let uiConfigBlobs: [String: Data] = [
+        "app": Data(#"{"colors": {}, "fonts": {}}"#.utf8),
+        "localizations": Data(#"{}"#.utf8),
+        "variable_config": Data(
+            #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#.utf8
+        ),
+        "custom_variables": Data(#"{}"#.utf8)
+    ]
+
     private static func workflowJSON(id: String) throws -> Data {
         let json = """
         {


### PR DESCRIPTION
## Motivation
Fetching workflows through the blob store is an asynchronous operation and relies on loading and decoding the data from disk. This introduced a (short) loading state when opening a workflow, resulting in a flash when opening the screen.

## Fix
This PR introduces an in-memory cache of the workflows marked with `prefetch:true`, as well as the shared `ui_config`. This results in the workflows being available synchronously, which avoids the quick flash when opening the screen. See the comparison table below for the visual difference.


| Before | After |
| --- | --- |
|<img width="3000" height="3260" alt="workflow-presentation-remote-config-baseline-first-transition" src="https://github.com/user-attachments/assets/98ef04f4-f926-42bd-9df9-d8189db0013f" /> |<img width="3000" height="3260" alt="workflow-presentation-remote-config-fixed-first-transition" src="https://github.com/user-attachments/assets/6d59cef7-cd3c-4d45-be67-c28f3d717bb4" /> |

Similar to Android PR https://github.com/RevenueCat/purchases-android/pull/3759

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches remote-config invalidation, offerings delivery gating, and first-frame paywall/workflow rendering; generation guards reduce stale-data risk but behavior changes when cache is warm vs cold.
> 
> **Overview**
> Adds **generation-guarded in-memory caching** for remote-config `ui_config` and `prefetch:true` workflow bodies, plus a synchronous **`cachedWorkflow`** path from `Purchases` through `PurchaseHandler` into `PaywallView` initialization.
> 
> **`PaywallView`** now seeds `offering` and `workflowContext` from `cachedInitialPaywallViewData` when warm cache data exists, so workflow paywalls can render on the first frame instead of showing the loading placeholder and flashing after async blob reads.
> 
> **`RemoteConfigManager`** exposes `configGeneration` (incremented on commit, cache clear, close, and disabling errors). **`GenerationGuardedCache`** stores values keyed by generation + topic snapshot so stale async work cannot repopulate memory after a newer config is active. **`UiConfigProvider`** and **`WorkflowsConfigProvider`** use this cache; workflow resolution re-validates the workflows topic generation after `ui_config` loads to avoid mixed-generation pairs.
> 
> **`OfferingsManager`**’s config-readiness gate now calls **`warmPrefetchedWorkflows()`** (decode prefetch workflows, optional background paywall asset warming) alongside `getUiConfig()`, sharing the same provider instances wired from **`Purchases`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88519b0ddc542e945711ed0d50e67b05a381c550. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->