### PR TITLE
test(workflows): add Maestro flows for custom variable default + override

### DIFF
--- a/Examples/rc-maestro/maestro/workflows/workflow_custom_variable_default.yaml
+++ b/Examples/rc-maestro/maestro/workflows/workflow_custom_variable_default.yaml
@@ -1,0 +1,33 @@
+# Opens the workflow paywall (offering `default_workflows`) and asserts the custom variable
+# `{{ custom.users_count }}` is replaced with its dashboard default value (50000), rather than
+# rendered literally.
+#
+# Run locally against the test store:
+#   maestro test -e MAESTRO_STORE=test_store Examples/rc-maestro/maestro/workflows/workflow_custom_variable_default.yaml
+
+appId: com.revenuecat.maestro.ios
+name: Workflow paywall renders the custom variable default value
+env:
+  MAESTRO_STORE: ${MAESTRO_STORE || 'test_store'}
+
+---
+- clearState
+# Dismiss any leftover system alerts from previous test runs.
+- pressKey: home
+- launchApp:
+    arguments:
+        e2e_test_flow: open_workflow
+- assertVisible: "entitlement (pro): nil"
+- extendedWaitUntil:
+    visible: "Present Paywall"
+    timeout: 15000
+- tapOn:
+    text: "Present Paywall"
+
+# The `{{ custom.users_count }}` template is replaced with its default value (50000), not shown raw.
+# (Leading `.*` tolerates the leading space in the source string " {{ custom.users_count }} Users".)
+- extendedWaitUntil:
+    visible: ".*50000 Users"
+    timeout: 15000
+- assertNotVisible: ".*users_count"
+- takeScreenshot: "workflow_custom_variable_default"

--- a/Examples/rc-maestro/maestro/workflows/workflow_custom_variable_override.yaml
+++ b/Examples/rc-maestro/maestro/workflows/workflow_custom_variable_override.yaml
@@ -1,0 +1,33 @@
+# Opens the workflow paywall (offering `default_workflows`) with a runtime custom-variable override
+# (`.customPaywallVariables(["users_count": .number(12345)])`, driven by the custom_users_count launch
+# argument) and asserts the overridden value (12345) renders instead of the dashboard default (50000).
+#
+# Run locally against the test store:
+#   maestro test -e MAESTRO_STORE=test_store Examples/rc-maestro/maestro/workflows/workflow_custom_variable_override.yaml
+
+appId: com.revenuecat.maestro.ios
+name: Workflow paywall renders an overridden custom variable value
+env:
+  MAESTRO_STORE: ${MAESTRO_STORE || 'test_store'}
+
+---
+- clearState
+# Dismiss any leftover system alerts from previous test runs.
+- pressKey: home
+- launchApp:
+    arguments:
+        e2e_test_flow: open_workflow
+        custom_users_count: "12345"
+- assertVisible: "entitlement (pro): nil"
+- extendedWaitUntil:
+    visible: "Present Paywall"
+    timeout: 15000
+- tapOn:
+    text: "Present Paywall"
+
+# The runtime override wins over the dashboard default: 12345 renders, 50000 does not.
+- extendedWaitUntil:
+    visible: ".*12345 Users"
+    timeout: 15000
+- assertNotVisible: ".*50000 Users"
+- takeScreenshot: "workflow_custom_variable_override"

