### PR TITLE
test(remote-config): add a real-backend health check for CDN blob downloads

### DIFF
--- a/Projects/RevenueCatTests/Project.swift
+++ b/Projects/RevenueCatTests/Project.swift
@@ -228,6 +228,34 @@ let project = Project(
             metadata: .metadata(tags: ["RevenueCatTests"])
         ),
 
+        // MARK: – RemoteConfigProductionTests
+        // Lean real-backend health check for the remote config CDN blob path. No StoreKit,
+        // so no host app: just RevenueCat + Nimble. Skips itself unless a live key is injected.
+        .target(
+            name: "RemoteConfigProductionTests",
+            destinations: .iOS,
+            product: .unitTests,
+            bundleId: "com.revenuecat.RemoteConfigProductionTests",
+            deploymentTargets: .iOS("16.0"),
+            infoPlist: .default,
+            sources: [
+                "../../Tests/RemoteConfigProductionTests/**/*.swift",
+                // Shared `TestCase` base (repo convention) and its helpers.
+                "../../Tests/UnitTests/Misc/**/TestCase.swift",
+                "../../Tests/UnitTests/Misc/XCTestCase+Extensions.swift",
+                "../../Tests/UnitTests/TestHelpers/**/TestLogHandler.swift",
+                "../../Tests/UnitTests/TestHelpers/**/CurrentTestCaseTracker.swift",
+                "../../Tests/UnitTests/TestHelpers/**/AsyncTestHelpers.swift",
+                "../../Tests/UnitTests/TestHelpers/**/OSVersionEquivalent.swift"
+            ],
+            dependencies: [
+                .revenueCat,
+                .nimble,
+                .snapshotTesting
+            ],
+            metadata: .metadata(tags: ["RevenueCatTests"])
+        ),
+
         // MARK: – RevenueCatAdMobTests
         .target(
             name: "RevenueCatAdMobTests",

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -2932,6 +2932,8 @@
 		A1B2C3D42FE6000000000009 /* RemoteConfigBlobDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobDownloaderTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE8000000000001 /* RemoteConfigIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigIntegrationTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE300000000001 /* ProductionRemoteConfigIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductionRemoteConfigIntegrationTests.swift; sourceTree = "<group>"; };
+		A1B2C3D42FEA000000000001 /* RecordingBlobDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingBlobDownloader.swift; sourceTree = "<group>"; };
+		A1B2C3D42FEA000000000002 /* RemoteConfigBlobHealthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobHealthTests.swift; sourceTree = "<group>"; };
 		E31E8A264E9F4375A3B29D78 /* RemoteConfigurationDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigurationDecodingTests.swift; sourceTree = "<group>"; };
 		FEDA000000000000000000A1 /* WeightedSourceSelectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightedSourceSelectorTests.swift; sourceTree = "<group>"; };
 		FEDA000000000000000000C1 /* RemoteConfigSourceProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigSourceProviderTests.swift; sourceTree = "<group>"; };
@@ -4109,6 +4111,7 @@
 			children = (
 				8337DD6D2E0A7CFE000798BF /* paywall-preview-resources */,
 				A1B2C3D42FE300000000000 /* BackendIntegrationTests */,
+				A1B2C3D42FEA000000000000 /* RemoteConfigProductionTests */,
 				2DD500EF2C519EB4009C19B7 /* TestingApps */,
 				2DAC5F7326F13C9800C5258F /* StoreKitUnitTests */,
 				57B425A3275800B60075BDC4 /* Test Plans */,
@@ -4653,6 +4656,15 @@
 				A1B2C3D42FE300000000001 /* ProductionRemoteConfigIntegrationTests.swift */,
 			);
 			path = BackendIntegrationTests;
