### PR TITLE
test(remote-config): fix integration test conformance to usesRemoteConfigAPISources

### DIFF
--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -263,6 +263,7 @@ extension BaseBackendIntegrationTests: InternalDangerousSettingsType {
     var forceSignatureFailures: Bool { return false }
     var disableHeaderSignatureVerification: Bool { return false }
     var testReceiptIdentifier: String? { return self.testUUID.uuidString }
+    var usesRemoteConfigAPISources: Bool { return false }
 
     final func serverDown() {
         self.forceServerErrorStrategy = .allServersDown


### PR DESCRIPTION
### Checklist
- [x] Unit tests

### Motivation
Follow-up to #7236. `BaseBackendIntegrationTests` conforms to `InternalDangerousSettingsType`, so the new `usesRemoteConfigAPISources` requirement broke the `BackendIntegrationTests` target compilation.

### Description
- Implements `usesRemoteConfigAPISources` (returns `false`) on the integration test helper's conformance, restoring compilation. No production code affected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only stub on an internal protocol; no runtime or production behavior changes.
> 
> **Overview**
> Adds **`usesRemoteConfigAPISources`** (returns `false`) to **`BaseBackendIntegrationTests`**’s **`InternalDangerousSettingsType`** conformance so **`BackendIntegrationTests`** compiles again after the protocol gained that requirement in #7236. **No production code changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 550deed15583e2f7c9d158f7de0ea652cc49f216. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->