### PR TITLE
other(paywalls): gate workflow exit offer by step on the present(offering:) path

### DIFF
--- a/Examples/rc-maestro/maestro/workflows/workflow_exit_offer_not_on_first_page.yaml
+++ b/Examples/rc-maestro/maestro/workflows/workflow_exit_offer_not_on_first_page.yaml
@@ -1,0 +1,33 @@
+# Closing the FIRST workflow page must NOT surface the exit offer: the exit offer is gated to the
+# last (exit-offer) step. Closing page 1 should just dismiss the workflow back to the launcher.
+# Presents via `.presentPaywall`. The close control is an unlabeled icon, tapped by coordinate
+# (top-center on the first page).
+#
+# Run locally against the test store:
+#   maestro test -e MAESTRO_STORE=test_store Examples/rc-maestro/maestro/workflows/workflow_exit_offer_not_on_first_page.yaml
+
+appId: com.revenuecat.maestro.ios
+name: Workflow exit offer is not shown when closing the first page
+env:
+  MAESTRO_STORE: ${MAESTRO_STORE || 'test_store'}
+
+---
+- clearState
+- pressKey: home
+- launchApp:
+    arguments:
+        e2e_test_flow: open_workflow_presented
+- extendedWaitUntil: { visible: "Present Paywall", timeout: 15000 }
+- tapOn: { text: "Present Paywall" }
+- extendedWaitUntil:
+    visible: "Start Your Free Week And Reclaim 30+ Minutes Daily"
+    timeout: 15000
+
+# Close the first page (unlabeled close icon, top-center).
+- tapOn: { point: "50%,16%" }
+- waitForAnimationToEnd: { timeout: 8000 }
+
+# The workflow is dismissed back to the launcher and the exit offer is NOT presented.
+- assertVisible: "Present Paywall"
+- assertNotVisible: "Paywall V2"
+- takeScreenshot: "workflow_exit_offer_not_on_first_page"

--- a/Examples/rc-maestro/maestro/workflows/workflow_exit_offer_on_last_page.yaml
+++ b/Examples/rc-maestro/maestro/workflows/workflow_exit_offer_on_last_page.yaml
@@ -1,0 +1,38 @@
+# Navigates a workflow to its last page (the exit-offer step) and closes it; the configured exit
+# offer (offering `default`) must be presented. Presents via `.presentPaywall` (the exit-offer-aware
+# path). The close control is an unlabeled icon, so it is tapped by coordinate (top-left on the paywall).
+#
+# Run locally against the test store:
+#   maestro test -e MAESTRO_STORE=test_store Examples/rc-maestro/maestro/workflows/workflow_exit_offer_on_last_page.yaml
+
+appId: com.revenuecat.maestro.ios
+name: Workflow exit offer is shown when closing the last page
+env:
+  MAESTRO_STORE: ${MAESTRO_STORE || 'test_store'}
+
+---
+- clearState
+- pressKey: home
+- launchApp:
+    arguments:
+        e2e_test_flow: open_workflow_presented
+- extendedWaitUntil: { visible: "Present Paywall", timeout: 15000 }
+- tapOn: { text: "Present Paywall" }
+- extendedWaitUntil:
+    visible: "Start Your Free Week And Reclaim 30+ Minutes Daily"
+    timeout: 15000
+- tapOn: { text: "Continue" }
+- extendedWaitUntil:
+    visible: "Most People Feel Calmer After Just 3 Sessions"
+    timeout: 15000
+- tapOn: { text: "Continue" }
+- extendedWaitUntil:
+    visible: "People Who Meditate Daily Sleep 40% Better"
+    timeout: 15000
+
+# Close the last page (unlabeled close icon, top-left) -> the exit offer paywall is presented.
+- tapOn: { point: "8%,11%" }
+- extendedWaitUntil:
+    visible: "Paywall V2"
+    timeout: 15000
+- takeScreenshot: "workflow_exit_offer_on_last_page"

--- a/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/RcMaestroApp.swift
+++ b/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/RcMaestroApp.swift
@@ -86,6 +86,7 @@ enum E2ETestFlow: String {
     case subscribeFromV2Paywall = "subscribe_from_v2_paywall"
     case openWorkflow = "open_workflow"
     case openNoPaywall = "open_no_paywall"
+    case openWorkflowPresented = "open_workflow_presented"
 
     @ViewBuilder
     var view: some View {
@@ -98,6 +99,8 @@ enum E2ETestFlow: String {
             E2ETestFlowView.OpenWorkflow()
         case .openNoPaywall:
             E2ETestFlowView.OpenNoPaywall()
+        case .openWorkflowPresented:
+            E2ETestFlowView.OpenWorkflowPresented()
         }
     }
 }

