### PR TITLE
ci(remote-config): run the blob health monitor

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1377,6 +1377,32 @@ jobs:
           no_output_timeout: 30m
       - slack-notify-on-fail
 
+  remote-config-production-tests:
+    executor:
+      name: macos-executor
+    steps:
+      - checkout
+      - install-dependencies
+      - update-spm-installation-commit
+      - tuist-generate-workspace:
+          include_test_dependencies: true
+      - run:
+          name: Export blob-monitor API keys into the simulator test process
+          command: |
+            echo 'export SIMCTL_CHILD_REVENUECAT_REMOTE_CONFIG_CDN_API_KEY="${RC_REMOTE_CONFIG_CDN_API_KEY}"' >> "$BASH_ENV"
+            echo 'export SIMCTL_CHILD_REVENUECAT_REMOTE_CONFIG_INLINE_API_KEY="${RC_REMOTE_CONFIG_INLINE_API_KEY}"' >> "$BASH_ENV"
+      - run:
+          name: Run RemoteConfig production blob health monitor
+          command: bundle exec fastlane remote_config_production_tests
+          no_output_timeout: 5m
+          environment:
+            SCAN_DEVICE: iPhone 16 (18.5)
+      - store_test_results:
+          path: fastlane/test_output
+      - store_artifacts:
+          path: fastlane/test_output/xctest
+          destination: scan-test-output
+
   backend-integration-tests-SK1:
     executor:
       name: macos-executor
@@ -2593,6 +2619,16 @@ workflows:
         - equal: ["release-train", << pipeline.schedule.name >>]
     jobs:
       - release-train
+
+  remote-config-blob-monitor:
+    when:
+      and:
+        - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+        - equal: ["remote_config_blob_monitor", << pipeline.schedule.name >>]
+    jobs:
+      - remote-config-production-tests:
+          context:
+            - slack-secrets
 
   daily-loadshedder-integration-tests:
     when:

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -2629,6 +2629,7 @@ workflows:
     jobs:
       - remote-config-production-tests:
           context:
+            - config-endpoint-tests
             - slack-secrets
 
   daily-loadshedder-integration-tests:

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1402,6 +1402,7 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
+      - slack-notify-on-fail
 
   backend-integration-tests-SK1:
     executor:

