### PR TITLE
Fix PaywallsTester paywall section grouping

### DIFF
--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
@@ -18,13 +18,41 @@ import UIKit
 
 struct APIKeyDashboardList: View {
 
-    fileprivate struct Template: Hashable {
-        var name: String?
+    enum PaywallSection: Hashable, Comparable {
+        case legacy(templateName: String)
+        case components
+        case noPaywall
+
+        init(hasPaywall: Bool, legacyTemplateName: String?) {
+            guard hasPaywall else {
+                self = .noPaywall
+                return
+            }
+
+            if let legacyTemplateName {
+                self = .legacy(templateName: legacyTemplateName)
+            } else {
+                self = .components
+            }
+        }
+
+        init(offering: Offering) {
+            self.init(
+                hasPaywall: offering.hasPaywall,
+                legacyTemplateName: offering.paywall?.templateName
+            )
+        }
+
+        static func < (lhs: Self, rhs: Self) -> Bool {
+            if lhs == .noPaywall { return false }
+            if rhs == .noPaywall { return true }
+            return lhs.description < rhs.description
+        }
     }
 
     fileprivate struct Data: Hashable {
-        var sections: [Template]
-        var offeringsBySection: [Template: [Offering]]
+        var sections: [PaywallSection]
+        var offeringsBySection: [PaywallSection: [Offering]]
     }
 
     fileprivate struct PresentedPaywall: Hashable {
@@ -151,28 +179,18 @@ struct APIKeyDashboardList: View {
 
             let offeringsBySection = Dictionary(
                 grouping: offerings,
-                by: { Template(name: templateGroupName(offering: $0)) }
+                by: PaywallSection.init(offering:)
             )
 
             self.offerings = .success(
                 .init(
-                    sections: Array(offeringsBySection.keys).sorted {
-                        switch ($0.name, $1.name) {
-                        case (nil, _): return false
-                        case (_, nil): return true
-                        default: return $0.description < $1.description
-                        }
-                    },
+                    sections: Array(offeringsBySection.keys).sorted(),
                     offeringsBySection: offeringsBySection
                 )
             )
         } catch let error as NSError {
             self.offerings = .failure(error)
         }
-    }
-
-    private func templateGroupName(offering: Offering) -> String? {
-        offering.paywall?.templateName ?? offering.paywallComponents?.data.templateName
     }
 
     @ViewBuilder
@@ -193,8 +211,8 @@ struct APIKeyDashboardList: View {
         }
     }
 
-    private func filteredOfferings(for template: Template, in data: Data) -> [Offering] {
-        let offerings = data.offeringsBySection[template] ?? []
+    private func filteredOfferings(for section: PaywallSection, in data: Data) -> [Offering] {
+        let offerings = data.offeringsBySection[section] ?? []
         guard !searchText.isEmpty else { return offerings }
         return offerings.filter {
             $0.id.localizedCaseInsensitiveContains(searchText) ||
@@ -206,8 +224,8 @@ struct APIKeyDashboardList: View {
     @ViewBuilder
     private func list(with data: Data) -> some View {
         List {
-            ForEach(data.sections, id: \.self) { template in
-                let offerings = filteredOfferings(for: template, in: data)
+            ForEach(data.sections, id: \.self) { section in
+                let offerings = filteredOfferings(for: section, in: data)
                 if !offerings.isEmpty {
                     Section {
                         ForEach(offerings, id: \.id) { offering in
@@ -259,7 +277,7 @@ struct APIKeyDashboardList: View {
                             }
                         }
                     } header: {
-                        Text(verbatim: template.description)
+                        Text(verbatim: section.description)
                     }
                 }
             }
@@ -273,7 +291,7 @@ struct APIKeyDashboardList: View {
                 .customPaywallVariables(self.customVariables)
                 .onAppear {
                     self.isLoadingPaywall = false
-                    if let errorInfo = paywall.offering.paywallComponents?.data.errorInfo {
+                    if let errorInfo = paywall.offering.internalPaywallComponents?.data.errorInfo {
                         print("Paywall V2 Error:", errorInfo.debugDescription)
                     }
                 }
@@ -287,7 +305,7 @@ struct APIKeyDashboardList: View {
                 .customPaywallVariables(self.customVariables)
                 .onAppear {
                     self.isLoadingPaywall = false
-                    if let errorInfo = paywall.offering.paywallComponents?.data.errorInfo {
+                    if let errorInfo = paywall.offering.internalPaywallComponents?.data.errorInfo {
                         print("Paywall V2 Error:", errorInfo.debugDescription)
                     }
                 }
@@ -430,7 +448,7 @@ struct APIKeyDashboardList: View {
                             .foregroundStyle(.secondary)
                     }
                     Spacer()
-                    if let errorInfo = self.offering.paywallComponents?.data.errorInfo, !errorInfo.isEmpty {
+                    if let errorInfo = self.offering.internalPaywallComponents?.data.errorInfo, !errorInfo.isEmpty {
                         Image(systemName: "exclamationmark.circle.fill")
                             .foregroundStyle(Color.red)
                     }
@@ -450,24 +468,23 @@ struct APIKeyDashboardList: View {
 
 }
 
-extension APIKeyDashboardList.Template: CustomStringConvertible {
+extension APIKeyDashboardList.PaywallSection: CustomStringConvertible {
 
     var description: String {
-        if let name = self.name {
-            if name == "components" {
-                return "V2"
+        switch self {
+        case let .legacy(templateName):
+            #if DEBUG
+            if let template = PaywallTemplate(rawValue: templateName) {
+                return template.name
             } else {
-                #if DEBUG
-                if let template = PaywallTemplate(rawValue: name) {
-                    return template.name
-                } else {
-                    return "Unrecognized template"
-                }
-                #else
-                return "Template \(name)"
-                #endif
+                return "Unrecognized template"
             }
-        } else {
+            #else
+            return "Template \(templateName)"
+            #endif
+        case .components:
+            return "V2"
+        case .noPaywall:
             return "No paywall"
         }
     }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/OfferingList/APIKeyDashboardList.swift
@@ -18,7 +18,7 @@ import UIKit
 
 struct APIKeyDashboardList: View {
 
-    enum PaywallSection: Hashable, Comparable {
+    fileprivate enum PaywallSection: Hashable, Comparable {
         case legacy(templateName: String)
         case components
         case noPaywall

--- a/Tests/TestingApps/PaywallsTester/PaywallsTesterTests/PaywallsTesterTests.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTesterTests/PaywallsTesterTests.swift
@@ -5,8 +5,9 @@
 //  Created by Noah Martin on 10/24/24.
 //
 
-import XCTest
 import SnapshottingTests
+@testable import PaywallsTester
+import XCTest
 
 final class PaywallsTesterTests: SnapshotTest {
     override class func snapshotPreviews() -> [String]? {
@@ -17,4 +18,60 @@ final class PaywallsTesterTests: SnapshotTest {
         // PR: https://github.com/EmergeTools/SnapshotPreviews/pull/239
         return ["PaywallsTester.*", "RevenueCatUI.*"]
     }
+}
+
+final class PaywallSectionTests: XCTestCase {
+
+    func testNoPaywallTakesPrecedenceOverLegacyTemplateName() {
+        let section = APIKeyDashboardList.PaywallSection(
+            hasPaywall: false,
+            legacyTemplateName: "1"
+        )
+
+        XCTAssertEqual(section, .noPaywall)
+        XCTAssertEqual(section.description, "No paywall")
+    }
+
+    func testClassicPaywallUsesLegacyTemplateSection() {
+        let section = APIKeyDashboardList.PaywallSection(
+            hasPaywall: true,
+            legacyTemplateName: "1"
+        )
+
+        XCTAssertEqual(section, .legacy(templateName: "1"))
+        XCTAssertEqual(section.description, "1: Minimalist")
+    }
+
+    func testRetainedV2PaywallUsesComponentsSection() {
+        let section = APIKeyDashboardList.PaywallSection(
+            hasPaywall: true,
+            legacyTemplateName: nil
+        )
+
+        XCTAssertEqual(section, .components)
+        XCTAssertEqual(section.description, "V2")
+    }
+
+    func testPrunedWorkflowPaywallUsesComponentsSection() {
+        let section = APIKeyDashboardList.PaywallSection(
+            hasPaywall: true,
+            legacyTemplateName: nil
+        )
+
+        XCTAssertEqual(section, .components)
+    }
+
+    func testNoPaywallSectionSortsLast() {
+        let sections: [APIKeyDashboardList.PaywallSection] = [
+            .noPaywall,
+            .components,
+            .legacy(templateName: "1")
+        ]
+
+        XCTAssertEqual(
+            sections.sorted(),
+            [.legacy(templateName: "1"), .components, .noPaywall]
+        )
+    }
+
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTesterTests/PaywallsTesterTests.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTesterTests/PaywallsTesterTests.swift
@@ -5,9 +5,8 @@
 //  Created by Noah Martin on 10/24/24.
 //
 
-import SnapshottingTests
-@testable import PaywallsTester
 import XCTest
+import SnapshottingTests
 
 final class PaywallsTesterTests: SnapshotTest {
     override class func snapshotPreviews() -> [String]? {
@@ -18,60 +17,4 @@ final class PaywallsTesterTests: SnapshotTest {
         // PR: https://github.com/EmergeTools/SnapshotPreviews/pull/239
         return ["PaywallsTester.*", "RevenueCatUI.*"]
     }
-}
-
-final class PaywallSectionTests: XCTestCase {
-
-    func testNoPaywallTakesPrecedenceOverLegacyTemplateName() {
-        let section = APIKeyDashboardList.PaywallSection(
-            hasPaywall: false,
-            legacyTemplateName: "1"
-        )
-
-        XCTAssertEqual(section, .noPaywall)
-        XCTAssertEqual(section.description, "No paywall")
-    }
-
-    func testClassicPaywallUsesLegacyTemplateSection() {
-        let section = APIKeyDashboardList.PaywallSection(
-            hasPaywall: true,
-            legacyTemplateName: "1"
-        )
-
-        XCTAssertEqual(section, .legacy(templateName: "1"))
-        XCTAssertEqual(section.description, "1: Minimalist")
-    }
-
-    func testRetainedV2PaywallUsesComponentsSection() {
-        let section = APIKeyDashboardList.PaywallSection(
-            hasPaywall: true,
-            legacyTemplateName: nil
-        )
-
-        XCTAssertEqual(section, .components)
-        XCTAssertEqual(section.description, "V2")
-    }
-
-    func testPrunedWorkflowPaywallUsesComponentsSection() {
-        let section = APIKeyDashboardList.PaywallSection(
-            hasPaywall: true,
-            legacyTemplateName: nil
-        )
-
-        XCTAssertEqual(section, .components)
-    }
-
-    func testNoPaywallSectionSortsLast() {
-        let sections: [APIKeyDashboardList.PaywallSection] = [
-            .noPaywall,
-            .components,
-            .legacy(templateName: "1")
-        ]
-
-        XCTAssertEqual(
-            sections.sorted(),
-            [.legacy(templateName: "1"), .components, .noPaywall]
-        )
-    }
-
 }


### PR DESCRIPTION
## Description
Tiny fix and simplifies the PaywallsTester paywalls section grouping. Paywalls through workflows were listed as `No paywall` because it relied on `.paywallComponents != nil`, which now no longer is a reliable proxy. This is now updated to `.hasPaywall` and I took the liberty to refactor the grouping logic to make it a bit simpler.

| Before | After |
|:---:|:---:|
| Workflow paywalls incorrectly listed under **No paywall** | Workflow paywalls correctly listed under **V2** |
| <img src="https://github.com/user-attachments/assets/719bb3f8-5216-405d-8189-4efad6b4f401" alt="Before: workflow paywalls listed under No paywall" width="320"> | <img src="https://github.com/user-attachments/assets/03491654-c863-47c6-ace7-cfb6e2151b25" alt="After: workflow paywalls listed under V2" width="320"> |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the PaywallsTester sample app UI; no production SDK or purchase flow impact.
> 
> **Overview**
> **PaywallsTester** live offerings list now buckets sections with a `PaywallSection` enum (**legacy**, **V2/components**, **no paywall**) instead of the old `Template` name helper.
> 
> Grouping keys off **`offering.hasPaywall`** and legacy `paywall?.templateName`, so workflow-backed offerings that have a paywall but no `paywallComponents` proxy land under **V2** instead of **No paywall**. Section order uses the enum’s `Comparable` + `description` labels (including DEBUG-friendly legacy template names).
> 
> V2 error badges and sheet `onAppear` logging now read **`internalPaywallComponents?.data.errorInfo`** instead of `paywallComponents`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71455e5aa6f0a5df1ccd327ca26a8b727d85a9b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->