### PR TITLE
Avoid decoding legacy paywall components for workflows

### DIFF
--- a/Sources/Caching/DeviceCache.swift
+++ b/Sources/Caching/DeviceCache.swift
@@ -98,7 +98,10 @@ class DeviceCache {
 
     // MARK: - generic methods
 
-    private func value<Key: DeviceCacheKeyType, Value: Codable>(for key: Key) -> Value? {
+    private func value<Key: DeviceCacheKeyType, Value: Codable>(
+        for key: Key,
+        decoder: JSONDecoder = .default
+    ) -> Value? {
         // Large data used to be stored in the user defaults and resulted in crashes, we need to ensure that
         // we are cleaning out that data
         userDefaults.write { defaults in
@@ -106,12 +109,12 @@ class DeviceCache {
         }
 
         // Try to get from new cache location first
-        if let value: Value = try? self.largeItemCache.value(forKey: key.rawValue) {
+        if let value: Value = try? self.largeItemCache.value(forKey: key.rawValue, decoder: decoder) {
             return value
         }
 
         // Check old documents directory and migrate if found
-        return self.migrateAndReturnValueIfNeeded(for: key.rawValue)
+        return self.migrateAndReturnValueIfNeeded(for: key.rawValue, decoder: decoder)
     }
 
     // MARK: - appUserID
@@ -211,8 +214,12 @@ class DeviceCache {
 
     // MARK: - Offerings
 
-    func cachedOfferingsContents(appUserID: String) -> Offerings.Contents? {
-        return self.value(for: CacheKey.offerings(appUserID))
+    func cachedOfferingsContents(
+        appUserID: String,
+        decodingMode: OfferingsResponse.DecodingMode = .full
+    ) -> Offerings.Contents? {
+        let decoder = OfferingsResponse.makeDecoder(decodingMode: decodingMode)
+        return self.value(for: CacheKey.offerings(appUserID), decoder: decoder)
     }
 
     func cache(
@@ -228,7 +235,24 @@ class DeviceCache {
         self.offeringsCachePreferredLocales.value = preferredLocales
 
         let key = CacheKey.offerings(appUserID).rawValue
-        if self.largeItemCache.set(codable: diskContents ?? offerings.contents, forKey: key) {
+        let contents = diskContents ?? offerings.contents
+        let didCache: Bool
+        if let responseData = contents.responseDataForCache {
+            do {
+                let data = try Self.offeringsCacheData(
+                    responseData: responseData,
+                    originalSource: contents.originalSource
+                )
+                didCache = self.largeItemCache.set(data: data, forKey: key)
+            } catch {
+                Logger.error(Strings.cache.failed_to_save_codable_to_cache(error))
+                didCache = false
+            }
+        } else {
+            didCache = self.largeItemCache.set(codable: contents, forKey: key)
+        }
+
+        if didCache {
 
             // Delete old file from documents directory if it exists
             self.deleteOldFileIfNeeded(for: key)
@@ -810,6 +834,22 @@ fileprivate extension UserDefaults {
 
 private extension DeviceCache {
 
+    static func offeringsCacheData(
+        responseData: Data,
+        originalSource: Offerings.OriginalSource
+    ) throws -> Data {
+        let value = try JSONSerialization.jsonObject(with: responseData)
+        guard var object = value as? [String: Any] else {
+            throw EncodingError.invalidValue(
+                value,
+                .init(codingPath: [], debugDescription: "Offerings response must be a JSON object")
+            )
+        }
+
+        object["original_source"] = originalSource.rawValue
+        return try JSONSerialization.data(withJSONObject: object)
+    }
+
     enum CacheDuration {
 
         // swiftlint:disable:next nesting
@@ -874,14 +914,17 @@ private extension DeviceCache {
     }
 
     // swiftlint:enable avoid_using_directory_apis_directly
-    private func migrateAndReturnValueIfNeeded<Value: Codable>(for key: String) -> Value? {
+    private func migrateAndReturnValueIfNeeded<Value: Codable>(
+        for key: String,
+        decoder: JSONDecoder = .default
+    ) -> Value? {
         return self.migrationLock.perform {
             guard let oldDirectoryURL = self.oldDocumentsDirectoryURL() else { return nil }
 
             let oldFileURL = oldDirectoryURL.appendingPathComponent(key)
 
             // Check if file already exists in new location (it may have been migrated before the lock was released)
-            if let value: Value = try? self.largeItemCache.value(forKey: key) {
+            if let value: Value = try? self.largeItemCache.value(forKey: key, decoder: decoder) {
                 // File already migrated, clean up old file if it still exists
                 if fileManager.fileExists(atPath: oldFileURL.path) {
                     try? fileManager.removeItem(at: oldFileURL)
@@ -898,7 +941,7 @@ private extension DeviceCache {
             // Try to load from old location
             // If decoding of the file from the old location fails, remove it since the file is corrupt
             guard let data = try? Data(contentsOf: oldFileURL),
-                  let value: Value = try? JSONDecoder.default.decode(jsonData: data, logErrors: true) else {
+                  let value: Value = try? decoder.decode(jsonData: data, logErrors: true) else {
                 try? fileManager.removeItem(at: oldFileURL)
                 return nil
             }

--- a/Sources/Caching/DeviceCache.swift
+++ b/Sources/Caching/DeviceCache.swift
@@ -100,7 +100,7 @@ class DeviceCache {
 
     private func value<Key: DeviceCacheKeyType, Value: Codable>(
         for key: Key,
-        decoder: JSONDecoder = .default
+        decoder: JSONDecoder
     ) -> Value? {
         // Large data used to be stored in the user defaults and resulted in crashes, we need to ensure that
         // we are cleaning out that data
@@ -458,7 +458,7 @@ class DeviceCache {
     }
 
     var cachedProductEntitlementMapping: ProductEntitlementMapping? {
-        return self.value(for: CacheKeys.productEntitlementMapping)
+        return self.value(for: CacheKeys.productEntitlementMapping, decoder: .default)
     }
 
     // MARK: - StoreKit 2
@@ -916,7 +916,7 @@ private extension DeviceCache {
     // swiftlint:enable avoid_using_directory_apis_directly
     private func migrateAndReturnValueIfNeeded<Value: Codable>(
         for key: String,
-        decoder: JSONDecoder = .default
+        decoder: JSONDecoder
     ) -> Value? {
         return self.migrationLock.perform {
             guard let oldDirectoryURL = self.oldDocumentsDirectoryURL() else { return nil }

--- a/Sources/Caching/DeviceCache.swift
+++ b/Sources/Caching/DeviceCache.swift
@@ -216,7 +216,7 @@ class DeviceCache {
 
     func cachedOfferingsContents(
         appUserID: String,
-        decodingMode: OfferingsResponse.DecodingMode = .full
+        decodingMode: OfferingsResponse.DecodingMode = .withPaywallComponents
     ) -> Offerings.Contents? {
         let decoder = OfferingsResponse.makeDecoder(decodingMode: decodingMode)
         return self.value(for: CacheKey.offerings(appUserID), decoder: decoder)

--- a/Sources/Caching/DeviceCache.swift
+++ b/Sources/Caching/DeviceCache.swift
@@ -224,7 +224,7 @@ class DeviceCache {
 
     func cache(
         offerings: Offerings,
-        diskContents: Offerings.Contents? = nil,
+        fetchResult: OfferingsFetchResult? = nil,
         preferredLocales: [String],
         appUserID: String
     ) {
@@ -235,12 +235,12 @@ class DeviceCache {
         self.offeringsCachePreferredLocales.value = preferredLocales
 
         let key = CacheKey.offerings(appUserID).rawValue
-        let contents = diskContents ?? offerings.contents
+        let contents = fetchResult?.contents ?? offerings.contents
         let didCache: Bool
-        if let responseData = contents.responseDataForCache {
+        if let rawResponseData = fetchResult?.rawResponseData {
             do {
                 let data = try Self.offeringsCacheData(
-                    responseData: responseData,
+                    responseData: rawResponseData,
                     originalSource: contents.originalSource
                 )
                 didCache = self.largeItemCache.set(data: data, forKey: key)

--- a/Sources/LocalReceiptParsing/DataConverters/Codable+Extensions.swift
+++ b/Sources/LocalReceiptParsing/DataConverters/Codable+Extensions.swift
@@ -95,7 +95,12 @@ extension JSONDecoder {
         return formatter
     }()
 
-    static let `default`: JSONDecoder = {
+    static let `default`: JSONDecoder = JSONDecoder.makeDefault()
+
+    /// Returns a new decoder with the SDK's standard configuration.
+    ///
+    /// Use this instead of mutating ``default`` when a call site needs request-specific `userInfo`.
+    static func makeDefault() -> JSONDecoder {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         decoder.dateDecodingStrategy = .custom { decoder in
@@ -114,6 +119,6 @@ extension JSONDecoder {
         }
 
         return decoder
-    }()
+    }
 
 }

--- a/Sources/Misc/Concurrency/SynchronizedLargeItemCache.swift
+++ b/Sources/Misc/Concurrency/SynchronizedLargeItemCache.swift
@@ -93,7 +93,7 @@ internal final class SynchronizedLargeItemCache {
 
     /// Load a codable value from the cache
     /// - Throws: If the file cannot be loaded or decoded
-    func value<T: Decodable>(forKey key: String, decoder: JSONDecoder = .default) throws -> T? {
+    func value<T: Decodable>(forKey key: String, decoder: JSONDecoder) throws -> T? {
         guard let fileURL = self.getFileURL(for: key) else {
             return nil
         }

--- a/Sources/Misc/Concurrency/SynchronizedLargeItemCache.swift
+++ b/Sources/Misc/Concurrency/SynchronizedLargeItemCache.swift
@@ -60,12 +60,18 @@ internal final class SynchronizedLargeItemCache {
     /// Save a codable value to the cache
     @discardableResult
     func set<T: Encodable>(codable value: T, forKey key: String) -> Bool {
-        guard let fileURL = self.getFileURL(for: key) else {
-            Logger.error(Strings.cache.cache_url_not_available)
+        guard let data = try? JSONEncoder.default.encode(value: value, logErrors: true) else {
             return false
         }
 
-        guard let data = try? JSONEncoder.default.encode(value: value, logErrors: true) else {
+        return self.set(data: data, forKey: key)
+    }
+
+    /// Save already-encoded data to the cache.
+    @discardableResult
+    func set(data: Data, forKey key: String) -> Bool {
+        guard let fileURL = self.getFileURL(for: key) else {
+            Logger.error(Strings.cache.cache_url_not_available)
             return false
         }
 
@@ -82,7 +88,7 @@ internal final class SynchronizedLargeItemCache {
 
     /// Load a codable value from the cache
     /// - Throws: If the file cannot be loaded or decoded
-    func value<T: Decodable>(forKey key: String) throws -> T? {
+    func value<T: Decodable>(forKey key: String, decoder: JSONDecoder = .default) throws -> T? {
         guard let fileURL = self.getFileURL(for: key) else {
             return nil
         }
@@ -93,7 +99,7 @@ internal final class SynchronizedLargeItemCache {
             }
 
             let data = try cache.loadFile(at: fileURL)
-            return try JSONDecoder.default.decode(jsonData: data, logErrors: true)
+            return try decoder.decode(jsonData: data, logErrors: true)
         }
     }
 

--- a/Sources/Misc/Concurrency/SynchronizedLargeItemCache.swift
+++ b/Sources/Misc/Concurrency/SynchronizedLargeItemCache.swift
@@ -60,6 +60,11 @@ internal final class SynchronizedLargeItemCache {
     /// Save a codable value to the cache
     @discardableResult
     func set<T: Encodable>(codable value: T, forKey key: String) -> Bool {
+        guard self.getFileURL(for: key) != nil else {
+            Logger.error(Strings.cache.cache_url_not_available)
+            return false
+        }
+
         guard let data = try? JSONEncoder.default.encode(value: value, logErrors: true) else {
             return false
         }

--- a/Sources/Networking/Caching/OfferingsCallback.swift
+++ b/Sources/Networking/Caching/OfferingsCallback.swift
@@ -17,6 +17,6 @@ struct OfferingsCallback: CacheKeyProviding {
 
     let cacheKey: String
     let decodingMode: OfferingsResponse.DecodingMode
-    let completion: (Result<Offerings.Contents, BackendError>) -> Void
+    let completion: (Result<OfferingsFetchResult, BackendError>) -> Void
 
 }

--- a/Sources/Networking/Caching/OfferingsCallback.swift
+++ b/Sources/Networking/Caching/OfferingsCallback.swift
@@ -16,6 +16,7 @@ import Foundation
 struct OfferingsCallback: CacheKeyProviding {
 
     let cacheKey: String
+    let decodingMode: OfferingsResponse.DecodingMode
     let completion: (Result<Offerings.Contents, BackendError>) -> Void
 
 }

--- a/Sources/Networking/HTTPClient/ETagManager.swift
+++ b/Sources/Networking/HTTPClient/ETagManager.swift
@@ -167,7 +167,7 @@ private extension ETagManager {
 
     func storedETagAndResponse(for request: URLRequest) -> Response? {
         if let cacheKey = Self.cacheKey(for: request) {
-            return try? self.cache.value(forKey: cacheKey)
+            return try? self.cache.value(forKey: cacheKey, decoder: .default)
         }
         return nil
     }

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -1021,13 +1021,19 @@ extension Result where Success == VerifiedHTTPResponse<Data>, Failure == Network
 
     // Parses a `Result<VerifiedHTTPResponse<Data>>` to `Result<VerifiedHTTPResponse<Value>>`
     func parseResponse<Value: HTTPResponseBody>() -> VerifiedHTTPResponse<Value>.Result {
+        return self.parseResponse { data, statusCode in
+            try Value.create(with: data, httpStatusCode: statusCode)
+        }
+    }
+
+    /// Parses a response using a request-specific decoder while preserving standard network decoding errors.
+    func parseResponse<Value: HTTPResponseBody>(
+        using create: (Data, HTTPStatusCode) throws -> Value
+    ) -> VerifiedHTTPResponse<Value>.Result {
         return self.flatMap { response in                   // Convert the `Result` type
             Result<VerifiedHTTPResponse<Value>, Error> {    // Create a new `Result<Value>`
                 try response.mapBody { data in              // Convert the from `Data` -> `Value`
-                    try Value.create(                       // Decode `Data` into `Value`
-                        with: data,
-                        httpStatusCode: response.httpStatusCode
-                    )
+                    try create(data, response.httpStatusCode)
                 }
                 .copyWithNewRequestDate()                   // Update request date for 304 responses
             }

--- a/Sources/Networking/OfferingsAPI.swift
+++ b/Sources/Networking/OfferingsAPI.swift
@@ -32,7 +32,7 @@ class OfferingsAPI {
 
     func getOfferings(appUserID: String,
                       isAppBackgrounded: Bool,
-                      decodingMode: OfferingsResponse.DecodingMode = .full,
+                      decodingMode: OfferingsResponse.DecodingMode = .withPaywallComponents,
                       completion: @escaping OfferingsResponseHandler) {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
                                                                 appUserID: appUserID)

--- a/Sources/Networking/OfferingsAPI.swift
+++ b/Sources/Networking/OfferingsAPI.swift
@@ -13,11 +13,16 @@
 
 import Foundation
 
+struct OfferingsFetchResult {
+    let contents: Offerings.Contents
+    let rawResponseData: Data?
+}
+
 class OfferingsAPI {
 
     typealias IntroEligibilityResponseHandler = ([String: IntroEligibility], BackendError?) -> Void
     typealias OfferSigningResponseHandler = Backend.ResponseHandler<PostOfferForSigningOperation.SigningData>
-    typealias OfferingsResponseHandler = Backend.ResponseHandler<Offerings.Contents>
+    typealias OfferingsResponseHandler = Backend.ResponseHandler<OfferingsFetchResult>
     typealias WebOfferingProductsResponseHandler = Backend.ResponseHandler<WebOfferingProductsResponse>
 
     private let offeringsCallbacksCache: CallbackCache<OfferingsCallback>

--- a/Sources/Networking/OfferingsAPI.swift
+++ b/Sources/Networking/OfferingsAPI.swift
@@ -32,6 +32,7 @@ class OfferingsAPI {
 
     func getOfferings(appUserID: String,
                       isAppBackgrounded: Bool,
+                      decodingMode: OfferingsResponse.DecodingMode = .full,
                       completion: @escaping OfferingsResponseHandler) {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
                                                                 appUserID: appUserID)
@@ -40,7 +41,11 @@ class OfferingsAPI {
             offeringsCallbackCache: self.offeringsCallbacksCache
         )
 
-        let offeringsCallback = OfferingsCallback(cacheKey: factory.cacheKey, completion: completion)
+        let offeringsCallback = OfferingsCallback(
+            cacheKey: factory.cacheKey,
+            decodingMode: decodingMode,
+            completion: completion
+        )
         let cacheStatus = self.offeringsCallbacksCache.add(offeringsCallback)
 
         if cacheStatus == .firstCallbackAddedToList {

--- a/Sources/Networking/Operations/GetOfferingsOperation.swift
+++ b/Sources/Networking/Operations/GetOfferingsOperation.swift
@@ -88,22 +88,26 @@ private extension GetOfferingsOperation {
         }
     }
 
-    typealias OfferingsResponseHandlerResult = Result<Offerings.Contents, BackendError>
+    typealias OfferingsResponseHandlerResult = Result<OfferingsFetchResult, BackendError>
 
     static func decode(
         _ response: VerifiedHTTPResponse<Data>.Result,
         using decodingMode: OfferingsResponse.DecodingMode
     ) -> OfferingsResponseHandlerResult {
-        let responseDataForCache = try? response.get().body
+        let rawResponseData = try? response.get().body
         let decodedResponse: VerifiedHTTPResponse<OfferingsResponse>.Result = response.parseResponse { data, _ in
             try OfferingsResponse.create(with: data, decodingMode: decodingMode)
         }
 
         return decodedResponse
             .map {
-                Offerings.Contents(response: $0.body,
-                                   httpResponseOriginalSource: $0.originalSource,
-                                   responseDataForCache: responseDataForCache)
+                OfferingsFetchResult(
+                    contents: Offerings.Contents(
+                        response: $0.body,
+                        httpResponseOriginalSource: $0.originalSource
+                    ),
+                    rawResponseData: rawResponseData
+                )
             }
             .mapError(BackendError.networkError)
     }

--- a/Sources/Networking/Operations/GetOfferingsOperation.swift
+++ b/Sources/Networking/Operations/GetOfferingsOperation.swift
@@ -66,21 +66,46 @@ private extension GetOfferingsOperation {
 
         let request = HTTPRequest(method: .get, path: .getOfferings(appUserID: appUserID))
 
-        httpClient.perform(request) { (response: VerifiedHTTPResponse<OfferingsResponse>.Result) in
+        httpClient.perform(request) { (response: VerifiedHTTPResponse<Data>.Result) in
             defer {
                 completion()
             }
 
+            var resultsByDecodingMode: [OfferingsResponse.DecodingMode: OfferingsResponseHandlerResult] = [:]
+
             self.offeringsCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callbackObject in
-                callbackObject.completion(response
-                    .map {
-                        Offerings.Contents(response: $0.body,
-                                           httpResponseOriginalSource: $0.originalSource)
-                    }
-                    .mapError(BackendError.networkError)
-                )
+                let decodingMode = callbackObject.decodingMode
+                let result: OfferingsResponseHandlerResult
+                if let cachedResult = resultsByDecodingMode[decodingMode] {
+                    result = cachedResult
+                } else {
+                    result = Self.decode(response, using: decodingMode)
+                    resultsByDecodingMode[decodingMode] = result
+                }
+
+                callbackObject.completion(result)
             }
         }
+    }
+
+    typealias OfferingsResponseHandlerResult = Result<Offerings.Contents, BackendError>
+
+    static func decode(
+        _ response: VerifiedHTTPResponse<Data>.Result,
+        using decodingMode: OfferingsResponse.DecodingMode
+    ) -> OfferingsResponseHandlerResult {
+        let responseDataForCache = try? response.get().body
+        let decodedResponse: VerifiedHTTPResponse<OfferingsResponse>.Result = response.parseResponse { data, _ in
+            try OfferingsResponse.create(with: data, decodingMode: decodingMode)
+        }
+
+        return decodedResponse
+            .map {
+                Offerings.Contents(response: $0.body,
+                                   httpResponseOriginalSource: $0.originalSource,
+                                   responseDataForCache: responseDataForCache)
+            }
+            .mapError(BackendError.networkError)
     }
 
 }

--- a/Sources/Networking/RemoteConfigDiskCache.swift
+++ b/Sources/Networking/RemoteConfigDiskCache.swift
@@ -121,7 +121,7 @@ final class RemoteConfigDiskCache: RemoteConfigDiskCacheType {
 
     private func readFromDisk() -> PersistedRemoteConfiguration? {
         do {
-            return try self.cache.value(forKey: Self.fileName)
+            return try self.cache.value(forKey: Self.fileName, decoder: .default)
         } catch {
             Logger.error(Strings.remoteConfig.failedToReadCache(error))
             return nil

--- a/Sources/Networking/Responses/OfferingsResponse.swift
+++ b/Sources/Networking/Responses/OfferingsResponse.swift
@@ -16,7 +16,7 @@ import Foundation
 struct OfferingsResponse {
 
     enum DecodingMode: Hashable, Sendable {
-        case full
+        case withPaywallComponents
         case withoutPaywallComponents
     }
 
@@ -147,10 +147,10 @@ extension OfferingsResponse.Offering: Codable, Equatable {
             forKey: .hasPaywallComponents
         )
         let decodingMode = decoder.userInfo[OfferingsResponse.decodingModeUserInfoKey]
-            as? OfferingsResponse.DecodingMode ?? .full
+            as? OfferingsResponse.DecodingMode ?? .withPaywallComponents
 
         switch decodingMode {
-        case .full:
+        case .withPaywallComponents:
             self.paywallComponents = try container.decodeIfPresent(
                 PaywallComponentsData.self,
                 forKey: .paywallComponents

--- a/Sources/Networking/Responses/OfferingsResponse.swift
+++ b/Sources/Networking/Responses/OfferingsResponse.swift
@@ -15,6 +15,18 @@ import Foundation
 
 struct OfferingsResponse {
 
+    enum DecodingMode: Hashable, Sendable {
+        case full
+        case withoutPaywallComponents
+    }
+
+    // The non-empty static key cannot fail construction.
+    // swiftlint:disable force_unwrapping
+    fileprivate static let decodingModeUserInfoKey = CodingUserInfoKey(
+        rawValue: "com.revenuecat.offerings-response-decoding-mode"
+    )!
+    // swiftlint:enable force_unwrapping
+
     struct Offering {
 
         // swiftlint:disable:next nesting
@@ -60,6 +72,16 @@ struct OfferingsResponse {
 
 extension OfferingsResponse {
 
+    static func create(with data: Data, decodingMode: DecodingMode) throws -> Self {
+        return try self.makeDecoder(decodingMode: decodingMode).decode(jsonData: data)
+    }
+
+    static func makeDecoder(decodingMode: DecodingMode) -> JSONDecoder {
+        let decoder = JSONDecoder.makeDefault()
+        decoder.userInfo[Self.decodingModeUserInfoKey] = decodingMode
+        return decoder
+    }
+
     var productIdentifiers: Set<String> {
         return Set(
             self.offerings
@@ -94,7 +116,63 @@ extension OfferingsResponse.Offering.Package {
 }
 
 extension OfferingsResponse.Offering.Package: Codable, Equatable {}
-extension OfferingsResponse.Offering: Codable, Equatable {}
+extension OfferingsResponse.Offering: Codable, Equatable {
+
+    private enum CodingKeys: String, CodingKey {
+        case identifier
+        case description
+        case packages
+        case paywall
+        case metadata
+        case paywallComponents
+        case hasPaywallComponents
+        case webCheckoutUrl
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.identifier = try container.decode(String.self, forKey: .identifier)
+        self.description = try container.decode(String.self, forKey: .description)
+        self.packages = try container.decode([Package].self, forKey: .packages)
+        self._paywall = container.decode(IgnoreDecodeErrors<PaywallData?>.self, forKey: .paywall)
+        self._metadata = try container.decode(
+            DefaultDecodable.EmptyDictionary<[String: AnyDecodable]>.self,
+            forKey: .metadata
+        )
+        self.webCheckoutUrl = try container.decodeIfPresent(URL.self, forKey: .webCheckoutUrl)
+
+        let explicitHasPaywallComponents = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .hasPaywallComponents
+        )
+        let decodingMode = decoder.userInfo[OfferingsResponse.decodingModeUserInfoKey]
+            as? OfferingsResponse.DecodingMode ?? .full
+
+        switch decodingMode {
+        case .full:
+            self.paywallComponents = try container.decodeIfPresent(
+                PaywallComponentsData.self,
+                forKey: .paywallComponents
+            )
+            self.hasPaywallComponents = explicitHasPaywallComponents
+
+        case .withoutPaywallComponents:
+            self.paywallComponents = nil
+            self.hasPaywallComponents = explicitHasPaywallComponents
+                ?? Self.hasNonNullValue(in: container, forKey: .paywallComponents)
+        }
+    }
+
+    private static func hasNonNullValue(
+        in container: KeyedDecodingContainer<CodingKeys>,
+        forKey key: CodingKeys
+    ) -> Bool? {
+        guard container.contains(key) else { return nil }
+        return (try? container.decodeNil(forKey: key)) == false
+    }
+
+}
 extension OfferingsResponse.Placements: Codable, Equatable {}
 extension OfferingsResponse.Targeting: Codable, Equatable {}
 extension OfferingsResponse: Codable, Equatable {}

--- a/Sources/Networking/Responses/OfferingsResponse.swift
+++ b/Sources/Networking/Responses/OfferingsResponse.swift
@@ -148,6 +148,9 @@ extension OfferingsResponse.Offering: Codable, Equatable {
         )
         let decodingMode = decoder.userInfo[OfferingsResponse.decodingModeUserInfoKey]
             as? OfferingsResponse.DecodingMode ?? .withPaywallComponents
+        let inferredHasPaywallComponents = decodingMode == .withoutPaywallComponents
+            ? Self.hasNonNullValue(in: container, forKey: .paywallComponents)
+            : nil
 
         switch decodingMode {
         case .withPaywallComponents:
@@ -155,13 +158,12 @@ extension OfferingsResponse.Offering: Codable, Equatable {
                 PaywallComponentsData.self,
                 forKey: .paywallComponents
             )
-            self.hasPaywallComponents = explicitHasPaywallComponents
 
         case .withoutPaywallComponents:
             self.paywallComponents = nil
-            self.hasPaywallComponents = explicitHasPaywallComponents
-                ?? Self.hasNonNullValue(in: container, forKey: .paywallComponents)
         }
+
+        self.hasPaywallComponents = explicitHasPaywallComponents ?? inferredHasPaywallComponents
     }
 
     private static func hasNonNullValue(

--- a/Sources/Purchasing/Offerings.swift
+++ b/Sources/Purchasing/Offerings.swift
@@ -218,15 +218,11 @@ extension Offerings {
     struct Contents {
         var response: OfferingsResponse
         var originalSource: Offerings.OriginalSource
-        /// Original verified response bytes used only to persist the existing offerings cache representation.
-        var responseDataForCache: Data?
 
         init(response: OfferingsResponse,
-             httpResponseOriginalSource: HTTPResponseOriginalSource,
-             responseDataForCache: Data? = nil) {
+             httpResponseOriginalSource: HTTPResponseOriginalSource) {
             self.response = response
             self.originalSource = Offerings.OriginalSource(httpResponseOriginalSource: httpResponseOriginalSource)
-            self.responseDataForCache = responseDataForCache
         }
     }
 }
@@ -254,7 +250,6 @@ extension Offerings.Contents: Codable {
         self.response = try OfferingsResponse(from: decoder)
         self.originalSource = try container.decodeIfPresent(Offerings.OriginalSource.self,
                                                             forKey: .originalSource) ?? .main
-        self.responseDataForCache = nil
     }
 
 }

--- a/Sources/Purchasing/Offerings.swift
+++ b/Sources/Purchasing/Offerings.swift
@@ -218,10 +218,15 @@ extension Offerings {
     struct Contents {
         var response: OfferingsResponse
         var originalSource: Offerings.OriginalSource
+        /// Original verified response bytes used only to persist the existing offerings cache representation.
+        var responseDataForCache: Data?
 
-        init(response: OfferingsResponse, httpResponseOriginalSource: HTTPResponseOriginalSource) {
+        init(response: OfferingsResponse,
+             httpResponseOriginalSource: HTTPResponseOriginalSource,
+             responseDataForCache: Data? = nil) {
             self.response = response
             self.originalSource = Offerings.OriginalSource(httpResponseOriginalSource: httpResponseOriginalSource)
+            self.responseDataForCache = responseDataForCache
         }
     }
 }
@@ -249,6 +254,7 @@ extension Offerings.Contents: Codable {
         self.response = try OfferingsResponse(from: decoder)
         self.originalSource = try container.decodeIfPresent(Offerings.OriginalSource.self,
                                                             forKey: .originalSource) ?? .main
+        self.responseDataForCache = nil
     }
 
 }

--- a/Sources/Purchasing/OfferingsFactory.swift
+++ b/Sources/Purchasing/OfferingsFactory.swift
@@ -44,9 +44,10 @@ class OfferingsFactory {
             return nil
         }
 
-        let storedContents = shouldCreatePaywallComponents
+        var storedContents = shouldCreatePaywallComponents
             ? contents
             : contents.removingPaywallComponents()
+        storedContents.responseDataForCache = nil
 
         return Offerings(offerings: offerings,
                          currentOfferingID: data.currentOfferingId,

--- a/Sources/Purchasing/OfferingsFactory.swift
+++ b/Sources/Purchasing/OfferingsFactory.swift
@@ -44,10 +44,9 @@ class OfferingsFactory {
             return nil
         }
 
-        var storedContents = shouldCreatePaywallComponents
+        let storedContents = shouldCreatePaywallComponents
             ? contents
             : contents.removingPaywallComponents()
-        storedContents.responseDataForCache = nil
 
         return Offerings(offerings: offerings,
                          currentOfferingID: data.currentOfferingId,

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -30,6 +30,7 @@ class OfferingsManager {
     private let remoteConfigManager: RemoteConfigManagerType?
     private let uiConfigProvider: UiConfigProvider?
     private let workflowAssetPrewarmer: WorkflowAssetPrewarmingType?
+    private let offeringsCacheGeneration = Atomic(0)
 
     init(deviceCache: DeviceCache,
          operationDispatcher: OperationDispatcher,
@@ -130,10 +131,15 @@ class OfferingsManager {
     ) {
         // We keep track of preferred locales at the time of launching the request
         let preferredLocales = systemInfo.preferredLocales
+        // Snapshot the generation before the mode. If remote config disables between these reads,
+        // the request is conservatively treated as stale instead of allowing a pruned response into
+        // the new generation.
+        let cacheGeneration = self.offeringsCacheGeneration.value
+        let decodingMode = self.offeringsResponseDecodingMode
         self.backend.offerings.getOfferings(
             appUserID: appUserID,
             isAppBackgrounded: isAppBackgrounded,
-            decodingMode: self.offeringsResponseDecodingMode
+            decodingMode: decodingMode
         ) { result in
             switch result {
             case let .success(contents):
@@ -142,6 +148,7 @@ class OfferingsManager {
                                                   isAppBackgrounded: isAppBackgrounded,
                                                   fetchPolicy: fetchPolicy,
                                                   preferredLocales: preferredLocales,
+                                                  cacheGeneration: cacheGeneration,
                                                   completion: completion)
 
             case let .failure(backendError) where backendError.shouldFallBackToCache:
@@ -206,6 +213,7 @@ class OfferingsManager {
     }
 
     func refreshCachedOfferingsForRemoteConfigDisable(appUserID: String) {
+        self.offeringsCacheGeneration.modify { $0 += 1 }
         let cachedOfferings = self.deviceCache.cachedOfferings
 
         // Preserve the full response on disk so it can provide legacy paywall components if the network fails.
@@ -371,6 +379,7 @@ private extension OfferingsManager {
         isAppBackgrounded: Bool,
         fetchPolicy: FetchPolicy,
         preferredLocales: [String],
+        cacheGeneration: Int,
         completion: (@MainActor @Sendable (Result<OfferingsResultData, Error>) -> Void)?
     ) {
         self.createOfferings(from: contents, loadedFromDiskCache: false, fetchPolicy: fetchPolicy) { result in
@@ -378,10 +387,18 @@ private extension OfferingsManager {
             case let .success(offeringsResultData):
                 Logger.rcSuccess(Strings.offering.offerings_stale_updated_from_network)
 
-                self.deviceCache.cache(offerings: offeringsResultData.offerings,
-                                       diskContents: contents,
-                                       preferredLocales: preferredLocales,
-                                       appUserID: appUserID)
+                let didCache = self.offeringsCacheGeneration.modify { currentGeneration in
+                    guard currentGeneration == cacheGeneration else { return false }
+
+                    self.deviceCache.cache(offerings: offeringsResultData.offerings,
+                                           diskContents: contents,
+                                           preferredLocales: preferredLocales,
+                                           appUserID: appUserID)
+                    return true
+                }
+
+                // Superseded background refreshes have nothing to deliver and must not mutate either cache.
+                guard didCache || completion != nil else { return }
 
                 // A background refresh (nil completion) only updates the cache; skip the
                 // readiness gate so it doesn't await (and decode) config for a no-op delivery.

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -550,7 +550,7 @@ private extension OfferingsManager {
     }
 
     var offeringsResponseDecodingMode: OfferingsResponse.DecodingMode {
-        return self.shouldCreatePaywallComponents ? .full : .withoutPaywallComponents
+        return self.shouldCreatePaywallComponents ? .withPaywallComponents : .withoutPaywallComponents
     }
 
     /// If remote config was disabled after a workflows-enabled offerings fetch, the in-memory offering

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -205,6 +205,19 @@ class OfferingsManager {
         }
     }
 
+    func refreshCachedOfferingsForRemoteConfigDisable(appUserID: String) {
+        let cachedOfferings = self.deviceCache.cachedOfferings
+
+        // Preserve the full response on disk so it can provide legacy paywall components if the network fails.
+        self.clearInMemoryOfferingsCache()
+
+        if cachedOfferings != nil {
+            self.offerings(appUserID: appUserID,
+                           fetchPolicy: .ignoreNotFoundProducts,
+                           trackDiagnostics: false) { @Sendable _ in }
+        }
+    }
+
 }
 
 private extension OfferingsManager {

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -130,7 +130,11 @@ class OfferingsManager {
     ) {
         // We keep track of preferred locales at the time of launching the request
         let preferredLocales = systemInfo.preferredLocales
-        self.backend.offerings.getOfferings(appUserID: appUserID, isAppBackgrounded: isAppBackgrounded) { result in
+        self.backend.offerings.getOfferings(
+            appUserID: appUserID,
+            isAppBackgrounded: isAppBackgrounded,
+            decodingMode: self.offeringsResponseDecodingMode
+        ) { result in
             switch result {
             case let .success(contents):
                 self.handleOfferingsBackendResult(with: contents,
@@ -244,7 +248,18 @@ private extension OfferingsManager {
         fetchPolicy: FetchPolicy,
         completion: (@escaping @Sendable (OfferingsResultData?) -> Void)
     ) {
-        guard let contents = self.deviceCache.cachedOfferingsContents(appUserID: appUserID) else {
+        guard let contents = self.deviceCache.cachedOfferingsContents(
+            appUserID: appUserID,
+            decodingMode: self.offeringsResponseDecodingMode
+        ) else {
+            completion(nil)
+            return
+        }
+
+        // A workflows-mode response intentionally omits legacy component bodies. Once remote config disables,
+        // that disk entry cannot provide the backwards-compatible paywall, so require a full network response
+        // instead of repeatedly rebuilding and rejecting the same pruned offering.
+        guard !self.shouldRejectPrunedDiskContents(contents) else {
             completion(nil)
             return
         }
@@ -504,6 +519,10 @@ private extension OfferingsManager {
         return self.remoteConfigManager?.isDisabled ?? true
     }
 
+    var offeringsResponseDecodingMode: OfferingsResponse.DecodingMode {
+        return self.shouldCreatePaywallComponents ? .full : .withoutPaywallComponents
+    }
+
     /// If remote config was disabled after a workflows-enabled offerings fetch, the in-memory offering
     /// can still carry only the lightweight paywall marker, not the renderable components payload.
     /// Refetch so the legacy offerings paywall fallback is restored for the disabled-RC path.
@@ -512,6 +531,14 @@ private extension OfferingsManager {
 
         return offerings.all.values.contains { offering in
             offering.hasPaywallComponents && offering.internalPaywallComponents == nil
+        }
+    }
+
+    private func shouldRejectPrunedDiskContents(_ contents: Offerings.Contents) -> Bool {
+        guard self.remoteConfigManager?.isDisabled == true else { return false }
+
+        return contents.response.offerings.contains { offering in
+            offering.hasPaywallComponents == true && offering.paywallComponents == nil
         }
     }
 

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -142,8 +142,8 @@ class OfferingsManager {
             decodingMode: decodingMode
         ) { result in
             switch result {
-            case let .success(contents):
-                self.handleOfferingsBackendResult(with: contents,
+            case let .success(fetchResult):
+                self.handleOfferingsBackendResult(with: fetchResult,
                                                   appUserID: appUserID,
                                                   isAppBackgrounded: isAppBackgrounded,
                                                   fetchPolicy: fetchPolicy,
@@ -374,7 +374,7 @@ private extension OfferingsManager {
 
     // swiftlint:disable:next function_parameter_count
     func handleOfferingsBackendResult(
-        with contents: Offerings.Contents,
+        with fetchResult: OfferingsFetchResult,
         appUserID: String,
         isAppBackgrounded: Bool,
         fetchPolicy: FetchPolicy,
@@ -382,6 +382,7 @@ private extension OfferingsManager {
         cacheGeneration: Int,
         completion: (@MainActor @Sendable (Result<OfferingsResultData, Error>) -> Void)?
     ) {
+        let contents = fetchResult.contents
         self.createOfferings(from: contents, loadedFromDiskCache: false, fetchPolicy: fetchPolicy) { result in
             switch result {
             case let .success(offeringsResultData):
@@ -391,7 +392,7 @@ private extension OfferingsManager {
                     guard currentGeneration == cacheGeneration else { return false }
 
                     self.deviceCache.cache(offerings: offeringsResultData.offerings,
-                                           diskContents: contents,
+                                           fetchResult: fetchResult,
                                            preferredLocales: preferredLocales,
                                            appUserID: appUserID)
                     return true

--- a/Sources/Purchasing/Purchases/LocalTransactionMetadataStore.swift
+++ b/Sources/Purchasing/Purchases/LocalTransactionMetadataStore.swift
@@ -79,7 +79,7 @@ final class LocalTransactionMetadataStore: LocalTransactionMetadataStoreType {
     func getMetadata(forTransactionId transactionId: String) -> LocalTransactionMetadata? {
         let key = self.getStoreKey(for: transactionId)
         do {
-            return try self.cache.value(forKey: key)
+            return try self.cache.value(forKey: key, decoder: .default)
         } catch {
             Logger.error("Error loading transaction metadata from cache: \(error.localizedDescription)")
             self.cache.removeObject(forKey: key)
@@ -107,7 +107,7 @@ final class LocalTransactionMetadataStore: LocalTransactionMetadataStoreType {
         let keys = self.cache.allKeys()
         return keys.compactMap { key -> LocalTransactionMetadata? in
             do {
-                return try self.cache.value(forKey: key)
+                return try self.cache.value(forKey: key, decoder: .default)
             } catch {
                 Logger.error("Error loading transaction metadata from cache: \(error.localizedDescription)")
                 self.cache.removeObject(forKey: key)

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -871,7 +871,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.identityManager.remoteConfigManager = self.remoteConfigManager
         self.remoteConfigManager.onRemoteConfigDisabled = { [weak self] in
             guard let self else { return }
-            self.offeringsManager.invalidateAndReFetchCachedOfferingsIfAppropiate(appUserID: self.appUserID)
+            self.offeringsManager.refreshCachedOfferingsForRemoteConfigDisable(appUserID: self.appUserID)
         }
 
         Logger.verbose(Strings.configure.purchases_init(self, paymentQueueWrapper))

--- a/Tests/UnitTests/Caching/DeviceCacheTests.swift
+++ b/Tests/UnitTests/Caching/DeviceCacheTests.swift
@@ -480,6 +480,80 @@ class DeviceCacheTests: TestCase {
         expect(cachedContents?.response.offerings.count) == offerings.contents.response.offerings.count
     }
 
+    func testRawNetworkResponseIsStoredInExistingCacheFormatAndDecodedUsingRequestedMode() throws {
+        let appUserID = "testUser"
+        let fixtureData = try BaseHTTPResponseTest.data(for: "OfferingsWithPaywallComponents")
+        var rawObject = try XCTUnwrap(JSONSerialization.jsonObject(with: fixtureData) as? [String: Any])
+        rawObject["future_backend_field"] = ["preserved": true]
+        let responseData = try JSONSerialization.data(withJSONObject: rawObject)
+        let response = try OfferingsResponse.create(
+            with: responseData,
+            decodingMode: .withoutPaywallComponents
+        )
+        let contents = Offerings.Contents(
+            response: response,
+            httpResponseOriginalSource: .fallbackUrl,
+            responseDataForCache: responseData
+        )
+
+        self.mockFileCache.stubSaveData(with: .success(.init(data: .init(), url: .mockFileLocation)))
+        self.deviceCache.cache(
+            offerings: .empty,
+            diskContents: contents,
+            preferredLocales: ["en-US"],
+            appUserID: appUserID
+        )
+
+        let cachedData = try XCTUnwrap(self.mockFileCache.saveDataInvocations.first?.data)
+        let cachedObject = try XCTUnwrap(JSONSerialization.jsonObject(with: cachedData) as? [String: Any])
+        expect(cachedObject["original_source"] as? String) == "fallback_url"
+        expect((cachedObject["future_backend_field"] as? [String: Bool])?["preserved"]) == true
+        let cachedOfferings = try XCTUnwrap(cachedObject["offerings"] as? [[String: Any]])
+        expect(cachedOfferings[safe: 1]?["draft_paywall_components"]).toNot(beNil())
+
+        let legacyDecoded = try JSONDecoder.default.decode(Offerings.Contents.self, from: cachedData)
+        expect(legacyDecoded.originalSource) == .fallbackUrl
+        expect(legacyDecoded.response.offerings.first?.paywallComponents).toNot(beNil())
+
+        self.mockFileCache.stubCachedContentExists(at: 0, with: true)
+        self.mockFileCache.stubCachedContentExists(at: 1, with: true)
+        self.mockFileCache.stubLoadFile(at: 0, with: .success(cachedData))
+        self.mockFileCache.stubLoadFile(at: 1, with: .success(cachedData))
+
+        let pruned = self.deviceCache.cachedOfferingsContents(
+            appUserID: appUserID,
+            decodingMode: .withoutPaywallComponents
+        )
+        let full = self.deviceCache.cachedOfferingsContents(appUserID: appUserID, decodingMode: .full)
+
+        expect(pruned?.originalSource) == .fallbackUrl
+        expect(pruned?.response.offerings.first?.paywallComponents).to(beNil())
+        expect(pruned?.response.offerings.first?.hasPaywallComponents) == true
+        expect(full?.originalSource) == .fallbackUrl
+        expect(full?.response.offerings.first?.paywallComponents).toNot(beNil())
+    }
+
+    func testInvalidRawResponseDoesNotOverwriteCacheWithPrunedContents() throws {
+        let response = try OfferingsResponse.create(
+            with: BaseHTTPResponseTest.data(for: "OfferingsWithPaywallComponents"),
+            decodingMode: .withoutPaywallComponents
+        )
+        let contents = Offerings.Contents(
+            response: response,
+            httpResponseOriginalSource: .mainServer,
+            responseDataForCache: Data("[]".utf8)
+        )
+
+        self.deviceCache.cache(
+            offerings: .empty,
+            diskContents: contents,
+            preferredLocales: ["en-US"],
+            appUserID: "testUser"
+        )
+
+        expect(self.mockFileCache.saveDataInvocations).to(beEmpty())
+    }
+
     func testOfferingsAreNeverSavedToUserDefaults() throws {
         let appUserID = "testUser"
         let offerings = try Self.createSampleOfferings()

--- a/Tests/UnitTests/Caching/DeviceCacheTests.swift
+++ b/Tests/UnitTests/Caching/DeviceCacheTests.swift
@@ -524,7 +524,10 @@ class DeviceCacheTests: TestCase {
             appUserID: appUserID,
             decodingMode: .withoutPaywallComponents
         )
-        let full = self.deviceCache.cachedOfferingsContents(appUserID: appUserID, decodingMode: .full)
+        let full = self.deviceCache.cachedOfferingsContents(
+            appUserID: appUserID,
+            decodingMode: .withPaywallComponents
+        )
 
         expect(pruned?.originalSource) == .fallbackUrl
         expect(pruned?.response.offerings.first?.paywallComponents).to(beNil())

--- a/Tests/UnitTests/Caching/DeviceCacheTests.swift
+++ b/Tests/UnitTests/Caching/DeviceCacheTests.swift
@@ -492,14 +492,13 @@ class DeviceCacheTests: TestCase {
         )
         let contents = Offerings.Contents(
             response: response,
-            httpResponseOriginalSource: .fallbackUrl,
-            responseDataForCache: responseData
+            httpResponseOriginalSource: .fallbackUrl
         )
 
         self.mockFileCache.stubSaveData(with: .success(.init(data: .init(), url: .mockFileLocation)))
         self.deviceCache.cache(
             offerings: .empty,
-            diskContents: contents,
+            fetchResult: .init(contents: contents, rawResponseData: responseData),
             preferredLocales: ["en-US"],
             appUserID: appUserID
         )
@@ -543,13 +542,12 @@ class DeviceCacheTests: TestCase {
         )
         let contents = Offerings.Contents(
             response: response,
-            httpResponseOriginalSource: .mainServer,
-            responseDataForCache: Data("[]".utf8)
+            httpResponseOriginalSource: .mainServer
         )
 
         self.deviceCache.cache(
             offerings: .empty,
-            diskContents: contents,
+            fetchResult: .init(contents: contents, rawResponseData: Data("[]".utf8)),
             preferredLocales: ["en-US"],
             appUserID: "testUser"
         )

--- a/Tests/UnitTests/Caching/DeviceCacheTests.swift
+++ b/Tests/UnitTests/Caching/DeviceCacheTests.swift
@@ -507,12 +507,11 @@ class DeviceCacheTests: TestCase {
         let cachedObject = try XCTUnwrap(JSONSerialization.jsonObject(with: cachedData) as? [String: Any])
         expect(cachedObject["original_source"] as? String) == "fallback_url"
         expect((cachedObject["future_backend_field"] as? [String: Bool])?["preserved"]) == true
-        let cachedOfferings = try XCTUnwrap(cachedObject["offerings"] as? [[String: Any]])
-        expect(cachedOfferings[safe: 1]?["draft_paywall_components"]).toNot(beNil())
 
-        let legacyDecoded = try JSONDecoder.default.decode(Offerings.Contents.self, from: cachedData)
-        expect(legacyDecoded.originalSource) == .fallbackUrl
-        expect(legacyDecoded.response.offerings.first?.paywallComponents).toNot(beNil())
+        let legacyDecoded = try JSONDecoder.default.decode(LegacyOfferingsCache.self, from: cachedData)
+        expect(legacyDecoded.originalSource) == "fallback_url"
+        expect(legacyDecoded.offerings.first?.paywallComponents?.id) == "pw_test_1"
+        expect(legacyDecoded.offerings.first?.paywallComponents?.revision) == 3
 
         self.mockFileCache.stubCachedContentExists(at: 0, with: true)
         self.mockFileCache.stubCachedContentExists(at: 1, with: true)
@@ -1273,6 +1272,48 @@ class DeviceCacheTests: TestCase {
         let finalOfferings = deviceCache.cachedOfferingsContents(appUserID: appUserID)
         expect(finalOfferings).toNot(beNil())
     }
+
+    func testMigratesPreviousSDKFullOfferingsCacheWithoutPruningStoredData() throws {
+        let appUserID = "previous-sdk-user"
+        let cacheData = try BaseHTTPResponseTest.data(for: "OfferingsCacheFromPreviousSDKFull")
+        let documentsURL = try XCTUnwrap(fileManager.urls(for: .documentDirectory, in: .userDomainMask).first)
+        let oldDirectoryURL = documentsURL.appendingPathComponent("RevenueCat")
+        let cacheKey = DeviceCache.CacheKey.offerings(appUserID).rawValue
+        let oldFileURL = oldDirectoryURL.appendingPathComponent(cacheKey)
+
+        try fileManager.createDirectory(
+            at: oldDirectoryURL,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+        try cacheData.write(to: oldFileURL)
+
+        let deviceCache = DeviceCache(
+            systemInfo: self.systemInfo,
+            userDefaults: self.makeIsolatedUserDefaults(),
+            cache: fileManager
+        )
+
+        let prunedContents = try XCTUnwrap(
+            deviceCache.cachedOfferingsContents(
+                appUserID: appUserID,
+                decodingMode: .withoutPaywallComponents
+            )
+        )
+        expect(prunedContents.originalSource) == .fallbackUrl
+        expect(prunedContents.response.offerings.first?.paywallComponents).to(beNil())
+        expect(prunedContents.response.offerings.first?.hasPaywallComponents) == true
+        XCTAssertFalse(fileManager.fileExists(atPath: oldFileURL.path))
+
+        let fullContents = try XCTUnwrap(
+            deviceCache.cachedOfferingsContents(
+                appUserID: appUserID,
+                decodingMode: .withPaywallComponents
+            )
+        )
+        expect(fullContents.originalSource) == .fallbackUrl
+        expect(fullContents.response.offerings.first?.paywallComponents?.id) == "pw_test_1"
+    }
 }
 
 private extension DeviceCacheTests {
@@ -1369,6 +1410,24 @@ private extension Offerings {
                                      httpResponseOriginalSource: .mainServer),
         loadedFromDiskCache: false
     )
+
+}
+
+/// Frozen subset of the pre-change cache model. This deliberately does not use
+/// `OfferingsResponse`, so writer and reader changes cannot make the compatibility test pass together.
+private struct LegacyOfferingsCache: Decodable {
+
+    struct Offering: Decodable {
+        let paywallComponents: PaywallComponents?
+    }
+
+    struct PaywallComponents: Decodable {
+        let id: String
+        let revision: Int
+    }
+
+    let offerings: [Offering]
+    let originalSource: String?
 
 }
 

--- a/Tests/UnitTests/Caching/SynchronizedLargeItemCacheTests.swift
+++ b/Tests/UnitTests/Caching/SynchronizedLargeItemCacheTests.swift
@@ -39,6 +39,15 @@ class SynchronizedLargeItemCacheTests: TestCase {
         XCTAssertEqual(mock.saveDataInvocations.count, 1)
     }
 
+    func testSetDataWritesBytesWithoutEncoding() {
+        let (mock, sut) = self.makeSystemUnderTest()
+        let data = Data([0x00, 0x01, 0xfe, 0xff])
+        mock.stubSaveData(with: .success(.init(data: data, url: baseDirectory)))
+
+        XCTAssertTrue(sut.set(data: data, forKey: "raw-key"))
+        XCTAssertEqual(mock.saveDataInvocations.first?.data, data)
+    }
+
     func testValueReturnsDecodedData() throws {
         let (mock, sut) = self.makeSystemUnderTest()
         let key = "value-key"

--- a/Tests/UnitTests/Caching/SynchronizedLargeItemCacheTests.swift
+++ b/Tests/UnitTests/Caching/SynchronizedLargeItemCacheTests.swift
@@ -48,6 +48,19 @@ class SynchronizedLargeItemCacheTests: TestCase {
         XCTAssertEqual(mock.saveDataInvocations.first?.data, data)
     }
 
+    func testSetCodableDoesNotEncodeWhenCacheDirectoryIsUnavailable() {
+        let mock = createAndTrackForMemoryLeak(MockSimpleCache(cacheDirectory: nil))
+        let sut = createAndTrackForMemoryLeak(
+            SynchronizedLargeItemCache(cache: mock, basePath: "unavailable-cache")
+        )
+        let value = EncodingProbe()
+
+        XCTAssertFalse(sut.set(codable: value, forKey: "key"))
+        XCTAssertFalse(value.wasEncoded)
+        XCTAssertTrue(mock.saveDataInvocations.isEmpty)
+        self.logger.verifyMessageWasLogged(Strings.cache.cache_url_not_available, level: .error)
+    }
+
     func testValueReturnsDecodedData() throws {
         let (mock, sut) = self.makeSystemUnderTest()
         let key = "value-key"
@@ -161,3 +174,11 @@ private struct TestValue: Codable, Equatable {
 }
 
 private struct MockError: Error { }
+
+private final class EncodingProbe: Encodable {
+    var wasEncoded = false
+
+    func encode(to encoder: Encoder) throws {
+        self.wasEncoded = true
+    }
+}

--- a/Tests/UnitTests/Caching/SynchronizedLargeItemCacheTests.swift
+++ b/Tests/UnitTests/Caching/SynchronizedLargeItemCacheTests.swift
@@ -69,7 +69,7 @@ class SynchronizedLargeItemCacheTests: TestCase {
         mock.stubCachedContentExists(with: true)
         mock.stubLoadFile(with: .success(value.asData))
 
-        let cached: TestValue? = try sut.value(forKey: key)
+        let cached: TestValue? = try sut.value(forKey: key, decoder: .default)
 
         XCTAssertEqual(cached, value)
     }
@@ -80,7 +80,7 @@ class SynchronizedLargeItemCacheTests: TestCase {
 
         // By default, cachedContentExists returns false
 
-        let cached: TestValue? = try? sut.value(forKey: key)
+        let cached: TestValue? = try? sut.value(forKey: key, decoder: .default)
 
         XCTAssertNil(cached)
     }
@@ -123,7 +123,7 @@ class SynchronizedLargeItemCacheTests: TestCase {
         // Return invalid JSON data that can't be decoded to TestValue
         mock.stubLoadFile(with: .success(Data("invalid json".utf8)))
 
-        XCTAssertThrowsError(try sut.value(forKey: key) as TestValue?)
+        XCTAssertThrowsError(try sut.value(forKey: key, decoder: .default) as TestValue?)
     }
 
     func testValueThrowsWhenLoadFileFails() throws {
@@ -133,7 +133,7 @@ class SynchronizedLargeItemCacheTests: TestCase {
         mock.stubCachedContentExists(with: true)
         mock.stubLoadFile(with: .failure(MockError()))
 
-        XCTAssertThrowsError(try sut.value(forKey: key) as TestValue?)
+        XCTAssertThrowsError(try sut.value(forKey: key, decoder: .default) as TestValue?)
     }
 
     // MARK: - Helpers

--- a/Tests/UnitTests/Mocks/MockDeviceCache.swift
+++ b/Tests/UnitTests/Mocks/MockDeviceCache.swift
@@ -106,6 +106,7 @@ class MockDeviceCache: DeviceCache {
     var cacheOfferingsCount = 0
     var latestCachePreferredLocales: [String]?
     var cacheOfferingsInMemoryCount = 0
+    var clearInMemoryOfferingsCacheCount = 0
     var clearCachedOfferingsCount = 0
     var clearOfferingsCacheTimestampCount = 0
     var setOfferingsCacheTimestampToNowCount = 0
@@ -131,6 +132,12 @@ class MockDeviceCache: DeviceCache {
     }
     override func cacheInMemory(offerings: Offerings) {
         self.cacheOfferingsInMemoryCount += 1
+        self.stubbedOfferings = offerings
+    }
+
+    override func clearInMemoryOfferingsCache() {
+        self.clearInMemoryOfferingsCacheCount += 1
+        self.stubbedOfferings = nil
     }
 
     override func isOfferingsCacheStale(isAppBackgrounded: Bool) -> Bool {
@@ -143,6 +150,8 @@ class MockDeviceCache: DeviceCache {
 
     override func clearOfferingsCache(appUserID: String) {
         self.clearCachedOfferingsCount += 1
+        self.stubbedOfferings = nil
+        self.stubbedCachedOfferingsData = nil
     }
 
     override func cachedOfferingsContents(

--- a/Tests/UnitTests/Mocks/MockDeviceCache.swift
+++ b/Tests/UnitTests/Mocks/MockDeviceCache.swift
@@ -129,6 +129,7 @@ class MockDeviceCache: DeviceCache {
         self.cacheOfferingsCount += 1
         self.latestCachePreferredLocales = preferredLocales
         self.latestCachedOfferingsContents = diskContents ?? offerings.contents
+        self.stubbedOfferings = offerings
     }
     override func cacheInMemory(offerings: Offerings) {
         self.cacheOfferingsInMemoryCount += 1

--- a/Tests/UnitTests/Mocks/MockDeviceCache.swift
+++ b/Tests/UnitTests/Mocks/MockDeviceCache.swift
@@ -157,7 +157,7 @@ class MockDeviceCache: DeviceCache {
 
     override func cachedOfferingsContents(
         appUserID: String,
-        decodingMode: OfferingsResponse.DecodingMode = .full
+        decodingMode: OfferingsResponse.DecodingMode = .withPaywallComponents
     ) -> Offerings.Contents? {
         if let stubbedCachedOfferingsData {
             let decoder = OfferingsResponse.makeDecoder(decodingMode: decodingMode)

--- a/Tests/UnitTests/Mocks/MockDeviceCache.swift
+++ b/Tests/UnitTests/Mocks/MockDeviceCache.swift
@@ -145,9 +145,13 @@ class MockDeviceCache: DeviceCache {
         self.clearCachedOfferingsCount += 1
     }
 
-    override func cachedOfferingsContents(appUserID: String) -> Offerings.Contents? {
+    override func cachedOfferingsContents(
+        appUserID: String,
+        decodingMode: OfferingsResponse.DecodingMode = .full
+    ) -> Offerings.Contents? {
         if let stubbedCachedOfferingsData {
-            return try? JSONDecoder.default.decode(Offerings.Contents.self, from: stubbedCachedOfferingsData)
+            let decoder = OfferingsResponse.makeDecoder(decodingMode: decodingMode)
+            return try? decoder.decode(Offerings.Contents.self, from: stubbedCachedOfferingsData)
         }
         return nil
     }

--- a/Tests/UnitTests/Mocks/MockDeviceCache.swift
+++ b/Tests/UnitTests/Mocks/MockDeviceCache.swift
@@ -114,6 +114,7 @@ class MockDeviceCache: DeviceCache {
     var stubbedOfferings: Offerings?
     var stubbedCachedOfferingsData: Data?
     var latestCachedOfferingsContents: Offerings.Contents?
+    var latestCachedOfferingsFetchResult: OfferingsFetchResult?
     var stubbedOfferingCacheStatus: CacheStatus?
 
     override var cachedOfferings: Offerings? {
@@ -122,13 +123,14 @@ class MockDeviceCache: DeviceCache {
 
     override func cache(
         offerings: Offerings,
-        diskContents: Offerings.Contents? = nil,
+        fetchResult: OfferingsFetchResult? = nil,
         preferredLocales: [String],
         appUserID: String
     ) {
         self.cacheOfferingsCount += 1
         self.latestCachePreferredLocales = preferredLocales
-        self.latestCachedOfferingsContents = diskContents ?? offerings.contents
+        self.latestCachedOfferingsContents = fetchResult?.contents ?? offerings.contents
+        self.latestCachedOfferingsFetchResult = fetchResult
         self.stubbedOfferings = offerings
     }
     override func cacheInMemory(offerings: Offerings) {

--- a/Tests/UnitTests/Mocks/MockOfferingsAPI.swift
+++ b/Tests/UnitTests/Mocks/MockOfferingsAPI.swift
@@ -48,6 +48,7 @@ class MockOfferingsAPI: OfferingsAPI {
                                                           decodingMode: OfferingsResponse.DecodingMode,
                                                           completion: OfferingsAPI.OfferingsResponseHandler?)]()
     var stubbedGetOfferingsCompletionResult: Result<Offerings.Contents, BackendError>?
+    var stubbedGetOfferingsRawResponseData: Data?
     var getOfferingsHandler: ((OfferingsResponse.DecodingMode, @escaping OfferingsResponseHandler) -> Void)?
 
     override func getOfferings(appUserID: String,
@@ -64,7 +65,11 @@ class MockOfferingsAPI: OfferingsAPI {
         if let getOfferingsHandler {
             getOfferingsHandler(decodingMode, completion)
         } else {
-            completion(self.stubbedGetOfferingsCompletionResult!)
+            completion(
+                self.stubbedGetOfferingsCompletionResult!.map {
+                    OfferingsFetchResult(contents: $0, rawResponseData: self.stubbedGetOfferingsRawResponseData)
+                }
+            )
         }
     }
 

--- a/Tests/UnitTests/Mocks/MockOfferingsAPI.swift
+++ b/Tests/UnitTests/Mocks/MockOfferingsAPI.swift
@@ -39,17 +39,26 @@ class MockOfferingsAPI: OfferingsAPI {
 
     var invokedGetOfferingsForAppUserID = false
     var invokedGetOfferingsForAppUserIDCount = 0
-    var invokedGetOfferingsForAppUserIDParameters: (appUserID: String?, isAppBackgrounded: Bool, completion: OfferingsAPI.OfferingsResponseHandler?)?
-    var invokedGetOfferingsForAppUserIDParametersList = [(appUserID: String?, isAppBackgrounded: Bool, completion: OfferingsAPI.OfferingsResponseHandler?)]()
+    var invokedGetOfferingsForAppUserIDParameters: (appUserID: String?,
+                                                     isAppBackgrounded: Bool,
+                                                     decodingMode: OfferingsResponse.DecodingMode,
+                                                     completion: OfferingsAPI.OfferingsResponseHandler?)?
+    var invokedGetOfferingsForAppUserIDParametersList = [(appUserID: String?,
+                                                          isAppBackgrounded: Bool,
+                                                          decodingMode: OfferingsResponse.DecodingMode,
+                                                          completion: OfferingsAPI.OfferingsResponseHandler?)]()
     var stubbedGetOfferingsCompletionResult: Result<Offerings.Contents, BackendError>?
 
     override func getOfferings(appUserID: String,
                                isAppBackgrounded: Bool,
+                               decodingMode: OfferingsResponse.DecodingMode = .full,
                                completion: @escaping OfferingsResponseHandler) {
         self.invokedGetOfferingsForAppUserID = true
         self.invokedGetOfferingsForAppUserIDCount += 1
-        self.invokedGetOfferingsForAppUserIDParameters = (appUserID, isAppBackgrounded, completion)
-        self.invokedGetOfferingsForAppUserIDParametersList.append((appUserID, isAppBackgrounded, completion))
+        self.invokedGetOfferingsForAppUserIDParameters = (appUserID, isAppBackgrounded, decodingMode, completion)
+        self.invokedGetOfferingsForAppUserIDParametersList.append(
+            (appUserID, isAppBackgrounded, decodingMode, completion)
+        )
 
         completion(self.stubbedGetOfferingsCompletionResult!)
     }

--- a/Tests/UnitTests/Mocks/MockOfferingsAPI.swift
+++ b/Tests/UnitTests/Mocks/MockOfferingsAPI.swift
@@ -52,7 +52,7 @@ class MockOfferingsAPI: OfferingsAPI {
 
     override func getOfferings(appUserID: String,
                                isAppBackgrounded: Bool,
-                               decodingMode: OfferingsResponse.DecodingMode = .full,
+                               decodingMode: OfferingsResponse.DecodingMode = .withPaywallComponents,
                                completion: @escaping OfferingsResponseHandler) {
         self.invokedGetOfferingsForAppUserID = true
         self.invokedGetOfferingsForAppUserIDCount += 1

--- a/Tests/UnitTests/Mocks/MockOfferingsAPI.swift
+++ b/Tests/UnitTests/Mocks/MockOfferingsAPI.swift
@@ -48,6 +48,7 @@ class MockOfferingsAPI: OfferingsAPI {
                                                           decodingMode: OfferingsResponse.DecodingMode,
                                                           completion: OfferingsAPI.OfferingsResponseHandler?)]()
     var stubbedGetOfferingsCompletionResult: Result<Offerings.Contents, BackendError>?
+    var getOfferingsHandler: ((OfferingsResponse.DecodingMode, @escaping OfferingsResponseHandler) -> Void)?
 
     override func getOfferings(appUserID: String,
                                isAppBackgrounded: Bool,
@@ -60,7 +61,11 @@ class MockOfferingsAPI: OfferingsAPI {
             (appUserID, isAppBackgrounded, decodingMode, completion)
         )
 
-        completion(self.stubbedGetOfferingsCompletionResult!)
+        if let getOfferingsHandler {
+            getOfferingsHandler(decodingMode, completion)
+        } else {
+            completion(self.stubbedGetOfferingsCompletionResult!)
+        }
     }
 
     var invokedGetWebOfferingProducts = false

--- a/Tests/UnitTests/Mocks/MockOfferingsManager.swift
+++ b/Tests/UnitTests/Mocks/MockOfferingsManager.swift
@@ -112,6 +112,16 @@ typealias OfferingsCompletion = @MainActor @Sendable (Result<Offerings, Error>) 
         invokedInvalidateAndReFetchCachedOfferingsIfAppropiateParametersList.append(appUserID)
     }
 
+    var invokedRefreshCachedOfferingsForRemoteConfigDisable = false
+    var invokedRefreshCachedOfferingsForRemoteConfigDisableCount = 0
+    var invokedRefreshCachedOfferingsForRemoteConfigDisableParameters: String?
+
+    override func refreshCachedOfferingsForRemoteConfigDisable(appUserID: String) {
+        invokedRefreshCachedOfferingsForRemoteConfigDisable = true
+        invokedRefreshCachedOfferingsForRemoteConfigDisableCount += 1
+        invokedRefreshCachedOfferingsForRemoteConfigDisableParameters = appUserID
+    }
+
 }
 
 extension MockOfferingsManager: @unchecked Sendable {}

--- a/Tests/UnitTests/Mocks/MockProductsManager.swift
+++ b/Tests/UnitTests/Mocks/MockProductsManager.swift
@@ -15,6 +15,8 @@ class MockProductsManager: ProductsManager {
     var invokedProductsParametersList = [Set<String>]()
     var stubbedProductsCompletionResult: Result<Set<StoreProduct>, PurchasesError>?
     var productResultDelay: TimeInterval?
+    var shouldDeferProductsCompletion = false
+    private(set) var deferredProductsCompletions: [() -> Void] = []
 
     override func products(withIdentifiers identifiers: Set<String>,
                            completion: @escaping (Result<Set<StoreProduct>, PurchasesError>) -> Void) {
@@ -22,14 +24,9 @@ class MockProductsManager: ProductsManager {
         self.invokedProductsCount += 1
         self.invokedProductsParameters = identifiers
         self.invokedProductsParametersList.append(identifiers)
-        if let result = self.stubbedProductsCompletionResult {
-            if let delay = self.productResultDelay {
-                DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-                    completion(result)
-                }
-            } else {
-                completion(result)
-            }
+        let result: Result<Set<StoreProduct>, PurchasesError>
+        if let stubbedResult = self.stubbedProductsCompletionResult {
+            result = stubbedResult
         } else {
             Logger.error("\(type(of: self)): no stubbed products, returning fake products for \(identifiers)")
 
@@ -46,8 +43,21 @@ class MockProductsManager: ProductsManager {
                 }
                 .map(StoreProduct.init(sk1Product:))
 
-            completion(.success(Set(products)))
+            result = .success(Set(products))
         }
+
+        let complete = { completion(result) }
+        if self.shouldDeferProductsCompletion {
+            self.deferredProductsCompletions.append(complete)
+        } else if let delay = self.productResultDelay {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: complete)
+        } else {
+            complete()
+        }
+    }
+
+    func completeDeferredProductsRequest(at index: Int) {
+        self.deferredProductsCompletions[index]()
     }
 
     var invokedCacheProduct = false
@@ -105,6 +115,8 @@ class MockProductsManager: ProductsManager {
         self.invokedProductsParameters = nil
         self.invokedProductsParametersList = []
         self.stubbedProductsCompletionResult = nil
+        self.shouldDeferProductsCompletion = false
+        self.deferredProductsCompletions = []
         self.invokedCacheProduct = false
         self.invokedCacheProductCount = 0
         self.invokedCacheProductParameter = nil

--- a/Tests/UnitTests/Networking/Backend/BackendGetOfferingsTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetOfferingsTests.swift
@@ -85,7 +85,7 @@ class BackendGetOfferingsTests: BaseBackendTests {
         self.offerings.getOfferings(
             appUserID: Self.userID,
             isAppBackgrounded: false,
-            decodingMode: .full
+            decodingMode: .withPaywallComponents
         ) { fullResult.value = $0 }
         self.offerings.getOfferings(
             appUserID: Self.userID,
@@ -121,7 +121,7 @@ class BackendGetOfferingsTests: BaseBackendTests {
         self.offerings.getOfferings(
             appUserID: Self.userID,
             isAppBackgrounded: false,
-            decodingMode: .full
+            decodingMode: .withPaywallComponents
         ) { fullResult.value = $0 }
         self.offerings.getOfferings(
             appUserID: Self.userID,

--- a/Tests/UnitTests/Networking/Backend/BackendGetOfferingsTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetOfferingsTests.swift
@@ -79,8 +79,8 @@ class BackendGetOfferingsTests: BaseBackendTests {
             )
         )
 
-        let fullResult: Atomic<Result<Offerings.Contents, BackendError>?> = nil
-        let prunedResult: Atomic<Result<Offerings.Contents, BackendError>?> = nil
+        let fullResult: Atomic<Result<OfferingsFetchResult, BackendError>?> = nil
+        let prunedResult: Atomic<Result<OfferingsFetchResult, BackendError>?> = nil
 
         self.offerings.getOfferings(
             appUserID: Self.userID,
@@ -97,13 +97,15 @@ class BackendGetOfferingsTests: BaseBackendTests {
         expect(prunedResult.value).toEventuallyNot(beNil())
         expect(self.httpClient.calls).to(haveCount(1))
 
-        let fullContents = try XCTUnwrap(fullResult.value?.value)
-        let prunedContents = try XCTUnwrap(prunedResult.value?.value)
+        let fullFetchResult = try XCTUnwrap(fullResult.value?.value)
+        let prunedFetchResult = try XCTUnwrap(prunedResult.value?.value)
+        let fullContents = fullFetchResult.contents
+        let prunedContents = prunedFetchResult.contents
         expect(fullContents.response.offerings.first?.paywallComponents).toNot(beNil())
         expect(prunedContents.response.offerings.first?.paywallComponents).to(beNil())
         expect(prunedContents.response.offerings.first?.hasPaywallComponents) == true
-        expect(fullContents.responseDataForCache) == responseData
-        expect(prunedContents.responseDataForCache) == responseData
+        expect(fullFetchResult.rawResponseData) == responseData
+        expect(prunedFetchResult.rawResponseData) == responseData
         expect(fullContents.originalSource) == .fallbackUrl
         expect(prunedContents.originalSource) == .fallbackUrl
     }
@@ -115,8 +117,8 @@ class BackendGetOfferingsTests: BaseBackendTests {
             response: .init(statusCode: .success, body: Data("{".utf8), delay: .milliseconds(10))
         )
 
-        let fullResult: Atomic<Result<Offerings.Contents, BackendError>?> = nil
-        let prunedResult: Atomic<Result<Offerings.Contents, BackendError>?> = nil
+        let fullResult: Atomic<Result<OfferingsFetchResult, BackendError>?> = nil
+        let prunedResult: Atomic<Result<OfferingsFetchResult, BackendError>?> = nil
 
         self.offerings.getOfferings(
             appUserID: Self.userID,
@@ -182,15 +184,16 @@ class BackendGetOfferingsTests: BaseBackendTests {
             response: .init(statusCode: .success, response: Self.oneOfferingResponse)
         )
 
-        let result: Atomic<Result<Offerings.Contents, BackendError>?> = nil
+        let result: Atomic<Result<OfferingsFetchResult, BackendError>?> = nil
         self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false) {
             result.value = $0
         }
 
         expect(result.value).toEventuallyNot(beNil())
 
-        let offeringsContents = try XCTUnwrap(result.value?.value)
-        expect(offeringsContents.responseDataForCache).toNot(beNil())
+        let fetchResult = try XCTUnwrap(result.value?.value)
+        expect(fetchResult.rawResponseData).toNot(beNil())
+        let offeringsContents = fetchResult.contents
         let response = offeringsContents.response
         let offerings = try XCTUnwrap(response.offerings)
         let offeringA = try XCTUnwrap(offerings.first)
@@ -221,14 +224,14 @@ class BackendGetOfferingsTests: BaseBackendTests {
             )
         )
 
-        let result: Atomic<Result<Offerings.Contents, BackendError>?> = nil
+        let result: Atomic<Result<OfferingsFetchResult, BackendError>?> = nil
         self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false) {
             result.value = $0
         }
 
         expect(result.value).toEventuallyNot(beNil())
 
-        let offeringsContents = try XCTUnwrap(result.value?.value)
+        let offeringsContents = try XCTUnwrap(result.value?.value?.contents)
         expect(offeringsContents.originalSource) == .main
     }
 
@@ -243,14 +246,14 @@ class BackendGetOfferingsTests: BaseBackendTests {
             )
         )
 
-        let result: Atomic<Result<Offerings.Contents, BackendError>?> = nil
+        let result: Atomic<Result<OfferingsFetchResult, BackendError>?> = nil
         self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false) {
             result.value = $0
         }
 
         expect(result.value).toEventuallyNot(beNil())
 
-        let offeringsContents = try XCTUnwrap(result.value?.value)
+        let offeringsContents = try XCTUnwrap(result.value?.value?.contents)
         expect(offeringsContents.originalSource) == .loadShedder
     }
 
@@ -265,14 +268,14 @@ class BackendGetOfferingsTests: BaseBackendTests {
             )
         )
 
-        let result: Atomic<Result<Offerings.Contents, BackendError>?> = nil
+        let result: Atomic<Result<OfferingsFetchResult, BackendError>?> = nil
         self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false) {
             result.value = $0
         }
 
         expect(result.value).toEventuallyNot(beNil())
 
-        let offeringsContents = try XCTUnwrap(result.value?.value)
+        let offeringsContents = try XCTUnwrap(result.value?.value?.contents)
         expect(offeringsContents.originalSource) == .fallbackUrl
     }
 
@@ -288,14 +291,14 @@ class BackendGetOfferingsTests: BaseBackendTests {
             )
         )
 
-        let result: Atomic<Result<Offerings.Contents, BackendError>?> = nil
+        let result: Atomic<Result<OfferingsFetchResult, BackendError>?> = nil
         self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false) {
             result.value = $0
         }
 
         expect(result.value).toEventuallyNot(beNil())
 
-        let offeringsContents = try XCTUnwrap(result.value?.value)
+        let offeringsContents = try XCTUnwrap(result.value?.value?.contents)
         expect(offeringsContents.originalSource) == .fallbackUrl
     }
 

--- a/Tests/UnitTests/Networking/Backend/BackendGetOfferingsTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetOfferingsTests.swift
@@ -66,6 +66,84 @@ class BackendGetOfferingsTests: BaseBackendTests {
         expect(self.httpClient.calls).toEventually(haveCount(1))
     }
 
+    func testGetOfferingsCoalescesDifferentDecodingModesAndDecodesForEachCallback() throws {
+        self.httpClient.disableSnapshotTesting()
+        let responseData = try BaseHTTPResponseTest.data(for: "OfferingsWithPaywallComponents")
+        self.httpClient.mock(
+            requestPath: .getOfferings(appUserID: Self.userID),
+            response: .init(
+                statusCode: .success,
+                body: responseData,
+                delay: .milliseconds(10),
+                isFallbackUrlResponse: true
+            )
+        )
+
+        let fullResult: Atomic<Result<Offerings.Contents, BackendError>?> = nil
+        let prunedResult: Atomic<Result<Offerings.Contents, BackendError>?> = nil
+
+        self.offerings.getOfferings(
+            appUserID: Self.userID,
+            isAppBackgrounded: false,
+            decodingMode: .full
+        ) { fullResult.value = $0 }
+        self.offerings.getOfferings(
+            appUserID: Self.userID,
+            isAppBackgrounded: false,
+            decodingMode: .withoutPaywallComponents
+        ) { prunedResult.value = $0 }
+
+        expect(fullResult.value).toEventuallyNot(beNil())
+        expect(prunedResult.value).toEventuallyNot(beNil())
+        expect(self.httpClient.calls).to(haveCount(1))
+
+        let fullContents = try XCTUnwrap(fullResult.value?.value)
+        let prunedContents = try XCTUnwrap(prunedResult.value?.value)
+        expect(fullContents.response.offerings.first?.paywallComponents).toNot(beNil())
+        expect(prunedContents.response.offerings.first?.paywallComponents).to(beNil())
+        expect(prunedContents.response.offerings.first?.hasPaywallComponents) == true
+        expect(fullContents.responseDataForCache) == responseData
+        expect(prunedContents.responseDataForCache) == responseData
+        expect(fullContents.originalSource) == .fallbackUrl
+        expect(prunedContents.originalSource) == .fallbackUrl
+    }
+
+    func testGetOfferingsDeliversMalformedResponseErrorToCallbacksWithDifferentModes() {
+        self.httpClient.disableSnapshotTesting()
+        self.httpClient.mock(
+            requestPath: .getOfferings(appUserID: Self.userID),
+            response: .init(statusCode: .success, body: Data("{".utf8), delay: .milliseconds(10))
+        )
+
+        let fullResult: Atomic<Result<Offerings.Contents, BackendError>?> = nil
+        let prunedResult: Atomic<Result<Offerings.Contents, BackendError>?> = nil
+
+        self.offerings.getOfferings(
+            appUserID: Self.userID,
+            isAppBackgrounded: false,
+            decodingMode: .full
+        ) { fullResult.value = $0 }
+        self.offerings.getOfferings(
+            appUserID: Self.userID,
+            isAppBackgrounded: false,
+            decodingMode: .withoutPaywallComponents
+        ) { prunedResult.value = $0 }
+
+        expect(fullResult.value).toEventually(beFailure())
+        expect(prunedResult.value).toEventually(beFailure())
+        expect(self.httpClient.calls).to(haveCount(1))
+
+        let subsequentResult = waitUntilValue { completed in
+            self.offerings.getOfferings(
+                appUserID: Self.userID,
+                isAppBackgrounded: false,
+                completion: completed
+            )
+        }
+        expect(subsequentResult).to(beFailure())
+        expect(self.httpClient.calls).to(haveCount(2))
+    }
+
     func testRepeatedRequestsLogDebugMessage() {
         self.httpClient.mock(
             requestPath: .getOfferings(appUserID: Self.userID),
@@ -112,6 +190,7 @@ class BackendGetOfferingsTests: BaseBackendTests {
         expect(result.value).toEventuallyNot(beNil())
 
         let offeringsContents = try XCTUnwrap(result.value?.value)
+        expect(offeringsContents.responseDataForCache).toNot(beNil())
         let response = offeringsContents.response
         let offerings = try XCTUnwrap(response.offerings)
         let offeringA = try XCTUnwrap(offerings.first)

--- a/Tests/UnitTests/Networking/Responses/BaseHTTPResponseTest.swift
+++ b/Tests/UnitTests/Networking/Responses/BaseHTTPResponseTest.swift
@@ -33,10 +33,10 @@ class BaseHTTPResponseTest: TestCase {
         return try T.create(with: self.data(for: name, file: file, line: line))
     }
 
-    private static func data(
+    static func data(
         for fileName: String,
-        file: StaticString,
-        line: UInt
+        file: StaticString = #filePath,
+        line: UInt = #line
     ) throws -> Data {
         let url = try XCTUnwrap(
             Bundle(for: BundleToken.self).url(forResource: fileName,

--- a/Tests/UnitTests/Networking/Responses/Fixtures/OfferingsCacheFromPreviousSDKFull.json
+++ b/Tests/UnitTests/Networking/Responses/Fixtures/OfferingsCacheFromPreviousSDKFull.json
@@ -1,0 +1,140 @@
+{
+  "current_offering_id": "default",
+  "offerings": [
+    {
+      "description": "Offering with paywall components",
+      "identifier": "paywall_components",
+      "packages": [
+        {
+          "identifier": "$rc_monthly",
+          "platform_product_identifier": "com.revenuecat.monthly_4.99.1_week_intro"
+        }
+      ],
+      "paywall_components": {
+        "id": "pw_test_1",
+        "default_locale": "en_US",
+        "revision": 3,
+        "template_name": "componentsTEST",
+        "asset_base_url": "https://assets.pawwalls.com",
+        "components_localizations": [],
+        "components_config": {
+          "base": {
+            "background": {
+              "type": "color",
+              "value": {
+                "light": {
+                  "type": "hex",
+                  "value": "#220000ff"
+                }
+              }
+            },
+            "stack": {
+              "type": "stack",
+              "components": [],
+              "margin": {},
+              "padding": {},
+              "size": {
+                "width": {
+                  "type": "fill"
+                },
+                "height": {
+                  "type": "fill"
+                }
+              },
+              "dimension": {
+                "type": "vertical",
+                "alignment": "center",
+                "distribution": "center"
+              },
+              "spacing": 16
+            }
+          }
+        }
+      }
+    }
+  ],
+  "ui_config": {
+    "app": {
+      "colors": {
+        "primary": {
+          "light": {
+            "type": "hex",
+            "value": "#ffcc00"
+          }
+        },
+        "secondary": {
+          "light": {
+            "type": "linear",
+            "degrees": 45,
+            "points": [
+              {
+                "color": "#032400ff",
+                "percent": 0
+              },
+              {
+                "color": "#090979ff",
+                "percent": 35
+              },
+              {
+                "color": "#216c32ff",
+                "percent": 100
+              }
+            ]
+          }
+        },
+        "tertiary": {
+          "light": {
+            "type": "radial",
+            "points": [
+              {
+                "color": "#032400ff",
+                "percent": 0
+              },
+              {
+                "color": "#090979ff",
+                "percent": 35
+              },
+              {
+                "color": "#216c32ff",
+                "percent": 100
+              }
+            ]
+          }
+        }
+      },
+      "fonts": {
+        "primary": {
+          "ios": {
+            "type": "name",
+            "value": "SF Pro"
+          },
+          "android": {
+            "type": "name",
+            "value": "Roboto"
+          },
+          "web": {
+            "type": "google_fonts",
+            "value": "Gothic"
+          }
+        }
+      }
+    },
+    "localizations": {
+      "en_US": {
+        "monthly": "monthly"
+      },
+      "es_ES": {
+        "monthly": "mensual"
+      }
+    },
+    "variable_config": {
+      "variable_compatibility_map": {
+        "new var": "guaranteed var"
+      },
+      "function_compatibility_map": {
+        "new fun": "guaranteed fun"
+      }
+    }
+  },
+  "original_source": "fallback_url"
+}

--- a/Tests/UnitTests/Networking/Responses/Fixtures/OfferingsCacheFromPreviousSDKPruned.json
+++ b/Tests/UnitTests/Networking/Responses/Fixtures/OfferingsCacheFromPreviousSDKPruned.json
@@ -1,0 +1,17 @@
+{
+  "current_offering_id": "default",
+  "offerings": [
+    {
+      "description": "Offering with pruned paywall components",
+      "identifier": "paywall_components",
+      "packages": [
+        {
+          "identifier": "$rc_monthly",
+          "platform_product_identifier": "com.revenuecat.monthly_4.99.1_week_intro"
+        }
+      ],
+      "has_paywall_components": true
+    }
+  ],
+  "original_source": "fallback_url"
+}

--- a/Tests/UnitTests/Networking/Responses/PaywallComponentsDataTests.swift
+++ b/Tests/UnitTests/Networking/Responses/PaywallComponentsDataTests.swift
@@ -116,7 +116,7 @@ class PaywallComponentsDecodingTests: BaseHTTPResponseTest {
 
         let data = try JSONSerialization.data(withJSONObject: ["offerings": [offering]])
         let full = try XCTUnwrap(
-            OfferingsResponse.create(with: data, decodingMode: .full).offerings.first
+            OfferingsResponse.create(with: data, decodingMode: .withPaywallComponents).offerings.first
         )
         let pruned = try XCTUnwrap(
             OfferingsResponse.create(with: data, decodingMode: .withoutPaywallComponents).offerings.first

--- a/Tests/UnitTests/Networking/Responses/PaywallComponentsDataTests.swift
+++ b/Tests/UnitTests/Networking/Responses/PaywallComponentsDataTests.swift
@@ -25,6 +25,113 @@ class PaywallComponentsDecodingTests: BaseHTTPResponseTest {
         self.response = try Self.decodeFixture("OfferingsWithPaywallComponents")
     }
 
+    func testDecodingWithoutPaywallComponentsSkipsPublishedBody() throws {
+        let response = try OfferingsResponse.create(
+            with: Self.data(for: "OfferingsWithPaywallComponents"),
+            decodingMode: .withoutPaywallComponents
+        )
+
+        expect(response.offerings).to(haveCount(self.response.offerings.count))
+        expect(response.offerings.first?.identifier) == self.response.offerings.first?.identifier
+        expect(response.offerings.first?.packages) == self.response.offerings.first?.packages
+        XCTAssertTrue(response.offerings.allSatisfy { $0.paywallComponents == nil })
+        expect(response.offerings.first?.hasPaywallComponents) == true
+    }
+
+    func testDecodingWithoutPaywallComponentsInfersMarkerWithoutDecodingMalformedPayload() throws {
+        let offering = try self.decodeOffering(
+            paywallComponents: ["intentionally_invalid": true],
+            hasPaywallComponents: nil
+        )
+
+        expect(offering.paywallComponents).to(beNil())
+        expect(offering.hasPaywallComponents) == true
+    }
+
+    func testDecodingWithoutPaywallComponentsPreservesExplicitFalseMarker() throws {
+        let offering = try self.decodeOffering(
+            paywallComponents: ["intentionally_invalid": true],
+            hasPaywallComponents: false
+        )
+
+        expect(offering.paywallComponents).to(beNil())
+        expect(offering.hasPaywallComponents) == false
+    }
+
+    func testDecodingWithoutPaywallComponentsTreatsNullPayloadAsNotPresent() throws {
+        let offering = try self.decodeOffering(paywallComponents: NSNull(), hasPaywallComponents: nil)
+
+        expect(offering.paywallComponents).to(beNil())
+        expect(offering.hasPaywallComponents) == false
+    }
+
+    func testDecodingWithoutPaywallComponentsPreservesMissingMarkerWhenPayloadIsMissing() throws {
+        let offering = try self.decodeOffering(paywallComponents: nil, hasPaywallComponents: nil)
+
+        expect(offering.paywallComponents).to(beNil())
+        expect(offering.hasPaywallComponents).to(beNil())
+    }
+
+    func testDecodingWithoutPaywallComponentsPreservesExplicitTrueMarkerWhenPayloadIsMissing() throws {
+        let offering = try self.decodeOffering(paywallComponents: nil, hasPaywallComponents: true)
+
+        expect(offering.paywallComponents).to(beNil())
+        expect(offering.hasPaywallComponents) == true
+    }
+
+    func testDecodingWithoutPaywallComponentsPreservesExplicitTrueMarkerWhenPayloadIsNull() throws {
+        let offering = try self.decodeOffering(paywallComponents: NSNull(), hasPaywallComponents: true)
+
+        expect(offering.paywallComponents).to(beNil())
+        expect(offering.hasPaywallComponents) == true
+    }
+
+    func testDecodingWithoutPaywallComponentsInfersMarkerWhenExplicitMarkerIsNull() throws {
+        let offering = try self.decodeOffering(
+            paywallComponents: ["intentionally_invalid": true],
+            hasPaywallComponents: NSNull()
+        )
+
+        expect(offering.paywallComponents).to(beNil())
+        expect(offering.hasPaywallComponents) == true
+    }
+
+    func testDecodingWithoutPaywallComponentsPreservesEveryOtherOfferingField() throws {
+        let componentFixture = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Self.data(for: "OfferingsWithPaywallComponents")) as? [String: Any]
+        )
+        let legacyFixture = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Self.data(for: "Offerings")) as? [String: Any]
+        )
+        var offering = try XCTUnwrap((componentFixture["offerings"] as? [[String: Any]])?[safe: 1])
+        let legacyPaywallOffering = try XCTUnwrap((legacyFixture["offerings"] as? [[String: Any]])?[safe: 2])
+
+        offering["paywall"] = legacyPaywallOffering["paywall"]
+        offering["metadata"] = ["string": "value", "number": 5, "boolean": true]
+        offering["has_paywall_components"] = true
+        offering["web_checkout_url"] = "https://example.com/offering"
+        var packages = try XCTUnwrap(offering["packages"] as? [[String: Any]])
+        packages[0]["web_checkout_url"] = "https://example.com/package"
+        offering["packages"] = packages
+
+        let data = try JSONSerialization.data(withJSONObject: ["offerings": [offering]])
+        let full = try XCTUnwrap(
+            OfferingsResponse.create(with: data, decodingMode: .full).offerings.first
+        )
+        let pruned = try XCTUnwrap(
+            OfferingsResponse.create(with: data, decodingMode: .withoutPaywallComponents).offerings.first
+        )
+
+        var expectedPruned = full
+        expectedPruned.paywallComponents = nil
+
+        expect(pruned) == expectedPruned
+        expect(pruned.paywall).toNot(beNil())
+        expect(pruned.metadata) == ["string": "value", "number": 5, "boolean": true]
+        expect(pruned.webCheckoutUrl) == URL(string: "https://example.com/offering")
+        expect(pruned.packages.first?.webCheckoutUrl) == URL(string: "https://example.com/package")
+    }
+
     func testDecodesPaywallComponents() throws {
         let offering = try XCTUnwrap(self.response.offerings[safe: 0])
 
@@ -112,4 +219,28 @@ class PaywallComponentsDecodingTests: BaseHTTPResponseTest {
         let components = try XCTUnwrap(offering.paywallComponents)
         expect(components.zeroDecimalPlaceCountries).to(beEmpty())
     }
+}
+
+private extension PaywallComponentsDecodingTests {
+
+    func decodeOffering(
+        paywallComponents: Any?,
+        hasPaywallComponents: Any?
+    ) throws -> OfferingsResponse.Offering {
+        var offering: [String: Any] = [
+            "identifier": "test",
+            "description": "Test offering",
+            "packages": [[
+                "identifier": "$rc_monthly",
+                "platform_product_identifier": "product"
+            ]]
+        ]
+        offering["paywall_components"] = paywallComponents
+        offering["has_paywall_components"] = hasPaywallComponents
+
+        let data = try JSONSerialization.data(withJSONObject: ["offerings": [offering]])
+        let response = try OfferingsResponse.create(with: data, decodingMode: .withoutPaywallComponents)
+        return try XCTUnwrap(response.offerings.first)
+    }
+
 }

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -1571,6 +1571,52 @@ extension OfferingsManagerTests {
         expect(self.mockOfferings.invokedGetOfferingsForAppUserIDCount) == 1
     }
 
+    func testRemoteConfigDisableRefreshPreservesFullDiskCacheWhenNetworkFails() throws {
+        let mockRemoteConfigManager = MockRemoteConfigManager()
+        mockRemoteConfigManager.isDisabled = true
+        let manager = self.makeOfferingsManager(
+            remoteConfigManager: mockRemoteConfigManager,
+            offeringsFactory: OfferingsFactory(systemInfo: self.mockSystemInfo)
+        )
+        self.mockDeviceCache.stubbedOfferings = MockData.makeSampleOfferings(hasPaywallComponents: true)
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .failure(.networkError(.serverDown()))
+
+        let response: OfferingsResponse = try BaseHTTPResponseTest.decodeFixture("OfferingsWithPaywallComponents")
+        let uiConfig: UIConfig = try BaseHTTPResponseTest.decodeFixture("UIConfig")
+        let cachedContents = Offerings.Contents(
+            response: .init(
+                currentOfferingId: response.currentOfferingId,
+                offerings: response.offerings,
+                placements: response.placements,
+                targeting: response.targeting,
+                uiConfig: uiConfig
+            ),
+            httpResponseOriginalSource: .mainServer
+        )
+        self.mockDeviceCache.stubbedCachedOfferingsData = try cachedContents.jsonEncodedData
+
+        manager.refreshCachedOfferingsForRemoteConfigDisable(appUserID: MockData.anyAppUserID)
+
+        expect(self.mockOfferings.invokedGetOfferingsForAppUserIDCount).toEventually(equal(1))
+        expect(self.mockDeviceCache.cacheOfferingsInMemoryCount).toEventually(equal(1))
+        expect(self.mockDeviceCache.clearInMemoryOfferingsCacheCount) == 1
+        expect(self.mockDeviceCache.clearCachedOfferingsCount) == 0
+        expect(self.mockDeviceCache.stubbedOfferings?.loadedFromDiskCache) == true
+        expect(self.mockDeviceCache.stubbedOfferings?.offering(identifier: "paywall_components")?
+            .paywallComponents).toNot(beNil())
+    }
+
+    func testGeneralInvalidateAndRefetchClearsDiskCache() {
+        let manager = self.makeOfferingsManager(remoteConfigManager: nil)
+        self.mockDeviceCache.stubbedOfferings = MockData.makeSampleOfferings()
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .failure(.networkError(.serverDown()))
+
+        manager.invalidateAndReFetchCachedOfferingsIfAppropiate(appUserID: MockData.anyAppUserID)
+
+        expect(self.mockDeviceCache.clearCachedOfferingsCount) == 1
+        expect(self.mockDeviceCache.clearInMemoryOfferingsCacheCount) == 0
+    }
+
     private func makeOfferingsManager(
         remoteConfigManager: RemoteConfigManagerType?,
         offeringsFactory: OfferingsFactory? = nil,

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -1161,11 +1161,15 @@ extension OfferingsManagerTests {
 
         expect(deliveredResult.value).toEventually(beSuccess())
         expect(self.mockOfferings.invokedGetOfferingsForAppUserIDCount) == 2
+        expect(self.mockOfferings.invokedGetOfferingsForAppUserIDParametersList.map(\.decodingMode)) == [
+            .withoutPaywallComponents,
+            .full
+        ]
         let deliveredOffering = deliveredResult.value?.value?.offering(identifier: "paywall_components")
         expect(deliveredOffering?.paywallComponents).toNot(beNil())
     }
 
-    func testGetOfferingsCachesFullPaywallComponentsToDiskWhenRemoteConfigManagerIsEnabled() throws {
+    func testGetOfferingsCarriesFullResponseDataToDiskCacheWhenRemoteConfigManagerIsEnabled() throws {
         let mockRemoteConfigManager = MockRemoteConfigManager()
         mockRemoteConfigManager.isDisabled = false
         let manager = self.makeOfferingsManager(
@@ -1174,15 +1178,33 @@ extension OfferingsManagerTests {
         )
         let response: OfferingsResponse = try BaseHTTPResponseTest.decodeFixture("OfferingsWithPaywallComponents")
         let uiConfig: UIConfig = try BaseHTTPResponseTest.decodeFixture("UIConfig")
-        let offeringResp = OfferingsResponse(
+        let decodedOfferingResponse = OfferingsResponse(
             currentOfferingId: response.currentOfferingId,
             offerings: response.offerings,
             placements: response.placements,
             targeting: response.targeting,
             uiConfig: uiConfig
         )
+        let prunedOfferings = decodedOfferingResponse.offerings.map { offering in
+            var offering = offering
+            offering.hasPaywallComponents = offering.hasPaywallComponents
+                ?? (decodedOfferingResponse.uiConfig != nil && offering.paywallComponents != nil)
+            offering.paywallComponents = nil
+            return offering
+        }
+        let offeringResp = OfferingsResponse(
+            currentOfferingId: decodedOfferingResponse.currentOfferingId,
+            offerings: prunedOfferings,
+            placements: decodedOfferingResponse.placements,
+            targeting: decodedOfferingResponse.targeting,
+            uiConfig: decodedOfferingResponse.uiConfig
+        )
         self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(
-            Offerings.Contents(response: offeringResp, httpResponseOriginalSource: .mainServer)
+            Offerings.Contents(
+                response: offeringResp,
+                httpResponseOriginalSource: .mainServer,
+                responseDataForCache: try decodedOfferingResponse.jsonEncodedData
+            )
         )
 
         let result = waitUntilValue { completed in
@@ -1191,8 +1213,14 @@ extension OfferingsManagerTests {
 
         expect(result).to(beSuccess())
         expect(result?.value?.offering(identifier: "paywall_components")?.paywallComponents).to(beNil())
+        expect(result?.value?.contents.responseDataForCache).to(beNil())
         expect(self.mockDeviceCache.latestCachedOfferingsContents?.response.offerings.first?.paywallComponents)
-            .toNot(beNil())
+            .to(beNil())
+        expect(self.mockDeviceCache.latestCachedOfferingsContents?.response.offerings.first?.hasPaywallComponents)
+            == true
+        expect(self.mockDeviceCache.latestCachedOfferingsContents?.responseDataForCache).toNot(beNil())
+        expect(self.mockOfferings.invokedGetOfferingsForAppUserIDParameters?.decodingMode)
+            == .withoutPaywallComponents
     }
 
     func testGetOfferingsDoesNotDeliverUntilConfigReady() {
@@ -1473,6 +1501,74 @@ extension OfferingsManagerTests {
         expect(result).to(beSuccess())
         expect(result?.value?.loadedFromDiskCache) == true
         expect(mockRemoteConfigManager.invokedTopicCount) > 0
+    }
+
+    func testDisabledRemoteConfigRejectsPrunedDiskCacheWithoutRefetchLoop() throws {
+        let mockRemoteConfigManager = MockRemoteConfigManager()
+        mockRemoteConfigManager.isDisabled = true
+        let manager = self.makeOfferingsManager(remoteConfigManager: mockRemoteConfigManager)
+        let error = BackendError.networkError(.serverDown())
+        self.mockDeviceCache.stubbedOfferings = nil
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .failure(error)
+
+        let original = MockData.anyBackendOfferingsContents
+        var prunedOffering = try XCTUnwrap(original.response.offerings.first)
+        prunedOffering.hasPaywallComponents = true
+        prunedOffering.paywallComponents = nil
+        let prunedContents = Offerings.Contents(
+            response: .init(
+                currentOfferingId: original.response.currentOfferingId,
+                offerings: [prunedOffering],
+                placements: original.response.placements,
+                targeting: original.response.targeting,
+                uiConfig: original.response.uiConfig
+            ),
+            httpResponseOriginalSource: .mainServer
+        )
+        self.mockDeviceCache.stubbedCachedOfferingsData = try prunedContents.jsonEncodedData
+
+        let result: Result<Offerings, OfferingsManager.Error>? = waitUntilValue { completed in
+            manager.offerings(appUserID: MockData.anyAppUserID) { completed($0) }
+        }
+
+        expect(result).to(beFailure())
+        expect(result?.error).to(matchError(OfferingsManager.Error.backendError(error)))
+        expect(self.mockOfferings.invokedGetOfferingsForAppUserIDCount) == 1
+        expect(self.mockOfferings.invokedGetOfferingsForAppUserIDParameters?.decodingMode) == .full
+    }
+
+    func testDisabledRemoteConfigUsesFullCompatibleDiskCacheWhenNetworkFails() throws {
+        let mockRemoteConfigManager = MockRemoteConfigManager()
+        mockRemoteConfigManager.isDisabled = true
+        let manager = self.makeOfferingsManager(
+            remoteConfigManager: mockRemoteConfigManager,
+            offeringsFactory: OfferingsFactory(systemInfo: self.mockSystemInfo)
+        )
+        self.mockDeviceCache.stubbedOfferings = nil
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .failure(.networkError(.serverDown()))
+
+        let response: OfferingsResponse = try BaseHTTPResponseTest.decodeFixture("OfferingsWithPaywallComponents")
+        let uiConfig: UIConfig = try BaseHTTPResponseTest.decodeFixture("UIConfig")
+        let cachedContents = Offerings.Contents(
+            response: .init(
+                currentOfferingId: response.currentOfferingId,
+                offerings: response.offerings,
+                placements: response.placements,
+                targeting: response.targeting,
+                uiConfig: uiConfig
+            ),
+            httpResponseOriginalSource: .mainServer
+        )
+        self.mockDeviceCache.stubbedCachedOfferingsData = try cachedContents.jsonEncodedData
+
+        let result: Result<Offerings, OfferingsManager.Error>? = waitUntilValue { completed in
+            manager.offerings(appUserID: MockData.anyAppUserID) { completed($0) }
+        }
+
+        expect(result).to(beSuccess())
+        expect(result?.value?.loadedFromDiskCache) == true
+        expect(result?.value?.offering(identifier: "paywall_components")?.paywallComponents).toNot(beNil())
+        expect(self.mockOfferings.invokedGetOfferingsForAppUserIDCount) == 1
     }
 
     private func makeOfferingsManager(

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -1202,10 +1202,10 @@ extension OfferingsManagerTests {
         self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(
             Offerings.Contents(
                 response: offeringResp,
-                httpResponseOriginalSource: .mainServer,
-                responseDataForCache: try decodedOfferingResponse.jsonEncodedData
+                httpResponseOriginalSource: .mainServer
             )
         )
+        self.mockOfferings.stubbedGetOfferingsRawResponseData = try decodedOfferingResponse.jsonEncodedData
 
         let result = waitUntilValue { completed in
             manager.offerings(appUserID: MockData.anyAppUserID) { completed($0) }
@@ -1213,12 +1213,11 @@ extension OfferingsManagerTests {
 
         expect(result).to(beSuccess())
         expect(result?.value?.offering(identifier: "paywall_components")?.paywallComponents).to(beNil())
-        expect(result?.value?.contents.responseDataForCache).to(beNil())
         expect(self.mockDeviceCache.latestCachedOfferingsContents?.response.offerings.first?.paywallComponents)
             .to(beNil())
         expect(self.mockDeviceCache.latestCachedOfferingsContents?.response.offerings.first?.hasPaywallComponents)
             == true
-        expect(self.mockDeviceCache.latestCachedOfferingsContents?.responseDataForCache).toNot(beNil())
+        expect(self.mockDeviceCache.latestCachedOfferingsFetchResult?.rawResponseData).toNot(beNil())
         expect(self.mockOfferings.invokedGetOfferingsForAppUserIDParameters?.decodingMode)
             == .withoutPaywallComponents
     }
@@ -1626,7 +1625,8 @@ extension OfferingsManagerTests {
 
         expect(self.mockDeviceCache.cacheOfferingsCount) == 1
         expect(self.mockDeviceCache.stubbedOfferings?.contents.originalSource) == .fallbackUrl
-        expect(self.mockDeviceCache.stubbedOfferings?.all.values.first?.internalPaywallComponents).toNot(beNil())
+        expect(self.mockDeviceCache.stubbedOfferings?.offering(identifier: "paywall_components")?
+            .internalPaywallComponents).toNot(beNil())
         expect(self.mockDeviceCache.latestCachedOfferingsContents?.originalSource) == .fallbackUrl
         expect(self.mockDeviceCache.latestCachedOfferingsContents?.response.offerings.first?
             .paywallComponents).toNot(beNil())
@@ -1651,7 +1651,8 @@ extension OfferingsManagerTests {
 
         expect(self.mockDeviceCache.cacheOfferingsCount) == 1
         expect(self.mockDeviceCache.stubbedOfferings?.contents.originalSource) == .fallbackUrl
-        expect(self.mockDeviceCache.stubbedOfferings?.all.values.first?.internalPaywallComponents).toNot(beNil())
+        expect(self.mockDeviceCache.stubbedOfferings?.offering(identifier: "paywall_components")?
+            .internalPaywallComponents).toNot(beNil())
         expect(self.mockDeviceCache.latestCachedOfferingsContents?.originalSource) == .fallbackUrl
     }
 
@@ -1710,17 +1711,22 @@ extension OfferingsManagerTests {
         )
         let prunedContents = Offerings.Contents(
             response: prunedResponse,
-            httpResponseOriginalSource: .mainServer,
-            responseDataForCache: responseData
+            httpResponseOriginalSource: .mainServer
         )
         let fullContents = Offerings.Contents(
             response: fullResponse,
-            httpResponseOriginalSource: .fallbackUrl,
-            responseDataForCache: responseData
+            httpResponseOriginalSource: .fallbackUrl
         )
 
         self.mockOfferings.getOfferingsHandler = { decodingMode, completion in
-            completion(.success(decodingMode == .withPaywallComponents ? fullContents : prunedContents))
+            completion(
+                .success(
+                    .init(
+                        contents: decodingMode == .withPaywallComponents ? fullContents : prunedContents,
+                        rawResponseData: responseData
+                    )
+                )
+            )
         }
         self.mockProductsManager.shouldDeferProductsCompletion = true
         self.mockDeviceCache.stubbedOfferings = MockData.makeSampleOfferings(hasPaywallComponents: true)

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -1163,7 +1163,7 @@ extension OfferingsManagerTests {
         expect(self.mockOfferings.invokedGetOfferingsForAppUserIDCount) == 2
         expect(self.mockOfferings.invokedGetOfferingsForAppUserIDParametersList.map(\.decodingMode)) == [
             .withoutPaywallComponents,
-            .full
+            .withPaywallComponents
         ]
         let deliveredOffering = deliveredResult.value?.value?.offering(identifier: "paywall_components")
         expect(deliveredOffering?.paywallComponents).toNot(beNil())
@@ -1534,7 +1534,8 @@ extension OfferingsManagerTests {
         expect(result).to(beFailure())
         expect(result?.error).to(matchError(OfferingsManager.Error.backendError(error)))
         expect(self.mockOfferings.invokedGetOfferingsForAppUserIDCount) == 1
-        expect(self.mockOfferings.invokedGetOfferingsForAppUserIDParameters?.decodingMode) == .full
+        expect(self.mockOfferings.invokedGetOfferingsForAppUserIDParameters?.decodingMode)
+            == .withPaywallComponents
     }
 
     func testDisabledRemoteConfigUsesFullCompatibleDiskCacheWhenNetworkFails() throws {
@@ -1719,7 +1720,7 @@ extension OfferingsManagerTests {
         )
 
         self.mockOfferings.getOfferingsHandler = { decodingMode, completion in
-            completion(.success(decodingMode == .full ? fullContents : prunedContents))
+            completion(.success(decodingMode == .withPaywallComponents ? fullContents : prunedContents))
         }
         self.mockProductsManager.shouldDeferProductsCompletion = true
         self.mockDeviceCache.stubbedOfferings = MockData.makeSampleOfferings(hasPaywallComponents: true)

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -1606,6 +1606,54 @@ extension OfferingsManagerTests {
             .paywallComponents).toNot(beNil())
     }
 
+    func testRemoteConfigDisableDoesNotAllowOlderPrunedRequestToOverwriteFullCache() throws {
+        let context = try self.makeRemoteConfigDisableRaceContext()
+
+        context.manager.updateOfferingsCache(
+            appUserID: MockData.anyAppUserID,
+            isAppBackgrounded: false,
+            completion: nil
+        )
+        expect(self.mockProductsManager.deferredProductsCompletions).to(haveCount(1))
+
+        context.remoteConfigManager.isDisabled = true
+        context.manager.refreshCachedOfferingsForRemoteConfigDisable(appUserID: MockData.anyAppUserID)
+        expect(self.mockProductsManager.deferredProductsCompletions).to(haveCount(2))
+
+        self.mockProductsManager.completeDeferredProductsRequest(at: 1)
+        self.mockProductsManager.completeDeferredProductsRequest(at: 0)
+
+        expect(self.mockDeviceCache.cacheOfferingsCount) == 1
+        expect(self.mockDeviceCache.stubbedOfferings?.contents.originalSource) == .fallbackUrl
+        expect(self.mockDeviceCache.stubbedOfferings?.all.values.first?.internalPaywallComponents).toNot(beNil())
+        expect(self.mockDeviceCache.latestCachedOfferingsContents?.originalSource) == .fallbackUrl
+        expect(self.mockDeviceCache.latestCachedOfferingsContents?.response.offerings.first?
+            .paywallComponents).toNot(beNil())
+    }
+
+    func testRemoteConfigDisableSkipsOlderPrunedCacheWriteWhenItFinishesFirst() throws {
+        let context = try self.makeRemoteConfigDisableRaceContext()
+
+        context.manager.updateOfferingsCache(
+            appUserID: MockData.anyAppUserID,
+            isAppBackgrounded: false,
+            completion: nil
+        )
+        context.remoteConfigManager.isDisabled = true
+        context.manager.refreshCachedOfferingsForRemoteConfigDisable(appUserID: MockData.anyAppUserID)
+        expect(self.mockProductsManager.deferredProductsCompletions).to(haveCount(2))
+
+        self.mockProductsManager.completeDeferredProductsRequest(at: 0)
+        expect(self.mockDeviceCache.cacheOfferingsCount) == 0
+
+        self.mockProductsManager.completeDeferredProductsRequest(at: 1)
+
+        expect(self.mockDeviceCache.cacheOfferingsCount) == 1
+        expect(self.mockDeviceCache.stubbedOfferings?.contents.originalSource) == .fallbackUrl
+        expect(self.mockDeviceCache.stubbedOfferings?.all.values.first?.internalPaywallComponents).toNot(beNil())
+        expect(self.mockDeviceCache.latestCachedOfferingsContents?.originalSource) == .fallbackUrl
+    }
+
     func testGeneralInvalidateAndRefetchClearsDiskCache() {
         let manager = self.makeOfferingsManager(remoteConfigManager: nil)
         self.mockDeviceCache.stubbedOfferings = MockData.makeSampleOfferings()
@@ -1631,6 +1679,52 @@ extension OfferingsManagerTests {
                                 diagnosticsTracker: self.mockDiagnosticsTracker,
                                 remoteConfigManager: remoteConfigManager,
                                 workflowAssetPrewarmer: workflowAssetPrewarmer)
+    }
+
+    private func makeRemoteConfigDisableRaceContext() throws -> (
+        manager: OfferingsManager,
+        remoteConfigManager: MockRemoteConfigManager
+    ) {
+        let remoteConfigManager = MockRemoteConfigManager()
+        remoteConfigManager.isDisabled = false
+        let manager = self.makeOfferingsManager(
+            remoteConfigManager: remoteConfigManager,
+            offeringsFactory: OfferingsFactory(systemInfo: self.mockSystemInfo)
+        )
+
+        let fixtureResponse: OfferingsResponse = try BaseHTTPResponseTest.decodeFixture(
+            "OfferingsWithPaywallComponents"
+        )
+        let fullResponse = OfferingsResponse(
+            currentOfferingId: fixtureResponse.currentOfferingId,
+            offerings: fixtureResponse.offerings,
+            placements: fixtureResponse.placements,
+            targeting: fixtureResponse.targeting,
+            uiConfig: try BaseHTTPResponseTest.decodeFixture("UIConfig")
+        )
+        let responseData = try fullResponse.jsonEncodedData
+        let prunedResponse = try OfferingsResponse.create(
+            with: responseData,
+            decodingMode: .withoutPaywallComponents
+        )
+        let prunedContents = Offerings.Contents(
+            response: prunedResponse,
+            httpResponseOriginalSource: .mainServer,
+            responseDataForCache: responseData
+        )
+        let fullContents = Offerings.Contents(
+            response: fullResponse,
+            httpResponseOriginalSource: .fallbackUrl,
+            responseDataForCache: responseData
+        )
+
+        self.mockOfferings.getOfferingsHandler = { decodingMode, completion in
+            completion(.success(decodingMode == .full ? fullContents : prunedContents))
+        }
+        self.mockProductsManager.shouldDeferProductsCompletion = true
+        self.mockDeviceCache.stubbedOfferings = MockData.makeSampleOfferings(hasPaywallComponents: true)
+
+        return (manager, remoteConfigManager)
     }
 
     private static let uiConfigTopic: [String: RemoteConfiguration.ConfigItem] = [

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -1510,21 +1510,9 @@ extension OfferingsManagerTests {
         self.mockDeviceCache.stubbedOfferings = nil
         self.mockOfferings.stubbedGetOfferingsCompletionResult = .failure(error)
 
-        let original = MockData.anyBackendOfferingsContents
-        var prunedOffering = try XCTUnwrap(original.response.offerings.first)
-        prunedOffering.hasPaywallComponents = true
-        prunedOffering.paywallComponents = nil
-        let prunedContents = Offerings.Contents(
-            response: .init(
-                currentOfferingId: original.response.currentOfferingId,
-                offerings: [prunedOffering],
-                placements: original.response.placements,
-                targeting: original.response.targeting,
-                uiConfig: original.response.uiConfig
-            ),
-            httpResponseOriginalSource: .mainServer
+        self.mockDeviceCache.stubbedCachedOfferingsData = try BaseHTTPResponseTest.data(
+            for: "OfferingsCacheFromPreviousSDKPruned"
         )
-        self.mockDeviceCache.stubbedCachedOfferingsData = try prunedContents.jsonEncodedData
 
         let result: Result<Offerings, OfferingsManager.Error>? = waitUntilValue { completed in
             manager.offerings(appUserID: MockData.anyAppUserID) { completed($0) }
@@ -1547,19 +1535,9 @@ extension OfferingsManagerTests {
         self.mockDeviceCache.stubbedOfferings = nil
         self.mockOfferings.stubbedGetOfferingsCompletionResult = .failure(.networkError(.serverDown()))
 
-        let response: OfferingsResponse = try BaseHTTPResponseTest.decodeFixture("OfferingsWithPaywallComponents")
-        let uiConfig: UIConfig = try BaseHTTPResponseTest.decodeFixture("UIConfig")
-        let cachedContents = Offerings.Contents(
-            response: .init(
-                currentOfferingId: response.currentOfferingId,
-                offerings: response.offerings,
-                placements: response.placements,
-                targeting: response.targeting,
-                uiConfig: uiConfig
-            ),
-            httpResponseOriginalSource: .mainServer
+        self.mockDeviceCache.stubbedCachedOfferingsData = try BaseHTTPResponseTest.data(
+            for: "OfferingsCacheFromPreviousSDKFull"
         )
-        self.mockDeviceCache.stubbedCachedOfferingsData = try cachedContents.jsonEncodedData
 
         let result: Result<Offerings, OfferingsManager.Error>? = waitUntilValue { completed in
             manager.offerings(appUserID: MockData.anyAppUserID) { completed($0) }

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -436,7 +436,7 @@ extension BasePurchasesTests {
 
         override func getOfferings(appUserID: String,
                                    isAppBackgrounded: Bool,
-                                   decodingMode: OfferingsResponse.DecodingMode = .full,
+                                   decodingMode: OfferingsResponse.DecodingMode = .withPaywallComponents,
                                    completion: @escaping OfferingsAPI.OfferingsResponseHandler) {
             self.gotOfferings += 1
             if self.failOfferings {

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -448,7 +448,7 @@ extension BasePurchasesTests {
                 return
             }
 
-            completion(.success(.mockContents))
+            completion(.success(.init(contents: .mockContents, rawResponseData: nil)))
         }
 
         var postOfferForSigningCalled = false

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -436,6 +436,7 @@ extension BasePurchasesTests {
 
         override func getOfferings(appUserID: String,
                                    isAppBackgrounded: Bool,
+                                   decodingMode: OfferingsResponse.DecodingMode = .full,
                                    completion: @escaping OfferingsAPI.OfferingsResponseHandler) {
             self.gotOfferings += 1
             if self.failOfferings {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
@@ -118,20 +118,21 @@ class PurchasesGetOfferingsTests: BasePurchasesTests {
         expect(self.deviceCache.clearOfferingsCacheTimestampCount) == 0
     }
 
-    func testRemoteConfigDisabledInvalidatesAndRefetchesOfferings() {
+    func testRemoteConfigDisabledUsesDedicatedOfferingsRefresh() {
         self.systemInfo.stubbedRemoteConfigEnabled = true
         self.setupPurchases()
 
-        self.mockOfferingsManager.invokedInvalidateAndReFetchCachedOfferingsIfAppropiate = false
-        self.mockOfferingsManager.invokedInvalidateAndReFetchCachedOfferingsIfAppropiateCount = 0
-        self.mockOfferingsManager.invokedInvalidateAndReFetchCachedOfferingsIfAppropiateParameters = nil
+        self.mockOfferingsManager.invokedRefreshCachedOfferingsForRemoteConfigDisable = false
+        self.mockOfferingsManager.invokedRefreshCachedOfferingsForRemoteConfigDisableCount = 0
+        self.mockOfferingsManager.invokedRefreshCachedOfferingsForRemoteConfigDisableParameters = nil
 
         self.mockRemoteConfigManager.onRemoteConfigDisabled?()
 
-        expect(self.mockOfferingsManager.invokedInvalidateAndReFetchCachedOfferingsIfAppropiate) == true
-        expect(self.mockOfferingsManager.invokedInvalidateAndReFetchCachedOfferingsIfAppropiateCount) == 1
-        expect(self.mockOfferingsManager.invokedInvalidateAndReFetchCachedOfferingsIfAppropiateParameters) ==
+        expect(self.mockOfferingsManager.invokedRefreshCachedOfferingsForRemoteConfigDisable) == true
+        expect(self.mockOfferingsManager.invokedRefreshCachedOfferingsForRemoteConfigDisableCount) == 1
+        expect(self.mockOfferingsManager.invokedRefreshCachedOfferingsForRemoteConfigDisableParameters) ==
             self.identityManager.currentAppUserID
+        expect(self.mockOfferingsManager.invokedInvalidateAndReFetchCachedOfferingsIfAppropiateCount) == 0
     }
 
     func testWarmsUpPaywallsCache() throws {


### PR DESCRIPTION
## Description
After our efforts to reduce memory consumption when using remote-config + workflows (and no longer relying on the `paywallComponents` from the offerings response), we decided to drop those from memory (`.paywallComponents = nil`).

However we were still decoding the fields prior to removing them from memory. And furthermore, we were storing the response to disk **after** removing the `paywallComponents. Which means that the on-disk cache was now also lacking them. In cases where remote config was disabled (using the killswitch for example), this caused a fresh network request to be sent since there was no (valid) local cache with `paywallComponents`.

## Changes
### Reducing CPU time
This is done by no longer decoding the `paywallComponents` (and `draftPaywallComponents`) whenever remote config / workflows is enabled. This has led to some nice CPU time savings. 

<details><summary>AI performance measurement context</summary>
<p>

### How it was measured

Measurements were captured using Instruments on the same iPhone 16 Pro simulator with Time Profiler, Allocations, and VM Tracker enabled. PaywallsTester was uninstalled before every run to ensure a cold SDK and disk cache.

The measured interval starts immediately before `Purchases.offerings()` and ends when it completes. Cumulative CPU time is the sum of Time Profiler sample weights across all threads within that interval. This measures processor work without counting time spent waiting for network requests.

Each configuration was run twice using the same API key, fixed user, external workflow blobs, simulator, and instrumentation. All runs returned 189 offerings.

Allocations instrumentation increases absolute CPU and allocation values, but the relative before/after comparison remains valid because every run used the same configuration.

</p>
</details> 

| Metric | RC enabled before | RC enabled after | Change |
|---|---:|---:|---:|
| Profiled CPU time | 5.020 s | 1.506 s | **−70.0%** |
| Cumulative allocations | 564.35 MB | 277.02 MB | **−50.9%** |
| Persistent allocations | 17.18 MB | 16.62 MB | **−3.3%** |
| `PaywallComponentsData.init(from:)` | ~2.17 s | Not present | **Removed** |

### Maintaining `paywallComponents` in on-disk cache
We're now receiving raw `Data` from the `HTTPClient`, decoding it (excluding the `paywallComponents`) using `JSONDecoder` for immediate use, but decoding it using `JSONSerialization`, adding the additional property `original_source` and re-encoding it before saving to disk (using `JSONSerialization` again). This is much cheaper than decoding it into concrete types using `JSONDecoder`, while still storing the original data to disk.

This allows for using the on-disk cache when we the remote config endpoint is disabled at a later stage, preserving the `paywallComponents`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes offerings fetch/decode/cache paths and remote-config-disable behavior; mistakes could break paywall fallback or cache coherency, but behavior is heavily covered by new unit tests.
> 
> **Overview**
> When remote config/workflows is active, offerings are now decoded in **without paywall components** mode so legacy `paywall_components` bodies are not parsed into memory, cutting CPU and allocation cost while still inferring `has_paywall_components` when needed.
> 
> **On-disk cache** keeps the full network JSON: raw response bytes are merged with `original_source` via `JSONSerialization` and written with `set(data:)`, while in-memory use still uses the pruned decode. Disk reads pick a decoder via `cachedOfferingsContents(decodingMode:)` so the same file can yield full or pruned `Offerings.Contents`.
> 
> **Remote config disable** no longer wipes disk offerings. `refreshCachedOfferingsForRemoteConfigDisable` clears only in-memory cache and refetches with full decoding; pruned disk entries are rejected when RC is off, and an **offerings cache generation** guard stops stale pruned network completions from overwriting a newer full cache after a disable race.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f672bc25eba97f187900fe644ddd3eab2672cb1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->