### PR TITLE
fix(paywalls): limit web_view fallback to unsupported capabilities

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentViewModel.swift
@@ -14,7 +14,7 @@ final class WebViewComponentViewModel: Hashable {
     let visible: Bool
     let componentID: String
 
-    lazy var url: URL? = Self.validatedHTTPSURL(from: self.urlString)
+    lazy var url: URL? = PaywallComponent.WebViewComponent.validatedHTTPSURL(from: self.urlString)
 
     #if canImport(WebKit)
     /// Canonical origin derived from ``url``. Because ``url`` is already validated as HTTPS with a
@@ -37,16 +37,6 @@ final class WebViewComponentViewModel: Hashable {
         self.size = component.size
         self.visible = component.visible ?? true
         self.componentID = component.id
-    }
-
-    private static func validatedHTTPSURL(from urlString: String) -> URL? {
-        guard !urlString.contains("{{"),
-              let url = URL(string: urlString),
-              url.scheme?.lowercased() == "https",
-              url.host?.isEmpty == false else {
-            return nil
-        }
-        return url
     }
 
     func hash(into hasher: inout Hasher) {

--- a/Sources/Paywalls/Components/Common/PaywallComponentBase.swift
+++ b/Sources/Paywalls/Components/Common/PaywallComponentBase.swift
@@ -240,6 +240,9 @@ import Foundation
     }
 
     private static func decodeWebView(from decoder: Decoder) throws -> PaywallComponent {
+        #if os(watchOS) || os(tvOS) || !canImport(WebKit)
+        return try Self.decodeFallback(from: decoder, typeString: ComponentType.webView.rawValue)
+        #else
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         // Gate a valid raw version before decoding the full model. This lets a newer protocol use
@@ -258,9 +261,6 @@ import Foundation
             throw DecodingError.dataCorrupted(context)
         }
 
-        #if os(watchOS) || os(tvOS) || !canImport(WebKit)
-        return try Self.decodeFallback(from: decoder, typeString: ComponentType.webView.rawValue)
-        #else
         return .webView(component)
         #endif
     }

--- a/Sources/Paywalls/Components/Common/PaywallComponentBase.swift
+++ b/Sources/Paywalls/Components/Common/PaywallComponentBase.swift
@@ -76,6 +76,7 @@ import Foundation
 
         case type
         case fallback
+        case protocolVersion
 
     }
 
@@ -232,17 +233,34 @@ import Foundation
         case .countdown:
             return .countdown(try CountdownComponent(from: decoder))
         case .webView:
-            let component = try WebViewComponent(from: decoder)
-            // A config declaring a bridge protocol version this SDK does not implement is treated
-            // like an unrecognized component: render the author-provided `fallback` (the backend
-            // also rejects unsupported versions at publish time). Mirrors purchases-android.
-            guard component.protocolVersion == WebViewComponent.supportedProtocolVersion else {
-                return try Self.decodeFallback(from: decoder, typeString: type.rawValue)
-            }
-            return .webView(component)
+            return try Self.decodeWebView(from: decoder)
         case .fallbackHeader:
             return .fallbackHeader
         }
+    }
+
+    private static func decodeWebView(from decoder: Decoder) throws -> PaywallComponent {
+        #if os(watchOS) || os(tvOS) || !canImport(WebKit)
+        return try Self.decodeFallback(from: decoder, typeString: ComponentType.webView.rawValue)
+        #else
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        // Gate the raw version before decoding the full model. This keeps a newer or malformed
+        // payload from failing on fields this SDK does not need in order to select its fallback.
+        guard let protocolVersion = try? container.decode(Int.self, forKey: .protocolVersion),
+              protocolVersion == WebViewComponent.supportedProtocolVersion else {
+            return try Self.decodeFallback(from: decoder, typeString: ComponentType.webView.rawValue)
+        }
+
+        // Once `web_view` is registered, a malformed model would normally abort the whole paywall.
+        // Treat any configuration this SDK cannot render like an unknown component instead.
+        guard let component = try? WebViewComponent(from: decoder),
+              component.hasRenderableConfiguration else {
+            return try Self.decodeFallback(from: decoder, typeString: ComponentType.webView.rawValue)
+        }
+
+        return .webView(component)
+        #endif
     }
 
 }

