### PR TITLE
feat(remote-config): add internal usesRemoteConfigAPISources dangerous setting

### DIFF
--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -16,6 +16,7 @@ import Foundation
     internal struct Internal: InternalDangerousSettingsType {
 
         let enableReceiptFetchRetry: Bool
+        let usesRemoteConfigAPISources: Bool
 
         #if DEBUG
         let forceServerErrorStrategy: ForceServerErrorStrategy?
@@ -25,12 +26,14 @@ import Foundation
 
         init(
             enableReceiptFetchRetry: Bool = false,
+            usesRemoteConfigAPISources: Bool = false,
             forceServerErrorStrategy: ForceServerErrorStrategy? = nil,
             forceSignatureFailures: Bool = false,
             disableHeaderSignatureVerification: Bool = false,
             testReceiptIdentifier: String? = nil
         ) {
             self.enableReceiptFetchRetry = enableReceiptFetchRetry
+            self.usesRemoteConfigAPISources = usesRemoteConfigAPISources
             self.forceServerErrorStrategy = forceServerErrorStrategy
             self.forceSignatureFailures = forceSignatureFailures
             self.disableHeaderSignatureVerification = disableHeaderSignatureVerification
@@ -38,9 +41,11 @@ import Foundation
         }
         #else
         init(
-            enableReceiptFetchRetry: Bool = false
+            enableReceiptFetchRetry: Bool = false,
+            usesRemoteConfigAPISources: Bool = false
         ) {
             self.enableReceiptFetchRetry = enableReceiptFetchRetry
+            self.usesRemoteConfigAPISources = usesRemoteConfigAPISources
         }
 
         #endif
@@ -177,6 +182,11 @@ internal protocol InternalDangerousSettingsType: Sendable {
 
     /// Whether `ReceiptFetcher` can retry fetching receipts.
     var enableReceiptFetchRetry: Bool { get }
+
+    /// Whether main-API requests resolve their base host from the remote-config API sources
+    /// instead of the static `SystemInfo.apiBaseURL`. Disabled by default; enabled in tests while
+    /// remote-config-driven host resolution is being validated.
+    var usesRemoteConfigAPISources: Bool { get }
 
     #if DEBUG
     /// The strategy for the `HTTPClient` to fake server errors. Meant for tests only.

--- a/Tests/UnitTests/Misc/DangerousSettingsTests.swift
+++ b/Tests/UnitTests/Misc/DangerousSettingsTests.swift
@@ -61,4 +61,15 @@ final class DangerousSettingsTests: TestCase {
         expect(lhs.hashValue) == rhs.hashValue
     }
 
+    // MARK: - Internal settings
+
+    func testUsesRemoteConfigAPISourcesIsDisabledByDefault() {
+        expect(DangerousSettings.Internal.default.usesRemoteConfigAPISources) == false
+    }
+
+    func testUsesRemoteConfigAPISourcesCanBeEnabled() {
+        let internalSettings = DangerousSettings.Internal(usesRemoteConfigAPISources: true)
+        expect(internalSettings.usesRemoteConfigAPISources) == true
+    }
+
 }


### PR DESCRIPTION
### Checklist
- [x] Unit tests

### Motivation
Groundwork for #7123. We want to start merging the API-sources host-resolution work without enabling it in production until it's more thoroughly tested.

### Description
- Adds a disabled-by-default internal `usesRemoteConfigAPISources` dangerous setting. #7123 will gate main-API host resolution behind it, so it can merge as a no-op while tests enable it on CI.

Android counterpart: RevenueCat/purchases-android#3792

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal dangerous setting defaults off with no production behavior change in this PR; only configuration surface and tests.
> 
> **Overview**
> Adds an internal-only **`usesRemoteConfigAPISources`** flag on `DangerousSettings.Internal` and `InternalDangerousSettingsType`, defaulting to **false** in both DEBUG and release builds. When enabled (intended for tests/CI), future work will route main-API base hosts from remote-config API sources instead of `SystemInfo.apiBaseURL`; this PR does not wire that behavior yet.
> 
> Unit tests assert the default is off and that the flag can be set to `true` via `DangerousSettings.Internal(usesRemoteConfigAPISources:)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 498b309c21287e6433b0f3aac238b61c06f64fc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->