### PR TITLE
feat(remote-config): force app_start on the first config request

### DIFF
--- a/Sources/Networking/Operations/GetRemoteConfigOperation.swift
+++ b/Sources/Networking/Operations/GetRemoteConfigOperation.swift
@@ -76,7 +76,6 @@ struct RemoteConfigRequest: Codable, Equatable, HTTPRequestBody {
 
     var cacheKey: String {
         [
-            "fetch_context=\(self.fetchContext.rawValue)",
             "app_user_id=\(self.appUserID)",
             "domain=\(self.domain)",
             "manifest=\(self.manifest ?? "")",

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -234,7 +234,8 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     private var isRefreshing = false
 
     /// Forces the first committed refresh of the session to report `.appStart`, regardless of the caller's context,
-    /// so the backend always sees `app_start` on a fresh app open. Set once, under `lock`, when the request is committed.
+    /// so the backend always sees `app_start` on a fresh app open. Set once, under `lock`, when the request is
+    /// committed.
     private var hasCommittedInitialRefresh = false
 
     /// Session-scoped kill switch set by disabling client errors. This is intentionally not reset by cache clears.

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -233,10 +233,11 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     /// Tracks the single config refresh whose completion read APIs may await.
     private var isRefreshing = false
 
-    /// Forces refreshes to report `.appStart` until the first one succeeds, regardless of the caller's context, so
-    /// the backend always sees `app_start` on a fresh app open. Set under `lock` when a refresh succeeds; a failed
-    /// attempt keeps forcing `.appStart` so a later attempt can still deliver it.
-    private var hasSucceededInitialRefresh = false
+    /// Forces refreshes to report `.appStart` until the session's first config is committed, regardless of the
+    /// caller's context, so the backend always sees `app_start` on a fresh app open. Set under `lock` only once config
+    /// is durably committed (persisted from a 200 or the fallback) or confirmed current (204); a failed refresh or an
+    /// undecodable/unpersistable 200 keeps forcing `.appStart` until a later attempt actually commits config.
+    private var hasCommittedInitialConfig = false
 
     /// Session-scoped kill switch set by disabling client errors. This is intentionally not reset by cache clears.
     private var isDisabledInternal = false
@@ -382,10 +383,10 @@ final class RemoteConfigManager: RemoteConfigManagerType {
 
 private extension RemoteConfigManager {
 
-    /// Overrides a refresh's context to `.appStart` until the first refresh succeeds, so the backend always sees
-    /// `app_start` first on a fresh app open. Must be called within `lock`.
+    /// Overrides a refresh's context to `.appStart` until the session's first config is committed, so the backend
+    /// always sees `app_start` first on a fresh app open. Must be called within `lock`.
     func fetchContextForRefresh(_ requested: RemoteConfigFetchContext) -> RemoteConfigFetchContext {
-        return self.hasSucceededInitialRefresh ? requested : .appStart
+        return self.hasCommittedInitialConfig ? requested : .appStart
     }
 
     func prepareRefreshIfNeeded(
@@ -514,8 +515,6 @@ private extension RemoteConfigManager {
     ) {
         guard self.isCurrent(requestEpoch) else { return }
         defer { self.releaseGuardIfOwned(requestEpoch: requestEpoch) }
-
-        self.markInitialRefreshSucceededIfCurrent(requestEpoch)
 
         guard let container = fetchResult.container else {
             Logger.debug(Strings.remoteConfig.notModified)
@@ -675,16 +674,10 @@ private extension RemoteConfigManager {
         }
     }
 
-    /// Records that a refresh succeeded so later refreshes stop being forced to `.appStart`.
-    func markInitialRefreshSucceededIfCurrent(_ requestEpoch: Int) {
-        self.lock.perform {
-            guard self.epoch == requestEpoch else { return }
-
-            self.hasSucceededInitialRefresh = true
-        }
-    }
-
+    /// Records a landed refresh: stamps the refresh time and marks the session's initial config as committed, so
+    /// later refreshes stop being forced to `.appStart`. Must be called within `lock`.
     func markRefreshed() {
+        self.hasCommittedInitialConfig = true
         self.lastRefreshedAt = self.dateProvider.now()
     }
 

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -233,6 +233,11 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     /// Tracks the single config refresh whose completion read APIs may await.
     private var isRefreshing = false
 
+    /// Forces the first committed refresh of the session to report `.appStart`, regardless of the caller's context,
+    /// so the backend always sees `app_start` on a fresh app open even when another trigger (e.g. a `read` from
+    /// `getOfferings`) wins the race to start the first request. Set once, under `lock`, when the request is committed.
+    private var hasCommittedInitialRefresh = false
+
     /// Session-scoped kill switch set by disabling client errors. This is intentionally not reset by cache clears.
     private var isDisabledInternal = false
 
@@ -377,6 +382,16 @@ final class RemoteConfigManager: RemoteConfigManagerType {
 
 private extension RemoteConfigManager {
 
+    /// Overrides the first committed refresh's context to `.appStart`, so the backend always sees `app_start`
+    /// first on a fresh app open. Must be called within `lock`, at the point a request is committed.
+    func fetchContextForCommittedRefresh(_ requested: RemoteConfigFetchContext) -> RemoteConfigFetchContext {
+        guard self.hasCommittedInitialRefresh else {
+            self.hasCommittedInitialRefresh = true
+            return .appStart
+        }
+        return requested
+    }
+
     func prepareRefreshIfNeeded(
         fetchContext: RemoteConfigFetchContext,
         appUserID: String
@@ -391,7 +406,7 @@ private extension RemoteConfigManager {
             return .init(
                 epoch: self.epoch,
                 requestAppUserID: requestAppUserID,
-                fetchContext: fetchContext
+                fetchContext: self.fetchContextForCommittedRefresh(fetchContext)
             )
         }
     }
@@ -419,7 +434,7 @@ private extension RemoteConfigManager {
             return .init(
                 epoch: self.epoch,
                 requestAppUserID: requestAppUserID,
-                fetchContext: fetchContext
+                fetchContext: self.fetchContextForCommittedRefresh(fetchContext)
             )
         }
     }

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -234,8 +234,7 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     private var isRefreshing = false
 
     /// Forces the first committed refresh of the session to report `.appStart`, regardless of the caller's context,
-    /// so the backend always sees `app_start` on a fresh app open even when another trigger (e.g. a `read` from
-    /// `getOfferings`) wins the race to start the first request. Set once, under `lock`, when the request is committed.
+    /// so the backend always sees `app_start` on a fresh app open. Set once, under `lock`, when the request is committed.
     private var hasCommittedInitialRefresh = false
 
     /// Session-scoped kill switch set by disabling client errors. This is intentionally not reset by cache clears.

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -233,10 +233,10 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     /// Tracks the single config refresh whose completion read APIs may await.
     private var isRefreshing = false
 
-    /// Forces the first committed refresh of the session to report `.appStart`, regardless of the caller's context,
-    /// so the backend always sees `app_start` on a fresh app open. Set once, under `lock`, when the request is
-    /// committed.
-    private var hasCommittedInitialRefresh = false
+    /// Forces refreshes to report `.appStart` until the first one succeeds, regardless of the caller's context, so
+    /// the backend always sees `app_start` on a fresh app open. Set under `lock` when a refresh succeeds; a failed
+    /// attempt keeps forcing `.appStart` so a later attempt can still deliver it.
+    private var hasSucceededInitialRefresh = false
 
     /// Session-scoped kill switch set by disabling client errors. This is intentionally not reset by cache clears.
     private var isDisabledInternal = false
@@ -382,14 +382,10 @@ final class RemoteConfigManager: RemoteConfigManagerType {
 
 private extension RemoteConfigManager {
 
-    /// Overrides the first committed refresh's context to `.appStart`, so the backend always sees `app_start`
-    /// first on a fresh app open. Must be called within `lock`, at the point a request is committed.
-    func fetchContextForCommittedRefresh(_ requested: RemoteConfigFetchContext) -> RemoteConfigFetchContext {
-        guard self.hasCommittedInitialRefresh else {
-            self.hasCommittedInitialRefresh = true
-            return .appStart
-        }
-        return requested
+    /// Overrides a refresh's context to `.appStart` until the first refresh succeeds, so the backend always sees
+    /// `app_start` first on a fresh app open. Must be called within `lock`.
+    func fetchContextForRefresh(_ requested: RemoteConfigFetchContext) -> RemoteConfigFetchContext {
+        return self.hasSucceededInitialRefresh ? requested : .appStart
     }
 
     func prepareRefreshIfNeeded(
@@ -406,7 +402,7 @@ private extension RemoteConfigManager {
             return .init(
                 epoch: self.epoch,
                 requestAppUserID: requestAppUserID,
-                fetchContext: self.fetchContextForCommittedRefresh(fetchContext)
+                fetchContext: self.fetchContextForRefresh(fetchContext)
             )
         }
     }
@@ -434,7 +430,7 @@ private extension RemoteConfigManager {
             return .init(
                 epoch: self.epoch,
                 requestAppUserID: requestAppUserID,
-                fetchContext: self.fetchContextForCommittedRefresh(fetchContext)
+                fetchContext: self.fetchContextForRefresh(fetchContext)
             )
         }
     }
@@ -518,6 +514,8 @@ private extension RemoteConfigManager {
     ) {
         guard self.isCurrent(requestEpoch) else { return }
         defer { self.releaseGuardIfOwned(requestEpoch: requestEpoch) }
+
+        self.markInitialRefreshSucceededIfCurrent(requestEpoch)
 
         guard let container = fetchResult.container else {
             Logger.debug(Strings.remoteConfig.notModified)
@@ -674,6 +672,15 @@ private extension RemoteConfigManager {
             guard self.epoch == requestEpoch else { return }
 
             self.markRefreshed()
+        }
+    }
+
+    /// Records that a refresh succeeded so later refreshes stop being forced to `.appStart`.
+    func markInitialRefreshSucceededIfCurrent(_ requestEpoch: Int) {
+        self.lock.perform {
+            guard self.epoch == requestEpoch else { return }
+
+            self.hasSucceededInitialRefresh = true
         }
     }
 

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -354,7 +354,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(self.httpClient.calls).to(haveCount(2))
     }
 
-    func testGetRemoteConfigDoesNotCoalesceSimultaneousRequestsWithDifferentFetchContexts() {
+    func testGetRemoteConfigCoalescesSimultaneousRequestsWithDifferentFetchContexts() {
         self.mockSuccessfulResponse(delay: .milliseconds(10))
 
         let responses: Atomic<Int> = .init(0)
@@ -370,7 +370,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         ) { _ in responses.value += 1 }
 
         expect(responses.value).toEventually(equal(2))
-        expect(self.httpClient.calls).to(haveCount(2))
+        expect(self.httpClient.calls).to(haveCount(1))
     }
 
     func testCoalescedRequestsLogDebugMessage() {

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -122,6 +122,60 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.fetchContext) == .identityChange
     }
 
+    func testForcingStopsOnceA200ConfigIsPersisted() throws {
+        self.diskCache.stubbedRead = nil
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.sources:etag2",
+          "active_topics": [],
+          "topics": {}
+        }
+        """
+
+        self.manager.refreshRemoteConfig(fetchContext: .identityChange, isAppBackgrounded: false)
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.fetchContext) == .appStart
+        self.remoteConfigAPI.complete(with: .success(.test(container: try Self.container(config: response))))
+
+        self.manager.refreshRemoteConfig(fetchContext: .identityChange, isAppBackgrounded: false)
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.fetchContext) == .identityChange
+    }
+
+    func testA200ThatFailsToParseKeepsForcingAppStart() throws {
+        self.diskCache.stubbedRead = nil
+
+        self.manager.refreshRemoteConfig(fetchContext: .identityChange, isAppBackgrounded: false)
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.fetchContext) == .appStart
+        // A 200 whose body fails to parse commits nothing, so the initial config is still not committed.
+        self.remoteConfigAPI.complete(with: .success(.test(container: try Self.container(config: "{ not valid json"))))
+
+        // The next refresh must still be forced to `.appStart`, since no config landed yet.
+        self.manager.refreshRemoteConfig(fetchContext: .identityChange, isAppBackgrounded: false)
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.fetchContext) == .appStart
+    }
+
+    func testForcingStopsOnceTheFallbackCommitsItsConfig() {
+        self.diskCache.stubbedRead = nil
+        let configuration = RemoteConfiguration(
+            domain: "app",
+            manifest: "v1.1710000100.sources:etag",
+            activeTopics: [],
+            prefetchBlobs: [],
+            topics: .init(entries: [:])
+        )
+
+        self.manager.refreshRemoteConfig(fetchContext: .identityChange, isAppBackgrounded: false)
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.fetchContext) == .appStart
+
+        // The main request fails on a cold cache, routing to the fallback, which commits its config.
+        self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
+        self.remoteConfigAPI.completeFallback(with: .success(.test(configuration: configuration)))
+
+        // The fallback commit counts as the initial config, so later refreshes report their own context.
+        self.manager.refreshRemoteConfig(fetchContext: .identityChange, isAppBackgrounded: false)
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.fetchContext) == .identityChange
+    }
+
     func testIsDisabledDefaultsToFalse() {
         expect(self.manager.isDisabled) == false
     }

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -58,16 +58,51 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testRefreshRemoteConfigIfStaleSendsForegroundFetchContext() {
+        // The first committed request is forced to `.appStart`, so prime it before asserting a `.foreground` refresh.
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
+        self.dateProvider.advance(by: 6)
+
         self.manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
 
-        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.fetchContext) == .foreground
     }
 
     func testRefreshRemoteConfigSendsPassedFetchContext() {
+        // The first committed request is forced to `.appStart`, so prime it before asserting the passed context.
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
+
+        self.manager.refreshRemoteConfig(fetchContext: .identityChange, isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.fetchContext) == .identityChange
+    }
+
+    func testFirstRefreshIsForcedToAppStartRegardlessOfRequestedContext() {
         self.manager.refreshRemoteConfig(fetchContext: .identityChange, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.fetchContext) == .appStart
+    }
+
+    func testFirstStaleRefreshIsForcedToAppStartRegardlessOfRequestedContext() {
+        self.manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.fetchContext) == .appStart
+    }
+
+    func testOnlyTheFirstRefreshIsForcedToAppStart() {
+        // First request forced to `.appStart`; the next committed request reports its own context.
+        self.manager.refreshRemoteConfig(fetchContext: .identityChange, isAppBackgrounded: false)
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.fetchContext) == .appStart
+        self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
+
+        self.manager.refreshRemoteConfig(fetchContext: .identityChange, isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.fetchContext) == .identityChange
     }
 
@@ -1628,10 +1663,15 @@ final class RemoteConfigManagerTests: TestCase {
         }
         """
 
+        // The first committed request is forced to `.appStart`, so prime it before asserting the cold read's `.read`.
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
+        self.dateProvider.advance(by: 6)
+
         let task = Task {
             await self.manager.blobData(for: .workflows, itemKey: "default")
         }
-        await self.waitForRemoteConfigRequestCount(1)
+        await self.waitForRemoteConfigRequestCount(2)
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.isAppBackgrounded) == false
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.fetchContext) == .read
         self.remoteConfigAPI.complete(

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -106,6 +106,22 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.fetchContext) == .identityChange
     }
 
+    func testRefreshKeepsForcingAppStartUntilARefreshSucceeds() {
+        // A failed first refresh must not consume the forced `.appStart`, so the next attempt is forced too.
+        self.manager.refreshRemoteConfig(fetchContext: .identityChange, isAppBackgrounded: false)
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.fetchContext) == .appStart
+        self.remoteConfigAPI.complete(with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1)))))
+        self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
+
+        self.manager.refreshRemoteConfig(fetchContext: .identityChange, isAppBackgrounded: false)
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.fetchContext) == .appStart
+
+        // Once a refresh succeeds, the forcing stops and later refreshes report their own context.
+        self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
+        self.manager.refreshRemoteConfig(fetchContext: .identityChange, isAppBackgrounded: false)
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.fetchContext) == .identityChange
+    }
+
     func testIsDisabledDefaultsToFalse() {
         expect(self.manager.isDisabled) == false
     }


