### PR TITLE
feat(remote-config): send fetch_context on config endpoint requests

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -949,6 +949,7 @@
 		A1B2C3D42FE4000000000002 /* RCContainerCompressionFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE4000000000001 /* RCContainerCompressionFixtureTests.swift */; };
 		A1B2C3D42FE2000000000002 /* RemoteConfigDiskCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE2000000000001 /* RemoteConfigDiskCache.swift */; };
 		A1B2C3D42FE2000000000004 /* RemoteConfigManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE2000000000003 /* RemoteConfigManager.swift */; };
+		A1B2C3D42FE3000000000002 /* RemoteConfigFetchContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE3000000000001 /* RemoteConfigFetchContext.swift */; };
 		B8EF700CBF25815EC2BF1253 /* UiConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB021C52E3CCC5EB17FFF795 /* UiConfigProvider.swift */; };
 		49B8016629C29C4691C0774A /* WorkflowsConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C390BBAC430231B23B4B5F8 /* WorkflowsConfigProvider.swift */; };
 		A1B2C3D42FE200000000000D /* RemoteConfigBlobStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE200000000000C /* RemoteConfigBlobStore.swift */; };
@@ -2915,6 +2916,7 @@
 		A1B2C3D42FE4000000000001 /* RCContainerCompressionFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RCContainerCompressionFixtureTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE2000000000001 /* RemoteConfigDiskCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigDiskCache.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE2000000000003 /* RemoteConfigManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigManager.swift; sourceTree = "<group>"; };
+		A1B2C3D42FE3000000000001 /* RemoteConfigFetchContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigFetchContext.swift; sourceTree = "<group>"; };
 		DB021C52E3CCC5EB17FFF795 /* UiConfigProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UiConfigProvider.swift; sourceTree = "<group>"; };
 		4C390BBAC430231B23B4B5F8 /* WorkflowsConfigProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowsConfigProvider.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE200000000000C /* RemoteConfigBlobStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobStore.swift; sourceTree = "<group>"; };
@@ -4584,6 +4586,7 @@
 				A1B2C3D42FE200000000000C /* RemoteConfigBlobStore.swift */,
 				A1B2C3D42FE2000000000001 /* RemoteConfigDiskCache.swift */,
 				A1B2C3D42FE2000000000003 /* RemoteConfigManager.swift */,
+				A1B2C3D42FE3000000000001 /* RemoteConfigFetchContext.swift */,
 				DB021C52E3CCC5EB17FFF795 /* UiConfigProvider.swift */,
 				4C390BBAC430231B23B4B5F8 /* WorkflowsConfigProvider.swift */,
 				A1B2C3D42FE7000000000001 /* RemoteConfigTopic.swift */,
@@ -7232,6 +7235,7 @@
 				A1B2C3D42FE200000000000D /* RemoteConfigBlobStore.swift in Sources */,
 				A1B2C3D42FE2000000000002 /* RemoteConfigDiskCache.swift in Sources */,
 				A1B2C3D42FE2000000000004 /* RemoteConfigManager.swift in Sources */,
+				A1B2C3D42FE3000000000002 /* RemoteConfigFetchContext.swift in Sources */,
 				B8EF700CBF25815EC2BF1253 /* UiConfigProvider.swift in Sources */,
 				49B8016629C29C4691C0774A /* WorkflowsConfigProvider.swift in Sources */,
 				A1B2C3D42FE2000000000006 /* RemoteConfigStrings.swift in Sources */,

