### PR TITLE
test: fix RevenueCatUI test compilation on older Xcode versions

### DIFF
--- a/Tests/RevenueCatUITests/PaywallsV2/VideoAudioSessionHandlerTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/VideoAudioSessionHandlerTests.swift
@@ -94,7 +94,7 @@ final class VideoAudioSessionHandlerTests: TestCase {
     func testDoesNotOverwriteHostConfigurationChangedDuringVideoPlayback() {
         let audioSession = MockAudioSession()
         let handler = VideoAudioSessionHandler(audioSession: audioSession)
-        let hostConfiguration = Configuration(category: .playAndRecord, mode: .videoChat, options: [.allowBluetoothHFP])
+        let hostConfiguration = Configuration(category: .playAndRecord, mode: .videoChat, options: [.duckOthers])
         audioSession.configuration = hostConfiguration
 
         handler.release()


### PR DESCRIPTION
Main is red: the `spm-revenuecat-ui-ios-15`, `spm-revenuecat-ui-ios-16`, and `run-revenuecat-ui-ios-18-and-17` jobs fail because `VideoAudioSessionHandlerTests.swift` (added in #7197) uses `.allowBluetoothHFP`, which doesn't exist in the older SDKs those jobs build with (e.g. Xcode 14.3.1 for the iOS 15 job).

Replaces `.allowBluetoothHFP` with `.duckOthers` in the one test that used it. The test only needs a distinctive host configuration to assert it isn't overwritten, and `.duckOthers` is available in all supported SDKs and already used elsewhere in the same file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production or runtime behavior impact.
> 
> **Overview**
> Fixes **RevenueCatUI** CI on older Xcode/iOS SDK jobs by updating `testDoesNotOverwriteHostConfigurationChangedDuringVideoPlayback` in `VideoAudioSessionHandlerTests.swift`.
> 
> The host `Configuration` options change from **`.allowBluetoothHFP`** to **`.duckOthers`**. The test still uses a distinct host setup to verify `release()` does not overwrite configuration changed during playback; only the option enum is swapped for API availability on iOS 15 / Xcode 14.x builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49d8e27fc71f59c04aa045ad6f4933b821757fa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->