### PR TITLE
ci: run the workflow Maestro flows on every PR

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1545,6 +1545,34 @@ jobs:
             echo "All test suites passed!"
           when: always
 
+  run-workflow-maestro-tests:
+    executor:
+      name: macos-executor
+      xcode_version: "26.5"
+    steps:
+      - macos/preboot-simulator:
+          version: "18.6"
+          platform: "iOS"
+          device: "iPhone 16 Pro"
+      - checkout
+      - install-dependencies
+      - revenuecat/install-maestro
+      - tuist-generate-workspace:
+          query: "Maestro"
+      - run:
+          name: Set API key for workflow e2e tests (test_store)
+          command: |
+            echo 'export REVENUECAT_API_KEY="${RC_E2E_TEST_API_KEY_PRODUCTION_TEST_STORE}"' >> $BASH_ENV
+      - run:
+          name: Run workflow e2e tests (production, test_store)
+          command: |
+            bundle exec fastlane run_maestro_e2e_tests_ios backend_environment:production store:test_store flow_subdir:workflows output_dir:test_output/workflows_production_test_store skip_slack_notification:true
+          no_output_timeout: 15m
+      - store_test_results:
+          path: fastlane/test_output
+      - store_artifacts:
+          path: fastlane/test_output
+
   release-checks:
     executor:
       name: macos-executor
@@ -2345,6 +2373,10 @@ workflows:
       - revenuecat-admob-tests:
           context:
             - slack-secrets
+      - run-workflow-maestro-tests:
+          context:
+            - e2e-tests
+            - slack-secrets
 
       # =============================================================
       # Hold gate for the Full Test Suite
@@ -2508,6 +2540,7 @@ workflows:
             - emerge_purchases_ui_snapshot_tests
             - emerge_binary_size_analysis
             - build-tv-watch-mac-and-visionos
+            - run-workflow-maestro-tests
             # Full Test Suite
             - backend-integration-tests-SK1
             - backend-integration-tests-SK2

--- a/.circleci/generate-requested-jobs-config.js
+++ b/.circleci/generate-requested-jobs-config.js
@@ -34,6 +34,7 @@ const JOBS = {
   "remote-config-production-tests": ["config-endpoint-tests", "slack-secrets"],
   "revenuecat-admob-tests": ["slack-secrets"],
   "run-all-maestro-e2e-tests": ["e2e-tests", "slack-secrets"],
+  "run-workflow-maestro-tests": ["e2e-tests", "slack-secrets"],
   "run-revenuecat-ui-ios-18-and-17": ["slack-secrets"],
   "run-revenuecat-ui-ios-26": ["slack-secrets"],
   "run-test-ios-15-and-14": ["slack-secrets"],

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1143,6 +1143,8 @@ platform :ios do
     backend_environment = options[:backend_environment] || "production"
     store = options[:store] || "app_store"
     output_dir = options[:output_dir] || "test_output/maestro"
+    # Which subdirectory of Examples/rc-maestro/maestro to run flows from (e.g. "e2e_tests", "workflows").
+    flow_subdir = options[:flow_subdir] || "e2e_tests"
     skip_slack_notification = options.fetch(:skip_slack_notification, true)
     base_path = "#{Dir.pwd}/.."
 
@@ -1237,7 +1239,7 @@ platform :ios do
 
     success = false
     begin
-      flow_dir = "#{base_path}/Examples/rc-maestro/maestro/e2e_tests"
+      flow_dir = "#{base_path}/Examples/rc-maestro/maestro/#{flow_subdir}"
 
       UI.message("Using flow directory: #{flow_dir}")
 


### PR DESCRIPTION
Runs the workflow Maestro flows (`Examples/rc-maestro/maestro/workflows/`) in CI, on every PR. They were local-only until now.

- Parameterizes `run_maestro_e2e_tests_ios` with a `flow_subdir` option (default `e2e_tests`, unchanged for the existing job).
- Adds a `run-workflow-maestro-tests` job (production + test store) and wires it into the auto-run (reduced) suite so it runs on every PR, plus the `all-tasks-passed` gate.

<details>
<summary>AI session context</summary>

## Metadata

- Branch: `facu/ci-run-workflow-maestro-tests`
- Author / human owner: facumenzella
- Agent(s): Claude Code (Opus 4.8, 1M context)
- Session source: current conversation
- Generated: 2026-07-16
- Context document version: 1

## Goal

Run the workflow Maestro flows in CI on every PR (they were local-only, skipped by `run-all-maestro-e2e-tests` which only runs `e2e_tests/`).

## Initial Prompt

"add the job to run these tests. Let's run them on every PR for now."

## Human Decisions

- Run on every PR (auto, ungated), not behind `approve-full-tests` — accepted the per-PR cost "for now."
- Ship as its own dedicated CI PR, separate from the fix (#7240) and config-fallback (#7235).

## Key Implementation Decisions

- Decision: parameterize the existing lane with `flow_subdir` rather than duplicate it. Rationale: one code path; the existing job keeps its default (`e2e_tests`).
- Decision: reuse the existing `e2e-tests` context / `RC_E2E_TEST_API_KEY_PRODUCTION_TEST_STORE` key. Rationale: project `6627e5bc` ("Automated SDK Tests") already hosts both the classic and workflow offerings.

## Files / Symbols Touched

- `fastlane/Fastfile` — `run_maestro_e2e_tests_ios` gains `flow_subdir` (default `e2e_tests`); `flow_dir` uses it.
- `.circleci/default_config.yml` — new `run-workflow-maestro-tests` job; added to the reduced (auto) suite + `all-tasks-passed`.
- `.circleci/generate-requested-jobs-config.js` — job→contexts entry for on-demand runs.

## Validation

- Commands run:
  - `circleci config validate .circleci/default_config.yml`: "is valid"
  - `ruby -c fastlane/Fastfile`: Syntax OK
  - `node --check .circleci/generate-requested-jobs-config.js`: OK
  - Locally, `maestro test` over `maestro/workflows/` passes for the flows present on the branch.
- CI: not yet observed for this job; this PR's own run is the first exercise.

## Validation Gaps / Reviewer Notes

- Unverified until the first CI run: that the `e2e-tests`-context test-store project has the workflow offerings with workflows enabled. If not, point the job at the workflow project's key or configure the offerings there.
- Per-PR cost/flakiness: live production backend + a real test-store purchase on every PR.

## Non-goals / Out of Scope

- No change to the existing `run-all-maestro-e2e-tests` matrix behavior (default `flow_subdir` preserves it).

## Omitted Context

- Raw transcript and unrelated exploration omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a macOS executor and live production/test-store Maestro run on every PR, which increases CI cost and flakiness risk but does not change SDK runtime or auth code.
> 
> **Overview**
> Adds **workflow Maestro E2E** to the default PR pipeline so flows under `Examples/rc-maestro/maestro/workflows/` run in CI instead of only locally.
> 
> `run_maestro_e2e_tests_ios` now accepts **`flow_subdir`** (default `e2e_tests`), so the Maestro flow path is configurable without duplicating the lane. A new CircleCI job **`run-workflow-maestro-tests`** boots the simulator, generates the Maestro workspace, runs **production + test_store** with `flow_subdir:workflows`, and stores artifacts. That job is in the **auto-run reduced suite** and **`all-tasks-passed`**, with **`e2e-tests`** context mapping for on-demand triggers in `generate-requested-jobs-config.js`.
> 
> Existing **`run-all-maestro-e2e-tests`** behavior is unchanged (default `flow_subdir`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0beda81c17d5497b3806a7027c12a18a201f326d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->