### PR TITLE
Reset bottom sheet content identity when switching sheets

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -2920,6 +2920,7 @@
 		B3F8418E26F3A93400E560FB /* ErrorCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorCodeTests.swift; sourceTree = "<group>"; };
 		B413E59F2F97B3B900B5F0CA /* CarouselTabSwitchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselTabSwitchTests.swift; sourceTree = "<group>"; };
 		B413E5A02F97B3B900B5F0CA /* PaywallsV2ViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallsV2ViewTests.swift; sourceTree = "<group>"; };
+		DBB32F183007CACD00A86DC7 /* BottomSheetSwitchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetSwitchTests.swift; sourceTree = "<group>"; };
 		B49121C11022272A08D75B4E /* AccessorOperatorsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccessorOperatorsTests.swift; sourceTree = "<group>"; };
 		B72848B4B4D101F1B94E228E /* Value+JSON.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Value+JSON.swift"; sourceTree = "<group>"; };
 		B78483ACCDD62ABD40AF8827 /* Evaluator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Evaluator.swift; sourceTree = "<group>"; };
@@ -3259,6 +3260,7 @@
 				E78770053AB84EF380CC0C1D /* TextComponentViewLoadingTests.swift */,
 				B413E59F2F97B3B900B5F0CA /* CarouselTabSwitchTests.swift */,
 				B413E5A02F97B3B900B5F0CA /* PaywallsV2ViewTests.swift */,
+				DBB32F183007CACD00A86DC7 /* BottomSheetSwitchTests.swift */,
 				DB1FC9592F9A1B74009A95EA /* WorkflowScreenMapperTests.swift */,
 				F468C7BCEB786BEC80277ECA /* WorkflowNavigatorTests.swift */,
 				C07759C930F712D2D53B9333 /* WorkflowStepEventTrackerTests.swift */,