--- a/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/e2e-test-flows/open-workflow-presented.swift
+++ b/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/e2e-test-flows/open-workflow-presented.swift
@@ -1,0 +1,76 @@
+//
+//  open-workflow-presented.swift
+//  Maestro
+//
+//  Copyright © 2025 RevenueCat, Inc. All rights reserved.
+//
+
+import SwiftUI
+import RevenueCat
+import RevenueCatUI
+
+extension E2ETestFlowView {
+    /// Opens the workflow paywall via the `.presentPaywall(offering:)` modifier rather than a raw
+    /// `PaywallView` sheet. This is the exit-offer-aware presentation path: it surfaces a configured
+    /// workflow exit offer when the paywall is dismissed (from the exit-offer step) without a purchase.
+    struct OpenWorkflowPresented: View {
+
+        static let offeringIdentifier = "default_workflows"
+
+        enum GetOfferingsState {
+            case loading
+            case loaded(Offering)
+            case failed(Error)
+        }
+
+        @State private var offeringsState: GetOfferingsState = .loading
+        @State private var presentedOffering: Offering?
+
+        var body: some View {
+            VStack {
+                Text("Workflow paywall (presented)")
+                    .font(.largeTitle)
+
+                switch offeringsState {
+                case .loading:
+                    Text("Loading offerings...")
+                case .loaded(let offering):
+                    Button("Present Paywall") {
+                        presentedOffering = offering
+                    }
+                    .buttonStyle(.borderedProminent)
+                case .failed(let error):
+                    Text("Error: \(error.localizedDescription)")
+                        .foregroundColor(.red)
+                }
+
+                EntitlementView(identifier: "pro")
+            }
+            .presentPaywall(offering: $presentedOffering)
+            .task {
+                do {
+                    let offerings = try await Purchases.shared.offerings()
+                    if let offering = offerings.offering(identifier: Self.offeringIdentifier) {
+                        offeringsState = .loaded(offering)
+                    } else {
+                        offeringsState = .failed(OfferingError.notFound)
+                    }
+                } catch {
+                    offeringsState = .failed(error)
+                }
+            }
+            .multilineTextAlignment(.center)
+        }
+
+        enum OfferingError: LocalizedError {
+            case notFound
+
+            var errorDescription: String? {
+                switch self {
+                case .notFound:
+                    return "Offering '\(OpenWorkflowPresented.offeringIdentifier)' not found"
+                }
+            }
+        }
+    }
+}

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1098,6 +1098,7 @@
 		887A60CC2C1D037000E1A461 /* PaywallFontProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A60602C1D037000E1A461 /* PaywallFontProvider.swift */; };
 		887A60CD2C1D037000E1A461 /* PaywallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A60612C1D037000E1A461 /* PaywallView.swift */; };
 		887A60CE2C1D037000E1A461 /* View+PresentPaywall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A60622C1D037000E1A461 /* View+PresentPaywall.swift */; };
+		451441F0014BC13272B179CC /* View+ExitOfferPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE8FCE0314FF930204BE4D33 /* View+ExitOfferPresentation.swift */; };
 		887A60CF2C1D037000E1A461 /* View+PresentPaywallFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A60632C1D037000E1A461 /* View+PresentPaywallFooter.swift */; };
 		887A60D02C1D037000E1A461 /* View+PurchaseRestoreCompleted.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887A60642C1D037000E1A461 /* View+PurchaseRestoreCompleted.swift */; };
 		887E7B592C13CD2C002977DE /* PurchasesAreCompletedBy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887E7B582C13CD2C002977DE /* PurchasesAreCompletedBy.swift */; };
@@ -2683,6 +2684,7 @@
 		887A60602C1D037000E1A461 /* PaywallFontProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaywallFontProvider.swift; sourceTree = "<group>"; };
 		887A60612C1D037000E1A461 /* PaywallView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaywallView.swift; sourceTree = "<group>"; };
 		887A60622C1D037000E1A461 /* View+PresentPaywall.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+PresentPaywall.swift"; sourceTree = "<group>"; };
+		FE8FCE0314FF930204BE4D33 /* View+ExitOfferPresentation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+ExitOfferPresentation.swift"; sourceTree = "<group>"; };
 		887A60632C1D037000E1A461 /* View+PresentPaywallFooter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+PresentPaywallFooter.swift"; sourceTree = "<group>"; };
 		887A60642C1D037000E1A461 /* View+PurchaseRestoreCompleted.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+PurchaseRestoreCompleted.swift"; sourceTree = "<group>"; };
 		887A61282C1D168B00E1A461 /* LocalizedAlertErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalizedAlertErrorTests.swift; sourceTree = "<group>"; };
@@ -2699,6 +2701,7 @@
 		887A61342C1D168B00E1A461 /* SnapshotTesting+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SnapshotTesting+Extensions.swift"; sourceTree = "<group>"; };
 		887A61352C1D168B00E1A461 /* TestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestCase.swift; sourceTree = "<group>"; };
 		887A61372C1D168B00E1A461 /* PurchaseHandlerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchaseHandlerTests.swift; sourceTree = "<group>"; };
+		B10A136C03A9FF34FB805EFA /* ExitOfferPresenterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExitOfferPresenterTests.swift; sourceTree = "<group>"; };
 		887A620F2C1D168B00E1A461 /* OtherPaywallViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OtherPaywallViewTests.swift; sourceTree = "<group>"; };
 		887A62102C1D168B00E1A461 /* PaywallViewDynamicTypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaywallViewDynamicTypeTests.swift; sourceTree = "<group>"; };
 		887A62112C1D168B00E1A461 /* PaywallViewLocalizationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaywallViewLocalizationTests.swift; sourceTree = "<group>"; };
@@ -5813,6 +5816,7 @@
 				887A60612C1D037000E1A461 /* PaywallView.swift */,
 				552CE0E02FD323EF006E41B4 /* Purchases+PreviewPaywall.swift */,
 				887A60622C1D037000E1A461 /* View+PresentPaywall.swift */,
