### PR TITLE
fix(remote-config): lazy-decode prefetched workflows

### DIFF
--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -11,7 +11,7 @@ protocol WorkflowsConfigProviderType {
 
     func workflowId(forOfferingId offeringId: String) async -> String?
     func getWorkflow(workflowId: String) async -> Result<WorkflowDataResult, WorkflowResolutionError>
-    func warmPrefetchedWorkflows() async
+    func warmPrefetchedWorkflows(currentOfferingId: String?) async
     func cachedWorkflow(forOfferingId offeringId: String) -> WorkflowDataResult?
 
 }
@@ -38,12 +38,10 @@ enum WorkflowResolutionError: Error, Equatable {
 final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
 
     typealias WorkflowDecoder = (Data) throws -> PublishedWorkflow
-    typealias CurrentOfferingIdProvider = @Sendable () -> String?
 
     private let manager: RemoteConfigManagerType
     private let uiConfigProvider: UiConfigProvider
     private let workflowDecoder: WorkflowDecoder
-    private let currentOfferingIdProvider: CurrentOfferingIdProvider
 
     /// The offeringId → workflowId map built from the last topic snapshot seen, keyed by that snapshot
     /// so a repeat call with an unchanged topic reuses it instead of rescanning every item's content.
@@ -57,12 +55,10 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     init(
         manager: RemoteConfigManagerType,
         uiConfigProvider: UiConfigProvider? = nil,
-        currentOfferingIdProvider: @escaping CurrentOfferingIdProvider = { nil },
         workflowDecoder: @escaping WorkflowDecoder = WorkflowsConfigProvider.decodeWorkflow
     ) {
         self.manager = manager
         self.uiConfigProvider = uiConfigProvider ?? UiConfigProvider(manager: manager)
-        self.currentOfferingIdProvider = currentOfferingIdProvider
         self.workflowDecoder = workflowDecoder
     }
 
@@ -135,13 +131,13 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         }
     }
 
