### PR TITLE
Fix PaywallsTester workflow paywall build in release

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -123,6 +123,20 @@ public struct PaywallView: View {
 
     // swiftlint:disable:next missing_docs
     @_spi(Internal) public init(
+        offeringIdentifier: String,
+        displayCloseButton: Bool = false
+    ) {
+        self.init(
+            configuration: .init(
+                content: .offeringIdentifier(offeringIdentifier, presentedOfferingContext: nil),
+                displayCloseButton: displayCloseButton,
+                purchaseHandler: .default()
+            )
+        )
+    }
+
+    // swiftlint:disable:next missing_docs
+    @_spi(Internal) public init(
         offering: Offering,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         displayCloseButton: Bool = false,

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
@@ -7,9 +7,9 @@
 
 @_spi(Internal) import RevenueCat
 #if DEBUG
-@testable import RevenueCatUI
+@_spi(Internal) @testable import RevenueCatUI
 #else
-import RevenueCatUI
+@_spi(Internal) import RevenueCatUI
 #endif
 import SwiftUI
 #if canImport(UIKit)
@@ -371,11 +371,7 @@ struct APIKeyDashboardList: View {
 
     @ViewBuilder
     private func workflowPaywallView(for offering: Offering) -> some View {
-        PaywallView(configuration: .init(
-            content: .offeringIdentifier(offering.identifier, presentedOfferingContext: nil),
-            displayCloseButton: true,
-            purchaseHandler: .default()
-        ))
+        PaywallView(offeringIdentifier: offering.identifier, displayCloseButton: true)
         #if DEBUG
         .environment(\.workflowExitOfferOfferingBinding, self.$workflowExitOfferOffering)
         #endif

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/PaywallPresenter.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/PaywallPresenter.swift
@@ -93,10 +93,7 @@ struct PaywallPresenter: View {
             fatalError()
 
         case .workflow:
-            PaywallView(configuration: .init(
-                content: .offeringIdentifier(offering.identifier, presentedOfferingContext: nil),
-                purchaseHandler: .default()
-            ))
+            PaywallView(offeringIdentifier: offering.identifier)
 
         case .presentWorkflow:
             fatalError()


### PR DESCRIPTION
## Motivation
Paywalls Tester used an internal `PaywallView(configuration:)` initializer, which worked due to the `@Testable import`. However when creating a release build (for TestFlight) this compilation fails.

## Fix
Added a narrow `@_spi(Internal)` initializer for this case, instead of relying on the `@Testable import` and ensured that the app now builds in release mode again.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tester-only call sites plus a new internal SPI convenience initializer; no change to public PaywallView APIs or purchase flow.
> 
> **Overview**
> Adds a narrow **`@_spi(Internal)`** `PaywallView(offeringIdentifier:displayCloseButton:)` that builds the same **offering-identifier + default purchase handler** setup the Paywalls Tester used via internal `PaywallView(configuration:)`.
> 
> **Paywalls Tester** now imports **`RevenueCatUI` with `@_spi(Internal)` in release** (not only `@testable` in DEBUG) and presents workflow paywalls through the new initializer instead of the non-public configuration API—so **TestFlight/release builds compile** again without changing public paywall behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b47a507db7fc9a6b69bf5bb5220ca5dad95b7b2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->