+				FE8FCE0314FF930204BE4D33 /* View+ExitOfferPresentation.swift */,
 				887A60632C1D037000E1A461 /* View+PresentPaywallFooter.swift */,
 				887A60642C1D037000E1A461 /* View+PurchaseRestoreCompleted.swift */,
 				1E8A607E2CDCE5EC0034ACF3 /* View+OnRedeemWebPurchaseAttempt.swift */,
@@ -5869,6 +5873,7 @@
 				57F4B2C12F8E10A600BB46C9 /* ExitOfferHelperTests.swift */,
 				16E146B42E99FF640089B609 /* MockStoreTransaction.swift */,
 				887A61372C1D168B00E1A461 /* PurchaseHandlerTests.swift */,
+				B10A136C03A9FF34FB805EFA /* ExitOfferPresenterTests.swift */,
 				7AA86A1D9F5AE92988B20230 /* WorkflowContextTests.swift */,
 				ECEA10EF63BC10F9BE6DB9F5 /* WorkflowPreviewTests.swift */,
 			);
@@ -8318,6 +8323,7 @@
 				887A606E2C1D037000E1A461 /* LocalizedAlertError.swift in Sources */,
 				887A60802C1D037000E1A461 /* Package+VariableDataProvider.swift in Sources */,
 				887A60CE2C1D037000E1A461 /* View+PresentPaywall.swift in Sources */,
+				451441F0014BC13272B179CC /* View+ExitOfferPresentation.swift in Sources */,
 				038211972DCA730C003C02C3 /* PurchaseButtonInPackagePreview.swift in Sources */,
 				038211982DCA730C003C02C3 /* ButtonWithFooterPreview.swift in Sources */,
 				887A60832C1D037000E1A461 /* VersionDetector.swift in Sources */,

