### PR TITLE
Eagerly prewarm workflow assets without retaining decoded workflows

### DIFF
--- a/Sources/Logging/Strings/PaywallsStrings.swift
+++ b/Sources/Logging/Strings/PaywallsStrings.swift
@@ -22,6 +22,7 @@ enum PaywallsStrings {
     case warming_up_fonts(fontsURLS: Set<URL>)
     case warming_up_videos(videoURLs: Set<URLWithValidation>)
     case warming_up_workflow(screenCount: Int)
+    case workflow_resolution_for_asset_prewarming_failed(workflowId: String, error: WorkflowResolutionError)
     case error_fetching_workflows_list(BackendError)
     case error_refreshing_workflow(workflowId: String, error: BackendError)
     case error_prefetching_image(URL, Error)
@@ -170,6 +171,9 @@ extension PaywallsStrings: LogMessage {
 
         case let .warming_up_workflow(screenCount):
             return "Warming up workflow caches for \(screenCount) screen(s)"
+
+        case let .workflow_resolution_for_asset_prewarming_failed(workflowId, error):
+            return "Unable to resolve workflow '\(workflowId)' for asset prewarming: \(error)"
 
         case let .error_fetching_workflows_list(error):
             return "Error fetching workflows list: \(error.localizedDescription)"

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -163,18 +163,7 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     /// current config generation, with the included offering's workflow first so `WorkflowManager` can prioritize
     /// its assets. Missing bodies are omitted so one failed download does not prevent the remaining workflows from
     /// proceeding.
-    @discardableResult
     func cachePrefetchedWorkflowBodyData(includingOfferingId: String?) async -> [String] {
-        return await Task.detached(priority: .utility) {
-            await self.cachePrefetchedWorkflowBodyDataOnBackgroundExecutor(
-                includingOfferingId: includingOfferingId
-            )
-        }.value
-    }
-
-    private func cachePrefetchedWorkflowBodyDataOnBackgroundExecutor(
-        includingOfferingId: String?
-    ) async -> [String] {
         if let cache = self.currentWorkflowCache(),
            cache.containsPrefetchedWorkflowBodyData(includingOfferingId: includingOfferingId) {
             return cache.workflowIDsWhoseBodiesShouldBeCached(includingOfferingId: includingOfferingId)
@@ -363,8 +352,9 @@ private struct PrefetchedWorkflowCache {
     }
 }
 
-/// Retains raw workflow bytes until first use, then atomically retains either the decoded workflow or
-/// its decoding failure. This keeps cached-body reads synchronous without eagerly building every workflow graph.
+/// Retains raw workflow bytes until first use. ``value()`` then atomically retains either the decoded
+/// workflow or its decoding failure; ``transientValue()`` decodes without retaining, for asset prewarming.
+/// This keeps cached-body reads synchronous without eagerly building every workflow graph.
 private final class LazyPublishedWorkflow {
 
     private enum State {

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -5,6 +5,8 @@
 //  Created by RevenueCat.
 //  Copyright © 2026 RevenueCat, Inc. All rights reserved.
 
+// swiftlint:disable file_length
+
 import Foundation
 
 protocol WorkflowsConfigProviderType {

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -17,7 +17,7 @@ protocol WorkflowsConfigProviderType {
         workflowId: String
     ) async -> Result<WorkflowDataResult, WorkflowResolutionError>
     @discardableResult
-    func cacheEligibleWorkflowBodyData(currentOfferingId: String?) async -> Set<String>
+    func cachePrefetchedWorkflowBodyData(includingOfferingId: String?) async -> Set<String>
     func cachedWorkflow(forOfferingId offeringId: String) -> WorkflowDataResult?
 
 }
@@ -42,9 +42,10 @@ enum WorkflowResolutionError: Error, Equatable {
 /// name, that an item's offering id lives in its inline content under `offeringIdentifier`, and how to
 /// parse a ``PublishedWorkflow``. Everything else is delegated to `RemoteConfigManager`.
 ///
-/// Eligible workflows—items marked `prefetch` plus the current offering's workflow—are cached as raw body `Data`.
+/// Prefetched workflows—items marked `prefetch` plus the implicitly prefetched current offering's workflow—are
+/// cached as raw body `Data`.
 /// Normal reads decode and retain their result lazily. Asset prewarming instead uses a transient decode so it can
-/// discover referenced assets without keeping every eligible workflow's component graph in memory.
+/// discover referenced assets without keeping every prefetched workflow's component graph in memory.
 final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
 
     typealias WorkflowDecoder = (Data) throws -> PublishedWorkflow
@@ -57,9 +58,9 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     /// so a repeat call with an unchanged topic reuses it instead of rescanning every item's content.
     private let cachedOfferingIdMap: Atomic<(topic: RemoteConfiguration.ConfigTopic, map: [String: String])?> = nil
 
-    private let eligibleWorkflowsCache = GenerationGuardedCache<
+    private let prefetchedWorkflowsCache = GenerationGuardedCache<
         RemoteConfiguration.ConfigTopic,
-        EligibleWorkflowCache
+        PrefetchedWorkflowCache
     >()
 
     init(
@@ -141,7 +142,7 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         }
     }
 
-    /// Decodes body data cached by ``cacheEligibleWorkflowBodyData(currentOfferingId:)`` without retaining the
+    /// Decodes body data cached by ``cachePrefetchedWorkflowBodyData(includingOfferingId:)`` without retaining the
     /// decoded workflow. The result stays alive only while the asset warmer uses it; an eventual render decodes
     /// normally.
     func decodeCachedWorkflowForAssetPrewarming(
@@ -162,16 +163,20 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     /// current config generation, allowing `WorkflowManager` to schedule transient decoding and asset prewarming.
     /// Missing bodies are omitted so one failed download does not prevent the remaining workflows from proceeding.
     @discardableResult
-    func cacheEligibleWorkflowBodyData(currentOfferingId: String?) async -> Set<String> {
+    func cachePrefetchedWorkflowBodyData(includingOfferingId: String?) async -> Set<String> {
         return await Task.detached(priority: .utility) {
-            await self.cacheEligibleWorkflowBodyDataOnBackgroundExecutor(currentOfferingId: currentOfferingId)
+            await self.cachePrefetchedWorkflowBodyDataOnBackgroundExecutor(
+                includingOfferingId: includingOfferingId
+            )
         }.value
     }
 
-    private func cacheEligibleWorkflowBodyDataOnBackgroundExecutor(currentOfferingId: String?) async -> Set<String> {
+    private func cachePrefetchedWorkflowBodyDataOnBackgroundExecutor(
+        includingOfferingId: String?
+    ) async -> Set<String> {
         if let cache = self.currentWorkflowCache(),
-           cache.containsEligibleWorkflowBodyData(currentOfferingId: currentOfferingId) {
-            return cache.workflowIDsWhoseBodiesShouldBeCached(currentOfferingId: currentOfferingId)
+           cache.containsPrefetchedWorkflowBodyData(includingOfferingId: includingOfferingId) {
+            return cache.workflowIDsWhoseBodiesShouldBeCached(includingOfferingId: includingOfferingId)
         }
         guard let topic = await self.manager.awaitTopicAndPrefetchBlobsReady(.workflows) else { return [] }
 
@@ -183,12 +188,12 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         let prefetchedWorkflowIds = Set(topic.compactMap { workflowId, item in
             item.prefetch ? workflowId : nil
         })
-        let workflowIDsWhoseBodiesShouldBeCached = workflowIDsEligibleForBodyDataCaching(
+        let workflowIDsWhoseBodiesShouldBeCached = workflowIDsToPrefetch(
             prefetchedWorkflowIds: prefetchedWorkflowIds,
             offeringIdMap: offeringIdMap,
-            currentOfferingId: currentOfferingId
+            includingOfferingId: includingOfferingId
         )
-        let cachedWorkflows = self.eligibleWorkflowsCache.value(for: snapshot)?.workflows ?? [:]
+        let cachedWorkflows = self.prefetchedWorkflowsCache.value(for: snapshot)?.workflows ?? [:]
         guard !workflowIDsWhoseBodiesShouldBeCached.isSubset(of: cachedWorkflows.keys) else {
             return workflowIDsWhoseBodiesShouldBeCached
         }
@@ -199,15 +204,15 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         let newWorkflowEntries = await self.readWorkflowBodyData(for: workflowIDsMissingBodyData)
 
         guard await self.manager.isCurrent(snapshot, for: .workflows) else {
-            self.eligibleWorkflowsCache.clearIfStale(currentGeneration: self.manager.configGeneration)
+            self.prefetchedWorkflowsCache.clearIfStale(currentGeneration: self.manager.configGeneration)
             return []
         }
 
         // Another concurrent cache operation may have populated more entries while the missing body data was read.
         // Preserve those entries (and any retained lazy decode results) when merging this result.
-        let latestWorkflows = self.eligibleWorkflowsCache.value(for: snapshot)?.workflows ?? cachedWorkflows
+        let latestWorkflows = self.prefetchedWorkflowsCache.value(for: snapshot)?.workflows ?? cachedWorkflows
         let workflows = latestWorkflows.merging(newWorkflowEntries) { cached, _ in cached }
-        self.eligibleWorkflowsCache.store(
+        self.prefetchedWorkflowsCache.store(
             .init(
                 offeringIdMap: offeringIdMap,
                 prefetchedWorkflowIds: prefetchedWorkflowIds,
@@ -232,7 +237,7 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         }
     }
 
-    private func resolvedWorkflowId(forOfferingId offeringId: String, in cache: EligibleWorkflowCache) -> String {
+    private func resolvedWorkflowId(forOfferingId offeringId: String, in cache: PrefetchedWorkflowCache) -> String {
         // Fall back to treating the input as a workflow id, matching the async resolution path.
         return cache.offeringIdMap[offeringId] ?? offeringId
     }
@@ -285,14 +290,14 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         }
     }
 
-    private func currentWorkflowCache() -> EligibleWorkflowCache? {
+    private func currentWorkflowCache() -> PrefetchedWorkflowCache? {
         return self.manager.withCurrentConfigGeneration { generation in
             self.currentWorkflowCache(currentGeneration: generation)
         }
     }
 
-    private func currentWorkflowCache(currentGeneration: Int) -> EligibleWorkflowCache? {
-        return self.eligibleWorkflowsCache.value(currentGeneration: currentGeneration)
+    private func currentWorkflowCache(currentGeneration: Int) -> PrefetchedWorkflowCache? {
+        return self.prefetchedWorkflowsCache.value(currentGeneration: currentGeneration)
     }
 
     private func readWorkflowBodyData(for workflowIds: Set<String>) async -> [String: LazyPublishedWorkflow] {
@@ -324,36 +329,36 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
 
 }
 
-private func workflowIDsEligibleForBodyDataCaching(
+private func workflowIDsToPrefetch(
     prefetchedWorkflowIds: Set<String>,
     offeringIdMap: [String: String],
-    currentOfferingId: String?
+    includingOfferingId: String?
 ) -> Set<String> {
     var workflowIds = prefetchedWorkflowIds
 
-    if let currentOfferingId,
-       let currentWorkflowId = offeringIdMap[currentOfferingId] {
-        workflowIds.insert(currentWorkflowId)
+    if let includingOfferingId,
+       let includedWorkflowId = offeringIdMap[includingOfferingId] {
+        workflowIds.insert(includedWorkflowId)
     }
 
     return workflowIds
 }
 
-private struct EligibleWorkflowCache {
+private struct PrefetchedWorkflowCache {
     let offeringIdMap: [String: String]
     let prefetchedWorkflowIds: Set<String>
     let workflows: [String: LazyPublishedWorkflow]
 
-    func containsEligibleWorkflowBodyData(currentOfferingId: String?) -> Bool {
-        return self.workflowIDsWhoseBodiesShouldBeCached(currentOfferingId: currentOfferingId)
+    func containsPrefetchedWorkflowBodyData(includingOfferingId: String?) -> Bool {
+        return self.workflowIDsWhoseBodiesShouldBeCached(includingOfferingId: includingOfferingId)
             .isSubset(of: self.workflows.keys)
     }
 
-    func workflowIDsWhoseBodiesShouldBeCached(currentOfferingId: String?) -> Set<String> {
-        return workflowIDsEligibleForBodyDataCaching(
+    func workflowIDsWhoseBodiesShouldBeCached(includingOfferingId: String?) -> Set<String> {
+        return workflowIDsToPrefetch(
             prefetchedWorkflowIds: self.prefetchedWorkflowIds,
             offeringIdMap: self.offeringIdMap,
-            currentOfferingId: currentOfferingId
+            includingOfferingId: includingOfferingId
         )
     }
 }

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -17,7 +17,7 @@ protocol WorkflowsConfigProviderType {
         workflowId: String
     ) async -> Result<WorkflowDataResult, WorkflowResolutionError>
     @discardableResult
-    func cachePrefetchedWorkflowBodyData(includingOfferingId: String?) async -> Set<String>
+    func cachePrefetchedWorkflowBodyData(includingOfferingId: String?) async -> [String]
     func cachedWorkflow(forOfferingId offeringId: String) -> WorkflowDataResult?
 
 }
@@ -160,10 +160,11 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     /// Ensures raw body data is cached for workflows marked `prefetch` and for the current offering's workflow.
     ///
     /// This method never decodes a workflow. It returns only workflow IDs whose body data is available in the
-    /// current config generation, allowing `WorkflowManager` to schedule transient decoding and asset prewarming.
-    /// Missing bodies are omitted so one failed download does not prevent the remaining workflows from proceeding.
+    /// current config generation, with the included offering's workflow first so `WorkflowManager` can prioritize
+    /// its assets. Missing bodies are omitted so one failed download does not prevent the remaining workflows from
+    /// proceeding.
     @discardableResult
-    func cachePrefetchedWorkflowBodyData(includingOfferingId: String?) async -> Set<String> {
+    func cachePrefetchedWorkflowBodyData(includingOfferingId: String?) async -> [String] {
         return await Task.detached(priority: .utility) {
             await self.cachePrefetchedWorkflowBodyDataOnBackgroundExecutor(
                 includingOfferingId: includingOfferingId
@@ -173,7 +174,7 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
 
     private func cachePrefetchedWorkflowBodyDataOnBackgroundExecutor(
         includingOfferingId: String?
-    ) async -> Set<String> {
+    ) async -> [String] {
         if let cache = self.currentWorkflowCache(),
            cache.containsPrefetchedWorkflowBodyData(includingOfferingId: includingOfferingId) {
             return cache.workflowIDsWhoseBodiesShouldBeCached(includingOfferingId: includingOfferingId)
@@ -185,17 +186,18 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
             key: topic
         )
         let offeringIdMap = self.buildOfferingIdMap(from: topic)
-        let prefetchedWorkflowIds = Set(topic.compactMap { workflowId, item in
+        let prefetchedWorkflowIds = topic.compactMap { workflowId, item in
             item.prefetch ? workflowId : nil
-        })
-        let workflowIDsWhoseBodiesShouldBeCached = workflowIDsToPrefetch(
+        }
+        let orderedWorkflowIDsToPrefetch = workflowIDsToPrefetch(
             prefetchedWorkflowIds: prefetchedWorkflowIds,
             offeringIdMap: offeringIdMap,
             includingOfferingId: includingOfferingId
         )
+        let workflowIDsWhoseBodiesShouldBeCached = Set(orderedWorkflowIDsToPrefetch)
         let cachedWorkflows = self.prefetchedWorkflowsCache.value(for: snapshot)?.workflows ?? [:]
         guard !workflowIDsWhoseBodiesShouldBeCached.isSubset(of: cachedWorkflows.keys) else {
-            return workflowIDsWhoseBodiesShouldBeCached
+            return orderedWorkflowIDsToPrefetch
         }
 
         // Keep only body bytes in memory here. `LazyPublishedWorkflow` performs and retains the decode
@@ -221,7 +223,7 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
             for: snapshot
         )
 
-        return workflowIDsWhoseBodiesShouldBeCached.intersection(workflows.keys)
+        return orderedWorkflowIDsToPrefetch.filter { workflows[$0] != nil }
     }
 
     func cachedWorkflow(forOfferingId offeringId: String) -> WorkflowDataResult? {
@@ -330,31 +332,29 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
 }
 
 private func workflowIDsToPrefetch(
-    prefetchedWorkflowIds: Set<String>,
+    prefetchedWorkflowIds: [String],
     offeringIdMap: [String: String],
     includingOfferingId: String?
-) -> Set<String> {
-    var workflowIds = prefetchedWorkflowIds
-
-    if let includingOfferingId,
-       let includedWorkflowId = offeringIdMap[includingOfferingId] {
-        workflowIds.insert(includedWorkflowId)
+) -> [String] {
+    guard let includingOfferingId,
+          let includedWorkflowId = offeringIdMap[includingOfferingId] else {
+        return prefetchedWorkflowIds
     }
 
-    return workflowIds
+    return [includedWorkflowId] + prefetchedWorkflowIds.filter { $0 != includedWorkflowId }
 }
 
 private struct PrefetchedWorkflowCache {
     let offeringIdMap: [String: String]
-    let prefetchedWorkflowIds: Set<String>
+    let prefetchedWorkflowIds: [String]
     let workflows: [String: LazyPublishedWorkflow]
 
     func containsPrefetchedWorkflowBodyData(includingOfferingId: String?) -> Bool {
-        return self.workflowIDsWhoseBodiesShouldBeCached(includingOfferingId: includingOfferingId)
+        return Set(self.workflowIDsWhoseBodiesShouldBeCached(includingOfferingId: includingOfferingId))
             .isSubset(of: self.workflows.keys)
     }
 
-    func workflowIDsWhoseBodiesShouldBeCached(includingOfferingId: String?) -> Set<String> {
+    func workflowIDsWhoseBodiesShouldBeCached(includingOfferingId: String?) -> [String] {
         return workflowIDsToPrefetch(
             prefetchedWorkflowIds: self.prefetchedWorkflowIds,
             offeringIdMap: self.offeringIdMap,

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -11,9 +11,11 @@ protocol WorkflowsConfigProviderType {
 
     func workflowId(forOfferingId offeringId: String) async -> String?
     func getWorkflow(workflowId: String) async -> Result<WorkflowDataResult, WorkflowResolutionError>
-    func getWorkflowForPrewarming(workflowId: String) async -> Result<WorkflowDataResult, WorkflowResolutionError>
+    func decodeCachedWorkflowForAssetPrewarming(
+        workflowId: String
+    ) async -> Result<WorkflowDataResult, WorkflowResolutionError>
     @discardableResult
-    func warmPrefetchedWorkflows(currentOfferingId: String?) async -> Set<String>
+    func cacheEligibleWorkflowBodyData(currentOfferingId: String?) async -> Set<String>
     func cachedWorkflow(forOfferingId offeringId: String) -> WorkflowDataResult?
 
 }
@@ -49,9 +51,9 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     /// so a repeat call with an unchanged topic reuses it instead of rescanning every item's content.
     private let cachedOfferingIdMap: Atomic<(topic: RemoteConfiguration.ConfigTopic, map: [String: String])?> = nil
 
-    private let prefetchedWorkflowsCache = GenerationGuardedCache<
+    private let eligibleWorkflowsCache = GenerationGuardedCache<
         RemoteConfiguration.ConfigTopic,
-        PrefetchedWorkflowCache
+        EligibleWorkflowCache
     >()
 
     init(
@@ -116,7 +118,7 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     /// config change fails the resolution instead of returning a mixed-generation workflow/config pair.
     func getWorkflow(workflowId: String) async -> Result<WorkflowDataResult, WorkflowResolutionError> {
         // Deliberately sequential, not `async let`: a miss or malformed body returns without paying for
-        // `ui_config`. A warm-cache hit decodes synchronously from in-memory bytes on the caller's thread.
+        // `ui_config`. A cached-body hit decodes synchronously from in-memory bytes on the caller's thread.
         if let cached = self.cachedWorkflowResult(workflowId: workflowId) {
             return await self.makeWorkflowResult(cached.result) {
                 self.manager.configGeneration == cached.generation
@@ -133,9 +135,10 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         }
     }
 
-    /// Decodes a body cached by ``warmPrefetchedWorkflows(currentOfferingId:)`` without retaining the decoded
-    /// workflow. The result stays alive only while the asset warmer uses it; an eventual render decodes normally.
-    func getWorkflowForPrewarming(
+    /// Decodes body data cached by ``cacheEligibleWorkflowBodyData(currentOfferingId:)`` without retaining the
+    /// decoded workflow. The result stays alive only while the asset warmer uses it; an eventual render decodes
+    /// normally.
+    func decodeCachedWorkflowForAssetPrewarming(
         workflowId: String
     ) async -> Result<WorkflowDataResult, WorkflowResolutionError> {
         guard let cached = self.cachedWorkflowResult(workflowId: workflowId, retainDecodedResult: false) else {
@@ -148,15 +151,16 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     }
 
     @discardableResult
-    func warmPrefetchedWorkflows(currentOfferingId: String?) async -> Set<String> {
+    func cacheEligibleWorkflowBodyData(currentOfferingId: String?) async -> Set<String> {
         return await Task.detached(priority: .utility) {
-            await self.warmPrefetchedWorkflowsOnBackgroundExecutor(currentOfferingId: currentOfferingId)
+            await self.cacheEligibleWorkflowBodyDataOnBackgroundExecutor(currentOfferingId: currentOfferingId)
         }.value
     }
 
-    private func warmPrefetchedWorkflowsOnBackgroundExecutor(currentOfferingId: String?) async -> Set<String> {
-        if let cache = self.currentWorkflowCache(), cache.isWarm(currentOfferingId: currentOfferingId) {
-            return cache.expectedWorkflowIds(currentOfferingId: currentOfferingId)
+    private func cacheEligibleWorkflowBodyDataOnBackgroundExecutor(currentOfferingId: String?) async -> Set<String> {
+        if let cache = self.currentWorkflowCache(),
+           cache.containsEligibleWorkflowBodyData(currentOfferingId: currentOfferingId) {
+            return cache.workflowIDsWhoseBodiesShouldBeCached(currentOfferingId: currentOfferingId)
         }
         guard let topic = await self.manager.awaitTopicAndPrefetchBlobsReady(.workflows) else { return [] }
 
@@ -168,29 +172,31 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         let prefetchedWorkflowIds = Set(topic.compactMap { workflowId, item in
             item.prefetch ? workflowId : nil
         })
-        let expectedWorkflowIds = workflowIdsToWarm(
+        let workflowIDsWhoseBodiesShouldBeCached = workflowIDsEligibleForBodyDataCaching(
             prefetchedWorkflowIds: prefetchedWorkflowIds,
             offeringIdMap: offeringIdMap,
             currentOfferingId: currentOfferingId
         )
-        let cachedWorkflows = self.prefetchedWorkflowsCache.value(for: snapshot)?.workflows ?? [:]
-        guard !expectedWorkflowIds.isSubset(of: cachedWorkflows.keys) else { return expectedWorkflowIds }
+        let cachedWorkflows = self.eligibleWorkflowsCache.value(for: snapshot)?.workflows ?? [:]
+        guard !workflowIDsWhoseBodiesShouldBeCached.isSubset(of: cachedWorkflows.keys) else {
+            return workflowIDsWhoseBodiesShouldBeCached
+        }
 
         // Keep only body bytes in memory here. `LazyPublishedWorkflow` performs and retains the decode
-        // synchronously on first access, so warming doesn't build every workflow's component graph.
-        let missingWorkflowIds = expectedWorkflowIds.subtracting(cachedWorkflows.keys)
-        let loadedWorkflows = await self.loadWorkflows(missingWorkflowIds)
+        // synchronously on first access, so caching body data doesn't build every workflow's component graph.
+        let workflowIDsMissingBodyData = workflowIDsWhoseBodiesShouldBeCached.subtracting(cachedWorkflows.keys)
+        let newWorkflowEntries = await self.readWorkflowBodyData(for: workflowIDsMissingBodyData)
 
         guard await self.manager.isCurrent(snapshot, for: .workflows) else {
-            self.prefetchedWorkflowsCache.clearIfStale(currentGeneration: self.manager.configGeneration)
+            self.eligibleWorkflowsCache.clearIfStale(currentGeneration: self.manager.configGeneration)
             return []
         }
 
-        // Another concurrent warm may have populated more entries while the missing bodies loaded.
-        // Preserve those entries (and any retained lazy decode results) when merging this warm.
-        let latestWorkflows = self.prefetchedWorkflowsCache.value(for: snapshot)?.workflows ?? cachedWorkflows
-        let workflows = latestWorkflows.merging(loadedWorkflows) { cached, _ in cached }
-        self.prefetchedWorkflowsCache.store(
+        // Another concurrent cache operation may have populated more entries while the missing body data was read.
+        // Preserve those entries (and any retained lazy decode results) when merging this result.
+        let latestWorkflows = self.eligibleWorkflowsCache.value(for: snapshot)?.workflows ?? cachedWorkflows
+        let workflows = latestWorkflows.merging(newWorkflowEntries) { cached, _ in cached }
+        self.eligibleWorkflowsCache.store(
             .init(
                 offeringIdMap: offeringIdMap,
                 prefetchedWorkflowIds: prefetchedWorkflowIds,
@@ -199,7 +205,7 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
             for: snapshot
         )
 
-        return expectedWorkflowIds.intersection(workflows.keys)
+        return workflowIDsWhoseBodiesShouldBeCached.intersection(workflows.keys)
     }
 
     func cachedWorkflow(forOfferingId offeringId: String) -> WorkflowDataResult? {
@@ -215,7 +221,7 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         }
     }
 
-    private func resolvedWorkflowId(forOfferingId offeringId: String, in cache: PrefetchedWorkflowCache) -> String {
+    private func resolvedWorkflowId(forOfferingId offeringId: String, in cache: EligibleWorkflowCache) -> String {
         // Fall back to treating the input as a workflow id, matching the async resolution path.
         return cache.offeringIdMap[offeringId] ?? offeringId
     }
@@ -268,17 +274,17 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         }
     }
 
-    private func currentWorkflowCache() -> PrefetchedWorkflowCache? {
+    private func currentWorkflowCache() -> EligibleWorkflowCache? {
         return self.manager.withCurrentConfigGeneration { generation in
             self.currentWorkflowCache(currentGeneration: generation)
         }
     }
 
-    private func currentWorkflowCache(currentGeneration: Int) -> PrefetchedWorkflowCache? {
-        return self.prefetchedWorkflowsCache.value(currentGeneration: currentGeneration)
+    private func currentWorkflowCache(currentGeneration: Int) -> EligibleWorkflowCache? {
+        return self.eligibleWorkflowsCache.value(currentGeneration: currentGeneration)
     }
 
-    private func loadWorkflows(_ workflowIds: Set<String>) async -> [String: LazyPublishedWorkflow] {
+    private func readWorkflowBodyData(for workflowIds: Set<String>) async -> [String: LazyPublishedWorkflow] {
         await withTaskGroup(of: (String, Data?).self) { group in
             for workflowId in workflowIds {
                 group.addTask {
@@ -307,7 +313,7 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
 
 }
 
-private func workflowIdsToWarm(
+private func workflowIDsEligibleForBodyDataCaching(
     prefetchedWorkflowIds: Set<String>,
     offeringIdMap: [String: String],
     currentOfferingId: String?
@@ -322,17 +328,18 @@ private func workflowIdsToWarm(
     return workflowIds
 }
 
-private struct PrefetchedWorkflowCache {
+private struct EligibleWorkflowCache {
     let offeringIdMap: [String: String]
     let prefetchedWorkflowIds: Set<String>
     let workflows: [String: LazyPublishedWorkflow]
 
-    func isWarm(currentOfferingId: String?) -> Bool {
-        return self.expectedWorkflowIds(currentOfferingId: currentOfferingId).isSubset(of: self.workflows.keys)
+    func containsEligibleWorkflowBodyData(currentOfferingId: String?) -> Bool {
+        return self.workflowIDsWhoseBodiesShouldBeCached(currentOfferingId: currentOfferingId)
+            .isSubset(of: self.workflows.keys)
     }
 
-    func expectedWorkflowIds(currentOfferingId: String?) -> Set<String> {
-        return workflowIdsToWarm(
+    func workflowIDsWhoseBodiesShouldBeCached(currentOfferingId: String?) -> Set<String> {
+        return workflowIDsEligibleForBodyDataCaching(
             prefetchedWorkflowIds: self.prefetchedWorkflowIds,
             offeringIdMap: self.offeringIdMap,
             currentOfferingId: currentOfferingId
@@ -341,7 +348,7 @@ private struct PrefetchedWorkflowCache {
 }
 
 /// Retains raw workflow bytes until first use, then atomically retains either the decoded workflow or
-/// its decoding failure. This keeps warm-cache reads synchronous without eagerly building every workflow graph.
+/// its decoding failure. This keeps cached-body reads synchronous without eagerly building every workflow graph.
 private final class LazyPublishedWorkflow {
 
     private enum State {

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -11,7 +11,9 @@ protocol WorkflowsConfigProviderType {
 
     func workflowId(forOfferingId offeringId: String) async -> String?
     func getWorkflow(workflowId: String) async -> Result<WorkflowDataResult, WorkflowResolutionError>
-    func warmPrefetchedWorkflows(currentOfferingId: String?) async
+    func getWorkflowForPrewarming(workflowId: String) async -> Result<WorkflowDataResult, WorkflowResolutionError>
+    @discardableResult
+    func warmPrefetchedWorkflows(currentOfferingId: String?) async -> Set<String>
     func cachedWorkflow(forOfferingId offeringId: String) -> WorkflowDataResult?
 
 }
@@ -131,17 +133,32 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         }
     }
 
-    func warmPrefetchedWorkflows(currentOfferingId: String?) async {
-        await Task.detached(priority: .utility) {
+    /// Decodes a body cached by ``warmPrefetchedWorkflows(currentOfferingId:)`` without retaining the decoded
+    /// workflow. The result stays alive only while the asset warmer uses it; an eventual render decodes normally.
+    func getWorkflowForPrewarming(
+        workflowId: String
+    ) async -> Result<WorkflowDataResult, WorkflowResolutionError> {
+        guard let cached = self.cachedWorkflowResult(workflowId: workflowId, retainDecodedResult: false) else {
+            return .failure(.notFound)
+        }
+
+        return await self.makeWorkflowResult(cached.result) {
+            self.manager.configGeneration == cached.generation
+        }
+    }
+
+    @discardableResult
+    func warmPrefetchedWorkflows(currentOfferingId: String?) async -> Set<String> {
+        return await Task.detached(priority: .utility) {
             await self.warmPrefetchedWorkflowsOnBackgroundExecutor(currentOfferingId: currentOfferingId)
         }.value
     }
 
-    private func warmPrefetchedWorkflowsOnBackgroundExecutor(currentOfferingId: String?) async {
+    private func warmPrefetchedWorkflowsOnBackgroundExecutor(currentOfferingId: String?) async -> Set<String> {
         if let cache = self.currentWorkflowCache(), cache.isWarm(currentOfferingId: currentOfferingId) {
-            return
+            return cache.expectedWorkflowIds(currentOfferingId: currentOfferingId)
         }
-        guard let topic = await self.manager.awaitTopicAndPrefetchBlobsReady(.workflows) else { return }
+        guard let topic = await self.manager.awaitTopicAndPrefetchBlobsReady(.workflows) else { return [] }
 
         let snapshot = GenerationGuardedCacheSnapshot(
             generation: self.manager.configGeneration,
@@ -157,7 +174,7 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
             currentOfferingId: currentOfferingId
         )
         let cachedWorkflows = self.prefetchedWorkflowsCache.value(for: snapshot)?.workflows ?? [:]
-        guard !expectedWorkflowIds.isSubset(of: cachedWorkflows.keys) else { return }
+        guard !expectedWorkflowIds.isSubset(of: cachedWorkflows.keys) else { return expectedWorkflowIds }
 
         // Keep only body bytes in memory here. `LazyPublishedWorkflow` performs and retains the decode
         // synchronously on first access, so warming doesn't build every workflow's component graph.
@@ -166,7 +183,7 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
 
         guard await self.manager.isCurrent(snapshot, for: .workflows) else {
             self.prefetchedWorkflowsCache.clearIfStale(currentGeneration: self.manager.configGeneration)
-            return
+            return []
         }
 
         // Another concurrent warm may have populated more entries while the missing bodies loaded.
@@ -181,6 +198,8 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
             ),
             for: snapshot
         )
+
+        return expectedWorkflowIds.intersection(workflows.keys)
     }
 
     func cachedWorkflow(forOfferingId offeringId: String) -> WorkflowDataResult? {
@@ -236,14 +255,16 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     }
 
     private func cachedWorkflowResult(
-        workflowId: String
+        workflowId: String,
+        retainDecodedResult: Bool = true
     ) -> (result: Result<PublishedWorkflow, WorkflowResolutionError>, generation: Int)? {
         return self.manager.withCurrentConfigGeneration { generation in
             guard let cache = self.currentWorkflowCache(currentGeneration: generation),
                   let workflow = cache.workflows[workflowId] else {
                 return nil
             }
-            return (result: workflow.value(), generation: generation)
+            let result = retainDecodedResult ? workflow.value() : workflow.transientValue()
+            return (result: result, generation: generation)
         }
     }
 
@@ -307,12 +328,15 @@ private struct PrefetchedWorkflowCache {
     let workflows: [String: LazyPublishedWorkflow]
 
     func isWarm(currentOfferingId: String?) -> Bool {
-        let expectedWorkflowIds = workflowIdsToWarm(
+        return self.expectedWorkflowIds(currentOfferingId: currentOfferingId).isSubset(of: self.workflows.keys)
+    }
+
+    func expectedWorkflowIds(currentOfferingId: String?) -> Set<String> {
+        return workflowIdsToWarm(
             prefetchedWorkflowIds: self.prefetchedWorkflowIds,
             offeringIdMap: self.offeringIdMap,
             currentOfferingId: currentOfferingId
         )
-        return expectedWorkflowIds.isSubset(of: self.workflows.keys)
     }
 }
 
@@ -342,6 +366,19 @@ private final class LazyPublishedWorkflow {
                 let result = self.decode(data)
                 state = .decoded(result)
                 return result
+            }
+        }
+    }
+
+    /// Decodes raw bytes without changing the cached state. If a real read already retained a decoded value,
+    /// reuse it; otherwise release this temporary graph after its caller finishes prewarming assets.
+    func transientValue() -> Result<PublishedWorkflow, WorkflowResolutionError> {
+        return self.state.modify { state in
+            switch state {
+            case let .decoded(result):
+                return result
+            case let .data(data):
+                return self.decode(data)
             }
         }
     }

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -39,6 +39,10 @@ enum WorkflowResolutionError: Error, Equatable {
 /// topic instead of a dedicated `/v1/workflows` list+detail fetch. It knows only the `workflows` topic
 /// name, that an item's offering id lives in its inline content under `offeringIdentifier`, and how to
 /// parse a ``PublishedWorkflow``. Everything else is delegated to `RemoteConfigManager`.
+///
+/// Eligible workflows—items marked `prefetch` plus the current offering's workflow—are cached as raw body `Data`.
+/// Normal reads decode and retain their result lazily. Asset prewarming instead uses a transient decode so it can
+/// discover referenced assets without keeping every eligible workflow's component graph in memory.
 final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
 
     typealias WorkflowDecoder = (Data) throws -> PublishedWorkflow
@@ -150,6 +154,11 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         }
     }
 
+    /// Ensures raw body data is cached for workflows marked `prefetch` and for the current offering's workflow.
+    ///
+    /// This method never decodes a workflow. It returns only workflow IDs whose body data is available in the
+    /// current config generation, allowing `WorkflowManager` to schedule transient decoding and asset prewarming.
+    /// Missing bodies are omitted so one failed download does not prevent the remaining workflows from proceeding.
     @discardableResult
     func cacheEligibleWorkflowBodyData(currentOfferingId: String?) async -> Set<String> {
         return await Task.detached(priority: .utility) {

--- a/Sources/Paywalls/PaywallCacheWarming.swift
+++ b/Sources/Paywalls/PaywallCacheWarming.swift
@@ -36,6 +36,9 @@ protocol PaywallCacheWarmingType: Sendable {
     @available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *)
     func prewarmWorkflowAssets(workflow: PublishedWorkflow, uiConfig: UIConfig) async
 
+    @available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *)
+    func hasStartedWorkflowAssetPrewarming(for workflowID: String) async -> Bool
+
 #if !os(tvOS) // For Paywalls
 
     @available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *)
@@ -226,6 +229,10 @@ actor PaywallCacheWarming: PaywallCacheWarmingType {
             }
             #endif
         }
+    }
+
+    func hasStartedWorkflowAssetPrewarming(for workflowID: String) async -> Bool {
+        return self.workflowIDsWithAssetPrewarmingStarted.contains(workflowID)
     }
 
 #if !os(tvOS)

--- a/Sources/Paywalls/PaywallCacheWarming.swift
+++ b/Sources/Paywalls/PaywallCacheWarming.swift
@@ -34,7 +34,7 @@ protocol PaywallCacheWarmingType: Sendable {
     func warmUpPaywallFontsCache(offerings: Offerings) async
 
     @available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *)
-    func warmUpWorkflowCaches(workflow: PublishedWorkflow, uiConfig: UIConfig) async
+    func prewarmWorkflowAssets(workflow: PublishedWorkflow, uiConfig: UIConfig) async
 
 #if !os(tvOS) // For Paywalls
 
@@ -63,7 +63,7 @@ actor PaywallCacheWarming: PaywallCacheWarmingType {
     private var warmedEligibilityProductIdentifiers: Set<String> = []
     private var hasLoadedImages = false
     private var hasLoadedVideos = false
-    private var warmedWorkflowIDs: Set<String> = []
+    private var workflowIDsWithAssetPrewarmingStarted: Set<String> = []
     private var ongoingFontDownloads: [URL: Task<Void, Never>] = [:]
 
     init(
@@ -177,9 +177,9 @@ actor PaywallCacheWarming: PaywallCacheWarmingType {
         }
     }
 
-    func warmUpWorkflowCaches(workflow: PublishedWorkflow, uiConfig: UIConfig) async {
-        guard !self.warmedWorkflowIDs.contains(workflow.id) else { return }
-        self.warmedWorkflowIDs.insert(workflow.id)
+    func prewarmWorkflowAssets(workflow: PublishedWorkflow, uiConfig: UIConfig) async {
+        guard !self.workflowIDsWithAssetPrewarmingStarted.contains(workflow.id) else { return }
+        self.workflowIDsWithAssetPrewarmingStarted.insert(workflow.id)
 
         // Intentionally prewarming all screens, not just those reachable from
         // `initialStepId`. This trades off potentially downloading assets for

--- a/Sources/Paywalls/PaywallCacheWarming.swift
+++ b/Sources/Paywalls/PaywallCacheWarming.swift
@@ -177,6 +177,10 @@ actor PaywallCacheWarming: PaywallCacheWarmingType {
         }
     }
 
+    /// Pre-downloads every screen's images and low-resolution videos plus downloadable `ui_config` fonts.
+    ///
+    /// The workflow ID is recorded before downloads start so the presentation and background body-data paths cannot
+    /// enqueue duplicate work. Individual downloads are best-effort and do not fail workflow delivery.
     func prewarmWorkflowAssets(workflow: PublishedWorkflow, uiConfig: UIConfig) async {
         guard !self.workflowIDsWithAssetPrewarmingStarted.contains(workflow.id) else { return }
         self.workflowIDsWithAssetPrewarmingStarted.insert(workflow.id)

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -29,7 +29,7 @@ class OfferingsManager {
     // Nil when remote config is disabled, in which case offerings delivery is unchanged.
     private let remoteConfigManager: RemoteConfigManagerType?
     private let uiConfigProvider: UiConfigProvider?
-    private let workflowsConfigProvider: WorkflowsConfigProviderType?
+    private let workflowPrewarmer: WorkflowPrewarmingType?
 
     init(deviceCache: DeviceCache,
          operationDispatcher: OperationDispatcher,
@@ -41,7 +41,7 @@ class OfferingsManager {
          dateProvider: DateProvider = DateProvider(),
          remoteConfigManager: RemoteConfigManagerType? = nil,
          uiConfigProvider: UiConfigProvider? = nil,
-         workflowsConfigProvider: WorkflowsConfigProviderType? = nil) {
+         workflowPrewarmer: WorkflowPrewarmingType? = nil) {
         self.deviceCache = deviceCache
         self.operationDispatcher = operationDispatcher
         self.systemInfo = systemInfo
@@ -52,7 +52,7 @@ class OfferingsManager {
         self.dateProvider = dateProvider
         self.remoteConfigManager = remoteConfigManager
         self.uiConfigProvider = uiConfigProvider
-        self.workflowsConfigProvider = workflowsConfigProvider
+        self.workflowPrewarmer = workflowPrewarmer
     }
 
     func offerings(
@@ -489,8 +489,8 @@ private extension OfferingsManager {
         remoteConfigManager: RemoteConfigManagerType,
         currentOfferingId: String?
     ) async {
-        if let workflowsConfigProvider = self.workflowsConfigProvider {
-            await workflowsConfigProvider.warmPrefetchedWorkflows(currentOfferingId: currentOfferingId)
+        if let workflowPrewarmer = self.workflowPrewarmer {
+            await workflowPrewarmer.prewarmWorkflows(currentOfferingId: currentOfferingId)
         } else {
             _ = await remoteConfigManager.awaitTopicAndPrefetchBlobsReady(.workflows)
         }

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -29,7 +29,7 @@ class OfferingsManager {
     // Nil when remote config is disabled, in which case offerings delivery is unchanged.
     private let remoteConfigManager: RemoteConfigManagerType?
     private let uiConfigProvider: UiConfigProvider?
-    private let workflowPrewarmer: WorkflowPrewarmingType?
+    private let workflowAssetPrewarmer: WorkflowAssetPrewarmingType?
 
     init(deviceCache: DeviceCache,
          operationDispatcher: OperationDispatcher,
@@ -41,7 +41,7 @@ class OfferingsManager {
          dateProvider: DateProvider = DateProvider(),
          remoteConfigManager: RemoteConfigManagerType? = nil,
          uiConfigProvider: UiConfigProvider? = nil,
-         workflowPrewarmer: WorkflowPrewarmingType? = nil) {
+         workflowAssetPrewarmer: WorkflowAssetPrewarmingType? = nil) {
         self.deviceCache = deviceCache
         self.operationDispatcher = operationDispatcher
         self.systemInfo = systemInfo
@@ -52,7 +52,7 @@ class OfferingsManager {
         self.dateProvider = dateProvider
         self.remoteConfigManager = remoteConfigManager
         self.uiConfigProvider = uiConfigProvider
-        self.workflowPrewarmer = workflowPrewarmer
+        self.workflowAssetPrewarmer = workflowAssetPrewarmer
     }
 
     func offerings(
@@ -439,12 +439,12 @@ private extension OfferingsManager {
         }
         Task {
             let uiConfigProvider = self.uiConfigProvider ?? UiConfigProvider(manager: remoteConfigManager)
-            async let workflowsReady: Void = self.warmWorkflowConfigIfNeeded(
+            async let workflowBodyDataReady: Void = self.cacheWorkflowBodyDataAndScheduleAssetPrewarmingIfNeeded(
                 remoteConfigManager: remoteConfigManager,
                 currentOfferingId: offerings.current?.identifier
             )
             async let uiConfigReady = uiConfigProvider.getUiConfig()
-            _ = await (workflowsReady, uiConfigReady)
+            _ = await (workflowBodyDataReady, uiConfigReady)
 
             if self.shouldRefreshOfferingsWithPrunedComponents(offerings) {
                 refreshIfNeeded()
@@ -485,12 +485,14 @@ private extension OfferingsManager {
         )
     }
 
-    private func warmWorkflowConfigIfNeeded(
+    private func cacheWorkflowBodyDataAndScheduleAssetPrewarmingIfNeeded(
         remoteConfigManager: RemoteConfigManagerType,
         currentOfferingId: String?
     ) async {
-        if let workflowPrewarmer = self.workflowPrewarmer {
-            await workflowPrewarmer.prewarmWorkflows(currentOfferingId: currentOfferingId)
+        if let workflowAssetPrewarmer = self.workflowAssetPrewarmer {
+            await workflowAssetPrewarmer.scheduleAssetPrewarmingForEligibleWorkflows(
+                currentOfferingId: currentOfferingId
+            )
         } else {
             _ = await remoteConfigManager.awaitTopicAndPrefetchBlobsReady(.workflows)
         }

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -441,7 +441,7 @@ private extension OfferingsManager {
             let uiConfigProvider = self.uiConfigProvider ?? UiConfigProvider(manager: remoteConfigManager)
             async let workflowBodyDataReady: Void = self.cacheWorkflowBodyDataAndScheduleAssetPrewarmingIfNeeded(
                 remoteConfigManager: remoteConfigManager,
-                currentOfferingId: offerings.current?.identifier
+                includingOfferingId: offerings.current?.identifier
             )
             async let uiConfigReady = uiConfigProvider.getUiConfig()
             _ = await (workflowBodyDataReady, uiConfigReady)
@@ -487,11 +487,11 @@ private extension OfferingsManager {
 
     private func cacheWorkflowBodyDataAndScheduleAssetPrewarmingIfNeeded(
         remoteConfigManager: RemoteConfigManagerType,
-        currentOfferingId: String?
+        includingOfferingId: String?
     ) async {
         if let workflowAssetPrewarmer = self.workflowAssetPrewarmer {
-            await workflowAssetPrewarmer.scheduleAssetPrewarmingForEligibleWorkflows(
-                currentOfferingId: currentOfferingId
+            await workflowAssetPrewarmer.scheduleAssetPrewarmingForPrefetchedWorkflows(
+                includingOfferingId: includingOfferingId
             )
         } else {
             _ = await remoteConfigManager.awaitTopicAndPrefetchBlobsReady(.workflows)

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -604,7 +604,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                                                 uiConfigProvider: systemInfo.remoteConfigEnabled
                                                 ? uiConfigProvider
                                                 : nil,
-                                                workflowPrewarmer: systemInfo.remoteConfigEnabled
+                                                workflowAssetPrewarmer: systemInfo.remoteConfigEnabled
                                                 ? workflowManager
                                                 : nil)
         let manageSubsHelper = ManageSubscriptionsHelper(systemInfo: systemInfo,

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -604,8 +604,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                                                 uiConfigProvider: systemInfo.remoteConfigEnabled
                                                 ? uiConfigProvider
                                                 : nil,
-                                                workflowsConfigProvider: systemInfo.remoteConfigEnabled
-                                                ? workflowsConfigProvider
+                                                workflowPrewarmer: systemInfo.remoteConfigEnabled
+                                                ? workflowManager
                                                 : nil)
         let manageSubsHelper = ManageSubscriptionsHelper(systemInfo: systemInfo,
                                                          customerInfoManager: customerInfoManager,

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -18,7 +18,7 @@ import Foundation
 /// work, but the asset-prewarming work itself is fire-and-forget.
 protocol WorkflowAssetPrewarmingType: Sendable {
 
-    func scheduleAssetPrewarmingForEligibleWorkflows(currentOfferingId: String?) async
+    func scheduleAssetPrewarmingForPrefetchedWorkflows(includingOfferingId: String?) async
 
 }
 
@@ -32,11 +32,11 @@ protocol WorkflowAssetPrewarmingType: Sendable {
 /// workflow body is a shared, content-addressed blob resolved (and downloaded on demand, deduped) by
 /// `RemoteConfigManager`.
 ///
-/// Workflow asset prewarming has two entry paths that converge on `handleResolvedWorkflow(_:)`:
+/// Workflow asset prewarming has two entry paths:
 ///
 /// - **Read path:** `getWorkflow` and `cachedWorkflow` already have a decoded workflow. They schedule its asset
 ///   prewarming while returning that same decoded value to the caller.
-/// - **Body-data path:** ``scheduleAssetPrewarmingForEligibleWorkflows(currentOfferingId:)`` first caches raw body
+/// - **Body-data path:** ``scheduleAssetPrewarmingForPrefetchedWorkflows(includingOfferingId:)`` first caches raw body
 ///   data for workflows marked `prefetch` plus the current offering's workflow. It then transiently decodes those
 ///   workflows on a background worker solely to discover their assets. That decode is never retained in
 ///   `LazyPublishedWorkflow`; the graph is released after the asset-prewarming task finishes.
@@ -63,7 +63,8 @@ class WorkflowManager: WorkflowAssetPrewarmingType {
     func getWorkflow(workflowId: String) async throws -> WorkflowDataResult {
         switch await self.workflowsConfigProvider.getWorkflow(workflowId: workflowId) {
         case let .success(result):
-            return self.handleResolvedWorkflow(result)
+            self.scheduleAssetPrewarming(for: result)
+            return result
         case .failure(.notFound):
             throw BackendError.workflowNotFound(workflowId: workflowId)
         case let .failure(.decodingFailed(error)):
@@ -82,7 +83,8 @@ class WorkflowManager: WorkflowAssetPrewarmingType {
             return nil
         }
 
-        return self.handleResolvedWorkflow(result)
+        self.scheduleAssetPrewarming(for: result)
+        return result
     }
 
     /// Resolves `offeringId` to its workflow for `Purchases.workflow(forOfferingIdentifier:)`. Fails
@@ -108,9 +110,9 @@ class WorkflowManager: WorkflowAssetPrewarmingType {
     /// workflow cannot prevent sibling workflows from prewarming or delay offerings delivery.
     ///
     /// Only body-data readiness is awaited; decoding and downloads never delay offerings.
-    func scheduleAssetPrewarmingForEligibleWorkflows(currentOfferingId: String?) async {
-        let workflowIDsWithCachedBodyData = await self.workflowsConfigProvider.cacheEligibleWorkflowBodyData(
-            currentOfferingId: currentOfferingId
+    func scheduleAssetPrewarmingForPrefetchedWorkflows(includingOfferingId: String?) async {
+        let workflowIDsWithCachedBodyData = await self.workflowsConfigProvider.cachePrefetchedWorkflowBodyData(
+            includingOfferingId: includingOfferingId
         )
         guard !workflowIDsWithCachedBodyData.isEmpty else { return }
 
@@ -123,7 +125,7 @@ class WorkflowManager: WorkflowAssetPrewarmingType {
                     workflowId: workflowId
                 ) else { continue }
 
-                _ = self.handleResolvedWorkflow(result)
+                self.scheduleAssetPrewarming(for: result)
             }
         }
     }
@@ -131,11 +133,6 @@ class WorkflowManager: WorkflowAssetPrewarmingType {
 }
 
 private extension WorkflowManager {
-
-    func handleResolvedWorkflow(_ result: WorkflowDataResult) -> WorkflowDataResult {
-        self.scheduleAssetPrewarming(for: result)
-        return result
-    }
 
     /// Fire-and-forget pre-download of a resolved workflow's images/videos/fonts. Remote config's own
     /// blob prefetch only covers the workflow's JSON body, not the assets it references.

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -13,6 +13,9 @@
 
 import Foundation
 
+/// Starts asset prewarming for workflows selected by remote config without making offerings delivery wait for
+/// workflow decoding or asset downloads. Implementations may await the workflow body data needed to enqueue that
+/// work, but the asset-prewarming work itself is fire-and-forget.
 protocol WorkflowAssetPrewarmingType: Sendable {
 
     func scheduleAssetPrewarmingForEligibleWorkflows(currentOfferingId: String?) async
@@ -28,6 +31,17 @@ protocol WorkflowAssetPrewarmingType: Sendable {
 /// no stale-while-revalidate, no disk fallback, and no synchronous cache seed here anymore — a
 /// workflow body is a shared, content-addressed blob resolved (and downloaded on demand, deduped) by
 /// `RemoteConfigManager`.
+///
+/// Workflow asset prewarming has two entry paths that converge on `handleResolvedWorkflow(_:)`:
+///
+/// - **Read path:** `getWorkflow` and `cachedWorkflow` already have a decoded workflow. They schedule its asset
+///   prewarming while returning that same decoded value to the caller.
+/// - **Body-data path:** ``scheduleAssetPrewarmingForEligibleWorkflows(currentOfferingId:)`` first caches raw body
+///   data for workflows marked `prefetch` plus the current offering's workflow. It then transiently decodes those
+///   workflows on a background worker solely to discover their assets. That decode is never retained in
+///   `LazyPublishedWorkflow`; the graph is released after the asset-prewarming task finishes.
+///
+/// Both paths use the same `PaywallCacheWarming` entry point, which deduplicates asset prewarming by workflow ID.
 class WorkflowManager: WorkflowAssetPrewarmingType {
 
     private let workflowsConfigProvider: WorkflowsConfigProviderType
@@ -86,8 +100,14 @@ class WorkflowManager: WorkflowAssetPrewarmingType {
     }
 
     /// Caches the prefetched and current-offering workflow body data before scheduling its decode and asset
-    /// prewarming in the background. Only body-data readiness is awaited; decoding and downloads never delay
-    /// offerings.
+    /// prewarming in the background.
+    ///
+    /// The returned body IDs belong to the current config generation and are decoded transiently: the decoded
+    /// graphs are passed to the shared asset-prewarming path without replacing their cached raw body data. A later
+    /// presentation therefore performs the normal retained decode. Individual failures are ignored so one malformed
+    /// workflow cannot prevent sibling workflows from prewarming or delay offerings delivery.
+    ///
+    /// Only body-data readiness is awaited; decoding and downloads never delay offerings.
     func scheduleAssetPrewarmingForEligibleWorkflows(currentOfferingId: String?) async {
         let workflowIDsWithCachedBodyData = await self.workflowsConfigProvider.cacheEligibleWorkflowBodyData(
             currentOfferingId: currentOfferingId

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -122,6 +122,11 @@ class WorkflowManager: WorkflowAssetPrewarmingType {
             guard #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *), let paywallCache else { return }
 
             for workflowId in workflowIDsWithCachedBodyData {
+                let hasStartedAssetPrewarming = await paywallCache.hasStartedWorkflowAssetPrewarming(
+                    for: workflowId
+                )
+                guard !hasStartedAssetPrewarming else { continue }
+
                 let resolution = await self.workflowsConfigProvider.decodeCachedWorkflowForAssetPrewarming(
                     workflowId: workflowId
                 )

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -122,12 +122,18 @@ class WorkflowManager: WorkflowAssetPrewarmingType {
             guard #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *), let paywallCache else { return }
 
             for workflowId in workflowIDsWithCachedBodyData {
-                guard case let .success(result) = await self.workflowsConfigProvider
-                    .decodeCachedWorkflowForAssetPrewarming(
+                let resolution = await self.workflowsConfigProvider.decodeCachedWorkflowForAssetPrewarming(
                     workflowId: workflowId
-                ) else { continue }
-
-                await paywallCache.prewarmWorkflowAssets(workflow: result.workflow, uiConfig: result.uiConfig)
+                )
+                switch resolution {
+                case let .success(result):
+                    await paywallCache.prewarmWorkflowAssets(workflow: result.workflow, uiConfig: result.uiConfig)
+                case let .failure(error):
+                    Logger.debug(Strings.paywalls.workflow_resolution_for_asset_prewarming_failed(
+                        workflowId: workflowId,
+                        error: error
+                    ))
+                }
             }
         }
     }

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -107,7 +107,8 @@ class WorkflowManager: WorkflowAssetPrewarmingType {
     /// The returned body IDs belong to the current config generation and are decoded transiently: the decoded
     /// graphs are passed to the shared asset-prewarming path without replacing their cached raw body data. A later
     /// presentation therefore performs the normal retained decode. Individual failures are ignored so one malformed
-    /// workflow cannot prevent sibling workflows from prewarming or delay offerings delivery.
+    /// workflow cannot prevent sibling workflows from prewarming or delay offerings delivery. The included
+    /// offering's workflow is warmed first, then the remaining prefetched workflows are warmed sequentially.
     ///
     /// Only body-data readiness is awaited; decoding and downloads never delay offerings.
     func scheduleAssetPrewarmingForPrefetchedWorkflows(includingOfferingId: String?) async {
@@ -118,6 +119,7 @@ class WorkflowManager: WorkflowAssetPrewarmingType {
 
         self.operationDispatcher.dispatchOnWorkerThread { [weak self] in
             guard let self else { return }
+            guard #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *), let paywallCache else { return }
 
             for workflowId in workflowIDsWithCachedBodyData {
                 guard case let .success(result) = await self.workflowsConfigProvider
@@ -125,7 +127,7 @@ class WorkflowManager: WorkflowAssetPrewarmingType {
                     workflowId: workflowId
                 ) else { continue }
 
-                self.scheduleAssetPrewarming(for: result)
+                await paywallCache.prewarmWorkflowAssets(workflow: result.workflow, uiConfig: result.uiConfig)
             }
         }
     }

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -13,9 +13,9 @@
 
 import Foundation
 
-protocol WorkflowPrewarmingType: Sendable {
+protocol WorkflowAssetPrewarmingType: Sendable {
 
-    func prewarmWorkflows(currentOfferingId: String?) async
+    func scheduleAssetPrewarmingForEligibleWorkflows(currentOfferingId: String?) async
 
 }
 
@@ -28,7 +28,7 @@ protocol WorkflowPrewarmingType: Sendable {
 /// no stale-while-revalidate, no disk fallback, and no synchronous cache seed here anymore — a
 /// workflow body is a shared, content-addressed blob resolved (and downloaded on demand, deduped) by
 /// `RemoteConfigManager`.
-class WorkflowManager: WorkflowPrewarmingType {
+class WorkflowManager: WorkflowAssetPrewarmingType {
 
     private let workflowsConfigProvider: WorkflowsConfigProviderType
     private let paywallCache: PaywallCacheWarmingType?
@@ -85,19 +85,21 @@ class WorkflowManager: WorkflowPrewarmingType {
         return try await self.getWorkflow(workflowId: workflowId)
     }
 
-    /// Loads the prefetched and current-offering workflow bodies before scheduling their decode and asset
-    /// warming in the background. Only body readiness is awaited; decoding and downloads never delay offerings.
-    func prewarmWorkflows(currentOfferingId: String?) async {
-        let workflowIds = await self.workflowsConfigProvider.warmPrefetchedWorkflows(
+    /// Caches the prefetched and current-offering workflow body data before scheduling its decode and asset
+    /// prewarming in the background. Only body-data readiness is awaited; decoding and downloads never delay
+    /// offerings.
+    func scheduleAssetPrewarmingForEligibleWorkflows(currentOfferingId: String?) async {
+        let workflowIDsWithCachedBodyData = await self.workflowsConfigProvider.cacheEligibleWorkflowBodyData(
             currentOfferingId: currentOfferingId
         )
-        guard !workflowIds.isEmpty else { return }
+        guard !workflowIDsWithCachedBodyData.isEmpty else { return }
 
         self.operationDispatcher.dispatchOnWorkerThread { [weak self] in
             guard let self else { return }
 
-            for workflowId in workflowIds {
-                guard case let .success(result) = await self.workflowsConfigProvider.getWorkflowForPrewarming(
+            for workflowId in workflowIDsWithCachedBodyData {
+                guard case let .success(result) = await self.workflowsConfigProvider
+                    .decodeCachedWorkflowForAssetPrewarming(
                     workflowId: workflowId
                 ) else { continue }
 
@@ -111,17 +113,17 @@ class WorkflowManager: WorkflowPrewarmingType {
 private extension WorkflowManager {
 
     func handleResolvedWorkflow(_ result: WorkflowDataResult) -> WorkflowDataResult {
-        self.warmUpAssets(for: result)
+        self.scheduleAssetPrewarming(for: result)
         return result
     }
 
     /// Fire-and-forget pre-download of a resolved workflow's images/videos/fonts. Remote config's own
     /// blob prefetch only covers the workflow's JSON body, not the assets it references.
-    func warmUpAssets(for result: WorkflowDataResult) {
+    func scheduleAssetPrewarming(for result: WorkflowDataResult) {
         guard #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *), let paywallCache else { return }
 
         self.operationDispatcher.dispatchOnWorkerThread {
-            await paywallCache.warmUpWorkflowCaches(workflow: result.workflow, uiConfig: result.uiConfig)
+            await paywallCache.prewarmWorkflowAssets(workflow: result.workflow, uiConfig: result.uiConfig)
         }
     }
 

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -13,6 +13,12 @@
 
 import Foundation
 
+protocol WorkflowPrewarmingType: Sendable {
+
+    func prewarmWorkflows(currentOfferingId: String?) async
+
+}
+
 /// The consumer-facing entry point for reading workflows. It stays as the seam the SDK calls (so
 /// `Purchases` and its public API are unchanged), but it is now a thin adapter that reads from the
 /// `/v1/config` layer through ``WorkflowsConfigProvider`` instead of calling a dedicated
@@ -22,7 +28,7 @@ import Foundation
 /// no stale-while-revalidate, no disk fallback, and no synchronous cache seed here anymore — a
 /// workflow body is a shared, content-addressed blob resolved (and downloaded on demand, deduped) by
 /// `RemoteConfigManager`.
-class WorkflowManager {
+class WorkflowManager: WorkflowPrewarmingType {
 
     private let workflowsConfigProvider: WorkflowsConfigProviderType
     private let paywallCache: PaywallCacheWarmingType?
@@ -43,8 +49,7 @@ class WorkflowManager {
     func getWorkflow(workflowId: String) async throws -> WorkflowDataResult {
         switch await self.workflowsConfigProvider.getWorkflow(workflowId: workflowId) {
         case let .success(result):
-            self.warmUpAssets(for: result)
-            return result
+            return self.handleResolvedWorkflow(result)
         case .failure(.notFound):
             throw BackendError.workflowNotFound(workflowId: workflowId)
         case let .failure(.decodingFailed(error)):
@@ -63,8 +68,7 @@ class WorkflowManager {
             return nil
         }
 
-        self.warmUpAssets(for: result)
-        return result
+        return self.handleResolvedWorkflow(result)
     }
 
     /// Resolves `offeringId` to its workflow for `Purchases.workflow(forOfferingIdentifier:)`. Fails
@@ -81,9 +85,35 @@ class WorkflowManager {
         return try await self.getWorkflow(workflowId: workflowId)
     }
 
+    /// Loads the prefetched and current-offering workflow bodies before scheduling their decode and asset
+    /// warming in the background. Only body readiness is awaited; decoding and downloads never delay offerings.
+    func prewarmWorkflows(currentOfferingId: String?) async {
+        let workflowIds = await self.workflowsConfigProvider.warmPrefetchedWorkflows(
+            currentOfferingId: currentOfferingId
+        )
+        guard !workflowIds.isEmpty else { return }
+
+        self.operationDispatcher.dispatchOnWorkerThread { [weak self] in
+            guard let self else { return }
+
+            for workflowId in workflowIds {
+                guard case let .success(result) = await self.workflowsConfigProvider.getWorkflowForPrewarming(
+                    workflowId: workflowId
+                ) else { continue }
+
+                _ = self.handleResolvedWorkflow(result)
+            }
+        }
+    }
+
 }
 
 private extension WorkflowManager {
+
+    func handleResolvedWorkflow(_ result: WorkflowDataResult) -> WorkflowDataResult {
+        self.warmUpAssets(for: result)
+        return result
+    }
 
     /// Fire-and-forget pre-download of a resolved workflow's images/videos/fonts. Remote config's own
     /// blob prefetch only covers the workflow's JSON body, not the assets it references.

--- a/Tests/UnitTests/Mocks/MockOperationDispatcher.swift
+++ b/Tests/UnitTests/Mocks/MockOperationDispatcher.swift
@@ -79,6 +79,7 @@ class MockOperationDispatcher: OperationDispatcher {
     var invokedDispatchAsyncOnWorkerThread = false
     var invokedDispatchAsyncOnWorkerThreadCount = 0
     var invokedDispatchAsyncOnWorkerThreadDelayParam: JitterableDelay?
+    private(set) var dispatchedAsyncWorkerThreadBlocks: [@Sendable () async -> Void] = []
 
     override func dispatchOnWorkerThread(
         jitterableDelay delay: JitterableDelay = .none,
@@ -87,6 +88,7 @@ class MockOperationDispatcher: OperationDispatcher {
         self.invokedDispatchAsyncOnWorkerThreadDelayParam = delay
         self.invokedDispatchAsyncOnWorkerThread = true
         self.invokedDispatchAsyncOnWorkerThreadCount += 1
+        self.dispatchedAsyncWorkerThreadBlocks.append(block)
 
         if self.forwardToOriginalDispatchOnWorkerThread {
             super.dispatchOnWorkerThread(jitterableDelay: delay, block: block)
@@ -110,6 +112,13 @@ class MockOperationDispatcher: OperationDispatcher {
             if result == .timedOut {
                 XCTFail("Dispatch on worker thread timed out")
             }
+        }
+    }
+
+    func invokeAllDispatchedAsyncWorkerThreadBlocks() async {
+        while !self.dispatchedAsyncWorkerThreadBlocks.isEmpty {
+            let block = self.dispatchedAsyncWorkerThreadBlocks.removeFirst()
+            await block()
         }
     }
 

--- a/Tests/UnitTests/Mocks/MockPaywallCacheWarming.swift
+++ b/Tests/UnitTests/Mocks/MockPaywallCacheWarming.swift
@@ -145,6 +145,10 @@ final class MockPaywallCacheWarming: PaywallCacheWarmingType {
         self.invokedPrewarmWorkflowAssetsUiConfig = uiConfig
     }
 
+    func hasStartedWorkflowAssetPrewarming(for workflowID: String) async -> Bool {
+        return self.invokedPrewarmWorkflowAssetIDs.contains(workflowID)
+    }
+
 #if !os(tvOS)
 
     private let _invokedTriggerFontDownloadIfNeeded: Atomic<Bool> = false

--- a/Tests/UnitTests/Mocks/MockPaywallCacheWarming.swift
+++ b/Tests/UnitTests/Mocks/MockPaywallCacheWarming.swift
@@ -111,33 +111,33 @@ final class MockPaywallCacheWarming: PaywallCacheWarmingType {
 
     // MARK: -
 
-    private let _invokedWarmUpWorkflowCaches: Atomic<Bool> = false
-    private let _invokedWarmUpWorkflowCachesCount: Atomic<Int> = .init(0)
-    private let _invokedWarmUpWorkflowCachesWorkflow: Atomic<PublishedWorkflow?> = nil
-    private let _invokedWarmUpWorkflowCachesUiConfig: Atomic<UIConfig?> = nil
+    private let _invokedPrewarmWorkflowAssets: Atomic<Bool> = false
+    private let _invokedPrewarmWorkflowAssetsCount: Atomic<Int> = .init(0)
+    private let _invokedPrewarmWorkflowAssetsWorkflow: Atomic<PublishedWorkflow?> = nil
+    private let _invokedPrewarmWorkflowAssetsUiConfig: Atomic<UIConfig?> = nil
 
-    var invokedWarmUpWorkflowCaches: Bool {
-        get { return self._invokedWarmUpWorkflowCaches.value }
-        set { self._invokedWarmUpWorkflowCaches.value = newValue }
+    var invokedPrewarmWorkflowAssets: Bool {
+        get { return self._invokedPrewarmWorkflowAssets.value }
+        set { self._invokedPrewarmWorkflowAssets.value = newValue }
     }
-    var invokedWarmUpWorkflowCachesCount: Int {
-        get { return self._invokedWarmUpWorkflowCachesCount.value }
-        set { self._invokedWarmUpWorkflowCachesCount.value = newValue }
+    var invokedPrewarmWorkflowAssetsCount: Int {
+        get { return self._invokedPrewarmWorkflowAssetsCount.value }
+        set { self._invokedPrewarmWorkflowAssetsCount.value = newValue }
     }
-    var invokedWarmUpWorkflowCachesWorkflow: PublishedWorkflow? {
-        get { return self._invokedWarmUpWorkflowCachesWorkflow.value }
-        set { self._invokedWarmUpWorkflowCachesWorkflow.value = newValue }
+    var invokedPrewarmWorkflowAssetsWorkflow: PublishedWorkflow? {
+        get { return self._invokedPrewarmWorkflowAssetsWorkflow.value }
+        set { self._invokedPrewarmWorkflowAssetsWorkflow.value = newValue }
     }
-    var invokedWarmUpWorkflowCachesUiConfig: UIConfig? {
-        get { return self._invokedWarmUpWorkflowCachesUiConfig.value }
-        set { self._invokedWarmUpWorkflowCachesUiConfig.value = newValue }
+    var invokedPrewarmWorkflowAssetsUiConfig: UIConfig? {
+        get { return self._invokedPrewarmWorkflowAssetsUiConfig.value }
+        set { self._invokedPrewarmWorkflowAssetsUiConfig.value = newValue }
     }
 
-    func warmUpWorkflowCaches(workflow: PublishedWorkflow, uiConfig: UIConfig) async {
-        self.invokedWarmUpWorkflowCaches = true
-        self._invokedWarmUpWorkflowCachesCount.modify { $0 += 1 }
-        self.invokedWarmUpWorkflowCachesWorkflow = workflow
-        self.invokedWarmUpWorkflowCachesUiConfig = uiConfig
+    func prewarmWorkflowAssets(workflow: PublishedWorkflow, uiConfig: UIConfig) async {
+        self.invokedPrewarmWorkflowAssets = true
+        self._invokedPrewarmWorkflowAssetsCount.modify { $0 += 1 }
+        self.invokedPrewarmWorkflowAssetsWorkflow = workflow
+        self.invokedPrewarmWorkflowAssetsUiConfig = uiConfig
     }
 
 #if !os(tvOS)

--- a/Tests/UnitTests/Mocks/MockPaywallCacheWarming.swift
+++ b/Tests/UnitTests/Mocks/MockPaywallCacheWarming.swift
@@ -113,6 +113,7 @@ final class MockPaywallCacheWarming: PaywallCacheWarmingType {
 
     private let _invokedPrewarmWorkflowAssets: Atomic<Bool> = false
     private let _invokedPrewarmWorkflowAssetsCount: Atomic<Int> = .init(0)
+    private let _invokedPrewarmWorkflowAssetIDs: Atomic<[String]> = .init([])
     private let _invokedPrewarmWorkflowAssetsWorkflow: Atomic<PublishedWorkflow?> = nil
     private let _invokedPrewarmWorkflowAssetsUiConfig: Atomic<UIConfig?> = nil
 
@@ -123,6 +124,9 @@ final class MockPaywallCacheWarming: PaywallCacheWarmingType {
     var invokedPrewarmWorkflowAssetsCount: Int {
         get { return self._invokedPrewarmWorkflowAssetsCount.value }
         set { self._invokedPrewarmWorkflowAssetsCount.value = newValue }
+    }
+    var invokedPrewarmWorkflowAssetIDs: [String] {
+        return self._invokedPrewarmWorkflowAssetIDs.value
     }
     var invokedPrewarmWorkflowAssetsWorkflow: PublishedWorkflow? {
         get { return self._invokedPrewarmWorkflowAssetsWorkflow.value }
@@ -136,6 +140,7 @@ final class MockPaywallCacheWarming: PaywallCacheWarmingType {
     func prewarmWorkflowAssets(workflow: PublishedWorkflow, uiConfig: UIConfig) async {
         self.invokedPrewarmWorkflowAssets = true
         self._invokedPrewarmWorkflowAssetsCount.modify { $0 += 1 }
+        self._invokedPrewarmWorkflowAssetIDs.modify { $0.append(workflow.id) }
         self.invokedPrewarmWorkflowAssetsWorkflow = workflow
         self.invokedPrewarmWorkflowAssetsUiConfig = uiConfig
     }

--- a/Tests/UnitTests/Mocks/MockWorkflowsConfigProvider.swift
+++ b/Tests/UnitTests/Mocks/MockWorkflowsConfigProvider.swift
@@ -54,9 +54,9 @@ final class MockWorkflowsConfigProvider: WorkflowsConfigProviderType, @unchecked
 
     private(set) var invokedCachePrefetchedWorkflowBodyDataCount = 0
     private(set) var invokedCachePrefetchedWorkflowBodyDataParameters: [String?] = []
-    var stubbedWorkflowIDsWithCachedBodyData: Set<String> = []
+    var stubbedWorkflowIDsWithCachedBodyData: [String] = []
 
-    func cachePrefetchedWorkflowBodyData(includingOfferingId: String?) async -> Set<String> {
+    func cachePrefetchedWorkflowBodyData(includingOfferingId: String?) async -> [String] {
         self.invokedCachePrefetchedWorkflowBodyDataCount += 1
         self.invokedCachePrefetchedWorkflowBodyDataParameters.append(includingOfferingId)
         return self.stubbedWorkflowIDsWithCachedBodyData

--- a/Tests/UnitTests/Mocks/MockWorkflowsConfigProvider.swift
+++ b/Tests/UnitTests/Mocks/MockWorkflowsConfigProvider.swift
@@ -30,6 +30,19 @@ final class MockWorkflowsConfigProvider: WorkflowsConfigProviderType, @unchecked
 
     func getWorkflow(workflowId: String) async -> Result<WorkflowDataResult, WorkflowResolutionError> {
         self.invokedGetWorkflowParameters.append(workflowId)
+        return self.workflowResult(workflowId: workflowId)
+    }
+
+    private(set) var invokedGetWorkflowForPrewarmingParameters: [String] = []
+
+    func getWorkflowForPrewarming(
+        workflowId: String
+    ) async -> Result<WorkflowDataResult, WorkflowResolutionError> {
+        self.invokedGetWorkflowForPrewarmingParameters.append(workflowId)
+        return self.workflowResult(workflowId: workflowId)
+    }
+
+    private func workflowResult(workflowId: String) -> Result<WorkflowDataResult, WorkflowResolutionError> {
         if let error = self.stubbedGetWorkflowError[workflowId] {
             return .failure(error)
         }
@@ -41,10 +54,12 @@ final class MockWorkflowsConfigProvider: WorkflowsConfigProviderType, @unchecked
 
     private(set) var invokedWarmPrefetchedWorkflowsCount = 0
     private(set) var invokedWarmPrefetchedWorkflowsParameters: [String?] = []
+    var stubbedWarmPrefetchedWorkflowIds: Set<String> = []
 
-    func warmPrefetchedWorkflows(currentOfferingId: String?) async {
+    func warmPrefetchedWorkflows(currentOfferingId: String?) async -> Set<String> {
         self.invokedWarmPrefetchedWorkflowsCount += 1
         self.invokedWarmPrefetchedWorkflowsParameters.append(currentOfferingId)
+        return self.stubbedWarmPrefetchedWorkflowIds
     }
 
     var stubbedCachedWorkflowResult: [String: WorkflowDataResult] = [:]
@@ -53,6 +68,16 @@ final class MockWorkflowsConfigProvider: WorkflowsConfigProviderType, @unchecked
     func cachedWorkflow(forOfferingId offeringId: String) -> WorkflowDataResult? {
         self.invokedCachedWorkflowParameters.append(offeringId)
         return self.stubbedCachedWorkflowResult[offeringId]
+    }
+
+}
+
+final class MockWorkflowPrewarmer: WorkflowPrewarmingType, @unchecked Sendable {
+
+    private(set) var invokedPrewarmWorkflowsParameters: [String?] = []
+
+    func prewarmWorkflows(currentOfferingId: String?) async {
+        self.invokedPrewarmWorkflowsParameters.append(currentOfferingId)
     }
 
 }

--- a/Tests/UnitTests/Mocks/MockWorkflowsConfigProvider.swift
+++ b/Tests/UnitTests/Mocks/MockWorkflowsConfigProvider.swift
@@ -33,12 +33,12 @@ final class MockWorkflowsConfigProvider: WorkflowsConfigProviderType, @unchecked
         return self.workflowResult(workflowId: workflowId)
     }
 
-    private(set) var invokedGetWorkflowForPrewarmingParameters: [String] = []
+    private(set) var invokedDecodeCachedWorkflowForAssetPrewarmingParameters: [String] = []
 
-    func getWorkflowForPrewarming(
+    func decodeCachedWorkflowForAssetPrewarming(
         workflowId: String
     ) async -> Result<WorkflowDataResult, WorkflowResolutionError> {
-        self.invokedGetWorkflowForPrewarmingParameters.append(workflowId)
+        self.invokedDecodeCachedWorkflowForAssetPrewarmingParameters.append(workflowId)
         return self.workflowResult(workflowId: workflowId)
     }
 
@@ -52,14 +52,14 @@ final class MockWorkflowsConfigProvider: WorkflowsConfigProviderType, @unchecked
         return .failure(.notFound)
     }
 
-    private(set) var invokedWarmPrefetchedWorkflowsCount = 0
-    private(set) var invokedWarmPrefetchedWorkflowsParameters: [String?] = []
-    var stubbedWarmPrefetchedWorkflowIds: Set<String> = []
+    private(set) var invokedCacheEligibleWorkflowBodyDataCount = 0
+    private(set) var invokedCacheEligibleWorkflowBodyDataParameters: [String?] = []
+    var stubbedWorkflowIDsWithCachedBodyData: Set<String> = []
 
-    func warmPrefetchedWorkflows(currentOfferingId: String?) async -> Set<String> {
-        self.invokedWarmPrefetchedWorkflowsCount += 1
-        self.invokedWarmPrefetchedWorkflowsParameters.append(currentOfferingId)
-        return self.stubbedWarmPrefetchedWorkflowIds
+    func cacheEligibleWorkflowBodyData(currentOfferingId: String?) async -> Set<String> {
+        self.invokedCacheEligibleWorkflowBodyDataCount += 1
+        self.invokedCacheEligibleWorkflowBodyDataParameters.append(currentOfferingId)
+        return self.stubbedWorkflowIDsWithCachedBodyData
     }
 
     var stubbedCachedWorkflowResult: [String: WorkflowDataResult] = [:]
@@ -72,12 +72,12 @@ final class MockWorkflowsConfigProvider: WorkflowsConfigProviderType, @unchecked
 
 }
 
-final class MockWorkflowPrewarmer: WorkflowPrewarmingType, @unchecked Sendable {
+final class MockWorkflowAssetPrewarmer: WorkflowAssetPrewarmingType, @unchecked Sendable {
 
-    private(set) var invokedPrewarmWorkflowsParameters: [String?] = []
+    private(set) var invokedScheduleAssetPrewarmingForEligibleWorkflowsParameters: [String?] = []
 
-    func prewarmWorkflows(currentOfferingId: String?) async {
-        self.invokedPrewarmWorkflowsParameters.append(currentOfferingId)
+    func scheduleAssetPrewarmingForEligibleWorkflows(currentOfferingId: String?) async {
+        self.invokedScheduleAssetPrewarmingForEligibleWorkflowsParameters.append(currentOfferingId)
     }
 
 }

--- a/Tests/UnitTests/Mocks/MockWorkflowsConfigProvider.swift
+++ b/Tests/UnitTests/Mocks/MockWorkflowsConfigProvider.swift
@@ -52,13 +52,13 @@ final class MockWorkflowsConfigProvider: WorkflowsConfigProviderType, @unchecked
         return .failure(.notFound)
     }
 
-    private(set) var invokedCacheEligibleWorkflowBodyDataCount = 0
-    private(set) var invokedCacheEligibleWorkflowBodyDataParameters: [String?] = []
+    private(set) var invokedCachePrefetchedWorkflowBodyDataCount = 0
+    private(set) var invokedCachePrefetchedWorkflowBodyDataParameters: [String?] = []
     var stubbedWorkflowIDsWithCachedBodyData: Set<String> = []
 
-    func cacheEligibleWorkflowBodyData(currentOfferingId: String?) async -> Set<String> {
-        self.invokedCacheEligibleWorkflowBodyDataCount += 1
-        self.invokedCacheEligibleWorkflowBodyDataParameters.append(currentOfferingId)
+    func cachePrefetchedWorkflowBodyData(includingOfferingId: String?) async -> Set<String> {
+        self.invokedCachePrefetchedWorkflowBodyDataCount += 1
+        self.invokedCachePrefetchedWorkflowBodyDataParameters.append(includingOfferingId)
         return self.stubbedWorkflowIDsWithCachedBodyData
     }
 
@@ -74,10 +74,10 @@ final class MockWorkflowsConfigProvider: WorkflowsConfigProviderType, @unchecked
 
 final class MockWorkflowAssetPrewarmer: WorkflowAssetPrewarmingType, @unchecked Sendable {
 
-    private(set) var invokedScheduleAssetPrewarmingForEligibleWorkflowsParameters: [String?] = []
+    private(set) var invokedPrefetchedAssetPrewarmingParameters: [String?] = []
 
-    func scheduleAssetPrewarmingForEligibleWorkflows(currentOfferingId: String?) async {
-        self.invokedScheduleAssetPrewarmingForEligibleWorkflowsParameters.append(currentOfferingId)
+    func scheduleAssetPrewarmingForPrefetchedWorkflows(includingOfferingId: String?) async {
+        self.invokedPrefetchedAssetPrewarmingParameters.append(includingOfferingId)
     }
 
 }

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -275,7 +275,7 @@ class WorkflowsConfigProviderTests: TestCase {
         expect(secondWorkflowId) == "wf-2"
     }
 
-    func testCacheEligibleWorkflowBodyDataCachesPrefetchedAndCurrentOfferingBodiesAndAllMappings() async throws {
+    func testCachePrefetchedWorkflowBodyDataCachesPrefetchedAndCurrentOfferingBodiesAndAllMappings() async throws {
         let prefetchedWorkflow = try Self.workflowJSON(id: "wf-prefetch")
         let currentWorkflow = try Self.workflowJSON(id: "wf-current")
         let otherWorkflow = try Self.workflowJSON(id: "wf-other")
@@ -305,7 +305,7 @@ class WorkflowsConfigProviderTests: TestCase {
             ]) { current, _ in current }
         )
 
-        async let cachedWorkflowIDs = self.provider.cacheEligibleWorkflowBodyData(currentOfferingId: "basic")
+        async let cachedWorkflowIDs = self.provider.cachePrefetchedWorkflowBodyData(includingOfferingId: "basic")
         async let uiConfigReady = self.uiConfigProvider.getUiConfig()
         let (workflowIDsWithCachedBodyData, _) = await (cachedWorkflowIDs, uiConfigReady)
 
@@ -324,7 +324,7 @@ class WorkflowsConfigProviderTests: TestCase {
         expect(self.blobFetcher.invokedEnsureDownloadedRefs).toNot(contain("wf-other-ref"))
     }
 
-    func testCacheEligibleWorkflowBodyDataDefersDecodingUntilFirstReadAndRetainsTheResult() async throws {
+    func testCachePrefetchedWorkflowBodyDataDefersDecodingUntilFirstReadAndRetainsTheResult() async throws {
         let decodeCount: Atomic<Int> = .init(0)
         self.provider = self.makeProvider(decodeCount: decodeCount)
         self.commit(
@@ -341,7 +341,7 @@ class WorkflowsConfigProviderTests: TestCase {
             ]) { current, _ in current }
         )
 
-        async let cachedWorkflowIDs = self.provider.cacheEligibleWorkflowBodyData(currentOfferingId: nil)
+        async let cachedWorkflowIDs = self.provider.cachePrefetchedWorkflowBodyData(includingOfferingId: nil)
         async let uiConfigReady = self.uiConfigProvider.getUiConfig()
         _ = await (cachedWorkflowIDs, uiConfigReady)
 
@@ -369,7 +369,7 @@ class WorkflowsConfigProviderTests: TestCase {
             ]) { current, _ in current }
         )
 
-        async let cachedWorkflowIDs = self.provider.cacheEligibleWorkflowBodyData(currentOfferingId: nil)
+        async let cachedWorkflowIDs = self.provider.cachePrefetchedWorkflowBodyData(includingOfferingId: nil)
         async let uiConfigReady = self.uiConfigProvider.getUiConfig()
         _ = await (cachedWorkflowIDs, uiConfigReady)
 
@@ -400,7 +400,7 @@ class WorkflowsConfigProviderTests: TestCase {
             ]) { current, _ in current }
         )
 
-        async let cachedWorkflowIDs = self.provider.cacheEligibleWorkflowBodyData(currentOfferingId: nil)
+        async let cachedWorkflowIDs = self.provider.cachePrefetchedWorkflowBodyData(includingOfferingId: nil)
         async let uiConfigReady = self.uiConfigProvider.getUiConfig()
         _ = await (cachedWorkflowIDs, uiConfigReady)
 
@@ -416,7 +416,7 @@ class WorkflowsConfigProviderTests: TestCase {
         expect(decodeCount.value) == 1
     }
 
-    func testCacheEligibleWorkflowBodyDataReturnsEarlyWhenBodiesAreAlreadyCachedForGeneration() async throws {
+    func testCachePrefetchedWorkflowBodyDataReturnsEarlyWhenBodiesAreAlreadyCachedForGeneration() async throws {
         self.commit(
             workflows: [
                 "wf-prefetch": .init(
@@ -431,18 +431,18 @@ class WorkflowsConfigProviderTests: TestCase {
             ]) { current, _ in current }
         )
 
-        async let cachedWorkflowIDs = self.provider.cacheEligibleWorkflowBodyData(currentOfferingId: nil)
+        async let cachedWorkflowIDs = self.provider.cachePrefetchedWorkflowBodyData(includingOfferingId: nil)
         async let uiConfigReady = self.uiConfigProvider.getUiConfig()
         _ = await (cachedWorkflowIDs, uiConfigReady)
         let ensureAllDownloadedCountAfterFirstCache = self.blobFetcher.invokedEnsureAllDownloadedRefs.count
 
-        await self.provider.cacheEligibleWorkflowBodyData(currentOfferingId: nil)
+        await self.provider.cachePrefetchedWorkflowBodyData(includingOfferingId: nil)
 
         expect(self.provider.cachedWorkflow(forOfferingId: "premium")?.workflow.id) == "wf-prefetch"
         expect(self.blobFetcher.invokedEnsureAllDownloadedRefs.count) == ensureAllDownloadedCountAfterFirstCache
     }
 
-    func testCacheEligibleWorkflowBodyDataCachesNewCurrentOfferingAndRetainsExistingWorkflow() async throws {
+    func testCachePrefetchedWorkflowBodyDataCachesNewCurrentOfferingAndRetainsExistingWorkflow() async throws {
         let decodeCount: Atomic<Int> = .init(0)
         self.provider = self.makeProvider(decodeCount: decodeCount)
         self.commit(
@@ -465,20 +465,20 @@ class WorkflowsConfigProviderTests: TestCase {
             ]) { current, _ in current }
         )
 
-        await self.provider.cacheEligibleWorkflowBodyData(currentOfferingId: "first")
+        await self.provider.cachePrefetchedWorkflowBodyData(includingOfferingId: "first")
         _ = await self.uiConfigProvider.getUiConfig()
         expect(self.provider.cachedWorkflow(forOfferingId: "first")?.workflow.id) == "wf-first"
         expect(decodeCount.value) == 1
         expect(self.provider.cachedWorkflow(forOfferingId: "second")).to(beNil())
 
-        await self.provider.cacheEligibleWorkflowBodyData(currentOfferingId: "second")
+        await self.provider.cachePrefetchedWorkflowBodyData(includingOfferingId: "second")
 
         expect(self.provider.cachedWorkflow(forOfferingId: "first")?.workflow.id) == "wf-first"
         expect(self.provider.cachedWorkflow(forOfferingId: "second")?.workflow.id) == "wf-second"
         expect(decodeCount.value) == 2
     }
 
-    func testCacheEligibleWorkflowBodyDataRetriesMissingCurrentOfferingBody() async throws {
+    func testCachePrefetchedWorkflowBodyDataRetriesMissingCurrentOfferingBody() async throws {
         self.commit(
             workflows: [
                 "wf-current": .init(
@@ -491,15 +491,15 @@ class WorkflowsConfigProviderTests: TestCase {
             blobs: Self.uiConfigBlobs
         )
 
-        let initiallyCachedWorkflowIDs = await self.provider.cacheEligibleWorkflowBodyData(
-            currentOfferingId: "current"
+        let initiallyCachedWorkflowIDs = await self.provider.cachePrefetchedWorkflowBodyData(
+            includingOfferingId: "current"
         )
         _ = await self.uiConfigProvider.getUiConfig()
         expect(initiallyCachedWorkflowIDs).to(beEmpty())
         expect(self.provider.cachedWorkflow(forOfferingId: "current")).to(beNil())
 
         self.blobStore.stubbedData["wf-current-ref"] = try Self.workflowJSON(id: "wf-current")
-        let retriedWorkflowIDs = await self.provider.cacheEligibleWorkflowBodyData(currentOfferingId: "current")
+        let retriedWorkflowIDs = await self.provider.cachePrefetchedWorkflowBodyData(includingOfferingId: "current")
 
         expect(retriedWorkflowIDs) == ["wf-current"]
         expect(self.provider.cachedWorkflow(forOfferingId: "current")?.workflow.id) == "wf-current"
@@ -520,7 +520,7 @@ class WorkflowsConfigProviderTests: TestCase {
                 "wf-prefetch-ref": try Self.workflowJSON(id: "wf-prefetch")
             ]) { current, _ in current }
         )
-        async let cachedWorkflowIDs = self.provider.cacheEligibleWorkflowBodyData(currentOfferingId: nil)
+        async let cachedWorkflowIDs = self.provider.cachePrefetchedWorkflowBodyData(includingOfferingId: nil)
         async let uiConfigReady = self.uiConfigProvider.getUiConfig()
         _ = await (cachedWorkflowIDs, uiConfigReady)
         expect(self.provider.cachedWorkflow(forOfferingId: "premium")).toNot(beNil())
@@ -530,7 +530,7 @@ class WorkflowsConfigProviderTests: TestCase {
         expect(self.provider.cachedWorkflow(forOfferingId: "premium")).to(beNil())
     }
 
-    func testCacheEligibleWorkflowBodyDataStoresCacheWhenGenerationChangesDuringInitialTopicRead() async throws {
+    func testCachePrefetchedWorkflowBodyDataStoresCacheWhenGenerationChangesDuringInitialTopicRead() async throws {
         let mockManager = MockRemoteConfigManager()
         let uiConfigProvider = UiConfigProvider(manager: mockManager)
         let provider = WorkflowsConfigProvider(manager: mockManager, uiConfigProvider: uiConfigProvider)
@@ -549,7 +549,7 @@ class WorkflowsConfigProviderTests: TestCase {
         mockManager.stubbedBlobData[.uiConfig] = Self.uiConfigBlobsByItemKey
         mockManager.shouldStoreTopicCompletion = true
 
-        async let cachedWorkflowIDs = provider.cacheEligibleWorkflowBodyData(currentOfferingId: nil)
+        async let cachedWorkflowIDs = provider.cachePrefetchedWorkflowBodyData(includingOfferingId: nil)
         await self.waitUntilTopicRequested(on: mockManager)
         mockManager.configGeneration += 1
         mockManager.completeStoredTopic(with: workflowsTopic)

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -318,7 +318,7 @@ class WorkflowsConfigProviderTests: TestCase {
         expect(cachedCurrent?.workflow.id) == "wf-current"
         expect(cachedOther).to(beNil())
         expect(mappedOther) == "wf-other"
-        expect(workflowIDsWithCachedBodyData) == ["wf-prefetch", "wf-current"]
+        expect(workflowIDsWithCachedBodyData) == ["wf-current", "wf-prefetch"]
         expect(self.blobFetcher.invokedEnsureDownloadedRefs).to(contain("wf-prefetch-ref"))
         expect(self.blobFetcher.invokedEnsureDownloadedRefs).to(contain("wf-current-ref"))
         expect(self.blobFetcher.invokedEnsureDownloadedRefs).toNot(contain("wf-other-ref"))

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -305,9 +305,9 @@ class WorkflowsConfigProviderTests: TestCase {
             ]) { current, _ in current }
         )
 
-        async let workflowsWarm: Void = self.provider.warmPrefetchedWorkflows(currentOfferingId: "basic")
+        async let workflowsWarm = self.provider.warmPrefetchedWorkflows(currentOfferingId: "basic")
         async let uiConfigWarm = self.uiConfigProvider.getUiConfig()
-        _ = await (workflowsWarm, uiConfigWarm)
+        let (warmedWorkflowIds, _) = await (workflowsWarm, uiConfigWarm)
 
         let cachedPrefetched = self.provider.cachedWorkflow(forOfferingId: "premium")
         let cachedCurrent = self.provider.cachedWorkflow(forOfferingId: "basic")
@@ -318,6 +318,7 @@ class WorkflowsConfigProviderTests: TestCase {
         expect(cachedCurrent?.workflow.id) == "wf-current"
         expect(cachedOther).to(beNil())
         expect(mappedOther) == "wf-other"
+        expect(warmedWorkflowIds) == ["wf-prefetch", "wf-current"]
         expect(self.blobFetcher.invokedEnsureDownloadedRefs).to(contain("wf-prefetch-ref"))
         expect(self.blobFetcher.invokedEnsureDownloadedRefs).to(contain("wf-current-ref"))
         expect(self.blobFetcher.invokedEnsureDownloadedRefs).toNot(contain("wf-other-ref"))
@@ -340,7 +341,7 @@ class WorkflowsConfigProviderTests: TestCase {
             ]) { current, _ in current }
         )
 
-        async let workflowsWarm: Void = self.provider.warmPrefetchedWorkflows(currentOfferingId: nil)
+        async let workflowsWarm = self.provider.warmPrefetchedWorkflows(currentOfferingId: nil)
         async let uiConfigWarm = self.uiConfigProvider.getUiConfig()
         _ = await (workflowsWarm, uiConfigWarm)
 
@@ -349,6 +350,37 @@ class WorkflowsConfigProviderTests: TestCase {
         expect(decodeCount.value) == 1
         expect(self.provider.cachedWorkflow(forOfferingId: "premium")?.workflow.id) == "wf-prefetch"
         expect(decodeCount.value) == 1
+    }
+
+    func testWorkflowPrewarmingDecodeIsNotRetainedForLaterUse() async throws {
+        let decodeCount: Atomic<Int> = .init(0)
+        self.provider = self.makeProvider(decodeCount: decodeCount)
+        self.commit(
+            workflows: [
+                "wf-prefetch": .init(
+                    blobRef: "wf-prefetch-ref",
+                    prefetch: true,
+                    content: ["offeringIdentifier": "premium"]
+                )
+            ],
+            uiConfig: Self.uiConfigTopic,
+            blobs: Self.uiConfigBlobs.merging([
+                "wf-prefetch-ref": try Self.workflowJSON(id: "wf-prefetch")
+            ]) { current, _ in current }
+        )
+
+        async let workflowsWarm = self.provider.warmPrefetchedWorkflows(currentOfferingId: nil)
+        async let uiConfigWarm = self.uiConfigProvider.getUiConfig()
+        _ = await (workflowsWarm, uiConfigWarm)
+
+        let prewarmResult = await self.provider.getWorkflowForPrewarming(workflowId: "wf-prefetch")
+        expect(try prewarmResult.get().workflow.id) == "wf-prefetch"
+        expect(decodeCount.value) == 1
+
+        expect(self.provider.cachedWorkflow(forOfferingId: "premium")?.workflow.id) == "wf-prefetch"
+        expect(decodeCount.value) == 2
+        expect(self.provider.cachedWorkflow(forOfferingId: "premium")?.workflow.id) == "wf-prefetch"
+        expect(decodeCount.value) == 2
     }
 
     func testMalformedPrefetchedWorkflowWarmsAsBytesAndFailsOnceWhenRead() async throws {
@@ -368,7 +400,7 @@ class WorkflowsConfigProviderTests: TestCase {
             ]) { current, _ in current }
         )
 
-        async let workflowsWarm: Void = self.provider.warmPrefetchedWorkflows(currentOfferingId: nil)
+        async let workflowsWarm = self.provider.warmPrefetchedWorkflows(currentOfferingId: nil)
         async let uiConfigWarm = self.uiConfigProvider.getUiConfig()
         _ = await (workflowsWarm, uiConfigWarm)
 
@@ -399,7 +431,7 @@ class WorkflowsConfigProviderTests: TestCase {
             ]) { current, _ in current }
         )
 
-        async let workflowsWarm: Void = self.provider.warmPrefetchedWorkflows(currentOfferingId: nil)
+        async let workflowsWarm = self.provider.warmPrefetchedWorkflows(currentOfferingId: nil)
         async let uiConfigWarm = self.uiConfigProvider.getUiConfig()
         _ = await (workflowsWarm, uiConfigWarm)
         let ensureAllDownloadedCountAfterFirstWarm = self.blobFetcher.invokedEnsureAllDownloadedRefs.count
@@ -459,13 +491,15 @@ class WorkflowsConfigProviderTests: TestCase {
             blobs: Self.uiConfigBlobs
         )
 
-        await self.provider.warmPrefetchedWorkflows(currentOfferingId: "current")
+        let initiallyWarmedWorkflowIds = await self.provider.warmPrefetchedWorkflows(currentOfferingId: "current")
         _ = await self.uiConfigProvider.getUiConfig()
+        expect(initiallyWarmedWorkflowIds).to(beEmpty())
         expect(self.provider.cachedWorkflow(forOfferingId: "current")).to(beNil())
 
         self.blobStore.stubbedData["wf-current-ref"] = try Self.workflowJSON(id: "wf-current")
-        await self.provider.warmPrefetchedWorkflows(currentOfferingId: "current")
+        let retriedWorkflowIds = await self.provider.warmPrefetchedWorkflows(currentOfferingId: "current")
 
+        expect(retriedWorkflowIds) == ["wf-current"]
         expect(self.provider.cachedWorkflow(forOfferingId: "current")?.workflow.id) == "wf-current"
         expect(self.blobFetcher.invokedEnsureDownloadedRefs.filter { $0 == "wf-current-ref" }.count) == 2
     }
@@ -484,7 +518,7 @@ class WorkflowsConfigProviderTests: TestCase {
                 "wf-prefetch-ref": try Self.workflowJSON(id: "wf-prefetch")
             ]) { current, _ in current }
         )
-        async let workflowsWarm: Void = self.provider.warmPrefetchedWorkflows(currentOfferingId: nil)
+        async let workflowsWarm = self.provider.warmPrefetchedWorkflows(currentOfferingId: nil)
         async let uiConfigWarm = self.uiConfigProvider.getUiConfig()
         _ = await (workflowsWarm, uiConfigWarm)
         expect(self.provider.cachedWorkflow(forOfferingId: "premium")).toNot(beNil())
@@ -513,12 +547,12 @@ class WorkflowsConfigProviderTests: TestCase {
         mockManager.stubbedBlobData[.uiConfig] = Self.uiConfigBlobsByItemKey
         mockManager.shouldStoreTopicCompletion = true
 
-        async let workflowsWarm: Void = provider.warmPrefetchedWorkflows(currentOfferingId: nil)
+        async let workflowsWarm = provider.warmPrefetchedWorkflows(currentOfferingId: nil)
         await self.waitUntilTopicRequested(on: mockManager)
         mockManager.configGeneration += 1
         mockManager.completeStoredTopic(with: workflowsTopic)
 
-        await workflowsWarm
+        _ = await workflowsWarm
         _ = await uiConfigProvider.getUiConfig()
 
         expect(provider.cachedWorkflow(forOfferingId: "premium")?.workflow.id) == "wf-prefetch"

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -275,7 +275,7 @@ class WorkflowsConfigProviderTests: TestCase {
         expect(secondWorkflowId) == "wf-2"
     }
 
-    func testWarmPrefetchedWorkflowsCachesPrefetchedAndCurrentOfferingBodiesAndAllMappings() async throws {
+    func testCacheEligibleWorkflowBodyDataCachesPrefetchedAndCurrentOfferingBodiesAndAllMappings() async throws {
         let prefetchedWorkflow = try Self.workflowJSON(id: "wf-prefetch")
         let currentWorkflow = try Self.workflowJSON(id: "wf-current")
         let otherWorkflow = try Self.workflowJSON(id: "wf-other")
@@ -305,9 +305,9 @@ class WorkflowsConfigProviderTests: TestCase {
             ]) { current, _ in current }
         )
 
-        async let workflowsWarm = self.provider.warmPrefetchedWorkflows(currentOfferingId: "basic")
-        async let uiConfigWarm = self.uiConfigProvider.getUiConfig()
-        let (warmedWorkflowIds, _) = await (workflowsWarm, uiConfigWarm)
+        async let cachedWorkflowIDs = self.provider.cacheEligibleWorkflowBodyData(currentOfferingId: "basic")
+        async let uiConfigReady = self.uiConfigProvider.getUiConfig()
+        let (workflowIDsWithCachedBodyData, _) = await (cachedWorkflowIDs, uiConfigReady)
 
         let cachedPrefetched = self.provider.cachedWorkflow(forOfferingId: "premium")
         let cachedCurrent = self.provider.cachedWorkflow(forOfferingId: "basic")
@@ -318,13 +318,13 @@ class WorkflowsConfigProviderTests: TestCase {
         expect(cachedCurrent?.workflow.id) == "wf-current"
         expect(cachedOther).to(beNil())
         expect(mappedOther) == "wf-other"
-        expect(warmedWorkflowIds) == ["wf-prefetch", "wf-current"]
+        expect(workflowIDsWithCachedBodyData) == ["wf-prefetch", "wf-current"]
         expect(self.blobFetcher.invokedEnsureDownloadedRefs).to(contain("wf-prefetch-ref"))
         expect(self.blobFetcher.invokedEnsureDownloadedRefs).to(contain("wf-current-ref"))
         expect(self.blobFetcher.invokedEnsureDownloadedRefs).toNot(contain("wf-other-ref"))
     }
 
-    func testWarmPrefetchedWorkflowsDefersDecodingUntilFirstReadAndRetainsTheResult() async throws {
+    func testCacheEligibleWorkflowBodyDataDefersDecodingUntilFirstReadAndRetainsTheResult() async throws {
         let decodeCount: Atomic<Int> = .init(0)
         self.provider = self.makeProvider(decodeCount: decodeCount)
         self.commit(
@@ -341,9 +341,9 @@ class WorkflowsConfigProviderTests: TestCase {
             ]) { current, _ in current }
         )
 
-        async let workflowsWarm = self.provider.warmPrefetchedWorkflows(currentOfferingId: nil)
-        async let uiConfigWarm = self.uiConfigProvider.getUiConfig()
-        _ = await (workflowsWarm, uiConfigWarm)
+        async let cachedWorkflowIDs = self.provider.cacheEligibleWorkflowBodyData(currentOfferingId: nil)
+        async let uiConfigReady = self.uiConfigProvider.getUiConfig()
+        _ = await (cachedWorkflowIDs, uiConfigReady)
 
         expect(decodeCount.value) == 0
         expect(self.provider.cachedWorkflow(forOfferingId: "premium")?.workflow.id) == "wf-prefetch"
@@ -352,7 +352,7 @@ class WorkflowsConfigProviderTests: TestCase {
         expect(decodeCount.value) == 1
     }
 
-    func testWorkflowPrewarmingDecodeIsNotRetainedForLaterUse() async throws {
+    func testAssetPrewarmingDecodeIsNotRetainedForLaterUse() async throws {
         let decodeCount: Atomic<Int> = .init(0)
         self.provider = self.makeProvider(decodeCount: decodeCount)
         self.commit(
@@ -369,12 +369,12 @@ class WorkflowsConfigProviderTests: TestCase {
             ]) { current, _ in current }
         )
 
-        async let workflowsWarm = self.provider.warmPrefetchedWorkflows(currentOfferingId: nil)
-        async let uiConfigWarm = self.uiConfigProvider.getUiConfig()
-        _ = await (workflowsWarm, uiConfigWarm)
+        async let cachedWorkflowIDs = self.provider.cacheEligibleWorkflowBodyData(currentOfferingId: nil)
+        async let uiConfigReady = self.uiConfigProvider.getUiConfig()
+        _ = await (cachedWorkflowIDs, uiConfigReady)
 
-        let prewarmResult = await self.provider.getWorkflowForPrewarming(workflowId: "wf-prefetch")
-        expect(try prewarmResult.get().workflow.id) == "wf-prefetch"
+        let decodedResult = await self.provider.decodeCachedWorkflowForAssetPrewarming(workflowId: "wf-prefetch")
+        expect(try decodedResult.get().workflow.id) == "wf-prefetch"
         expect(decodeCount.value) == 1
 
         expect(self.provider.cachedWorkflow(forOfferingId: "premium")?.workflow.id) == "wf-prefetch"
@@ -383,7 +383,7 @@ class WorkflowsConfigProviderTests: TestCase {
         expect(decodeCount.value) == 2
     }
 
-    func testMalformedPrefetchedWorkflowWarmsAsBytesAndFailsOnceWhenRead() async throws {
+    func testMalformedPrefetchedWorkflowCachesAsBodyDataAndFailsOnceWhenRead() async throws {
         let decodeCount: Atomic<Int> = .init(0)
         self.provider = self.makeProvider(decodeCount: decodeCount)
         self.commit(
@@ -400,9 +400,9 @@ class WorkflowsConfigProviderTests: TestCase {
             ]) { current, _ in current }
         )
 
-        async let workflowsWarm = self.provider.warmPrefetchedWorkflows(currentOfferingId: nil)
-        async let uiConfigWarm = self.uiConfigProvider.getUiConfig()
-        _ = await (workflowsWarm, uiConfigWarm)
+        async let cachedWorkflowIDs = self.provider.cacheEligibleWorkflowBodyData(currentOfferingId: nil)
+        async let uiConfigReady = self.uiConfigProvider.getUiConfig()
+        _ = await (cachedWorkflowIDs, uiConfigReady)
 
         expect(decodeCount.value) == 0
         expect(self.provider.cachedWorkflow(forOfferingId: "premium")).to(beNil())
@@ -416,7 +416,7 @@ class WorkflowsConfigProviderTests: TestCase {
         expect(decodeCount.value) == 1
     }
 
-    func testWarmPrefetchedWorkflowsReturnsEarlyWhenCacheAlreadyWarmForGeneration() async throws {
+    func testCacheEligibleWorkflowBodyDataReturnsEarlyWhenBodiesAreAlreadyCachedForGeneration() async throws {
         self.commit(
             workflows: [
                 "wf-prefetch": .init(
@@ -431,18 +431,18 @@ class WorkflowsConfigProviderTests: TestCase {
             ]) { current, _ in current }
         )
 
-        async let workflowsWarm = self.provider.warmPrefetchedWorkflows(currentOfferingId: nil)
-        async let uiConfigWarm = self.uiConfigProvider.getUiConfig()
-        _ = await (workflowsWarm, uiConfigWarm)
-        let ensureAllDownloadedCountAfterFirstWarm = self.blobFetcher.invokedEnsureAllDownloadedRefs.count
+        async let cachedWorkflowIDs = self.provider.cacheEligibleWorkflowBodyData(currentOfferingId: nil)
+        async let uiConfigReady = self.uiConfigProvider.getUiConfig()
+        _ = await (cachedWorkflowIDs, uiConfigReady)
+        let ensureAllDownloadedCountAfterFirstCache = self.blobFetcher.invokedEnsureAllDownloadedRefs.count
 
-        await self.provider.warmPrefetchedWorkflows(currentOfferingId: nil)
+        await self.provider.cacheEligibleWorkflowBodyData(currentOfferingId: nil)
 
         expect(self.provider.cachedWorkflow(forOfferingId: "premium")?.workflow.id) == "wf-prefetch"
-        expect(self.blobFetcher.invokedEnsureAllDownloadedRefs.count) == ensureAllDownloadedCountAfterFirstWarm
+        expect(self.blobFetcher.invokedEnsureAllDownloadedRefs.count) == ensureAllDownloadedCountAfterFirstCache
     }
 
-    func testWarmPrefetchedWorkflowsWarmsNewCurrentOfferingAndRetainsExistingWorkflow() async throws {
+    func testCacheEligibleWorkflowBodyDataCachesNewCurrentOfferingAndRetainsExistingWorkflow() async throws {
         let decodeCount: Atomic<Int> = .init(0)
         self.provider = self.makeProvider(decodeCount: decodeCount)
         self.commit(
@@ -465,20 +465,20 @@ class WorkflowsConfigProviderTests: TestCase {
             ]) { current, _ in current }
         )
 
-        await self.provider.warmPrefetchedWorkflows(currentOfferingId: "first")
+        await self.provider.cacheEligibleWorkflowBodyData(currentOfferingId: "first")
         _ = await self.uiConfigProvider.getUiConfig()
         expect(self.provider.cachedWorkflow(forOfferingId: "first")?.workflow.id) == "wf-first"
         expect(decodeCount.value) == 1
         expect(self.provider.cachedWorkflow(forOfferingId: "second")).to(beNil())
 
-        await self.provider.warmPrefetchedWorkflows(currentOfferingId: "second")
+        await self.provider.cacheEligibleWorkflowBodyData(currentOfferingId: "second")
 
         expect(self.provider.cachedWorkflow(forOfferingId: "first")?.workflow.id) == "wf-first"
         expect(self.provider.cachedWorkflow(forOfferingId: "second")?.workflow.id) == "wf-second"
         expect(decodeCount.value) == 2
     }
 
-    func testWarmPrefetchedWorkflowsRetriesMissingCurrentOfferingBody() async throws {
+    func testCacheEligibleWorkflowBodyDataRetriesMissingCurrentOfferingBody() async throws {
         self.commit(
             workflows: [
                 "wf-current": .init(
@@ -491,15 +491,17 @@ class WorkflowsConfigProviderTests: TestCase {
             blobs: Self.uiConfigBlobs
         )
 
-        let initiallyWarmedWorkflowIds = await self.provider.warmPrefetchedWorkflows(currentOfferingId: "current")
+        let initiallyCachedWorkflowIDs = await self.provider.cacheEligibleWorkflowBodyData(
+            currentOfferingId: "current"
+        )
         _ = await self.uiConfigProvider.getUiConfig()
-        expect(initiallyWarmedWorkflowIds).to(beEmpty())
+        expect(initiallyCachedWorkflowIDs).to(beEmpty())
         expect(self.provider.cachedWorkflow(forOfferingId: "current")).to(beNil())
 
         self.blobStore.stubbedData["wf-current-ref"] = try Self.workflowJSON(id: "wf-current")
-        let retriedWorkflowIds = await self.provider.warmPrefetchedWorkflows(currentOfferingId: "current")
+        let retriedWorkflowIDs = await self.provider.cacheEligibleWorkflowBodyData(currentOfferingId: "current")
 
-        expect(retriedWorkflowIds) == ["wf-current"]
+        expect(retriedWorkflowIDs) == ["wf-current"]
         expect(self.provider.cachedWorkflow(forOfferingId: "current")?.workflow.id) == "wf-current"
         expect(self.blobFetcher.invokedEnsureDownloadedRefs.filter { $0 == "wf-current-ref" }.count) == 2
     }
@@ -518,9 +520,9 @@ class WorkflowsConfigProviderTests: TestCase {
                 "wf-prefetch-ref": try Self.workflowJSON(id: "wf-prefetch")
             ]) { current, _ in current }
         )
-        async let workflowsWarm = self.provider.warmPrefetchedWorkflows(currentOfferingId: nil)
-        async let uiConfigWarm = self.uiConfigProvider.getUiConfig()
-        _ = await (workflowsWarm, uiConfigWarm)
+        async let cachedWorkflowIDs = self.provider.cacheEligibleWorkflowBodyData(currentOfferingId: nil)
+        async let uiConfigReady = self.uiConfigProvider.getUiConfig()
+        _ = await (cachedWorkflowIDs, uiConfigReady)
         expect(self.provider.cachedWorkflow(forOfferingId: "premium")).toNot(beNil())
 
         self.manager.clearCache()
@@ -528,7 +530,7 @@ class WorkflowsConfigProviderTests: TestCase {
         expect(self.provider.cachedWorkflow(forOfferingId: "premium")).to(beNil())
     }
 
-    func testWarmPrefetchedWorkflowsStoresCacheWhenGenerationChangesDuringInitialTopicRead() async throws {
+    func testCacheEligibleWorkflowBodyDataStoresCacheWhenGenerationChangesDuringInitialTopicRead() async throws {
         let mockManager = MockRemoteConfigManager()
         let uiConfigProvider = UiConfigProvider(manager: mockManager)
         let provider = WorkflowsConfigProvider(manager: mockManager, uiConfigProvider: uiConfigProvider)
@@ -547,12 +549,12 @@ class WorkflowsConfigProviderTests: TestCase {
         mockManager.stubbedBlobData[.uiConfig] = Self.uiConfigBlobsByItemKey
         mockManager.shouldStoreTopicCompletion = true
 
-        async let workflowsWarm = provider.warmPrefetchedWorkflows(currentOfferingId: nil)
+        async let cachedWorkflowIDs = provider.cacheEligibleWorkflowBodyData(currentOfferingId: nil)
         await self.waitUntilTopicRequested(on: mockManager)
         mockManager.configGeneration += 1
         mockManager.completeStoredTopic(with: workflowsTopic)
 
-        _ = await workflowsWarm
+        _ = await cachedWorkflowIDs
         _ = await uiConfigProvider.getUiConfig()
 
         expect(provider.cachedWorkflow(forOfferingId: "premium")?.workflow.id) == "wf-prefetch"

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -436,7 +436,7 @@ class WorkflowsConfigProviderTests: TestCase {
         _ = await (cachedWorkflowIDs, uiConfigReady)
         let ensureAllDownloadedCountAfterFirstCache = self.blobFetcher.invokedEnsureAllDownloadedRefs.count
 
-        await self.provider.cachePrefetchedWorkflowBodyData(includingOfferingId: nil)
+        _ = await self.provider.cachePrefetchedWorkflowBodyData(includingOfferingId: nil)
 
         expect(self.provider.cachedWorkflow(forOfferingId: "premium")?.workflow.id) == "wf-prefetch"
         expect(self.blobFetcher.invokedEnsureAllDownloadedRefs.count) == ensureAllDownloadedCountAfterFirstCache
@@ -465,13 +465,13 @@ class WorkflowsConfigProviderTests: TestCase {
             ]) { current, _ in current }
         )
 
-        await self.provider.cachePrefetchedWorkflowBodyData(includingOfferingId: "first")
+        _ = await self.provider.cachePrefetchedWorkflowBodyData(includingOfferingId: "first")
         _ = await self.uiConfigProvider.getUiConfig()
         expect(self.provider.cachedWorkflow(forOfferingId: "first")?.workflow.id) == "wf-first"
         expect(decodeCount.value) == 1
         expect(self.provider.cachedWorkflow(forOfferingId: "second")).to(beNil())
 
-        await self.provider.cachePrefetchedWorkflowBodyData(includingOfferingId: "second")
+        _ = await self.provider.cachePrefetchedWorkflowBodyData(includingOfferingId: "second")
 
         expect(self.provider.cachedWorkflow(forOfferingId: "first")?.workflow.id) == "wf-first"
         expect(self.provider.cachedWorkflow(forOfferingId: "second")?.workflow.id) == "wf-second"

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -1015,10 +1015,10 @@ extension OfferingsManagerTests {
 
     func testGetOfferingsWarmsWorkflowForCurrentOffering() {
         let mockRemoteConfigManager = MockRemoteConfigManager()
-        let mockWorkflowsConfigProvider = MockWorkflowsConfigProvider()
+        let mockWorkflowPrewarmer = MockWorkflowPrewarmer()
         let manager = self.makeOfferingsManager(
             remoteConfigManager: mockRemoteConfigManager,
-            workflowsConfigProvider: mockWorkflowsConfigProvider
+            workflowPrewarmer: mockWorkflowPrewarmer
         )
         self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsContents)
 
@@ -1027,7 +1027,7 @@ extension OfferingsManagerTests {
         }
 
         expect(result).to(beSuccess())
-        expect(mockWorkflowsConfigProvider.invokedWarmPrefetchedWorkflowsParameters) == ["base"]
+        expect(mockWorkflowPrewarmer.invokedPrewarmWorkflowsParameters) == ["base"]
     }
 
     func testGetOfferingsDeliversImmediatelyWhenRemoteConfigManagerIsNil() {
@@ -1479,7 +1479,7 @@ extension OfferingsManagerTests {
     private func makeOfferingsManager(
         remoteConfigManager: RemoteConfigManagerType?,
         offeringsFactory: OfferingsFactory? = nil,
-        workflowsConfigProvider: WorkflowsConfigProviderType? = nil
+        workflowPrewarmer: WorkflowPrewarmingType? = nil
     ) -> OfferingsManager {
         return OfferingsManager(deviceCache: self.mockDeviceCache,
                                 operationDispatcher: self.mockOperationDispatcher,
@@ -1489,7 +1489,7 @@ extension OfferingsManagerTests {
                                 productsManager: self.mockProductsManager,
                                 diagnosticsTracker: self.mockDiagnosticsTracker,
                                 remoteConfigManager: remoteConfigManager,
-                                workflowsConfigProvider: workflowsConfigProvider)
+                                workflowPrewarmer: workflowPrewarmer)
     }
 
     private static let uiConfigTopic: [String: RemoteConfiguration.ConfigItem] = [

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -1027,7 +1027,7 @@ extension OfferingsManagerTests {
         }
 
         expect(result).to(beSuccess())
-        expect(mockWorkflowAssetPrewarmer.invokedScheduleAssetPrewarmingForEligibleWorkflowsParameters) == ["base"]
+        expect(mockWorkflowAssetPrewarmer.invokedPrefetchedAssetPrewarmingParameters) == ["base"]
     }
 
     func testGetOfferingsDeliversImmediatelyWhenRemoteConfigManagerIsNil() {

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -1013,12 +1013,12 @@ private extension OfferingsManagerTests {
 
 extension OfferingsManagerTests {
 
-    func testGetOfferingsWarmsWorkflowForCurrentOffering() {
+    func testGetOfferingsSchedulesAssetPrewarmingForCurrentOfferingWorkflow() {
         let mockRemoteConfigManager = MockRemoteConfigManager()
-        let mockWorkflowPrewarmer = MockWorkflowPrewarmer()
+        let mockWorkflowAssetPrewarmer = MockWorkflowAssetPrewarmer()
         let manager = self.makeOfferingsManager(
             remoteConfigManager: mockRemoteConfigManager,
-            workflowPrewarmer: mockWorkflowPrewarmer
+            workflowAssetPrewarmer: mockWorkflowAssetPrewarmer
         )
         self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsContents)
 
@@ -1027,7 +1027,7 @@ extension OfferingsManagerTests {
         }
 
         expect(result).to(beSuccess())
-        expect(mockWorkflowPrewarmer.invokedPrewarmWorkflowsParameters) == ["base"]
+        expect(mockWorkflowAssetPrewarmer.invokedScheduleAssetPrewarmingForEligibleWorkflowsParameters) == ["base"]
     }
 
     func testGetOfferingsDeliversImmediatelyWhenRemoteConfigManagerIsNil() {
@@ -1479,7 +1479,7 @@ extension OfferingsManagerTests {
     private func makeOfferingsManager(
         remoteConfigManager: RemoteConfigManagerType?,
         offeringsFactory: OfferingsFactory? = nil,
-        workflowPrewarmer: WorkflowPrewarmingType? = nil
+        workflowAssetPrewarmer: WorkflowAssetPrewarmingType? = nil
     ) -> OfferingsManager {
         return OfferingsManager(deviceCache: self.mockDeviceCache,
                                 operationDispatcher: self.mockOperationDispatcher,
@@ -1489,7 +1489,7 @@ extension OfferingsManagerTests {
                                 productsManager: self.mockProductsManager,
                                 diagnosticsTracker: self.mockDiagnosticsTracker,
                                 remoteConfigManager: remoteConfigManager,
-                                workflowPrewarmer: workflowPrewarmer)
+                                workflowAssetPrewarmer: workflowAssetPrewarmer)
     }
 
     private static let uiConfigTopic: [String: RemoteConfiguration.ConfigItem] = [

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -125,6 +125,50 @@ class WorkflowManagerTests: TestCase {
         expect(self.mockPaywallCache.invokedWarmUpWorkflowCachesUiConfig) == expected.uiConfig
     }
 
+    // MARK: - prewarmWorkflows
+
+    func testPrewarmWorkflowsResolvesEveryWarmedBodyAndWarmsAssets() async throws {
+        guard #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *) else {
+            throw XCTSkip("warmUpWorkflowCaches requires iOS 15+")
+        }
+        let first = try Self.workflowDataResult(id: "wf_1")
+        let second = try Self.workflowDataResult(id: "wf_2")
+        self.mockProvider.stubbedWarmPrefetchedWorkflowIds = ["wf_1", "wf_2"]
+        self.mockProvider.stubbedGetWorkflowResult = ["wf_1": first, "wf_2": second]
+
+        await self.manager.prewarmWorkflows(currentOfferingId: "current")
+
+        expect(self.mockProvider.invokedWarmPrefetchedWorkflowsParameters) == ["current"]
+        expect(Set(self.mockProvider.invokedGetWorkflowForPrewarmingParameters)) == ["wf_1", "wf_2"]
+        expect(self.mockProvider.invokedGetWorkflowParameters).to(beEmpty())
+        expect(self.mockPaywallCache.invokedWarmUpWorkflowCachesCount) == 2
+    }
+
+    func testPrewarmWorkflowsDoesNotRunResolutionInline() async {
+        self.mockProvider.stubbedWarmPrefetchedWorkflowIds = ["wf_1"]
+        self.mockOperationDispatcher.shouldInvokeDispatchOnWorkerThreadBlock = false
+
+        await self.manager.prewarmWorkflows(currentOfferingId: "current")
+
+        expect(self.mockOperationDispatcher.invokedDispatchAsyncOnWorkerThread) == true
+        expect(self.mockProvider.invokedGetWorkflowForPrewarmingParameters).to(beEmpty())
+    }
+
+    func testPrewarmWorkflowsContinuesAfterAResolutionFailure() async throws {
+        guard #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *) else {
+            throw XCTSkip("warmUpWorkflowCaches requires iOS 15+")
+        }
+        self.mockProvider.stubbedWarmPrefetchedWorkflowIds = ["broken", "working"]
+        self.mockProvider.stubbedGetWorkflowError = ["broken": .notFound]
+        self.mockProvider.stubbedGetWorkflowResult = ["working": try Self.workflowDataResult(id: "working")]
+
+        await self.manager.prewarmWorkflows(currentOfferingId: nil)
+
+        expect(Set(self.mockProvider.invokedGetWorkflowForPrewarmingParameters)) == ["broken", "working"]
+        expect(self.mockPaywallCache.invokedWarmUpWorkflowCachesCount) == 1
+        expect(self.mockPaywallCache.invokedWarmUpWorkflowCachesWorkflow?.id) == "working"
+    }
+
     // MARK: - workflowId(forOfferingId:)
 
     func testWorkflowIdForOfferingIdDelegatesToProvider() async {

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -30,6 +30,7 @@ class WorkflowManagerTests: TestCase {
         self.mockProvider = MockWorkflowsConfigProvider()
         self.mockPaywallCache = MockPaywallCacheWarming()
         self.mockOperationDispatcher = MockOperationDispatcher()
+        self.mockOperationDispatcher.shouldInvokeDispatchOnWorkerThreadBlock = false
         self.manager = WorkflowManager(
             workflowsConfigProvider: self.mockProvider,
             paywallCache: self.mockPaywallCache,
@@ -56,9 +57,8 @@ class WorkflowManagerTests: TestCase {
         let expected = try Self.workflowDataResult(id: "wf_1")
         self.mockProvider.stubbedGetWorkflowResult = ["wf_1": expected]
 
-        // MockOperationDispatcher's async dispatchOnWorkerThread blocks until the block finishes, so
-        // asset prewarming has already run by the time this returns.
         _ = try await self.manager.getWorkflow(workflowId: "wf_1")
+        await self.mockOperationDispatcher.invokeAllDispatchedAsyncWorkerThreadBlocks()
 
         expect(self.mockPaywallCache.invokedPrewarmWorkflowAssets) == true
         expect(self.mockPaywallCache.invokedPrewarmWorkflowAssetsWorkflow?.id) == "wf_1"
@@ -109,7 +109,7 @@ class WorkflowManagerTests: TestCase {
 
     // MARK: - cachedWorkflow(forOfferingId:)
 
-    func testCachedWorkflowSchedulesAssetPrewarmingOnSuccess() throws {
+    func testCachedWorkflowSchedulesAssetPrewarmingOnSuccess() async throws {
         guard #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *) else {
             throw XCTSkip("prewarmWorkflowAssets requires iOS 15+")
         }
@@ -117,6 +117,7 @@ class WorkflowManagerTests: TestCase {
         self.mockProvider.stubbedCachedWorkflowResult = ["default": expected]
 
         let result = self.manager.cachedWorkflow(forOfferingId: "default")
+        await self.mockOperationDispatcher.invokeAllDispatchedAsyncWorkerThreadBlocks()
 
         expect(result) == expected
         expect(self.mockProvider.invokedCachedWorkflowParameters) == ["default"]
@@ -137,6 +138,7 @@ class WorkflowManagerTests: TestCase {
         self.mockProvider.stubbedGetWorkflowResult = ["wf_1": first, "wf_2": second]
 
         await self.manager.scheduleAssetPrewarmingForPrefetchedWorkflows(includingOfferingId: "current")
+        await self.mockOperationDispatcher.invokeAllDispatchedAsyncWorkerThreadBlocks()
 
         expect(self.mockProvider.invokedCachePrefetchedWorkflowBodyDataParameters) == ["current"]
         expect(Set(self.mockProvider.invokedDecodeCachedWorkflowForAssetPrewarmingParameters)) == ["wf_1", "wf_2"]
@@ -146,8 +148,6 @@ class WorkflowManagerTests: TestCase {
 
     func testScheduleAssetPrewarmingDoesNotDecodeInline() async {
         self.mockProvider.stubbedWorkflowIDsWithCachedBodyData = ["wf_1"]
-        self.mockOperationDispatcher.shouldInvokeDispatchOnWorkerThreadBlock = false
-
         await self.manager.scheduleAssetPrewarmingForPrefetchedWorkflows(includingOfferingId: "current")
 
         expect(self.mockOperationDispatcher.invokedDispatchAsyncOnWorkerThread) == true
@@ -163,6 +163,7 @@ class WorkflowManagerTests: TestCase {
         self.mockProvider.stubbedGetWorkflowResult = ["working": try Self.workflowDataResult(id: "working")]
 
         await self.manager.scheduleAssetPrewarmingForPrefetchedWorkflows(includingOfferingId: nil)
+        await self.mockOperationDispatcher.invokeAllDispatchedAsyncWorkerThreadBlocks()
 
         expect(Set(self.mockProvider.invokedDecodeCachedWorkflowForAssetPrewarmingParameters)) == ["broken", "working"]
         expect(self.mockPaywallCache.invokedPrewarmWorkflowAssetsCount) == 1

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -185,6 +185,13 @@ class WorkflowManagerTests: TestCase {
         expect(Set(self.mockProvider.invokedDecodeCachedWorkflowForAssetPrewarmingParameters)) == ["broken", "working"]
         expect(self.mockPaywallCache.invokedPrewarmWorkflowAssetsCount) == 1
         expect(self.mockPaywallCache.invokedPrewarmWorkflowAssetsWorkflow?.id) == "working"
+        self.logger.verifyMessageWasLogged(
+            Strings.paywalls.workflow_resolution_for_asset_prewarming_failed(
+                workflowId: "broken",
+                error: .notFound
+            ),
+            level: .debug
+        )
     }
 
     // MARK: - workflowId(forOfferingId:)

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -49,20 +49,20 @@ class WorkflowManagerTests: TestCase {
         expect(self.mockProvider.invokedGetWorkflowParameters) == ["wf_1"]
     }
 
-    func testGetWorkflowWarmsUpAssetsOnSuccess() async throws {
+    func testGetWorkflowSchedulesAssetPrewarmingOnSuccess() async throws {
         guard #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *) else {
-            throw XCTSkip("warmUpWorkflowCaches requires iOS 15+")
+            throw XCTSkip("prewarmWorkflowAssets requires iOS 15+")
         }
         let expected = try Self.workflowDataResult(id: "wf_1")
         self.mockProvider.stubbedGetWorkflowResult = ["wf_1": expected]
 
         // MockOperationDispatcher's async dispatchOnWorkerThread blocks until the block finishes, so
-        // warm-up has already run by the time this returns.
+        // asset prewarming has already run by the time this returns.
         _ = try await self.manager.getWorkflow(workflowId: "wf_1")
 
-        expect(self.mockPaywallCache.invokedWarmUpWorkflowCaches) == true
-        expect(self.mockPaywallCache.invokedWarmUpWorkflowCachesWorkflow?.id) == "wf_1"
-        expect(self.mockPaywallCache.invokedWarmUpWorkflowCachesUiConfig) == expected.uiConfig
+        expect(self.mockPaywallCache.invokedPrewarmWorkflowAssets) == true
+        expect(self.mockPaywallCache.invokedPrewarmWorkflowAssetsWorkflow?.id) == "wf_1"
+        expect(self.mockPaywallCache.invokedPrewarmWorkflowAssetsUiConfig) == expected.uiConfig
     }
 
     func testGetWorkflowFailsWithWorkflowNotFoundWhenProviderReportsNotFound() async {
@@ -109,9 +109,9 @@ class WorkflowManagerTests: TestCase {
 
     // MARK: - cachedWorkflow(forOfferingId:)
 
-    func testCachedWorkflowWarmsUpAssetsOnSuccess() throws {
+    func testCachedWorkflowSchedulesAssetPrewarmingOnSuccess() throws {
         guard #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *) else {
-            throw XCTSkip("warmUpWorkflowCaches requires iOS 15+")
+            throw XCTSkip("prewarmWorkflowAssets requires iOS 15+")
         }
         let expected = try Self.workflowDataResult(id: "wf_1")
         self.mockProvider.stubbedCachedWorkflowResult = ["default": expected]
@@ -120,53 +120,53 @@ class WorkflowManagerTests: TestCase {
 
         expect(result) == expected
         expect(self.mockProvider.invokedCachedWorkflowParameters) == ["default"]
-        expect(self.mockPaywallCache.invokedWarmUpWorkflowCaches) == true
-        expect(self.mockPaywallCache.invokedWarmUpWorkflowCachesWorkflow?.id) == "wf_1"
-        expect(self.mockPaywallCache.invokedWarmUpWorkflowCachesUiConfig) == expected.uiConfig
+        expect(self.mockPaywallCache.invokedPrewarmWorkflowAssets) == true
+        expect(self.mockPaywallCache.invokedPrewarmWorkflowAssetsWorkflow?.id) == "wf_1"
+        expect(self.mockPaywallCache.invokedPrewarmWorkflowAssetsUiConfig) == expected.uiConfig
     }
 
-    // MARK: - prewarmWorkflows
+    // MARK: - scheduleAssetPrewarmingForEligibleWorkflows
 
-    func testPrewarmWorkflowsResolvesEveryWarmedBodyAndWarmsAssets() async throws {
+    func testScheduleAssetPrewarmingDecodesEveryCachedBodyAndPrewarmsAssets() async throws {
         guard #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *) else {
-            throw XCTSkip("warmUpWorkflowCaches requires iOS 15+")
+            throw XCTSkip("prewarmWorkflowAssets requires iOS 15+")
         }
         let first = try Self.workflowDataResult(id: "wf_1")
         let second = try Self.workflowDataResult(id: "wf_2")
-        self.mockProvider.stubbedWarmPrefetchedWorkflowIds = ["wf_1", "wf_2"]
+        self.mockProvider.stubbedWorkflowIDsWithCachedBodyData = ["wf_1", "wf_2"]
         self.mockProvider.stubbedGetWorkflowResult = ["wf_1": first, "wf_2": second]
 
-        await self.manager.prewarmWorkflows(currentOfferingId: "current")
+        await self.manager.scheduleAssetPrewarmingForEligibleWorkflows(currentOfferingId: "current")
 
-        expect(self.mockProvider.invokedWarmPrefetchedWorkflowsParameters) == ["current"]
-        expect(Set(self.mockProvider.invokedGetWorkflowForPrewarmingParameters)) == ["wf_1", "wf_2"]
+        expect(self.mockProvider.invokedCacheEligibleWorkflowBodyDataParameters) == ["current"]
+        expect(Set(self.mockProvider.invokedDecodeCachedWorkflowForAssetPrewarmingParameters)) == ["wf_1", "wf_2"]
         expect(self.mockProvider.invokedGetWorkflowParameters).to(beEmpty())
-        expect(self.mockPaywallCache.invokedWarmUpWorkflowCachesCount) == 2
+        expect(self.mockPaywallCache.invokedPrewarmWorkflowAssetsCount) == 2
     }
 
-    func testPrewarmWorkflowsDoesNotRunResolutionInline() async {
-        self.mockProvider.stubbedWarmPrefetchedWorkflowIds = ["wf_1"]
+    func testScheduleAssetPrewarmingDoesNotDecodeInline() async {
+        self.mockProvider.stubbedWorkflowIDsWithCachedBodyData = ["wf_1"]
         self.mockOperationDispatcher.shouldInvokeDispatchOnWorkerThreadBlock = false
 
-        await self.manager.prewarmWorkflows(currentOfferingId: "current")
+        await self.manager.scheduleAssetPrewarmingForEligibleWorkflows(currentOfferingId: "current")
 
         expect(self.mockOperationDispatcher.invokedDispatchAsyncOnWorkerThread) == true
-        expect(self.mockProvider.invokedGetWorkflowForPrewarmingParameters).to(beEmpty())
+        expect(self.mockProvider.invokedDecodeCachedWorkflowForAssetPrewarmingParameters).to(beEmpty())
     }
 
-    func testPrewarmWorkflowsContinuesAfterAResolutionFailure() async throws {
+    func testScheduleAssetPrewarmingContinuesAfterADecodingFailure() async throws {
         guard #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *) else {
-            throw XCTSkip("warmUpWorkflowCaches requires iOS 15+")
+            throw XCTSkip("prewarmWorkflowAssets requires iOS 15+")
         }
-        self.mockProvider.stubbedWarmPrefetchedWorkflowIds = ["broken", "working"]
+        self.mockProvider.stubbedWorkflowIDsWithCachedBodyData = ["broken", "working"]
         self.mockProvider.stubbedGetWorkflowError = ["broken": .notFound]
         self.mockProvider.stubbedGetWorkflowResult = ["working": try Self.workflowDataResult(id: "working")]
 
-        await self.manager.prewarmWorkflows(currentOfferingId: nil)
+        await self.manager.scheduleAssetPrewarmingForEligibleWorkflows(currentOfferingId: nil)
 
-        expect(Set(self.mockProvider.invokedGetWorkflowForPrewarmingParameters)) == ["broken", "working"]
-        expect(self.mockPaywallCache.invokedWarmUpWorkflowCachesCount) == 1
-        expect(self.mockPaywallCache.invokedWarmUpWorkflowCachesWorkflow?.id) == "working"
+        expect(Set(self.mockProvider.invokedDecodeCachedWorkflowForAssetPrewarmingParameters)) == ["broken", "working"]
+        expect(self.mockPaywallCache.invokedPrewarmWorkflowAssetsCount) == 1
+        expect(self.mockPaywallCache.invokedPrewarmWorkflowAssetsWorkflow?.id) == "working"
     }
 
     // MARK: - workflowId(forOfferingId:)

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -146,6 +146,23 @@ class WorkflowManagerTests: TestCase {
         expect(self.mockPaywallCache.invokedPrewarmWorkflowAssetsCount) == 2
     }
 
+    func testScheduleAssetPrewarmingPreservesCurrentFirstOrder() async throws {
+        guard #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *) else {
+            throw XCTSkip("prewarmWorkflowAssets requires iOS 15+")
+        }
+        let current = try Self.workflowDataResult(id: "wf_current")
+        let prefetched = try Self.workflowDataResult(id: "wf_prefetched")
+        self.mockProvider.stubbedWorkflowIDsWithCachedBodyData = ["wf_current", "wf_prefetched"]
+        self.mockProvider.stubbedGetWorkflowResult = ["wf_current": current, "wf_prefetched": prefetched]
+
+        await self.manager.scheduleAssetPrewarmingForPrefetchedWorkflows(includingOfferingId: "current")
+        await self.mockOperationDispatcher.invokeAllDispatchedAsyncWorkerThreadBlocks()
+
+        expect(self.mockProvider.invokedDecodeCachedWorkflowForAssetPrewarmingParameters)
+            == ["wf_current", "wf_prefetched"]
+        expect(self.mockPaywallCache.invokedPrewarmWorkflowAssetIDs) == ["wf_current", "wf_prefetched"]
+    }
+
     func testScheduleAssetPrewarmingDoesNotDecodeInline() async {
         self.mockProvider.stubbedWorkflowIDsWithCachedBodyData = ["wf_1"]
         await self.manager.scheduleAssetPrewarmingForPrefetchedWorkflows(includingOfferingId: "current")

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -163,6 +163,22 @@ class WorkflowManagerTests: TestCase {
         expect(self.mockPaywallCache.invokedPrewarmWorkflowAssetIDs) == ["wf_current", "wf_prefetched"]
     }
 
+    func testScheduleAssetPrewarmingDoesNotDecodeWorkflowsWhoseAssetPrewarmingStarted() async throws {
+        guard #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *) else {
+            throw XCTSkip("prewarmWorkflowAssets requires iOS 15+")
+        }
+        self.mockProvider.stubbedWorkflowIDsWithCachedBodyData = ["wf_1"]
+        self.mockProvider.stubbedGetWorkflowResult = ["wf_1": try Self.workflowDataResult(id: "wf_1")]
+
+        await self.manager.scheduleAssetPrewarmingForPrefetchedWorkflows(includingOfferingId: nil)
+        await self.mockOperationDispatcher.invokeAllDispatchedAsyncWorkerThreadBlocks()
+        await self.manager.scheduleAssetPrewarmingForPrefetchedWorkflows(includingOfferingId: nil)
+        await self.mockOperationDispatcher.invokeAllDispatchedAsyncWorkerThreadBlocks()
+
+        expect(self.mockProvider.invokedDecodeCachedWorkflowForAssetPrewarmingParameters) == ["wf_1"]
+        expect(self.mockPaywallCache.invokedPrewarmWorkflowAssetsCount) == 1
+    }
+
     func testScheduleAssetPrewarmingDoesNotDecodeInline() async {
         self.mockProvider.stubbedWorkflowIDsWithCachedBodyData = ["wf_1"]
         await self.manager.scheduleAssetPrewarmingForPrefetchedWorkflows(includingOfferingId: "current")
@@ -192,6 +208,25 @@ class WorkflowManagerTests: TestCase {
             ),
             level: .debug
         )
+    }
+
+    func testScheduleAssetPrewarmingRetriesWorkflowResolutionFailures() async throws {
+        guard #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *) else {
+            throw XCTSkip("prewarmWorkflowAssets requires iOS 15+")
+        }
+        self.mockProvider.stubbedWorkflowIDsWithCachedBodyData = ["wf_1"]
+        self.mockProvider.stubbedGetWorkflowError = ["wf_1": .uiConfigUnavailable]
+
+        await self.manager.scheduleAssetPrewarmingForPrefetchedWorkflows(includingOfferingId: nil)
+        await self.mockOperationDispatcher.invokeAllDispatchedAsyncWorkerThreadBlocks()
+
+        self.mockProvider.stubbedGetWorkflowError = [:]
+        self.mockProvider.stubbedGetWorkflowResult = ["wf_1": try Self.workflowDataResult(id: "wf_1")]
+        await self.manager.scheduleAssetPrewarmingForPrefetchedWorkflows(includingOfferingId: nil)
+        await self.mockOperationDispatcher.invokeAllDispatchedAsyncWorkerThreadBlocks()
+
+        expect(self.mockProvider.invokedDecodeCachedWorkflowForAssetPrewarmingParameters) == ["wf_1", "wf_1"]
+        expect(self.mockPaywallCache.invokedPrewarmWorkflowAssetsCount) == 1
     }
 
     // MARK: - workflowId(forOfferingId:)

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -125,7 +125,7 @@ class WorkflowManagerTests: TestCase {
         expect(self.mockPaywallCache.invokedPrewarmWorkflowAssetsUiConfig) == expected.uiConfig
     }
 
-    // MARK: - scheduleAssetPrewarmingForEligibleWorkflows
+    // MARK: - scheduleAssetPrewarmingForPrefetchedWorkflows
 
     func testScheduleAssetPrewarmingDecodesEveryCachedBodyAndPrewarmsAssets() async throws {
         guard #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *) else {
@@ -136,9 +136,9 @@ class WorkflowManagerTests: TestCase {
         self.mockProvider.stubbedWorkflowIDsWithCachedBodyData = ["wf_1", "wf_2"]
         self.mockProvider.stubbedGetWorkflowResult = ["wf_1": first, "wf_2": second]
 
-        await self.manager.scheduleAssetPrewarmingForEligibleWorkflows(currentOfferingId: "current")
+        await self.manager.scheduleAssetPrewarmingForPrefetchedWorkflows(includingOfferingId: "current")
 
-        expect(self.mockProvider.invokedCacheEligibleWorkflowBodyDataParameters) == ["current"]
+        expect(self.mockProvider.invokedCachePrefetchedWorkflowBodyDataParameters) == ["current"]
         expect(Set(self.mockProvider.invokedDecodeCachedWorkflowForAssetPrewarmingParameters)) == ["wf_1", "wf_2"]
         expect(self.mockProvider.invokedGetWorkflowParameters).to(beEmpty())
         expect(self.mockPaywallCache.invokedPrewarmWorkflowAssetsCount) == 2
@@ -148,7 +148,7 @@ class WorkflowManagerTests: TestCase {
         self.mockProvider.stubbedWorkflowIDsWithCachedBodyData = ["wf_1"]
         self.mockOperationDispatcher.shouldInvokeDispatchOnWorkerThreadBlock = false
 
-        await self.manager.scheduleAssetPrewarmingForEligibleWorkflows(currentOfferingId: "current")
+        await self.manager.scheduleAssetPrewarmingForPrefetchedWorkflows(includingOfferingId: "current")
 
         expect(self.mockOperationDispatcher.invokedDispatchAsyncOnWorkerThread) == true
         expect(self.mockProvider.invokedDecodeCachedWorkflowForAssetPrewarmingParameters).to(beEmpty())
@@ -162,7 +162,7 @@ class WorkflowManagerTests: TestCase {
         self.mockProvider.stubbedGetWorkflowError = ["broken": .notFound]
         self.mockProvider.stubbedGetWorkflowResult = ["working": try Self.workflowDataResult(id: "working")]
 
-        await self.manager.scheduleAssetPrewarmingForEligibleWorkflows(currentOfferingId: nil)
+        await self.manager.scheduleAssetPrewarmingForPrefetchedWorkflows(includingOfferingId: nil)
 
         expect(Set(self.mockProvider.invokedDecodeCachedWorkflowForAssetPrewarmingParameters)) == ["broken", "working"]
         expect(self.mockPaywallCache.invokedPrewarmWorkflowAssetsCount) == 1


### PR DESCRIPTION
## Description
Implements workflow asset prewarming now that workflows are no longer always decoded and available in memory. Will temporarily decode the workflows body bytes into the decoded model if needed, and prewarm all assets for all screens in the workflow. This is done in a fire-and-forget way, and will never block workflows / offerings loading.

If the workflow was already decoded and available in memory that value will be used instead. However the opposite isn't true,  a temporarily decoded workflow body will not be retained in order to keep the memory footprint low. It will instead be decoded again once it's actually needed for displaying.

## Flow

```mermaid
flowchart TD
    A["OfferingsManager.deliverWhenConfigReady"] --> B["WorkflowManager.scheduleAssetPrewarmingForPrefetchedWorkflows"]
    B --> C["WorkflowsConfigProvider.cachePrefetchedWorkflowBodyData<br/>(prefetch-flagged + current offering)"]
    C --> D["Workflow IDs with cached bodies"]
    D --> E["Deliver offerings"]

    D -. "background / fire-and-forget" .-> F["decodeCachedWorkflowForAssetPrewarming<br/>(temporary decode)"]
    F --> G["scheduleAssetPrewarming"]
    G --> H["PaywallCache.prewarmWorkflowAssets"]
    F -. "after asset warming" .-> I["Release temporary workflow"]

    J["getWorkflow / cachedWorkflow"] --> K["Decode and retain workflow"]
    K --> G
    K --> L["Use for presentation"]
```

Similar to Android's https://github.com/RevenueCat/purchases-android/pull/3775

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches offerings delivery timing and workflow caching/memory behavior, but decode and downloads stay off the critical path and failures during prewarming are isolated per workflow.
> 
> **Overview**
> Workflow asset prewarming is split from full workflow caching so offerings delivery only waits on **raw workflow body bytes**, not decode or image/font/video downloads.
> 
> **`WorkflowsConfigProvider`** replaces `warmPrefetchedWorkflows` with `cachePrefetchedWorkflowBodyData`, which returns ordered workflow IDs (current offering first). Asset discovery uses **`decodeCachedWorkflowForAssetPrewarming`** and **`LazyPublishedWorkflow.transientValue()`** so prefetched workflows are decoded temporarily and not kept in memory for later presentation.
> 
> **`WorkflowManager`** implements **`WorkflowAssetPrewarmingType`**: after body data is cached it fire-and-forgets on a worker to transient-decode and call **`PaywallCacheWarming.prewarmWorkflowAssets`**, with per-workflow deduplication via **`hasStartedWorkflowAssetPrewarming`**. The read path (`getWorkflow` / `cachedWorkflow`) still schedules the same prewarming when a decoded workflow is already available.
> 
> **`OfferingsManager`** wires **`workflowAssetPrewarmer`** (typically `WorkflowManager`) instead of calling the config provider directly during the config-ready gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f5e96736393eb6d86c4bdb8b81f5e004fad9233. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->