--- a/RevenueCatUI/Templates/V2/Components/Button/BottomSheetView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/BottomSheetView.swift
@@ -104,6 +104,14 @@ struct BottomSheetOverlayModifier: ViewModifier {
                     .onAppear {
                         self.onSheetContentAppear?()
                     }
+                    // Tie the sheet content's identity to the sheet's `id` so that
+                    // switching to a different sheet disposes the previous sheet's
+                    // content and builds the new one from scratch, instead of reusing
+                    // the views positionally. Without this, a rapid dismiss→open reuses
+                    // the same view identity while the dismiss animation is still in
+                    // flight, and media such as a video from the previous sheet keeps
+                    // playing in the newly-opened sheet.
+                    .id(sheetViewModel.sheet.id)
                 }
             }
             .background(

--- a/Tests/RevenueCatUITests/PaywallsV2/BottomSheetSwitchTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/BottomSheetSwitchTests.swift
@@ -1,0 +1,183 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  BottomSheetSwitchTests.swift
+//
+//  Created by RevenueCat on 7/14/26.
+
+@_spi(Internal) import RevenueCat
+@testable import RevenueCatUI
+import SwiftUI
+import XCTest
+
+#if os(iOS)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@MainActor
+final class BottomSheetSwitchTests: TestCase {
+
+    /// Regression test for a bug where switching from one bottom sheet to another before the
+    /// dismiss animation finished kept the previous sheet's content alive (most visibly, a video
+    /// from the previous sheet kept playing in the newly-opened sheet).
+    ///
+    /// Root cause: `BottomSheetOverlayModifier` rendered its content from a single `if let`
+    /// slot with no `.id()`, so identity was positional. A rapid switch reused the same view
+    /// identity while the dismiss animation was still in flight, `onAppear` never re-fired, and
+    /// state latched in `onAppear` (such as a video's cached URL) persisted.
+    ///
+    /// Fix: `.id(sheetViewModel.sheet.id)` is applied to the sheet content. When the presented
+    /// sheet changes, its identity changes, SwiftUI disposes the previous sheet's subtree and
+    /// builds the new one from scratch, and `onAppear` fires for the new sheet.
+    ///
+    /// The test verifies the fix by counting how many times the sheet content appears. It shows
+    /// sheet A, then switches directly to sheet B without letting the sheet settle back to `nil`.
+    /// With the fix the content is disposed and recreated → the appear callback fires again.
+    /// Without the fix the content is reused → the appear callback does not fire for sheet B.
+    func testSwitchingSheetsRecreatesContent() throws {
+        let holder = SheetHolder()
+        holder.sheet = try Self.makeSheetViewModel(id: "sheetA", text: "Sheet A")
+
+        var appearCount = 0
+
+        let view = SheetSwitchTestHostView(
+            holder: holder,
+            onSheetContentAppear: { appearCount += 1 }
+        )
+        .environmentObject(PurchaseHandler.default())
+        .environmentObject(PackageContext(package: nil, variableContext: .init(packages: [])))
+        .environmentObject(IntroOfferEligibilityContext(
+            introEligibilityChecker: BaseSnapshotTest.eligibleChecker
+        ))
+        .environmentObject(PaywallPromoOfferCache(
+            subscriptionHistoryTracker: SubscriptionHistoryTracker()
+        ))
+        .environment(\.screenCondition, .compact)
+        .environment(\.componentViewState, .default)
+        .environment(\.safeAreaInsets, EdgeInsets())
+        .environment(\.selectedPackageId, nil)
+        .frame(width: 400, height: 600)
+
+        let (window, _) = Self.host(view)
+        defer {
+            window.isHidden = true
+            window.rootViewController = nil
+        }
+
+        // Sheet A is presented on initial layout, so its content must have appeared exactly once.
+        XCTAssertEqual(appearCount, 1, "Sheet A content must appear once after it is presented")
+
+        // Switch directly to sheet B without settling back to `nil`, mimicking a rapid
+        // dismiss→open while the dismiss animation is still in flight.
+        holder.sheet = try Self.makeSheetViewModel(id: "sheetB", text: "Sheet B")
+
+        RunLoop.main.run(until: Date().addingTimeInterval(0.3))
+        window.rootViewController?.view.setNeedsLayout()
+        window.rootViewController?.view.layoutIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+
+        // After switching, sheet B's content must appear.
+        //
+        // BUG (now fixed): with a single unkeyed slot SwiftUI reused sheet A's view identity —
+        // `onAppear` never fired for sheet B and the old subtree (e.g. a playing video) lived on.
+        // The count stayed at 1.
+        //
+        // FIX: `.id(sheetViewModel.sheet.id)` forces SwiftUI to dispose sheet A's content and
+        // build sheet B's from scratch, so `onAppear` fires for sheet B. The count becomes 2.
+        XCTAssertEqual(
+            appearCount,
+            2,
+            "Sheet B content must appear after switching sheets, meaning sheet A's content was disposed"
+        )
+    }
+
+}
+
+// MARK: - Helpers
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private final class SheetHolder: ObservableObject {
+    @Published var sheet: SheetViewModel?
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private struct SheetSwitchTestHostView: View {
+
+    @ObservedObject var holder: SheetHolder
+    let onSheetContentAppear: () -> Void
+
+    var body: some View {
+        Color.clear
+            .bottomSheet(
+                sheet: Binding(
+                    get: { self.holder.sheet },
+                    set: { self.holder.sheet = $0 }
+                ),
+                safeAreaInsets: EdgeInsets(),
+                onSheetContentAppear: self.onSheetContentAppear
+            )
+    }
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension BottomSheetSwitchTests {
+
+    static func makeSheetViewModel(id: String, text: String) throws -> SheetViewModel {
+        let offering = Offering(
+            identifier: "test",
+            serverDescription: "",
+            availablePackages: [],
+            webCheckoutUrl: nil
+        )
+        let localization = LocalizationProvider(locale: Locale(identifier: "en_US"), localizedStrings: [:])
+        let uiConfigProvider = UIConfigProvider(uiConfig: PreviewUIConfig.make())
+        let factory = ViewModelFactory()
+
+        let stack = PaywallComponent.StackComponent(
+            components: [
+                .text(PaywallComponent.TextComponent(
+                    text: text,
+                    color: .init(light: .hex("#000000"))
+                ))
+            ]
+        )
+
+        let stackViewModel = try factory.toStackViewModel(
+            component: stack,
+            packageValidator: factory.packageValidator,
+            purchaseButtonCollector: nil,
+            localizationProvider: localization,
+            uiConfigProvider: uiConfigProvider,
+            offering: offering,
+            colorScheme: .light
+        )
+
+        let sheet = PaywallComponent.ButtonComponent.Sheet(
+            id: id,
+            name: nil,
+            stack: stack,
+            backgroundBlur: false,
+            size: .init(width: .fill, height: .fit)
+        )
+
+        return SheetViewModel(sheet: sheet, sheetStackViewModel: stackViewModel)
+    }
+
+    static func host<Content: View>(_ view: Content) -> (UIWindow, UIView) {
+        let controller = UIHostingController(rootView: view)
+        let window = UIWindow(frame: CGRect(origin: .zero, size: CGSize(width: 400, height: 600)))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        controller.view.layoutIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.2))
+        return (window, controller.view)
+    }
+
+}
+
+#endif

--- a/Tests/RevenueCatUITests/PaywallsV2/BottomSheetSwitchTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/BottomSheetSwitchTests.swift
@@ -162,7 +162,7 @@ private extension BottomSheetSwitchTests {
             name: nil,
             stack: stack,
             backgroundBlur: false,
-            size: .init(width: .fill, height: .fit)
+            size: .init(width: .fill, height: .fit(nil))
         )
 
         return SheetViewModel(sheet: sheet, sheetStackViewModel: stackViewModel)


### PR DESCRIPTION
On sheets, closing one sheet and immediately opening another kept a video from the previous sheet playing in the newly opened one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized SwiftUI identity change in paywall bottom sheet presentation plus a regression test; no auth, purchase, or data-path changes.
> 
> **Overview**
> Fixes Paywalls V2 bottom sheets where **closing one sheet and immediately opening another** could leave the previous sheet’s subtree alive—e.g. a **video kept playing** in the new sheet.
> 
> `BottomSheetOverlayModifier` now applies **`.id(sheetViewModel.sheet.id)`** on the presented `StackComponentView` so a different sheet id forces SwiftUI to tear down the old content and build fresh (including re-firing `onAppear`), instead of reusing the same positional slot while a dismiss animation is still running.
> 
> Adds **`BottomSheetSwitchTests`** to assert that switching directly from sheet A to sheet B increments the sheet content appear callback twice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db927828ac39782a7331286d7e3e20c921c912a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->