### PR TITLE
test(workflows): add Maestro flow for classic-paywall fallback on config failure

### DIFF
--- a/Examples/rc-maestro/maestro/workflows/navigate_workflow_back.yaml
+++ b/Examples/rc-maestro/maestro/workflows/navigate_workflow_back.yaml
@@ -1,6 +1,5 @@
 # Opens a workflow paywall (offering `default_workflows`), advances to screen 2,
 # taps the back button, and asserts screen 1 is shown again.
-# Local-only for now (not under e2e_tests/, so the CI lane does not run it).
 #
 # Run locally against the test store:
 #   maestro test -e MAESTRO_STORE=test_store Examples/rc-maestro/maestro/workflows/navigate_workflow_back.yaml

--- a/Examples/rc-maestro/maestro/workflows/workflow_config_fallback.yaml
+++ b/Examples/rc-maestro/maestro/workflows/workflow_config_fallback.yaml
@@ -1,0 +1,37 @@
+# Opens a workflow offering (`default_workflows`) while forcing a 4xx on the /v1/config
+# endpoint (its session kill-switch). The SDK should fall back to the classic single-page
+# paywall (the workflow's last page) instead of the multipage workflow, and never crash.
+# The force_server_error_strategy launch argument is read by the Maestro app's Constants.
+# Local-only for now (not under e2e_tests/, so the CI lane does not run it).
+#
+# Run locally against the test store:
+#   maestro test -e MAESTRO_STORE=test_store Examples/rc-maestro/maestro/workflows/workflow_config_fallback.yaml
+
+appId: com.revenuecat.maestro.ios
+name: Workflow offering falls back to the classic paywall on config failure
+env:
+  MAESTRO_STORE: ${MAESTRO_STORE || 'test_store'}
+
+---
+- clearState
+# Dismiss any leftover system alerts from previous test runs.
+- pressKey: home
+- launchApp:
+    arguments:
+        e2e_test_flow: open_workflow
+        force_server_error_strategy: remote_config_not_found
+- assertVisible: "entitlement (pro): nil"
+# Wait for offerings to load before the button appears.
+- extendedWaitUntil:
+    visible: "Present Paywall"
+    timeout: 15000
+- tapOn:
+    text: "Present Paywall"
+
+# With /v1/config failing, the classic single-page paywall is shown directly.
+- extendedWaitUntil:
+    visible: "People Who Meditate Daily Sleep 40% Better"
+    timeout: 15000
+# The multipage workflow entry screen is never rendered in the fallback path.
+- assertNotVisible: "Start Your Free Week And Reclaim 30+ Minutes Daily"
+- takeScreenshot: "workflow_config_fallback - classic paywall"

--- a/Examples/rc-maestro/maestro/workflows/workflow_config_fallback.yaml
+++ b/Examples/rc-maestro/maestro/workflows/workflow_config_fallback.yaml
@@ -2,7 +2,6 @@
 # endpoint (its session kill-switch). The SDK should fall back to the classic single-page
 # paywall (the workflow's last page) instead of the multipage workflow, and never crash.
 # The force_server_error_strategy launch argument is read by the Maestro app's Constants.
-# Local-only for now (not under e2e_tests/, so the CI lane does not run it).
 #
 # Run locally against the test store:
 #   maestro test -e MAESTRO_STORE=test_store Examples/rc-maestro/maestro/workflows/workflow_config_fallback.yaml