-    func warmPrefetchedWorkflows() async {
+    func warmPrefetchedWorkflows(currentOfferingId: String?) async {
         await Task.detached(priority: .utility) {
-            await self.warmPrefetchedWorkflowsOnBackgroundExecutor()
+            await self.warmPrefetchedWorkflowsOnBackgroundExecutor(currentOfferingId: currentOfferingId)
         }.value
     }
 
-    private func warmPrefetchedWorkflowsOnBackgroundExecutor() async {
+    private func warmPrefetchedWorkflowsOnBackgroundExecutor(currentOfferingId: String?) async {
         guard self.currentWorkflowCache() == nil else { return }
         guard let topic = await self.manager.awaitTopicAndPrefetchBlobsReady(.workflows) else { return }
         guard self.currentWorkflowCache() == nil else { return }
@@ -154,7 +150,11 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         // synchronously on first access, so warming doesn't build every workflow's component graph.
         let offeringIdMap = self.buildOfferingIdMap(from: topic)
         let workflows = await self.loadWorkflows(
-            self.workflowIdsToWarm(from: topic, offeringIdMap: offeringIdMap)
+            self.workflowIdsToWarm(
+                from: topic,
+                offeringIdMap: offeringIdMap,
+                currentOfferingId: currentOfferingId
+            )
         )
 
         guard await self.manager.isCurrent(snapshot, for: .workflows) else {
@@ -244,13 +244,14 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
 
     private func workflowIdsToWarm(
         from topic: RemoteConfiguration.ConfigTopic,
-        offeringIdMap: [String: String]
+        offeringIdMap: [String: String],
+        currentOfferingId: String?
     ) -> [String] {
         var workflowIds = Set(topic.compactMap { workflowId, item in
             item.prefetch ? workflowId : nil
         })
 
-        if let currentOfferingId = self.currentOfferingIdProvider(),
+        if let currentOfferingId,
            let currentWorkflowId = offeringIdMap[currentOfferingId] {
             workflowIds.insert(currentWorkflowId)
         }

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -117,7 +117,7 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         // `ui_config`. A warm-cache hit decodes synchronously from in-memory bytes on the caller's thread.
         if let cached = self.cachedWorkflowResult(workflowId: workflowId) {
             return await self.makeWorkflowResult(cached.result) {
-                self.manager.withCurrentConfigGeneration({ $0 == cached.generation }) == true
+                self.manager.configGeneration == cached.generation
             }
         }
 
@@ -162,7 +162,7 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         // Keep only body bytes in memory here. `LazyPublishedWorkflow` performs and retains the decode
         // synchronously on first access, so warming doesn't build every workflow's component graph.
         let missingWorkflowIds = expectedWorkflowIds.subtracting(cachedWorkflows.keys)
-        let loadedWorkflows = await self.loadWorkflows(missingWorkflowIds.sorted())
+        let loadedWorkflows = await self.loadWorkflows(missingWorkflowIds)
 
         guard await self.manager.isCurrent(snapshot, for: .workflows) else {
             self.prefetchedWorkflowsCache.clearIfStale(currentGeneration: self.manager.configGeneration)
@@ -257,7 +257,7 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         return self.prefetchedWorkflowsCache.value(currentGeneration: currentGeneration)
     }
 
-    private func loadWorkflows(_ workflowIds: [String]) async -> [String: LazyPublishedWorkflow] {
+    private func loadWorkflows(_ workflowIds: Set<String>) async -> [String: LazyPublishedWorkflow] {
         await withTaskGroup(of: (String, Data?).self) { group in
             for workflowId in workflowIds {
                 group.addTask {

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -138,32 +138,47 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     }
 
     private func warmPrefetchedWorkflowsOnBackgroundExecutor(currentOfferingId: String?) async {
-        guard self.currentWorkflowCache() == nil else { return }
+        if let cache = self.currentWorkflowCache(), cache.isWarm(currentOfferingId: currentOfferingId) {
+            return
+        }
         guard let topic = await self.manager.awaitTopicAndPrefetchBlobsReady(.workflows) else { return }
-        guard self.currentWorkflowCache() == nil else { return }
 
         let snapshot = GenerationGuardedCacheSnapshot(
             generation: self.manager.configGeneration,
             key: topic
         )
+        let offeringIdMap = self.buildOfferingIdMap(from: topic)
+        let prefetchedWorkflowIds = Set(topic.compactMap { workflowId, item in
+            item.prefetch ? workflowId : nil
+        })
+        let expectedWorkflowIds = workflowIdsToWarm(
+            prefetchedWorkflowIds: prefetchedWorkflowIds,
+            offeringIdMap: offeringIdMap,
+            currentOfferingId: currentOfferingId
+        )
+        let cachedWorkflows = self.prefetchedWorkflowsCache.value(for: snapshot)?.workflows ?? [:]
+        guard !expectedWorkflowIds.isSubset(of: cachedWorkflows.keys) else { return }
+
         // Keep only body bytes in memory here. `LazyPublishedWorkflow` performs and retains the decode
         // synchronously on first access, so warming doesn't build every workflow's component graph.
-        let offeringIdMap = self.buildOfferingIdMap(from: topic)
-        let workflows = await self.loadWorkflows(
-            self.workflowIdsToWarm(
-                from: topic,
-                offeringIdMap: offeringIdMap,
-                currentOfferingId: currentOfferingId
-            )
-        )
+        let missingWorkflowIds = expectedWorkflowIds.subtracting(cachedWorkflows.keys)
+        let loadedWorkflows = await self.loadWorkflows(missingWorkflowIds.sorted())
 
         guard await self.manager.isCurrent(snapshot, for: .workflows) else {
             self.prefetchedWorkflowsCache.clearIfStale(currentGeneration: self.manager.configGeneration)
             return
         }
 
+        // Another concurrent warm may have populated more entries while the missing bodies loaded.
+        // Preserve those entries (and any retained lazy decode results) when merging this warm.
+        let latestWorkflows = self.prefetchedWorkflowsCache.value(for: snapshot)?.workflows ?? cachedWorkflows
+        let workflows = latestWorkflows.merging(loadedWorkflows) { cached, _ in cached }
         self.prefetchedWorkflowsCache.store(
-            .init(offeringIdMap: offeringIdMap, workflows: workflows),
+            .init(
+                offeringIdMap: offeringIdMap,
+                prefetchedWorkflowIds: prefetchedWorkflowIds,
+                workflows: workflows
+            ),
             for: snapshot
         )
     }
@@ -242,23 +257,6 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         return self.prefetchedWorkflowsCache.value(currentGeneration: currentGeneration)
     }
 
-    private func workflowIdsToWarm(
-        from topic: RemoteConfiguration.ConfigTopic,
-        offeringIdMap: [String: String],
-        currentOfferingId: String?
-    ) -> [String] {
-        var workflowIds = Set(topic.compactMap { workflowId, item in
-            item.prefetch ? workflowId : nil
-        })
-
-        if let currentOfferingId,
-           let currentWorkflowId = offeringIdMap[currentOfferingId] {
-            workflowIds.insert(currentWorkflowId)
-        }
-
-        return workflowIds.sorted()
-    }
-
     private func loadWorkflows(_ workflowIds: [String]) async -> [String: LazyPublishedWorkflow] {
         await withTaskGroup(of: (String, Data?).self) { group in
             for workflowId in workflowIds {
@@ -288,9 +286,34 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
 
 }
 
+private func workflowIdsToWarm(
+    prefetchedWorkflowIds: Set<String>,
+    offeringIdMap: [String: String],
+    currentOfferingId: String?
+) -> Set<String> {
+    var workflowIds = prefetchedWorkflowIds
+
+    if let currentOfferingId,
+       let currentWorkflowId = offeringIdMap[currentOfferingId] {
+        workflowIds.insert(currentWorkflowId)
+    }
+
+    return workflowIds
+}
+
 private struct PrefetchedWorkflowCache {
     let offeringIdMap: [String: String]
+    let prefetchedWorkflowIds: Set<String>
     let workflows: [String: LazyPublishedWorkflow]
+
+    func isWarm(currentOfferingId: String?) -> Bool {
+        let expectedWorkflowIds = workflowIdsToWarm(
+            prefetchedWorkflowIds: self.prefetchedWorkflowIds,
+            offeringIdMap: self.offeringIdMap,
+            currentOfferingId: currentOfferingId
+        )
+        return expectedWorkflowIds.isSubset(of: self.workflows.keys)
+    }
 }
 
 /// Retains raw workflow bytes until first use, then atomically retains either the decoded workflow or

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -38,10 +38,12 @@ enum WorkflowResolutionError: Error, Equatable {
 final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
 
     typealias WorkflowDecoder = (Data) throws -> PublishedWorkflow
+    typealias CurrentOfferingIdProvider = @Sendable () -> String?
 
     private let manager: RemoteConfigManagerType
     private let uiConfigProvider: UiConfigProvider
     private let workflowDecoder: WorkflowDecoder
+    private let currentOfferingIdProvider: CurrentOfferingIdProvider
 
     /// The offeringId → workflowId map built from the last topic snapshot seen, keyed by that snapshot
     /// so a repeat call with an unchanged topic reuses it instead of rescanning every item's content.
@@ -55,10 +57,12 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     init(
         manager: RemoteConfigManagerType,
         uiConfigProvider: UiConfigProvider? = nil,
+        currentOfferingIdProvider: @escaping CurrentOfferingIdProvider = { nil },
         workflowDecoder: @escaping WorkflowDecoder = WorkflowsConfigProvider.decodeWorkflow
     ) {
         self.manager = manager
         self.uiConfigProvider = uiConfigProvider ?? UiConfigProvider(manager: manager)
+        self.currentOfferingIdProvider = currentOfferingIdProvider
         self.workflowDecoder = workflowDecoder
     }
 
@@ -149,7 +153,9 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         // Keep only body bytes in memory here. `LazyPublishedWorkflow` performs and retains the decode
         // synchronously on first access, so warming doesn't build every workflow's component graph.
         let offeringIdMap = self.buildOfferingIdMap(from: topic)
-        let workflows = await self.loadPrefetchedWorkflows(from: topic)
+        let workflows = await self.loadWorkflows(
+            self.workflowIdsToWarm(from: topic, offeringIdMap: offeringIdMap)
+        )
 
         guard await self.manager.isCurrent(snapshot, for: .workflows) else {
             self.prefetchedWorkflowsCache.clearIfStale(currentGeneration: self.manager.configGeneration)
@@ -236,12 +242,25 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         return self.prefetchedWorkflowsCache.value(currentGeneration: currentGeneration)
     }
 
-    private func loadPrefetchedWorkflows(
-        from topic: RemoteConfiguration.ConfigTopic
-    ) async -> [String: LazyPublishedWorkflow] {
+    private func workflowIdsToWarm(
+        from topic: RemoteConfiguration.ConfigTopic,
+        offeringIdMap: [String: String]
+    ) -> [String] {
+        var workflowIds = Set(topic.compactMap { workflowId, item in
+            item.prefetch ? workflowId : nil
+        })
+
+        if let currentOfferingId = self.currentOfferingIdProvider(),
+           let currentWorkflowId = offeringIdMap[currentOfferingId] {
+            workflowIds.insert(currentWorkflowId)
+        }
+
+        return workflowIds.sorted()
+    }
+
+    private func loadWorkflows(_ workflowIds: [String]) async -> [String: LazyPublishedWorkflow] {
         await withTaskGroup(of: (String, Data?).self) { group in
-            for workflowId in topic.keys.sorted() {
-                guard topic[workflowId]?.prefetch == true else { continue }
+            for workflowId in workflowIds {
                 group.addTask {
                     return (workflowId, await self.manager.blobData(for: .workflows, itemKey: workflowId))
                 }

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -37,10 +37,11 @@ enum WorkflowResolutionError: Error, Equatable {
 /// parse a ``PublishedWorkflow``. Everything else is delegated to `RemoteConfigManager`.
 final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
 
+    typealias WorkflowDecoder = (Data) throws -> PublishedWorkflow
+
     private let manager: RemoteConfigManagerType
     private let uiConfigProvider: UiConfigProvider
-    private let paywallCache: PaywallCacheWarmingType?
-    private let operationDispatcher: OperationDispatcher
+    private let workflowDecoder: WorkflowDecoder
 
     /// The offeringId → workflowId map built from the last topic snapshot seen, keyed by that snapshot
     /// so a repeat call with an unchanged topic reuses it instead of rescanning every item's content.
@@ -54,13 +55,11 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     init(
         manager: RemoteConfigManagerType,
         uiConfigProvider: UiConfigProvider? = nil,
-        paywallCache: PaywallCacheWarmingType? = nil,
-        operationDispatcher: OperationDispatcher = .default
+        workflowDecoder: @escaping WorkflowDecoder = WorkflowsConfigProvider.decodeWorkflow
     ) {
         self.manager = manager
         self.uiConfigProvider = uiConfigProvider ?? UiConfigProvider(manager: manager)
-        self.paywallCache = paywallCache
-        self.operationDispatcher = operationDispatcher
+        self.workflowDecoder = workflowDecoder
     }
 
     /// Resolves `offeringId` to its workflow id via an offeringId → workflowId map built from the
@@ -114,8 +113,12 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     /// Cache misses validate the workflow topic's generation after `ui_config` resolves, so an in-flight
     /// config change fails the resolution instead of returning a mixed-generation workflow/config pair.
     func getWorkflow(workflowId: String) async -> Result<WorkflowDataResult, WorkflowResolutionError> {
-        if let cached = self.cachedWorkflow(workflowId: workflowId) {
-            return .success(cached)
+        // Deliberately sequential, not `async let`: a miss or malformed body returns without paying for
+        // `ui_config`. A warm-cache hit decodes synchronously from in-memory bytes on the caller's thread.
+        if let cached = self.cachedWorkflowResult(workflowId: workflowId) {
+            return await self.makeWorkflowResult(cached.result) {
+                self.manager.withCurrentConfigGeneration({ $0 == cached.generation }) == true
+            }
         }
 
         guard let snapshot = await self.manager.topicCacheSnapshot(.workflows),
@@ -123,26 +126,9 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
             return .failure(.notFound)
         }
 
-        // Deliberately sequential, not `async let`: an `async let` for `ui_config` started alongside the
-        // workflow-body read would still be implicitly awaited (Swift cancels but does not fast-fail an
-        // unconsumed `async let` when its scope exits) if the body turns out missing or malformed, so a
-        // miss would pay for `ui_config`'s network reads anyway instead of returning immediately.
-        let workflow: PublishedWorkflow
-        switch await self.fetchWorkflow(workflowId: workflowId) {
-        case let .success(fetched):
-            workflow = fetched
-        case let .failure(error):
-            return .failure(error)
+        return await self.makeWorkflowResult(await self.fetchWorkflow(workflowId: workflowId)) {
+            await self.manager.isCurrent(snapshot, for: .workflows)
         }
-
-        guard let uiConfig = await self.uiConfigProvider.getUiConfig() else {
-            return .failure(.uiConfigUnavailable)
-        }
-        guard await self.manager.isCurrent(snapshot, for: .workflows) else {
-            return .failure(.notFound)
-        }
-
-        return .success(WorkflowDataResult(workflow: workflow, uiConfig: uiConfig, enrolledVariants: nil))
     }
 
     func warmPrefetchedWorkflows() async {
@@ -152,22 +138,18 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     }
 
     private func warmPrefetchedWorkflowsOnBackgroundExecutor() async {
-        guard self.currentWorkflowCache()?.isComplete != true else { return }
+        guard self.currentWorkflowCache() == nil else { return }
         guard let topic = await self.manager.awaitTopicAndPrefetchBlobsReady(.workflows) else { return }
+        guard self.currentWorkflowCache() == nil else { return }
 
         let snapshot = GenerationGuardedCacheSnapshot(
             generation: self.manager.configGeneration,
             key: topic
         )
-        let cachedWorkflows = self.prefetchedWorkflowsCache.value(for: snapshot)?.workflows ?? [:]
-        let expectedWorkflowIds = Set(topic.compactMap { workflowId, item in
-            item.prefetch ? workflowId : nil
-        })
-        guard !expectedWorkflowIds.isSubset(of: cachedWorkflows.keys) else { return }
-
+        // Keep only body bytes in memory here. `LazyPublishedWorkflow` performs and retains the decode
+        // synchronously on first access, so warming doesn't build every workflow's component graph.
         let offeringIdMap = self.buildOfferingIdMap(from: topic)
-        let decodedWorkflows = await self.decodePrefetchedWorkflows(from: topic)
-        let workflows = cachedWorkflows.merging(decodedWorkflows) { _, decoded in decoded }
+        let workflows = await self.loadPrefetchedWorkflows(from: topic)
 
         guard await self.manager.isCurrent(snapshot, for: .workflows) else {
             self.prefetchedWorkflowsCache.clearIfStale(currentGeneration: self.manager.configGeneration)
@@ -175,23 +157,17 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         }
 
         self.prefetchedWorkflowsCache.store(
-            .init(
-                offeringIdMap: offeringIdMap,
-                workflows: workflows,
-                isComplete: expectedWorkflowIds.isSubset(of: workflows.keys)
-            ),
+            .init(offeringIdMap: offeringIdMap, workflows: workflows),
             for: snapshot
         )
-
-        self.warmPrefetchedWorkflowAssetsInBackground(decodedWorkflows)
     }
 
     func cachedWorkflow(forOfferingId offeringId: String) -> WorkflowDataResult? {
         return self.manager.withCurrentConfigGeneration { generation in
             guard let cache = self.currentWorkflowCache(currentGeneration: generation) else { return nil }
             let workflowId = self.resolvedWorkflowId(forOfferingId: offeringId, in: cache)
-            guard let workflow = cache.workflows[workflowId],
-                  let uiConfig = self.uiConfigProvider.cachedUiConfig(currentGeneration: generation) else {
+            guard let uiConfig = self.uiConfigProvider.cachedUiConfig(currentGeneration: generation),
+                  case let .success(workflow)? = cache.workflows[workflowId]?.value() else {
                 return nil
             }
 
@@ -218,15 +194,35 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         }
     }
 
-    private func cachedWorkflow(workflowId: String) -> WorkflowDataResult? {
+    private func makeWorkflowResult(
+        _ workflowResult: Result<PublishedWorkflow, WorkflowResolutionError>,
+        isCurrent: () async -> Bool
+    ) async -> Result<WorkflowDataResult, WorkflowResolutionError> {
+        let workflow: PublishedWorkflow
+        switch workflowResult {
+        case let .success(value):
+            workflow = value
+        case let .failure(error):
+            return .failure(error)
+        }
+
+        guard let uiConfig = await self.uiConfigProvider.getUiConfig() else {
+            return .failure(.uiConfigUnavailable)
+        }
+        guard await isCurrent() else { return .failure(.notFound) }
+
+        return .success(WorkflowDataResult(workflow: workflow, uiConfig: uiConfig, enrolledVariants: nil))
+    }
+
+    private func cachedWorkflowResult(
+        workflowId: String
+    ) -> (result: Result<PublishedWorkflow, WorkflowResolutionError>, generation: Int)? {
         return self.manager.withCurrentConfigGeneration { generation in
             guard let cache = self.currentWorkflowCache(currentGeneration: generation),
-                  let workflow = cache.workflows[workflowId],
-                  let uiConfig = self.uiConfigProvider.cachedUiConfig(currentGeneration: generation) else {
+                  let workflow = cache.workflows[workflowId] else {
                 return nil
             }
-
-            return WorkflowDataResult(workflow: workflow, uiConfig: uiConfig, enrolledVariants: nil)
+            return (result: workflow.value(), generation: generation)
         }
     }
 
@@ -240,56 +236,32 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         return self.prefetchedWorkflowsCache.value(currentGeneration: currentGeneration)
     }
 
-    private func decodePrefetchedWorkflows(
+    private func loadPrefetchedWorkflows(
         from topic: RemoteConfiguration.ConfigTopic
-    ) async -> [String: PublishedWorkflow] {
-        await withTaskGroup(of: (String, PublishedWorkflow?).self) { group in
+    ) async -> [String: LazyPublishedWorkflow] {
+        await withTaskGroup(of: (String, Data?).self) { group in
             for workflowId in topic.keys.sorted() {
                 guard topic[workflowId]?.prefetch == true else { continue }
                 group.addTask {
-                    do {
-                        return (
-                            workflowId,
-                            try await self.manager.blobData(
-                                for: .workflows,
-                                itemKey: workflowId,
-                                as: PublishedWorkflow.self
-                            )
-                        )
-                    } catch {
-                        Logger.error(Strings.codable.decoding_error(error, PublishedWorkflow.self))
-                        return (workflowId, nil)
-                    }
+                    return (workflowId, await self.manager.blobData(for: .workflows, itemKey: workflowId))
                 }
             }
 
-            var workflows: [String: PublishedWorkflow] = [:]
-            for await (workflowId, workflow) in group {
-                if let workflow {
-                    workflows[workflowId] = workflow
+            var workflows: [String: LazyPublishedWorkflow] = [:]
+            for await (workflowId, data) in group {
+                if let data {
+                    workflows[workflowId] = LazyPublishedWorkflow(
+                        data: data,
+                        decoder: self.workflowDecoder
+                    )
                 }
             }
             return workflows
         }
     }
 
-    private func warmPrefetchedWorkflowAssetsInBackground(_ workflows: [String: PublishedWorkflow]) {
-        self.operationDispatcher.dispatchOnWorkerThread {
-            await self.warmPrefetchedWorkflowAssets(workflows)
-        }
-    }
-
-    private func warmPrefetchedWorkflowAssets(_ workflows: [String: PublishedWorkflow]) async {
-        guard #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *),
-              let paywallCache,
-              let uiConfig = await self.uiConfigProvider.getUiConfig() else {
-            return
-        }
-
-        for workflowId in workflows.keys.sorted() {
-            guard let workflow = workflows[workflowId] else { continue }
-            await paywallCache.warmUpWorkflowCaches(workflow: workflow, uiConfig: uiConfig)
-        }
+    private static func decodeWorkflow(data: Data) throws -> PublishedWorkflow {
+        return try JSONDecoder.default.decode(PublishedWorkflow.self, from: data)
     }
 
     private static let offeringIdentifierKey = "offeringIdentifier"
@@ -298,6 +270,48 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
 
 private struct PrefetchedWorkflowCache {
     let offeringIdMap: [String: String]
-    let workflows: [String: PublishedWorkflow]
-    let isComplete: Bool
+    let workflows: [String: LazyPublishedWorkflow]
 }
+
+/// Retains raw workflow bytes until first use, then atomically retains either the decoded workflow or
+/// its decoding failure. This keeps warm-cache reads synchronous without eagerly building every workflow graph.
+private final class LazyPublishedWorkflow {
+
+    private enum State {
+        case data(Data)
+        case decoded(Result<PublishedWorkflow, WorkflowResolutionError>)
+    }
+
+    private let decoder: WorkflowsConfigProvider.WorkflowDecoder
+    private let state: Atomic<State>
+
+    init(data: Data, decoder: @escaping WorkflowsConfigProvider.WorkflowDecoder) {
+        self.decoder = decoder
+        self.state = .init(.data(data))
+    }
+
+    func value() -> Result<PublishedWorkflow, WorkflowResolutionError> {
+        return self.state.modify { state in
+            switch state {
+            case let .decoded(result):
+                return result
+            case let .data(data):
+                let result = self.decode(data)
+                state = .decoded(result)
+                return result
+            }
+        }
+    }
+
+    private func decode(_ data: Data) -> Result<PublishedWorkflow, WorkflowResolutionError> {
+        do {
+            return .success(try self.decoder(data))
+        } catch {
+            Logger.error(Strings.codable.decoding_error(error, PublishedWorkflow.self))
+            return .failure(.decodingFailed(error as NSError))
+        }
+    }
+
+}
+
+extension LazyPublishedWorkflow: @unchecked Sendable {}

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -439,7 +439,10 @@ private extension OfferingsManager {
         }
         Task {
             let uiConfigProvider = self.uiConfigProvider ?? UiConfigProvider(manager: remoteConfigManager)
-            async let workflowsReady: Void = self.warmWorkflowConfigIfNeeded(remoteConfigManager: remoteConfigManager)
+            async let workflowsReady: Void = self.warmWorkflowConfigIfNeeded(
+                remoteConfigManager: remoteConfigManager,
+                currentOfferingId: offerings.current?.identifier
+            )
             async let uiConfigReady = uiConfigProvider.getUiConfig()
             _ = await (workflowsReady, uiConfigReady)
 
@@ -482,9 +485,12 @@ private extension OfferingsManager {
         )
     }
 
-    private func warmWorkflowConfigIfNeeded(remoteConfigManager: RemoteConfigManagerType) async {
+    private func warmWorkflowConfigIfNeeded(
+        remoteConfigManager: RemoteConfigManagerType,
+        currentOfferingId: String?
+    ) async {
         if let workflowsConfigProvider = self.workflowsConfigProvider {
-            await workflowsConfigProvider.warmPrefetchedWorkflows()
+            await workflowsConfigProvider.warmPrefetchedWorkflows(currentOfferingId: currentOfferingId)
         } else {
             _ = await remoteConfigManager.awaitTopicAndPrefetchBlobsReady(.workflows)
         }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -582,9 +582,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         let uiConfigProvider = UiConfigProvider(manager: remoteConfigManager)
         let workflowsConfigProvider = WorkflowsConfigProvider(
             manager: remoteConfigManager,
-            uiConfigProvider: uiConfigProvider,
-            paywallCache: paywallCache,
-            operationDispatcher: operationDispatcher
+            uiConfigProvider: uiConfigProvider
         )
 
         let workflowManager = WorkflowManager(

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -582,8 +582,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         let uiConfigProvider = UiConfigProvider(manager: remoteConfigManager)
         let workflowsConfigProvider = WorkflowsConfigProvider(
             manager: remoteConfigManager,
-            uiConfigProvider: uiConfigProvider,
-            currentOfferingIdProvider: { deviceCache.cachedOfferings?.current?.identifier }
+            uiConfigProvider: uiConfigProvider
         )
 
         let workflowManager = WorkflowManager(

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -582,7 +582,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         let uiConfigProvider = UiConfigProvider(manager: remoteConfigManager)
         let workflowsConfigProvider = WorkflowsConfigProvider(
             manager: remoteConfigManager,
-            uiConfigProvider: uiConfigProvider
+            uiConfigProvider: uiConfigProvider,
+            currentOfferingIdProvider: { deviceCache.cachedOfferings?.current?.identifier }
         )
 
         let workflowManager = WorkflowManager(

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -59,7 +59,12 @@ class WorkflowManager {
     }
 
     func cachedWorkflow(forOfferingId offeringId: String) -> WorkflowDataResult? {
-        return self.workflowsConfigProvider.cachedWorkflow(forOfferingId: offeringId)
+        guard let result = self.workflowsConfigProvider.cachedWorkflow(forOfferingId: offeringId) else {
+            return nil
+        }
+
+        self.warmUpAssets(for: result)
+        return result
     }
 
     /// Resolves `offeringId` to its workflow for `Purchases.workflow(forOfferingIdentifier:)`. Fails

--- a/Tests/UnitTests/Mocks/MockWorkflowsConfigProvider.swift
+++ b/Tests/UnitTests/Mocks/MockWorkflowsConfigProvider.swift
@@ -40,9 +40,11 @@ final class MockWorkflowsConfigProvider: WorkflowsConfigProviderType, @unchecked
     }
 
     private(set) var invokedWarmPrefetchedWorkflowsCount = 0
+    private(set) var invokedWarmPrefetchedWorkflowsParameters: [String?] = []
 
-    func warmPrefetchedWorkflows() async {
+    func warmPrefetchedWorkflows(currentOfferingId: String?) async {
         self.invokedWarmPrefetchedWorkflowsCount += 1
+        self.invokedWarmPrefetchedWorkflowsParameters.append(currentOfferingId)
     }
 
     var stubbedCachedWorkflowResult: [String: WorkflowDataResult] = [:]

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -410,6 +410,66 @@ class WorkflowsConfigProviderTests: TestCase {
         expect(self.blobFetcher.invokedEnsureAllDownloadedRefs.count) == ensureAllDownloadedCountAfterFirstWarm
     }
 
+    func testWarmPrefetchedWorkflowsWarmsNewCurrentOfferingAndRetainsExistingWorkflow() async throws {
+        let decodeCount: Atomic<Int> = .init(0)
+        self.provider = self.makeProvider(decodeCount: decodeCount)
+        self.commit(
+            workflows: [
+                "wf-first": .init(
+                    blobRef: "wf-first-ref",
+                    prefetch: false,
+                    content: ["offeringIdentifier": "first"]
+                ),
+                "wf-second": .init(
+                    blobRef: "wf-second-ref",
+                    prefetch: false,
+                    content: ["offeringIdentifier": "second"]
+                )
+            ],
+            uiConfig: Self.uiConfigTopic,
+            blobs: Self.uiConfigBlobs.merging([
+                "wf-first-ref": try Self.workflowJSON(id: "wf-first"),
+                "wf-second-ref": try Self.workflowJSON(id: "wf-second")
+            ]) { current, _ in current }
+        )
+
+        await self.provider.warmPrefetchedWorkflows(currentOfferingId: "first")
+        _ = await self.uiConfigProvider.getUiConfig()
+        expect(self.provider.cachedWorkflow(forOfferingId: "first")?.workflow.id) == "wf-first"
+        expect(decodeCount.value) == 1
+        expect(self.provider.cachedWorkflow(forOfferingId: "second")).to(beNil())
+
+        await self.provider.warmPrefetchedWorkflows(currentOfferingId: "second")
+
+        expect(self.provider.cachedWorkflow(forOfferingId: "first")?.workflow.id) == "wf-first"
+        expect(self.provider.cachedWorkflow(forOfferingId: "second")?.workflow.id) == "wf-second"
+        expect(decodeCount.value) == 2
+    }
+
+    func testWarmPrefetchedWorkflowsRetriesMissingCurrentOfferingBody() async throws {
+        self.commit(
+            workflows: [
+                "wf-current": .init(
+                    blobRef: "wf-current-ref",
+                    prefetch: false,
+                    content: ["offeringIdentifier": "current"]
+                )
+            ],
+            uiConfig: Self.uiConfigTopic,
+            blobs: Self.uiConfigBlobs
+        )
+
+        await self.provider.warmPrefetchedWorkflows(currentOfferingId: "current")
+        _ = await self.uiConfigProvider.getUiConfig()
+        expect(self.provider.cachedWorkflow(forOfferingId: "current")).to(beNil())
+
+        self.blobStore.stubbedData["wf-current-ref"] = try Self.workflowJSON(id: "wf-current")
+        await self.provider.warmPrefetchedWorkflows(currentOfferingId: "current")
+
+        expect(self.provider.cachedWorkflow(forOfferingId: "current")?.workflow.id) == "wf-current"
+        expect(self.blobFetcher.invokedEnsureDownloadedRefs.filter { $0 == "wf-current-ref" }.count) == 2
+    }
+
     func testCachedPrefetchedWorkflowMissesAfterGenerationInvalidates() async throws {
         self.commit(
             workflows: [

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -275,9 +275,15 @@ class WorkflowsConfigProviderTests: TestCase {
         expect(secondWorkflowId) == "wf-2"
     }
 
-    func testWarmPrefetchedWorkflowsCachesOnlyPrefetchTrueBodiesAndAllOfferingMappings() async throws {
+    func testWarmPrefetchedWorkflowsCachesPrefetchedAndCurrentOfferingBodiesAndAllMappings() async throws {
         let prefetchedWorkflow = try Self.workflowJSON(id: "wf-prefetch")
-        let onDemandWorkflow = try Self.workflowJSON(id: "wf-on-demand")
+        let currentWorkflow = try Self.workflowJSON(id: "wf-current")
+        let otherWorkflow = try Self.workflowJSON(id: "wf-other")
+        self.provider = WorkflowsConfigProvider(
+            manager: self.manager,
+            uiConfigProvider: self.uiConfigProvider,
+            currentOfferingIdProvider: { "basic" }
+        )
         self.commit(
             workflows: [
                 "wf-prefetch": .init(
@@ -285,16 +291,22 @@ class WorkflowsConfigProviderTests: TestCase {
                     prefetch: true,
                     content: ["offeringIdentifier": "premium"]
                 ),
-                "wf-on-demand": .init(
-                    blobRef: "wf-on-demand-ref",
+                "wf-current": .init(
+                    blobRef: "wf-current-ref",
                     prefetch: false,
                     content: ["offeringIdentifier": "basic"]
+                ),
+                "wf-other": .init(
+                    blobRef: "wf-other-ref",
+                    prefetch: false,
+                    content: ["offeringIdentifier": "other"]
                 )
             ],
             uiConfig: Self.uiConfigTopic,
             blobs: Self.uiConfigBlobs.merging([
                 "wf-prefetch-ref": prefetchedWorkflow,
-                "wf-on-demand-ref": onDemandWorkflow
+                "wf-current-ref": currentWorkflow,
+                "wf-other-ref": otherWorkflow
             ]) { current, _ in current }
         )
 
@@ -303,14 +315,17 @@ class WorkflowsConfigProviderTests: TestCase {
         _ = await (workflowsWarm, uiConfigWarm)
 
         let cachedPrefetched = self.provider.cachedWorkflow(forOfferingId: "premium")
-        let cachedOnDemand = self.provider.cachedWorkflow(forOfferingId: "basic")
-        let mappedOnDemand = await self.provider.workflowId(forOfferingId: "basic")
+        let cachedCurrent = self.provider.cachedWorkflow(forOfferingId: "basic")
+        let cachedOther = self.provider.cachedWorkflow(forOfferingId: "other")
+        let mappedOther = await self.provider.workflowId(forOfferingId: "other")
 
         expect(cachedPrefetched?.workflow.id) == "wf-prefetch"
-        expect(cachedOnDemand).to(beNil())
-        expect(mappedOnDemand) == "wf-on-demand"
+        expect(cachedCurrent?.workflow.id) == "wf-current"
+        expect(cachedOther).to(beNil())
+        expect(mappedOther) == "wf-other"
         expect(self.blobFetcher.invokedEnsureDownloadedRefs).to(contain("wf-prefetch-ref"))
-        expect(self.blobFetcher.invokedEnsureDownloadedRefs).toNot(contain("wf-on-demand-ref"))
+        expect(self.blobFetcher.invokedEnsureDownloadedRefs).to(contain("wf-current-ref"))
+        expect(self.blobFetcher.invokedEnsureDownloadedRefs).toNot(contain("wf-other-ref"))
     }
 
     func testWarmPrefetchedWorkflowsDefersDecodingUntilFirstReadAndRetainsTheResult() async throws {

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -279,11 +279,6 @@ class WorkflowsConfigProviderTests: TestCase {
         let prefetchedWorkflow = try Self.workflowJSON(id: "wf-prefetch")
         let currentWorkflow = try Self.workflowJSON(id: "wf-current")
         let otherWorkflow = try Self.workflowJSON(id: "wf-other")
-        self.provider = WorkflowsConfigProvider(
-            manager: self.manager,
-            uiConfigProvider: self.uiConfigProvider,
-            currentOfferingIdProvider: { "basic" }
-        )
         self.commit(
             workflows: [
                 "wf-prefetch": .init(
@@ -310,7 +305,7 @@ class WorkflowsConfigProviderTests: TestCase {
             ]) { current, _ in current }
         )
 
-        async let workflowsWarm: Void = self.provider.warmPrefetchedWorkflows()
+        async let workflowsWarm: Void = self.provider.warmPrefetchedWorkflows(currentOfferingId: "basic")
         async let uiConfigWarm = self.uiConfigProvider.getUiConfig()
         _ = await (workflowsWarm, uiConfigWarm)
 
@@ -345,7 +340,7 @@ class WorkflowsConfigProviderTests: TestCase {
             ]) { current, _ in current }
         )
 
-        async let workflowsWarm: Void = self.provider.warmPrefetchedWorkflows()
+        async let workflowsWarm: Void = self.provider.warmPrefetchedWorkflows(currentOfferingId: nil)
         async let uiConfigWarm = self.uiConfigProvider.getUiConfig()
         _ = await (workflowsWarm, uiConfigWarm)
 
@@ -373,7 +368,7 @@ class WorkflowsConfigProviderTests: TestCase {
             ]) { current, _ in current }
         )
 
-        async let workflowsWarm: Void = self.provider.warmPrefetchedWorkflows()
+        async let workflowsWarm: Void = self.provider.warmPrefetchedWorkflows(currentOfferingId: nil)
         async let uiConfigWarm = self.uiConfigProvider.getUiConfig()
         _ = await (workflowsWarm, uiConfigWarm)
 
@@ -404,12 +399,12 @@ class WorkflowsConfigProviderTests: TestCase {
             ]) { current, _ in current }
         )
 
-        async let workflowsWarm: Void = self.provider.warmPrefetchedWorkflows()
+        async let workflowsWarm: Void = self.provider.warmPrefetchedWorkflows(currentOfferingId: nil)
         async let uiConfigWarm = self.uiConfigProvider.getUiConfig()
         _ = await (workflowsWarm, uiConfigWarm)
         let ensureAllDownloadedCountAfterFirstWarm = self.blobFetcher.invokedEnsureAllDownloadedRefs.count
 
-        await self.provider.warmPrefetchedWorkflows()
+        await self.provider.warmPrefetchedWorkflows(currentOfferingId: nil)
 
         expect(self.provider.cachedWorkflow(forOfferingId: "premium")?.workflow.id) == "wf-prefetch"
         expect(self.blobFetcher.invokedEnsureAllDownloadedRefs.count) == ensureAllDownloadedCountAfterFirstWarm
@@ -429,7 +424,7 @@ class WorkflowsConfigProviderTests: TestCase {
                 "wf-prefetch-ref": try Self.workflowJSON(id: "wf-prefetch")
             ]) { current, _ in current }
         )
-        async let workflowsWarm: Void = self.provider.warmPrefetchedWorkflows()
+        async let workflowsWarm: Void = self.provider.warmPrefetchedWorkflows(currentOfferingId: nil)
         async let uiConfigWarm = self.uiConfigProvider.getUiConfig()
         _ = await (workflowsWarm, uiConfigWarm)
         expect(self.provider.cachedWorkflow(forOfferingId: "premium")).toNot(beNil())
@@ -458,7 +453,7 @@ class WorkflowsConfigProviderTests: TestCase {
         mockManager.stubbedBlobData[.uiConfig] = Self.uiConfigBlobsByItemKey
         mockManager.shouldStoreTopicCompletion = true
 
-        async let workflowsWarm: Void = provider.warmPrefetchedWorkflows()
+        async let workflowsWarm: Void = provider.warmPrefetchedWorkflows(currentOfferingId: nil)
         await self.waitUntilTopicRequested(on: mockManager)
         mockManager.configGeneration += 1
         mockManager.completeStoredTopic(with: workflowsTopic)

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -313,6 +313,67 @@ class WorkflowsConfigProviderTests: TestCase {
         expect(self.blobFetcher.invokedEnsureDownloadedRefs).toNot(contain("wf-on-demand-ref"))
     }
 
+    func testWarmPrefetchedWorkflowsDefersDecodingUntilFirstReadAndRetainsTheResult() async throws {
+        let decodeCount: Atomic<Int> = .init(0)
+        self.provider = self.makeProvider(decodeCount: decodeCount)
+        self.commit(
+            workflows: [
+                "wf-prefetch": .init(
+                    blobRef: "wf-prefetch-ref",
+                    prefetch: true,
+                    content: ["offeringIdentifier": "premium"]
+                )
+            ],
+            uiConfig: Self.uiConfigTopic,
+            blobs: Self.uiConfigBlobs.merging([
+                "wf-prefetch-ref": try Self.workflowJSON(id: "wf-prefetch")
+            ]) { current, _ in current }
+        )
+
+        async let workflowsWarm: Void = self.provider.warmPrefetchedWorkflows()
+        async let uiConfigWarm = self.uiConfigProvider.getUiConfig()
+        _ = await (workflowsWarm, uiConfigWarm)
+
+        expect(decodeCount.value) == 0
+        expect(self.provider.cachedWorkflow(forOfferingId: "premium")?.workflow.id) == "wf-prefetch"
+        expect(decodeCount.value) == 1
+        expect(self.provider.cachedWorkflow(forOfferingId: "premium")?.workflow.id) == "wf-prefetch"
+        expect(decodeCount.value) == 1
+    }
+
+    func testMalformedPrefetchedWorkflowWarmsAsBytesAndFailsOnceWhenRead() async throws {
+        let decodeCount: Atomic<Int> = .init(0)
+        self.provider = self.makeProvider(decodeCount: decodeCount)
+        self.commit(
+            workflows: [
+                "wf-prefetch": .init(
+                    blobRef: "wf-prefetch-ref",
+                    prefetch: true,
+                    content: ["offeringIdentifier": "premium"]
+                )
+            ],
+            uiConfig: Self.uiConfigTopic,
+            blobs: Self.uiConfigBlobs.merging([
+                "wf-prefetch-ref": Data(#"{ "not": "a workflow" }"#.utf8)
+            ]) { current, _ in current }
+        )
+
+        async let workflowsWarm: Void = self.provider.warmPrefetchedWorkflows()
+        async let uiConfigWarm = self.uiConfigProvider.getUiConfig()
+        _ = await (workflowsWarm, uiConfigWarm)
+
+        expect(decodeCount.value) == 0
+        expect(self.provider.cachedWorkflow(forOfferingId: "premium")).to(beNil())
+        expect(decodeCount.value) == 1
+
+        let result = await self.provider.getWorkflow(workflowId: "wf-prefetch")
+        guard case .failure(.decodingFailed) = result else {
+            fail("Expected a decodingFailed failure, got \(result)")
+            return
+        }
+        expect(decodeCount.value) == 1
+    }
+
     func testWarmPrefetchedWorkflowsReturnsEarlyWhenCacheAlreadyWarmForGeneration() async throws {
         self.commit(
             workflows: [
@@ -337,115 +398,6 @@ class WorkflowsConfigProviderTests: TestCase {
 
         expect(self.provider.cachedWorkflow(forOfferingId: "premium")?.workflow.id) == "wf-prefetch"
         expect(self.blobFetcher.invokedEnsureAllDownloadedRefs.count) == ensureAllDownloadedCountAfterFirstWarm
-    }
-
-    func testWarmPrefetchedWorkflowsRetriesIncompleteCache() async throws {
-        self.commit(
-            workflows: [
-                "wf-first": .init(
-                    blobRef: "wf-first-ref",
-                    prefetch: true,
-                    content: ["offeringIdentifier": "first"]
-                ),
-                "wf-second": .init(
-                    blobRef: "wf-second-ref",
-                    prefetch: true,
-                    content: ["offeringIdentifier": "second"]
-                )
-            ],
-            uiConfig: Self.uiConfigTopic,
-            blobs: Self.uiConfigBlobs.merging([
-                "wf-first-ref": try Self.workflowJSON(id: "wf-first"),
-                "wf-second-ref": Data("invalid".utf8)
-            ]) { current, _ in current }
-        )
-
-        async let workflowsWarm: Void = self.provider.warmPrefetchedWorkflows()
-        async let uiConfigWarm = self.uiConfigProvider.getUiConfig()
-        _ = await (workflowsWarm, uiConfigWarm)
-
-        expect(self.provider.cachedWorkflow(forOfferingId: "first")?.workflow.id) == "wf-first"
-        expect(self.provider.cachedWorkflow(forOfferingId: "second")).to(beNil())
-
-        self.blobStore.stubbedData["wf-second-ref"] = try Self.workflowJSON(id: "wf-second")
-        await self.provider.warmPrefetchedWorkflows()
-
-        expect(self.provider.cachedWorkflow(forOfferingId: "first")?.workflow.id) == "wf-first"
-        expect(self.provider.cachedWorkflow(forOfferingId: "second")?.workflow.id) == "wf-second"
-    }
-
-    func testWarmPrefetchedWorkflowsWarmsAssetsForPrefetchTrueBodies() async throws {
-        guard #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *) else {
-            throw XCTSkip("warmUpWorkflowCaches requires iOS 15+")
-        }
-
-        let paywallCache = MockPaywallCacheWarming()
-        let operationDispatcher = MockOperationDispatcher()
-        self.provider = WorkflowsConfigProvider(
-            manager: self.manager,
-            uiConfigProvider: self.uiConfigProvider,
-            paywallCache: paywallCache,
-            operationDispatcher: operationDispatcher
-        )
-        self.commit(
-            workflows: [
-                "wf-prefetch": .init(
-                    blobRef: "wf-prefetch-ref",
-                    prefetch: true,
-                    content: ["offeringIdentifier": "premium"]
-                ),
-                "wf-on-demand": .init(
-                    blobRef: "wf-on-demand-ref",
-                    prefetch: false,
-                    content: ["offeringIdentifier": "basic"]
-                )
-            ],
-            uiConfig: Self.uiConfigTopic,
-            blobs: Self.uiConfigBlobs.merging([
-                "wf-prefetch-ref": try Self.workflowJSON(id: "wf-prefetch"),
-                "wf-on-demand-ref": try Self.workflowJSON(id: "wf-on-demand")
-            ]) { current, _ in current }
-        )
-
-        await self.provider.warmPrefetchedWorkflows()
-
-        expect(operationDispatcher.invokedDispatchAsyncOnWorkerThread) == true
-        expect(paywallCache.invokedWarmUpWorkflowCachesCount) == 1
-        expect(paywallCache.invokedWarmUpWorkflowCachesWorkflow?.id) == "wf-prefetch"
-        expect(paywallCache.invokedWarmUpWorkflowCachesUiConfig) == self.uiConfigProvider.cachedUiConfig()
-    }
-
-    func testWarmPrefetchedWorkflowsDoesNotWaitForAssetWarming() async throws {
-        let paywallCache = MockPaywallCacheWarming()
-        let operationDispatcher = MockOperationDispatcher()
-        operationDispatcher.shouldInvokeDispatchOnWorkerThreadBlock = false
-        self.provider = WorkflowsConfigProvider(
-            manager: self.manager,
-            uiConfigProvider: self.uiConfigProvider,
-            paywallCache: paywallCache,
-            operationDispatcher: operationDispatcher
-        )
-        self.commit(
-            workflows: [
-                "wf-prefetch": .init(
-                    blobRef: "wf-prefetch-ref",
-                    prefetch: true,
-                    content: ["offeringIdentifier": "premium"]
-                )
-            ],
-            uiConfig: Self.uiConfigTopic,
-            blobs: Self.uiConfigBlobs.merging([
-                "wf-prefetch-ref": try Self.workflowJSON(id: "wf-prefetch")
-            ]) { current, _ in current }
-        )
-
-        async let workflowsWarm: Void = self.provider.warmPrefetchedWorkflows()
-        async let uiConfigWarm = self.uiConfigProvider.getUiConfig()
-        _ = await (workflowsWarm, uiConfigWarm)
-
-        expect(operationDispatcher.invokedDispatchAsyncOnWorkerThread) == true
-        expect(paywallCache.invokedWarmUpWorkflowCachesCount) == 0
-        expect(self.provider.cachedWorkflow(forOfferingId: "premium")?.workflow.id) == "wf-prefetch"
     }
 
     func testCachedPrefetchedWorkflowMissesAfterGenerationInvalidates() async throws {
@@ -503,6 +455,17 @@ class WorkflowsConfigProviderTests: TestCase {
     }
 
     // MARK: - Helpers
+
+    private func makeProvider(decodeCount: Atomic<Int>) -> WorkflowsConfigProvider {
+        return WorkflowsConfigProvider(
+            manager: self.manager,
+            uiConfigProvider: self.uiConfigProvider,
+            workflowDecoder: { data in
+                decodeCount.modify { $0 += 1 }
+                return try JSONDecoder.default.decode(PublishedWorkflow.self, from: data)
+            }
+        )
+    }
 
     private func commit(
         workflows: [String: RemoteConfiguration.ConfigItem] = [:],

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -1013,6 +1013,23 @@ private extension OfferingsManagerTests {
 
 extension OfferingsManagerTests {
 
+    func testGetOfferingsWarmsWorkflowForCurrentOffering() {
+        let mockRemoteConfigManager = MockRemoteConfigManager()
+        let mockWorkflowsConfigProvider = MockWorkflowsConfigProvider()
+        let manager = self.makeOfferingsManager(
+            remoteConfigManager: mockRemoteConfigManager,
+            workflowsConfigProvider: mockWorkflowsConfigProvider
+        )
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsContents)
+
+        let result = waitUntilValue { completed in
+            manager.offerings(appUserID: MockData.anyAppUserID) { completed($0) }
+        }
+
+        expect(result).to(beSuccess())
+        expect(mockWorkflowsConfigProvider.invokedWarmPrefetchedWorkflowsParameters) == ["base"]
+    }
+
     func testGetOfferingsDeliversImmediatelyWhenRemoteConfigManagerIsNil() {
         // The default `offeringsManager` is built without a remote config manager (workflows
         // disabled), so offerings delivery must be unchanged.
@@ -1461,7 +1478,8 @@ extension OfferingsManagerTests {
 
     private func makeOfferingsManager(
         remoteConfigManager: RemoteConfigManagerType?,
-        offeringsFactory: OfferingsFactory? = nil
+        offeringsFactory: OfferingsFactory? = nil,
+        workflowsConfigProvider: WorkflowsConfigProviderType? = nil
     ) -> OfferingsManager {
         return OfferingsManager(deviceCache: self.mockDeviceCache,
                                 operationDispatcher: self.mockOperationDispatcher,
@@ -1470,7 +1488,8 @@ extension OfferingsManagerTests {
                                 offeringsFactory: offeringsFactory ?? self.mockOfferingsFactory,
                                 productsManager: self.mockProductsManager,
                                 diagnosticsTracker: self.mockDiagnosticsTracker,
-                                remoteConfigManager: remoteConfigManager)
+                                remoteConfigManager: remoteConfigManager,
+                                workflowsConfigProvider: workflowsConfigProvider)
     }
 
     private static let uiConfigTopic: [String: RemoteConfiguration.ConfigItem] = [

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -107,6 +107,24 @@ class WorkflowManagerTests: TestCase {
         }
     }
 
+    // MARK: - cachedWorkflow(forOfferingId:)
+
+    func testCachedWorkflowWarmsUpAssetsOnSuccess() throws {
+        guard #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *) else {
+            throw XCTSkip("warmUpWorkflowCaches requires iOS 15+")
+        }
+        let expected = try Self.workflowDataResult(id: "wf_1")
+        self.mockProvider.stubbedCachedWorkflowResult = ["default": expected]
+
+        let result = self.manager.cachedWorkflow(forOfferingId: "default")
+
+        expect(result) == expected
+        expect(self.mockProvider.invokedCachedWorkflowParameters) == ["default"]
+        expect(self.mockPaywallCache.invokedWarmUpWorkflowCaches) == true
+        expect(self.mockPaywallCache.invokedWarmUpWorkflowCachesWorkflow?.id) == "wf_1"
+        expect(self.mockPaywallCache.invokedWarmUpWorkflowCachesUiConfig) == expected.uiConfig
+    }
+
     // MARK: - workflowId(forOfferingId:)
 
     func testWorkflowIdForOfferingIdDelegatesToProvider() async {


### PR DESCRIPTION
## Description
We're now loading all workflows into memory in order to have them be ready when presenting them, instead of having to read them from disk + decode at that point. However decoding all workflows at once right away increases memory consumption, while probably many of them won't be used.

With this PR we're keeping the raw `Data` in memory, but will defer decoding to first use of the workflow.

| Measurement | Eager decoding | Lazy decoding | Improvement |
| --- | ---: | ---: | ---: |
| Physical footprint | 80.1 MB | 71.9 MB | 8.2 MB lower (10%) |
| Heap allocated | 38.68 MB | 30.87 MB | 7.81 MB lower (20%) |
| Heap nodes | 243,363 | 192,687 | 50,676 fewer (21%) |
| Decoded workflow screen dictionaries | 85 | 0 | Eliminated until use |
| Decoded workflow step dictionaries | 85 | 0 | Eliminated until use |
| Workflow stack components | 3,026 | 0 | Eliminated until use |
| Workflow text components | 1,987 | 0 | Eliminated until use |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote-config workflow caching, warming scope, and when paywall assets prefetch—behavioral shifts on memory and presentation timing, but no auth or purchase-path changes.
> 
> **Overview**
> **Workflow prefetch warming** now loads and caches **raw JSON bytes** instead of eagerly decoding every prefetched workflow, cutting heap use until a workflow is actually read. Decoding happens once on first access via **`LazyPublishedWorkflow`**, with decode failures retained like before.
> 
> **`warmPrefetchedWorkflows`** takes **`currentOfferingId`** so warming includes prefetch-flagged workflows **plus** the workflow mapped to the current offering (not only `prefetch: true` items). **`OfferingsManager`** passes **`offerings.current?.identifier`** when gating offerings delivery on config readiness.
> 
> **Paywall asset warming** is **removed** from the config provider’s background warm path and moved to **`WorkflowManager`**, which triggers **`warmUpWorkflowCaches`** when a cached or successfully resolved workflow is returned—so images/fonts warm only after a workflow is actually used.
> 
> **`getWorkflow`** cache hits share a new **`makeWorkflowResult`** path that still fetches **`ui_config`** and validates generation before returning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee24316179af2af9e3a113d5653ad0179f1311a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->