### PR TITLE
fix(paywalls): open web_view bridge channel only after init is delivered

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
@@ -251,8 +251,7 @@ struct WebViewRepresentable: PlatformViewRepresentable {
         self.session?.onContentResize = self.onContentResize
         self.session?.onDocumentReset = self.onDocumentReset
         self.session?.evaluateJavaScript = { [weak webView] script in
-            // A released web view means the frame never reaches the page; report the miss so the
-            // bridge does not open the channel on an `init` that was silently dropped.
+            // A released web view means the frame never reaches the page; report the miss
             guard let webView else { return false }
             webView.evaluateJavaScript(script) { _, error in
                 if let error {

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
@@ -100,7 +100,7 @@ private struct BridgedWebViewComponentView: View {
                     width: viewModel.size.width.isFit,
                     height: viewModel.size.height.isFit
                 ),
-                evaluateJavaScript: { _ in },
+                evaluateJavaScript: { _ in false },
                 currentURL: { nil }
             )
         )
@@ -251,11 +251,15 @@ struct WebViewRepresentable: PlatformViewRepresentable {
         self.session?.onContentResize = self.onContentResize
         self.session?.onDocumentReset = self.onDocumentReset
         self.session?.evaluateJavaScript = { [weak webView] script in
-            webView?.evaluateJavaScript(script) { _, error in
+            // A released web view means the frame never reaches the page; report the miss so the
+            // bridge does not open the channel on an `init` that was silently dropped.
+            guard let webView else { return false }
+            webView.evaluateJavaScript(script) { _, error in
                 if let error {
                     Logger.debug(Strings.paywall_web_view_post_message_failed(String(describing: error)))
                 }
             }
+            return true
         }
         self.session?.currentURL = { [weak webView] in
             webView?.url

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewSession.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewSession.swift
@@ -21,7 +21,10 @@ final class WebViewSession: NSObject, ObservableObject, WKScriptMessageHandler {
     var onDocumentReset: (@MainActor () -> Void)?
     private(set) var channelOpen = false
 
-    var evaluateJavaScript: (String) -> Void
+    /// Delivers a JS snippet to the web view. Returns `false` when the frame could not be handed
+    /// off (e.g. the backing web view was released), so callers can tell a real delivery from a
+    /// no-op and avoid opening the channel on an `init` that never reached the page.
+    var evaluateJavaScript: (String) -> Bool
     var currentURL: () -> URL?
 
     let fitAxes: (width: Bool, height: Bool)
@@ -38,7 +41,7 @@ final class WebViewSession: NSObject, ObservableObject, WKScriptMessageHandler {
         componentID: String,
         expectedOrigin: String,
         fitAxes: (width: Bool, height: Bool),
-        evaluateJavaScript: @escaping (String) -> Void,
+        evaluateJavaScript: @escaping (String) -> Bool,
         currentURL: @escaping () -> URL?
     ) {
         self.componentID = componentID
@@ -138,20 +141,22 @@ final class WebViewSession: NSObject, ObservableObject, WKScriptMessageHandler {
             return
         }
 
-        if protocolVersion == self.protocolVersion {
-            self.channelOpen = true
-            // Handshake replies (`init` and the follow-up fit message) use `allowBeforeNavigation:
-            // true`: the `connect` that triggered them was already gated against the authoritative
-            // sender-frame origin, but the WebView's top-level `url` may not be populated yet this
-            // early, and dropping these would leave the bridge half-open. The stricter current-URL
-            // check still applies to every later send.
-            self.send(.init(kind: .`init`, componentID: self.componentID), allowBeforeNavigation: true)
-            self.sendFitMessageIfNeeded()
-        } else {
+        guard protocolVersion == self.protocolVersion else {
             let error = "Unsupported protocol_version \(protocolVersion); " +
                 "native host supports \(self.protocolVersion)"
             self.send(.init(kind: .reject, componentID: "", error: error), allowBeforeNavigation: true)
+            return
         }
+
+        // Open the channel only once `init` is actually delivered, so a dropped `init` lets a later
+        // `connect` retry instead of stranding the bridge half-open (native "open", page never got
+        // `init`). `allowBeforeNavigation: true` because the top-level `url` may not be populated
+        // this early; the `connect` was already origin-gated and later sends still check it.
+        guard self.send(.init(kind: .`init`, componentID: self.componentID), allowBeforeNavigation: true) else {
+            return
+        }
+        self.channelOpen = true
+        self.sendFitMessageIfNeeded()
     }
 
     private func handleResize(_ payload: [String: PaywallWebViewValue]?) {
@@ -191,22 +196,27 @@ final class WebViewSession: NSObject, ObservableObject, WKScriptMessageHandler {
         )
     }
 
-    private func send(_ envelope: WebViewEnvelope.Envelope, allowBeforeNavigation: Bool) {
-        guard self.channelOpen || envelope.kind == .reject else {
+    /// Delivers a host-to-content frame. Returns `true` only when the frame was handed to the web
+    /// view.
+    @discardableResult
+    private func send(_ envelope: WebViewEnvelope.Envelope, allowBeforeNavigation: Bool) -> Bool {
+        // `init` and `reject` are handshake frames delivered while the channel is still opening;
+        // every other kind requires an already-open channel.
+        guard self.channelOpen || envelope.kind == .`init` || envelope.kind == .reject else {
             Logger.warning(Strings.paywall_web_view_post_message_skipped(reason: "channel-not-open"))
-            return
+            return false
         }
         // Defense in depth: drop outbound frames if the top-level URL left the expected origin.
         guard self.isCurrentURLTrusted(allowBeforeNavigation: allowBeforeNavigation) else {
             Logger.warning(Strings.paywall_web_view_post_message_skipped(reason: "untrusted-current-url"))
-            return
+            return false
         }
         guard let script = Self.receiveScript(for: envelope) else {
             Logger.debug(Strings.paywall_web_view_post_message_failed("encoding failed"))
-            return
+            return false
         }
 
-        self.evaluateJavaScript(script)
+        return self.evaluateJavaScript(script)
     }
 
     /// Serializes `envelope` into the JS snippet injected into the web view to deliver a

--- a/Tests/RevenueCatUITests/PaywallsV2/WebViewComponentViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WebViewComponentViewTests.swift
@@ -119,7 +119,7 @@ final class WebViewCoordinatorLifecycleTests: TestCase {
             componentID: "web",
             expectedOrigin: "https://example.com",
             fitAxes: (width: false, height: false),
-            evaluateJavaScript: { _ in },
+            evaluateJavaScript: { _ in true },
             currentURL: { nil }
         )
         let data = try! JSONEncoder().encode(WebViewEnvelope.Envelope(kind: .connect, componentID: ""))

--- a/Tests/RevenueCatUITests/PaywallsV2/WebViewSessionTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WebViewSessionTests.swift
@@ -375,13 +375,49 @@ final class WebViewSessionTests: TestCase {
     func testDropsOutboundAfterNavigationToUnexpectedOrigin() {
         let harness = Harness()
         // Inbound source is still the trusted origin, but the top-level URL has left it: every
-        // outbound frame (even `init`) must be dropped.
+        // outbound frame (even `init`) must be dropped. Because `init` never reaches the page, the
+        // channel must stay closed so a later `connect` can retry instead of stranding it half-open.
         harness.currentURL = URL(string: "https://evil.example.org/phish.html")!
 
         harness.handle(.init(kind: .connect, componentID: ""))
 
-        XCTAssertTrue(harness.session.channelOpen)
+        XCTAssertFalse(harness.session.channelOpen)
         XCTAssertTrue(harness.capturedScripts.isEmpty)
+    }
+
+    func testConnectRetriesAfterDroppedInitFromUntrustedURL() throws {
+        let harness = Harness(size: (width: false, height: true))
+        // First `connect` arrives while the top-level URL is off-origin, so `init` is dropped and
+        // the channel must remain closed.
+        harness.currentURL = URL(string: "https://evil.example.org/phish.html")!
+        harness.handle(.init(kind: .connect, componentID: ""))
+        XCTAssertFalse(harness.session.channelOpen)
+        XCTAssertTrue(harness.capturedScripts.isEmpty)
+
+        // Once the top-level URL is back on the expected origin, a retried `connect` opens the
+        // channel and delivers `init` (+ fit) — the bridge is not stuck from the earlier failure.
+        harness.currentURL = URL(string: "https://example.com/path")!
+        harness.handle(.init(kind: .connect, componentID: ""))
+
+        XCTAssertTrue(harness.session.channelOpen)
+        XCTAssertEqual(try harness.outboundEnvelopes().map(\.kind), [.`init`, .message])
+    }
+
+    func testConnectRetriesAfterInitDeliveryMiss() throws {
+        let harness = Harness()
+        // Simulate the backing web view being unavailable when the first `connect` arrives: the
+        // `init` frame is never handed off, so the channel must stay closed.
+        harness.deliverOutbound = false
+        harness.handle(.init(kind: .connect, componentID: ""))
+        XCTAssertFalse(harness.session.channelOpen)
+        XCTAssertTrue(harness.capturedScripts.isEmpty)
+
+        // With the web view available again, a retried `connect` opens the channel and delivers init.
+        harness.deliverOutbound = true
+        harness.handle(.init(kind: .connect, componentID: ""))
+
+        XCTAssertTrue(harness.session.channelOpen)
+        XCTAssertEqual(try harness.outboundEnvelopes().map(\.kind), [.`init`])
     }
 
     // MARK: - Round trip through a real WKWebView
@@ -392,7 +428,7 @@ final class WebViewSessionTests: TestCase {
             componentID: "web",
             expectedOrigin: "https://example.com",
             fitAxes: (width: false, height: false),
-            evaluateJavaScript: { _ in },
+            evaluateJavaScript: { _ in false },
             currentURL: { nil }
         )
 
@@ -403,7 +439,9 @@ final class WebViewSessionTests: TestCase {
         )
         let webView = WKWebView(frame: .zero, configuration: configuration)
         session.evaluateJavaScript = { [weak webView] script in
-            webView?.evaluateJavaScript(script)
+            guard let webView else { return false }
+            webView.evaluateJavaScript(script)
+            return true
         }
         session.currentURL = { [weak webView] in
             webView?.url
@@ -542,6 +580,9 @@ private final class Harness {
     let session: WebViewSession
     var capturedScripts: [String] = []
     var currentURL: URL? = URL(string: "https://example.com/path")!
+    /// Simulates a delivery miss (e.g. a released web view): when `false`, outbound frames are not
+    /// captured and `evaluateJavaScript` reports failure.
+    var deliverOutbound = true
 
     init(
         size: (width: Bool, height: Bool) = (false, false),
@@ -551,11 +592,15 @@ private final class Harness {
             componentID: "web",
             expectedOrigin: expectedOrigin,
             fitAxes: size,
-            evaluateJavaScript: { _ in },
+            evaluateJavaScript: { _ in false },
             currentURL: { nil }
         )
         self.session.evaluateJavaScript = { [weak self] script in
-            self?.capturedScripts.append(script)
+            guard let self, self.deliverOutbound else {
+                return false
+            }
+            self.capturedScripts.append(script)
+            return true
         }
         self.session.currentURL = { [weak self] in
             self?.currentURL


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests

### Motivation
Bugbot on [purchases-android#3798](https://github.com/RevenueCat/purchases-android/pull/3798#discussion_r3623391021) flagged that the `web_view` JS bridge marks its channel open *before* `init` is delivered. iOS has the same half-open bug: if the `init` send is dropped, the native side stays "open" while the page never received it, and every later `connect` is swallowed until a navigation reset.

### Description
- `handleConnect` now sets `channelOpen = true` only after `init` is actually delivered, so a dropped `init` leaves the channel closed and a later `connect` retries.
- `evaluateJavaScript` reports whether the frame reached the web view, so a released web view counts as a miss.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches paywall web-view handshake and origin-gated messaging; behavior change fixes stuck bridges but affects when the channel opens relative to `connect`.
> 
> **Overview**
> Fixes a **half-open** Paywalls V2 `web_view` JS bridge: native could mark the channel open before the page received `init`, so a dropped handshake left later `connect` messages ignored until navigation reset.
> 
> **`evaluateJavaScript`** now returns **`Bool`** so the session knows whether a frame was handed to the web view (including when the backing `WKWebView` is released). **`handleConnect`** sets **`channelOpen = true` only after `init` is successfully sent**; failed delivery (untrusted top-level URL, encoding failure, or delivery miss) keeps the channel closed so a later `connect` can retry. **`send`** propagates that success/failure and explicitly allows handshake frames **`init`** and **`reject`** while the channel is still opening.
> 
> Unit tests cover off-origin dropped `init`, retry after URL recovery, and simulated delivery misses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a132f26c03c31c4ecf3b18ae7c051e00d3778420. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->