### PR TITLE
refactor(remote-config) reduce offerings memory when using remote-config (and thus workflows)

### DIFF
--- a/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/RcMaestroApp.swift
+++ b/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/RcMaestroApp.swift
@@ -39,6 +39,12 @@ struct RcMaestroApp: App {
                                 case .never, .remoteConfigNotFound:
                                     return false
                                 case .primaryBackendDown:
+                                    // Remote config uses a separate request path whose primary URL is already
+                                    // the fallback backend, so it does not have a fallbackUrlIndex.
+                                    if let fallbackPath = request.httpRequest.path as? HTTPRequest.FallbackPath,
+                                       case .remoteConfig = fallbackPath {
+                                        return false
+                                    }
                                     return request.fallbackUrlIndex == nil
                                 }
                             }

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -2995,6 +2995,7 @@
 		A1B2C3D42FE6000000000009 /* RemoteConfigBlobDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobDownloaderTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE8000000000001 /* RemoteConfigIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigIntegrationTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE300000000001 /* ProductionRemoteConfigIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductionRemoteConfigIntegrationTests.swift; sourceTree = "<group>"; };
+		A1B2C3D42FE300000000002 /* ProductionWorkflowsPaywallComponentsIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductionWorkflowsPaywallComponentsIntegrationTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FEA000000000001 /* RecordingBlobDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingBlobDownloader.swift; sourceTree = "<group>"; };
 		A1B2C3D42FEA000000000002 /* RemoteConfigBlobHealthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobHealthTests.swift; sourceTree = "<group>"; };
 		E31E8A264E9F4375A3B29D78 /* RemoteConfigurationDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigurationDecodingTests.swift; sourceTree = "<group>"; };
@@ -6204,6 +6205,7 @@
 			isa = PBXGroup;
 			children = (
 				A1B2C3D42FE300000000001 /* ProductionRemoteConfigIntegrationTests.swift */,
+				A1B2C3D42FE300000000002 /* ProductionWorkflowsPaywallComponentsIntegrationTests.swift */,
 			);
 			path = BackendIntegrationTests;
 			sourceTree = "<group>";

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -2995,7 +2995,7 @@
 		A1B2C3D42FE6000000000009 /* RemoteConfigBlobDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobDownloaderTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE8000000000001 /* RemoteConfigIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigIntegrationTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE300000000001 /* ProductionRemoteConfigIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductionRemoteConfigIntegrationTests.swift; sourceTree = "<group>"; };
-		A1B2C3D42FE300000000002 /* ProductionWorkflowsPaywallComponentsIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductionWorkflowsPaywallComponentsIntegrationTests.swift; sourceTree = "<group>"; };
+		A1B2C3D42FE300000000002 /* WorkflowComponentsIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowComponentsIntegrationTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FEA000000000001 /* RecordingBlobDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingBlobDownloader.swift; sourceTree = "<group>"; };
 		A1B2C3D42FEA000000000002 /* RemoteConfigBlobHealthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobHealthTests.swift; sourceTree = "<group>"; };
 		E31E8A264E9F4375A3B29D78 /* RemoteConfigurationDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigurationDecodingTests.swift; sourceTree = "<group>"; };
@@ -6205,7 +6205,7 @@
 			isa = PBXGroup;
 			children = (
 				A1B2C3D42FE300000000001 /* ProductionRemoteConfigIntegrationTests.swift */,
-				A1B2C3D42FE300000000002 /* ProductionWorkflowsPaywallComponentsIntegrationTests.swift */,
+				A1B2C3D42FE300000000002 /* WorkflowComponentsIntegrationTests.swift */,
 			);
 			path = BackendIntegrationTests;
 			sourceTree = "<group>";

--- a/Sources/Caching/DeviceCache.swift
+++ b/Sources/Caching/DeviceCache.swift
@@ -215,7 +215,12 @@ class DeviceCache {
         return self.value(for: CacheKey.offerings(appUserID))
     }
 