--- a/Sources/Paywalls/Components/Common/PaywallComponentBase.swift
+++ b/Sources/Paywalls/Components/Common/PaywallComponentBase.swift
@@ -240,25 +240,27 @@ import Foundation
     }
 
     private static func decodeWebView(from decoder: Decoder) throws -> PaywallComponent {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        // Gate a valid raw version before decoding the full model. This lets a newer protocol use
+        // its fallback without requiring this SDK to understand that protocol's remaining fields.
+        let protocolVersion = try container.decode(Int.self, forKey: .protocolVersion)
+        guard protocolVersion == WebViewComponent.supportedProtocolVersion else {
+            return try Self.decodeFallback(from: decoder, typeString: ComponentType.webView.rawValue)
+        }
+
+        let component = try WebViewComponent(from: decoder)
+        if let validationError = component.configurationValidationError {
+            let context = DecodingError.Context(
+                codingPath: decoder.codingPath,
+                debugDescription: validationError
+            )
+            throw DecodingError.dataCorrupted(context)
+        }
+
         #if os(watchOS) || os(tvOS) || !canImport(WebKit)
         return try Self.decodeFallback(from: decoder, typeString: ComponentType.webView.rawValue)
         #else
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-
-        // Gate the raw version before decoding the full model. This keeps a newer or malformed
-        // payload from failing on fields this SDK does not need in order to select its fallback.
-        guard let protocolVersion = try? container.decode(Int.self, forKey: .protocolVersion),
-              protocolVersion == WebViewComponent.supportedProtocolVersion else {
-            return try Self.decodeFallback(from: decoder, typeString: ComponentType.webView.rawValue)
-        }
-
-        // Once `web_view` is registered, a malformed model would normally abort the whole paywall.
-        // Treat any configuration this SDK cannot render like an unknown component instead.
-        guard let component = try? WebViewComponent(from: decoder),
-              component.hasRenderableConfiguration else {
-            return try Self.decodeFallback(from: decoder, typeString: ComponentType.webView.rawValue)
-        }
-
         return .webView(component)
         #endif
     }

--- a/Sources/Paywalls/Components/PaywallWebViewComponent.swift
+++ b/Sources/Paywalls/Components/PaywallWebViewComponent.swift
@@ -33,6 +33,20 @@ import Foundation
 
         public let size: Size
 
