### PR TITLE
test(workflows): add Maestro flow for workflow paywall back navigation

### DIFF
--- a/Examples/rc-maestro/maestro/workflows/navigate_workflow_back.yaml
+++ b/Examples/rc-maestro/maestro/workflows/navigate_workflow_back.yaml
@@ -40,10 +40,7 @@ env:
 - tapOn:
     text: "Back"
 
-# Back on screen 1. Screen 1's headline is only present in the tree while it is the
-# foreground step (a forward step hides the previous page), so its reappearance proves
-# the back navigation. We do not assert screen 2 is gone: visited steps stay mounted
-# (parked) and remain in the accessibility tree after back navigation.
+# Back on screen 1
 - extendedWaitUntil:
     visible: "Start Your Free Week And Reclaim 30+ Minutes Daily"
     timeout: 15000

--- a/Examples/rc-maestro/maestro/workflows/navigate_workflow_back.yaml
+++ b/Examples/rc-maestro/maestro/workflows/navigate_workflow_back.yaml
@@ -1,0 +1,50 @@
+# Opens a workflow paywall (offering `default_workflows`), advances to screen 2,
+# taps the back button, and asserts screen 1 is shown again.
+# Local-only for now (not under e2e_tests/, so the CI lane does not run it).
+#
+# Run locally against the test store:
+#   maestro test -e MAESTRO_STORE=test_store Examples/rc-maestro/maestro/workflows/navigate_workflow_back.yaml
+
+appId: com.revenuecat.maestro.ios
+name: Navigate a workflow paywall back to the first screen
+env:
+  MAESTRO_STORE: ${MAESTRO_STORE || 'test_store'}
+
+---
+- clearState
+# Dismiss any leftover system alerts from previous test runs.
+- pressKey: home
+- launchApp:
+    arguments:
+        e2e_test_flow: open_workflow
+- assertVisible: "entitlement (pro): nil"
+# Wait for offerings to load before the button appears.
+- extendedWaitUntil:
+    visible: "Present Paywall"
+    timeout: 15000
+- tapOn:
+    text: "Present Paywall"
+
+# Screen 1
+- extendedWaitUntil:
+    visible: "Start Your Free Week And Reclaim 30+ Minutes Daily"
+    timeout: 15000
+- tapOn:
+    text: "Continue"
+
+# Screen 2
+- extendedWaitUntil:
+    visible: "Most People Feel Calmer After Just 3 Sessions"
+    timeout: 15000
+- takeScreenshot: "navigate_workflow_back - screen 2"
+- tapOn:
+    text: "Back"
+
+# Back on screen 1. Screen 1's headline is only present in the tree while it is the
+# foreground step (a forward step hides the previous page), so its reappearance proves
+# the back navigation. We do not assert screen 2 is gone: visited steps stay mounted
+# (parked) and remain in the accessibility tree after back navigation.
+- extendedWaitUntil:
+    visible: "Start Your Free Week And Reclaim 30+ Minutes Daily"
+    timeout: 15000
+- takeScreenshot: "navigate_workflow_back - back on screen 1"


### PR DESCRIPTION
We're bashing like pros.

This covers a test case to make sure that "back" works.

<details>
<summary>AI session context</summary>

## Metadata

- PR: `facu/maestro-workflow-back-navigation`
- Branch: `facu/maestro-workflow-back-navigation`
- Author / human owner: facumenzella
- Agent(s): Claude Code (Opus 4.8, 1M context)
- Session source: current conversation
- Generated: 2026-07-15
- Context document version: 1

## Goal

Add a Maestro test that verifies workflow-paywall back navigation: navigate to screen 2, tap the (new) Back button, and confirm screen 1 is shown again.

## Initial Prompt

"Check the maestro test that opens a workflow and navigates." Then: the second screen now has a Back button, add a new test case that goes to screen 2, taps back, and verifies screen 1 is there. Then: run it against project `6627e5bc`, and open a draft PR if it works.

## Important Follow-up Prompts