--- a/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/e2e-test-flows/open-workflow.swift
+++ b/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/e2e-test-flows/open-workflow.swift
@@ -14,6 +14,16 @@ extension E2ETestFlowView {
 
         static let offeringIdentifier = "default_workflows"
 
+        /// Custom paywall variable overrides read from a launch argument (used by E2E tests). Empty when
+        /// `custom_users_count` is not provided, so the workflow renders the dashboard default value.
+        static var customVariableOverrides: [String: CustomVariableValue] {
+            guard let raw = UserDefaults.standard.string(forKey: "custom_users_count"),
+                  let value = Double(raw) else {
+                return [:]
+            }
+            return ["users_count": .number(value)]
+        }
+
         enum GetOfferingsState {
             case loading
             case loaded(Offering)
@@ -38,6 +48,7 @@ extension E2ETestFlowView {
                     .buttonStyle(.borderedProminent)
                     .sheet(isPresented: $presentPaywall) {
                         PaywallView(offering: offering)
+                            .customPaywallVariables(Self.customVariableOverrides)
                     }
                 case .failed(let error):
                     Text("Error: \(error.localizedDescription)")


### PR DESCRIPTION
Covers custom paywall variable replacement in a workflow paywall (bug-bash 6, variables).

- **Default:** `{{ custom.users_count }}` renders its dashboard default value (`50000`), not the literal template.
- **Override:** the app supplies a runtime value via `.customPaywallVariables(["users_count": .number(12345)])` and the paywall renders `12345` instead of `50000`.

`OpenWorkflow` reads the override from a `custom_users_count` launch argument (empty → dashboard default), mirroring the existing `force_server_error_strategy` launch-arg pattern. Reuses the merged `open_workflow` flow; both flows run under the workflow Maestro CI job (#7241).

<details>
<summary>AI session context</summary>

## Metadata
- Branch: `facu/maestro-workflow-custom-variable`
- Author / human owner: facumenzella
- Agent(s): Claude Code (Opus 4.8, 1M context)
- Session source: current conversation
- Generated: 2026-07-16

## Goal
Test that a workflow paywall replaces a custom variable with its default value, and with a runtime override, after a `custom.users_count` variable (default 50000) was added to the test project.

## Initial Prompt
"I've just added a custom variable. How can we test replacing it?" (+ "The default value is 50000 now"; "verify the default value, and replacing it with another number".)

## Agent Contribution
- Located the variable (`{{ custom.users_count }}`) and its usage via mafdet; confirmed on-device that it resolves to the default `50000 Users`.
- Found the existing override API (`View.customPaywallVariables(_:)`, `CustomVariableValue`) and wired `OpenWorkflow` to apply it from a launch argument.
- Verified both flows on-device (default 50000; override 12345, 50000 absent).

## Key Implementation Decisions
- Decision: override via the `custom_users_count` launch arg feeding `.customPaywallVariables`, applied to the shared `OpenWorkflow` flow (empty dict → no override). Rationale: one flow, per-run toggle, no new flow file; empty dict is a no-op for the other workflow tests.
- Assertions use a leading `.*` because the source string is " {{ custom.users_count }} Users" (leading space) and Maestro anchors text matches.

## Files / Symbols Touched
- `Examples/rc-maestro/rc-maestro/Sources/rc-maestro/e2e-test-flows/open-workflow.swift` — `customVariableOverrides` + `.customPaywallVariables(...)`.
- `Examples/rc-maestro/maestro/workflows/workflow_custom_variable_default.yaml`, `workflow_custom_variable_override.yaml` (new).

## Validation
- `maestro test` (test store): both flows pass on-device; screenshots confirm 50000 (default) and 12345 (override).
- SwiftLint clean. CI: not run yet (draft).

## Validation Gaps
- Asserted numbers are coupled to the project's current custom-variable default (50000); update if the dashboard default changes.

## Omitted Context
- Raw transcript and unrelated exploration omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the Maestro example app and new E2E YAML; production SDK/paywall logic is not modified.
> 
> **Overview**
> Adds **Maestro E2E coverage** for workflow paywall custom variable substitution: `{{ custom.users_count }}` must show the dashboard default (**50000**) when no override is passed, and a runtime value when one is supplied.
> 
> **`OpenWorkflow`** now reads an optional `custom_users_count` launch argument (same **UserDefaults** pattern as `force_server_error_strategy`) and passes the result into **`.customPaywallVariables`** on `PaywallView`; an empty map leaves defaults unchanged so existing workflow tests stay unaffected.
> 
> Two new flows exercise the shared **`open_workflow`** E2E path: one without the launch arg (asserts `50000 Users`, not raw `users_count`), one with `custom_users_count: "12345"` (asserts **12345** and absence of **50000**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7e6d702235db141572915aaf0f1c0e2a3dfc281. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->