### PR TITLE
Deprecate Offering.paywallComponents

### DIFF
--- a/RevenueCatUI/Helpers/ExitOfferHelper.swift
+++ b/RevenueCatUI/Helpers/ExitOfferHelper.swift
@@ -88,7 +88,7 @@ enum ExitOfferHelper {
 extension Offering {
 
     var exitOfferOfferingId: String? {
-        return self.paywallComponents?.data.exitOffers?.dismiss?.offeringId
+        return self.internalPaywallComponents?.data.exitOffers?.dismiss?.offeringId
     }
 
 }

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -352,7 +352,10 @@ public struct PaywallView: View {
         purchaseHandler: PurchaseHandler
     ) -> some View {
 
-        if let paywallComponents = useDraftPaywall ? offering.draftPaywallComponents : offering.paywallComponents {
+        let selectedPaywallComponents = useDraftPaywall
+            ? offering.draftPaywallComponents
+            : offering.internalPaywallComponents
+        if let paywallComponents = selectedPaywallComponents {
             // For V2 paywalls, prefer zeroDecimalPlaceCountries from paywallComponents
             let zeroDecimalPlaceCountries = paywallComponents.data.zeroDecimalPlaceCountries
             let showZeroDecimalPlacePrices = self.showZeroDecimalPlacePrices(

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -465,7 +465,7 @@ extension PurchaseHandler {
 
             return .init(offering: context.initialOffering, workflowContext: context)
         } catch {
-            guard offering.paywallComponents != nil, error.isWorkflowFetchFallbackEligible else {
+            guard offering.internalPaywallComponents != nil, error.isWorkflowFetchFallbackEligible else {
                 throw error
             }
 

--- a/Sources/Paywalls/PaywallCacheWarming.swift
+++ b/Sources/Paywalls/PaywallCacheWarming.swift
@@ -336,7 +336,7 @@ private extension Offerings {
                 .all
                 .values
                 .lazy
-                .compactMap(\.paywallComponents)
+                .compactMap(\.internalPaywallComponents)
                 .flatMap(\.data.allLowResVideoUrls)
         )
     }
@@ -393,7 +393,7 @@ private extension Offerings {
                 .all
                 .values
                 .lazy
-                .compactMap(\.paywallComponents)
+                .compactMap(\.internalPaywallComponents)
                 .flatMap(\.data.allImageURLs)
         )
     }

--- a/Sources/Purchasing/Offering.swift
+++ b/Sources/Purchasing/Offering.swift
@@ -79,6 +79,7 @@ import Foundation
 
      Use ``hasPaywall`` to check if the offering has a paywall.
      */
+    @available(*, deprecated, message: "Use hasPaywall to check whether the Offering has a paywall.")
     public let paywallComponents: PaywallComponents?
 
     /**

--- a/Sources/Purchasing/Offering.swift
+++ b/Sources/Purchasing/Offering.swift
@@ -80,13 +80,18 @@ import Foundation
      Use ``hasPaywall`` to check if the offering has a paywall.
      */
     @available(*, deprecated, message: "Use hasPaywall to check whether the Offering has a paywall.")
-    public let paywallComponents: PaywallComponents?
+    public var paywallComponents: PaywallComponents? { self.internalPaywallComponents }
+
+    /**
+     Paywall components configuration defined in RevenueCat dashboard, used internally by the SDK.
+     */
+    @_spi(Internal) public let internalPaywallComponents: PaywallComponents?
 
     /**
      Whether the offering contains a paywall.
      */
     public var hasPaywall: Bool {
-        return paywall != nil || paywallComponents != nil
+        return paywall != nil || internalPaywallComponents != nil
     }
 
     /**
@@ -245,7 +250,7 @@ import Foundation
         self.availablePackages = availablePackages
         self._metadata = Metadata(data: metadata)
         self.paywall = paywall
-        self.paywallComponents = paywallComponents
+        self.internalPaywallComponents = paywallComponents
         self.draftPaywallComponents = draftPaywallComponents
         self.webCheckoutUrl = webCheckoutUrl
 
@@ -316,7 +321,7 @@ public extension Offering {
             serverDescription: serverDescription,
             metadata: metadata,
             paywall: paywall,
-            paywallComponents: paywallComponents,
+            paywallComponents: internalPaywallComponents,
             draftPaywallComponents: draftPaywallComponents,
             availablePackages: availablePackages.map { $0.withPresentedOfferingContext(presentedOfferingContext) },
             webCheckoutUrl: webCheckoutUrl

--- a/Sources/Purchasing/Offerings.swift
+++ b/Sources/Purchasing/Offerings.swift
@@ -177,7 +177,7 @@ private extension Offering {
                         serverDescription: self.serverDescription,
                         metadata: self.metadata,
                         paywall: self.paywall,
-                        paywallComponents: self.paywallComponents,
+                        paywallComponents: self.internalPaywallComponents,
                         availablePackages: updatedPackages,
                         webCheckoutUrl: self.webCheckoutUrl
         )

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/OfferingAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/OfferingAPI.swift
@@ -15,6 +15,7 @@ import Foundation
 import RevenueCat
 
 var off: Offering!
+@available(*, deprecated) // Ignore deprecation warnings
 func checkOfferingAPI() {
     struct Data: Decodable {}
 

--- a/api/revenuecat-api-ios-simulator.swiftinterface
+++ b/api/revenuecat-api-ios-simulator.swiftinterface
@@ -1848,7 +1848,9 @@ extension RevenueCat.NonSubscriptionTransaction : Swift.Sendable {
   }
   final public let paywall: RevenueCat.PaywallData?
   @available(*, deprecated, message: "Use hasPaywall to check whether the Offering has a paywall.")
-  final public let paywallComponents: RevenueCat.Offering.PaywallComponents?
+  final public var paywallComponents: RevenueCat.Offering.PaywallComponents? {
+    get
+  }
   final public var hasPaywall: Swift.Bool {
     get
   }

--- a/api/revenuecat-api-ios-simulator.swiftinterface
+++ b/api/revenuecat-api-ios-simulator.swiftinterface
@@ -1847,6 +1847,7 @@ extension RevenueCat.NonSubscriptionTransaction : Swift.Sendable {
     @objc get
   }
   final public let paywall: RevenueCat.PaywallData?
+  @available(*, deprecated, message: "Use hasPaywall to check whether the Offering has a paywall.")
   final public let paywallComponents: RevenueCat.Offering.PaywallComponents?
   final public var hasPaywall: Swift.Bool {
     get

--- a/api/revenuecat-api-ios.swiftinterface
+++ b/api/revenuecat-api-ios.swiftinterface
@@ -1848,7 +1848,9 @@ extension RevenueCat.NonSubscriptionTransaction : Swift.Sendable {
   }
   final public let paywall: RevenueCat.PaywallData?
   @available(*, deprecated, message: "Use hasPaywall to check whether the Offering has a paywall.")
-  final public let paywallComponents: RevenueCat.Offering.PaywallComponents?
+  final public var paywallComponents: RevenueCat.Offering.PaywallComponents? {
+    get
+  }
   final public var hasPaywall: Swift.Bool {
     get
   }

--- a/api/revenuecat-api-ios.swiftinterface
+++ b/api/revenuecat-api-ios.swiftinterface
@@ -1847,6 +1847,7 @@ extension RevenueCat.NonSubscriptionTransaction : Swift.Sendable {
     @objc get
   }
   final public let paywall: RevenueCat.PaywallData?
+  @available(*, deprecated, message: "Use hasPaywall to check whether the Offering has a paywall.")
   final public let paywallComponents: RevenueCat.Offering.PaywallComponents?
   final public var hasPaywall: Swift.Bool {
     get

--- a/api/revenuecat-api-macos.swiftinterface
+++ b/api/revenuecat-api-macos.swiftinterface
@@ -1814,6 +1814,7 @@ extension RevenueCat.NonSubscriptionTransaction : Swift.Sendable {
     @objc get
   }
   final public let paywall: RevenueCat.PaywallData?
+  @available(*, deprecated, message: "Use hasPaywall to check whether the Offering has a paywall.")
   final public let paywallComponents: RevenueCat.Offering.PaywallComponents?
   final public var hasPaywall: Swift.Bool {
     get

--- a/api/revenuecat-api-macos.swiftinterface
+++ b/api/revenuecat-api-macos.swiftinterface
@@ -1815,7 +1815,9 @@ extension RevenueCat.NonSubscriptionTransaction : Swift.Sendable {
   }
   final public let paywall: RevenueCat.PaywallData?
   @available(*, deprecated, message: "Use hasPaywall to check whether the Offering has a paywall.")
-  final public let paywallComponents: RevenueCat.Offering.PaywallComponents?
+  final public var paywallComponents: RevenueCat.Offering.PaywallComponents? {
+    get
+  }
   final public var hasPaywall: Swift.Bool {
     get
   }

--- a/api/revenuecat-api-tvos-simulator.swiftinterface
+++ b/api/revenuecat-api-tvos-simulator.swiftinterface
@@ -1814,6 +1814,7 @@ extension RevenueCat.NonSubscriptionTransaction : Swift.Sendable {
     @objc get
   }
   final public let paywall: RevenueCat.PaywallData?
+  @available(*, deprecated, message: "Use hasPaywall to check whether the Offering has a paywall.")
   final public let paywallComponents: RevenueCat.Offering.PaywallComponents?
   final public var hasPaywall: Swift.Bool {
     get

--- a/api/revenuecat-api-tvos-simulator.swiftinterface
+++ b/api/revenuecat-api-tvos-simulator.swiftinterface
@@ -1815,7 +1815,9 @@ extension RevenueCat.NonSubscriptionTransaction : Swift.Sendable {
   }
   final public let paywall: RevenueCat.PaywallData?
   @available(*, deprecated, message: "Use hasPaywall to check whether the Offering has a paywall.")
-  final public let paywallComponents: RevenueCat.Offering.PaywallComponents?
+  final public var paywallComponents: RevenueCat.Offering.PaywallComponents? {
+    get
+  }
   final public var hasPaywall: Swift.Bool {
     get
   }

--- a/api/revenuecat-api-tvos.swiftinterface
+++ b/api/revenuecat-api-tvos.swiftinterface
@@ -1814,6 +1814,7 @@ extension RevenueCat.NonSubscriptionTransaction : Swift.Sendable {
     @objc get
   }
   final public let paywall: RevenueCat.PaywallData?
+  @available(*, deprecated, message: "Use hasPaywall to check whether the Offering has a paywall.")
   final public let paywallComponents: RevenueCat.Offering.PaywallComponents?
   final public var hasPaywall: Swift.Bool {
     get

--- a/api/revenuecat-api-tvos.swiftinterface
+++ b/api/revenuecat-api-tvos.swiftinterface
@@ -1815,7 +1815,9 @@ extension RevenueCat.NonSubscriptionTransaction : Swift.Sendable {
   }
   final public let paywall: RevenueCat.PaywallData?
   @available(*, deprecated, message: "Use hasPaywall to check whether the Offering has a paywall.")
-  final public let paywallComponents: RevenueCat.Offering.PaywallComponents?
+  final public var paywallComponents: RevenueCat.Offering.PaywallComponents? {
+    get
+  }
   final public var hasPaywall: Swift.Bool {
     get
   }

--- a/api/revenuecat-api-visionos-simulator.swiftinterface
+++ b/api/revenuecat-api-visionos-simulator.swiftinterface
@@ -1848,7 +1848,9 @@ extension RevenueCat.NonSubscriptionTransaction : Swift.Sendable {
   }
   final public let paywall: RevenueCat.PaywallData?
   @available(*, deprecated, message: "Use hasPaywall to check whether the Offering has a paywall.")
-  final public let paywallComponents: RevenueCat.Offering.PaywallComponents?
+  final public var paywallComponents: RevenueCat.Offering.PaywallComponents? {
+    get
+  }
   final public var hasPaywall: Swift.Bool {
     get
   }

--- a/api/revenuecat-api-visionos-simulator.swiftinterface
+++ b/api/revenuecat-api-visionos-simulator.swiftinterface
@@ -1847,6 +1847,7 @@ extension RevenueCat.NonSubscriptionTransaction : Swift.Sendable {
     @objc get
   }
   final public let paywall: RevenueCat.PaywallData?
+  @available(*, deprecated, message: "Use hasPaywall to check whether the Offering has a paywall.")
   final public let paywallComponents: RevenueCat.Offering.PaywallComponents?
   final public var hasPaywall: Swift.Bool {
     get

--- a/api/revenuecat-api-visionos.swiftinterface
+++ b/api/revenuecat-api-visionos.swiftinterface
@@ -1848,7 +1848,9 @@ extension RevenueCat.NonSubscriptionTransaction : Swift.Sendable {
   }
   final public let paywall: RevenueCat.PaywallData?
   @available(*, deprecated, message: "Use hasPaywall to check whether the Offering has a paywall.")
-  final public let paywallComponents: RevenueCat.Offering.PaywallComponents?
+  final public var paywallComponents: RevenueCat.Offering.PaywallComponents? {
+    get
+  }
   final public var hasPaywall: Swift.Bool {
     get
   }

--- a/api/revenuecat-api-visionos.swiftinterface
+++ b/api/revenuecat-api-visionos.swiftinterface
@@ -1847,6 +1847,7 @@ extension RevenueCat.NonSubscriptionTransaction : Swift.Sendable {
     @objc get
   }
   final public let paywall: RevenueCat.PaywallData?
+  @available(*, deprecated, message: "Use hasPaywall to check whether the Offering has a paywall.")
   final public let paywallComponents: RevenueCat.Offering.PaywallComponents?
   final public var hasPaywall: Swift.Bool {
     get

--- a/api/revenuecat-api-watchos-simulator.swiftinterface
+++ b/api/revenuecat-api-watchos-simulator.swiftinterface
@@ -1815,6 +1815,7 @@ extension RevenueCat.NonSubscriptionTransaction : Swift.Sendable {
     @objc get
   }
   final public let paywall: RevenueCat.PaywallData?
+  @available(*, deprecated, message: "Use hasPaywall to check whether the Offering has a paywall.")
   final public let paywallComponents: RevenueCat.Offering.PaywallComponents?
   final public var hasPaywall: Swift.Bool {
     get

--- a/api/revenuecat-api-watchos-simulator.swiftinterface
+++ b/api/revenuecat-api-watchos-simulator.swiftinterface
@@ -1816,7 +1816,9 @@ extension RevenueCat.NonSubscriptionTransaction : Swift.Sendable {
   }
   final public let paywall: RevenueCat.PaywallData?
   @available(*, deprecated, message: "Use hasPaywall to check whether the Offering has a paywall.")
-  final public let paywallComponents: RevenueCat.Offering.PaywallComponents?
+  final public var paywallComponents: RevenueCat.Offering.PaywallComponents? {
+    get
+  }
   final public var hasPaywall: Swift.Bool {
     get
   }

--- a/api/revenuecat-api-watchos.swiftinterface
+++ b/api/revenuecat-api-watchos.swiftinterface
@@ -1815,6 +1815,7 @@ extension RevenueCat.NonSubscriptionTransaction : Swift.Sendable {
     @objc get
   }
   final public let paywall: RevenueCat.PaywallData?
+  @available(*, deprecated, message: "Use hasPaywall to check whether the Offering has a paywall.")
   final public let paywallComponents: RevenueCat.Offering.PaywallComponents?
   final public var hasPaywall: Swift.Bool {
     get

--- a/api/revenuecat-api-watchos.swiftinterface
+++ b/api/revenuecat-api-watchos.swiftinterface
@@ -1816,7 +1816,9 @@ extension RevenueCat.NonSubscriptionTransaction : Swift.Sendable {
   }
   final public let paywall: RevenueCat.PaywallData?
   @available(*, deprecated, message: "Use hasPaywall to check whether the Offering has a paywall.")
-  final public let paywallComponents: RevenueCat.Offering.PaywallComponents?
+  final public var paywallComponents: RevenueCat.Offering.PaywallComponents? {
+    get
+  }
   final public var hasPaywall: Swift.Bool {
     get
   }


### PR DESCRIPTION
### Motivation

Once workflows are enabled, `Offering.paywallComponents` may no longer be populated — a behavior change. Deprecating it now starts discouraging its use ahead of that.

### Description

- Deprecates the public `Offering.paywallComponents`, pointing callers to `hasPaywall`.
- The SDK still consumes these components internally (paywall rendering, cache warming), so internal reads now go through a non-deprecated `@_spi(Internal) internalPaywallComponents`, and the public property is a thin deprecated wrapper over it. This keeps the SDK's own sources free of deprecation warnings, which `pod lib lint` treats as errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible API deprecation with unchanged runtime behavior for apps that still read paywallComponents; main risk is integrators seeing new deprecation warnings.
> 
> **Overview**
> **Deprecates** the public `Offering.paywallComponents` property and steers integrators toward `hasPaywall`, ahead of workflows potentially leaving that field unset.
> 
> Storage moves to `@_spi(Internal) internalPaywallComponents`; the public `paywallComponents` is now a deprecated computed accessor over the same value, so existing apps keep working but get a compile-time warning. `hasPaywall` reads from `internalPaywallComponents` instead of the public property.
> 
> SDK-only paths (paywall rendering, workflow fallback, exit offers, cache warming for V2 images/videos, offering copies) are updated to use `internalPaywallComponents` so `pod lib lint` does not fail on deprecation-as-error. Public API stubs and the Swift API tester are adjusted accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa74b1ffb1c06cacc3023a0c0f64f94a97bb9fcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->