### PR TITLE
Fix xcodeproj remove stale `PaywallWebViewAPI` references

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1351,7 +1351,6 @@
 		F5E5E2EE28479BD000216ECD /* ProductsFetcherSK2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E5E2E82847953000216ECD /* ProductsFetcherSK2Tests.swift */; };
 		F5FCD3EA27DA0D0B003BDC04 /* PriceFormatterProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5FCD3E927DA0D0B003BDC04 /* PriceFormatterProvider.swift */; };
 		F5FCD3FC27DA2034003BDC04 /* PriceFormatterProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5FCD3FB27DA2034003BDC04 /* PriceFormatterProviderTests.swift */; };
-		FA4A2DF41FC434A9401F08CC /* PaywallWebViewAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D0C57ECDF0E7F1A5B4418FF /* PaywallWebViewAPI.swift */; };
 		FA6ABC7C2A81673F00353AF7 /* SystemFontRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6ABC7B2A81673F00353AF8 /* SystemFontRegistryTests.swift */; };
 		FACD000C2F61A1230073D2DE /* PackageVisibilityPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACD000B2F61A1230073D2DE /* PackageVisibilityPreview.swift */; };
 		FACE0000000000000000A001 /* BackendRemoteConfigLaneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACE0000000000000000A002 /* BackendRemoteConfigLaneTests.swift */; };
@@ -2792,7 +2791,6 @@
 		9D09F3CA2E3A859A0002840E /* sr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sr; path = sr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9D09F3CB2E3A859A0002840F /* sr_Latn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sr_Latn; path = sr_Latn.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9D09F3CC2E3A859A00028410 /* sl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sl; path = sl.lproj/Localizable.strings; sourceTree = "<group>"; };
-		9D0C57ECDF0E7F1A5B4418FF /* PaywallWebViewAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallWebViewAPI.swift; sourceTree = "<group>"; };
 		9E174FCB9B889D4CACED0088 /* Value.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Value.swift; sourceTree = "<group>"; };
 		9F576269BC7130E5B553FB5A /* StringArrayOperatorsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StringArrayOperatorsTests.swift; sourceTree = "<group>"; };
 		9FA3AA2BC4C1B8CE7E9A3B59 /* WorkflowPreview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowPreview.swift; sourceTree = "<group>"; };
@@ -6425,14 +6423,6 @@
 				B34D2AA526976FC700D88C3A /* ErrorCode.swift */,
 			);
 			path = Generated;
-			sourceTree = "<group>";
-		};
-		EB23E44596DD9714E81840CF /* WebView */ = {
-			isa = PBXGroup;
-			children = (
-				9D0C57ECDF0E7F1A5B4418FF /* PaywallWebViewAPI.swift */,
-			);
-			path = WebView;
 			sourceTree = "<group>";
 		};
 		F5714EA626D7A82E00635477 /* CodableExtensions */ = {


### PR DESCRIPTION
The `release-checks` CI job fails on `main` with:

```
error: Build input file cannot be found: '.../RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewAPI.swift'
```

`PaywallWebViewAPI.swift` was renamed to `PaywallWebViewValue.swift` in #7228. A messy merge in #7197 reintroduced it under the old name.

This is why #7274 (the automatic 5.81.2 release PR) is failing checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Project file cleanup only; no application logic or API surface changes.
> 
> **Overview**
> **Fixes `release-checks` / Xcode build failures** caused by the project still listing `PaywallWebViewAPI.swift`, which no longer exists on disk (it was renamed to `PaywallWebViewValue.swift` in an earlier PR; a merge had reintroduced the old filename in `project.pbxproj`).
> 
> This change **only edits `RevenueCat.xcodeproj/project.pbxproj`**: it drops the `PBXBuildFile`, `PBXFileReference`, and `WebView` group entry for `PaywallWebViewAPI.swift`. No Swift source or runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3848ecec2b772cd7c551f1da4506c045d75c5066. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->