### PR DESCRIPTION
### Motivation
On a fresh app open the backend should bypass its 30-min config cache. If another trigger (e.g. a `read` from `getOfferings`) wins the race to send the first `/v1/config` request, the backend would only see that context and could serve stale config. Follow-up to the `fetch_context` work (#7214), per the team decision.

### Description
- `RemoteConfigManager` overrides the first committed refresh of the session to `.appStart`, regardless of the caller's context; subsequent refreshes report their real context.
- Removed `fetch_context` from the request dedup cache key, so concurrent requests differing only by context now coalesce.
- Added unit tests for the forced first request and that only the first one is overridden.

### Checklist
- [x] Unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which `fetch_context` the backend sees on cold start and merges concurrent config requests that used to be separate; mis-timed commits could briefly keep forcing `app_start` or coalesce with a non-ideal shared request.
> 
> **Overview**
> Ensures the backend always receives **`app_start`** on the first `/v1/config` call of a session, even when offerings or other paths trigger config first with a different `fetch_context`.
> 
> **`RemoteConfigManager`** tracks `hasCommittedInitialConfig` and routes refreshes through `fetchContextForRefresh` so every attempt stays **`.appStart`** until config is actually committed (persisted 200, successful fallback, or 204). Failed or unparseable responses do not clear that gate. **`RemoteConfigRequest.cacheKey`** no longer includes `fetch_context`, so in-flight requests that only differ by context **coalesce** to one network call.
> 
> Unit tests cover the override lifecycle, coalescing, and updated expectations where tests must prime an initial commit before asserting caller-specific contexts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b3f2fec1f76d74836606914867e520b8263c587. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->