--- a/RevenueCatUI/Purchasing/PurchaseHandler+TestData.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler+TestData.swift
@@ -34,6 +34,7 @@ extension PurchaseHandler {
         performPurchase: PerformPurchase? = nil,
         performRestore: PerformRestore? = nil,
         preferredLocaleOverride: String? = nil,
+        remoteConfigEnabled: Bool = false,
         purchaseResultPublisher: AnyPublisher<PurchaseResultData, Never> = Just(
             (
                 transaction: nil,
@@ -61,6 +62,7 @@ extension PurchaseHandler {
             } customerInfo: {
                 return customerInfo
             }
+        purchases.remoteConfigEnabled = remoteConfigEnabled
         return self.init(
             purchases: purchases,
             performPurchase: performPurchase,

--- a/RevenueCatUI/View+ExitOfferPresentation.swift
+++ b/RevenueCatUI/View+ExitOfferPresentation.swift
@@ -1,0 +1,150 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  View+ExitOfferPresentation.swift
+
+@_spi(Internal) import RevenueCat
+import SwiftUI
+
+#if !os(tvOS)
+
+/// Single owner of the exit-offer lifecycle (sourcing, state, present/dismiss/track), so present
+/// functions don't each re-implement it.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@MainActor
+final class ExitOfferPresenter: ObservableObject {
+
+    /// Resolved exit offer for the current step (or legacy prefetch).
+    @Published private var exitOfferOffering: Offering?
+
+    /// The exit offer currently being presented.
+    @Published private var presentedExitOffer: Offering?
+
+    private let purchaseHandler: PurchaseHandler
+
+    init(purchaseHandler: PurchaseHandler) {
+        self.purchaseHandler = purchaseHandler
+    }
+
+    var isPresentingExitOffer: Bool {
+        self.presentedExitOffer != nil
+    }
+
+    /// Written by `WorkflowPaywallView` via the environment. Primary path; the preference is a fallback.
+    var workflowBinding: Binding<Offering?> {
+        Binding(
+            get: { [weak self] in self?.exitOfferOffering },
+            set: { [weak self] in self?.exitOfferOffering = $0 }
+        )
+    }
+
+    /// Drives the exit-offer sheet/cover.
+    var presentedBinding: Binding<Offering?> {
+        Binding(
+            get: { [weak self] in self?.presentedExitOffer },
+            set: { [weak self] in self?.presentedExitOffer = $0 }
+        )
+    }
+
+    /// Guarded so a late `nil` during the dismiss animation can't clear an already-presented offer.
+    func updateFromWorkflowPreference(_ context: WorkflowExitOfferContext?) {
+        guard self.purchaseHandler.remoteConfigEnabled else { return }
+        guard context != nil || self.presentedExitOffer == nil else { return }
+        self.exitOfferOffering = context?.exitOfferOffering
+    }
+
+    /// Legacy offering-level prefetch, used only when workflows (remote config) are disabled.
+    func prefetchLegacyExitOffer(resolveOffering: () async -> Offering?) async {
+        guard !self.purchaseHandler.remoteConfigEnabled else { return }
+        guard let offering = await resolveOffering() else { return }
+        self.exitOfferOffering = await ExitOfferHelper.fetchValidExitOffer(for: offering)
+    }
+
+    /// Presents the exit offer if available. Returns `true` if it took over (caller shouldn't dismiss).
+    @discardableResult
+    func presentIfAvailable() -> Bool {
+        guard self.presentedExitOffer == nil else { return true }
+        guard let offering = self.exitOfferOffering else { return false }
+
+        Logger.debug(Strings.presentingExitOffer(offering.identifier))
+        self.purchaseHandler.trackExitOffer(
+            exitOfferType: .dismiss,
+            exitOfferingIdentifier: offering.identifier
+        )
+        self.presentedExitOffer = offering
+        return true
+    }
+
+    /// Dismisses the presented exit offer (fires the sheet's `onDismiss`, which calls `reset()`).
+    func dismissPresentedExitOffer() {
+        self.presentedExitOffer = nil
+    }
+
+    func reset() {
+        self.presentedExitOffer = nil
+        self.exitOfferOffering = nil
+        self.purchaseHandler.resetForNewSession()
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(tvOS, unavailable)
+extension View {
+
+    /// Sources the workflow exit offer onto the presenter. Apply to the main paywall view (keeps the
+    /// binding/preference off the sheet boundary).
+    func workflowExitOfferSource(
+        presenter: ExitOfferPresenter,
+        resolveLegacyOffering: @escaping () async -> Offering?
+    ) -> some View {
+        self
+            .environment(\.workflowExitOfferOfferingBinding, presenter.workflowBinding)
+            .onPreferenceChange(WorkflowExitOfferPreferenceKey.self) { context in
+                presenter.updateFromWorkflowPreference(context)
+            }
+            .task {
+                await presenter.prefetchLegacyExitOffer(resolveOffering: resolveLegacyOffering)
+            }
+    }
+
+    /// Presents the exit offer as a sibling sheet/cover (after the main paywall dismisses, not nested).
+    func exitOfferSheet<ExitOfferView: View>(
+        presenter: ExitOfferPresenter,
+        presentationMode: PaywallPresentationMode,
+        onDismiss: (() -> Void)?,
+        @ViewBuilder makeExitOfferView: @escaping (Offering) -> ExitOfferView
+    ) -> some View {
+        let handleDismiss: () -> Void = {
+            presenter.reset()
+            onDismiss?()
+        }
+
+        return Group {
+            switch presentationMode {
+            case .sheet:
+                self.sheet(item: presenter.presentedBinding, onDismiss: handleDismiss) { offering in
+                    makeExitOfferView(offering)
+                    #if targetEnvironment(macCatalyst) || os(macOS)
+                        .frame(minHeight: 667)
+                    #endif
+                }
+            #if !os(macOS)
+            case .fullScreen:
+                self.fullScreenCover(item: presenter.presentedBinding, onDismiss: handleDismiss) { offering in
+                    makeExitOfferView(offering)
+                }
+            #endif
+            }
+        }
+    }
+
+}
+
+#endif

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -521,6 +521,7 @@ private struct PresentingPaywallModifier: ViewModifier {
             PurchaseHandler.default(performPurchase: myAppPurchaseLogic?.performPurchase,
                                     performRestore: myAppPurchaseLogic?.performRestore)
         self._purchaseHandler = .init(wrappedValue: handler)
+        self._exitOfferPresenter = .init(wrappedValue: ExitOfferPresenter(purchaseHandler: handler))
         self._promoOfferCacheOwner = .init(wrappedValue:
             PromoOfferCacheOwner(
                 cache: PaywallPromoOfferCache(
@@ -539,21 +540,14 @@ private struct PresentingPaywallModifier: ViewModifier {
     @State
     private var data: Data?
 
-    /// The prefetched exit offer, loaded while the main paywall is showing.
-    /// This enables immediate presentation when the main paywall dismisses (no loading delay).
-    /// Copied to `presentedExitOffer` when ready to show.
-    @State
-    private var exitOfferOffering: Offering?
+    /// Owns the exit-offer lifecycle (sourcing + presentation state + transitions).
+    @StateObject
+    private var exitOfferPresenter: ExitOfferPresenter
 
     /// Set when a workflow completes through purchase or restore-driven dismissal.
     /// Regular paywalls ignore this environment value; only `WorkflowPaywallView` consumes it.
     @State
     private var workflowCompletedInSession = false
-
-    /// The exit offer currently being presented. Controls the sheet/fullScreenCover.
-    /// Set from `exitOfferOffering` when the main paywall dismisses without a purchase.
-    @State
-    private var presentedExitOffer: Offering?
 
     func body(content: Content) -> some View {
         Group {
@@ -572,28 +566,21 @@ private struct PresentingPaywallModifier: ViewModifier {
                             .frame(height: 667)
                         #endif
                     }
-                    .sheet(item: self.$presentedExitOffer, onDismiss: self.handleExitOfferDismiss) { offering in
-                        self.exitOfferPaywallView(for: offering)
-                        #if targetEnvironment(macCatalyst) || os(macOS)
-                        // this should be minHeight, but for consistency with the first paywall it will be
-                        // like this for now
-                            .frame(height: 667)
-                        #endif
-                    }
             #if !os(macOS)
             case .fullScreen:
                 content
                     .fullScreenCover(item: self.$data, onDismiss: self.handleMainPaywallDismiss) { data in
                         self.paywallView(data)
                     }
-                    .fullScreenCover(
-                        item: self.$presentedExitOffer,
-                        onDismiss: self.handleExitOfferDismiss
-                    ) { offering in
-                        self.exitOfferPaywallView(for: offering)
-                    }
             #endif
             }
+        }
+        .exitOfferSheet(
+            presenter: self.exitOfferPresenter,
+            presentationMode: self.presentationMode,
+            onDismiss: self.onDismiss
+        ) { offering in
+            self.exitOfferPaywallView(for: offering)
         }
         .task {
             await self.updateCustomerInfo()
@@ -645,7 +632,6 @@ private struct PresentingPaywallModifier: ViewModifier {
                 promoOfferCache: self.promoOfferCacheOwner.cache
             )
         )
-        .environment(\.workflowExitOfferOfferingBinding, self.$exitOfferOffering)
         .environment(\.workflowCompletedInSessionBinding, self.$workflowCompletedInSession)
         .onAppear(perform: self.resetWorkflowCompletedInSession)
         .onPurchaseStarted {
@@ -674,17 +660,8 @@ private struct PresentingPaywallModifier: ViewModifier {
             self.restoreFailure?($0)
         }
         .interactiveDismissDisabled(self.purchaseHandler.actionInProgress)
-        .onPreferenceChange(WorkflowExitOfferPreferenceKey.self) { context in
-            self.handleWorkflowExitOfferPreferenceChange(context)
-        }
-        .task {
-            // When remote config (and, with it, workflows) is enabled, exit offers are resolved
-            // synchronously from WorkflowContext.allOfferings via the preference key above — no
-            // fetch needed.
-            guard !self.purchaseHandler.remoteConfigEnabled else { return }
-
-            guard let offering = await self.purchaseHandler.resolveOffering(for: self.content) else { return }
-            self.exitOfferOffering = await ExitOfferHelper.fetchValidExitOffer(for: offering)
+        .workflowExitOfferSource(presenter: self.exitOfferPresenter) {
+            await self.purchaseHandler.resolveOffering(for: self.content)
         }
     }
 
@@ -692,13 +669,6 @@ private struct PresentingPaywallModifier: ViewModifier {
         Logger.debug(Strings.dismissing_paywall)
 
         self.data = nil
-    }
-
-    private func closeExitOffer() {
-        Logger.debug(Strings.dismissing_paywall)
-
-        self.presentedExitOffer = nil
-        self.exitOfferOffering = nil
     }
 
     private func resetWorkflowCompletedInSession() {
@@ -725,7 +695,7 @@ private struct PresentingPaywallModifier: ViewModifier {
         // For restore, check shouldDisplay since restore might succeed without granting the expected entitlement.
         if result.success && !self.shouldDisplay(result.customerInfo) {
             self.markWorkflowCompletedInSession()
-            self.closeExitOffer()
+            self.exitOfferPresenter.dismissPresentedExitOffer()
         }
     }
 
@@ -736,7 +706,7 @@ private struct PresentingPaywallModifier: ViewModifier {
     /// - This ensures consistent behavior with how the first paywall decides to show/close
     private func handleMainPaywallDismiss() {
         // Prevent double processing
-        guard self.presentedExitOffer == nil else { return }
+        guard !self.exitOfferPresenter.isPresentingExitOffer else { return }
 
         guard !purchaseHandler.hasPurchasedInSession else {
             self.purchaseHandler.trackPaywallClose()
@@ -757,33 +727,11 @@ private struct PresentingPaywallModifier: ViewModifier {
 
         self.purchaseHandler.trackPaywallClose()
 
-        if let exitOffering = self.exitOfferOffering {
-            Logger.debug(Strings.presentingExitOffer(exitOffering.identifier))
-            self.purchaseHandler.trackExitOffer(
-                exitOfferType: .dismiss,
-                exitOfferingIdentifier: exitOffering.identifier
-            )
-            self.presentedExitOffer = exitOffering
-        } else {
+        // Present the exit offer if one is available; otherwise dismiss normally.
+        if !self.exitOfferPresenter.presentIfAvailable() {
             self.purchaseHandler.resetForNewSession()
             self.onDismiss?()
         }
-    }
-
-    private func handleExitOfferDismiss() {
-        self.presentedExitOffer = nil
-        self.exitOfferOffering = nil
-        self.purchaseHandler.resetForNewSession()
-        self.onDismiss?()
-    }
-
-    private func handleWorkflowExitOfferPreferenceChange(_ context: WorkflowExitOfferContext?) {
-        guard self.purchaseHandler.remoteConfigEnabled else { return }
-        // Don't nil out exitOfferOffering once an exit offer is already being presented:
-        // SwiftUI may fire a final nil preference update during the dismiss animation, after
-        // handleMainPaywallDismiss has already copied exitOfferOffering into presentedExitOffer.
-        guard context != nil || self.presentedExitOffer == nil else { return }
-        self.exitOfferOffering = context?.exitOfferOffering
     }
 
     private func exitOfferPaywallView(for offering: Offering) -> some View {
@@ -806,7 +754,7 @@ private struct PresentingPaywallModifier: ViewModifier {
             self.markWorkflowCompletedInSession()
             self.purchaseCompleted?(customerInfo)
             // Always close on successful purchase - shouldDisplay drives when to show, not when to close
-            self.closeExitOffer()
+            self.exitOfferPresenter.dismissPresentedExitOffer()
         }
         .onPurchaseCancelled {
             self.purchaseCancelled?()
@@ -861,21 +809,14 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
     var restoreFailure: PurchaseFailureHandler?
     var onDismiss: (() -> Void)?
 
-    /// The prefetched exit offer, loaded while the main paywall is showing.
-    /// This enables immediate presentation when the main paywall dismisses (no loading delay).
-    /// Copied to `presentedExitOffer` when ready to show.
-    @State
-    private var exitOfferOffering: Offering?
+    /// Owns the exit-offer lifecycle (sourcing + presentation state + transitions).
+    @StateObject
+    private var exitOfferPresenter: ExitOfferPresenter
 
     /// Set when a workflow completes through purchase or restore-driven dismissal.
     /// Regular paywalls ignore this environment value; only `WorkflowPaywallView` consumes it.
     @State
     private var workflowCompletedInSession = false
-
-    /// The exit offer currently being presented. Controls the sheet/fullScreenCover.
-    /// Set from `exitOfferOffering` when the main paywall dismisses without a purchase.
-    @State
-    private var presentedExitOffer: Offering?
 
     @StateObject
     private var purchaseHandler: PurchaseHandler
@@ -911,6 +852,7 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
         let handler = PurchaseHandler.default(performPurchase: myAppPurchaseLogic?.performPurchase,
                                               performRestore: myAppPurchaseLogic?.performRestore)
         self._purchaseHandler = .init(wrappedValue: handler)
+        self._exitOfferPresenter = .init(wrappedValue: ExitOfferPresenter(purchaseHandler: handler))
         self._promoOfferCacheOwner = .init(wrappedValue:
             PromoOfferCacheOwner(
                 cache: PaywallPromoOfferCache(
@@ -931,26 +873,21 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
                             .frame(minHeight: 667)
                         #endif
                     }
-                    .sheet(item: self.$presentedExitOffer, onDismiss: self.handleExitOfferDismiss) { exitOffering in
-                        self.exitOfferPaywallView(for: exitOffering)
-                        #if targetEnvironment(macCatalyst) || os(macOS)
-                            .frame(minHeight: 667)
-                        #endif
-                    }
             #if !os(macOS)
             case .fullScreen:
                 content
                     .fullScreenCover(item: self.$offering, onDismiss: self.handleMainPaywallDismiss) { offering in
                         self.paywallView(for: offering)
                     }
-                    .fullScreenCover(
-                        item: self.$presentedExitOffer,
-                        onDismiss: self.handleExitOfferDismiss
-                    ) { exitOffering in
-                        self.exitOfferPaywallView(for: exitOffering)
-                    }
             #endif
             }
+        }
+        .exitOfferSheet(
+            presenter: self.exitOfferPresenter,
+            presentationMode: self.presentationMode,
+            onDismiss: self.onDismiss
+        ) { exitOffering in
+            self.exitOfferPaywallView(for: exitOffering)
         }
     }
 
@@ -992,8 +929,8 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
             self.restoreFailure?($0)
         }
         .interactiveDismissDisabled(self.purchaseHandler.actionInProgress)
-        .task {
-            self.exitOfferOffering = await ExitOfferHelper.fetchValidExitOffer(for: offering)
+        .workflowExitOfferSource(presenter: self.exitOfferPresenter) {
+            offering
         }
     }
 
@@ -1016,8 +953,7 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
             self.markWorkflowCompletedInSession()
             self.purchaseCompleted?(customerInfo)
             // Always close on successful purchase
-            self.presentedExitOffer = nil
-            self.exitOfferOffering = nil
+            self.exitOfferPresenter.dismissPresentedExitOffer()
         }
         .onPurchaseCancelled {
             self.purchaseCancelled?()
@@ -1059,8 +995,7 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
 
         // Close on successful restore.
         self.markWorkflowCompletedInSession()
-        self.presentedExitOffer = nil
-        self.exitOfferOffering = nil
+        self.exitOfferPresenter.dismissPresentedExitOffer()
     }
 
     /// Handles dismissal of the main paywall, checking for exit offers.
@@ -1070,7 +1005,7 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
     /// - Fetching `CustomerInfo` may return cached data that hasn't been updated yet
     private func handleMainPaywallDismiss() {
         // Prevent double processing
-        guard self.presentedExitOffer == nil else { return }
+        guard !self.exitOfferPresenter.isPresentingExitOffer else { return }
 
         guard !self.purchaseHandler.hasPurchasedInSession else {
             self.purchaseHandler.trackPaywallClose()
@@ -1087,24 +1022,11 @@ private struct PresentingPaywallBindingModifier: ViewModifier {
 
         self.purchaseHandler.trackPaywallClose()
 
-        if let exitOffering = self.exitOfferOffering {
-            Logger.debug(Strings.presentingExitOffer(exitOffering.identifier))
-            self.purchaseHandler.trackExitOffer(
-                exitOfferType: .dismiss,
-                exitOfferingIdentifier: exitOffering.identifier
-            )
-            self.presentedExitOffer = exitOffering
-        } else {
+        // Present the exit offer if one is available; otherwise dismiss normally.
+        if !self.exitOfferPresenter.presentIfAvailable() {
             self.purchaseHandler.resetForNewSession()
             self.onDismiss?()
         }
-    }
-
-    private func handleExitOfferDismiss() {
-        self.presentedExitOffer = nil
-        self.exitOfferOffering = nil
-        self.purchaseHandler.resetForNewSession()
-        self.onDismiss?()
     }
 
 }

--- a/Tests/RevenueCatUITests/Purchasing/ExitOfferPresenterTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/ExitOfferPresenterTests.swift
@@ -1,0 +1,85 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ExitOfferPresenterTests.swift
+
+import Nimble
+@_spi(Internal) @testable import RevenueCat
+@testable import RevenueCatUI
+import XCTest
+
+#if !os(tvOS)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@MainActor
+class ExitOfferPresenterTests: TestCase {
+
+    private let offering = TestData.offeringWithNoIntroOffer
+
+    func testWorkflowPreferenceSetsOfferWhenRemoteConfigEnabled() {
+        let presenter = ExitOfferPresenter(purchaseHandler: .mock(remoteConfigEnabled: true))
+
+        presenter.updateFromWorkflowPreference(.init(exitOfferOffering: self.offering))
+
+        expect(presenter.workflowBinding.wrappedValue?.identifier) == self.offering.identifier
+        expect(presenter.presentIfAvailable()) == true
+        expect(presenter.isPresentingExitOffer) == true
+    }
+
+    func testWorkflowPreferenceIgnoredWhenRemoteConfigDisabled() {
+        let presenter = ExitOfferPresenter(purchaseHandler: .mock(remoteConfigEnabled: false))
+
+        presenter.updateFromWorkflowPreference(.init(exitOfferOffering: self.offering))
+
+        expect(presenter.workflowBinding.wrappedValue).to(beNil())
+        expect(presenter.presentIfAvailable()) == false
+        expect(presenter.isPresentingExitOffer) == false
+    }
+
+    func testNilPreferenceDoesNotClearAlreadyPresentedOffer() {
+        let presenter = ExitOfferPresenter(purchaseHandler: .mock(remoteConfigEnabled: true))
+
+        presenter.updateFromWorkflowPreference(.init(exitOfferOffering: self.offering))
+        expect(presenter.presentIfAvailable()) == true
+
+        // A late nil preference (fired during the dismiss animation) must not clear the offer being shown.
+        presenter.updateFromWorkflowPreference(nil)
+
+        expect(presenter.isPresentingExitOffer) == true
+        expect(presenter.workflowBinding.wrappedValue?.identifier) == self.offering.identifier
+    }
+
+    func testNilPreferenceClearsOfferWhenNotPresenting() {
+        let presenter = ExitOfferPresenter(purchaseHandler: .mock(remoteConfigEnabled: true))
+
+        presenter.updateFromWorkflowPreference(.init(exitOfferOffering: self.offering))
+        presenter.updateFromWorkflowPreference(nil)
+
+        expect(presenter.workflowBinding.wrappedValue).to(beNil())
+        expect(presenter.presentIfAvailable()) == false
+    }
+
+    func testLegacyPrefetchSkippedWhenRemoteConfigEnabled() async {
+        let presenter = ExitOfferPresenter(purchaseHandler: .mock(remoteConfigEnabled: true))
+        var resolveOfferingCalled = false
+
+        await presenter.prefetchLegacyExitOffer {
+            resolveOfferingCalled = true
+            return self.offering
+        }
+
+        // Under workflows the exit offer comes from the step-aware preference, so the offering-level
+        // prefetch must not run (this is the gap that surfaced the exit offer on non-exit-offer steps).
+        expect(resolveOfferingCalled) == false
+        expect(presenter.workflowBinding.wrappedValue).to(beNil())
+    }
+
+}
+
+#endif


### PR DESCRIPTION
### Motivation

`.presentPaywall(offering:)` resolved the exit offer at the offering level and showed it on **any** dismiss, so closing a non-exit-offer workflow step (e.g. the first page) surfaced the exit offer. **It should only fire on the paywall step.**

### What

Adopts the shared-component approach from #6918: extract the exit-offer lifecycle into one `ExitOfferPresenter` and route **both** present modifiers through it, so the binding path is now step-aware too and skips the offering-level prefetch when remote config is on. Closing #6918 in favor of this.


https://github.com/user-attachments/assets/b5aae7f8-9f1d-4773-a0eb-fa60cff72fcf

https://github.com/user-attachments/assets/d8396ac0-0fc6-4719-92c9-935ea9acdcd7



<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- Branch: `facu/maestro-workflow-exit-offer` (base: `main`)
- Supersedes: #6918
- Author / human owner: facumenzella (Facundo Menzella)
- Agent: Claude Code (Opus 4.8, 1M context)
- Session source: current conversation

## Goal

Prove and fix that a workflow exit offer fired when closing a non-exit-offer step on the `.presentPaywall(offering:)` path, using two Maestro flows as the RED→GREEN check.

## First actionable instruction

"just added an exit offer. it should only be fired when closing the paywall (last page) ... 1- it's not fired when closing the first page ... 2- check another paywall is opened when closing the last page" then "let's write both tests, and use them as a check to fix the bug."

## Important follow-up prompts

- "yeah let's use present for this" — the repro flow presents via `.presentPaywall(offering:)`.
- "I had #6918 open for a while. Maybe we can take some ideas from there?" → chose to adopt its `ExitOfferPresenter` extraction here.
- "open a draft, link it to the old pr and close the old one."

## Root cause (verified)

`PresentingPaywallBindingModifier` (the `offering:` path) did not wire the step-aware workflow exit offer: no `workflowExitOfferOfferingBinding`, no `WorkflowExitOfferPreferenceKey` observer, and its `.task` ran `ExitOfferHelper.fetchValidExitOffer(for:)` unconditionally. So `exitOfferOffering` was non-nil the moment the paywall opened and `handleMainPaywallDismiss` presented it on any close. `PresentingPaywallModifier` already did the right thing (gated `.task` on `remoteConfigEnabled`). Confirmed by reading both modifiers; independently corroborated by #6918 ("also gives `.presentPaywall(offering:)` the workflow exit-offer support it was missing").

## Agent contribution

- Added `RevenueCatUI/View+ExitOfferPresentation.swift`: `ExitOfferPresenter` (`workflowBinding`, `presentedBinding`, `updateFromWorkflowPreference`, `prefetchLegacyExitOffer`, `presentIfAvailable`, `dismissPresentedExitOffer`, `reset`, `isPresentingExitOffer`) + `View.workflowExitOfferSource` / `View.exitOfferSheet`. Ported from #6918, gate adapted to `remoteConfigEnabled`.
- Converted both `PresentingPaywallModifier` and `PresentingPaywallBindingModifier` in `View+PresentPaywall.swift` to the shared presenter; removed the duplicated `@State`/sheets/dismiss handlers.
- Maestro: new `OpenWorkflowPresented` flow + `open_workflow_presented` registration; `workflow_exit_offer_on_last_page.yaml`, `workflow_exit_offer_not_on_first_page.yaml`.
- Tests: `ExitOfferPresenterTests` (5 cases); added a defaulted `remoteConfigEnabled` param to `PurchaseHandler.mock`.

## Human decisions

- Adopt #6918's `ExitOfferPresenter` extraction in this branch (over a minimal parity patch or reviving #6918 directly).
- Close #6918 in favor of this PR.

## Files / symbols touched

- `RevenueCatUI/View+ExitOfferPresentation.swift` (new)
- `RevenueCatUI/View+PresentPaywall.swift` — both modifiers now use `ExitOfferPresenter`
- `RevenueCatUI/Purchasing/PurchaseHandler+TestData.swift` — `mock(remoteConfigEnabled:)`
- `Tests/RevenueCatUITests/Purchasing/ExitOfferPresenterTests.swift` (new)
- `Examples/rc-maestro/...` — new flow + 2 Maestro tests

## Validation

- `swift build --target RevenueCatUI`: Build complete.
- `swiftlint` on changed files: no violations (pre-commit clean).
- `xcodebuild test ... -only-testing:RevenueCatUITests/ExitOfferPresenterTests`: 5/5 passed.
- Maestro on iPhone 16e (iOS 18.4, test_store): `workflow_exit_offer_on_last_page` GREEN; `workflow_exit_offer_not_on_first_page` RED before fix, GREEN after.
- No public API change (all added symbols internal; `.mock` param is test-only).

## Risks / reviewer notes

- Parity point (matches shipped `presentPaywallIfNeeded`): under remote config the offering-level `fetchValidExitOffer` prefetch is skipped on the binding path too; a non-workflow offering's legacy offering-level exit offer would not surface via this path. Consistent with the other modifier and #6918.
- `presentPaywallIfNeeded` runtime path not separately E2E-exercised (structurally identical now; build + unit + binding-path E2E cover the shared component).

</details>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches paywall dismiss and exit-offer presentation for both public present modifiers; behavior change is intentional but affects a revenue-sensitive UX path. Mitigated by unit tests and Maestro coverage on the binding path.
> 
> **Overview**
> Fixes workflow exit offers firing when users close an **early** workflow page via **`.presentPaywall(offering:)`**. That path used to prefetch an offering-level exit offer as soon as the paywall opened, so dismiss on any step could show **Paywall V2** instead of only on the exit-offer step.
> 
> Introduces **`ExitOfferPresenter`** and shared **`workflowExitOfferSource`** / **`exitOfferSheet`** helpers, then wires both **`presentPaywallIfNeeded`** and **`presentPaywall(offering:)`** modifiers through them. With remote config (workflows) on, the exit offer comes from step-aware **`WorkflowExitOfferPreferenceKey`** / workflow binding and **skips** legacy **`ExitOfferHelper.fetchValidExitOffer`** prefetch—the change that stops the first-page close bug.
> 
> Adds **`ExitOfferPresenterTests`**, a Maestro **`open_workflow_presented`** flow, and two Maestro workflows asserting exit offer **not** shown on first-page close and **shown** on last-page close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35e1859f7bd28c584bf89c49add33c23af1b0c5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->