### PR TITLE
Move initial paywall data seeding into purchase handler

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -202,16 +202,13 @@ public struct PaywallView: View {
 
         self._introEligibility = .init(wrappedValue: configuration.introEligibility ?? .default())
 
-        let seededWorkflowContext = configuration.injectedWorkflowContext
-        let cachedPaywallViewData = seededWorkflowContext == nil
-            ? configuration.purchaseHandler.cachedInitialPaywallViewData(for: configuration.content)
-            : nil
-        self._workflowContext = .init(
-            initialValue: seededWorkflowContext ?? cachedPaywallViewData?.workflowContext
+        let initialPaywallViewData = configuration.purchaseHandler.cachedInitialPaywallViewData(
+            for: configuration.content,
+            injectedWorkflowContext: configuration.injectedWorkflowContext
         )
+        self._workflowContext = .init(initialValue: initialPaywallViewData?.workflowContext)
         self._offering = .init(
-            initialValue: seededWorkflowContext?.initialOffering
-                ?? cachedPaywallViewData?.offering
+            initialValue: initialPaywallViewData?.offering
         )
         self._customerInfo = .init(
             initialValue: configuration.customerInfo ?? Self.loadCachedCustomerInfoIfPossible()

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -309,6 +309,20 @@ extension PurchaseHandler {
 
 #if !os(tvOS)
     func cachedInitialPaywallViewData(
+        for content: PaywallViewConfiguration.Content,
+        injectedWorkflowContext: WorkflowContext?
+    ) -> ResolvedPaywallViewData? {
+        if let injectedWorkflowContext {
+            return .init(
+                offering: injectedWorkflowContext.initialOffering,
+                workflowContext: injectedWorkflowContext
+            )
+        }
+
+        return self.cachedInitialPaywallViewData(for: content)
+    }
+
+    func cachedInitialPaywallViewData(
         for content: PaywallViewConfiguration.Content
     ) -> ResolvedPaywallViewData? {
         return self.cachedInitialPaywallViewData(

--- a/Tests/RevenueCatUITests/Data/PaywallViewConfigurationTests.swift
+++ b/Tests/RevenueCatUITests/Data/PaywallViewConfigurationTests.swift
@@ -43,6 +43,25 @@ final class PaywallViewConfigurationTests: TestCase {
         )).to(beNil())
     }
 
+    func testCachedInitialPaywallViewDataReturnsLegacyOfferingWhenRemoteConfigEnabled() {
+        let cachedOffering = TestData.offeringWithNoIntroOffer
+        let purchases = Self.createMockPurchases()
+        let handler = Self.createPurchaseHandler(purchases: purchases)
+
+        purchases.cachedOfferings = Self.createOfferings(
+            [cachedOffering],
+            currentOfferingID: cachedOffering.identifier
+        )
+
+        let result = handler.cachedInitialPaywallViewData(
+            for: .defaultOffering,
+            remoteConfigEnabled: true
+        )
+
+        expect(result?.offering.identifier) == cachedOffering.identifier
+        expect(result?.workflowContext).to(beNil())
+    }
+
     func testCachedInitialOfferingUsesCachedOfferingsWhenRemoteConfigDisabled() {
         let cachedOffering = TestData.offeringWithNoIntroOffer
         let purchases = Self.createMockPurchases()
@@ -65,6 +84,47 @@ final class PaywallViewConfigurationTests: TestCase {
             for: .offeringIdentifier(cachedOffering.identifier, presentedOfferingContext: nil),
             remoteConfigEnabled: false
         )?.identifier) == cachedOffering.identifier
+    }
+
+    func testCachedInitialPaywallViewDataUsesCachedOfferingsWhenRemoteConfigDisabled() {
+        let cachedOffering = TestData.offeringWithNoIntroOffer
+        let purchases = Self.createMockPurchases()
+        let handler = Self.createPurchaseHandler(purchases: purchases)
+
+        purchases.cachedOfferings = Self.createOfferings(
+            [cachedOffering],
+            currentOfferingID: cachedOffering.identifier
+        )
+
+        let result = handler.cachedInitialPaywallViewData(
+            for: .defaultOffering,
+            remoteConfigEnabled: false
+        )
+
+        expect(result?.offering.identifier) == cachedOffering.identifier
+        expect(result?.workflowContext).to(beNil())
+    }
+
+    func testCachedInitialPaywallViewDataUsesInjectedWorkflowContext() throws {
+        let initialOffering = Self.createOffering(identifier: "offering_a")
+        let workflowContext = WorkflowContext(
+            workflow: try Self.createWorkflow(offeringIdentifier: initialOffering.identifier),
+            uiConfig: PreviewUIConfig.make(),
+            allOfferings: Self.createOfferings([initialOffering]),
+            initialOffering: initialOffering,
+            presentedOfferingContext: initialOffering.presentedOfferingContext
+        )
+        let purchases = Self.createMockPurchases()
+        let handler = Self.createPurchaseHandler(purchases: purchases)
+
+        let result = handler.cachedInitialPaywallViewData(
+            for: .defaultOffering,
+            injectedWorkflowContext: workflowContext
+        )
+
+        expect(result?.offering.identifier) == initialOffering.identifier
+        expect(result?.workflowContext?.initialOffering.identifier) == workflowContext.initialOffering.identifier
+        expect(result?.workflowContext?.workflow.id) == workflowContext.workflow.id
     }
 
     func testResolvePaywallViewDataReturnsNilWorkflowContextWhenRemoteConfigDisabled() async throws {


### PR DESCRIPTION
## Motivation
Follow up on https://github.com/RevenueCat/purchases-ios/pull/7213#discussion_r3586448966

Simplifies the creation of the initial `paywallViewData` / `workflowContext` and `offering` and moves it from the `PaywallView` to the `PurchaseHandler`.

This is the initial step in making the `PaywallView` less knowledgable about offerings vs workflows and remote config, while keeping the diff compact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with behavior preserved and new unit tests; touches paywall first paint but logic was relocated, not rewritten.
> 
> **Overview**
> Moves **initial `offering` / `workflowContext` seeding** out of `PaywallView` and into `PurchaseHandler`, so the view no longer branches on injected workflow context vs cached offerings.
> 
> `PaywallView` now calls `cachedInitialPaywallViewData(for:injectedWorkflowContext:)` once and seeds `@State` from the returned `ResolvedPaywallViewData`. **`PurchaseHandler`** gains an overload that returns the injected `WorkflowContext`’s offering and context when present, otherwise delegates to the existing cache/remote-config path.
> 
> Tests cover legacy cached offerings (remote config on/off) and injected workflow context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5aca0ba693c6239ebb9d986acefa6837cf9a368d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->