### PR TITLE
other(paywalls): render the default paywall when an offering has no workflow

### DIFF
--- a/Examples/rc-maestro/maestro/workflows/no_workflow_default_paywall.yaml
+++ b/Examples/rc-maestro/maestro/workflows/no_workflow_default_paywall.yaml
@@ -1,0 +1,31 @@
+# Opens an offering that has no paywall and no workflow attached (`no_paywall`). The SDK should
+# fall back to rendering the default paywall (the same behavior as the classic offerings path),
+# not surface an error.
+#
+# Run locally against the test store:
+#   maestro test -e MAESTRO_STORE=test_store Examples/rc-maestro/maestro/workflows/no_workflow_default_paywall.yaml
+
+appId: com.revenuecat.maestro.ios
+name: Offering with no paywall or workflow renders the default paywall
+env:
+  MAESTRO_STORE: ${MAESTRO_STORE || 'test_store'}
+
+---
+- clearState
+- pressKey: home
+- launchApp:
+    arguments:
+        e2e_test_flow: open_no_paywall
+- assertVisible: "entitlement (pro): nil"
+- extendedWaitUntil:
+    visible: "Present Paywall"
+    timeout: 15000
+- tapOn:
+    text: "Present Paywall"
+
+# The default paywall renders (has a Restore purchases control); no error alert.
+- extendedWaitUntil:
+    visible: "Restore purchases"
+    timeout: 15000
+- assertNotVisible: "OK"
+- takeScreenshot: "no_workflow_default_paywall"

--- a/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/RcMaestroApp.swift
+++ b/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/RcMaestroApp.swift
@@ -79,6 +79,7 @@ enum E2ETestFlow: String {
     case subscribeFromV1Paywall = "subscribe_from_v1_paywall"
     case subscribeFromV2Paywall = "subscribe_from_v2_paywall"
     case openWorkflow = "open_workflow"
+    case openNoPaywall = "open_no_paywall"
 
     @ViewBuilder
     var view: some View {
@@ -89,6 +90,8 @@ enum E2ETestFlow: String {
             E2ETestFlowView.SubscribeFromV2Paywall()
         case .openWorkflow:
             E2ETestFlowView.OpenWorkflow()
+        case .openNoPaywall:
+            E2ETestFlowView.OpenNoPaywall()
         }
     }
 }

