### PR TITLE
fix(danger): don't crash on renamed production Swift files

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -137,7 +137,16 @@ def pr_size_messages
   prod_files = (git.modified_files + git.added_files).uniq.select { |f| production_swift_file?(f) }
 
   total_changed = prod_files.sum do |f|
-    info = git.info_for_file(f)
+    # `git.info_for_file` raises for renamed files: the new path is listed in
+    # `added_files`/`modified_files`, but git keys the diff stats under the
+    # `{old => new}` rename entry, so the internal `stats[:insertions]` lookup
+    # hits nil. Treat any file whose churn we can't resolve as zero.
+    info =
+      begin
+        git.info_for_file(f)
+      rescue StandardError
+        nil
+      end
     info ? info[:insertions] + info[:deletions] : 0
   end
 


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Danger errors out (`undefined method [] for nil:NilClass`) on any PR that renames a production Swift file (e.g. #7228 --> failure [here](https://app.circleci.com/pipelines/gh/RevenueCat/purchases-ios/41094/workflows/38622db1-ed1f-446a-adab-2f407fcaae2f/jobs/680227)) failing the check for reasons unrelated to the PR's content.

### Description
`git.info_for_file` raises for renamed files: the new path appears in `added`/`modified` files (clearing its early guard), but git keys the diff stats under the `{old => new}` rename entry, so the internal `stats[:insertions]` lookup hits `nil`. The `pr_size_messages` size check now rescues that lookup and treats unresolvable churn as zero.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to error handling in the PR size check; no runtime app or SDK behavior.
> 
> **Overview**
> Fixes Danger CI failures when a PR **renames** production Swift files: `pr_size_messages` no longer blows up on `git.info_for_file` for paths whose diff stats live under git’s `{old => new}` rename key.
> 
> The production Swift line-count check now **rescues** lookup errors and counts unresolvable churn as **0**, so rename-only PRs aren’t blocked by a nil `stats[:insertions]` crash unrelated to PR size.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb9e36573c3460f097381d32f28473e7f67be038. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->