### PR TITLE
fix(paywalls): allow web_view content to scroll on iOS

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
@@ -241,7 +241,7 @@ struct WebViewRepresentable: PlatformViewRepresentable {
         #else
         webView.isOpaque = false
         webView.backgroundColor = .clear
-        webView.scrollView.isScrollEnabled = false
+        webView.scrollView.isScrollEnabled = true
         webView.scrollView.bounces = false
         webView.scrollView.minimumZoomScale = 1
         webView.scrollView.maximumZoomScale = 1


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Full-screen (`fill`/`fixed`-height) `web_view` components couldn't scroll on iOS: the `WKWebView` scroll view was disabled, so content taller than the frame was clipped with no way to reach it.

### Description
Enables the web view's scroll view. Fit-height components are unaffected — their frame grows to the measured content height, leaving no scrollable overflow, so the outer paywall keeps handling the scroll. Tested on device with a fill-height bundle whose content exceeds the screen.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line iOS scroll behavior change in Paywalls V2 web views with no auth, data, or payment logic touched.
> 
> **Overview**
> On iOS, Paywalls V2 **`web_view`** components now enable scrolling on the embedded **`WKWebView`** scroll view (`isScrollEnabled = true`), so **fill** / **fixed**-height web views can scroll when page content is taller than the frame instead of clipping it.
> 
> **Fit**-height web views are unchanged in practice: the component frame still grows to measured content height, so there is usually no overflow to scroll inside the web view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d42d2b06ce4492e1a2741f91f334f7c9fbaadd29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->