### PR TITLE
fix(paywalls): restore MainActor isolation on exit-offer View helpers

### DIFF
--- a/RevenueCatUI/View+ExitOfferPresentation.swift
+++ b/RevenueCatUI/View+ExitOfferPresentation.swift
@@ -96,6 +96,7 @@ final class ExitOfferPresenter: ObservableObject {
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(tvOS, unavailable)
+@MainActor
 extension View {
 
     /// Sources the workflow exit offer onto the presenter. Apply to the main paywall view (keeps the
@@ -121,25 +122,36 @@ extension View {
         onDismiss: (() -> Void)?,
         @ViewBuilder makeExitOfferView: @escaping (Offering) -> ExitOfferView
     ) -> some View {
-        let handleDismiss: () -> Void = {
-            presenter.reset()
-            onDismiss?()
-        }
-
+        // Inline the dismiss closures (rather than a typed local) so they inherit the extension's
+        // @MainActor isolation and can call the presenter's main-actor methods on older toolchains.
         return Group {
             switch presentationMode {
             case .sheet:
-                self.sheet(item: presenter.presentedBinding, onDismiss: handleDismiss) { offering in
-                    makeExitOfferView(offering)
-                    #if targetEnvironment(macCatalyst) || os(macOS)
-                        .frame(minHeight: 667)
-                    #endif
-                }
+                self.sheet(
+                    item: presenter.presentedBinding,
+                    onDismiss: {
+                        presenter.reset()
+                        onDismiss?()
+                    },
+                    content: { offering in
+                        makeExitOfferView(offering)
+                        #if targetEnvironment(macCatalyst) || os(macOS)
+                            .frame(minHeight: 667)
+                        #endif
+                    }
+                )
             #if !os(macOS)
             case .fullScreen:
-                self.fullScreenCover(item: presenter.presentedBinding, onDismiss: handleDismiss) { offering in
-                    makeExitOfferView(offering)
-                }
+                self.fullScreenCover(
+                    item: presenter.presentedBinding,
+                    onDismiss: {
+                        presenter.reset()
+                        onDismiss?()
+                    },
+                    content: { offering in
+                        makeExitOfferView(offering)
+                    }
+                )
             #endif
             }
         }


### PR DESCRIPTION
### Motivation

#7245 broke `main`: `spm-revenuecat-ui-ios-15` and `spm-revenuecat-ui-ios-16` fail to compile. These tests don't run on every PR. My mistake

The new exit-offer `View` extension in `View+ExitOfferPresentation.swift` references `@MainActor`-isolated members of `ExitOfferPresenter` from a non-isolated context. On Xcode 16+ SwiftUI's `View` protocol is implicitly `@MainActor`, so extension methods inherit it and it compiles (iOS 17/18/26 jobs pass). On Xcode 14.3.1 / 15.4 `View` isn't main-actor isolated, so those references are hard errors. The pre-refactor code lived inside a `ViewModifier.body` (already `@MainActor`), which is why it compiled before.

### Fix

- Mark the `View` extension `@MainActor`.
- Inline the exit-offer dismiss closures instead of a typed `let handleDismiss: () -> Void` local, so the closure literals inherit the extension's isolation and can call the presenter's main-actor methods on older toolchains.

### Testing

Verified locally with `swift build -c release --target RevenueCatUI` + SwiftLint. Real verification is the full test suite (`spm-revenuecat-ui-ios-15/16`), which is approval-gated on PRs and must be run here.

<details>
<summary>AI session context</summary>

**Task:** Diagnose and fix the `main` breakage introduced by #7245 (commit 8f31ff65d).

**Investigation**
- `gh api .../status` on the merged commit: only `spm-revenuecat-ui-ios-15` and `spm-revenuecat-ui-ios-16` failed; iOS 17/18/26 UI jobs passed.
- CircleCI config: iOS-15 job uses Xcode 14.3.1, iOS-16 uses Xcode 15.4; failing jobs are older toolchains than the passing ones.
- Reproduced the compiler errors (4 × "main actor-isolated ... can not be referenced from a non-isolated context" in `View+ExitOfferPresentation.swift`, lines 108/110/125/132).

**Root cause:** the exit-offer `View` extension is non-isolated but references `@MainActor` members of `ExitOfferPresenter`. Compiles on Xcode 16+ (SwiftUI `View` is implicitly `@MainActor`) but not on Xcode ≤15.4. `PurchaseHandler` is not `@MainActor`, which is why the pre-refactor inline `.sheet` in `body` compiled.

**Fix:** `@MainActor` on the extension (covers direct references + the `onPreferenceChange` closure literal, per the compiler's own note) and inlined the dismiss closures (the explicitly-typed `let handleDismiss: () -> Void` blocked isolation inheritance on line 125).

**Verification limits:** only Xcode 26 is installed locally, so `swift build` cannot distinguish fixed from unfixed (it compiles both). Ground truth is the approval-gated `spm-revenuecat-ui-ios-15/16` jobs on this PR. `Not run locally: old-toolchain compile.`

**AI involvement:** investigation, root-cause analysis, and the fix were done by Claude (Opus 4.8) in a Claude Code session, reviewed by the author.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow compile/isolation fix in paywall presentation helpers with no new logic paths; behavior should match prior intent on all supported OS versions.
> 
> **Overview**
> Fixes **compile failures** on older Xcode (14.3.1 / 15.4) for the exit-offer `View` helpers in `View+ExitOfferPresentation.swift`, where calling `@MainActor` `ExitOfferPresenter` APIs from a non-isolated extension was rejected.
> 
> The **`View` extension** is now explicitly marked **`@MainActor`**, matching newer SwiftUI where `View` is implicitly main-actor isolated. In **`exitOfferSheet`**, the sheet/fullScreenCover **`onDismiss`** handlers are **inlined** instead of stored in a typed `() -> Void` local, so those closures inherit the extension’s isolation and can call `presenter.reset()` on older toolchains.
> 
> No intended runtime behavior change—only concurrency annotations and closure structure for cross-toolchain builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19a0b2cf816f9b225e61b7e4b03ea2501f8d1eac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->