### PR TITLE
test(remote-config): don't send app_start in no-content config tests

### DIFF
--- a/Tests/BackendIntegrationTests/ProductionRemoteConfigIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/ProductionRemoteConfigIntegrationTests.swift
@@ -25,11 +25,14 @@ class BaseProductionRemoteConfigIntegrationTests: BaseBackendIntegrationTests {
     private lazy var remoteConfigAPI = self.createRemoteConfigAPI()
     private lazy var appUserID = self.createAppUserID()
 
-    func fetchRemoteConfig(manifest: String? = nil) async throws -> RemoteConfigFetchResult {
+    func fetchRemoteConfig(
+        fetchContext: RemoteConfigFetchContext,
+        manifest: String? = nil
+    ) async throws -> RemoteConfigFetchResult {
         return try await withCheckedThrowingContinuation { continuation in
             self.remoteConfigAPI.getRemoteConfig(
                 request: .init(
-                    fetchContext: .appStart,
+                    fetchContext: fetchContext,
                     appUserID: self.appUserID,
                     domain: Self.domain,
                     manifest: manifest,
@@ -137,17 +140,19 @@ final class ProductionRemoteConfigIntegrationTests: BaseProductionRemoteConfigIn
     }
 
     func testCanFetchRemoteConfig() async throws {
-        let result = try await self.fetchRemoteConfig()
+        let result = try await self.fetchRemoteConfig(fetchContext: .appStart)
 
         _ = try self.verifyContainerResponse(result)
     }
 
     func testReplayingManifestReturnsNoContent() async throws {
         let configuration = try self.verifyContainerResponse(
-            try await self.fetchRemoteConfig()
+            try await self.fetchRemoteConfig(fetchContext: .appStart)
         )
 
-        let result = try await self.fetchRemoteConfig(manifest: configuration.manifest)
+        // A `.read` context lets the backend honor the refresh-interval fast path and return no content,
+        // whereas `.appStart` would force a full resolve and return the config again.
+        let result = try await self.fetchRemoteConfig(fetchContext: .read, manifest: configuration.manifest)
 
         self.verifyNoContentResponse(result)
     }
@@ -167,17 +172,19 @@ final class EnforcedProductionRemoteConfigIntegrationTests: BaseProductionRemote
     }
 
     func testVerifiesSignedResponseWhenVerificationIsEnforced() async throws {
-        let result = try await self.fetchRemoteConfig()
+        let result = try await self.fetchRemoteConfig(fetchContext: .appStart)
 
         _ = try self.verifyContainerResponse(result)
     }
 
     func testVerifiesNoContentResponseWhenVerificationIsEnforced() async throws {
         let configuration = try self.verifyContainerResponse(
-            try await self.fetchRemoteConfig()
+            try await self.fetchRemoteConfig(fetchContext: .appStart)
         )
 
-        let result = try await self.fetchRemoteConfig(manifest: configuration.manifest)
+        // A `.read` context lets the backend honor the refresh-interval fast path and return no content,
+        // whereas `.appStart` would force a full resolve and return the config again.
+        let result = try await self.fetchRemoteConfig(fetchContext: .read, manifest: configuration.manifest)
 
         self.verifyNoContentResponse(result)
     }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests

### Motivation
`ProductionRemoteConfigIntegrationTests` manifest-replay assertions started failing on CI because they send `.appStart`, which the backend ([khepri#22748](https://github.com/RevenueCat/khepri/pull/22748)) deliberately uses to bypass the refresh-interval fast path — so the server does a full resolve and returns config instead of the expected `204`.

### Description
The two no-content tests now replay the manifest with a `.read` context, which the backend treats as a normal periodic sync and answers with no content. The "can fetch" tests keep `.appStart`. `fetchContext` is now an explicit parameter on the test helper.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to integration helpers and fetch context; no production SDK or networking logic is modified.
> 
> **Overview**
> Updates **production remote config integration tests** so manifest-replay scenarios match backend behavior after the refresh-interval fast path change.
> 
> `fetchRemoteConfig` now takes an explicit `RemoteConfigFetchContext` instead of always sending `.appStart`. Initial fetch tests still use `.appStart`; the two **no-content** tests (informational and enforced signing) replay the manifest with **`.read`**, which exercises the periodic-sync path and expects a verified empty response. Comments document why `.appStart` would force a full resolve and break those assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adc8a509995f9594f4da9f373b4c89c15dd05188. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->