+        /// Whether this SDK can create a functional web view from the decoded static configuration.
+        var hasRenderableConfiguration: Bool {
+            guard self.protocolVersion == Self.supportedProtocolVersion,
+                  !self.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                  !self.url.contains("{{"),
+                  let url = URL(string: self.url),
+                  url.scheme?.lowercased() == "https",
+                  url.host?.isEmpty == false else {
+                return false
+            }
+
+            return true
+        }
+
         public init(
             id: String,
             name: String? = nil,

--- a/Sources/Paywalls/Components/PaywallWebViewComponent.swift
+++ b/Sources/Paywalls/Components/PaywallWebViewComponent.swift
@@ -33,16 +33,25 @@ import Foundation
 
         public let size: Size
 
+        /// Resolves a URL that is safe to use as a web view component entry point.
+        public static func validatedHTTPSURL(from urlString: String) -> URL? {
+            guard !urlString.contains("{{"),
+                  let url = URL(string: urlString),
+                  url.scheme?.lowercased() == "https",
+                  url.host?.isEmpty == false else {
+                return nil
+            }
+
+            return url
+        }
+
         /// Describes why the decoded static configuration is invalid, if applicable.
         var configurationValidationError: String? {
             if self.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 return "Web view component ID must not be blank."
             }
 
-            guard !self.url.contains("{{"),
-                  let url = URL(string: self.url),
-                  url.scheme?.lowercased() == "https",
-                  url.host?.isEmpty == false else {
+            guard Self.validatedHTTPSURL(from: self.url) != nil else {
                 return "Web view component URL must be a resolved HTTPS URL with a host."
             }
 

--- a/Sources/Paywalls/Components/PaywallWebViewComponent.swift
+++ b/Sources/Paywalls/Components/PaywallWebViewComponent.swift
@@ -33,18 +33,20 @@ import Foundation
 
         public let size: Size
 
-        /// Whether this SDK can create a functional web view from the decoded static configuration.
-        var hasRenderableConfiguration: Bool {
-            guard self.protocolVersion == Self.supportedProtocolVersion,
-                  !self.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-                  !self.url.contains("{{"),
+        /// Describes why the decoded static configuration is invalid, if applicable.
+        var configurationValidationError: String? {
+            if self.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return "Web view component ID must not be blank."
+            }
+
+            guard !self.url.contains("{{"),
                   let url = URL(string: self.url),
                   url.scheme?.lowercased() == "https",
                   url.host?.isEmpty == false else {
-                return false
+                return "Web view component URL must be a resolved HTTPS URL with a host."
             }
 
-            return true
+            return nil
         }
 
         public init(

--- a/Tests/UnitTests/Paywalls/Components/WebViewComponentTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/WebViewComponentTests.swift
@@ -421,3 +421,32 @@ final class WebViewComponentTests: TestCase {
 }
 
 #endif
+
+#if os(tvOS)
+
+@available(tvOS 15.0, *)
+final class WebViewComponentTVOSFallbackTests: TestCase {
+
+    func testRendersFallbackWithoutDecodingWebViewFields() throws {
+        let decoded = try JSONDecoder.default.decode(PaywallComponent.self, from: Data("""
+        {
+          "type": "web_view",
+          "fallback": {
+            "type": "stack",
+            "dimension": { "type": "vertical", "alignment": "center", "distribution": "start" },
+            "size": { "width": { "type": "fill" }, "height": { "type": "fill" } },
+            "padding": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 },
+            "margin": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 },
+            "components": []
+          }
+        }
+        """.utf8))
+
+        guard case .stack = decoded else {
+            return XCTFail("Expected fallback stack, got \(decoded)")
+        }
+    }
+
+}
+
+#endif

--- a/Tests/UnitTests/Paywalls/Components/WebViewComponentTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/WebViewComponentTests.swift
@@ -90,7 +90,7 @@ final class WebViewComponentTests: TestCase {
     }
 
     func testDecodesTemplateURLVerbatim() throws {
-        // Template placeholders in the URL are resolved elsewhere; decoding must preserve them as-is.
+        // Direct schema decoding is lossless; PaywallComponent applies the renderability gate.
         let component = try JSONDecoder.default.decode(PaywallComponent.WebViewComponent.self, from: Data("""
         {
           "type": "web_view",
@@ -179,6 +179,7 @@ final class WebViewComponentTests: TestCase {
 
     // MARK: - Decoding through PaywallComponent (registered type + protocol_version gate)
 
+    #if canImport(WebKit) && !os(watchOS)
     func testDecodesFullJSONThroughPaywallComponent() throws {
         let full = try JSONDecoder.default.decode(PaywallComponent.self, from: Data("""
         {
@@ -222,11 +223,12 @@ final class WebViewComponentTests: TestCase {
         }
         XCTAssertEqual(component.url, "https://example.com/index.html")
     }
+    #endif
 
     func testUnsupportedProtocolVersionRendersFallbackThroughPaywallComponent() throws {
         // A version this SDK cannot service is treated like an unrecognized component: the author's
         // fallback is rendered instead of the web view.
-        let decoded = try JSONDecoder.default.decode(PaywallComponent.self, from: Data("""
+        try assertDecodesFallback("""
         {
           "type": "web_view",
           "id": "web",
@@ -235,11 +237,104 @@ final class WebViewComponentTests: TestCase {
           "size": { "width": { "type": "fill" }, "height": { "type": "fit" } },
           "fallback": \(Self.fallbackStackJSON)
         }
-        """.utf8))
-
-        guard case .stack = decoded else {
-            return XCTFail("Expected fallback stack, got \(decoded)")
+        """)
+        try assertDecodesFallback("""
+        {
+          "type": "web_view",
+          "id": "web",
+          "protocol_version": 1,
+          "size": { "width": { "type": "fill" }, "height": { "type": "fit" } },
+          "fallback": \(Self.fallbackStackJSON)
         }
+        """)
+    }
+
+    func testUnsupportedProtocolVersionDoesNotRequireOtherWebViewFieldsToRenderFallback() throws {
+        try assertDecodesFallback("""
+        {
+          "type": "web_view",
+          "protocol_version": 2,
+          "fallback": \(Self.fallbackStackJSON)
+        }
+        """)
+    }
+
+    func testMissingOrMalformedProtocolVersionRendersFallback() throws {
+        try assertDecodesFallback("""
+        {
+          "type": "web_view",
+          "id": "web",
+          "url": "https://example.com/index.html",
+          "size": { "width": { "type": "fill" }, "height": { "type": "fit" } },
+          "fallback": \(Self.fallbackStackJSON)
+        }
+        """)
+        try assertDecodesFallback("""
+        {
+          "type": "web_view",
+          "id": "web",
+          "protocol_version": "1",
+          "url": "https://example.com/index.html",
+          "size": { "width": { "type": "fill" }, "height": { "type": "fit" } },
+          "fallback": \(Self.fallbackStackJSON)
+        }
+        """)
+    }
+
+    func testMalformedWebViewFieldsRenderFallback() throws {
+        try assertDecodesFallback("""
+        {
+          "type": "web_view",
+          "protocol_version": 1,
+          "url": "https://example.com/index.html",
+          "size": { "width": { "type": "fill" }, "height": { "type": "fit" } },
+          "fallback": \(Self.fallbackStackJSON)
+        }
+        """)
+        try assertDecodesFallback("""
+        {
+          "type": "web_view",
+          "id": "web",
+          "protocol_version": 1,
+          "url": "https://example.com/index.html",
+          "fallback": \(Self.fallbackStackJSON)
+        }
+        """)
+    }
+
+    func testUnrenderableIDOrURLRendersFallback() throws {
+        for (id, url) in [
+            ("   ", "https://example.com/index.html"),
+            ("web", "http://example.com/index.html"),
+            ("web", "https:///missing-host"),
+            ("web", "https://example.com/{{ custom.path }}")
+        ] {
+            try assertDecodesFallback("""
+            {
+              "type": "web_view",
+              "id": "\(id)",
+              "protocol_version": 1,
+              "url": "\(url)",
+              "size": { "width": { "type": "fill" }, "height": { "type": "fit" } },
+              "fallback": \(Self.fallbackStackJSON)
+            }
+            """)
+        }
+    }
+
+    func testUnsupportedPlatformRendersFallback() throws {
+        #if os(watchOS) || os(tvOS) || !canImport(WebKit)
+        try assertDecodesFallback("""
+        {
+          "type": "web_view",
+          "id": "web",
+          "protocol_version": 1,
+          "url": "https://example.com/index.html",
+          "size": { "width": { "type": "fill" }, "height": { "type": "fit" } },
+          "fallback": \(Self.fallbackStackJSON)
+        }
+        """)
+        #endif
     }
 
     func testUnsupportedProtocolVersionWithoutFallbackThrows() {
@@ -250,6 +345,20 @@ final class WebViewComponentTests: TestCase {
               "id": "web",
               "protocol_version": 2,
               "url": "https://example.com/index.html",
+              "size": { "width": { "type": "fill" }, "height": { "type": "fit" } }
+            }
+            """.utf8))
+        )
+    }
+
+    func testUnrenderableConfigurationWithoutFallbackThrows() {
+        XCTAssertThrowsError(
+            try JSONDecoder.default.decode(PaywallComponent.self, from: Data("""
+            {
+              "type": "web_view",
+              "id": "   ",
+              "protocol_version": 1,
+              "url": "http://example.com/index.html",
               "size": { "width": { "type": "fill" }, "height": { "type": "fit" } }
             }
             """.utf8))
@@ -284,6 +393,18 @@ final class WebViewComponentTests: TestCase {
         "components": []
     }
     """
+
+    private func assertDecodesFallback(
+        _ json: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let decoded = try JSONDecoder.default.decode(PaywallComponent.self, from: Data(json.utf8))
+
+        guard case .stack = decoded else {
+            return XCTFail("Expected fallback stack, got \(decoded)", file: file, line: line)
+        }
+    }
 
 }
 

--- a/Tests/UnitTests/Paywalls/Components/WebViewComponentTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/WebViewComponentTests.swift
@@ -250,6 +250,7 @@ final class WebViewComponentTests: TestCase {
         """)
     }
 
+    #if canImport(WebKit) && !os(watchOS)
     func testMissingOrMalformedProtocolVersionThrowsEvenWithFallback() {
         assertDecodingThrows("""
         {
@@ -321,16 +322,13 @@ final class WebViewComponentTests: TestCase {
             """)
         }
     }
+    #endif
 
-    func testUnsupportedPlatformRendersFallback() throws {
+    func testUnsupportedPlatformRendersFallbackWithoutDecodingWebViewFields() throws {
         #if os(watchOS) || os(tvOS) || !canImport(WebKit)
         try assertDecodesFallback("""
         {
           "type": "web_view",
-          "id": "web",
-          "protocol_version": 1,
-          "url": "https://example.com/index.html",
-          "size": { "width": { "type": "fill" }, "height": { "type": "fit" } },
           "fallback": \(Self.fallbackStackJSON)
         }
         """)
@@ -351,6 +349,7 @@ final class WebViewComponentTests: TestCase {
         )
     }
 
+    #if canImport(WebKit) && !os(watchOS)
     func testUnrenderableConfigurationWithoutFallbackThrows() {
         XCTAssertThrowsError(
             try JSONDecoder.default.decode(PaywallComponent.self, from: Data("""
@@ -364,6 +363,7 @@ final class WebViewComponentTests: TestCase {
             """.utf8))
         )
     }
+    #endif
 
     func testDecodesFitLoadingDefaults() throws {
         let component = try JSONDecoder.default.decode(PaywallComponent.WebViewComponent.self, from: Data("""

--- a/Tests/UnitTests/Paywalls/Components/WebViewComponentTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/WebViewComponentTests.swift
@@ -238,15 +238,6 @@ final class WebViewComponentTests: TestCase {
           "fallback": \(Self.fallbackStackJSON)
         }
         """)
-        try assertDecodesFallback("""
-        {
-          "type": "web_view",
-          "id": "web",
-          "protocol_version": 1,
-          "size": { "width": { "type": "fill" }, "height": { "type": "fit" } },
-          "fallback": \(Self.fallbackStackJSON)
-        }
-        """)
     }
 
     func testUnsupportedProtocolVersionDoesNotRequireOtherWebViewFieldsToRenderFallback() throws {
@@ -259,8 +250,8 @@ final class WebViewComponentTests: TestCase {
         """)
     }
 
-    func testMissingOrMalformedProtocolVersionRendersFallback() throws {
-        try assertDecodesFallback("""
+    func testMissingOrMalformedProtocolVersionThrowsEvenWithFallback() {
+        assertDecodingThrows("""
         {
           "type": "web_view",
           "id": "web",
@@ -269,7 +260,7 @@ final class WebViewComponentTests: TestCase {
           "fallback": \(Self.fallbackStackJSON)
         }
         """)
-        try assertDecodesFallback("""
+        assertDecodingThrows("""
         {
           "type": "web_view",
           "id": "web",
@@ -281,8 +272,8 @@ final class WebViewComponentTests: TestCase {
         """)
     }
 
-    func testMalformedWebViewFieldsRenderFallback() throws {
-        try assertDecodesFallback("""
+    func testMalformedWebViewFieldsThrowEvenWithFallback() {
+        assertDecodingThrows("""
         {
           "type": "web_view",
           "protocol_version": 1,
@@ -291,7 +282,7 @@ final class WebViewComponentTests: TestCase {
           "fallback": \(Self.fallbackStackJSON)
         }
         """)
-        try assertDecodesFallback("""
+        assertDecodingThrows("""
         {
           "type": "web_view",
           "id": "web",
@@ -300,16 +291,25 @@ final class WebViewComponentTests: TestCase {
           "fallback": \(Self.fallbackStackJSON)
         }
         """)
+        assertDecodingThrows("""
+        {
+          "type": "web_view",
+          "id": "web",
+          "protocol_version": 1,
+          "size": { "width": { "type": "fill" }, "height": { "type": "fit" } },
+          "fallback": \(Self.fallbackStackJSON)
+        }
+        """)
     }
 
-    func testUnrenderableIDOrURLRendersFallback() throws {
+    func testUnrenderableIDOrURLThrowsEvenWithFallback() {
         for (id, url) in [
             ("   ", "https://example.com/index.html"),
             ("web", "http://example.com/index.html"),
             ("web", "https:///missing-host"),
             ("web", "https://example.com/{{ custom.path }}")
         ] {
-            try assertDecodesFallback("""
+            assertDecodingThrows("""
             {
               "type": "web_view",
               "id": "\(id)",
@@ -404,6 +404,18 @@ final class WebViewComponentTests: TestCase {
         guard case .stack = decoded else {
             return XCTFail("Expected fallback stack, got \(decoded)", file: file, line: line)
         }
+    }
+
+    private func assertDecodingThrows(
+        _ json: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertThrowsError(
+            try JSONDecoder.default.decode(PaywallComponent.self, from: Data(json.utf8)),
+            file: file,
+            line: line
+        )
     }
 
 }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Before this PR, the complete `web_view` model was decoded before checking whether its protocol version is supported. A future protocol can therefore fail on fields this SDK should not need to understand, and platforms that cannot render WebViews should not decode WebView configuration at all.

### Description
On unsupported platforms, immediately decodes the authored fallback without inspecting any WebView-specific fields.

On supported platforms, decodes the raw protocol version first and uses the fallback only for a valid but unsupported version. Supported-v1 payloads are fully decoded and validated, so missing or malformed fields, blank IDs, and invalid URLs throw consistently with other known components—even when a fallback exists.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall JSON decode behavior for web_view (when fallback applies vs decode errors), which can affect how misconfigured or future-protocol paywalls render at runtime.
> 
> **Overview**
> Tightens **when** paywall `web_view` JSON uses the authored `fallback` versus failing decode, so newer protocols and unsupported platforms do not depend on decoding full WebView payloads.
> 
> **`PaywallComponent` decoding** now routes `web_view` through `decodeWebView`: on watchOS, tvOS, or without WebKit, it jumps straight to `fallback` without reading WebView fields. On supported platforms it reads `protocol_version` first—only a **valid but unsupported** version uses `fallback` (even if other fields are missing or unknown). Supported v1 configs are fully decoded, then checked via new **`configurationValidationError`** (non-blank id, resolved HTTPS URL with host, no `{{` templates); invalid configs **throw** even when `fallback` is present.
> 
> **`validatedHTTPSURL`** moves onto `WebViewComponent` (shared with `WebViewComponentViewModel`). Unit tests cover protocol gating, platform fallback, malformed fields, and unrenderable id/URL cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96536ed51bb233ef74da3cb55cc8adca2d1cf81f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->