### PR TITLE
Remove unused draft paywall components

### DIFF
--- a/RevenueCatUI/Data/PaywallViewConfiguration.swift
+++ b/RevenueCatUI/Data/PaywallViewConfiguration.swift
@@ -22,7 +22,6 @@ struct PaywallViewConfiguration {
     /// can have their own close buttons configured via the dashboard, so it's not used by the
     /// PaywallsV2View success path.
     var displayCloseButton: Bool
-    let useDraftPaywall: Bool
     var introEligibility: TrialOrIntroEligibilityChecker?
     var purchaseHandler: PurchaseHandler
     var promoOfferCache: PaywallPromoOfferCache?
@@ -39,7 +38,6 @@ struct PaywallViewConfiguration {
         mode: PaywallViewMode = .default,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         displayCloseButton: Bool = false,
-        useDraftPaywall: Bool = false,
         introEligibility: TrialOrIntroEligibilityChecker? = nil,
         purchaseHandler: PurchaseHandler,
         promoOfferCache: PaywallPromoOfferCache? = nil
@@ -49,7 +47,6 @@ struct PaywallViewConfiguration {
         self.mode = mode
         self.fonts = fonts
         self.displayCloseButton = displayCloseButton
-        self.useDraftPaywall = useDraftPaywall
         self.introEligibility = introEligibility
         self.purchaseHandler = purchaseHandler
         self.promoOfferCache = promoOfferCache
@@ -82,7 +79,6 @@ extension PaywallViewConfiguration {
         mode: PaywallViewMode = .default,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         displayCloseButton: Bool = false,
-        useDraftPaywall: Bool = false,
         introEligibility: TrialOrIntroEligibilityChecker? = nil,
         purchaseHandler: PurchaseHandler = PurchaseHandler.default(),
         promoOfferCache: PaywallPromoOfferCache? = nil
@@ -95,7 +91,6 @@ extension PaywallViewConfiguration {
             mode: mode,
             fonts: fonts,
             displayCloseButton: displayCloseButton,
-            useDraftPaywall: useDraftPaywall,
             introEligibility: introEligibility,
             purchaseHandler: handler,
             promoOfferCache: promoOfferCache

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -30,8 +30,6 @@ public struct PaywallView: View {
     private let fonts: PaywallFontProvider
     private let displayCloseButton: Bool
     private let paywallViewOwnsPurchaseHandler: Bool
-    private let useDraftPaywall: Bool
-
     @StateObject
     private var internalPurchaseHandler: PurchaseHandler
 
@@ -140,7 +138,7 @@ public struct PaywallView: View {
         offering: Offering,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         displayCloseButton: Bool = false,
-        useDraftPaywall: Bool,
+        useDraftPaywall _: Bool,
         introEligibility: TrialOrIntroEligibilityChecker? = nil,
         simulatePromoEligible: Bool = false,
         performPurchase: PerformPurchase? = nil,
@@ -153,7 +151,6 @@ public struct PaywallView: View {
                 offering: offering,
                 fonts: fonts,
                 displayCloseButton: displayCloseButton,
-                useDraftPaywall: useDraftPaywall,
                 introEligibility: introEligibility,
                 purchaseHandler: purchaseHandler,
                 promoOfferCache: simulatePromoEligible ? PaywallPromoOfferCache(simulateEligible: true) : nil
@@ -218,7 +215,6 @@ public struct PaywallView: View {
         self.mode = configuration.mode
         self.fonts = configuration.fonts
         self.displayCloseButton = configuration.displayCloseButton
-        self.useDraftPaywall = configuration.useDraftPaywall
         self.promoOfferCache = configuration.promoOfferCache
 
         self.initializationError = Self.checkForConfigurationConsistency(purchaseHandler: configuration.purchaseHandler)
@@ -278,7 +274,6 @@ public struct PaywallView: View {
                 if let offering = self.offering, let customerInfo = self.customerInfo {
                     self.paywallView(for: offering,
                                      workflowContext: self.workflowContext,
-                                     useDraftPaywall: self.useDraftPaywall,
                                      activelySubscribedProductIdentifiers: customerInfo.activeSubscriptions,
                                      fonts: self.fonts,
                                      checker: self.introEligibility,
@@ -342,17 +337,13 @@ public struct PaywallView: View {
     private func paywallView(
         for offering: Offering,
         workflowContext: WorkflowContext?,
-        useDraftPaywall: Bool,
         activelySubscribedProductIdentifiers: Set<String>,
         fonts: PaywallFontProvider,
         checker: TrialOrIntroEligibilityChecker,
         purchaseHandler: PurchaseHandler
     ) -> some View {
 
-        let selectedPaywallComponents = useDraftPaywall
-            ? offering.draftPaywallComponents
-            : offering.internalPaywallComponents
-        if let paywallComponents = selectedPaywallComponents {
+        if let paywallComponents = offering.internalPaywallComponents {
             // For V2 paywalls, prefer zeroDecimalPlaceCountries from paywallComponents
             let zeroDecimalPlaceCountries = paywallComponents.data.zeroDecimalPlaceCountries
             let showZeroDecimalPlacePrices = self.showZeroDecimalPlacePrices(

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -109,14 +109,16 @@ public struct PaywallView: View {
         performPurchase: PerformPurchase? = nil,
         performRestore: PerformRestore? = nil
     ) {
+        let purchaseHandler = PurchaseHandler.default(performPurchase: performPurchase, performRestore: performRestore)
+
         self.init(
-            offering: offering,
-            fonts: fonts,
-            displayCloseButton: displayCloseButton,
-            useDraftPaywall: false,
-            performPurchase: performPurchase,
-            performRestore: performRestore
+            configuration: .init(
+                offering: offering,
+                fonts: fonts,
+                displayCloseButton: displayCloseButton,
+                purchaseHandler: purchaseHandler
             )
+        )
     }
 
     // swiftlint:disable:next missing_docs
@@ -138,7 +140,6 @@ public struct PaywallView: View {
         offering: Offering,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         displayCloseButton: Bool = false,
-        useDraftPaywall _: Bool,
         introEligibility: TrialOrIntroEligibilityChecker? = nil,
         simulatePromoEligible: Bool = false,
         performPurchase: PerformPurchase? = nil,

--- a/Sources/Networking/Responses/OfferingsResponse.swift
+++ b/Sources/Networking/Responses/OfferingsResponse.swift
@@ -35,7 +35,6 @@ struct OfferingsResponse {
         @DefaultDecodable.EmptyDictionary
         var metadata: [String: AnyDecodable]
         var paywallComponents: PaywallComponentsData?
-        var draftPaywallComponents: PaywallComponentsData?
         var hasPaywallComponents: Bool?
         let webCheckoutUrl: URL?
     }

--- a/Sources/Purchasing/Offering.swift
+++ b/Sources/Purchasing/Offering.swift
@@ -101,11 +101,6 @@ import Foundation
     let hasPaywallComponents: Bool
 
     /**
-     Draft paywall components configuration defined in RevenueCat dashboard.
-     */
-    @_spi(Internal) public let draftPaywallComponents: PaywallComponents?
-
-    /**
      Array of ``Package`` objects available for purchase.
      */
     @objc public let availablePackages: [Package]
@@ -221,7 +216,7 @@ import Foundation
         webCheckoutUrl: URL?
     ) {
         self.init(identifier: identifier, serverDescription: serverDescription, metadata: metadata,
-                  paywall: paywall, paywallComponents: nil, draftPaywallComponents: nil,
+                  paywall: paywall, paywallComponents: nil, hasPaywallComponents: false,
                   availablePackages: availablePackages, webCheckoutUrl: webCheckoutUrl)
     }
 
@@ -237,7 +232,8 @@ import Foundation
     ) {
         self.init(identifier: identifier, serverDescription: serverDescription, metadata: metadata,
                   paywall: paywall, paywallComponents: paywallComponents,
-                  draftPaywallComponents: nil, availablePackages: availablePackages,
+                  hasPaywallComponents: paywallComponents != nil,
+                  availablePackages: availablePackages,
                   webCheckoutUrl: webCheckoutUrl)
     }
 
@@ -248,7 +244,6 @@ import Foundation
         paywall: PaywallData? = nil,
         paywallComponents: PaywallComponents? = nil,
         hasPaywallComponents: Bool = false,
-        draftPaywallComponents: PaywallComponents?,
         availablePackages: [Package],
         webCheckoutUrl: URL?
     ) {
@@ -259,7 +254,6 @@ import Foundation
         self.paywall = paywall
         self.internalPaywallComponents = paywallComponents
         self.hasPaywallComponents = hasPaywallComponents || paywallComponents != nil
-        self.draftPaywallComponents = draftPaywallComponents
         self.webCheckoutUrl = webCheckoutUrl
 
         var foundPackages: [PackageType: Package] = [:]
@@ -331,7 +325,6 @@ public extension Offering {
             paywall: paywall,
             paywallComponents: internalPaywallComponents,
             hasPaywallComponents: hasPaywallComponents,
-            draftPaywallComponents: draftPaywallComponents,
             availablePackages: availablePackages.map { $0.withPresentedOfferingContext(presentedOfferingContext) },
             webCheckoutUrl: webCheckoutUrl
         )
@@ -346,7 +339,6 @@ public extension Offering {
             paywall: paywall,
             paywallComponents: paywallComponents,
             hasPaywallComponents: true,
-            draftPaywallComponents: draftPaywallComponents,
             availablePackages: availablePackages,
             webCheckoutUrl: webCheckoutUrl
         )

--- a/Sources/Purchasing/Offerings.swift
+++ b/Sources/Purchasing/Offerings.swift
@@ -179,7 +179,6 @@ private extension Offering {
                         paywall: self.paywall,
                         paywallComponents: self.internalPaywallComponents,
                         hasPaywallComponents: self.hasPaywallComponents,
-                        draftPaywallComponents: self.draftPaywallComponents,
                         availablePackages: updatedPackages,
                         webCheckoutUrl: self.webCheckoutUrl
         )

--- a/Sources/Purchasing/OfferingsFactory.swift
+++ b/Sources/Purchasing/OfferingsFactory.swift
@@ -90,25 +90,12 @@ class OfferingsFactory {
             return nil
         }()
 
-        let paywallDraftComponents: Offering.PaywallComponents? = {
-            if shouldCreatePaywallComponents,
-               let uiConfig,
-               let paywallDraftComponents = offering.draftPaywallComponents {
-                return .init(
-                    uiConfig: uiConfig,
-                    data: paywallDraftComponents
-                )
-            }
-            return nil
-        }()
-
         return Offering(identifier: offering.identifier,
                         serverDescription: offering.description,
                         metadata: offering.metadata.mapValues(\.asAny),
                         paywall: offering.paywall,
                         paywallComponents: paywallComponents,
                         hasPaywallComponents: hasPaywallComponents,
-                        draftPaywallComponents: paywallDraftComponents,
                         availablePackages: availablePackages,
                         webCheckoutUrl: offering.webCheckoutUrl)
     }
@@ -174,7 +161,6 @@ private extension Offerings.Contents {
             let canCreatePaywallComponents = self.response.uiConfig != nil && offering.paywallComponents != nil
             offering.hasPaywallComponents = offering.hasPaywallComponents ?? canCreatePaywallComponents
             offering.paywallComponents = nil
-            offering.draftPaywallComponents = nil
             return offering
         }
         let response = OfferingsResponse(

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallPreviewResourcesLoader.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallPreviewResourcesLoader.swift
@@ -114,7 +114,6 @@ class PaywallPreviewResourcesLoader {
                     description: offering.description,
                     packages: packages.packages,
                     paywallComponents: offering.paywallComponents,
-                    draftPaywallComponents: offering.draftPaywallComponents,
                     hasPaywallComponents: offering.hasPaywallComponents,
                     webCheckoutUrl: offering.webCheckoutUrl
                 )

--- a/Tests/UnitTests/Networking/Responses/PaywallComponentsDataTests.swift
+++ b/Tests/UnitTests/Networking/Responses/PaywallComponentsDataTests.swift
@@ -25,7 +25,7 @@ class PaywallComponentsDecodingTests: BaseHTTPResponseTest {
         self.response = try Self.decodeFixture("OfferingsWithPaywallComponents")
     }
 
-    func testDecodesPaywallComponentsNoDraftPaywallComponents() throws {
+    func testDecodesPaywallComponents() throws {
         let offering = try XCTUnwrap(self.response.offerings[safe: 0])
 
         expect(offering.identifier) == "paywall_components"
@@ -42,11 +42,9 @@ class PaywallComponentsDecodingTests: BaseHTTPResponseTest {
         expect(components.componentsConfig.base.stack.spacing) == 16
         expect(components.componentsConfig.base.stack.dimension) == .vertical(.center, .center)
         expect(components.componentsConfig.base.stack.components).to(haveCount(0))
-
-        expect(offering.draftPaywallComponents) == nil
     }
 
-    func testDecodesPaywallComponentsWithDraftPaywallComponents() throws {
+    func testDecodesPaywallComponentsWhenResponseAlsoContainsDraftComponents() throws {
         let offering = try XCTUnwrap(self.response.offerings[safe: 1])
 
         expect(offering.identifier) == "paywall_components_with_draft"
@@ -62,15 +60,6 @@ class PaywallComponentsDecodingTests: BaseHTTPResponseTest {
         expect(components.componentsConfig.base.stack.spacing) == 16
         expect(components.componentsConfig.base.stack.dimension) == .vertical(.center, .center)
         expect(components.componentsConfig.base.stack.components).to(haveCount(1))
-
-        let draftComponents = try XCTUnwrap(offering.draftPaywallComponents)
-        expect(draftComponents.templateName) == "newComponentsTEST"
-        expect(draftComponents.revision) == 4
-        expect(draftComponents.componentsConfig.base.background) == .color(.init(light: .hex("#110000ff"), dark: nil))
-        expect(draftComponents.componentsConfig.base.stickyFooter) == nil
-        expect(draftComponents.componentsConfig.base.stack.spacing) == 0
-        expect(draftComponents.componentsConfig.base.stack.dimension) == .vertical(.leading, .end)
-        expect(draftComponents.componentsConfig.base.stack.components).to(haveCount(1))
     }
 
     func testDecodesPaywallComponentsWithOnlyDraftPaywallComponents() throws {
@@ -83,14 +72,6 @@ class PaywallComponentsDecodingTests: BaseHTTPResponseTest {
 
         XCTAssertNil(offering.paywallComponents)
 
-        let draftComponents = try XCTUnwrap(offering.draftPaywallComponents)
-        expect(draftComponents.templateName) == "newComponentsTEST"
-        expect(draftComponents.revision) == 4
-        expect(draftComponents.componentsConfig.base.background) == .color(.init(light: .hex("#110000ff"), dark: nil))
-        expect(draftComponents.componentsConfig.base.stickyFooter) == nil
-        expect(draftComponents.componentsConfig.base.stack.spacing) == 0
-        expect(draftComponents.componentsConfig.base.stack.dimension) == .vertical(.leading, .end)
-        expect(draftComponents.componentsConfig.base.stack.components).to(haveCount(1))
     }
 
     func testDecodesPaywallComponentsWithExitOffers() throws {

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -982,7 +982,6 @@ private extension OfferingsManagerTests {
                             metadata: offering.metadata,
                             paywallComponents: nil,
                             hasPaywallComponents: hasPaywallComponents,
-                            draftPaywallComponents: nil,
                             availablePackages: offering.packages.map { package in
                                 .init(
                                     identifier: package.identifier,

--- a/Tests/UnitTests/Purchasing/OfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsTests.swift
@@ -807,7 +807,6 @@ class OfferingsTests: TestCase {
 
         expect(offering.paywall).to(beNil())
         expect(offering.paywallComponents).to(beNil())
-        expect(offering.draftPaywallComponents).to(beNil())
         expect(offering.hasPaywall) == false
     }
 
@@ -835,7 +834,6 @@ class OfferingsTests: TestCase {
 
         expect(offering.paywall).toNot(beNil())
         expect(offering.paywallComponents).to(beNil())
-        expect(offering.draftPaywallComponents).to(beNil())
         expect(offering.hasPaywall) == true
     }
 
@@ -861,7 +859,6 @@ class OfferingsTests: TestCase {
 
         expect(offering.paywall).to(beNil())
         expect(offering.paywallComponents).toNot(beNil())
-        expect(offering.draftPaywallComponents).to(beNil())
         expect(offering.hasPaywall) == true
     }
 
@@ -888,35 +885,6 @@ class OfferingsTests: TestCase {
 
         expect(offering.paywall).to(beNil())
         expect(offering.paywallComponents).to(beNil())
-        expect(offering.draftPaywallComponents).to(beNil())
-        expect(offering.hasPaywall) == true
-    }
-
-    func testCreateOfferingWithDraftPaywallComponentsSkipsPayloadWhenPaywallComponentsDisabled() throws {
-        let monthlyProduct = MockSK1Product(mockProductIdentifier: "com.revenuecat.monthly_4.99.1_week_intro")
-        let products = [
-            "com.revenuecat.monthly_4.99.1_week_intro": StoreProduct(sk1Product: monthlyProduct)
-        ]
-
-        let offeringResp: OfferingsResponse = try BaseHTTPResponseTest.decodeFixture("OfferingsWithPaywallComponents")
-        let offeringResponse0 = try XCTUnwrap(offeringResp.offerings[safe: 1])
-
-        expect(offeringResponse0.identifier) == "paywall_components_with_draft"
-        expect(offeringResponse0.paywallComponents).toNot(beNil())
-        expect(offeringResponse0.draftPaywallComponents).toNot(beNil())
-
-        let uiConfig: UIConfig = try XCTUnwrap(BaseHTTPResponseTest.decodeFixture("UIConfig"))
-
-        let offering = try XCTUnwrap(
-            self.offeringsFactory.createOffering(from: products,
-                                                 offering: offeringResponse0,
-                                                 uiConfig: uiConfig,
-                                                 shouldCreatePaywallComponents: false)
-        )
-
-        expect(offering.paywall).to(beNil())
-        expect(offering.paywallComponents).to(beNil())
-        expect(offering.draftPaywallComponents).to(beNil())
         expect(offering.hasPaywall) == true
     }
 
@@ -939,10 +907,8 @@ class OfferingsTests: TestCase {
 
         expect(offering.paywall).to(beNil())
         expect(offering.paywallComponents).to(beNil())
-        expect(offering.draftPaywallComponents).to(beNil())
         expect(offering.hasPaywall) == true
         expect(offerings.response.offerings.first?.paywallComponents).to(beNil())
-        expect(offerings.response.offerings[safe: 1]?.draftPaywallComponents).to(beNil())
         expect(offerings.response.offerings.first?.hasPaywallComponents) == true
         expect(offerings.response.offerings[safe: 1]?.hasPaywallComponents) == true
         expect(offerings.response.offerings[safe: 2]?.hasPaywallComponents) == false
@@ -972,36 +938,9 @@ class OfferingsTests: TestCase {
         let offering = try XCTUnwrap(rebuiltOfferings.offering(identifier: "paywall_components"))
 
         expect(offering.paywallComponents).to(beNil())
-        expect(offering.draftPaywallComponents).to(beNil())
         expect(offering.hasPaywall) == true
         expect(rebuiltOfferings.response.offerings.first?.paywallComponents).to(beNil())
         expect(rebuiltOfferings.response.offerings.first?.hasPaywallComponents) == true
-    }
-
-    func testCreateOfferingWithPaywallComponentsAndDraftPaywallComponents() throws {
-        let monthlyProduct = MockSK1Product(mockProductIdentifier: "com.revenuecat.monthly_4.99.1_week_intro")
-        let products = [
-            "com.revenuecat.monthly_4.99.1_week_intro": StoreProduct(sk1Product: monthlyProduct)
-        ]
-
-        let offeringResp: OfferingsResponse = try BaseHTTPResponseTest.decodeFixture("OfferingsWithPaywallComponents")
-        let offeringResponse0 = try XCTUnwrap(offeringResp.offerings[safe: 1])
-
-        expect(offeringResponse0.identifier) == "paywall_components_with_draft"
-        expect(offeringResponse0.description) == "Offering with paywall components + draft paywall"
-
-        let uiConfig: UIConfig = try XCTUnwrap(BaseHTTPResponseTest.decodeFixture("UIConfig"))
-
-        let offering = try XCTUnwrap(
-            self.offeringsFactory.createOffering(from: products,
-                                                 offering: offeringResponse0,
-                                                 uiConfig: uiConfig)
-            )
-
-        expect(offering.paywall).to(beNil())
-        expect(offering.paywallComponents).toNot(beNil())
-        expect(offering.draftPaywallComponents).toNot(beNil())
-        expect(offering.hasPaywall) == true
     }
 
     func testCreateOfferingWithOnlyDraftPaywallComponents() throws {
@@ -1026,7 +965,6 @@ class OfferingsTests: TestCase {
 
         expect(offering.paywall).to(beNil())
         expect(offering.paywallComponents).to(beNil())
-        expect(offering.draftPaywallComponents).toNot(beNil())
         expect(offering.hasPaywall) == false
     }
 


### PR DESCRIPTION
## Description
Since `draftPaywallComponents` aren't being used by the SDK, and the RC mobile app has since migrated away from using it as well, I don't think there is any reason for us to maintain it. 

Not decoding it should save some CPU and removing the code simplified maintenance and work in my remote config follow up PR.

RC Mobile app PR ensuring compatibility https://github.com/RevenueCat/revenuecat-mobile-ios/pull/956

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall data plumbing and SPI (`useDraftPaywall`, `draftPaywallComponents`); offerings that only had draft components in the API will no longer expose paywall components, though that path was unused.
> 
> **Overview**
> Removes **draft paywall components** end-to-end: the offerings response no longer decodes `draftPaywallComponents`, `Offering` and `OfferingsFactory` no longer build or cache draft payloads, and related copy/helpers are trimmed.
> 
> **RevenueCatUI** drops `useDraftPaywall` from `PaywallViewConfiguration` and `PaywallView`. V2 paywalls always render from `offering.internalPaywallComponents` (published components only). Draft preview is expected via injected `WorkflowContext` / workflow preview, not offerings draft fields.
> 
> Tests and preview loaders are updated; draft-specific factory/decoding assertions are removed or narrowed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cec0720b26e276d498d86c055018b5b17a43c069. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->