### PR TITLE
Allow media playback without a user gesture in paywall web views

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
@@ -197,7 +197,7 @@ struct WebViewRepresentable: PlatformViewRepresentable {
     #endif
 
     @MainActor
-    private func makeWebView(context: Context) -> PlatformWebView {
+    static func makeConfiguration(session: WebViewSession?) -> WKWebViewConfiguration {
         let configuration = WKWebViewConfiguration()
         configuration.websiteDataStore = .nonPersistent()
         configuration.userContentController = WKUserContentController()
@@ -224,6 +224,12 @@ struct WebViewRepresentable: PlatformViewRepresentable {
         )
         #endif
 
+        return configuration
+    }
+
+    @MainActor
+    private func makeWebView(context: Context) -> PlatformWebView {
+        let configuration = Self.makeConfiguration(session: session)
         let webView = WKWebView(frame: .zero, configuration: configuration)
         webView.navigationDelegate = context.coordinator
 

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
@@ -209,6 +209,9 @@ struct WebViewRepresentable: PlatformViewRepresentable {
             )
         }
 
+        // This is required to allow media to begin playing without a user gesture
+        configuration.mediaTypesRequiringUserActionForPlayback = []
+
         #if os(iOS)
         configuration.allowsInlineMediaPlayback = true
         let disableZoomScript = """

--- a/Tests/RevenueCatUITests/PaywallsV2/WebViewComponentViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WebViewComponentViewTests.swift
@@ -156,6 +156,11 @@ final class WebViewCoordinatorLifecycleTests: TestCase {
         XCTAssertFalse(session.channelOpen)
     }
 
+    func testConfigurationAllowsMediaPlaybackWithoutUserGesture() {
+        let configuration = WebViewRepresentable.makeConfiguration(session: nil)
+        XCTAssertTrue(configuration.mediaTypesRequiringUserActionForPlayback.isEmpty)
+    }
+
     func testProcessTerminationInvokesCallbackOncePerCall() {
         let coordinator = WebViewRepresentable.Coordinator(
             expectedOrigin: WebViewOrigin(string: "https://example.com")!


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Media in paywall web view components couldn't start playing on its own; playback was gated behind a user gesture.

### Description
Set `mediaTypesRequiringUserActionForPlayback = []` on the web view configuration so `<audio>`/`<video>` (and Web Audio, confirmed on device) can autoplay. Config-building is extracted into a testable `makeConfiguration(session:)` seam with a unit test asserting the setting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, scoped change to paywall web view WKWebView configuration with a unit test; no auth, data, or purchase flow changes.
> 
> **Overview**
> Paywall V2 **web view** components can now start **audio/video (and related Web media)** without a tap, by clearing `mediaTypesRequiringUserActionForPlayback` on the `WKWebViewConfiguration`.
> 
> **WKWebView** setup is refactored: configuration is built in a new static `WebViewRepresentable.makeConfiguration(session:)`, which `makeWebView` uses. A unit test asserts the playback-gesture requirement list is empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9637971a2d1441f741ce332840e7d293a984887a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->