--- a/Sources/Networking/Operations/GetRemoteConfigOperation.swift
+++ b/Sources/Networking/Operations/GetRemoteConfigOperation.swift
@@ -76,6 +76,7 @@ struct RemoteConfigRequest: Codable, Equatable, HTTPRequestBody {
 
     var cacheKey: String {
         [
+            "fetch_context=\(self.fetchContext.rawValue)",
             "app_user_id=\(self.appUserID)",
             "domain=\(self.domain)",
             "manifest=\(self.manifest ?? "")",

--- a/Sources/Networking/Operations/GetRemoteConfigOperation.swift
+++ b/Sources/Networking/Operations/GetRemoteConfigOperation.swift
@@ -47,23 +47,27 @@ final class GetRemoteConfigOperation: CacheableNetworkOperation {
 
 struct RemoteConfigRequest: Codable, Equatable, HTTPRequestBody {
 
+    let fetchContext: RemoteConfigFetchContext
     let appUserID: String
     let domain: String
     let manifest: String?
     let prefetchedBlobs: [String]
 
     private enum CodingKeys: String, CodingKey {
+        case fetchContext
         case appUserID = "appUserId"
         case manifest
         case prefetchedBlobs
     }
 
     init(
+        fetchContext: RemoteConfigFetchContext,
         appUserID: String,
         domain: String = RemoteConfiguration.defaultDomain,
         manifest: String? = nil,
         prefetchedBlobs: [String] = []
     ) {
+        self.fetchContext = fetchContext
         self.appUserID = appUserID
         self.domain = domain
         self.manifest = manifest
@@ -81,6 +85,7 @@ struct RemoteConfigRequest: Codable, Equatable, HTTPRequestBody {
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.fetchContext, forKey: .fetchContext)
         try container.encode(self.appUserID, forKey: .appUserID)
         try container.encodeIfPresent(self.manifest, forKey: .manifest)
         try container.encode(self.prefetchedBlobs, forKey: .prefetchedBlobs)
@@ -89,6 +94,7 @@ struct RemoteConfigRequest: Codable, Equatable, HTTPRequestBody {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
+        self.fetchContext = try container.decode(RemoteConfigFetchContext.self, forKey: .fetchContext)
         self.appUserID = try container.decode(String.self, forKey: .appUserID)
         self.domain = RemoteConfiguration.defaultDomain
         self.manifest = try container.decodeIfPresent(String.self, forKey: .manifest)

--- a/Sources/Networking/RemoteConfigFetchContext.swift
+++ b/Sources/Networking/RemoteConfigFetchContext.swift
@@ -1,0 +1,20 @@
+//
+//  RemoteConfigFetchContext.swift
+//  RevenueCat
+//
+//  Created by Antonio Pallares.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+//
+
+import Foundation
+
+/// Describes why the SDK is requesting remote config.
+///
+/// Each case maps to the SDK situation that triggered the config fetch. The raw `String` value is sent on the wire
+/// in the `fetch_context` request field.
+enum RemoteConfigFetchContext: String, Codable, Equatable {
+    case appStart = "app_start"
+    case foreground = "foreground"
+    case identityChange = "identity_change"
+    case read = "read"
+}

--- a/Sources/Networking/RemoteConfigFetchContext.swift
+++ b/Sources/Networking/RemoteConfigFetchContext.swift
@@ -10,8 +10,8 @@ import Foundation
 
 /// Describes why the SDK is requesting remote config.
 ///
-/// Each case maps to the SDK situation that triggered the config fetch. The raw `String` value is sent on the wire
-/// in the `fetch_context` request field.
+/// Each case maps to the SDK situation that triggered the config fetch. The raw `String` value is sent in the
+/// remote config request body as the `fetch_context` field.
 enum RemoteConfigFetchContext: String, Codable, Equatable {
     case appStart = "app_start"
     case foreground = "foreground"

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -13,8 +13,8 @@ protocol RemoteConfigManagerType: AnyObject {
 
     /// Whether remote config should be ignored for the current manager lifetime.
     var isDisabled: Bool { get }
-    func refreshRemoteConfig(isAppBackgrounded: Bool)
-    func refreshRemoteConfigIfStale(isAppBackgrounded: Bool)
+    func refreshRemoteConfig(fetchContext: RemoteConfigFetchContext, isAppBackgrounded: Bool)
+    func refreshRemoteConfigIfStale(fetchContext: RemoteConfigFetchContext, isAppBackgrounded: Bool)
 
     /// Returns the committed item index for a known topic.
     ///
@@ -168,9 +168,9 @@ final class NoOpRemoteConfigManager: RemoteConfigManagerType {
 
     let isDisabled = true
 
-    func refreshRemoteConfig(isAppBackgrounded: Bool) {}
+    func refreshRemoteConfig(fetchContext: RemoteConfigFetchContext, isAppBackgrounded: Bool) {}
 
-    func refreshRemoteConfigIfStale(isAppBackgrounded: Bool) {}
+    func refreshRemoteConfigIfStale(fetchContext: RemoteConfigFetchContext, isAppBackgrounded: Bool) {}
 
     func topic(_ topic: RemoteConfigTopic) async -> RemoteConfiguration.ConfigTopic? {
         return nil
@@ -221,6 +221,7 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     fileprivate struct RefreshRequestContext {
         let epoch: Int
         let requestAppUserID: String
+        let fetchContext: RemoteConfigFetchContext
     }
 
     /// Runs blocking committed-state reads away from the caller's executor.
@@ -287,16 +288,20 @@ final class RemoteConfigManager: RemoteConfigManagerType {
         }
     }
 
-    func refreshRemoteConfig(isAppBackgrounded: Bool) {
+    func refreshRemoteConfig(fetchContext: RemoteConfigFetchContext, isAppBackgrounded: Bool) {
         let appUserID = self.currentUserProvider.currentAppUserID
-        guard let requestContext = self.prepareRefreshIfNeeded(appUserID: appUserID) else { return }
+        guard let requestContext = self.prepareRefreshIfNeeded(
+            fetchContext: fetchContext,
+            appUserID: appUserID
+        ) else { return }
 
         self.startRefresh(isAppBackgrounded: isAppBackgrounded, requestContext: requestContext)
     }
 
-    func refreshRemoteConfigIfStale(isAppBackgrounded: Bool) {
+    func refreshRemoteConfigIfStale(fetchContext: RemoteConfigFetchContext, isAppBackgrounded: Bool) {
         let appUserID = self.currentUserProvider.currentAppUserID
         guard let requestContext = self.prepareRefreshIfStale(
+            fetchContext: fetchContext,
             isAppBackgrounded: isAppBackgrounded,
             appUserID: appUserID
         ) else { return }
@@ -372,7 +377,10 @@ final class RemoteConfigManager: RemoteConfigManagerType {
 
 private extension RemoteConfigManager {
 
-    func prepareRefreshIfNeeded(appUserID: String) -> RefreshRequestContext? {
+    func prepareRefreshIfNeeded(
+        fetchContext: RemoteConfigFetchContext,
+        appUserID: String
+    ) -> RefreshRequestContext? {
         return self.lock.perform {
             guard !self.isRefreshing,
                   !self.isDisabledInternal,
@@ -382,12 +390,14 @@ private extension RemoteConfigManager {
             self.isRefreshing = true
             return .init(
                 epoch: self.epoch,
-                requestAppUserID: requestAppUserID
+                requestAppUserID: requestAppUserID,
+                fetchContext: fetchContext
             )
         }
     }
 
     func prepareRefreshIfStale(
+        fetchContext: RemoteConfigFetchContext,
         isAppBackgrounded: Bool,
         appUserID: String,
         expectedEpoch: Int? = nil
@@ -408,7 +418,8 @@ private extension RemoteConfigManager {
             self.isRefreshing = true
             return .init(
                 epoch: self.epoch,
-                requestAppUserID: requestAppUserID
+                requestAppUserID: requestAppUserID,
+                fetchContext: fetchContext
             )
         }
     }
@@ -416,6 +427,7 @@ private extension RemoteConfigManager {
     func startRefresh(isAppBackgrounded: Bool, requestContext: RefreshRequestContext) {
         let persisted = self.diskCache.read()
         let request = RemoteConfigRequest(
+            fetchContext: requestContext.fetchContext,
             appUserID: requestContext.requestAppUserID,
             domain: persisted?.domain ?? Self.defaultDomain,
             manifest: persisted?.manifest,
@@ -677,6 +689,7 @@ private extension RemoteConfigManager {
 
         let appUserID = self.currentUserProvider.currentAppUserID
         if let requestContext = self.prepareRefreshIfStale(
+            fetchContext: .read,
             isAppBackgrounded: false,
             appUserID: appUserID,
             expectedEpoch: expectedEpoch

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -2641,7 +2641,7 @@ private extension Purchases {
         // Note: it's important that we observe "will enter foreground" instead of
         // "did become active" so that we don't trigger cache updates in the middle
         // of purchases due to pop-ups stealing focus from the app.
-        self.updateAllCachesIfNeeded(isAppBackgrounded: false)
+        self.updateAllCachesIfNeeded(isAppBackgrounded: false, fetchContext: .foreground)
         self.dispatchSyncSubscriberAttributes()
         self.transactionMetadataSyncHelper.syncIfNeeded(
             allowSharingAppStoreAccount: self.purchasesOrchestrator.allowSharingAppStoreAccount
@@ -2746,7 +2746,7 @@ private extension Purchases {
     }
     #endif
 
-    func updateAllCachesIfNeeded(isAppBackgrounded: Bool) {
+    func updateAllCachesIfNeeded(isAppBackgrounded: Bool, fetchContext: RemoteConfigFetchContext) {
         guard !self.systemInfo.dangerousSettings.uiPreviewMode else {
             // No need to update caches every time when in UI preview mode.
             // Only needed at configuration time
@@ -2768,7 +2768,7 @@ private extension Purchases {
         }
 
         self.remoteConfigManager.refreshRemoteConfigIfStale(
-            fetchContext: .foreground,
+            fetchContext: fetchContext,
             isAppBackgrounded: isAppBackgrounded
         )
     }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1067,7 +1067,10 @@ public extension Purchases {
 
             self.systemInfo.isApplicationBackgrounded { isAppBackgrounded in
                 self.updateOfferingsCache(isAppBackgrounded: isAppBackgrounded)
-                self.remoteConfigManager.refreshRemoteConfig(isAppBackgrounded: isAppBackgrounded)
+                self.remoteConfigManager.refreshRemoteConfig(
+                    fetchContext: .identityChange,
+                    isAppBackgrounded: isAppBackgrounded
+                )
             }
         }
     }
@@ -1102,7 +1105,7 @@ public extension Purchases {
                 return
             }
 
-            self.updateAllCaches {
+            self.updateAllCaches(fetchContext: .identityChange) {
                 completion?($0.value, $0.error)
             }
         }
@@ -1213,7 +1216,10 @@ extension Purchases {
 
         self.systemInfo.isApplicationBackgrounded { isBackgrounded in
             self.updateOfferingsCache(isAppBackgrounded: isBackgrounded)
-            self.remoteConfigManager.refreshRemoteConfig(isAppBackgrounded: isBackgrounded)
+            self.remoteConfigManager.refreshRemoteConfig(
+                fetchContext: .identityChange,
+                isAppBackgrounded: isBackgrounded
+            )
         }
     }
 
@@ -2700,7 +2706,11 @@ private extension Purchases {
             guard !isBackgrounded, let self = self else { return }
 
             self.operationDispatcher.dispatchOnWorkerThread { [weak self] in
-                self?.updateAllCaches(isAppBackgrounded: isBackgrounded, completion: nil)
+                self?.updateAllCaches(
+                    isAppBackgrounded: isBackgrounded,
+                    fetchContext: .appStart,
+                    completion: nil
+                )
 
                 // Run the health check after all cache operations have been
                 // enqueued on the serial queue, so it doesn't block user-facing requests.
@@ -2757,18 +2767,28 @@ private extension Purchases {
             self.updateOfferingsCache(isAppBackgrounded: isAppBackgrounded)
         }
 
-        self.remoteConfigManager.refreshRemoteConfigIfStale(isAppBackgrounded: isAppBackgrounded)
+        self.remoteConfigManager.refreshRemoteConfigIfStale(
+            fetchContext: .foreground,
+            isAppBackgrounded: isAppBackgrounded
+        )
     }
 
-    func updateAllCaches(completion: ((Result<CustomerInfo, PublicError>) -> Void)?) {
+    func updateAllCaches(
+        fetchContext: RemoteConfigFetchContext,
+        completion: ((Result<CustomerInfo, PublicError>) -> Void)?
+    ) {
         self.systemInfo.isApplicationBackgrounded { isAppBackgrounded in
-            self.updateAllCaches(isAppBackgrounded: isAppBackgrounded,
-                                 completion: completion)
+            self.updateAllCaches(
+                isAppBackgrounded: isAppBackgrounded,
+                fetchContext: fetchContext,
+                completion: completion
+            )
         }
     }
 
     func updateAllCaches(
         isAppBackgrounded: Bool,
+        fetchContext: RemoteConfigFetchContext,
         completion: ((Result<CustomerInfo, PublicError>) -> Void)?
     ) {
         Logger.verbose(Strings.purchase.updating_all_caches)
@@ -2792,7 +2812,10 @@ private extension Purchases {
         }
 
         self.updateOfferingsCache(isAppBackgrounded: isAppBackgrounded)
-        self.remoteConfigManager.refreshRemoteConfig(isAppBackgrounded: isAppBackgrounded)
+        self.remoteConfigManager.refreshRemoteConfig(
+            fetchContext: fetchContext,
+            isAppBackgrounded: isAppBackgrounded
+        )
     }
 
     // Used when delegate is being set

--- a/Tests/BackendIntegrationTests/ProductionRemoteConfigIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/ProductionRemoteConfigIntegrationTests.swift
@@ -29,6 +29,7 @@ class BaseProductionRemoteConfigIntegrationTests: BaseBackendIntegrationTests {
         return try await withCheckedThrowingContinuation { continuation in
             self.remoteConfigAPI.getRemoteConfig(
                 request: .init(
+                    fetchContext: .appStart,
                     appUserID: self.appUserID,
                     domain: Self.domain,
                     manifest: manifest,

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -354,6 +354,25 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(self.httpClient.calls).to(haveCount(2))
     }
 
+    func testGetRemoteConfigDoesNotCoalesceSimultaneousRequestsWithDifferentFetchContexts() {
+        self.mockSuccessfulResponse(delay: .milliseconds(10))
+
+        let responses: Atomic<Int> = .init(0)
+
+        self.remoteConfigAPI.getRemoteConfig(
+            request: .init(fetchContext: .appStart, appUserID: Self.appUserID, manifest: "v1.10.paywalls:etag-a"),
+            isAppBackgrounded: false
+        ) { _ in responses.value += 1 }
+
+        self.remoteConfigAPI.getRemoteConfig(
+            request: .init(fetchContext: .read, appUserID: Self.appUserID, manifest: "v1.10.paywalls:etag-a"),
+            isAppBackgrounded: false
+        ) { _ in responses.value += 1 }
+
+        expect(responses.value).toEventually(equal(2))
+        expect(self.httpClient.calls).to(haveCount(2))
+    }
+
     func testCoalescedRequestsLogDebugMessage() {
         self.mockSuccessfulResponse(delay: .milliseconds(10))
 

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -281,12 +281,22 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         let responses: Atomic<Int> = .init(0)
 
         self.remoteConfigAPI.getRemoteConfig(
-            request: .init(fetchContext: .appStart, appUserID: Self.appUserID, domain: "app", manifest: "v1.10.paywalls:etag-a"),
+            request: .init(
+                fetchContext: .appStart,
+                appUserID: Self.appUserID,
+                domain: "app",
+                manifest: "v1.10.paywalls:etag-a"
+            ),
             isAppBackgrounded: false
         ) { _ in responses.value += 1 }
 
         self.remoteConfigAPI.getRemoteConfig(
-            request: .init(fetchContext: .appStart, appUserID: Self.appUserID, domain: "app_workflows", manifest: "v1.10.paywalls:etag-a"),
+            request: .init(
+                fetchContext: .appStart,
+                appUserID: Self.appUserID,
+                domain: "app_workflows",
+                manifest: "v1.10.paywalls:etag-a"
+            ),
             isAppBackgrounded: false
         ) { _ in responses.value += 1 }
 
@@ -321,12 +331,22 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         let responses: Atomic<Int> = .init(0)
 
         self.remoteConfigAPI.getRemoteConfig(
-            request: .init(fetchContext: .appStart, appUserID: Self.appUserID, manifest: "v1.10.paywalls:etag-a", prefetchedBlobs: ["blob-a"]),
+            request: .init(
+                fetchContext: .appStart,
+                appUserID: Self.appUserID,
+                manifest: "v1.10.paywalls:etag-a",
+                prefetchedBlobs: ["blob-a"]
+            ),
             isAppBackgrounded: false
         ) { _ in responses.value += 1 }
 
         self.remoteConfigAPI.getRemoteConfig(
-            request: .init(fetchContext: .appStart, appUserID: Self.appUserID, manifest: "v1.10.paywalls:etag-a", prefetchedBlobs: ["blob-b"]),
+            request: .init(
+                fetchContext: .appStart,
+                appUserID: Self.appUserID,
+                manifest: "v1.10.paywalls:etag-a",
+                prefetchedBlobs: ["blob-b"]
+            ),
             isAppBackgrounded: false
         ) { _ in responses.value += 1 }
 

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -70,6 +70,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         let body = try XCTUnwrap(self.httpClient.calls.first?.request.requestBody?.asJSONDictionary())
 
         expect(body["app_user_id"] as? String) == Self.appUserID
+        expect(body["fetch_context"] as? String) == "app_start"
         expect(body["domain"]).to(beNil())
         expect(body["manifest"]).to(beNil())
         expect(body["prefetched_blobs"] as? [String]).to(beEmpty())
@@ -79,6 +80,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         self.mockSuccessfulResponse(domain: "project")
 
         let request = RemoteConfigRequest(
+            fetchContext: .identityChange,
             appUserID: Self.appUserID,
             domain: "project",
             manifest: "v1.123.paywalls:etag-paywalls,product_entitlement_mapping:etag-pem",
@@ -94,8 +96,8 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
         let body = try XCTUnwrap(self.httpClient.calls.first?.request.requestBody?.asJSONDictionary())
 
-        expect(self.httpClient.calls.first?.request.path.relativePath) == "/v1/config/project"
         expect(body["app_user_id"] as? String) == Self.appUserID
+        expect(body["fetch_context"] as? String) == "identity_change"
         expect(body["domain"]).to(beNil())
         expect(body["manifest"] as? String) == "v1.123.paywalls:etag-paywalls,product_entitlement_mapping:etag-pem"
         expect(body["prefetched_blobs"] as? [String]) == ["blob-b"]
@@ -240,6 +242,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
 
         let responses: Atomic<Int> = .init(0)
         let request = RemoteConfigRequest(
+            fetchContext: .appStart,
             appUserID: Self.appUserID,
             manifest: "v1.10.paywalls:etag-a",
             prefetchedBlobs: ["blob-b", "blob-a"]
@@ -258,12 +261,12 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         let responses: Atomic<Int> = .init(0)
 
         self.remoteConfigAPI.getRemoteConfig(
-            request: .init(appUserID: Self.appUserID, manifest: "v1.10.paywalls:etag-a"),
+            request: .init(fetchContext: .appStart, appUserID: Self.appUserID, manifest: "v1.10.paywalls:etag-a"),
             isAppBackgrounded: false
         ) { _ in responses.value += 1 }
 
         self.remoteConfigAPI.getRemoteConfig(
-            request: .init(appUserID: Self.appUserID, manifest: "v1.10.paywalls:etag-b"),
+            request: .init(fetchContext: .appStart, appUserID: Self.appUserID, manifest: "v1.10.paywalls:etag-b"),
             isAppBackgrounded: false
         ) { _ in responses.value += 1 }
 
@@ -278,12 +281,12 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         let responses: Atomic<Int> = .init(0)
 
         self.remoteConfigAPI.getRemoteConfig(
-            request: .init(appUserID: Self.appUserID, domain: "app", manifest: "v1.10.paywalls:etag-a"),
+            request: .init(fetchContext: .appStart, appUserID: Self.appUserID, domain: "app", manifest: "v1.10.paywalls:etag-a"),
             isAppBackgrounded: false
         ) { _ in responses.value += 1 }
 
         self.remoteConfigAPI.getRemoteConfig(
-            request: .init(appUserID: Self.appUserID, domain: "app_workflows", manifest: "v1.10.paywalls:etag-a"),
+            request: .init(fetchContext: .appStart, appUserID: Self.appUserID, domain: "app_workflows", manifest: "v1.10.paywalls:etag-a"),
             isAppBackgrounded: false
         ) { _ in responses.value += 1 }
 
@@ -299,12 +302,12 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         let responses: Atomic<Int> = .init(0)
 
         self.remoteConfigAPI.getRemoteConfig(
-            request: .init(appUserID: "app-user-a", manifest: "v1.10.paywalls:etag-a"),
+            request: .init(fetchContext: .appStart, appUserID: "app-user-a", manifest: "v1.10.paywalls:etag-a"),
             isAppBackgrounded: false
         ) { _ in responses.value += 1 }
 
         self.remoteConfigAPI.getRemoteConfig(
-            request: .init(appUserID: "app-user-b", manifest: "v1.10.paywalls:etag-a"),
+            request: .init(fetchContext: .appStart, appUserID: "app-user-b", manifest: "v1.10.paywalls:etag-a"),
             isAppBackgrounded: false
         ) { _ in responses.value += 1 }
 
@@ -318,12 +321,12 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         let responses: Atomic<Int> = .init(0)
 
         self.remoteConfigAPI.getRemoteConfig(
-            request: .init(appUserID: Self.appUserID, manifest: "v1.10.paywalls:etag-a", prefetchedBlobs: ["blob-a"]),
+            request: .init(fetchContext: .appStart, appUserID: Self.appUserID, manifest: "v1.10.paywalls:etag-a", prefetchedBlobs: ["blob-a"]),
             isAppBackgrounded: false
         ) { _ in responses.value += 1 }
 
         self.remoteConfigAPI.getRemoteConfig(
-            request: .init(appUserID: Self.appUserID, manifest: "v1.10.paywalls:etag-a", prefetchedBlobs: ["blob-b"]),
+            request: .init(fetchContext: .appStart, appUserID: Self.appUserID, manifest: "v1.10.paywalls:etag-a", prefetchedBlobs: ["blob-b"]),
             isAppBackgrounded: false
         ) { _ in responses.value += 1 }
 
@@ -679,7 +682,7 @@ private extension BackendGetRemoteConfigTests {
     static let appUserID = "app-user-id"
 
     static var defaultRequest: RemoteConfigRequest {
-        return .init(appUserID: Self.appUserID)
+        return .init(fetchContext: .appStart, appUserID: Self.appUserID)
     }
 
     static var containerData: Data {

--- a/Tests/UnitTests/Networking/Backend/BackendRemoteConfigLaneTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendRemoteConfigLaneTests.swift
@@ -47,7 +47,7 @@ final class BackendRemoteConfigLaneTests: BaseBackendTests {
 
         waitUntil { completed in
             backend.remoteConfigAPI.getRemoteConfig(
-                request: .init(appUserID: Self.userID),
+                request: .init(fetchContext: .appStart, appUserID: Self.userID),
                 isAppBackgrounded: false
             ) { _ in completed() }
         }
@@ -72,7 +72,7 @@ final class BackendRemoteConfigLaneTests: BaseBackendTests {
 
         waitUntil { completed in
             backend.remoteConfigAPI.getRemoteConfig(
-                request: .init(appUserID: Self.userID),
+                request: .init(fetchContext: .appStart, appUserID: Self.userID),
                 isAppBackgrounded: false
             ) { _ in completed() }
         }
@@ -171,7 +171,7 @@ final class BackendRemoteConfigLaneParallelTests: TestCase {
             timeout: .seconds(5)
         ) { completed in
             backend.remoteConfigAPI.getRemoteConfig(
-                request: .init(appUserID: Self.userID),
+                request: .init(fetchContext: .appStart, appUserID: Self.userID),
                 isAppBackgrounded: false,
                 completion: completed
             )

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1163,7 +1163,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
 
     func testRemoteConfigDoesNotUseETagCacheEvenIfResponseIncludesETagHeader() {
         let request = HTTPRequest(
-            method: .post(RemoteConfigRequest(appUserID: "app-user-id")),
+            method: .post(RemoteConfigRequest(fetchContext: .appStart, appUserID: "app-user-id")),
             path: HTTPRequest.Path.remoteConfig(domain: "app")
         )
         let headerPresent: Atomic<Bool?> = nil

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -307,7 +307,7 @@ class HTTPRequestTests: TestCase {
 
     func testRemoteConfigUsesRCContainerAcceptHeaders() {
         let request: HTTPRequest = .init(
-            method: .post(RemoteConfigRequest(appUserID: "app-user-id")),
+            method: .post(RemoteConfigRequest(fetchContext: .appStart, appUserID: "app-user-id")),
             path: HTTPRequest.Path.remoteConfig(domain: "app")
         )
         let headers = request.headers(

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
@@ -414,7 +414,7 @@ final class RemoteConfigIntegrationTests: TestCase {
             code: .success
         ))
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         await self.waitForRemoteConfigRequestCount(1)
 
         expect(self.diskCache.read()).to(beNil())
@@ -495,7 +495,7 @@ final class RemoteConfigIntegrationTests: TestCase {
     func testEndpointDisabledPreventsReadTriggeredNetworkWork() async throws {
         self.mockRemoteConfigError(Self.disablingNetworkError)
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         await self.waitForRemoteConfigRequestCount(1)
 
         let topic = await self.manager.topic(.workflows)
@@ -513,7 +513,7 @@ final class RemoteConfigIntegrationTests: TestCase {
     func testMalformedRawContainerResponseDoesNotPersistConfigOrBlobs() async throws {
         self.mockRemoteConfigResponse(body: #"{"not":"an rc container"}"#.asData)
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         await self.waitForRemoteConfigRequestCount(1)
 
         expect(self.diskCache.read()).to(beNil())
@@ -553,7 +553,7 @@ private extension RemoteConfigIntegrationTests {
     ) async {
         self.mockRemoteConfigResponse(body: body, verificationResult: verificationResult)
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         await self.waitForRemoteConfigRequestCount(1)
         await self.waitForPersistedManifest(Self.manifest)
     }
@@ -568,7 +568,7 @@ private extension RemoteConfigIntegrationTests {
         ))
         self.mockRemoteConfigFallbackResponse(body: body, verificationResult: verificationResult)
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         await self.waitForRemoteConfigRequestCount(1)
         await self.waitForRemoteConfigFallbackRequestCount(1)
         await self.waitForPersistedManifest(Self.manifest)

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -57,54 +57,68 @@ final class RemoteConfigManagerTests: TestCase {
         try super.tearDownWithError()
     }
 
+    func testRefreshRemoteConfigIfStaleSendsForegroundFetchContext() {
+        self.manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.fetchContext) == .foreground
+    }
+
+    func testRefreshRemoteConfigSendsPassedFetchContext() {
+        self.manager.refreshRemoteConfig(fetchContext: .identityChange, isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.fetchContext) == .identityChange
+    }
+
     func testIsDisabledDefaultsToFalse() {
         expect(self.manager.isDisabled) == false
     }
 
     func testRefreshRemoteConfigIfStaleRefreshesWhenNeverRefreshed() {
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
     }
 
     func testNoContentResponseMarksRefreshAsFresh() {
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
 
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
     }
 
     func testFreshRefreshDoesNotStartAnotherRequest() {
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
 
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
     }
 
     func testFailureDoesNotMarkRefreshAsFresh() {
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1)))))
         self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
 
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
     }
 
     func testRefreshRemoteConfigIfStaleUsesForegroundAndBackgroundDurations() {
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
 
         self.dateProvider.advance(by: 6)
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: true)
+        self.manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: true)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
 
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
     }
@@ -112,8 +126,8 @@ final class RemoteConfigManagerTests: TestCase {
     func testClosePreventsNewRefreshes() {
         self.manager.close()
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 0
     }
@@ -162,7 +176,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.manager.close()
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
@@ -176,10 +190,11 @@ final class RemoteConfigManagerTests: TestCase {
     func testFirstRunSendsDefaultAppDomainManifest() throws {
         self.diskCache.stubbedRead = nil
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.appUserID) == Self.appUserID
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.fetchContext) == .appStart
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.manifest).to(beNil())
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.prefetchedBlobs).to(beEmpty())
     }
@@ -194,7 +209,7 @@ final class RemoteConfigManagerTests: TestCase {
             topics: .init()
         )
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: true)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.appUserID) == Self.appUserID
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.domain) == "custom"
@@ -204,13 +219,13 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testOverlappingRefreshesAreIgnoredUntilInFlightRefreshCompletes() {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: true)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
 
         self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: true)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.isAppBackgrounded) == true
@@ -224,7 +239,7 @@ final class RemoteConfigManagerTests: TestCase {
             topics: .init()
         )
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: true)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.prefetchedBlobs) == ["cachedBlob"]
         expect(self.blobStore.invokedCachedRefsCount) == 1
@@ -250,7 +265,7 @@ final class RemoteConfigManagerTests: TestCase {
             topics: .init(entries: ["sources": ["api": item]])
         )
         self.diskCache.stubbedRead = persisted
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.diskCache.readHandler = {
             self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
             return persisted
@@ -398,7 +413,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         let task = Task {
             await self.manager.topic(.sources)?["api"]?.content["url"]
         }
@@ -420,7 +435,7 @@ final class RemoteConfigManagerTests: TestCase {
                 "sources": ["api": .init(content: ["url": "https://api.revenuecat.com"])]
             ])
         )
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
 
         let topic = await self.manager.topic(.sources)
@@ -711,7 +726,7 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testMergeItemsBlobDataReturnsNilForEmptyItemKeysWhenRemoteConfigIsDisabledWithoutReadingBlobs() async throws {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
 
         let value = try await self.manager.mergeItemsBlobData(
@@ -892,7 +907,7 @@ final class RemoteConfigManagerTests: TestCase {
             topics: .init(entries: ["workflows": ["wf1": .init(blobRef: ref)]])
         )
         self.blobStore.stubbedReadDataByRef[ref] = blob
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
 
         let value = try await self.manager.mergeItemsBlobData(
@@ -1108,7 +1123,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
         )
@@ -1136,7 +1151,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.compressedContainer(
                 config: response,
@@ -1169,7 +1184,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
         )
@@ -1203,7 +1218,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
         )
@@ -1240,7 +1255,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
         )
@@ -1270,7 +1285,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
         )
@@ -1291,7 +1306,7 @@ final class RemoteConfigManagerTests: TestCase {
         )
         self.diskCache.stubbedRead = previous
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
 
         expect(self.diskCache.invokedWriteCount) == 0
@@ -1303,7 +1318,7 @@ final class RemoteConfigManagerTests: TestCase {
     func testNoContentResponseWithNoPersistedCacheLeavesCacheUntouched() {
         self.diskCache.stubbedRead = nil
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
 
         expect(self.diskCache.invokedWriteCount) == 0
@@ -1317,7 +1332,7 @@ final class RemoteConfigManagerTests: TestCase {
             manifest: "v1.1710000100.sources:etag1"
         )
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1))))
         )
@@ -1343,11 +1358,11 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
         )
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
         expect(self.diskCache.invokedWriteCount) == 0
@@ -1362,10 +1377,10 @@ final class RemoteConfigManagerTests: TestCase {
         )
 
         expect(self.manager.isDisabled) == false
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .invalidRequest)))
         expect(self.manager.isDisabled) == true
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
         expect(self.diskCache.invokedReadCount) == 1
@@ -1377,33 +1392,33 @@ final class RemoteConfigManagerTests: TestCase {
 
     func testTooManyRequestsResponseDisablesRemoteConfig() {
         expect(self.manager.isDisabled) == false
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .tooManyRequests)))
         expect(self.manager.isDisabled) == true
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
         expect(self.diskCache.invokedReadCount) == 1
     }
 
     func testServerErrorDoesNotDisableRemoteConfig() {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
         self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
         expect(self.manager.isDisabled) == false
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
         expect(self.diskCache.invokedReadCount) == 2
     }
 
     func testFallbackClientErrorDisablesRemoteConfig() {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
         self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .invalidRequest)))
         expect(self.manager.isDisabled) == true
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
         expect(self.remoteConfigAPI.invokedGetRemoteConfigFallbackCount) == 1
@@ -1411,7 +1426,7 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testPrimaryServerErrorTriggersFallbackConfigRequest() {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: true)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigFallbackCount) == 1
@@ -1422,7 +1437,7 @@ final class RemoteConfigManagerTests: TestCase {
     func testPrimaryServerErrorWithPersistedCacheDoesNotTriggerFallbackConfigRequest() {
         self.diskCache.stubbedRead = Self.persisted(domain: "app", manifest: "cached-manifest")
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: true)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
 
         expect(self.manager.isDisabled) == false
@@ -1434,7 +1449,7 @@ final class RemoteConfigManagerTests: TestCase {
         SystemInfo.proxyURL = try XCTUnwrap(URL(string: "https://proxy.revenuecat.com"))
         defer { SystemInfo.proxyURL = nil }
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: true)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
 
         expect(self.manager.isDisabled) == false
@@ -1443,7 +1458,7 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testPrimaryClientErrorDisablesRemoteConfigAndDoesNotTriggerFallbackConfigRequest() {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
 
         expect(self.manager.isDisabled) == true
@@ -1463,7 +1478,7 @@ final class RemoteConfigManagerTests: TestCase {
             ])
         )
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
         self.remoteConfigAPI.completeFallback(with: .success(.test(configuration: configuration)))
 
@@ -1478,11 +1493,11 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testFallbackConfigFailureLeavesCacheUntouchedAndDoesNotMarkRefreshFresh() {
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
         self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
 
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
         expect(self.diskCache.invokedWriteCount) == 0
@@ -1492,25 +1507,25 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testTransportNetworkErrorDoesNotDisableRemoteConfig() {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1))))
         )
         self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
         expect(self.manager.isDisabled) == false
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
         expect(self.diskCache.invokedReadCount) == 2
     }
 
     func testClearCacheDoesNotReenableDisabledRemoteConfigRefresh() {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
         expect(self.manager.isDisabled) == true
         self.manager.clearCache(forAppUserID: Self.appUserID)
         expect(self.manager.isDisabled) == true
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
         expect(self.diskCache.invokedClearCount) == 1
@@ -1518,7 +1533,7 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testMalformedConfigPayloadLeavesCacheUntouched() throws {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: "{ not valid json")))
         )
@@ -1544,7 +1559,7 @@ final class RemoteConfigManagerTests: TestCase {
         """
         let invalidContentElement = "{ invalid content element json".asData
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response, contentElements: [invalidContentElement])
@@ -1576,7 +1591,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         let task = Task {
             await self.manager.blobData(for: .workflows, itemKey: "default")
         }
@@ -1618,6 +1633,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         await self.waitForRemoteConfigRequestCount(1)
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.isAppBackgrounded) == false
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.fetchContext) == .read
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
         )
@@ -1708,13 +1724,13 @@ final class RemoteConfigManagerTests: TestCase {
     func testRefreshUsesBoundAppUserIDIfIdentityClearRacesRefreshPreparation() {
         self.manager.clearCache(forAppUserID: "new-user")
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.appUserID) == "new-user"
     }
 
     func testBlobDataNoContentRefreshCompletesWaitingRead() async {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
 
         let task = Task {
             await self.manager.blobData(for: .sources, itemKey: "api")
@@ -1728,7 +1744,7 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testBlobDataFailedRefreshCompletesWaitingRead() async {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
 
         let task = Task {
             await self.manager.blobData(for: .sources, itemKey: "api")
@@ -1743,7 +1759,7 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testBlobDataMalformedRefreshCompletesWaitingRead() async throws {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
 
         let task = Task {
             await self.manager.blobData(for: .sources, itemKey: "api")
@@ -1759,7 +1775,7 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testBlobDataClearCacheCompletesWaitingRead() async {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
 
         let task = Task {
             await self.manager.blobData(for: .sources, itemKey: "api")
@@ -1816,7 +1832,7 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testBlobDataCloseCompletesWaitingRead() async {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
 
         let task = Task {
             await self.manager.blobData(for: .sources, itemKey: "api")
@@ -1830,7 +1846,7 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testBlobDataDoesNotTriggerRefreshWhenRemoteConfigIsDisabled() async {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
 
         let data = await self.manager.blobData(for: .sources, itemKey: "api")
@@ -1845,7 +1861,7 @@ final class RemoteConfigManagerTests: TestCase {
             manifest: "v1.1710000100.workflows:etag1",
             topics: .init(entries: ["workflows": ["default": .init(blobRef: ref)]])
         )
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .forbidden)))
         let readCountAfterDisabling = self.diskCache.invokedReadCount
 
@@ -1873,7 +1889,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response, contentElements: [blob]),
@@ -1905,7 +1921,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response, contentElements: [blob]),
@@ -1926,7 +1942,7 @@ final class RemoteConfigManagerTests: TestCase {
         let workflowBlobRef = RCContainerTestData.blobRef(for: RCContainerTestData.workflowBlob)
         let summerWorkflowBlobRef = RCContainerTestData.blobRef(for: RCContainerTestData.summerWorkflowBlob)
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: container,
@@ -1958,7 +1974,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.compressedContainer(
@@ -1989,7 +2005,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.compressedContainer(
@@ -2020,7 +2036,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try RemoteConfigContainer(
@@ -2056,7 +2072,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response, contentElements: [referencedBlob, unreferencedBlob]),
@@ -2086,7 +2102,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response, contentElements: [prefetchBlob]),
@@ -2125,7 +2141,7 @@ final class RemoteConfigManagerTests: TestCase {
             }
         )
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try RemoteConfigContainer(data: containerData),
@@ -2155,7 +2171,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response),
@@ -2179,7 +2195,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response),
@@ -2202,7 +2218,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response),
@@ -2237,7 +2253,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response),
@@ -2270,7 +2286,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(
                 container: try Self.container(config: response, contentElements: [blob]),
@@ -2293,11 +2309,11 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
         )
-        self.manager.refreshRemoteConfigIfStale(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
     }
@@ -2324,7 +2340,7 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.manager.clearCache(forAppUserID: Self.appUserID)
         self.remoteConfigAPI.complete(
             at: 0,
@@ -2342,7 +2358,7 @@ final class RemoteConfigManagerTests: TestCase {
             return nil
         }
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 0
         expect(self.diskCache.invokedClearCount) == 1
@@ -2350,17 +2366,17 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testStaleNoContentResponseDoesNotReleaseNewerRefreshGuard() {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.manager.clearCache(forAppUserID: Self.appUserID)
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: true)
 
         self.remoteConfigAPI.complete(at: 0, with: .success(.test(container: nil)))
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
 
         self.remoteConfigAPI.complete(at: 1, with: .success(.test(container: nil)))
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 3
     }
@@ -2379,57 +2395,57 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.manager.clearCache(forAppUserID: Self.appUserID)
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: true)
 
         self.remoteConfigAPI.complete(
             at: 0,
             with: .success(.test(container: try Self.container(config: response)))
         )
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
         expect(self.diskCache.invokedWriteCount) == 0
 
         self.remoteConfigAPI.complete(at: 1, with: .success(.test(container: nil)))
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 3
     }
 
     func testStaleErrorResponseDoesNotReleaseNewerRefreshGuard() {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.manager.clearCache(forAppUserID: Self.appUserID)
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: true)
 
         self.remoteConfigAPI.complete(
             at: 0,
             with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1))))
         )
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
 
         self.remoteConfigAPI.complete(at: 1, with: .success(.test(container: nil)))
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 3
     }
 
     func testStaleFourHundredResponseDoesNotDisableRemoteConfig() {
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.manager.clearCache(forAppUserID: Self.appUserID)
-        self.manager.refreshRemoteConfig(isAppBackgrounded: true)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: true)
 
         self.remoteConfigAPI.complete(at: 0, with: .failure(Self.backendError(statusCode: .invalidRequest)))
         expect(self.manager.isDisabled) == false
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
 
         self.remoteConfigAPI.complete(at: 1, with: .success(.test(container: nil)))
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 3
     }
@@ -2450,7 +2466,7 @@ final class RemoteConfigManagerTests: TestCase {
         """
 
         self.manager.clearCache(forAppUserID: Self.appUserID)
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
             with: .success(.test(container: try Self.container(config: response)))
         )
@@ -2487,7 +2503,7 @@ final class RemoteConfigManagerTests: TestCase {
             clearEntered.signal()
         }
 
-        self.manager.refreshRemoteConfig(isAppBackgrounded: false)
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         DispatchQueue.global().async {
             self.remoteConfigAPI.complete(
                 with: .success(.test(container: container))

--- a/Tests/UnitTests/Networking/Responses/RemoteConfigurationDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/RemoteConfigurationDecodingTests.swift
@@ -373,6 +373,7 @@ final class RemoteConfigurationDecodingTests: TestCase {
 
     func testRequestEncodingOmitsDomain() throws {
         let request = RemoteConfigRequest(
+            fetchContext: .appStart,
             appUserID: "app-user-id",
             domain: "project",
             manifest: "v1.123.sources:sources-etag",
@@ -383,18 +384,20 @@ final class RemoteConfigurationDecodingTests: TestCase {
         let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
 
         expect(json["app_user_id"] as? String) == "app-user-id"
+        expect(json["fetch_context"] as? String) == "app_start"
         expect(json["domain"]).to(beNil())
         expect(json["manifest"] as? String) == "v1.123.sources:sources-etag"
         expect(json["prefetched_blobs"] as? [String]) == ["blob-b", "blob-a"]
     }
 
     func testFirstRunRequestEncodingIncludesEmptyPrefetchedBlobs() throws {
-        let request = RemoteConfigRequest(appUserID: "app-user-id")
+        let request = RemoteConfigRequest(fetchContext: .appStart, appUserID: "app-user-id")
 
         let data = try JSONEncoder.default.encode(request)
         let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
 
         expect(json["app_user_id"] as? String) == "app-user-id"
+        expect(json["fetch_context"] as? String) == "app_start"
         expect(json["domain"]).to(beNil())
         expect(json["manifest"]).to(beNil())
         expect(json["prefetched_blobs"] as? [String]).to(beEmpty())

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -1302,7 +1302,7 @@ private extension BaseSignatureVerificationHTTPClientTests {
 
     static var remoteConfigRequest: HTTPRequest {
         return .init(
-            method: .post(RemoteConfigRequest(appUserID: "app-user-id")),
+            method: .post(RemoteConfigRequest(fetchContext: .appStart, appUserID: "app-user-id")),
             path: HTTPRequest.Path.remoteConfig(domain: "app")
         )
     }

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -675,6 +675,7 @@ extension BasePurchasesTests.MockOfferingsAPI: @unchecked Sendable {}
 final class MockRemoteConfigManager: RemoteConfigManagerType {
 
     struct RefreshParameters {
+        let fetchContext: RemoteConfigFetchContext
         let isAppBackgrounded: Bool
     }
 
@@ -688,14 +689,18 @@ final class MockRemoteConfigManager: RemoteConfigManagerType {
     private(set) var invokedRefreshRemoteConfigIfStaleParametersList: [RefreshParameters] = []
     private(set) var invokedClearCacheAppUserIDs: [String] = []
 
-    func refreshRemoteConfig(isAppBackgrounded: Bool) {
+    func refreshRemoteConfig(fetchContext: RemoteConfigFetchContext, isAppBackgrounded: Bool) {
         self.invokedRefreshRemoteConfigCount += 1
-        self.invokedRefreshRemoteConfigParametersList.append(.init(isAppBackgrounded: isAppBackgrounded))
+        self.invokedRefreshRemoteConfigParametersList.append(
+            .init(fetchContext: fetchContext, isAppBackgrounded: isAppBackgrounded)
+        )
     }
 
-    func refreshRemoteConfigIfStale(isAppBackgrounded: Bool) {
+    func refreshRemoteConfigIfStale(fetchContext: RemoteConfigFetchContext, isAppBackgrounded: Bool) {
         self.invokedRefreshRemoteConfigIfStaleCount += 1
-        self.invokedRefreshRemoteConfigIfStaleParametersList.append(.init(isAppBackgrounded: isAppBackgrounded))
+        self.invokedRefreshRemoteConfigIfStaleParametersList.append(
+            .init(fetchContext: fetchContext, isAppBackgrounded: isAppBackgrounded)
+        )
     }
 
     var stubbedTopics: [RemoteConfigTopic: RemoteConfiguration.ConfigTopic] = [:]


### PR DESCRIPTION
### Checklist
- [x] Unit tests
- [ ] Follow-up issues for `purchases-android` and hybrids

### Motivation
The backend caches resolved config for ~30 minutes, so config changes don't reach clients until the cache expires. Telling the backend why the SDK is fetching lets it decide when to force a fresh resolution.

### Description
Adds a `fetch_context` field to every `POST /v1/config/app` request, backed by a new `RemoteConfigFetchContext` enum (`app_start`, `foreground`, `identity_change`, `read`). `fetch_context` is also part of the request `cacheKey`, so concurrent fetches made for different reasons no longer coalesce — otherwise a fresh-wanting fetch (e.g. `app_start`) could piggyback on an in-flight `read` and receive a backend-cached response. Same-context triggers still coalesce into one request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the remote config request contract and coalescing behavior across lifecycle and identity paths; risk is mitigated by broad test updates but backend must honor the new field correctly.
> 
> **Overview**
> Adds **`fetch_context`** to every remote config `POST` so the backend knows **why** the SDK is fetching (`app_start`, `foreground`, `identity_change`, `read`) and can decide when to bypass its ~30-minute resolved-config cache.
> 
> A new **`RemoteConfigFetchContext`** enum is encoded on **`RemoteConfigRequest`** and threaded through **`RemoteConfigManager`** refresh APIs. **`Purchases`** passes the matching context from lifecycle and identity flows (initial foreground setup → `app_start`, foreground → `foreground`, login/logout/switch user → `identity_change`). Read-driven stale refreshes from **`RemoteConfigManager`** use **`read`**.
> 
> **`fetch_context` is included in the request `cacheKey`**, so in-flight coalescing no longer merges requests that differ only by reason—avoiding a high-priority fetch piggybacking on a `read` and getting a cached response. Same-context requests still coalesce.
> 
> Tests cover JSON encoding, manager forwarding, and a new coalescing case for differing contexts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ff9c62612fac4e80143d1f1e319b30a6b1304ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->