-    func cache(offerings: Offerings, preferredLocales: [String], appUserID: String) {
+    func cache(
+        offerings: Offerings,
+        diskContents: Offerings.Contents? = nil,
+        preferredLocales: [String],
+        appUserID: String
+    ) {
         // We can't get the preferred locales from the `systemInfo` object because they may change
         // during the get offerings request, before this cache method gets called.
         // For the cache we need the preferred locales that were used in the request.
@@ -223,7 +228,7 @@ class DeviceCache {
         self.offeringsCachePreferredLocales.value = preferredLocales
 
         let key = CacheKey.offerings(appUserID).rawValue
-        if self.largeItemCache.set(codable: offerings.contents, forKey: key) {
+        if self.largeItemCache.set(codable: diskContents ?? offerings.contents, forKey: key) {
 
             // Delete old file from documents directory if it exists
             self.deleteOldFileIfNeeded(for: key)

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -17,6 +17,8 @@ protocol RemoteConfigManagerType: AnyObject {
     /// Monotonically increases whenever committed remote config state is replaced or invalidated.
     var configGeneration: Int { get }
 
+    var onRemoteConfigDisabled: (() -> Void)? { get set }
+
     func refreshRemoteConfig(fetchContext: RemoteConfigFetchContext, isAppBackgrounded: Bool)
     func refreshRemoteConfigIfStale(fetchContext: RemoteConfigFetchContext, isAppBackgrounded: Bool)
 
@@ -200,6 +202,7 @@ final class NoOpRemoteConfigManager: RemoteConfigManagerType {
 
     let isDisabled = true
     let configGeneration = 0
+    var onRemoteConfigDisabled: (() -> Void)?
 
     func refreshRemoteConfig(fetchContext: RemoteConfigFetchContext, isAppBackgrounded: Bool) {}
 
@@ -284,6 +287,8 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     /// Incremented whenever committed config changes or becomes invalid. Async cache warmers use this
     /// as a stale-write guard so older work cannot repopulate memory after a newer config is active.
     private var generation = 0
+
+    var onRemoteConfigDisabled: (() -> Void)?
 
     /// App user ID captured by an identity-bound cache clear.
     ///
@@ -684,28 +689,39 @@ private extension RemoteConfigManager {
         requestEpoch: Int,
         shouldDisableRefresh: Bool
     ) {
-        let continuations = self.lock.perform {
-            guard self.epoch == requestEpoch else { return nil as [CheckedContinuation<Void, Never>]? }
+        let result = self.lock.perform {
+            guard self.epoch == requestEpoch else {
+                return nil as (continuations: [CheckedContinuation<Void, Never>], didDisable: Bool)?
+            }
 
+            let didDisable: Bool
             if shouldDisableRefresh {
-                self.disableRefreshIfNeeded(for: error)
+                didDisable = self.disableRefreshIfNeeded(for: error)
+            } else {
+                didDisable = false
             }
             self.isRefreshing = false
 
-            return self.drainRefreshContinuations()
+            return (self.drainRefreshContinuations(), didDisable)
         }
 
-        guard let continuations else { return }
-        continuations.forEach { $0.resume() }
+        guard let result else { return }
+        result.continuations.forEach { $0.resume() }
+
+        if result.didDisable {
+            self.onRemoteConfigDisabled?()
+        }
 
         Logger.error(Strings.remoteConfig.refreshFailed(error))
     }
 
-    func disableRefreshIfNeeded(for error: BackendError) {
-        guard error.isRemoteConfigDisablingClientError else { return }
+    func disableRefreshIfNeeded(for error: BackendError) -> Bool {
+        guard error.isRemoteConfigDisablingClientError,
+              !self.isDisabledInternal else { return false }
 
         self.isDisabledInternal = true
         self.generation += 1
+        return true
     }
 
     func isCurrent(_ requestEpoch: Int) -> Bool {

--- a/Sources/Networking/Responses/OfferingsResponse.swift
+++ b/Sources/Networking/Responses/OfferingsResponse.swift
@@ -36,6 +36,7 @@ struct OfferingsResponse {
         var metadata: [String: AnyDecodable]
         var paywallComponents: PaywallComponentsData?
         var draftPaywallComponents: PaywallComponentsData?
+        var hasPaywallComponents: Bool?
         let webCheckoutUrl: URL?
     }
 

--- a/Sources/Purchasing/Offering.swift
+++ b/Sources/Purchasing/Offering.swift
@@ -88,11 +88,17 @@ import Foundation
     @_spi(Internal) public let internalPaywallComponents: PaywallComponents?
 
     /**
-     Whether the offering contains a paywall.
+    Whether the offering contains a paywall.
      */
     public var hasPaywall: Bool {
-        return paywall != nil || internalPaywallComponents != nil
+        return paywall != nil || internalPaywallComponents != nil || hasPaywallComponents
     }
+
+    /**
+     Whether the backend served paywall components for this offering, tracked independently
+     of whether the components payload is retained in memory.
+     */
+    let hasPaywallComponents: Bool
 
     /**
      Draft paywall components configuration defined in RevenueCat dashboard.
@@ -241,6 +247,7 @@ import Foundation
         metadata: [String: Any] = [:],
         paywall: PaywallData? = nil,
         paywallComponents: PaywallComponents? = nil,
+        hasPaywallComponents: Bool = false,
         draftPaywallComponents: PaywallComponents?,
         availablePackages: [Package],
         webCheckoutUrl: URL?
@@ -251,6 +258,7 @@ import Foundation
         self._metadata = Metadata(data: metadata)
         self.paywall = paywall
         self.internalPaywallComponents = paywallComponents
+        self.hasPaywallComponents = hasPaywallComponents || paywallComponents != nil
         self.draftPaywallComponents = draftPaywallComponents
         self.webCheckoutUrl = webCheckoutUrl
 
@@ -322,6 +330,7 @@ public extension Offering {
             metadata: metadata,
             paywall: paywall,
             paywallComponents: internalPaywallComponents,
+            hasPaywallComponents: hasPaywallComponents,
             draftPaywallComponents: draftPaywallComponents,
             availablePackages: availablePackages.map { $0.withPresentedOfferingContext(presentedOfferingContext) },
             webCheckoutUrl: webCheckoutUrl
@@ -336,6 +345,7 @@ public extension Offering {
             metadata: metadata,
             paywall: paywall,
             paywallComponents: paywallComponents,
+            hasPaywallComponents: true,
             draftPaywallComponents: draftPaywallComponents,
             availablePackages: availablePackages,
             webCheckoutUrl: webCheckoutUrl

--- a/Sources/Purchasing/Offerings.swift
+++ b/Sources/Purchasing/Offerings.swift
@@ -178,6 +178,8 @@ private extension Offering {
                         metadata: self.metadata,
                         paywall: self.paywall,
                         paywallComponents: self.internalPaywallComponents,
+                        hasPaywallComponents: self.hasPaywallComponents,
+                        draftPaywallComponents: self.draftPaywallComponents,
                         availablePackages: updatedPackages,
                         webCheckoutUrl: self.webCheckoutUrl
         )

--- a/Sources/Purchasing/OfferingsFactory.swift
+++ b/Sources/Purchasing/OfferingsFactory.swift
@@ -78,7 +78,8 @@ class OfferingsFactory {
             return nil
         }
 
-        let hasPaywallComponents = uiConfig != nil && offering.paywallComponents != nil
+        let hasPaywallComponents = offering.hasPaywallComponents == true
+            || (uiConfig != nil && offering.paywallComponents != nil)
         let paywallComponents: Offering.PaywallComponents? = {
             if shouldCreatePaywallComponents, let uiConfig, let paywallComponents = offering.paywallComponents {
                 return .init(
@@ -170,6 +171,9 @@ private extension Offerings.Contents {
     func removingPaywallComponents() -> Self {
         let prunedOfferings = self.response.offerings.map { offering in
             var offering = offering
+            offering.hasPaywallComponents = offering.hasPaywallComponents ?? (
+                self.response.uiConfig != nil && offering.paywallComponents != nil
+            )
             offering.paywallComponents = nil
             offering.draftPaywallComponents = nil
             return offering

--- a/Sources/Purchasing/OfferingsFactory.swift
+++ b/Sources/Purchasing/OfferingsFactory.swift
@@ -44,7 +44,7 @@ class OfferingsFactory {
             return nil
         }
 
-        let retainedContents = shouldCreatePaywallComponents
+        let storedContents = shouldCreatePaywallComponents
             ? contents
             : contents.removingPaywallComponents()
 
@@ -52,7 +52,7 @@ class OfferingsFactory {
                          currentOfferingID: data.currentOfferingId,
                          placements: createPlacement(with: data.placements),
                          targeting: data.targeting.flatMap { .init(revision: $0.revision, ruleId: $0.ruleId) },
-                         contents: retainedContents,
+                         contents: storedContents,
                          loadedFromDiskCache: loadedFromDiskCache)
     }
 

--- a/Sources/Purchasing/OfferingsFactory.swift
+++ b/Sources/Purchasing/OfferingsFactory.swift
@@ -186,9 +186,14 @@ private extension Offerings.Contents {
             uiConfig: self.response.uiConfig
         )
 
-        var contents = self
-        contents.response = response
-        return contents
+        return self.replacingResponse(with: response)
+    }
+
+    /// Returns a copy that preserves all SDK-generated metadata while replacing only the backend response.
+    func replacingResponse(with response: OfferingsResponse) -> Self {
+        var copy = self
+        copy.response = response
+        return copy
     }
 
 }

--- a/Sources/Purchasing/OfferingsFactory.swift
+++ b/Sources/Purchasing/OfferingsFactory.swift
@@ -171,9 +171,8 @@ private extension Offerings.Contents {
     func removingPaywallComponents() -> Self {
         let prunedOfferings = self.response.offerings.map { offering in
             var offering = offering
-            offering.hasPaywallComponents = offering.hasPaywallComponents ?? (
-                self.response.uiConfig != nil && offering.paywallComponents != nil
-            )
+            let canCreatePaywallComponents = self.response.uiConfig != nil && offering.paywallComponents != nil
+            offering.hasPaywallComponents = offering.hasPaywallComponents ?? canCreatePaywallComponents
             offering.paywallComponents = nil
             offering.draftPaywallComponents = nil
             return offering

--- a/Sources/Purchasing/OfferingsFactory.swift
+++ b/Sources/Purchasing/OfferingsFactory.swift
@@ -26,7 +26,8 @@ class OfferingsFactory {
     func createOfferings(
         from storeProductsByID: [String: StoreProduct],
         contents: Offerings.Contents,
-        loadedFromDiskCache: Bool
+        loadedFromDiskCache: Bool,
+        shouldCreatePaywallComponents: Bool = true
     ) -> Offerings? {
         let data = contents.response
         let offerings: [String: Offering] = data
@@ -34,7 +35,8 @@ class OfferingsFactory {
             .compactMap { offeringData in
                 createOffering(from: storeProductsByID,
                                offering: offeringData,
-                               uiConfig: data.uiConfig)
+                               uiConfig: data.uiConfig,
+                               shouldCreatePaywallComponents: shouldCreatePaywallComponents)
             }
             .dictionaryAllowingDuplicateKeys { $0.identifier }
 
@@ -42,18 +44,23 @@ class OfferingsFactory {
             return nil
         }
 
+        let retainedContents = shouldCreatePaywallComponents
+            ? contents
+            : contents.removingPaywallComponents()
+
         return Offerings(offerings: offerings,
                          currentOfferingID: data.currentOfferingId,
                          placements: createPlacement(with: data.placements),
                          targeting: data.targeting.flatMap { .init(revision: $0.revision, ruleId: $0.ruleId) },
-                         contents: contents,
+                         contents: retainedContents,
                          loadedFromDiskCache: loadedFromDiskCache)
     }
 
     func createOffering(
         from storeProductsByID: [String: StoreProduct],
         offering: OfferingsResponse.Offering,
-        uiConfig: UIConfig?
+        uiConfig: UIConfig?,
+        shouldCreatePaywallComponents: Bool = true
     ) -> Offering? {
         let availablePackages: [Package] = offering.packages.compactMap { package in
             createPackage(with: package, productsByID: storeProductsByID, offeringIdentifier: offering.identifier)
@@ -71,8 +78,9 @@ class OfferingsFactory {
             return nil
         }
 
+        let hasPaywallComponents = uiConfig != nil && offering.paywallComponents != nil
         let paywallComponents: Offering.PaywallComponents? = {
-            if let uiConfig, let paywallComponents = offering.paywallComponents {
+            if shouldCreatePaywallComponents, let uiConfig, let paywallComponents = offering.paywallComponents {
                 return .init(
                     uiConfig: uiConfig,
                     data: paywallComponents
@@ -82,7 +90,9 @@ class OfferingsFactory {
         }()
 
         let paywallDraftComponents: Offering.PaywallComponents? = {
-            if let uiConfig, let paywallDraftComponents = offering.draftPaywallComponents {
+            if shouldCreatePaywallComponents,
+               let uiConfig,
+               let paywallDraftComponents = offering.draftPaywallComponents {
                 return .init(
                     uiConfig: uiConfig,
                     data: paywallDraftComponents
@@ -96,6 +106,7 @@ class OfferingsFactory {
                         metadata: offering.metadata.mapValues(\.asAny),
                         paywall: offering.paywall,
                         paywallComponents: paywallComponents,
+                        hasPaywallComponents: hasPaywallComponents,
                         draftPaywallComponents: paywallDraftComponents,
                         availablePackages: availablePackages,
                         webCheckoutUrl: offering.webCheckoutUrl)
@@ -147,6 +158,33 @@ private extension Package {
                   storeProduct: product,
                   offeringIdentifier: offeringIdentifier,
                   webCheckoutUrl: webCheckoutUrl)
+    }
+
+}
+
+private extension Offerings.Contents {
+
+    /// Drops offerings-provided paywall component bodies from the retained/cacheable response.
+    /// When workflows are active, those component bodies are served by remote config instead, so
+    /// retaining them here duplicates memory.
+    func removingPaywallComponents() -> Self {
+        let prunedOfferings = self.response.offerings.map { offering in
+            var offering = offering
+            offering.paywallComponents = nil
+            offering.draftPaywallComponents = nil
+            return offering
+        }
+        let response = OfferingsResponse(
+            currentOfferingId: self.response.currentOfferingId,
+            offerings: prunedOfferings,
+            placements: self.response.placements,
+            targeting: self.response.targeting,
+            uiConfig: self.response.uiConfig
+        )
+
+        var contents = self
+        contents.response = response
+        return contents
     }
 
 }

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -109,17 +109,12 @@ class OfferingsManager {
             // delivery (a no-op once config has synced). A stale snapshot may be returned
             // even if the background refresh finished first; that matches the stale-cache
             // model, and the refresh still updates the cache for the next call.
-            self.deliverWhenConfigReady {
-                // Tracked inside the gate so the recorded latency includes the readiness
-                // wait this delivery now pays, not just the cache lookup.
-                self.trackGetOfferingsResultIfNeeded(trackDiagnostics: trackDiagnostics,
-                                                     startTime: startTime,
-                                                     cacheStatus: cacheStatus,
-                                                     error: nil,
-                                                     requestedProductIds: nil,
-                                                     notFoundProductIds: nil)
-                self.dispatchCompletionOnMainThreadIfPossible(completion, value: .success(memoryCachedOfferings))
-            }
+            self.deliverCachedOfferingsWhenConfigReady(appUserID: appUserID,
+                                                       offerings: memoryCachedOfferings,
+                                                       fetchPolicy: fetchPolicy,
+                                                       trackingContext: trackingContext,
+                                                       cacheStatus: cacheStatus,
+                                                       completion: completion)
         }
     }
 
@@ -155,9 +150,17 @@ class OfferingsManager {
                         // Deliver via the config-ready gate too, so an offerings backend failure that
                         // falls back to disk still waits for remote config's first sync instead of
                         // leaving workflow resolution unresolved.
-                        self.deliverWhenConfigReady {
-                            self.dispatchCompletionOnMainThreadIfPossible(completion, value: .success(offerings))
-                        }
+                        self.deliverWhenConfigReady(
+                            offerings: offerings.offerings,
+                            refreshIfNeeded: {
+                                self.fetchFromNetwork(appUserID: appUserID,
+                                                      fetchPolicy: fetchPolicy,
+                                                      completion: completion)
+                            },
+                            deliver: {
+                                self.dispatchCompletionOnMainThreadIfPossible(completion, value: .success(offerings))
+                            }
+                        )
                     } else {
                         self.handleOfferingsUpdateError(.backendError(backendError),
                                                         completion: completion)
@@ -357,9 +360,18 @@ private extension OfferingsManager {
                 guard let completion else { return }
                 // Delivers offerings only once remote config has synced at least once, so the
                 // `workflows` topic is available for resolving a workflow right after this call.
-                self.deliverWhenConfigReady {
-                    self.dispatchCompletionOnMainThreadIfPossible(completion, value: .success(offeringsResultData))
-                }
+                self.deliverWhenConfigReady(
+                    offerings: offeringsResultData.offerings,
+                    refreshIfNeeded: {
+                        self.fetchFromNetwork(appUserID: appUserID,
+                                              fetchPolicy: fetchPolicy,
+                                              completion: completion)
+                    },
+                    deliver: {
+                        self.dispatchCompletionOnMainThreadIfPossible(completion,
+                                                                      value: .success(offeringsResultData))
+                    }
+                )
 
             case let .failure(error):
                 self.handleOfferingsUpdateError(error, completion: completion)
@@ -416,7 +428,11 @@ private extension OfferingsManager {
     /// the `workflows` topic (with its prefetch-flagged blobs) and the `ui_config` body,
     /// resolved concurrently. Both are best-effort (nil on failure, never throwing), so
     /// delivery can never be stranded; when no manager is wired, `deliver` runs immediately.
-    private func deliverWhenConfigReady(deliver: @escaping () -> Void) {
+    private func deliverWhenConfigReady(
+        offerings: Offerings,
+        refreshIfNeeded: @escaping () -> Void,
+        deliver: @escaping () -> Void
+    ) {
         guard let remoteConfigManager = self.remoteConfigManager else {
             deliver()
             return
@@ -426,8 +442,44 @@ private extension OfferingsManager {
             async let workflowsReady: Void = self.warmWorkflowConfigIfNeeded(remoteConfigManager: remoteConfigManager)
             async let uiConfigReady = uiConfigProvider.getUiConfig()
             _ = await (workflowsReady, uiConfigReady)
-            deliver()
+
+            if self.shouldRefreshOfferingsWithPrunedComponents(offerings) {
+                refreshIfNeeded()
+            } else {
+                deliver()
+            }
         }
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    private func deliverCachedOfferingsWhenConfigReady(
+        appUserID: String,
+        offerings: Offerings,
+        fetchPolicy: FetchPolicy,
+        trackingContext: OfferingsTrackingContext,
+        cacheStatus: CacheStatus,
+        completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?
+    ) {
+        self.deliverWhenConfigReady(
+            offerings: offerings,
+            refreshIfNeeded: {
+                self.fetchFromNetworkAndTrackResult(appUserID: appUserID,
+                                                    fetchPolicy: fetchPolicy,
+                                                    trackingContext: trackingContext,
+                                                    cacheStatus: .stale,
+                                                    completion: completion)
+            },
+            deliver: {
+                // Track inside the gate so the recorded latency includes the readiness wait.
+                self.trackGetOfferingsResultIfNeeded(trackDiagnostics: trackingContext.trackDiagnostics,
+                                                     startTime: trackingContext.startTime,
+                                                     cacheStatus: cacheStatus,
+                                                     error: nil,
+                                                     requestedProductIds: nil,
+                                                     notFoundProductIds: nil)
+                self.dispatchCompletionOnMainThreadIfPossible(completion, value: .success(offerings))
+            }
+        )
     }
 
     private func warmWorkflowConfigIfNeeded(remoteConfigManager: RemoteConfigManagerType) async {

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -95,6 +95,20 @@ class OfferingsManager {
                 return
             }
 
+            guard !self.shouldRefreshOfferingsWithPrunedComponents(memoryCachedOfferings) else {
+                self.fetchFromNetwork(appUserID: appUserID,
+                                      fetchPolicy: fetchPolicy) { [weak self] result in
+                    self?.trackGetOfferingsResultIfNeeded(trackDiagnostics: trackDiagnostics,
+                                                          startTime: startTime,
+                                                          cacheStatus: .stale,
+                                                          error: result.error,
+                                                          requestedProductIds: result.value?.requestedProductIds,
+                                                          notFoundProductIds: result.value?.notFoundProductIds)
+                    completion?(result.map(\.offerings))
+                }
+                return
+            }
+
             let cacheStatus = self.deviceCache.offeringsCacheStatus(isAppBackgrounded: isAppBackgrounded)
             Logger.debug(Strings.offering.vending_offerings_cache_from_memory)
             if cacheStatus == .stale {
@@ -301,7 +315,8 @@ private extension OfferingsManager {
             if let createdOfferings = self.offeringsFactory.createOfferings(
                 from: productsByID,
                 contents: contents,
-                loadedFromDiskCache: loadedFromDiskCache
+                loadedFromDiskCache: loadedFromDiskCache,
+                shouldCreatePaywallComponents: self.shouldCreatePaywallComponents
             ) {
                 completion(.success(OfferingsResultData(offerings: createdOfferings,
                                                         requestedProductIds: productIdentifiers,
@@ -413,6 +428,23 @@ private extension OfferingsManager {
             await workflowsConfigProvider.warmPrefetchedWorkflows()
         } else {
             _ = await remoteConfigManager.awaitTopicAndPrefetchBlobsReady(.workflows)
+        }
+    }
+
+    /// Keep the offerings-provided components path when remote config is not active. When it is active,
+    /// workflows resolve paywall components from `/v1/config`, so retaining the offerings copy duplicates memory.
+    var shouldCreatePaywallComponents: Bool {
+        return self.remoteConfigManager?.isDisabled ?? true
+    }
+
+    /// If remote config was disabled after a workflows-enabled offerings fetch, the in-memory offering
+    /// can still carry only the lightweight paywall marker, not the renderable components payload.
+    /// Refetch so the legacy offerings paywall fallback is restored for the disabled-RC path.
+    func shouldRefreshOfferingsWithPrunedComponents(_ offerings: Offerings) -> Bool {
+        guard self.remoteConfigManager?.isDisabled == true else { return false }
+
+        return offerings.all.values.contains { offering in
+            offering.hasPaywallComponents && offering.paywallComponents == nil
         }
     }
 

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -66,46 +66,33 @@ class OfferingsManager {
         let startTime = self.dateProvider.now()
 
         self.systemInfo.isApplicationBackgrounded { isAppBackgrounded in
+            let trackingContext = OfferingsTrackingContext(trackDiagnostics: trackDiagnostics,
+                                                           startTime: startTime)
 
             guard !fetchCurrent && !self.systemInfo.dangerousSettings.uiPreviewMode else {
-                self.fetchFromNetwork(appUserID: appUserID,
-                                      fetchPolicy: fetchPolicy) { [weak self] result in
-                    self?.trackGetOfferingsResultIfNeeded(trackDiagnostics: trackDiagnostics,
-                                                          startTime: startTime,
-                                                          cacheStatus: .notChecked,
-                                                          error: result.error,
-                                                          requestedProductIds: result.value?.requestedProductIds,
-                                                          notFoundProductIds: result.value?.notFoundProductIds)
-                    completion?(result.map(\.offerings))
-                }
+                self.fetchFromNetworkAndTrackResult(appUserID: appUserID,
+                                                    fetchPolicy: fetchPolicy,
+                                                    trackingContext: trackingContext,
+                                                    cacheStatus: .notChecked,
+                                                    completion: completion)
                 return
             }
 
             guard let memoryCachedOfferings = self.cachedOfferings else {
-                self.fetchFromNetwork(appUserID: appUserID,
-                                      fetchPolicy: fetchPolicy) { [weak self] result in
-                    self?.trackGetOfferingsResultIfNeeded(trackDiagnostics: trackDiagnostics,
-                                                          startTime: startTime,
-                                                          cacheStatus: .notFound,
-                                                          error: result.error,
-                                                          requestedProductIds: result.value?.requestedProductIds,
-                                                          notFoundProductIds: result.value?.notFoundProductIds)
-                    completion?(result.map(\.offerings))
-                }
+                self.fetchFromNetworkAndTrackResult(appUserID: appUserID,
+                                                    fetchPolicy: fetchPolicy,
+                                                    trackingContext: trackingContext,
+                                                    cacheStatus: .notFound,
+                                                    completion: completion)
                 return
             }
 
             guard !self.shouldRefreshOfferingsWithPrunedComponents(memoryCachedOfferings) else {
-                self.fetchFromNetwork(appUserID: appUserID,
-                                      fetchPolicy: fetchPolicy) { [weak self] result in
-                    self?.trackGetOfferingsResultIfNeeded(trackDiagnostics: trackDiagnostics,
-                                                          startTime: startTime,
-                                                          cacheStatus: .stale,
-                                                          error: result.error,
-                                                          requestedProductIds: result.value?.requestedProductIds,
-                                                          notFoundProductIds: result.value?.notFoundProductIds)
-                    completion?(result.map(\.offerings))
-                }
+                self.fetchFromNetworkAndTrackResult(appUserID: appUserID,
+                                                    fetchPolicy: fetchPolicy,
+                                                    trackingContext: trackingContext,
+                                                    cacheStatus: .stale,
+                                                    completion: completion)
                 return
             }
 
@@ -227,6 +214,25 @@ private extension OfferingsManager {
                                       isAppBackgrounded: isAppBackgrounded,
                                       fetchPolicy: fetchPolicy,
                                       completion: completion)
+        }
+    }
+
+    func fetchFromNetworkAndTrackResult(
+        appUserID: String,
+        fetchPolicy: FetchPolicy,
+        trackingContext: OfferingsTrackingContext,
+        cacheStatus: CacheStatus,
+        completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?
+    ) {
+        self.fetchFromNetwork(appUserID: appUserID,
+                              fetchPolicy: fetchPolicy) { [weak self] result in
+            self?.trackGetOfferingsResultIfNeeded(trackDiagnostics: trackingContext.trackDiagnostics,
+                                                  startTime: trackingContext.startTime,
+                                                  cacheStatus: cacheStatus,
+                                                  error: result.error,
+                                                  requestedProductIds: result.value?.requestedProductIds,
+                                                  notFoundProductIds: result.value?.notFoundProductIds)
+            completion?(result.map(\.offerings))
         }
     }
 
@@ -714,6 +720,11 @@ struct OfferingsResultData {
     let offerings: Offerings
     let requestedProductIds: Set<String>
     let notFoundProductIds: Set<String>
+}
+
+private struct OfferingsTrackingContext {
+    let trackDiagnostics: Bool
+    let startTime: Date
 }
 
 /// For UI Preview mode only.

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -348,6 +348,7 @@ private extension OfferingsManager {
                 Logger.rcSuccess(Strings.offering.offerings_stale_updated_from_network)
 
                 self.deviceCache.cache(offerings: offeringsResultData.offerings,
+                                       diskContents: contents,
                                        preferredLocales: preferredLocales,
                                        appUserID: appUserID)
 

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -503,7 +503,7 @@ private extension OfferingsManager {
         guard self.remoteConfigManager?.isDisabled == true else { return false }
 
         return offerings.all.values.contains { offering in
-            offering.hasPaywallComponents && offering.paywallComponents == nil
+            offering.hasPaywallComponents && offering.internalPaywallComponents == nil
         }
     }
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -871,6 +871,10 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         super.init()
 
         self.identityManager.remoteConfigManager = self.remoteConfigManager
+        self.remoteConfigManager.onRemoteConfigDisabled = { [weak self] in
+            guard let self else { return }
+            self.offeringsManager.invalidateAndReFetchCachedOfferingsIfAppropiate(appUserID: self.appUserID)
+        }
 
         Logger.verbose(Strings.configure.purchases_init(self, paymentQueueWrapper))
 

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -62,6 +62,7 @@ class BaseBackendIntegrationTests: TestCase {
     class var responseVerificationMode: Signing.ResponseVerificationMode {
         return .enforced(Signing.loadPublicKey())
     }
+    class var useWorkflows: Bool { return false }
     var enableReceiptFetchRetry: Bool = true
 
     var apiKey: String { return Constants.apiKey }
@@ -253,7 +254,8 @@ private extension BaseBackendIntegrationTests {
 
     private var dangerousSettings: DangerousSettings {
         return .init(autoSyncPurchases: true,
-                     internalSettings: self)
+                     internalSettings: self,
+                     useWorkflows: Self.useWorkflows)
     }
 
 }

--- a/Tests/BackendIntegrationTests/ProductionWorkflowsPaywallComponentsIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/ProductionWorkflowsPaywallComponentsIntegrationTests.swift
@@ -17,7 +17,7 @@ import XCTest
 #endif
 
 @MainActor
-final class ProductionWorkflowsPaywallComponentsIntegrationTests: BaseStoreKitIntegrationTests {
+final class WorkflowComponentsIntegrationTests: BaseStoreKitIntegrationTests {
 
     override class var storeKitVersion: StoreKitVersion { .storeKit2 }
     override class var useWorkflows: Bool { true }
@@ -76,22 +76,30 @@ private final class RemoteConfigKillSwitchFake: @unchecked Sendable {
         }
 
         if self.disableRemoteConfig {
-            return (
-                HTTPURLResponse(url: request.httpRequest.path.url!,
-                                statusCode: 400,
-                                httpVersion: nil,
-                                headerFields: nil)!,
-                Data(#"{"code":7000,"message":"remote config disabled for test"}"#.utf8)
+            return self.response(
+                statusCode: 400,
+                data: Data(#"{"code":7000,"message":"remote config disabled for test"}"#.utf8),
+                request: request
             )
         } else {
-            return (
-                HTTPURLResponse(url: request.httpRequest.path.url!,
-                                statusCode: 204,
-                                httpVersion: nil,
-                                headerFields: nil)!,
-                Data()
-            )
+            return self.response(statusCode: 204, data: Data(), request: request)
         }
+    }
+
+    private func response(
+        statusCode: Int,
+        data: Data,
+        request: HTTPClient.Request
+    ) -> (HTTPURLResponse, Data)? {
+        guard let url = request.httpRequest.path.url,
+              let response = HTTPURLResponse(url: url,
+                                             statusCode: statusCode,
+                                             httpVersion: nil,
+                                             headerFields: nil) else {
+            return nil
+        }
+
+        return (response, data)
     }
 
 }

--- a/Tests/BackendIntegrationTests/ProductionWorkflowsPaywallComponentsIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/ProductionWorkflowsPaywallComponentsIntegrationTests.swift
@@ -17,7 +17,7 @@ import XCTest
 #endif
 
 @MainActor
-final class WorkflowComponentsIntegrationTests: BaseStoreKitIntegrationTests {
+final class ProductionWorkflowsPaywallComponentsIntegrationTests: BaseStoreKitIntegrationTests {
 
     override class var storeKitVersion: StoreKitVersion { .storeKit2 }
     override class var useWorkflows: Bool { true }

--- a/Tests/BackendIntegrationTests/ProductionWorkflowsPaywallComponentsIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/ProductionWorkflowsPaywallComponentsIntegrationTests.swift
@@ -1,0 +1,97 @@
+//
+//  ProductionWorkflowsPaywallComponentsIntegrationTests.swift
+//  BackendIntegrationTests
+//
+//  Created by Rick van der Linden on 7/15/26.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+//
+
+import Foundation
+import Nimble
+import XCTest
+
+#if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+@_spi(Internal) @testable import RevenueCat_CustomEntitlementComputation
+#else
+@_spi(Internal) @testable import RevenueCat
+#endif
+
+@MainActor
+final class ProductionWorkflowsPaywallComponentsIntegrationTests: BaseStoreKitIntegrationTests {
+
+    override class var storeKitVersion: StoreKitVersion { .storeKit2 }
+    override class var useWorkflows: Bool { true }
+
+    private let remoteConfigFake = RemoteConfigKillSwitchFake()
+
+    override func setUp() async throws {
+        self.forceServerErrorStrategy = ForceServerErrorStrategy(
+            fakeResponseWithoutPerformingRequest: { [remoteConfigFake] request in
+                remoteConfigFake.response(for: request)
+            },
+            shouldForceServerError: { _ in false }
+        )
+
+        try await super.setUp()
+    }
+
+    func testOfferingsSkipPaywallComponentsUntilRemoteConfigKillSwitch() async throws {
+        let phase1Current = try await self.currentOffering
+        expect(phase1Current.identifier) == "default"
+        expect(phase1Current.hasPaywall) == true
+        expect(phase1Current.paywallComponents).to(beNil())
+
+        self.remoteConfigFake.disableRemoteConfig = true
+        _ = try? await self.purchases.logIn("integration-test-workflows-\(UUID().uuidString)")
+
+        let phase2Current = try await self.currentOfferingWithComponents()
+        expect(phase2Current.identifier) == "default"
+        expect(phase2Current.hasPaywall) == true
+        expect(phase2Current.paywallComponents).toNot(beNil())
+        expect(phase2Current.paywallComponents?.data).toNot(beNil())
+    }
+
+    private func currentOfferingWithComponents() async throws -> Offering {
+        for _ in 0..<20 {
+            let current = try await self.currentOffering
+            if current.paywallComponents != nil {
+                return current
+            }
+
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+
+        return try await self.currentOffering
+    }
+
+}
+
+private final class RemoteConfigKillSwitchFake: @unchecked Sendable {
+
+    var disableRemoteConfig = false
+
+    func response(for request: HTTPClient.Request) -> (HTTPURLResponse, Data)? {
+        guard case HTTPRequest.Path.remoteConfig = request.httpRequest.path else {
+            return nil
+        }
+
+        if self.disableRemoteConfig {
+            return (
+                HTTPURLResponse(url: request.httpRequest.path.url!,
+                                statusCode: 400,
+                                httpVersion: nil,
+                                headerFields: nil)!,
+                Data(#"{"code":7000,"message":"remote config disabled for test"}"#.utf8)
+            )
+        } else {
+            return (
+                HTTPURLResponse(url: request.httpRequest.path.url!,
+                                statusCode: 204,
+                                httpVersion: nil,
+                                headerFields: nil)!,
+                Data()
+            )
+        }
+    }
+
+}

--- a/Tests/BackendIntegrationTests/WorkflowComponentsIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/WorkflowComponentsIntegrationTests.swift
@@ -1,5 +1,5 @@
 //
-//  ProductionWorkflowsPaywallComponentsIntegrationTests.swift
+//  WorkflowComponentsIntegrationTests.swift
 //  BackendIntegrationTests
 //
 //  Created by Rick van der Linden on 7/15/26.
@@ -17,7 +17,7 @@ import XCTest
 #endif
 
 @MainActor
-final class ProductionWorkflowsPaywallComponentsIntegrationTests: BaseStoreKitIntegrationTests {
+final class WorkflowComponentsIntegrationTests: BaseStoreKitIntegrationTests {
 
     override class var storeKitVersion: StoreKitVersion { .storeKit2 }
     override class var useWorkflows: Bool { true }

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallPreviewResourcesLoader.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallPreviewResourcesLoader.swift
@@ -115,6 +115,7 @@ class PaywallPreviewResourcesLoader {
                     packages: packages.packages,
                     paywallComponents: offering.paywallComponents,
                     draftPaywallComponents: offering.draftPaywallComponents,
+                    hasPaywallComponents: offering.hasPaywallComponents,
                     webCheckoutUrl: offering.webCheckoutUrl
                 )
             }

--- a/Tests/UnitTests/Mocks/MockDeviceCache.swift
+++ b/Tests/UnitTests/Mocks/MockDeviceCache.swift
@@ -112,15 +112,22 @@ class MockDeviceCache: DeviceCache {
     var stubbedIsOfferingsCacheStale = false
     var stubbedOfferings: Offerings?
     var stubbedCachedOfferingsData: Data?
+    var latestCachedOfferingsContents: Offerings.Contents?
     var stubbedOfferingCacheStatus: CacheStatus?
 
     override var cachedOfferings: Offerings? {
         return stubbedOfferings
     }
 
-    override func cache(offerings: Offerings, preferredLocales: [String], appUserID: String) {
+    override func cache(
+        offerings: Offerings,
+        diskContents: Offerings.Contents? = nil,
+        preferredLocales: [String],
+        appUserID: String
+    ) {
         self.cacheOfferingsCount += 1
         self.latestCachePreferredLocales = preferredLocales
+        self.latestCachedOfferingsContents = diskContents ?? offerings.contents
     }
     override func cacheInMemory(offerings: Offerings) {
         self.cacheOfferingsInMemoryCount += 1

--- a/Tests/UnitTests/Mocks/MockOfferingsFactory.swift
+++ b/Tests/UnitTests/Mocks/MockOfferingsFactory.swift
@@ -9,6 +9,7 @@ class MockOfferingsFactory: OfferingsFactory {
 
     var emptyOfferings = false
     var nilOfferings = false
+    var invokedCreateOfferingsShouldCreatePaywallComponents: Bool?
 
     override init(systemInfo: SystemInfo = MockSystemInfo(finishTransactions: true)) {
         super.init(systemInfo: systemInfo)
@@ -17,8 +18,11 @@ class MockOfferingsFactory: OfferingsFactory {
     override func createOfferings(
         from storeProductsByID: [String: StoreProduct],
         contents: Offerings.Contents,
-        loadedFromDiskCache: Bool
+        loadedFromDiskCache: Bool,
+        shouldCreatePaywallComponents: Bool = true
     ) -> Offerings? {
+        self.invokedCreateOfferingsShouldCreatePaywallComponents = shouldCreatePaywallComponents
+
         if emptyOfferings {
             let response = OfferingsResponse(currentOfferingId: "base",
                                              offerings: [],

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -1495,6 +1495,19 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.blobFetcher.invokedPrefetchCount) == 0
     }
 
+    func testFourHundredResponseNotifiesWhenRemoteConfigIsDisabled() {
+        var disabledCallbackCount = 0
+        self.manager.onRemoteConfigDisabled = { disabledCallbackCount += 1 }
+
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .invalidRequest)))
+
+        expect(disabledCallbackCount) == 1
+
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
+        expect(disabledCallbackCount) == 1
+    }
+
     func testTooManyRequestsResponseDisablesRemoteConfig() {
         expect(self.manager.isDisabled) == false
         self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -1090,7 +1090,15 @@ extension OfferingsManagerTests {
         )
         self.mockDeviceCache.stubbedOfferings = MockData.makeSampleOfferings(hasPaywallComponents: true)
         self.mockDeviceCache.stubbedOfferingCacheStatus = .valid
-        let offeringResp: OfferingsResponse = try BaseHTTPResponseTest.decodeFixture("OfferingsWithPaywallComponents")
+        let response: OfferingsResponse = try BaseHTTPResponseTest.decodeFixture("OfferingsWithPaywallComponents")
+        let uiConfig: UIConfig = try BaseHTTPResponseTest.decodeFixture("UIConfig")
+        let offeringResp = OfferingsResponse(
+            currentOfferingId: response.currentOfferingId,
+            offerings: response.offerings,
+            placements: response.placements,
+            targeting: response.targeting,
+            uiConfig: uiConfig
+        )
         self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(
             Offerings.Contents(response: offeringResp, httpResponseOriginalSource: .mainServer)
         )

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -972,15 +972,18 @@ private extension OfferingsManagerTests {
         static let sampleOfferings: Offerings = MockData.makeSampleOfferings()
 
         /// A fresh `Offerings` instance per call, for tests that need two distinguishable snapshots.
-        static func makeSampleOfferings() -> Offerings {
+        static func makeSampleOfferings(hasPaywallComponents: Bool = false) -> Offerings {
             return .init(
-            offerings: MockData.anyBackendOfferingsContents.response.offerings
-                .map { offering in
-                    Offering(
-                        identifier: offering.identifier,
-                        serverDescription: offering.description,
-                        metadata: offering.metadata,
-                        availablePackages: offering.packages.map { package in
+                offerings: MockData.anyBackendOfferingsContents.response.offerings
+                    .map { offering in
+                        Offering(
+                            identifier: offering.identifier,
+                            serverDescription: offering.description,
+                            metadata: offering.metadata,
+                            paywallComponents: nil,
+                            hasPaywallComponents: hasPaywallComponents,
+                            draftPaywallComponents: nil,
+                            availablePackages: offering.packages.map { package in
                                 .init(
                                     identifier: package.identifier,
                                     packageType: Package.packageType(from: package.identifier),
@@ -990,16 +993,16 @@ private extension OfferingsManagerTests {
                                     offeringIdentifier: offering.identifier,
                                     webCheckoutUrl: nil
                                 )
-                        },
-                        webCheckoutUrl: nil
-                    )
-                }
-                .dictionaryWithKeys(\.identifier),
-            currentOfferingID: MockData.anyBackendOfferingsContents.response.currentOfferingId,
-            placements: nil,
-            targeting: nil,
-            contents: MockData.anyBackendOfferingsContents,
-            loadedFromDiskCache: false
+                            },
+                            webCheckoutUrl: nil
+                        )
+                    }
+                    .dictionaryWithKeys(\.identifier),
+                currentOfferingID: MockData.anyBackendOfferingsContents.response.currentOfferingId,
+                placements: nil,
+                targeting: nil,
+                contents: MockData.anyBackendOfferingsContents,
+                loadedFromDiskCache: false
             )
         }
     }
@@ -1020,6 +1023,85 @@ extension OfferingsManagerTests {
         }
 
         expect(result).to(beSuccess())
+    }
+
+    func testGetOfferingsKeepsPaywallComponentsWhenRemoteConfigManagerIsNil() {
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsContents)
+
+        let result = waitUntilValue { completed in
+            self.offeringsManager.offerings(appUserID: MockData.anyAppUserID) { completed($0) }
+        }
+
+        expect(result).to(beSuccess())
+        expect(self.mockOfferingsFactory.invokedCreateOfferingsShouldCreatePaywallComponents) == true
+    }
+
+    func testGetOfferingsSkipsPaywallComponentsWhenRemoteConfigManagerIsEnabled() {
+        let mockRemoteConfigManager = MockRemoteConfigManager()
+        mockRemoteConfigManager.isDisabled = false
+        let manager = self.makeOfferingsManager(remoteConfigManager: mockRemoteConfigManager)
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsContents)
+
+        let result = waitUntilValue { completed in
+            manager.offerings(appUserID: MockData.anyAppUserID) { completed($0) }
+        }
+
+        expect(result).to(beSuccess())
+        expect(self.mockOfferingsFactory.invokedCreateOfferingsShouldCreatePaywallComponents) == false
+    }
+
+    func testGetOfferingsKeepsPaywallComponentsWhenRemoteConfigManagerIsDisabled() {
+        let mockRemoteConfigManager = MockRemoteConfigManager()
+        mockRemoteConfigManager.isDisabled = true
+        let manager = self.makeOfferingsManager(remoteConfigManager: mockRemoteConfigManager)
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsContents)
+
+        let result = waitUntilValue { completed in
+            manager.offerings(appUserID: MockData.anyAppUserID) { completed($0) }
+        }
+
+        expect(result).to(beSuccess())
+        expect(self.mockOfferingsFactory.invokedCreateOfferingsShouldCreatePaywallComponents) == true
+    }
+
+    func testGetOfferingsUsesPrunedMemoryCacheWhenRemoteConfigManagerIsEnabled() {
+        let mockRemoteConfigManager = MockRemoteConfigManager()
+        mockRemoteConfigManager.isDisabled = false
+        let manager = self.makeOfferingsManager(remoteConfigManager: mockRemoteConfigManager)
+        let cachedOfferings = MockData.makeSampleOfferings(hasPaywallComponents: true)
+        self.mockDeviceCache.stubbedOfferings = cachedOfferings
+        self.mockDeviceCache.stubbedOfferingCacheStatus = .valid
+
+        let result = waitUntilValue { completed in
+            manager.offerings(appUserID: MockData.anyAppUserID) { completed($0) }
+        }
+
+        expect(result).to(beSuccess())
+        expect(result?.value).to(beIdenticalTo(cachedOfferings))
+        expect(self.mockOfferings.invokedGetOfferingsForAppUserID) == false
+    }
+
+    func testGetOfferingsRefetchesPrunedMemoryCacheWhenRemoteConfigManagerIsDisabled() throws {
+        let mockRemoteConfigManager = MockRemoteConfigManager()
+        mockRemoteConfigManager.isDisabled = true
+        let manager = self.makeOfferingsManager(
+            remoteConfigManager: mockRemoteConfigManager,
+            offeringsFactory: OfferingsFactory(systemInfo: self.mockSystemInfo)
+        )
+        self.mockDeviceCache.stubbedOfferings = MockData.makeSampleOfferings(hasPaywallComponents: true)
+        self.mockDeviceCache.stubbedOfferingCacheStatus = .valid
+        let offeringResp: OfferingsResponse = try BaseHTTPResponseTest.decodeFixture("OfferingsWithPaywallComponents")
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(
+            Offerings.Contents(response: offeringResp, httpResponseOriginalSource: .mainServer)
+        )
+
+        let result = waitUntilValue { completed in
+            manager.offerings(appUserID: MockData.anyAppUserID) { completed($0) }
+        }
+
+        expect(result).to(beSuccess())
+        expect(self.mockOfferings.invokedGetOfferingsForAppUserID) == true
+        expect(result?.value?.offering(identifier: "paywall_components")?.paywallComponents).toNot(beNil())
     }
 
     func testGetOfferingsDoesNotDeliverUntilConfigReady() {
@@ -1302,12 +1384,15 @@ extension OfferingsManagerTests {
         expect(mockRemoteConfigManager.invokedTopicCount) > 0
     }
 
-    private func makeOfferingsManager(remoteConfigManager: RemoteConfigManagerType?) -> OfferingsManager {
+    private func makeOfferingsManager(
+        remoteConfigManager: RemoteConfigManagerType?,
+        offeringsFactory: OfferingsFactory? = nil
+    ) -> OfferingsManager {
         return OfferingsManager(deviceCache: self.mockDeviceCache,
                                 operationDispatcher: self.mockOperationDispatcher,
                                 systemInfo: self.mockSystemInfo,
                                 backend: self.mockBackend,
-                                offeringsFactory: self.mockOfferingsFactory,
+                                offeringsFactory: offeringsFactory ?? self.mockOfferingsFactory,
                                 productsManager: self.mockProductsManager,
                                 diagnosticsTracker: self.mockDiagnosticsTracker,
                                 remoteConfigManager: remoteConfigManager)

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -1112,6 +1112,36 @@ extension OfferingsManagerTests {
         expect(result?.value?.offering(identifier: "paywall_components")?.paywallComponents).toNot(beNil())
     }
 
+    func testGetOfferingsCachesFullPaywallComponentsToDiskWhenRemoteConfigManagerIsEnabled() throws {
+        let mockRemoteConfigManager = MockRemoteConfigManager()
+        mockRemoteConfigManager.isDisabled = false
+        let manager = self.makeOfferingsManager(
+            remoteConfigManager: mockRemoteConfigManager,
+            offeringsFactory: OfferingsFactory(systemInfo: self.mockSystemInfo)
+        )
+        let response: OfferingsResponse = try BaseHTTPResponseTest.decodeFixture("OfferingsWithPaywallComponents")
+        let uiConfig: UIConfig = try BaseHTTPResponseTest.decodeFixture("UIConfig")
+        let offeringResp = OfferingsResponse(
+            currentOfferingId: response.currentOfferingId,
+            offerings: response.offerings,
+            placements: response.placements,
+            targeting: response.targeting,
+            uiConfig: uiConfig
+        )
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(
+            Offerings.Contents(response: offeringResp, httpResponseOriginalSource: .mainServer)
+        )
+
+        let result = waitUntilValue { completed in
+            manager.offerings(appUserID: MockData.anyAppUserID) { completed($0) }
+        }
+
+        expect(result).to(beSuccess())
+        expect(result?.value?.offering(identifier: "paywall_components")?.paywallComponents).to(beNil())
+        expect(self.mockDeviceCache.latestCachedOfferingsContents?.response.offerings.first?.paywallComponents)
+            .toNot(beNil())
+    }
+
     func testGetOfferingsDoesNotDeliverUntilConfigReady() {
         let mockRemoteConfigManager = MockRemoteConfigManager()
         mockRemoteConfigManager.shouldStoreTopicCompletion = true

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -1112,6 +1112,43 @@ extension OfferingsManagerTests {
         expect(result?.value?.offering(identifier: "paywall_components")?.paywallComponents).toNot(beNil())
     }
 
+    func testGetOfferingsRefetchesIfRemoteConfigDisablesBeforeReadinessDelivery() throws {
+        let mockRemoteConfigManager = MockRemoteConfigManager()
+        mockRemoteConfigManager.isDisabled = false
+        mockRemoteConfigManager.shouldStoreTopicCompletion = true
+        let manager = self.makeOfferingsManager(
+            remoteConfigManager: mockRemoteConfigManager,
+            offeringsFactory: OfferingsFactory(systemInfo: self.mockSystemInfo)
+        )
+        let response: OfferingsResponse = try BaseHTTPResponseTest.decodeFixture("OfferingsWithPaywallComponents")
+        let uiConfig: UIConfig = try BaseHTTPResponseTest.decodeFixture("UIConfig")
+        let offeringResp = OfferingsResponse(
+            currentOfferingId: response.currentOfferingId,
+            offerings: response.offerings,
+            placements: response.placements,
+            targeting: response.targeting,
+            uiConfig: uiConfig
+        )
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(
+            Offerings.Contents(response: offeringResp, httpResponseOriginalSource: .mainServer)
+        )
+
+        let deliveredResult: Atomic<Result<Offerings, OfferingsManager.Error>?> = nil
+        manager.offerings(appUserID: MockData.anyAppUserID) { deliveredResult.value = $0 }
+
+        expect(self.mockOfferings.invokedGetOfferingsForAppUserIDCount).toEventually(equal(1))
+        expect(mockRemoteConfigManager.invokedTopicCount).toEventually(beGreaterThan(0))
+        expect(deliveredResult.value).to(beNil())
+
+        mockRemoteConfigManager.isDisabled = true
+        mockRemoteConfigManager.completeStoredTopic()
+
+        expect(deliveredResult.value).toEventually(beSuccess())
+        expect(self.mockOfferings.invokedGetOfferingsForAppUserIDCount) == 2
+        let deliveredOffering = deliveredResult.value?.value?.offering(identifier: "paywall_components")
+        expect(deliveredOffering?.paywallComponents).toNot(beNil())
+    }
+
     func testGetOfferingsCachesFullPaywallComponentsToDiskWhenRemoteConfigManagerIsEnabled() throws {
         let mockRemoteConfigManager = MockRemoteConfigManager()
         mockRemoteConfigManager.isDisabled = false

--- a/Tests/UnitTests/Purchasing/OfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsTests.swift
@@ -865,6 +865,86 @@ class OfferingsTests: TestCase {
         expect(offering.hasPaywall) == true
     }
 
+    func testCreateOfferingWithPaywallComponentsSkipsPayloadWhenPaywallComponentsDisabled() throws {
+        let monthlyProduct = MockSK1Product(mockProductIdentifier: "com.revenuecat.monthly_4.99.1_week_intro")
+        let products = [
+            "com.revenuecat.monthly_4.99.1_week_intro": StoreProduct(sk1Product: monthlyProduct)
+        ]
+
+        let offeringResp: OfferingsResponse = try BaseHTTPResponseTest.decodeFixture("OfferingsWithPaywallComponents")
+        let offeringResponse0 = try XCTUnwrap(offeringResp.offerings[safe: 0])
+
+        expect(offeringResponse0.identifier) == "paywall_components"
+        expect(offeringResponse0.paywallComponents).toNot(beNil())
+
+        let uiConfig: UIConfig = try XCTUnwrap(BaseHTTPResponseTest.decodeFixture("UIConfig"))
+
+        let offering = try XCTUnwrap(
+            self.offeringsFactory.createOffering(from: products,
+                                                 offering: offeringResponse0,
+                                                 uiConfig: uiConfig,
+                                                 shouldCreatePaywallComponents: false)
+            )
+
+        expect(offering.paywall).to(beNil())
+        expect(offering.paywallComponents).to(beNil())
+        expect(offering.draftPaywallComponents).to(beNil())
+        expect(offering.hasPaywall) == true
+    }
+
+    func testCreateOfferingWithDraftPaywallComponentsSkipsPayloadWhenPaywallComponentsDisabled() throws {
+        let monthlyProduct = MockSK1Product(mockProductIdentifier: "com.revenuecat.monthly_4.99.1_week_intro")
+        let products = [
+            "com.revenuecat.monthly_4.99.1_week_intro": StoreProduct(sk1Product: monthlyProduct)
+        ]
+
+        let offeringResp: OfferingsResponse = try BaseHTTPResponseTest.decodeFixture("OfferingsWithPaywallComponents")
+        let offeringResponse0 = try XCTUnwrap(offeringResp.offerings[safe: 1])
+
+        expect(offeringResponse0.identifier) == "paywall_components_with_draft"
+        expect(offeringResponse0.paywallComponents).toNot(beNil())
+        expect(offeringResponse0.draftPaywallComponents).toNot(beNil())
+
+        let uiConfig: UIConfig = try XCTUnwrap(BaseHTTPResponseTest.decodeFixture("UIConfig"))
+
+        let offering = try XCTUnwrap(
+            self.offeringsFactory.createOffering(from: products,
+                                                 offering: offeringResponse0,
+                                                 uiConfig: uiConfig,
+                                                 shouldCreatePaywallComponents: false)
+        )
+
+        expect(offering.paywall).to(beNil())
+        expect(offering.paywallComponents).to(beNil())
+        expect(offering.draftPaywallComponents).to(beNil())
+        expect(offering.hasPaywall) == true
+    }
+
+    func testCreateOfferingsWithPaywallComponentsSkipsPayloadInRetainedContentsWhenPaywallComponentsDisabled() throws {
+        let monthlyProduct = MockSK1Product(mockProductIdentifier: "com.revenuecat.monthly_4.99.1_week_intro")
+        let products = [
+            "com.revenuecat.monthly_4.99.1_week_intro": StoreProduct(sk1Product: monthlyProduct)
+        ]
+
+        let offeringResp: OfferingsResponse = try BaseHTTPResponseTest.decodeFixture("OfferingsWithPaywallComponents")
+        let contents = Offerings.Contents(response: offeringResp, httpResponseOriginalSource: .mainServer)
+
+        let offerings = try XCTUnwrap(
+            self.offeringsFactory.createOfferings(from: products,
+                                                  contents: contents,
+                                                  loadedFromDiskCache: false,
+                                                  shouldCreatePaywallComponents: false)
+        )
+        let offering = try XCTUnwrap(offerings.offering(identifier: "paywall_components"))
+
+        expect(offering.paywall).to(beNil())
+        expect(offering.paywallComponents).to(beNil())
+        expect(offering.draftPaywallComponents).to(beNil())
+        expect(offering.hasPaywall) == true
+        expect(offerings.response.offerings.first?.paywallComponents).to(beNil())
+        expect(offerings.response.offerings[safe: 1]?.draftPaywallComponents).to(beNil())
+    }
+
     func testCreateOfferingWithPaywallComponentsAndDraftPaywallComponents() throws {
         let monthlyProduct = MockSK1Product(mockProductIdentifier: "com.revenuecat.monthly_4.99.1_week_intro")
         let products = [

--- a/Tests/UnitTests/Purchasing/OfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsTests.swift
@@ -926,7 +926,7 @@ class OfferingsTests: TestCase {
             "com.revenuecat.monthly_4.99.1_week_intro": StoreProduct(sk1Product: monthlyProduct)
         ]
 
-        let offeringResp: OfferingsResponse = try BaseHTTPResponseTest.decodeFixture("OfferingsWithPaywallComponents")
+        let offeringResp: OfferingsResponse = try Self.offeringsWithPaywallComponentsAndUiConfig()
         let contents = Offerings.Contents(response: offeringResp, httpResponseOriginalSource: .mainServer)
 
         let offerings = try XCTUnwrap(
@@ -943,6 +943,39 @@ class OfferingsTests: TestCase {
         expect(offering.hasPaywall) == true
         expect(offerings.response.offerings.first?.paywallComponents).to(beNil())
         expect(offerings.response.offerings[safe: 1]?.draftPaywallComponents).to(beNil())
+        expect(offerings.response.offerings.first?.hasPaywallComponents) == true
+        expect(offerings.response.offerings[safe: 1]?.hasPaywallComponents) == true
+        expect(offerings.response.offerings[safe: 2]?.hasPaywallComponents) == false
+    }
+
+    func testCreateOfferingsFromPrunedContentsPreservesPaywallComponentsMarker() throws {
+        let monthlyProduct = MockSK1Product(mockProductIdentifier: "com.revenuecat.monthly_4.99.1_week_intro")
+        let products = [
+            "com.revenuecat.monthly_4.99.1_week_intro": StoreProduct(sk1Product: monthlyProduct)
+        ]
+
+        let offeringResp: OfferingsResponse = try Self.offeringsWithPaywallComponentsAndUiConfig()
+        let contents = Offerings.Contents(response: offeringResp, httpResponseOriginalSource: .mainServer)
+        let prunedOfferings = try XCTUnwrap(
+            self.offeringsFactory.createOfferings(from: products,
+                                                  contents: contents,
+                                                  loadedFromDiskCache: false,
+                                                  shouldCreatePaywallComponents: false)
+        )
+
+        let rebuiltOfferings = try XCTUnwrap(
+            self.offeringsFactory.createOfferings(from: products,
+                                                  contents: prunedOfferings.contents,
+                                                  loadedFromDiskCache: true,
+                                                  shouldCreatePaywallComponents: false)
+        )
+        let offering = try XCTUnwrap(rebuiltOfferings.offering(identifier: "paywall_components"))
+
+        expect(offering.paywallComponents).to(beNil())
+        expect(offering.draftPaywallComponents).to(beNil())
+        expect(offering.hasPaywall) == true
+        expect(rebuiltOfferings.response.offerings.first?.paywallComponents).to(beNil())
+        expect(rebuiltOfferings.response.offerings.first?.hasPaywallComponents) == true
     }
 
     func testCreateOfferingWithPaywallComponentsAndDraftPaywallComponents() throws {
@@ -1018,6 +1051,19 @@ class OfferingsTests: TestCase {
         let contents = Offerings.Contents(response: offeringResp,
                                           httpResponseOriginalSource: .loadShedder)
         expect(contents.originalSource) == .loadShedder
+    }
+
+    private static func offeringsWithPaywallComponentsAndUiConfig() throws -> OfferingsResponse {
+        let response: OfferingsResponse = try BaseHTTPResponseTest.decodeFixture("OfferingsWithPaywallComponents")
+        let uiConfig: UIConfig = try BaseHTTPResponseTest.decodeFixture("UIConfig")
+
+        return OfferingsResponse(
+            currentOfferingId: response.currentOfferingId,
+            offerings: response.offerings,
+            placements: response.placements,
+            targeting: response.targeting,
+            uiConfig: uiConfig
+        )
     }
 
 }

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -680,6 +680,7 @@ final class MockRemoteConfigManager: RemoteConfigManagerType {
     }
 
     var isDisabled = false
+    var onRemoteConfigDisabled: (() -> Void)?
     var onConfigGenerationRead: (() -> Void)?
     var configGeneration: Int {
         get {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
@@ -119,6 +119,7 @@ class PurchasesGetOfferingsTests: BasePurchasesTests {
     }
 
     func testRemoteConfigDisabledInvalidatesAndRefetchesOfferings() {
+        self.systemInfo.stubbedRemoteConfigEnabled = true
         self.setupPurchases()
 
         self.mockOfferingsManager.invokedInvalidateAndReFetchCachedOfferingsIfAppropiate = false

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
@@ -118,6 +118,21 @@ class PurchasesGetOfferingsTests: BasePurchasesTests {
         expect(self.deviceCache.clearOfferingsCacheTimestampCount) == 0
     }
 
+    func testRemoteConfigDisabledInvalidatesAndRefetchesOfferings() {
+        self.setupPurchases()
+
+        self.mockOfferingsManager.invokedInvalidateAndReFetchCachedOfferingsIfAppropiate = false
+        self.mockOfferingsManager.invokedInvalidateAndReFetchCachedOfferingsIfAppropiateCount = 0
+        self.mockOfferingsManager.invokedInvalidateAndReFetchCachedOfferingsIfAppropiateParameters = nil
+
+        self.mockRemoteConfigManager.onRemoteConfigDisabled?()
+
+        expect(self.mockOfferingsManager.invokedInvalidateAndReFetchCachedOfferingsIfAppropiate) == true
+        expect(self.mockOfferingsManager.invokedInvalidateAndReFetchCachedOfferingsIfAppropiateCount) == 1
+        expect(self.mockOfferingsManager.invokedInvalidateAndReFetchCachedOfferingsIfAppropiateParameters) ==
+            self.identityManager.currentAppUserID
+    }
+
     func testWarmsUpPaywallsCache() throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 


### PR DESCRIPTION
Stacked on https://github.com/RevenueCat/purchases-ios/pull/7213

## Motivation
When using Workflows through the remote-config infrastructure, we were still decoding the `paywallComponents` on `Offerings`, even though they weren't used. This increased the memory footprint since we'll now also have the workflows equivalent in memory.

## Changes
This PR changes this such that `paywallComponents` are only decoded when we are **not** using workflows through the remote-config infrastructure. Essentially only when remote-config disabled (either by feature flag or killswitch).

This mirrors Android PR https://github.com/RevenueCat/purchases-android/pull/3772

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core offerings caching and paywall resolution when remote config toggles; incorrect pruning or refetch timing could break paywalls or regress memory behavior, though behavior is heavily tested.
> 
> **Overview**
> When **remote config is enabled** (workflows path), offerings no longer build or retain full **paywall component payloads** in memory; workflows load that data from `/v1/config` instead. A new **`hasPaywallComponents`** flag (API + `Offering`) keeps **`hasPaywall`** accurate after the bodies are stripped.
> 
> **`OfferingsFactory`** gains **`shouldCreatePaywallComponents`** and **`removingPaywallComponents()`** so in-memory offerings and retained **`Contents`** drop component JSON while disk cache can still store the **full** network response via **`DeviceCache.cache(..., diskContents:)`**.
> 
> **`OfferingsManager`** ties creation to **`remoteConfigManager?.isDisabled`**, refetches when cache has only the lightweight marker after RC turns off, and extends the config-readiness gate to **refresh** instead of delivering pruned offerings. **`RemoteConfigManager`** fires **`onRemoteConfigDisabled`** once on kill-switch; **`Purchases`** uses it to **invalidate and refetch** offerings.
> 
> Tests add unit coverage, a backend integration test for RC disable → legacy components restored, and a small Maestro fix for remote-config paths in **`primaryBackendDown`** simulation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c8c3beb511d41dee7504020cba117918330d343. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->