### PR TITLE
Add `DangerousSettings(autoSyncPurchases:uiPreviewMode:useWorkflows:)` init

### DIFF
--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -151,6 +151,20 @@ import Foundation
                   useWorkflows: useWorkflows)
     }
 
+    /**
+     * Used to enable RevenueCat Workflows (multipage paywalls) while controlling auto-sync.
+     * Internal RevenueCat use only; behavior may change without warning.
+     *
+     * - Parameter autoSyncPurchases: whether the SDK observes the StoreKit queue and syncs purchases.
+     * - Parameter useWorkflows: if `true`, the SDK wires up the workflows endpoint so multipage
+     * paywalls can be rendered.
+     */
+    @_spi(Internal) public convenience init(autoSyncPurchases: Bool, useWorkflows: Bool) {
+        self.init(autoSyncPurchases: autoSyncPurchases,
+                  internalSettings: Internal.default,
+                  useWorkflows: useWorkflows)
+    }
+
     /// Designated initializer
     internal init(autoSyncPurchases: Bool,
                   customEntitlementComputation: Bool = false,

--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -152,23 +152,16 @@ import Foundation
     }
 
     /**
-     * Used to control auto-sync, UI preview mode, and RevenueCat Workflows (multipage paywalls)
-     * together. Internal RevenueCat use only; behavior may change without warning.
+     * Used to enable RevenueCat Workflows (multipage paywalls) while controlling auto-sync.
+     * Internal RevenueCat use only; behavior may change without warning.
      *
      * - Parameter autoSyncPurchases: whether the SDK observes the StoreKit queue and syncs purchases.
-     * - Parameter uiPreviewMode: if `true`, the SDK will return a set of mock products instead of the
-     * products obtained from StoreKit. This is useful for testing or preview purposes.
      * - Parameter useWorkflows: if `true`, the SDK wires up the workflows endpoint so multipage
      * paywalls can be rendered.
      */
-    @_spi(Internal) public convenience init(
-        autoSyncPurchases: Bool = true,
-        uiPreviewMode: Bool = false,
-        useWorkflows: Bool = false
-    ) {
+    @_spi(Internal) public convenience init(autoSyncPurchases: Bool, useWorkflows: Bool) {
         self.init(autoSyncPurchases: autoSyncPurchases,
                   internalSettings: Internal.default,
-                  uiPreviewMode: uiPreviewMode,
                   useWorkflows: useWorkflows)
     }
 

--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -152,16 +152,23 @@ import Foundation
     }
 
     /**
-     * Used to enable RevenueCat Workflows (multipage paywalls) while controlling auto-sync.
-     * Internal RevenueCat use only; behavior may change without warning.
+     * Used to control auto-sync, UI preview mode, and RevenueCat Workflows (multipage paywalls)
+     * together. Internal RevenueCat use only; behavior may change without warning.
      *
      * - Parameter autoSyncPurchases: whether the SDK observes the StoreKit queue and syncs purchases.
+     * - Parameter uiPreviewMode: if `true`, the SDK will return a set of mock products instead of the
+     * products obtained from StoreKit. This is useful for testing or preview purposes.
      * - Parameter useWorkflows: if `true`, the SDK wires up the workflows endpoint so multipage
      * paywalls can be rendered.
      */
-    @_spi(Internal) public convenience init(autoSyncPurchases: Bool, useWorkflows: Bool) {
+    @_spi(Internal) public convenience init(
+        autoSyncPurchases: Bool = true,
+        uiPreviewMode: Bool = false,
+        useWorkflows: Bool = false
+    ) {
         self.init(autoSyncPurchases: autoSyncPurchases,
                   internalSettings: Internal.default,
+                  uiPreviewMode: uiPreviewMode,
                   useWorkflows: useWorkflows)
     }
 

--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -139,19 +139,6 @@ import Foundation
     }
 
     /**
-     * Used to enable RevenueCat Workflows (multipage paywalls). Internal RevenueCat use only;
-     * behavior may change without warning.
-     *
-     * - Parameter useWorkflows: if `true`, the SDK wires up the workflows endpoint so multipage
-     * paywalls can be rendered.
-     */
-    @_spi(Internal) public convenience init(useWorkflows: Bool) {
-        self.init(autoSyncPurchases: true,
-                  internalSettings: Internal.default,
-                  useWorkflows: useWorkflows)
-    }
-
-    /**
      * Used to enable RevenueCat Workflows (multipage paywalls) while controlling auto-sync.
      * Internal RevenueCat use only; behavior may change without warning.
      *
@@ -159,7 +146,7 @@ import Foundation
      * - Parameter useWorkflows: if `true`, the SDK wires up the workflows endpoint so multipage
      * paywalls can be rendered.
      */
