### PR TITLE
test(workflows): add Maestro flow that navigates a workflow paywall to purchase

### DIFF
--- a/Examples/rc-maestro/maestro/workflows/open_workflow.yaml
+++ b/Examples/rc-maestro/maestro/workflows/open_workflow.yaml
@@ -1,0 +1,58 @@
+# Opens a workflow paywall (offering `default_workflows`), navigates all three screens via the
+# "Continue" button, and purchases on the last one, then asserts the entitlement unlocks.
+# Local-only for now (not under e2e_tests/, so the CI lane does not run it).
+#
+# Run locally against the test store:
+#   maestro test -e MAESTRO_STORE=test_store Examples/rc-maestro/maestro/workflows/open_workflow.yaml
+
+appId: com.revenuecat.maestro.ios
+name: Navigate a workflow paywall to purchase
+env:
+  MAESTRO_STORE: ${MAESTRO_STORE || 'test_store'}
+
+---
+- clearState
+# Dismiss any leftover system alerts from previous test runs.
+- pressKey: home
+- launchApp:
+    arguments:
+        e2e_test_flow: open_workflow
+- assertVisible: "entitlement (pro): nil"
+# Wait for offerings to load before the button appears.
+- extendedWaitUntil:
+    visible: "Present Paywall"
+    timeout: 15000
+- tapOn:
+    text: "Present Paywall"
+
+# Screen 1
+- extendedWaitUntil:
+    visible: "Start Your Free Week And Reclaim 30+ Minutes Daily"
+    timeout: 15000
+- takeScreenshot: "open_workflow - screen 1"
+- tapOn:
+    text: "Continue"
+
+# Screen 2
+- extendedWaitUntil:
+    visible: "Most People Feel Calmer After Just 3 Sessions"
+    timeout: 15000
+- takeScreenshot: "open_workflow - screen 2"
+- tapOn:
+    text: "Continue"
+
+# Paywall screen (Yearly is preselected); the last Continue starts the purchase.
+- extendedWaitUntil:
+    visible: "People Who Meditate Daily Sleep 40% Better"
+    timeout: 15000
+- takeScreenshot: "open_workflow - paywall screen"
+- tapOn:
+    text: "Continue"
+
+- runFlow:
+    file: ../utils/confirm_purchase.yaml
+    env:
+      SCREENSHOT_PREFIX: open_workflow
+
+- assertVisible: "entitlement (pro): active"
+- takeScreenshot: "open_workflow - unlocked entitlement"

--- a/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/RcMaestroApp.swift
+++ b/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/RcMaestroApp.swift
@@ -27,7 +27,10 @@ struct RcMaestroApp: App {
                                 return request.fallbackUrlIndex == nil
                             }
                         }
-                    )
+                    ),
+                    // Workflows (multipage paywalls) read through remote config; this internal flag
+                    // is the runtime gate (no compile flag needed for the Maestro app).
+                    useWorkflows: true
                 ))
                 .build()
         )