--- a/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/Constants.swift
+++ b/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/Constants.swift
@@ -41,6 +41,12 @@ enum Constants {
      REVENUECAT_FORCE_SERVER_ERROR_STRATEGY = primary_domain_down
      */
     static var forceServerErrorStrategy: Constants.ForceServerErrorStrategy {
+        // Launch-argument override so E2E tests can toggle the strategy per run without a rebuild.
+        if let launchArgument = UserDefaults.standard.string(forKey: "force_server_error_strategy"),
+           let strategy = ForceServerErrorStrategy(rawValue: launchArgument) {
+            return strategy
+        }
+
         guard let value = Bundle.main.object(forInfoDictionaryKey: "REVENUECAT_FORCE_SERVER_ERROR_STRATEGY") as? String else {
             return .never
         }
@@ -64,6 +70,7 @@ enum Constants {
 
     enum ForceServerErrorStrategy: String {
         case primaryBackendDown = "primary_backend_down"
+        case remoteConfigNotFound = "remote_config_not_found"
         case never
     }
 }

--- a/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/RcMaestroApp.swift
+++ b/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/RcMaestroApp.swift
@@ -19,14 +19,30 @@ struct RcMaestroApp: App {
                 .with(dangerousSettings: .init(
                     autoSyncPurchases: true,
                     internalSettings: DangerousSettings.Internal(
-                        forceServerErrorStrategy: .init { request in
-                            switch Constants.forceServerErrorStrategy {
-                            case .never:
-                                return false
-                            case .primaryBackendDown:
-                                return request.fallbackUrlIndex == nil
+                        forceServerErrorStrategy: .init(
+                            fakeResponseWithoutPerformingRequest: { request in
+                                // Simulate a 4xx on the /v1/config endpoint (its session kill-switch),
+                                // so we can exercise the classic-paywall fallback for workflow offerings.
+                                guard case .remoteConfigNotFound = Constants.forceServerErrorStrategy,
+                                      request.path.contains("config/"),
+                                      let url = URL(string: "https://api.revenuecat.com"),
+                                      let response = HTTPURLResponse(url: url,
+                                                                     statusCode: 404,
+                                                                     httpVersion: nil,
+                                                                     headerFields: nil) else {
+                                    return nil
+                                }
+                                return (response, Data("{}".utf8))
+                            },
+                            shouldForceServerError: { request in
+                                switch Constants.forceServerErrorStrategy {
+                                case .never, .remoteConfigNotFound:
+                                    return false
+                                case .primaryBackendDown:
+                                    return request.fallbackUrlIndex == nil
+                                }
                             }
-                        }
+                        )
                     ),
                     // Workflows (multipage paywalls) read through remote config; this internal flag
                     // is the runtime gate (no compile flag needed for the Maestro app).


### PR DESCRIPTION
Bug-bash case 20: a workflow offering should fall back to the classic single-page paywall (never crash) when `/v1/config` is unavailable.

Related to #7224 (workflow back-navigation Maestro test), part of the same workflow Maestro test set.

### Description

Adds a Maestro flow that forces a 4xx on `/v1/config` and asserts the classic paywall renders directly instead of the multipage workflow. 

To toggle the failure per-run without a rebuild, the Maestro app now reads `force_server_error_strategy` from a launch argument (falling back to the xcconfig value), and gained a `remoteConfigNotFound` strategy that fakes a 404 on config requests.


> Not running yet

<details>
<summary>AI session context</summary>

## Metadata

- PR: `facu/maestro-config-fallback`
- Branch: `facu/maestro-config-fallback`
- Author / human owner: facumenzella
- Agent(s): Claude Code (Opus 4.8, 1M context)
- Session source: current conversation
- Generated: 2026-07-16
- Context document version: 1

## Goal

Automate bug-bash case #20 (Workflows + Config endpoint bash): confirm a workflow offering falls back to the classic single-page paywall when the `/v1/config` session kill-switch (4xx) fires, without crashing.

## Initial Prompt

Draft a plan for the remaining bug-bash test cases that can be deterministically automated (based on the workflow Maestro tests already added), then implement the ones that make sense. #20 was selected as the one genuinely deterministic, in-pattern candidate.

## Important Follow-up Prompts

- Only automate deterministic cases; do not commit/push until validated.
- Validated the flow visually across two runs before opening this draft.

## Agent Contribution

- Added `Examples/rc-maestro/maestro/workflows/workflow_config_fallback.yaml`.
- App changes to force the failure per-run: launch-argument override for the error strategy + a `remoteConfigNotFound` strategy that returns a fake 404 for `/v1/config` requests.
- Verified via unified logs that `POST /v1/config/app` is faked to 404, and screenshotted the resulting classic paywall.

## Human Decisions

- Scoped to deterministic cases only; dropped the `no_paywall` case (known backend bug: offering with no workflow fails to display a paywall) and the exit-offer case (#9, not configured in the test workflow).
- Chose to merge tests before wiring CI.

## Key Implementation Decisions

- Decision: force the config 4xx via `ForceServerErrorStrategy.fakeResponseWithoutPerformingRequest`, matching requests whose path contains `config/`.
  - Rationale: the primary config request's `relativePath` is `/v1/config/app`, so a prefix match on `config/` misses it; `contains("config/")` matches and collides with no other endpoint (customer-center paths use `customercenter/`).
  - Rejected: `shouldForceServerError` (routes to a 502, not the 4xx kill-switch); build-time-only xcconfig toggling (would need a separate build per scenario).
- Decision: read `force_server_error_strategy` from a launch argument, preferring it over the Info.plist/xcconfig value.
  - Rationale: lets a single build run both the normal and config-down scenarios, and makes the flow independent of the CI build-time environment matrix.

## Files / Symbols Touched

- `Examples/rc-maestro/maestro/workflows/workflow_config_fallback.yaml`
  - Why: the new flow.
  - Review relevance: assertions (classic paywall visible; workflow entry screen not rendered).
- `Examples/rc-maestro/rc-maestro/Sources/rc-maestro/Constants.swift`
  - Why: launch-argument override + `remoteConfigNotFound` case.
  - Symbols: `Constants.forceServerErrorStrategy`, `Constants.ForceServerErrorStrategy`.
- `Examples/rc-maestro/rc-maestro/Sources/rc-maestro/RcMaestroApp.swift`
  - Why: fake-404 injection for config requests.
  - Symbols: `RcMaestroApp.init` (dangerousSettings `forceServerErrorStrategy`).

## Dependencies / Config / Migrations

- None committed. Local run used a gitignored `Local.xcconfig` with the test-store API key (not committed). Only affects the Maestro example app (DEBUG-only hooks); no SDK behavior change.

## Validation

- Commands run:
  - `xcodebuild ... -scheme Maestro build`: `BUILD SUCCEEDED`
  - `maestro test -e MAESTRO_STORE=test_store .../workflow_config_fallback.yaml`: all steps COMPLETED (run twice, identical)
  - `maestro test .../open_workflow.yaml`: exit 0 (no regression from the app changes)
  - SwiftLint on changed files: no violations
- Manual verification:
  - Unified log confirms `POST /v1/config/app` faked to 404; screenshot confirms the classic paywall renders and the workflow entry screen does not.
- CI:
  - Not run (flow is local-only; `run-all-maestro-e2e-tests` only runs `maestro/e2e_tests/`).

## Validation Gaps

- Ran only on iPhone 16e / iOS 18.4 simulator, test store, `default_workflows` offering.
- Not wired into CI (intentional; separate follow-up).

## Review Focus

- Is `contains("config/")` an acceptable, collision-free way to target the config endpoint from the Maestro app?
- Is the launch-argument override of the error strategy acceptable (it takes precedence over the xcconfig value used by the CI matrix)?

## Risks / Reviewer Notes

- Risk: the flow depends on the `default_workflows` workflow's last-page paywall headline string.
  - Evidence: same string-coupling as the merged `open_workflow.yaml`.
  - Mitigation: local-only, so it won't gate CI.
- Note: the error-strategy hooks are `#if DEBUG` and only in the example app; no SDK surface changes.

## Non-goals / Out of Scope

- No SDK code changes. No CI wiring. No fix for the dropped `no_paywall` backend bug.

## Omitted Context

- Raw transcript, unrelated exploration, sensitive details, repetitive attempts, and chain-of-thought-style content were omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the Maestro example app and local E2E YAML; no production SDK behavior is modified.
> 
> **Overview**
> Adds a **local Maestro flow** that opens a workflow offering while simulating a **404 on `/v1/config`**, and asserts the app shows the **classic single-page paywall** (last workflow page headline) instead of the multipage workflow entry screen.
> 
> The **Maestro example app** gains per-run test hooks: `force_server_error_strategy` can be set via **launch argument** (overriding xcconfig), plus a new **`remote_config_not_found`** strategy that **fakes a 404** on requests whose path contains `config/` through `fakeResponseWithoutPerformingRequest` (replacing the prior `shouldForceServerError`-only setup for that scenario). A stale “local-only / not in CI” note was removed from `navigate_workflow_back.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c12aae001880513917cd078cbb90b26d27f6685. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->