### PR TITLE
Deduplicate workflow font install during prewarming

### DIFF
--- a/Sources/Paywalls/PaywallCacheWarming.swift
+++ b/Sources/Paywalls/PaywallCacheWarming.swift
@@ -59,13 +59,6 @@ protocol PaywallFontManagerType: Sendable {
 @available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *)
 actor PaywallCacheWarming: PaywallCacheWarmingType {
 
-    private struct WorkflowFontAsset: Hashable {
-        let name: String
-        let fontFamily: String?
-        let url: URL
-        let hash: String
-    }
-
     private let introEligibiltyChecker: TrialOrIntroPriceEligibilityCheckerType
     private let fontsManager: PaywallFontManagerType
     private let fileRepository: FileRepositoryType
@@ -74,7 +67,7 @@ actor PaywallCacheWarming: PaywallCacheWarmingType {
     private var hasLoadedImages = false
     private var hasLoadedVideos = false
     private var workflowIDsWithAssetPrewarmingStarted: Set<String> = []
-    private var workflowFontAssetsWithPrewarmingAttempted: Set<WorkflowFontAsset> = []
+    private var workflowFontAssetsWithPrewarmingAttempted: Set<DownloadableFont> = []
     private var ongoingFontDownloads: [URL: Task<Void, Never>] = [:]
 
     init(
@@ -212,12 +205,7 @@ actor PaywallCacheWarming: PaywallCacheWarmingType {
         let fonts = uiConfig.app.allDownloadableFonts.filter {
             // Background prewarming is best-effort once per shared font asset. Presentation-time font loading
             // bypasses this set, so a failed prewarm can still be retried when the font is actually needed.
-            self.workflowFontAssetsWithPrewarmingAttempted.insert(.init(
-                name: $0.name,
-                fontFamily: $0.fontFamily,
-                url: $0.url,
-                hash: $0.hash
-            )).inserted
+            self.workflowFontAssetsWithPrewarmingAttempted.insert($0).inserted
         }
         #endif
 
@@ -442,7 +430,7 @@ private extension PaywallData.Configuration.Images {
 }
 
 /// Business logic object to easily manage the download of fonts.
-struct DownloadableFont: Sendable {
+struct DownloadableFont: Sendable, Hashable {
 
     /// The font name.
     let name: String

--- a/Sources/Paywalls/PaywallCacheWarming.swift
+++ b/Sources/Paywalls/PaywallCacheWarming.swift
@@ -59,6 +59,13 @@ protocol PaywallFontManagerType: Sendable {
 @available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *)
 actor PaywallCacheWarming: PaywallCacheWarmingType {
 
+    private struct WorkflowFontAsset: Hashable {
+        let name: String
+        let fontFamily: String?
+        let url: URL
+        let hash: String
+    }
+
     private let introEligibiltyChecker: TrialOrIntroPriceEligibilityCheckerType
     private let fontsManager: PaywallFontManagerType
     private let fileRepository: FileRepositoryType
@@ -67,6 +74,7 @@ actor PaywallCacheWarming: PaywallCacheWarmingType {
     private var hasLoadedImages = false
     private var hasLoadedVideos = false
     private var workflowIDsWithAssetPrewarmingStarted: Set<String> = []
+    private var workflowFontAssetsWithPrewarmingAttempted: Set<WorkflowFontAsset> = []
     private var ongoingFontDownloads: [URL: Task<Void, Never>] = [:]
 
     init(
@@ -201,7 +209,16 @@ actor PaywallCacheWarming: PaywallCacheWarmingType {
         let imageURLs = Set(screens.flatMap(\.allImageURLs))
         let videoURLs = Set(screens.flatMap(\.allLowResVideoUrls))
         #if !os(tvOS)
-        let fonts = uiConfig.app.allDownloadableFonts
+        let fonts = uiConfig.app.allDownloadableFonts.filter {
+            // Background prewarming is best-effort once per shared font asset. Presentation-time font loading
+            // bypasses this set, so a failed prewarm can still be retried when the font is actually needed.
+            self.workflowFontAssetsWithPrewarmingAttempted.insert(.init(
+                name: $0.name,
+                fontFamily: $0.fontFamily,
+                url: $0.url,
+                hash: $0.hash
+            )).inserted
+        }
         #endif
 
         await withTaskGroup(of: Void.self) { group in

--- a/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
@@ -218,6 +218,26 @@ final class PaywallCacheWarmingTests: TestCase {
         )
     }
 
+    func testWorkflowAssetPrewarmingAttemptsSharedFontOnlyOnce() async {
+        let installCallCount = await self.workflowFontInstallCallCount(fontNames: ["MockFont", "MockFont"])
+        XCTAssertEqual(installCallCount, 1)
+    }
+
+    func testWorkflowAssetPrewarmingDoesNotDeduplicateDistinctFontNames() async {
+        let installCallCount = await self.workflowFontInstallCallCount(
+            fontNames: ["Font Regular", "Font Bold"]
+        )
+        XCTAssertEqual(installCallCount, 2)
+    }
+
+    func testWorkflowAssetPrewarmingDoesNotRepeatFailedSharedFontAttempt() async {
+        let installCallCount = await self.workflowFontInstallCallCount(
+            fontNames: ["MockFont", "MockFont"],
+            shouldFailInstallation: true
+        )
+        XCTAssertEqual(installCallCount, 1)
+    }
+
 #endif
 
     func testDownloadFont_PerformsExpectedActions() async throws {
@@ -331,6 +351,52 @@ final class PaywallCacheWarmingTests: TestCase {
 @available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *)
 private extension PaywallCacheWarmingTests {
 
+#if !os(tvOS)
+    func workflowFontInstallCallCount(
+        fontNames: [String],
+        shouldFailInstallation: Bool = false
+    ) async -> Int {
+        let fontURL = URL(string: "https://example.com/font.ttf")!
+        let fontsManager = MockFontsManager(
+            installDelayInSeconds: 0,
+            shouldFailInstallation: shouldFailInstallation
+        )
+        let cache = PaywallCacheWarming(
+            introEligibiltyChecker: self.eligibilityChecker,
+            fontsManager: fontsManager
+        )
+
+        for (index, fontName) in fontNames.enumerated() {
+            let uiConfig = UIConfig(
+                app: .init(
+                    colors: [:],
+                    fonts: [
+                        "font": .init(
+                            ios: .init(
+                                name: fontName,
+                                webFontInfo: .init(url: fontURL.absoluteString, hash: "abc123")
+                            )
+                        )
+                    ]
+                ),
+                localizations: [:],
+                variableConfig: .init(variableCompatibilityMap: [:], functionCompatibilityMap: [:])
+            )
+            let workflow = PublishedWorkflow(
+                id: "workflow-\(index)",
+                displayName: "Test",
+                initialStepId: "step",
+                singleStepFallbackId: nil,
+                steps: [:],
+                screens: [:]
+            )
+            await cache.prewarmWorkflowAssets(workflow: workflow, uiConfig: uiConfig)
+        }
+
+        return await fontsManager.installCallCount
+    }
+#endif
+
     static func createOffering(
         identifier: String,
         paywall: PaywallData?,
@@ -438,12 +504,18 @@ final actor MockFontsManager: PaywallFontManagerType {
     private(set) var installCallCount = 0
     var installDelayInSeconds: TimeInterval = 0
 
-    init(installDelayInSeconds: TimeInterval, fontIsAlreadyInstalled: Bool = false) {
+    init(
+        installDelayInSeconds: TimeInterval,
+        fontIsAlreadyInstalled: Bool = false,
+        shouldFailInstallation: Bool = false
+    ) {
         self.installDelayInSeconds = installDelayInSeconds
         self.fontIsAlreadyInstalled = fontIsAlreadyInstalled
+        self.shouldFailInstallation = shouldFailInstallation
     }
 
     let fontIsAlreadyInstalled: Bool
+    let shouldFailInstallation: Bool
 
     nonisolated func fontIsAlreadyInstalled(fontName: String, fontFamily: String?) -> Bool {
         return self.fontIsAlreadyInstalled
@@ -451,6 +523,10 @@ final actor MockFontsManager: PaywallFontManagerType {
 
     func installFont(_ font: RevenueCat.DownloadableFont) async throws {
         installCallCount += 1
+
+        if self.shouldFailInstallation {
+            throw NSError(domain: "MockFontsManager", code: 1)
+        }
 
         let duration = UInt64(installDelayInSeconds * 1_000_000_000)
         try await Task.sleep(nanoseconds: duration)


### PR DESCRIPTION
## Description
Deduplicates font installation during workflow/paywall prewarming. Each call would independently call `PaywallCacheWarming.installFont`, in my testing for 142 workflows (since they share the same `UIConfig`) the same font was installed 142 times.

## Fix
We now deduplicate the font based on its hash value and only install / register it once during prewarming. In case it fails to download/install during prewarming it is tried once more when actually displaying the paywall, bypassing the deduplication (as it should).

| Measurement | Before | After | Reduction |
|---|---:|---:|---:|
| Font installation CPU | 733 ms | 21 ms | 712 ms (97%) |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Best-effort prewarming optimization with presentation-time fallback unchanged; scope is limited to workflow asset warming and tests.
> 
> **Overview**
> **Workflow font prewarming** no longer installs the same downloadable font once per workflow when many workflows share one `UIConfig`. `prewarmWorkflowAssets` tracks attempted font assets in `workflowFontAssetsWithPrewarmingAttempted` and only queues install for fonts not yet seen during background prewarm.
> 
> `DownloadableFont` is now `Hashable` so set membership matches full font identity (name, family, URL, hash). Distinct font entries still prewarm separately; a failed prewarm is not retried on a later workflow prewarm, while **`triggerFontDownloadIfNeeded`** is unchanged and can still install when the paywall is shown.
> 
> Unit tests cover shared-font deduplication, distinct fonts, and failed-install behavior; **`MockFontsManager`** gains optional install failure for those cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61052ce32942c6ed60823170c7e3dbd2f580cb1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->