-    @_spi(Internal) public convenience init(autoSyncPurchases: Bool, useWorkflows: Bool) {
+    @_spi(Internal) public convenience init(autoSyncPurchases: Bool = true, useWorkflows: Bool) {
         self.init(autoSyncPurchases: autoSyncPurchases,
                   internalSettings: Internal.default,
                   useWorkflows: useWorkflows)

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/DangerousSettingsAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/DangerousSettingsAPI.swift
@@ -18,6 +18,7 @@ func checkDangerousSettingsAPI() {
     let _: DangerousSettings = DangerousSettings(autoSyncPurchases: true)
     let _: DangerousSettings = DangerousSettings(useWorkflows: true)
     let _: DangerousSettings = DangerousSettings(autoSyncPurchases: true, useWorkflows: true)
+    let _: DangerousSettings = DangerousSettings(autoSyncPurchases: true, uiPreviewMode: true, useWorkflows: true)
     let settings: DangerousSettings = DangerousSettings(uiPreviewMode: true)
 
     let _: Bool = settings.autoSyncPurchases

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/DangerousSettingsAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/DangerousSettingsAPI.swift
@@ -16,6 +16,8 @@
 func checkDangerousSettingsAPI() {
     let _: DangerousSettings = DangerousSettings()
     let _: DangerousSettings = DangerousSettings(autoSyncPurchases: true)
+    let _: DangerousSettings = DangerousSettings(useWorkflows: true)
+    let _: DangerousSettings = DangerousSettings(autoSyncPurchases: true, useWorkflows: true)
     let settings: DangerousSettings = DangerousSettings(uiPreviewMode: true)
 
     let _: Bool = settings.autoSyncPurchases

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/DangerousSettingsAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/DangerousSettingsAPI.swift
@@ -16,9 +16,6 @@
 func checkDangerousSettingsAPI() {
     let _: DangerousSettings = DangerousSettings()
     let _: DangerousSettings = DangerousSettings(autoSyncPurchases: true)
-    let _: DangerousSettings = DangerousSettings(useWorkflows: true)
-    let _: DangerousSettings = DangerousSettings(autoSyncPurchases: true, useWorkflows: true)
-    let _: DangerousSettings = DangerousSettings(autoSyncPurchases: true, uiPreviewMode: true, useWorkflows: true)
     let settings: DangerousSettings = DangerousSettings(uiPreviewMode: true)
 
     let _: Bool = settings.autoSyncPurchases

--- a/Tests/UnitTests/Misc/DangerousSettingsTests.swift
+++ b/Tests/UnitTests/Misc/DangerousSettingsTests.swift
@@ -57,6 +57,14 @@ final class DangerousSettingsTests: TestCase {
         expect(settings.useWorkflows) == true
     }
 
+    func testConsolidatedInitSetsAllThreeFlagsIndependently() {
+        let settings = DangerousSettings(autoSyncPurchases: false, uiPreviewMode: true, useWorkflows: true)
+
+        expect(settings.autoSyncPurchases) == false
+        expect(settings.uiPreviewMode) == true
+        expect(settings.useWorkflows) == true
+    }
+
     func testInternalSettingsAreExcludedFromEquality() {
         let defaultInternal: InternalDangerousSettingsType = DangerousSettings.Internal.default
         let customInternal: InternalDangerousSettingsType = DangerousSettings.Internal(enableReceiptFetchRetry: true)

--- a/Tests/UnitTests/Misc/DangerousSettingsTests.swift
+++ b/Tests/UnitTests/Misc/DangerousSettingsTests.swift
@@ -50,6 +50,13 @@ final class DangerousSettingsTests: TestCase {
             != DangerousSettings(uiPreviewMode: false)
     }
 
+    func testAutoSyncPurchasesAndUseWorkflowsCanBeSetIndependently() {
+        let settings = DangerousSettings(autoSyncPurchases: false, useWorkflows: true)
+
+        expect(settings.autoSyncPurchases) == false
+        expect(settings.useWorkflows) == true
+    }
+
     func testInternalSettingsAreExcludedFromEquality() {
         let defaultInternal: InternalDangerousSettingsType = DangerousSettings.Internal.default
         let customInternal: InternalDangerousSettingsType = DangerousSettings.Internal(enableReceiptFetchRetry: true)

--- a/Tests/UnitTests/Misc/DangerousSettingsTests.swift
+++ b/Tests/UnitTests/Misc/DangerousSettingsTests.swift
@@ -57,14 +57,6 @@ final class DangerousSettingsTests: TestCase {
         expect(settings.useWorkflows) == true
     }
 
-    func testConsolidatedInitSetsAllThreeFlagsIndependently() {
-        let settings = DangerousSettings(autoSyncPurchases: false, uiPreviewMode: true, useWorkflows: true)
-
-        expect(settings.autoSyncPurchases) == false
-        expect(settings.uiPreviewMode) == true
-        expect(settings.useWorkflows) == true
-    }
-
     func testInternalSettingsAreExcludedFromEquality() {
         let defaultInternal: InternalDangerousSettingsType = DangerousSettings.Internal.default
         let customInternal: InternalDangerousSettingsType = DangerousSettings.Internal(enableReceiptFetchRetry: true)


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
The only workflows-capable initializer, `init(useWorkflows:)`, hardcodes `autoSyncPurchases: true`. Hybrid bridges (PHC → Unity/RN) need to enable Workflows while independently controlling auto-sync, and today that combination can't be expressed, causing an iOS-vs-Android divergence.

### Description
Extends `init(useWorkflows:)` to `init(autoSyncPurchases: Bool = true, useWorkflows: Bool)`. `autoSyncPurchases` defaults to `true`, preserving current behavior for existing callers; `useWorkflows` stays required, so this can't collide with `init(autoSyncPurchases: Bool = true)`. No API tester coverage added — these are `@_spi(Internal)` APIs, not part of the public surface the API testers lock in.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal SPI-only initializer change with a default-preserving parameter; covered by a focused unit test and no public API surface change.
> 
> **Overview**
> Extends the internal `@_spi(Internal)` `DangerousSettings` workflows initializer so **`autoSyncPurchases` is configurable** (default `true`) instead of always forcing StoreKit queue observation when `useWorkflows` is enabled. Hybrid bridges can now turn on multipage paywalls while leaving auto-sync off, matching Android behavior.
> 
> Adds a unit test that **`autoSyncPurchases: false` and `useWorkflows: true`** can be set together.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0062ecaa9a0ec9c6a9aa87b09678e8f42b0727ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->