### PR TITLE
Avoid paywall loading state when remote config is disabled through killswitch

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -202,16 +202,13 @@ public struct PaywallView: View {
 
         self._introEligibility = .init(wrappedValue: configuration.introEligibility ?? .default())
 
-        let seededWorkflowContext = configuration.injectedWorkflowContext
-        let cachedPaywallViewData = seededWorkflowContext == nil
-            ? configuration.purchaseHandler.cachedInitialPaywallViewData(for: configuration.content)
-            : nil
-        self._workflowContext = .init(
-            initialValue: seededWorkflowContext ?? cachedPaywallViewData?.workflowContext
+        let initialPaywallViewData = configuration.purchaseHandler.cachedInitialPaywallViewData(
+            for: configuration.content,
+            injectedWorkflowContext: configuration.injectedWorkflowContext
         )
+        self._workflowContext = .init(initialValue: initialPaywallViewData?.workflowContext)
         self._offering = .init(
-            initialValue: seededWorkflowContext?.initialOffering
-                ?? cachedPaywallViewData?.offering
+            initialValue: initialPaywallViewData?.offering
         )
         self._customerInfo = .init(
             initialValue: configuration.customerInfo ?? Self.loadCachedCustomerInfoIfPossible()

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -309,6 +309,20 @@ extension PurchaseHandler {
 
 #if !os(tvOS)
     func cachedInitialPaywallViewData(
+        for content: PaywallViewConfiguration.Content,
+        injectedWorkflowContext: WorkflowContext?
+    ) -> ResolvedPaywallViewData? {
+        if let injectedWorkflowContext {
+            return .init(
+                offering: injectedWorkflowContext.initialOffering,
+                workflowContext: injectedWorkflowContext
+            )
+        }
+
+        return self.cachedInitialPaywallViewData(for: content)
+    }
+
+    func cachedInitialPaywallViewData(
         for content: PaywallViewConfiguration.Content
     ) -> ResolvedPaywallViewData? {
         return self.cachedInitialPaywallViewData(

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -2435,11 +2435,11 @@ extension Purchases {
         return self.systemInfo.preferredLocaleOverride
     }
 
-    // Exposes the single workflows + remote config gate to RevenueCatUI, which can't see the
-    // ENABLE_REMOTE_CONFIG compile flag directly.
+    // Exposes whether workflows and remote config are currently available to RevenueCatUI, which
+    // can't see either the ENABLE_REMOTE_CONFIG compile flag or the remote config manager's kill switch.
     // swiftlint:disable missing_docs
     @_spi(Internal) public var remoteConfigEnabled: Bool {
-        return self.systemInfo.remoteConfigEnabled
+        return self.systemInfo.remoteConfigEnabled && !self.remoteConfigManager.isDisabled
     }
 
     // swiftlint:disable missing_docs

--- a/Tests/RevenueCatUITests/Data/PaywallViewConfigurationTests.swift
+++ b/Tests/RevenueCatUITests/Data/PaywallViewConfigurationTests.swift
@@ -43,6 +43,25 @@ final class PaywallViewConfigurationTests: TestCase {
         )).to(beNil())
     }
 
+    func testCachedInitialPaywallViewDataReturnsLegacyOfferingWhenRemoteConfigEnabled() {
+        let cachedOffering = TestData.offeringWithNoIntroOffer
+        let purchases = Self.createMockPurchases()
+        let handler = Self.createPurchaseHandler(purchases: purchases)
+
+        purchases.cachedOfferings = Self.createOfferings(
+            [cachedOffering],
+            currentOfferingID: cachedOffering.identifier
+        )
+
+        let result = handler.cachedInitialPaywallViewData(
+            for: .defaultOffering,
+            remoteConfigEnabled: true
+        )
+
+        expect(result?.offering.identifier) == cachedOffering.identifier
+        expect(result?.workflowContext).to(beNil())
+    }
+
     func testCachedInitialOfferingUsesCachedOfferingsWhenRemoteConfigDisabled() {
         let cachedOffering = TestData.offeringWithNoIntroOffer
         let purchases = Self.createMockPurchases()
@@ -65,6 +84,47 @@ final class PaywallViewConfigurationTests: TestCase {
             for: .offeringIdentifier(cachedOffering.identifier, presentedOfferingContext: nil),
             remoteConfigEnabled: false
         )?.identifier) == cachedOffering.identifier
+    }
+
+    func testCachedInitialPaywallViewDataUsesCachedOfferingsWhenRemoteConfigDisabled() {
+        let cachedOffering = TestData.offeringWithNoIntroOffer
+        let purchases = Self.createMockPurchases()
+        let handler = Self.createPurchaseHandler(purchases: purchases)
+
+        purchases.cachedOfferings = Self.createOfferings(
+            [cachedOffering],
+            currentOfferingID: cachedOffering.identifier
+        )
+
+        let result = handler.cachedInitialPaywallViewData(
+            for: .defaultOffering,
+            remoteConfigEnabled: false
+        )
+
+        expect(result?.offering.identifier) == cachedOffering.identifier
+        expect(result?.workflowContext).to(beNil())
+    }
+
+    func testCachedInitialPaywallViewDataUsesInjectedWorkflowContext() throws {
+        let initialOffering = Self.createOffering(identifier: "offering_a")
+        let workflowContext = WorkflowContext(
+            workflow: try Self.createWorkflow(offeringIdentifier: initialOffering.identifier),
+            uiConfig: PreviewUIConfig.make(),
+            allOfferings: Self.createOfferings([initialOffering]),
+            initialOffering: initialOffering,
+            presentedOfferingContext: initialOffering.presentedOfferingContext
+        )
+        let purchases = Self.createMockPurchases()
+        let handler = Self.createPurchaseHandler(purchases: purchases)
+
+        let result = handler.cachedInitialPaywallViewData(
+            for: .defaultOffering,
+            injectedWorkflowContext: workflowContext
+        )
+
+        expect(result?.offering.identifier) == initialOffering.identifier
+        expect(result?.workflowContext?.initialOffering.identifier) == workflowContext.initialOffering.identifier
+        expect(result?.workflowContext?.workflow.id) == workflowContext.workflow.id
     }
 
     func testResolvePaywallViewDataReturnsNilWorkflowContextWhenRemoteConfigDisabled() async throws {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesWorkflowTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesWorkflowTests.swift
@@ -20,13 +20,20 @@ import XCTest
 /// off `RemoteConfigManager` now, not a dedicated `WorkflowsAPI` backend call.
 class PurchasesWorkflowTests: BasePurchasesTests {
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-
+    func testRemoteConfigEnabledReturnsFalseWhenDisabledByKillSwitch() {
+        self.systemInfo.stubbedRemoteConfigEnabled = true
         self.setupPurchases()
+
+        expect(self.purchases.remoteConfigEnabled) == true
+
+        self.mockRemoteConfigManager.isDisabled = true
+
+        expect(self.purchases.remoteConfigEnabled) == false
     }
 
     func testWorkflowForOfferingIdentifierThrowsWhenOfferingHasNoWorkflow() async throws {
+        self.setupPurchases()
+
         // The `workflows` topic has synced, but no item maps to the "default" offering (its item carries
         // no matching `offeringIdentifier`). With no mapping, resolution fails fast with a distinct
         // `offeringHasNoWorkflow` and does NOT attempt a fetch by offering id — the prior lazy


### PR DESCRIPTION
## Description
Fixes an issue where the loading state is briefly visible, for offerings that are displayed when the remote config feature is enabled, but the killswitch is activated. Thus deactivating remote config even though the feature itself is enabled for the app. 

`remoteConfigEnabled` is used for determining whether to use the cached offerings or cached workflows data, however it did not take into account a disabled remote config in response to the killswitch, causing the workflow to return `nil` and having the paywall go through it's normal loading flow, which loaded the offerings again under the hood because the remote config was now killswitched.

| Before | After |
|:--:|:--:|
| <img src="https://github.com/user-attachments/assets/3e88cb77-1ba0-46d1-ae43-038637a03b82" width="600" alt="paywallstester_killswitch_first_open_matrix"> | <img src="https://github.com/user-attachments/assets/c724815c-0007-44ea-9ee9-9496d54f0b8e" width="600" alt="paywallstester_killswitch_first_open_fixed_matrix"> |
| Loading skeleton flashes while presenting the paywall. | The rendered paywall animates in directly. |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change to an internal SPI gate used by RevenueCatUI; covered by a focused unit test with no auth or purchase-path changes.
> 
> **Overview**
> Fixes a brief paywall loading skeleton when remote config is compiled in but the server **kill switch** has disabled it.
> 
> **`Purchases.remoteConfigEnabled`** (exposed to RevenueCatUI) now requires both the compile-time remote config flag **and** `!remoteConfigManager.isDisabled`, so UI logic that chooses workflows vs cached offerings matches runtime remote config availability.
> 
> A unit test asserts the property flips to `false` when the mock manager’s kill switch is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0be63872162a13c2a03014a5d2cb633777c3af3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->