--- a/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/e2e-test-flows/open-no-paywall.swift
+++ b/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/e2e-test-flows/open-no-paywall.swift
@@ -1,0 +1,77 @@
+//
+//  open-no-paywall.swift
+//  Maestro
+//
+//  Copyright © 2025 RevenueCat, Inc. All rights reserved.
+//
+
+import SwiftUI
+import RevenueCat
+import RevenueCatUI
+
+extension E2ETestFlowView {
+    /// Opens an offering that has neither a paywall nor a workflow attached. The SDK should
+    /// fall back to rendering the default paywall instead of erroring or showing nothing.
+    struct OpenNoPaywall: View {
+
+        static let offeringIdentifier = "no_paywall"
+
+        enum GetOfferingsState {
+            case loading
+            case loaded(Offering)
+            case failed(Error)
+        }
+
+        @State private var offeringsState: GetOfferingsState = .loading
+        @State private var presentPaywall = false
+
+        var body: some View {
+            VStack {
+                Text("Offering without a paywall")
+                    .font(.largeTitle)
+
+                switch offeringsState {
+                case .loading:
+                    Text("Loading offerings...")
+                case .loaded(let offering):
+                    Button("Present Paywall") {
+                        presentPaywall = true
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .sheet(isPresented: $presentPaywall) {
+                        PaywallView(offering: offering)
+                    }
+                case .failed(let error):
+                    Text("Error: \(error.localizedDescription)")
+                        .foregroundColor(.red)
+                }
+
+                EntitlementView(identifier: "pro")
+            }
+            .task {
+                do {
+                    let offerings = try await Purchases.shared.offerings()
+                    if let offering = offerings.offering(identifier: Self.offeringIdentifier) {
+                        offeringsState = .loaded(offering)
+                    } else {
+                        offeringsState = .failed(OfferingError.notFound)
+                    }
+                } catch {
+                    offeringsState = .failed(error)
+                }
+            }
+            .multilineTextAlignment(.center)
+        }
+
+        enum OfferingError: LocalizedError {
+            case notFound
+
+            var errorDescription: String? {
+                switch self {
+                case .notFound:
+                    return "Offering '\(OpenNoPaywall.offeringIdentifier)' not found"
+                }
+            }
+        }
+    }
+}

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -446,7 +446,9 @@ extension PurchaseHandler {
     /// `offering.paywall == nil` is the durable marker of a non-legacy paywall: a v1 paywall always
     /// carries `paywall`, so a legacy offering renders directly without a workflow fetch. If the
     /// workflow fetch fails, falls back to `paywallComponents` (the offerings-provided paywall) when
-    /// available and the failure is fetch-eligible; otherwise the failure propagates.
+    /// available; when the offering simply has no workflow attached, it falls back to the default
+    /// paywall even without components (matching the legacy path). Other failures with no components
+    /// (e.g. network, malformed workflow) propagate, as do non-fetch-eligible failures.
     private func resolvePaywallViewData(
         for offering: Offering,
         offerings: Offerings?,
@@ -465,7 +467,12 @@ extension PurchaseHandler {
 
             return .init(offering: context.initialOffering, workflowContext: context)
         } catch {
-            guard offering.paywallComponents != nil, error.isWorkflowFetchFallbackEligible else {
+            // Fall back to rendering the offering when there are components to show, or when the
+            // offering simply has no workflow attached (render the default paywall, matching the
+            // legacy path). Other failures with no components — including a mapped workflow whose item
+            // or blob failed to resolve — still propagate so a broken rollout surfaces.
+            guard error.isWorkflowFetchFallbackEligible,
+                  offering.paywallComponents != nil || error.isOfferingWithoutWorkflowError else {
                 throw error
             }
 

--- a/Sources/Error Handling/BackendError.swift
+++ b/Sources/Error Handling/BackendError.swift
@@ -291,6 +291,11 @@ extension BackendError {
 
         /// A workflow lookup found a matching item, but its body couldn't be decoded.
         case workflowDecodingFailed(workflowId: String, error: NSError)
+
+        /// The offering has no workflow attached (no offeringId → workflowId mapping and the offering
+        /// id is not itself a workflow key). Distinct from ``workflowNotFound`` (a mapped workflow whose
+        /// item or blob failed to resolve) so callers can render the default paywall for this case only.
+        case offeringHasNoWorkflow(offeringId: String)
     }
 
 }
@@ -317,6 +322,8 @@ extension BackendError.UnexpectedBackendResponseError: DescribableError {
             return "Workflow '\(workflowId)' not found in remote config."
         case let .workflowDecodingFailed(workflowId, error):
             return "Workflow '\(workflowId)' could not be decoded from remote config: \(error)."
+        case let .offeringHasNoWorkflow(offeringId):
+            return "Offering '\(offeringId)' has no workflow attached in remote config."
         }
     }
 
@@ -348,6 +355,17 @@ extension BackendError {
     ) -> Self {
         return .unexpectedBackendResponse(
             .workflowDecodingFailed(workflowId: workflowId, error: error),
+            extraContext: nil,
+            .init(file: file, function: function, line: line)
+        )
+    }
+
+    static func offeringHasNoWorkflow(
+        offeringId: String,
+        file: String = #fileID, function: String = #function, line: UInt = #line
+    ) -> Self {
+        return .unexpectedBackendResponse(
+            .offeringHasNoWorkflow(offeringId: offeringId),
             extraContext: nil,
             .init(file: file, function: function, line: line)
         )

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -92,19 +92,26 @@ private extension WorkflowManager {
 // - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.
 extension WorkflowManager: @unchecked Sendable {}
 
-extension Error {
+extension BackendError {
 
     /// Whether this error signals that an offering has no workflow attached (as opposed to a mapped
-    /// workflow that failed to resolve, or a config outage, which must surface). Exposed via SPI so
-    /// RevenueCatUI's paywall fallback can render the default paywall for this case only, without
-    /// seeing the internal `BackendError` type.
-    @_spi(Internal) public var isOfferingWithoutWorkflowError: Bool {
-        guard let backendError = self as? BackendError,
-              case let .unexpectedBackendResponse(response, _, _) = backendError,
+    /// workflow that failed to resolve, or a config outage, which must surface).
+    var isOfferingWithoutWorkflow: Bool {
+        guard case let .unexpectedBackendResponse(response, _, _) = self,
               case .offeringHasNoWorkflow = response else {
             return false
         }
         return true
+    }
+
+}
+
+extension Error {
+
+    /// SPI bridge so RevenueCatUI's paywall fallback can detect the no-workflow case without seeing the
+    /// internal `BackendError` type. Forwards to ``BackendError/isOfferingWithoutWorkflow``.
+    @_spi(Internal) public var isOfferingWithoutWorkflowError: Bool {
+        (self as? BackendError)?.isOfferingWithoutWorkflow ?? false
     }
 
 }

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -58,14 +58,17 @@ class WorkflowManager {
         return await self.workflowsConfigProvider.workflowId(forOfferingId: offeringId)
     }
 
-    /// Resolves `offeringId` to its workflow, combining `workflowId(forOfferingId:)` and
-    /// `getWorkflow(workflowId:)` into the single call `Purchases.workflow(forOfferingIdentifier:)`
-    /// needs, instead of it having to orchestrate both individually.
+    /// Resolves `offeringId` to its workflow for `Purchases.workflow(forOfferingIdentifier:)`. Fails
+    /// fast when the offering has no mapped workflow: the config path has no lazy offering→workflow
+    /// conversion, so a missing mapping means the offering simply has no workflow attached. It surfaces
+    /// a distinct `offeringHasNoWorkflow` error (instead of a guaranteed-miss fetch by offering id) so
+    /// the paywall can fall back to the offering's own paywall / the default paywall. A mapped workflow
+    /// that fails to resolve still throws `workflowNotFound` and surfaces. Mirrors purchases-android's
+    /// `presentWorkflow` (#3760).
     func getWorkflow(forOfferingId offeringId: String) async throws -> WorkflowDataResult {
-        // Prefer the workflowId resolved from remote config (offeringId → workflowId), falling back
-        // to the offering identifier itself, which is also accepted as a workflow key. The mapping is
-        // nil until remote config has synced, so the fallback preserves the original behavior.
-        let workflowId = await self.workflowId(forOfferingId: offeringId) ?? offeringId
+        guard let workflowId = await self.workflowId(forOfferingId: offeringId) else {
+            throw BackendError.offeringHasNoWorkflow(offeringId: offeringId)
+        }
         return try await self.getWorkflow(workflowId: workflowId)
     }
 
@@ -88,3 +91,20 @@ private extension WorkflowManager {
 // @unchecked because:
 // - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.
 extension WorkflowManager: @unchecked Sendable {}
+
+extension Error {
+
+    /// Whether this error signals that an offering has no workflow attached (as opposed to a mapped
+    /// workflow that failed to resolve, or a config outage, which must surface). Exposed via SPI so
+    /// RevenueCatUI's paywall fallback can render the default paywall for this case only, without
+    /// seeing the internal `BackendError` type.
+    @_spi(Internal) public var isOfferingWithoutWorkflowError: Bool {
+        guard let backendError = self as? BackendError,
+              case let .unexpectedBackendResponse(response, _, _) = backendError,
+              case .offeringHasNoWorkflow = response else {
+            return false
+        }
+        return true
+    }
+
+}

--- a/Tests/RevenueCatUITests/Data/PaywallViewConfigurationTests.swift
+++ b/Tests/RevenueCatUITests/Data/PaywallViewConfigurationTests.swift
@@ -302,6 +302,85 @@ final class PaywallViewConfigurationTests: TestCase {
         }
     }
 
+    func testResolvePaywallViewDataFallsBackToDefaultPaywallWhenOfferingHasNoWorkflow() async throws {
+        // An offering with neither a legacy paywall nor components, whose workflow lookup reports the
+        // offering simply has no workflow attached, must fall back to the default paywall (matching
+        // the legacy offerings path) instead of surfacing an error.
+        let offering = Self.createOffering(identifier: "offering_a", paywall: nil)
+        let purchases = Self.createMockPurchases()
+        let handler = Self.createPurchaseHandler(purchases: purchases)
+
+        purchases.offeringsBlock = {
+            Self.createOfferings([offering], currentOfferingID: offering.identifier)
+        }
+        purchases.workflowBlock = { _ in
+            throw BackendError.offeringHasNoWorkflow(offeringId: "offering_a")
+        }
+
+        let result = try await handler.resolvePaywallViewData(
+            for: .offering(offering),
+            remoteConfigEnabled: true
+        )
+
+        expect(result.workflowContext).to(beNil())
+        expect(result.offering.identifier) == offering.identifier
+    }
+
+    func testResolvePaywallViewDataThrowsWhenMappedWorkflowUnresolvableWithNoFallback() async throws {
+        // A mapped workflow whose item or blob failed to resolve surfaces as `workflowNotFound`. With
+        // no components to fall back to it must still throw, so a broken rollout is not silently masked
+        // by the default paywall. Only the distinct "offering has no workflow" case degrades.
+        let offering = Self.createOffering(identifier: "offering_a", paywall: nil)
+        let purchases = Self.createMockPurchases()
+        let handler = Self.createPurchaseHandler(purchases: purchases)
+
+        purchases.offeringsBlock = {
+            Self.createOfferings([offering], currentOfferingID: offering.identifier)
+        }
+        purchases.workflowBlock = { _ in
+            throw BackendError.workflowNotFound(workflowId: "wf_test")
+        }
+
+        do {
+            _ = try await handler.resolvePaywallViewData(
+                for: .offering(offering),
+                remoteConfigEnabled: true
+            )
+            XCTFail("Expected resolvePaywallViewData to throw")
+        } catch {
+            expect(error.isOfferingWithoutWorkflowError) == false
+        }
+    }
+
+    func testResolvePaywallViewDataThrowsWhenWorkflowDecodingFailsWithNoFallback() async throws {
+        // A malformed workflow (decoding failure) with no fallback must still surface, so a broken
+        // rollout is not silently masked by the default paywall. Only the explicit no-workflow case
+        // degrades to the default paywall.
+        let offering = Self.createOffering(identifier: "offering_a", paywall: nil)
+        let purchases = Self.createMockPurchases()
+        let handler = Self.createPurchaseHandler(purchases: purchases)
+
+        purchases.offeringsBlock = {
+            Self.createOfferings([offering], currentOfferingID: offering.identifier)
+        }
+        purchases.workflowBlock = { _ in
+            throw BackendError.workflowDecodingFailed(
+                workflowId: "offering_a",
+                error: NSError(domain: "test", code: 1)
+            )
+        }
+
+        do {
+            _ = try await handler.resolvePaywallViewData(
+                for: .offering(offering),
+                remoteConfigEnabled: true
+            )
+            XCTFail("Expected resolvePaywallViewData to throw")
+        } catch {
+            expect(error.isOfferingWithoutWorkflowError) == false
+        }
+    }
+
     func testResolvePaywallViewDataThrowsWithScreenOfferingIdWhenScreenOfferingMissing() async throws {
         // The workflow screen resolves to "offering_b", but the offerings snapshot only contains the
         // trigger offering "offering_a". The error must report the screen's offering id that was

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesWorkflowTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesWorkflowTests.swift
@@ -26,30 +26,30 @@ class PurchasesWorkflowTests: BasePurchasesTests {
         self.setupPurchases()
     }
 
-    func testWorkflowForOfferingIdentifierFallsBackToOfferingIdAsWorkflowId() async throws {
-        // The `workflows` topic has synced, but its "default" item has no `offeringIdentifier` match,
-        // so the offeringId → workflowId scan misses and the offering identifier itself is used as the
-        // workflow lookup key, preserving the prior behavior. (A real `RemoteConfigManager` can't return
-        // blob data for an item absent from the topic or without a `blobRef`, so the topic item must be
-        // stubbed with one too, not just the blob bytes.)
+    func testWorkflowForOfferingIdentifierThrowsWhenOfferingHasNoWorkflow() async throws {
+        // The `workflows` topic has synced, but no item maps to the "default" offering (its item carries
+        // no matching `offeringIdentifier`). With no mapping, resolution fails fast with a distinct
+        // `offeringHasNoWorkflow` and does NOT attempt a fetch by offering id — the prior lazy
+        // offering-id-as-workflow-key behavior was dropped to match purchases-android #3760.
         self.mockRemoteConfigManager.stubbedTopics[.workflows] = ["default": .init(blobRef: "default", content: [:])]
         self.mockRemoteConfigManager.stubbedBlobData[.workflows] = ["default": try Self.workflowJSON(id: "default")]
-        self.mockRemoteConfigManager.stubbedBlobData[.uiConfig] = [
-            "app": Data(#"{"colors": {}, "fonts": {}}"#.utf8),
-            "localizations": Data(#"{}"#.utf8),
-            "variable_config": Data(
-                #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#.utf8
-            ),
-            "custom_variables": Data(#"{}"#.utf8)
-        ]
 
-        let result = try await self.purchases.workflow(forOfferingIdentifier: "default")
+        do {
+            _ = try await self.purchases.workflow(forOfferingIdentifier: "default")
+            fail("Expected workflow(forOfferingIdentifier:) to throw")
+        } catch {
+            expect(error as? BackendError) == .unexpectedBackendResponse(
+                .offeringHasNoWorkflow(offeringId: "default"),
+                extraContext: nil,
+                .init(file: "", function: "", line: 0)
+            )
+        }
 
-        expect(result.workflow.id) == "default"
+        // Failed fast on the missing mapping: no workflow blob was fetched.
         let requestedWorkflowKeys = self.mockRemoteConfigManager.invokedBlobDataParameters
             .filter { $0.topic == .workflows }
             .map(\.itemKey)
-        expect(requestedWorkflowKeys) == ["default"]
+        expect(requestedWorkflowKeys).to(beEmpty())
     }
 
     // MARK: - Helpers

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -138,15 +138,40 @@ class WorkflowManagerTests: TestCase {
         expect(self.mockProvider.invokedGetWorkflowParameters) == ["wf_1"]
     }
 
-    func testGetWorkflowForOfferingIdFallsBackToOfferingIdAsWorkflowId() async throws {
-        // No entry in stubbedWorkflowIdForOfferingId, so the mapping is unresolved.
-        let expected = try Self.workflowDataResult(id: "default")
-        self.mockProvider.stubbedGetWorkflowResult = ["default": expected]
+    func testGetWorkflowForOfferingIdThrowsOfferingHasNoWorkflowWithoutFetchingWhenUnmapped() async {
+        // No offeringId → workflowId mapping: the offering has no workflow attached. This fails fast
+        // with a distinct error (so the paywall falls back to the default paywall) and must NOT attempt
+        // a guaranteed-miss fetch by offering id. Mirrors purchases-android's presentWorkflow (#3760).
+        do {
+            _ = try await self.manager.getWorkflow(forOfferingId: "default")
+            fail("Expected getWorkflow(forOfferingId:) to throw")
+        } catch {
+            expect(error as? BackendError) == .unexpectedBackendResponse(
+                .offeringHasNoWorkflow(offeringId: "default"),
+                extraContext: nil,
+                .init(file: "", function: "", line: 0)
+            )
+        }
+        expect(self.mockProvider.invokedGetWorkflowParameters).to(beEmpty())
+    }
 
-        let result = try await self.manager.getWorkflow(forOfferingId: "default")
+    func testGetWorkflowForOfferingIdSurfacesWorkflowNotFoundWhenMappedWorkflowUnresolvable() async {
+        // The offering maps to a workflow, but that workflow can't be resolved (a broken rollout, not
+        // an unmapped offering). It must surface as `workflowNotFound` — which does NOT trigger the
+        // default-paywall fallback — never `offeringHasNoWorkflow`.
+        self.mockProvider.stubbedWorkflowIdForOfferingId = ["default": "wf_1"]
+        self.mockProvider.stubbedGetWorkflowError = ["wf_1": .notFound]
 
-        expect(result) == expected
-        expect(self.mockProvider.invokedGetWorkflowParameters) == ["default"]
+        do {
+            _ = try await self.manager.getWorkflow(forOfferingId: "default")
+            fail("Expected getWorkflow(forOfferingId:) to throw")
+        } catch {
+            expect(error as? BackendError) == .unexpectedBackendResponse(
+                .workflowNotFound(workflowId: "wf_1"),
+                extraContext: nil,
+                .init(file: "", function: "", line: 0)
+            )
+        }
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
Adds a Maestro flow (`open_no_paywall`) that opens the paywall-less/workflow-less offering and asserts the default paywall renders (green with workflows on).

I noticed that  https://github.com/RevenueCat/purchases-android/pull/3760 was merged after having a chat with @vegaro so took advantage of that to fix this.


https://github.com/user-attachments/assets/ebfa357a-0d7d-407c-8c7e-f4dec85dcffc



<details>
<summary>AI session context</summary>

## Metadata

- PR: `facu/fix-offering-no-workflow-default-paywall`
- Author / human owner: facumenzella
- Agent(s): Claude Code (Opus 4.8, 1M context)
- Session source: current conversation
- Generated: 2026-07-16
- Context document version: 1

## Goal

Fix that a workflow-enabled build errors (instead of rendering the default paywall) when an offering has no workflow attached, and cover it with a Maestro test. Authoritative reference: purchases-android #3760.

## Initial Prompt

Debug why opening the `no_paywall` offering errors out (`RevenueCat.BackendError error 8`) instead of showing the default paywall; then fix it, surgically.

## Important Follow-up Prompts

- "have you confirmed this is how the old system works?" / "verify on main with workflows disabled" — established the baseline: workflows-off renders the default paywall; workflows-on errors (the regression).
- "the fix has to be quirurgical [surgical]" and "run it through /codex-review-fix-loop".
- "I think step 2 makes no sense anymore. Check if android has it in main" → pointed to purchases-android #3760, which reframed the fix as fail-fast on a missing mapping.

## Agent Contribution

- Root-caused via logs + code trace; confirmed baseline behavior on-device (workflows on/off) with the Maestro app.
- Iterated the fix through an adversarial review loop; several intermediate approaches were rejected (see Key Implementation Decisions) before landing on the Android-aligned fail-fast.
- Added SDK + UI + Maestro tests.

## Human Decisions

- Required a surgical fix; vetoed silently masking broken rollouts.
- Directed alignment with Android #3760 (fail fast on missing mapping, no offering-id fetch).
- Chose to ship this as its own PR, separate from the config-fallback Maestro test (#7235).

## Key Implementation Decisions

- Decision: fail fast when `workflowId(forOfferingId:)` is nil — throw `BackendError.offeringHasNoWorkflow`; no `?? offeringId` fetch. Rationale: mirrors merged purchases-android #3760; the config path has no lazy offering->workflow conversion, so a missing mapping means no workflow.
  - Rejected (round 1): drop the fallback guard unconditionally — broke the existing `networkError`-surfaces test and masked decoding failures.
  - Rejected (round 2): fall back only on `workflowNotFound` — masked blob-download failures.
  - Rejected (rounds 3-4): distinguish `notFound`/`blobUnavailable`/topic-nil in `WorkflowsConfigProvider` — each attempt only relocated the same conflation (culminating in a healthy no-workflows config being misread as an outage). Reverted entirely once #3760 showed the fetch shouldn't happen at all.
- Decision: keep `PurchaseHandler`'s existing fallback rule (`paywallComponents != nil || isOfferingWithoutWorkflowError`), and expose the classifier via `@_spi(Internal) Error.isOfferingWithoutWorkflowError` in `WorkflowManager.swift` (a file already in the checked-in Xcode project) rather than a new file.

## Files / Symbols Touched

- `Sources/Purchasing/WorkflowManager.swift` — fail-fast `getWorkflow(forOfferingId:)`; `Error.isOfferingWithoutWorkflowError`.
- `Sources/Error Handling/BackendError.swift` — `UnexpectedBackendResponseError.offeringHasNoWorkflow` + constructor + description.
- `RevenueCatUI/Purchasing/PurchaseHandler.swift` — fall back on `offeringHasNoWorkflow`.
- `Tests/UnitTests/Purchasing/WorkflowManagerTests.swift`, `Tests/RevenueCatUITests/Data/PaywallViewConfigurationTests.swift` — coverage.
- `Examples/rc-maestro/...` — `open_no_paywall` flow + `no_workflow_default_paywall.yaml`.

## Dependencies / Config / Migrations

- None. `WorkflowsConfigProvider` was touched during iteration but reverted to its original form; no provider/protocol change ships.

## Validation

- Commands run:
  - `xcodebuild ... -scheme Maestro build`: `BUILD SUCCEEDED`
  - `maestro test -e MAESTRO_STORE=test_store .../no_workflow_default_paywall.yaml`: all steps passed (default paywall renders, no error alert)
  - `UnitTests/WorkflowManagerTests`, `UnitTests/WorkflowsConfigProviderTests`, `RevenueCatUITests/PaywallViewConfigurationTests`: passed
  - SwiftLint on changed files: clean
- Manual verification:
  - On-device (iPhone 16e / iOS 18.4, test store): workflows on -> default paywall; a mapped-but-unresolvable workflow still surfaces.
- CI:
  - Not run yet (draft). The Maestro flow is local-only (outside `e2e_tests/`).

## Validation Gaps

- Cold-start remote-config outage for a real-workflow offering with no components is treated as "no workflow" (renders the default paywall) rather than surfaced — matching Android #3760's accepted behavior. Distinguishing outage from genuine-absence would require exposing config-fetch state from `RemoteConfigManager` and should be done cross-platform, out of scope here.

## Review Focus

- Does failing fast on a nil mapping (no offering-id fetch) match #3760, and is `offeringHasNoWorkflow` the right seam for the UI fallback?
- The iOS/Android divergence for no-mapping + no-components: iOS renders the default paywall, Android shows an error. Intended on iOS (matches its workflows-off legacy).

## Risks / Reviewer Notes

- Risk: a mapped workflow whose blob fails, on an offering with no components, surfaces an error (no silent default-paywall).
  - Evidence: covered by `testResolvePaywallViewDataThrowsWhenMappedWorkflowUnresolvableWithNoFallback` and `...WhenWorkflowDecodingFailsWithNoFallback`.

## Non-goals / Out of Scope

- No `RemoteConfigManager` change to distinguish outage vs genuine no-workflow.
- No change to the config-fallback Maestro test (#7235).

## Omitted Context

- Raw transcript, unrelated exploration, and repetitive review iterations were summarized, not reproduced.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workflow-to-paywall routing when remote config is on; incorrect classification could hide broken workflows or mis-handle outages, though tests explicitly keep rollout failures visible.
> 
> **Overview**
> With workflows enabled, offerings that have **no legacy paywall and no remote-config workflow mapping** no longer error when presenting a paywall. Resolution **fails fast** with a new `offeringHasNoWorkflow` backend error (aligned with purchases-android #3760) instead of treating the offering id as a workflow key. **RevenueCatUI** treats that case like the classic path and **falls back to the default paywall** even when the offering has no `paywallComponents`; mapped workflows that fail to load (`workflowNotFound`, decode errors, network, etc.) still **surface** rather than silently showing the default.
> 
> Adds a Maestro **`open_no_paywall`** flow and unit/UI tests for the new error seam and fallback rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb3b6e826e497d28b13066fcda9b92d0080d5a32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->