--- a/.circleci/generate-requested-jobs-config.js
+++ b/.circleci/generate-requested-jobs-config.js
@@ -31,6 +31,7 @@ const JOBS = {
   "integration-tests-all": ["slack-secrets"],
   "lint": ["slack-secrets"],
   "pod-lib-lint": ["slack-secrets"],
+  "remote-config-production-tests": ["config-endpoint-tests", "slack-secrets"],
   "revenuecat-admob-tests": ["slack-secrets"],
   "run-all-maestro-e2e-tests": ["e2e-tests", "slack-secrets"],
   "run-revenuecat-ui-ios-18-and-17": ["slack-secrets"],

--- a/Tests/RemoteConfigProductionTests/RemoteConfigBlobHealthTests.swift
+++ b/Tests/RemoteConfigProductionTests/RemoteConfigBlobHealthTests.swift
@@ -20,10 +20,11 @@ import XCTest
 
 final class RemoteConfigBlobHealthTests: TestCase {
 
-    // Two projects with fixed serving modes. Substituted at CI time; each test skips until its key
-    // is provided. `cdnApiKey` must be a project with the CDN-offload flag on; `inlineApiKey` off.
-    private static let cdnApiKey = "REVENUECAT_REMOTE_CONFIG_CDN_API_KEY"
-    private static let inlineApiKey = "REVENUECAT_REMOTE_CONFIG_INLINE_API_KEY"
+    // Keys come from the environment (CI sets them from provisioned secrets), so no key ever lives in
+    // source and each test skips when its var is unset. The CDN project has the CDN-offload flag on;
+    // the inline project has it off. To run locally, set these in the scheme's Test env vars.
+    private static let cdnApiKey = ProcessInfo.processInfo.environment["REVENUECAT_REMOTE_CONFIG_CDN_API_KEY"]
+    private static let inlineApiKey = ProcessInfo.processInfo.environment["REVENUECAT_REMOTE_CONFIG_INLINE_API_KEY"]
 
     private var rootURL: URL!
 
@@ -43,12 +44,8 @@ final class RemoteConfigBlobHealthTests: TestCase {
 
     // The CDN-forced project: every referenced blob must be downloaded from the CDN, once, one host.
     func testCDNProjectDownloadsEveryReferencedBlobFromOneHost() async throws {
-        try XCTSkipIf(
-            Self.cdnApiKey == "REVENUECAT_REMOTE_CONFIG_CDN_API_KEY",
-            "No CDN-project key substituted; skipping."
-        )
-
-        let (blobRefs, recorder) = try await self.resolveWorkflowBlobs(apiKey: Self.cdnApiKey)
+        let apiKey = try self.requireKey(Self.cdnApiKey, "REVENUECAT_REMOTE_CONFIG_CDN_API_KEY")
+        let (blobRefs, recorder) = try await self.resolveWorkflowBlobs(apiKey: apiKey)
 
         // resolveWorkflowBlobs guarantees blobRefs is non-empty (and every blob read back), so these
         // checks are not vacuous. Every workflows blob was served from the CDN, and none failed. No
@@ -62,12 +59,8 @@ final class RemoteConfigBlobHealthTests: TestCase {
 
     // The inline project: blobs arrive inside the config response, so nothing hits the CDN.
     func testInlineProjectServesEveryBlobWithoutHittingTheCDN() async throws {
-        try XCTSkipIf(
-            Self.inlineApiKey == "REVENUECAT_REMOTE_CONFIG_INLINE_API_KEY",
-            "No inline-project key substituted; skipping."
-        )
-
-        let (blobRefs, recorder) = try await self.resolveWorkflowBlobs(apiKey: Self.inlineApiKey)
+        let apiKey = try self.requireKey(Self.inlineApiKey, "REVENUECAT_REMOTE_CONFIG_INLINE_API_KEY")
+        let (blobRefs, recorder) = try await self.resolveWorkflowBlobs(apiKey: apiKey)
 
         // resolveWorkflowBlobs guarantees blobRefs is non-empty (and every blob read back), so these
         // checks are not vacuous. No workflows blob touched the CDN: none downloaded, none failed.
@@ -75,6 +68,14 @@ final class RemoteConfigBlobHealthTests: TestCase {
             .to(beFalse(), description: "A workflows blob was unexpectedly downloaded from the CDN.")
         expect(blobRefs.contains { recorder.didFail(ref: $0) })
             .to(beFalse(), description: "A workflows blob download failed.")
+    }
+
+    /// Returns the key, or skips the test if the environment variable is unset (local/normal runs).
+    private func requireKey(_ key: String?, _ variable: String) throws -> String {
+        guard let key, !key.isEmpty else {
+            throw XCTSkip("\(variable) not set; skipping the real-backend blob health check.")
+        }
+        return key
     }
 
     /// Builds a real manager for `apiKey`, resolves the workflows topic's blobs through the real

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1821,6 +1821,24 @@ platform :ios do
   end
 
   desc "Run BackendIntegrationTests"
+  desc "Runs the remote config blob health monitor against the live backend (two projects)"
+  desc "Keys come from the environment (REVENUECAT_REMOTE_CONFIG_CDN_API_KEY / _INLINE_API_KEY);"
+  desc "each test skips if its key is unset, so no key is ever written into source."
+  lane :remote_config_production_tests do
+    scan(
+      workspace: 'RevenueCat-Tuist.xcworkspace',
+      scheme: "RemoteConfigProductionTests",
+      device: ENV['SCAN_DEVICE'] || "iPhone 16 (18.5)",
+      ensure_devices_found: true,
+      derived_data_path: "scan_derived_data",
+      output_types: 'junit',
+      result_bundle: true,
+      configuration: 'Debug',
+      output_directory: "fastlane/test_output/xctest/ios",
+      number_of_retries: 3
+    )
+  end
+
   lane :backend_integration_tests do |options|
     generate_snapshots = ENV["CIRCLECI_TESTS_GENERATE_SNAPSHOTS"] == "true"
     test_configuration = generate_snapshots ? "GenerateSnapshots" : "Default"


### PR DESCRIPTION
> Stacked on #7215 (the `RemoteConfigProductionTests` target). Review/merge that first; this only adds the CI wiring.

### Why

This makes it run on a schedule so we actually find out when the CDN/inline blob path breaks in production.

### Description

- **Keys via the environment.** The tests read the two project keys from `ProcessInfo` (`REVENUECAT_REMOTE_CONFIG_CDN_API_KEY` / `REVENUECAT_REMOTE_CONFIG_INLINE_API_KEY`) and skip when unset, so no key ever lives in source and there's no substitution step to maintain.
- **Fastlane lane** `remote_config_production_tests` scans the `RemoteConfigProductionTests` scheme.

It should run on a schedule (need to set that up on circleci)

### Required setup (one-time, before this does anything)

1. **Two CircleCI secrets** (env vars available to the job): `RC_REMOTE_CONFIG_CDN_API_KEY` (a project with the CDN-offload flag on) and `RC_REMOTE_CONFIG_INLINE_API_KEY` (flag off).
2. **A scheduled pipeline** named `remote_config_blob_monitor` (the workflow gates on `pipeline.schedule.name == "remote_config_blob_monitor"`), at whatever cadence you want.

Until both exist, the job never triggers; if it triggers without the secrets, both tests just skip.

### Testing (beyond the diff)

`circleci config validate` passes; the fastlane file parses (`ruby -c`); the target builds and both tests skip cleanly with no keys set. The end-to-end scheduled run can only be verified once the secrets + schedule are provisioned. Locally, both tests were run green earlier against the two projects by setting the env vars in the scheme.

<details>
<summary>AI session context</summary>

**Scope:** this block covers only this PR (CI wiring for the blob monitor), stacked on #7215.

**Metadata**
- Branch: `facu/remote-config-production-tests-ci`, base `facu/remote-config-production-tests` (#7215)
- Head: `3055cd816`
- Change: test key-sourcing switched to env, plus a fastlane lane and a scheduled CircleCI job/workflow
- Label: `pr:other`

**What changed and why:** the monitor from #7215 needed to actually run. Chose a scheduled cadence (it hits prod) and env-based keys (cleaner than the repo's sed-into-`Constants.swift` pattern: no source mutation, no key can be committed). Keys reach the simulator test process via `SIMCTL_CHILD_` (env in the CI shell is not otherwise visible to the sim test process).

**Human decisions:** scheduled/nightly over PR-gated; keys handled via the environment rather than source substitution.

**Files:** `Tests/RemoteConfigProductionTests/RemoteConfigBlobHealthTests.swift` (env keys + `requireKey` skip helper), `fastlane/Fastfile` (`remote_config_production_tests` lane), `.circleci/default_config.yml` (`remote-config-production-tests` job + `remote-config-blob-monitor` scheduled workflow).

**Proof:** `circleci config validate` = valid; `ruby -c` = Syntax OK; target builds, both tests skip with no keys.

**Risks / reviewer notes:**
- Needs two CircleCI secrets and a scheduled pipeline (see "Required setup") — the job is inert until then.
- `SIMCTL_CHILD_` is the mechanism for getting env into the simulator test process; if the job ever moves to a macOS test host, plain env inheritance would work and the prefix could be dropped.
- Scheduled only, so it won't appear on normal PR runs.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production API keys and scheduled live-backend checks; misconfigured secrets or schedule only cause skips or a no-op job, but a failing monitor correctly signals prod/CDN regressions.
> 
> **Overview**
> Wires the **RemoteConfig production blob health monitor** into CircleCI so it runs on a schedule against the live backend (not on every PR).
> 
> **Test key sourcing** moves from placeholder strings to `ProcessInfo` env vars (`REVENUECAT_REMOTE_CONFIG_CDN_API_KEY` / `_INLINE_API_KEY`), with a `requireKey` helper that **skips** when unset—no keys in source and no sed/substitution step.
> 
> **Fastlane** adds `remote_config_production_tests`, which scans the `RemoteConfigProductionTests` scheme on a simulator.
> 
> **CircleCI** adds job `remote-config-production-tests` (Tuist workspace, injects Circle secrets into the XCTest process via `SIMCTL_CHILD_*` → `BASH_ENV`), workflow `remote-config-blob-monitor` gated on schedule name `remote_config_blob_monitor`, and on-demand job allowlisting in `generate-requested-jobs-config.js` with `config-endpoint-tests` + `slack-secrets` contexts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa650265d4046096eff786329d945dd201d02d25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->