- "are you sure you're up-to-date with main?" — surfaced that the worktree was 2 commits behind; the workflow Maestro flow (#7221) was already on `origin/main`. Rebased before proceeding.
- "Do we have a test that tries to purchase?" — confirmed `open_workflow.yaml` (#7221) already covers navigate-all-screens + purchase.

## Agent Contribution

- Added `Examples/rc-maestro/maestro/workflows/navigate_workflow_back.yaml`.
- Built and ran the flow end-to-end on the iOS simulator against the `default_workflows` offering (test store).
- Diagnosed why an initial `assertNotVisible` on the screen-2 headline failed, via a dedicated probe flow, and settled the assertion strategy on evidence.

## Human Decisions

- Chose a new, separate test case (not an extension of `open_workflow.yaml`).
- Selected project/offering to run against (`6627e5bc`, `default_workflows`).

## Key Implementation Decisions

- Decision: assert back navigation via `assertVisible` on screen 1's headline only; do not assert screen 2 is not visible.
  - Rationale: a probe showed screen 1's headline is absent from the tree while on screen 2 (forward steps hide the previous page), so its reappearance uniquely identifies foreground=screen 1.
  - Rejected: `assertNotVisible` / `extendedWaitUntil notVisible` on the screen-2 headline. Empirically fails even after a 15s settle, because visited steps stay mounted (parked) and remain in the accessibility tree after back navigation.

## Files / Symbols Touched

- `Examples/rc-maestro/maestro/workflows/navigate_workflow_back.yaml`
  - Why: new back-navigation flow.
  - Symbols: `Not applicable` (Maestro YAML).
  - Review relevance: assertion strategy and the header comment explaining it.

## Dependencies / Config / Migrations

- None committed. Local run required a gitignored `Local.xcconfig` with the project's test-store API key (not committed).

## Validation

- Commands run:
  - `tuist install` / `tuist generate` (rc-maestro): success
  - `xcodebuild -workspace Maestro.xcworkspace -scheme Maestro ... build`: `BUILD SUCCEEDED`
  - `maestro test -e MAESTRO_STORE=test_store .../navigate_workflow_back.yaml`: all steps COMPLETED
- Manual verification:
  - Inspected screenshots: screen 2 shows the Back button + headline; after Back, screen 1 is foreground.
- CI:
  - Not captured (flow is local-only; CI lane skips files outside `e2e_tests/`).

## Validation Gaps

- Ran only on iPhone 16e / iOS 18.4 simulator, test store. Not run against app_store, other devices, or other offerings.

## Review Focus

- Is asserting only screen 1's reappearance acceptable proof of back navigation, given parked steps linger in the accessibility tree?

## Risks / Reviewer Notes

- Risk: relies on the exact headline strings and the visible "Back" label of the `default_workflows` workflow.
  - Evidence: same string-coupling as the merged `open_workflow.yaml`.
  - Mitigation: strings live in one workflow config; local-only so it won't gate CI.
- Note: after back navigation the page you came from remains in the accessibility tree at its foreground bounds, unlike forward navigation which hides the previous page. Possibly an accessibility (VoiceOver) concern in the workflow parking logic, worth a separate look; out of scope here.

## Non-goals / Out of Scope

- No SDK/app code changes. No CI wiring. No fix for the accessibility-tree asymmetry noted above.

## Omitted Context

- Raw transcript, unrelated exploration, sensitive details, repetitive attempts, and chain-of-thought-style content were omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only YAML with no production or SDK changes; local Maestro flow does not affect CI gates.
> 
> **Overview**
> Adds a **local-only** Maestro workflow (`navigate_workflow_back.yaml`) that exercises **Back** on a workflow paywall: open `default_workflows` via the existing `open_workflow` e2e launch arg, advance from screen 1 to screen 2, tap **Back**, then wait until screen 1’s headline is visible again (with screenshots on screen 2 and after returning).
> 
> The flow is intentionally **not** under `e2e_tests/`, so it won’t run in CI—same pattern as `open_workflow.yaml`. Verification relies on the same offering copy strings and the visible **Back** label; it does **not** assert that screen 2 disappears, because parked workflow steps can remain in the accessibility tree after navigating back.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd91f2490cafd673576684f972eaa295f69ff4a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->