+			sourceTree = "<group>";
+		};
+		A1B2C3D42FEA000000000000 /* RemoteConfigProductionTests */ = {
+			isa = PBXGroup;
+			children = (
+				A1B2C3D42FEA000000000001 /* RecordingBlobDownloader.swift */,
+				A1B2C3D42FEA000000000002 /* RemoteConfigBlobHealthTests.swift */,
+			);
+			path = RemoteConfigProductionTests;
 			sourceTree = "<group>";
 		};
 		35E840C1270FB45600899AE2 /* Support */ = {

--- a/Tests/RemoteConfigProductionTests/RecordingBlobDownloader.swift
+++ b/Tests/RemoteConfigProductionTests/RecordingBlobDownloader.swift
@@ -9,9 +9,9 @@
 //
 //  RecordingBlobDownloader.swift
 //
-//  Wraps the real blob downloader and records what actually crossed the network, so a real-backend
-//  test can check whether a specific blob was served from the CDN (its ref appears in a download
-//  URL), how many downloads failed, and how many distinct hosts were hit.
+//  Wraps the real blob downloader and records the URL of every download attempt by outcome, so a
+//  real-backend test can check a SPECIFIC blob's transport (its ref is substituted into the source
+//  URL) rather than a global count that mixes in unrelated topics fetched during the same sync.
 
 import Foundation
 @testable import RevenueCat
@@ -22,21 +22,20 @@ final class RecordingBlobDownloader: RemoteConfigBlobDownloaderType {
     private let lock = NSLock()
 
     private var _downloadedURLs: [URL] = []
-    private var _failureCount = 0
+    private var _failedURLs: [URL] = []
 
     init(wrapping wrapped: RemoteConfigBlobDownloaderType = URLSessionRemoteConfigBlobDownloader()) {
         self.wrapped = wrapped
     }
 
-    var failureCount: Int { self.lock.withLock { self._failureCount } }
-
-    var distinctHostCount: Int {
-        self.lock.withLock { Set(self._downloadedURLs.compactMap(\.host)).count }
-    }
-
     /// Whether this blob ref was downloaded from the CDN (the ref is substituted into the source URL).
     func didDownload(ref: String) -> Bool {
         self.lock.withLock { self._downloadedURLs.contains { $0.absoluteString.contains(ref) } }
+    }
+
+    /// Whether a download attempt for this blob ref failed (a primary that later fell over counts).
+    func didFail(ref: String) -> Bool {
+        self.lock.withLock { self._failedURLs.contains { $0.absoluteString.contains(ref) } }
     }
 
     func data(from url: URL) async throws -> Data {
@@ -45,7 +44,7 @@ final class RecordingBlobDownloader: RemoteConfigBlobDownloaderType {
             self.lock.withLock { self._downloadedURLs.append(url) }
             return data
         } catch {
-            self.lock.withLock { self._failureCount += 1 }
+            self.lock.withLock { self._failedURLs.append(url) }
             throw error
         }
     }

--- a/Tests/RemoteConfigProductionTests/RecordingBlobDownloader.swift
+++ b/Tests/RemoteConfigProductionTests/RecordingBlobDownloader.swift
@@ -38,6 +38,17 @@ final class RecordingBlobDownloader: RemoteConfigBlobDownloaderType {
         self.lock.withLock { self._failedURLs.contains { $0.absoluteString.contains(ref) } }
     }
 
+    /// Distinct hosts among successful downloads for the given refs (should be 1: no fallback host).
+    func distinctDownloadHosts(matchingAnyOf refs: Set<String>) -> Int {
+        self.lock.withLock {
+            Set(
+                self._downloadedURLs
+                    .filter { url in refs.contains { url.absoluteString.contains($0) } }
+                    .compactMap(\.host)
+            ).count
+        }
+    }
+
     func data(from url: URL) async throws -> Data {
         do {
             let data = try await self.wrapped.data(from: url)

--- a/Tests/RemoteConfigProductionTests/RecordingBlobDownloader.swift
+++ b/Tests/RemoteConfigProductionTests/RecordingBlobDownloader.swift
@@ -1,0 +1,56 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  RecordingBlobDownloader.swift
+//
+//  Wraps the real blob downloader and records what actually crossed the network, so a
+//  real-backend test can check transport health the SDK does not expose (how many blobs
+//  downloaded, how many failed, total bytes, and which hosts were hit).
+
+import Foundation
+@testable import RevenueCat
+
+final class RecordingBlobDownloader: RemoteConfigBlobDownloaderType {
+
+    private let wrapped: RemoteConfigBlobDownloaderType
+    private let lock = NSLock()
+
+    private var _successCount = 0
+    private var _failureCount = 0
+    private var _totalBytes = 0
+    private var _hosts: [String] = []
+
+    init(wrapping wrapped: RemoteConfigBlobDownloaderType = URLSessionRemoteConfigBlobDownloader()) {
+        self.wrapped = wrapped
+    }
+
+    var successCount: Int { self.lock.withLock { self._successCount } }
+    var failureCount: Int { self.lock.withLock { self._failureCount } }
+    var totalBytes: Int { self.lock.withLock { self._totalBytes } }
+    var distinctHostCount: Int { self.lock.withLock { Set(self._hosts).count } }
+
+    func data(from url: URL) async throws -> Data {
+        do {
+            let data = try await self.wrapped.data(from: url)
+            self.lock.withLock {
+                self._successCount += 1
+                self._totalBytes += data.count
+                if let host = url.host { self._hosts.append(host) }
+            }
+            return data
+        } catch {
+            self.lock.withLock {
+                self._failureCount += 1
+                if let host = url.host { self._hosts.append(host) }
+            }
+            throw error
+        }
+    }
+
+}

--- a/Tests/RemoteConfigProductionTests/RecordingBlobDownloader.swift
+++ b/Tests/RemoteConfigProductionTests/RecordingBlobDownloader.swift
@@ -9,9 +9,9 @@
 //
 //  RecordingBlobDownloader.swift
 //
-//  Wraps the real blob downloader and records what actually crossed the network, so a
-//  real-backend test can check transport health the SDK does not expose (how many blobs
-//  downloaded, how many failed, total bytes, and which hosts were hit).
+//  Wraps the real blob downloader and records what actually crossed the network, so a real-backend
+//  test can check whether a specific blob was served from the CDN (its ref appears in a download
+//  URL), how many downloads failed, and how many distinct hosts were hit.
 
 import Foundation
 @testable import RevenueCat
@@ -21,34 +21,31 @@ final class RecordingBlobDownloader: RemoteConfigBlobDownloaderType {
     private let wrapped: RemoteConfigBlobDownloaderType
     private let lock = NSLock()
 
-    private var _successCount = 0
+    private var _downloadedURLs: [URL] = []
     private var _failureCount = 0
-    private var _totalBytes = 0
-    private var _hosts: [String] = []
 
     init(wrapping wrapped: RemoteConfigBlobDownloaderType = URLSessionRemoteConfigBlobDownloader()) {
         self.wrapped = wrapped
     }
 
-    var successCount: Int { self.lock.withLock { self._successCount } }
     var failureCount: Int { self.lock.withLock { self._failureCount } }
-    var totalBytes: Int { self.lock.withLock { self._totalBytes } }
-    var distinctHostCount: Int { self.lock.withLock { Set(self._hosts).count } }
+
+    var distinctHostCount: Int {
+        self.lock.withLock { Set(self._downloadedURLs.compactMap(\.host)).count }
+    }
+
+    /// Whether this blob ref was downloaded from the CDN (the ref is substituted into the source URL).
+    func didDownload(ref: String) -> Bool {
+        self.lock.withLock { self._downloadedURLs.contains { $0.absoluteString.contains(ref) } }
+    }
 
     func data(from url: URL) async throws -> Data {
         do {
             let data = try await self.wrapped.data(from: url)
-            self.lock.withLock {
-                self._successCount += 1
-                self._totalBytes += data.count
-                if let host = url.host { self._hosts.append(host) }
-            }
+            self.lock.withLock { self._downloadedURLs.append(url) }
             return data
         } catch {
-            self.lock.withLock {
-                self._failureCount += 1
-                if let host = url.host { self._hosts.append(host) }
-            }
+            self.lock.withLock { self._failureCount += 1 }
             throw error
         }
     }

--- a/Tests/RemoteConfigProductionTests/RemoteConfigBlobHealthTests.swift
+++ b/Tests/RemoteConfigProductionTests/RemoteConfigBlobHealthTests.swift
@@ -50,8 +50,9 @@ final class RemoteConfigBlobHealthTests: TestCase {
 
         let (blobRefs, recorder) = try await self.resolveWorkflowBlobs(apiKey: Self.cdnApiKey)
 
-        // Every workflows blob was served from the CDN, and none failed. No workflows failure also
-        // means no fallback to another host, since a fallback only happens after a failure.
+        // resolveWorkflowBlobs guarantees blobRefs is non-empty (and every blob read back), so these
+        // checks are not vacuous. Every workflows blob was served from the CDN, and none failed. No
+        // workflows failure also means no fallback to another host (fallback only happens after one).
         expect(blobRefs.allSatisfy { recorder.didDownload(ref: $0) })
             .to(beTrue(), description: "Not every workflows blob was downloaded from the CDN.")
         expect(blobRefs.contains { recorder.didFail(ref: $0) })
@@ -67,7 +68,8 @@ final class RemoteConfigBlobHealthTests: TestCase {
 
         let (blobRefs, recorder) = try await self.resolveWorkflowBlobs(apiKey: Self.inlineApiKey)
 
-        // No workflows blob touched the CDN: none downloaded, none failed trying (they arrive inline).
+        // resolveWorkflowBlobs guarantees blobRefs is non-empty (and every blob read back), so these
+        // checks are not vacuous. No workflows blob touched the CDN: none downloaded, none failed.
         expect(blobRefs.contains { recorder.didDownload(ref: $0) })
             .to(beFalse(), description: "A workflows blob was unexpectedly downloaded from the CDN.")
         expect(blobRefs.contains { recorder.didFail(ref: $0) })

--- a/Tests/RemoteConfigProductionTests/RemoteConfigBlobHealthTests.swift
+++ b/Tests/RemoteConfigProductionTests/RemoteConfigBlobHealthTests.swift
@@ -57,6 +57,7 @@ final class RemoteConfigBlobHealthTests: TestCase {
             .to(beTrue(), description: "Not every workflows blob was downloaded from the CDN.")
         expect(blobRefs.contains { recorder.didFail(ref: $0) })
             .to(beFalse(), description: "A workflows blob download failed or fell back to another source.")
+        expect(recorder.distinctDownloadHosts(matchingAnyOf: blobRefs)) == 1
     }
 
     // The inline project: blobs arrive inside the config response, so nothing hits the CDN.

--- a/Tests/RemoteConfigProductionTests/RemoteConfigBlobHealthTests.swift
+++ b/Tests/RemoteConfigProductionTests/RemoteConfigBlobHealthTests.swift
@@ -9,9 +9,9 @@
 //
 //  RemoteConfigBlobHealthTests.swift
 //
-//  Real-backend health check for the remote config CDN blob path. Runs against a live project
-//  that serves CDN blobs and verifies they actually download and validate, so we find out when
-//  production (the backend, the CDN, or the offload flag) is broken, which mocked tests cannot.
+//  Real-backend health check for the remote config blob path. Runs against two live projects with
+//  fixed serving modes so we find out when production (the backend, the CDN, or the offload flag)
+//  is broken, which mocked tests cannot: one project forces blobs onto the CDN, one serves inline.
 
 import Foundation
 import Nimble
@@ -20,25 +20,88 @@ import XCTest
 
 final class RemoteConfigBlobHealthTests: TestCase {
 
-    // Substituted at CI time. Must be a project that serves CDN blobs (the prepared stress-test
-    // project with the CDN-offload flag on); otherwise there is nothing to download to check.
-    private static let apiKey = "REVENUECAT_REMOTE_CONFIG_API_KEY"
+    // Two projects with fixed serving modes. Substituted at CI time; each test skips until its key
+    // is provided. `cdnApiKey` must be a project with the CDN-offload flag on; `inlineApiKey` off.
+    private static let cdnApiKey = "REVENUECAT_REMOTE_CONFIG_CDN_API_KEY"
+    private static let inlineApiKey = "REVENUECAT_REMOTE_CONFIG_INLINE_API_KEY"
 
     private var rootURL: URL!
-    private var recorder: RecordingBlobDownloader!
-    private var blobStore: RemoteConfigBlobStore!
-    private var manager: RemoteConfigManager!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-
-        try XCTSkipIf(
-            Self.apiKey == "REVENUECAT_REMOTE_CONFIG_API_KEY",
-            "No live API key substituted; skipping the real-backend blob health check."
-        )
-
         self.rootURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("RemoteConfigProductionTests-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let rootURL = self.rootURL {
+            try? FileManager.default.removeItem(at: rootURL)
+        }
+        self.rootURL = nil
+        try super.tearDownWithError()
+    }
+
+    // The CDN-forced project: every referenced blob must be downloaded from the CDN, once, one host.
+    func testCDNProjectDownloadsEveryReferencedBlobFromOneHost() async throws {
+        try XCTSkipIf(
+            Self.cdnApiKey == "REVENUECAT_REMOTE_CONFIG_CDN_API_KEY",
+            "No CDN-project key substituted; skipping."
+        )
+
+        let (blobRefs, recorder) = try await self.resolveWorkflowBlobs(apiKey: Self.cdnApiKey)
+
+        // Every workflows blob was served from the CDN, none failed, all from a single host.
+        expect(blobRefs.allSatisfy { recorder.didDownload(ref: $0) })
+            .to(beTrue(), description: "Not every workflows blob was downloaded from the CDN.")
+        expect(recorder.failureCount) == 0
+        expect(recorder.distinctHostCount) == 1
+    }
+
+    // The inline project: blobs arrive inside the config response, so nothing hits the CDN.
+    func testInlineProjectServesEveryBlobWithoutHittingTheCDN() async throws {
+        try XCTSkipIf(
+            Self.inlineApiKey == "REVENUECAT_REMOTE_CONFIG_INLINE_API_KEY",
+            "No inline-project key substituted; skipping."
+        )
+
+        let (blobRefs, recorder) = try await self.resolveWorkflowBlobs(apiKey: Self.inlineApiKey)
+
+        // No workflows blob was fetched from the CDN (they arrive inline), and nothing failed trying.
+        expect(blobRefs.contains { recorder.didDownload(ref: $0) })
+            .to(beFalse(), description: "A workflows blob was unexpectedly downloaded from the CDN.")
+        expect(recorder.failureCount) == 0
+    }
+
+    /// Builds a real manager for `apiKey`, resolves the workflows topic's blobs through the real
+    /// backend, asserts every referenced blob is present and non-empty (shared by both modes), and
+    /// returns the distinct blob refs plus the recorder for the caller's transport assertions.
+    private func resolveWorkflowBlobs(
+        apiKey: String
+    ) async throws -> (blobRefs: Set<String>, recorder: RecordingBlobDownloader) {
+        let recorder = RecordingBlobDownloader()
+        let manager = try self.makeManager(apiKey: apiKey, recorder: recorder)
+        defer { manager.close() }
+
+        let maybeTopic = await manager.awaitTopicAndPrefetchBlobsReady(.workflows)
+        let topic = try XCTUnwrap(maybeTopic, "No workflows topic returned from the live backend.")
+
+        let blobRefs = Set(topic.values.compactMap(\.blobRef))
+        let blobItemKeys = topic.compactMap { key, item in item.blobRef == nil ? nil : key }
+
+        // The project must actually reference blobs, or there is nothing to monitor.
+        expect(blobRefs).toNot(beEmpty())
+
+        // Every referenced blob resolves to non-empty content (a bad checksum stores nothing -> nil).
+        for key in blobItemKeys {
+            let data = await manager.blobData(for: .workflows, itemKey: key)
+            let blob = try XCTUnwrap(data, "Blob for item \(key) did not resolve.")
+            expect(blob.isEmpty).to(beFalse(), description: "Blob for item \(key) was empty.")
+        }
+
+        return (blobRefs, recorder)
+    }
+
+    private func makeManager(apiKey: String, recorder: RecordingBlobDownloader) throws -> RemoteConfigManager {
         let directoryType = DirectoryHelper.DirectoryType.applicationSupport(overrideURL: self.rootURL)
         let cacheBasePath = "\(RemoteConfigDiskCache.basePath)-\(UUID().uuidString)"
         let synchronizedCache = SynchronizedLargeItemCache(
@@ -50,23 +113,16 @@ final class RemoteConfigBlobHealthTests: TestCase {
             .appendingPathComponent(cacheBasePath, isDirectory: true)
 
         let diskCache = RemoteConfigDiskCache(cache: synchronizedCache)
-        self.blobStore = RemoteConfigBlobStore(
+        let blobStore = RemoteConfigBlobStore(
             fileManager: .default,
             directoryURL: cacheDirectoryURL.appendingPathComponent("blobs", isDirectory: true)
         )
         let sourceProvider = RemoteConfigSourceProvider(topicStore: diskCache)
-        self.recorder = RecordingBlobDownloader()
-        self.manager = self.makeManager(diskCache: diskCache, sourceProvider: sourceProvider)
-    }
 
-    private func makeManager(
-        diskCache: RemoteConfigDiskCache,
-        sourceProvider: RemoteConfigSourceProvider
-    ) -> RemoteConfigManager {
         let systemInfo = SystemInfo(
             platformInfo: nil,
             finishTransactions: true,
-            apiKey: Self.apiKey,
+            apiKey: apiKey,
             preferredLocalesProvider: PreferredLocalesProvider(preferredLocaleOverride: nil)
         )
         let backend = Backend(
@@ -83,48 +139,14 @@ final class RemoteConfigBlobHealthTests: TestCase {
         return RemoteConfigManager(
             remoteConfigAPI: backend.remoteConfigAPI,
             diskCache: diskCache,
-            blobStore: self.blobStore,
+            blobStore: blobStore,
             blobFetcher: RemoteConfigBlobFetcher(
-                blobStore: self.blobStore,
+                blobStore: blobStore,
                 sourceProvider: sourceProvider,
-                downloader: self.recorder
+                downloader: recorder
             ),
             currentUserProvider: ProductionTestUserProvider()
         )
-    }
-
-    override func tearDownWithError() throws {
-        self.manager?.close()
-        if let rootURL = self.rootURL {
-            try? FileManager.default.removeItem(at: rootURL)
-        }
-        self.manager = nil
-        self.blobStore = nil
-        self.recorder = nil
-        self.rootURL = nil
-        try super.tearDownWithError()
-    }
-
-    func testProductionWorkflowBlobsDownloadAndValidateHealthily() async throws {
-        // Fetch config from the live backend and download the workflows topic's prefetch blobs
-        // through the real CDN path.
-        let maybeTopic = await self.manager.awaitTopicAndPrefetchBlobsReady(.workflows)
-        let topic = try XCTUnwrap(maybeTopic, "No workflows topic returned from the live backend.")
-
-        let blobItemKeys = topic.compactMap { key, item in item.blobRef == nil ? nil : key }
-
-        // Every blob-backed item must read back. A download or checksum failure returns nil,
-        // so this covers checksum-failures == 0 and "all referenced blobs present".
-        for key in blobItemKeys {
-            let data = await self.manager.blobData(for: .workflows, itemKey: key)
-            expect(data).toNot(beNil(), description: "Blob for item \(key) did not resolve.")
-        }
-
-        // Transport-health invariants (recorded by RecordingBlobDownloader):
-        expect(self.recorder.successCount) > 0        // blobs_downloaded > 0
-        expect(self.recorder.failureCount) == 0       // error_count / failed_requests == 0
-        expect(self.recorder.distinctHostCount) <= 1  // fallback_host_requests == 0 (no second host)
-        expect(self.recorder.totalBytes) > 0          // blob bytes
     }
 
 }

--- a/Tests/RemoteConfigProductionTests/RemoteConfigBlobHealthTests.swift
+++ b/Tests/RemoteConfigProductionTests/RemoteConfigBlobHealthTests.swift
@@ -1,0 +1,135 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  RemoteConfigBlobHealthTests.swift
+//
+//  Real-backend health check for the remote config CDN blob path. Runs against a live project
+//  that serves CDN blobs and verifies they actually download and validate, so we find out when
+//  production (the backend, the CDN, or the offload flag) is broken, which mocked tests cannot.
+
+import Foundation
+import Nimble
+@testable import RevenueCat
+import XCTest
+
+final class RemoteConfigBlobHealthTests: TestCase {
+
+    // Substituted at CI time. Must be a project that serves CDN blobs (the prepared stress-test
+    // project with the CDN-offload flag on); otherwise there is nothing to download to check.
+    private static let apiKey = "REVENUECAT_REMOTE_CONFIG_API_KEY"
+
+    private var rootURL: URL!
+    private var recorder: RecordingBlobDownloader!
+    private var blobStore: RemoteConfigBlobStore!
+    private var manager: RemoteConfigManager!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        try XCTSkipIf(
+            Self.apiKey == "REVENUECAT_REMOTE_CONFIG_API_KEY",
+            "No live API key substituted; skipping the real-backend blob health check."
+        )
+
+        self.rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RemoteConfigProductionTests-\(UUID().uuidString)", isDirectory: true)
+        let directoryType = DirectoryHelper.DirectoryType.applicationSupport(overrideURL: self.rootURL)
+        let cacheBasePath = "\(RemoteConfigDiskCache.basePath)-\(UUID().uuidString)"
+        let synchronizedCache = SynchronizedLargeItemCache(
+            cache: FileManager.default,
+            basePath: cacheBasePath,
+            directoryType: directoryType
+        )
+        let cacheDirectoryURL = try XCTUnwrap(DirectoryHelper.baseUrl(for: directoryType))
+            .appendingPathComponent(cacheBasePath, isDirectory: true)
+
+        let diskCache = RemoteConfigDiskCache(cache: synchronizedCache)
+        self.blobStore = RemoteConfigBlobStore(
+            fileManager: .default,
+            directoryURL: cacheDirectoryURL.appendingPathComponent("blobs", isDirectory: true)
+        )
+        let sourceProvider = RemoteConfigSourceProvider(topicStore: diskCache)
+        self.recorder = RecordingBlobDownloader()
+        self.manager = self.makeManager(diskCache: diskCache, sourceProvider: sourceProvider)
+    }
+
+    private func makeManager(
+        diskCache: RemoteConfigDiskCache,
+        sourceProvider: RemoteConfigSourceProvider
+    ) -> RemoteConfigManager {
+        let systemInfo = SystemInfo(
+            platformInfo: nil,
+            finishTransactions: true,
+            apiKey: Self.apiKey,
+            preferredLocalesProvider: PreferredLocalesProvider(preferredLocaleOverride: nil)
+        )
+        let backend = Backend(
+            systemInfo: systemInfo,
+            eTagManager: ETagManager(),
+            operationDispatcher: .default,
+            attributionFetcher: AttributionFetcher(
+                attributionFactory: AttributionTypeFactory(),
+                systemInfo: systemInfo
+            ),
+            offlineCustomerInfoCreator: nil,
+            diagnosticsTracker: nil
+        )
+        return RemoteConfigManager(
+            remoteConfigAPI: backend.remoteConfigAPI,
+            diskCache: diskCache,
+            blobStore: self.blobStore,
+            blobFetcher: RemoteConfigBlobFetcher(
+                blobStore: self.blobStore,
+                sourceProvider: sourceProvider,
+                downloader: self.recorder
+            ),
+            currentUserProvider: ProductionTestUserProvider()
+        )
+    }
+
+    override func tearDownWithError() throws {
+        self.manager?.close()
+        if let rootURL = self.rootURL {
+            try? FileManager.default.removeItem(at: rootURL)
+        }
+        self.manager = nil
+        self.blobStore = nil
+        self.recorder = nil
+        self.rootURL = nil
+        try super.tearDownWithError()
+    }
+
+    func testProductionWorkflowBlobsDownloadAndValidateHealthily() async throws {
+        // Fetch config from the live backend and download the workflows topic's prefetch blobs
+        // through the real CDN path.
+        let maybeTopic = await self.manager.awaitTopicAndPrefetchBlobsReady(.workflows)
+        let topic = try XCTUnwrap(maybeTopic, "No workflows topic returned from the live backend.")
+
+        let blobItemKeys = topic.compactMap { key, item in item.blobRef == nil ? nil : key }
+
+        // Every blob-backed item must read back. A download or checksum failure returns nil,
+        // so this covers checksum-failures == 0 and "all referenced blobs present".
+        for key in blobItemKeys {
+            let data = await self.manager.blobData(for: .workflows, itemKey: key)
+            expect(data).toNot(beNil(), description: "Blob for item \(key) did not resolve.")
+        }
+
+        // Transport-health invariants (recorded by RecordingBlobDownloader):
+        expect(self.recorder.successCount) > 0        // blobs_downloaded > 0
+        expect(self.recorder.failureCount) == 0       // error_count / failed_requests == 0
+        expect(self.recorder.distinctHostCount) <= 1  // fallback_host_requests == 0 (no second host)
+        expect(self.recorder.totalBytes) > 0          // blob bytes
+    }
+
+}
+
+private struct ProductionTestUserProvider: CurrentUserProvider {
+    var currentAppUserID: String { "remote-config-production-test-user" }
+    var currentUserIsAnonymous: Bool { true }
+}

--- a/Tests/RemoteConfigProductionTests/RemoteConfigBlobHealthTests.swift
+++ b/Tests/RemoteConfigProductionTests/RemoteConfigBlobHealthTests.swift
@@ -50,11 +50,12 @@ final class RemoteConfigBlobHealthTests: TestCase {
 
         let (blobRefs, recorder) = try await self.resolveWorkflowBlobs(apiKey: Self.cdnApiKey)
 
-        // Every workflows blob was served from the CDN, none failed, all from a single host.
+        // Every workflows blob was served from the CDN, and none failed. No workflows failure also
+        // means no fallback to another host, since a fallback only happens after a failure.
         expect(blobRefs.allSatisfy { recorder.didDownload(ref: $0) })
             .to(beTrue(), description: "Not every workflows blob was downloaded from the CDN.")
-        expect(recorder.failureCount) == 0
-        expect(recorder.distinctHostCount) == 1
+        expect(blobRefs.contains { recorder.didFail(ref: $0) })
+            .to(beFalse(), description: "A workflows blob download failed or fell back to another source.")
     }
 
     // The inline project: blobs arrive inside the config response, so nothing hits the CDN.
@@ -66,10 +67,11 @@ final class RemoteConfigBlobHealthTests: TestCase {
 
         let (blobRefs, recorder) = try await self.resolveWorkflowBlobs(apiKey: Self.inlineApiKey)
 
-        // No workflows blob was fetched from the CDN (they arrive inline), and nothing failed trying.
+        // No workflows blob touched the CDN: none downloaded, none failed trying (they arrive inline).
         expect(blobRefs.contains { recorder.didDownload(ref: $0) })
             .to(beFalse(), description: "A workflows blob was unexpectedly downloaded from the CDN.")
-        expect(recorder.failureCount) == 0
+        expect(blobRefs.contains { recorder.didFail(ref: $0) })
+            .to(beFalse(), description: "A workflows blob download failed.")
     }
 
     /// Builds a real manager for `apiKey`, resolves the workflows topic's blobs through the real


### PR DESCRIPTION
### Why

The goal is to have a test suite that hits a real backend (no mocks). This adds a real-backend check for exactly that.

### Description

A small, standalone test target (`RemoteConfigProductionTests`) that hits the live backend and verifies the remote config blob path against **two projects with fixed serving modes**, so each test is deterministic instead of depending on a flag:

- **CDN project** (blobs forced to the CDN): every workflows blob was downloaded from the CDN, from a single host, none failed.
- **Inline project** (blobs served inline): no workflows blob was downloaded, none failed.

This is not yet connected in the CI.

<details>
<summary>AI session context</summary>

**Scope:** this block covers only this PR (the real-backend blob health target). Other work in the same session is unrelated and excluded.

**Metadata**
- Branch: `facu/remote-config-production-tests` (off `origin/main`)
- Head: `b1a262e69`
- Change: test-only, new target (2 files + a target in `Projects/RevenueCatTests/Project.swift`)
- Label: `pr:other` (no shipping code change)

**First actionable instruction:** build a check that tells us when the blob path is broken in production — blobs downloaded, no failures, no fallback host, all referenced blobs present.

**What changed and why:** those signals are not on the SDK's public surface, so a plain unit test can't read them. They're recorded at the network boundary with a test-only downloader wrapper, against the real backend, in a dedicated lean target. Two projects with fixed modes (CDN vs inline) make the assertions deterministic without toggling a flag.

**Human decisions:** preferred a dedicated target over reusing `BackendIntegrationTests` (isolation, own cadence); chose two fixed-mode projects over one flag-toggled project; asked for explicit, non-vague assertions; target + test now, CI wiring as a follow-up.

**Key correctness note (found by running against the live backend):** the recorder sees downloads for ALL topics (workflows + ui_config, both prefetched), so comparing a global download count to the workflows-only ref count over-counts (144 vs 142), and the "inline" project still serves one ui_config blob via CDN. Fixed by scoping the check per workflows ref (`recorder.didDownload(ref:)`), not by global counts.

**Files / symbols**
- `Tests/RemoteConfigProductionTests/RemoteConfigBlobHealthTests.swift` (new; two tests, inherits `TestCase`)
- `Tests/RemoteConfigProductionTests/RecordingBlobDownloader.swift` (new; wraps `URLSessionRemoteConfigBlobDownloader`)
- `Projects/RevenueCatTests/Project.swift` (new lean `.unitTests` target)
- Exercised (unchanged): `RemoteConfigManager.awaitTopicAndPrefetchBlobsReady`, `RemoteConfigBlobFetcher`, `RemoteConfigBlobStore`

**Proof:** both tests pass against the two live projects (CDN: every workflows blob downloaded, one host; inline: none downloaded). With no keys, both skip cleanly (0 failures). SwiftLint clean.

**Risks / reviewer notes:**
- Real-network test: belongs on its own lane, not the hermetic unit suite; assertions are invariants, not exact numbers (project content drifts).
- Requires two projects with fixed modes; the keys are placeholders substituted at CI time (`REVENUECAT_REMOTE_CONFIG_CDN_API_KEY` / `..._INLINE_API_KEY`).
- New target's files are registered in the legacy `RevenueCat.xcodeproj` (file-refs only, no build phase) to satisfy the Danger project-sync check until the #7014 migration lands.

**Open follow-up:** CI wiring (job + fastlane lane + key substitution for both projects). Until then the target only runs on demand.

**Related:** two companion test-only PRs from the same coverage audit — #7211 (gate delivers when a blob download fails) and #7212 (several config blobs at once, merged).

</details>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions with no SDK or production behavior changes; optional live-network runs gated by placeholder API keys.
> 
> **Overview**
> Adds a **lean `RemoteConfigProductionTests` unit target** (Tuist + legacy Xcode file refs) that exercises the live remote-config blob pipeline without StoreKit or a host app. Tests **skip** unless CI substitutes two API keys for projects with fixed serving modes.
> 
> Introduces **`RecordingBlobDownloader`**, which wraps the real `URLSession` downloader and records success/failure URLs so assertions can target **workflows blob refs** instead of global download counts (which mix in other prefetched topics).
> 
> **`RemoteConfigBlobHealthTests`** wires a real `RemoteConfigManager` and shared helper that loads the workflows topic, checks every referenced blob resolves to non-empty data, then mode-specific transport rules: **CDN project** — every workflows ref was downloaded, none failed, single host; **inline project** — no workflows ref was downloaded or failed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b9b9f4c6a03127f112eb28b7554c0c1243bdf04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->