@@ -59,7 +62,8 @@ struct RcMaestroApp: App {
 enum E2ETestFlow: String {
     case subscribeFromV1Paywall = "subscribe_from_v1_paywall"
     case subscribeFromV2Paywall = "subscribe_from_v2_paywall"
-    
+    case openWorkflow = "open_workflow"
+
     @ViewBuilder
     var view: some View {
         switch self {
@@ -67,6 +71,8 @@ enum E2ETestFlow: String {
             E2ETestFlowView.SubscribeFromV1Paywall()
         case .subscribeFromV2Paywall:
             E2ETestFlowView.SubscribeFromV2Paywall()
+        case .openWorkflow:
+            E2ETestFlowView.OpenWorkflow()
         }
     }
 }

--- a/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/e2e-test-flows/open-workflow.swift
+++ b/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/e2e-test-flows/open-workflow.swift
@@ -1,0 +1,75 @@
+//
+//  open-workflow.swift
+//  Maestro
+//
+//  Copyright © 2025 RevenueCat, Inc. All rights reserved.
+//
+
+import SwiftUI
+import RevenueCat
+import RevenueCatUI
+
+extension E2ETestFlowView {
+    struct OpenWorkflow: View {
+
+        static let offeringIdentifier = "default_workflows"
+
+        enum GetOfferingsState {
+            case loading
+            case loaded(Offering)
+            case failed(Error)
+        }
+
+        @State private var offeringsState: GetOfferingsState = .loading
+        @State private var presentPaywall = false
+
+        var body: some View {
+            VStack {
+                Text("Workflow paywall")
+                    .font(.largeTitle)
+
+                switch offeringsState {
+                case .loading:
+                    Text("Loading offerings...")
+                case .loaded(let offering):
+                    Button("Present Paywall") {
+                        presentPaywall = true
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .sheet(isPresented: $presentPaywall) {
+                        PaywallView(offering: offering)
+                    }
+                case .failed(let error):
+                    Text("Error: \(error.localizedDescription)")
+                        .foregroundColor(.red)
+                }
+
+                EntitlementView(identifier: "pro")
+            }
+            .task {
+                do {
+                    let offerings = try await Purchases.shared.offerings()
+                    if let offering = offerings.offering(identifier: Self.offeringIdentifier) {
+                        offeringsState = .loaded(offering)
+                    } else {
+                        offeringsState = .failed(OfferingError.notFound)
+                    }
+                } catch {
+                    offeringsState = .failed(error)
+                }
+            }
+            .multilineTextAlignment(.center)
+        }
+
+        enum OfferingError: LocalizedError {
+            case notFound
+
+            var errorDescription: String? {
+                switch self {
+                case .notFound:
+                    return "Offering '\(OpenWorkflow.offeringIdentifier)' not found"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
We had no Maestro coverage for workflow (multipage) paywalls. This adds a first end-to-end flow so we catch regressions when the SDK renders and navigates a dashboard workflow.

### Description
Adds an `open_workflow` flow that opens the `default_workflows` offering's workflow, walks all three screens via "Continue", and purchases on the last one, asserting the entitlement unlocks. Also adds the driver-app flow view and sets `useWorkflows` in the app's `configure` (the runtime gate for workflows, since the Maestro app can't set a compile flag). Kept local-only (under `maestro/workflows/`, not `e2e_tests/`) so CI doesn't run it yet while we set up more complex workflows on the project.

<details>
<summary>AI session context</summary>

## Metadata
- Branch: `facu/maestro-open-workflow` (off `origin/main`)
- Scope: `Examples/rc-maestro` only (Maestro e2e); no SDK changes
- Agent: Claude Opus 4.8

## First actionable instruction
Add Maestro tests that open a workflow and navigate; started by exploring the existing Maestro suite to learn the pattern (launch arg `e2e_test_flow` routes the driver app to a flow view).

## What changed
- `Examples/rc-maestro/rc-maestro/Sources/rc-maestro/RcMaestroApp.swift`: new `openWorkflow` `E2ETestFlow` case + `useWorkflows: true` in `Purchases.configure`.
- `.../e2e-test-flows/open-workflow.swift`: flow view presenting `PaywallView(offering: "default_workflows")` (mirrors the existing v1 flow).
- `Examples/rc-maestro/maestro/workflows/open_workflow.yaml`: navigates 3 screens via "Continue", purchases on the last (Test Store), asserts `entitlement (pro): active`. Local-only.

## Human decisions
- Offering `default_workflows`, workflow `wf2935f50262d5460d`, project `6627e5bc` (provided by author).
- Navigate all 3 screens (each button is "Continue"); the last Continue is the purchase.
- Keep local-only (not `e2e_tests/`) until more workflows exist on the project.

## Validation
- Proof: `maestro test -e MAESTRO_STORE=test_store` on an iPhone 16e simulator; `MAESTRO_EXIT=0`. All three screen titles asserted ("Start Your Free Week…", "Most People Feel Calmer…", "People Who Meditate Daily Sleep 40% Better"), Test Store purchase confirmed, `entitlement (pro): active` asserted. Screenshots captured per step.
- The first run surfaced `WorkflowError.uiConfigUnavailable` (the workflow body loaded but the config endpoint wasn't yet serving a complete `ui_config` for the project); the flow passed once that `ui_config` became available. This is exactly the kind of regression the test is meant to catch.

## Review focus / risks
- Screen-title assertions are content-coupled: if the workflow's copy changes, update the yaml.
- Local-only by design; the CI maestro lane runs `e2e_tests/` only, so this is not wired into CI yet.
- `useWorkflows` is `@_spi(Internal)`, reached via `@testable import RevenueCat` in the test app only.

## Not committed
- The app's API key lives only in a gitignored `Local.xcconfig`; it is not in the diff.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the rc-maestro example app and test YAML; no production SDK behavior is modified.
> 
> **Overview**
> Adds the first Maestro end-to-end coverage for **workflow (multipage) paywalls**, which the existing v1/v2 paywall flows did not exercise.
> 
> The Maestro driver app gains an **`open_workflow`** launch flow: it loads the `default_workflows` offering, presents `PaywallView`, and shows entitlement state like the other e2e screens. **`useWorkflows: true`** is set in `Purchases.configure` so workflows are enabled at runtime in the Maestro app without a compile flag.
> 
> A new **`open_workflow.yaml`** flow walks three workflow screens via **Continue**, completes a Test Store purchase through the shared `confirm_purchase` helper, and asserts **`entitlement (pro): active`**. It lives under **`maestro/workflows/`** (not `e2e_tests/`), so CI’s Maestro lane does not run it yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03827ce621446649862d53a97defef86b41ff9b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->