### PR TITLE
fix(paywalls): arbitrate web_view drag gestures with paywall scroll on iOS

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		11CC2EA83C56933E40D8E5D8 /* WebViewEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89DD761C9E00E61032AAEB44 /* WebViewEnvelope.swift */; };
 		0F4E490A741F00F18C4985D8 /* WebViewSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CC1CD0385BF18D1392EB43 /* WebViewSession.swift */; };
 		D969194D68D6967E81788B1F /* WebViewComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A2779D02050D28BF369658 /* WebViewComponentView.swift */; };
+		B3728970B7484A89838D0504 /* WebViewScrollGestureArbitration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 047CB41107F93D74B35CED61 /* WebViewScrollGestureArbitration.swift */; };
 		B53032B7D38B14FE9850F314 /* WebViewComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F6E5F9ABE99E8F2BC1DE237 /* WebViewComponentViewModel.swift */; };
 		16DA8F1E2E4FB6E200283940 /* ImageComponent.json in Resources */ = {isa = PBXBuildFile; fileRef = 16DA8F1B2E4FB6E200283940 /* ImageComponent.json */; };
 		16DA8F1F2E4FB6E200283940 /* VideoComponent.json in Resources */ = {isa = PBXBuildFile; fileRef = 16DA8F1C2E4FB6E200283940 /* VideoComponent.json */; };
@@ -1666,6 +1667,7 @@
 		686562C08D953A27986DB276 /* PaywallWebViewValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallWebViewValueTests.swift; sourceTree = "<group>"; };
 		72CC1CD0385BF18D1392EB43 /* WebViewSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewSession.swift; sourceTree = "<group>"; };
 		D0A2779D02050D28BF369658 /* WebViewComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewComponentView.swift; sourceTree = "<group>"; };
+		047CB41107F93D74B35CED61 /* WebViewScrollGestureArbitration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewScrollGestureArbitration.swift; sourceTree = "<group>"; };
 		6F6E5F9ABE99E8F2BC1DE237 /* WebViewComponentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewComponentViewModel.swift; sourceTree = "<group>"; };
 		F75819E258F47D1DB058500D /* WebViewSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewSessionTests.swift; sourceTree = "<group>"; };
 		16DA8F1B2E4FB6E200283940 /* ImageComponent.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ImageComponent.json; sourceTree = "<group>"; };
@@ -3353,6 +3355,7 @@
 				89DD761C9E00E61032AAEB44 /* WebViewEnvelope.swift */,
 				72CC1CD0385BF18D1392EB43 /* WebViewSession.swift */,
 				D0A2779D02050D28BF369658 /* WebViewComponentView.swift */,
+				047CB41107F93D74B35CED61 /* WebViewScrollGestureArbitration.swift */,
 				6F6E5F9ABE99E8F2BC1DE237 /* WebViewComponentViewModel.swift */,
 			);
 			path = WebView;
@@ -8315,6 +8318,7 @@
 				11CC2EA83C56933E40D8E5D8 /* WebViewEnvelope.swift in Sources */,
 				0F4E490A741F00F18C4985D8 /* WebViewSession.swift in Sources */,
 				D969194D68D6967E81788B1F /* WebViewComponentView.swift in Sources */,
+				B3728970B7484A89838D0504 /* WebViewScrollGestureArbitration.swift in Sources */,
 				B53032B7D38B14FE9850F314 /* WebViewComponentViewModel.swift in Sources */,
 				DBAA1FC22F8D4ED8000E8C81 /* HeaderNestedHeroZLayerSafeAreaPreview.swift in Sources */,
 				164681D22E6B577600854AA5 /* VideoComponentViewModel.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1670,6 +1670,7 @@
 		047CB41107F93D74B35CED61 /* WebViewScrollGestureArbitration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewScrollGestureArbitration.swift; sourceTree = "<group>"; };
 		6F6E5F9ABE99E8F2BC1DE237 /* WebViewComponentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewComponentViewModel.swift; sourceTree = "<group>"; };
 		F75819E258F47D1DB058500D /* WebViewSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewSessionTests.swift; sourceTree = "<group>"; };
+		F1A2B3C4D5E6A7B8C9D0E1F2 /* WebViewScrollGestureArbitrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewScrollGestureArbitrationTests.swift; sourceTree = "<group>"; };
 		16DA8F1B2E4FB6E200283940 /* ImageComponent.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ImageComponent.json; sourceTree = "<group>"; };
 		16DA8F1C2E4FB6E200283940 /* VideoComponent.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = VideoComponent.json; sourceTree = "<group>"; };
 		16E146AB2E99F1E20089B609 /* TransactionNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionNotifications.swift; sourceTree = "<group>"; };
@@ -3211,6 +3212,7 @@
 				686562C08D953A27986DB276 /* PaywallWebViewValueTests.swift */,
 				C1B939C7DAAFEA1DE2DE2674 /* WebViewEnvelopeTests.swift */,
 				F75819E258F47D1DB058500D /* WebViewSessionTests.swift */,
+				F1A2B3C4D5E6A7B8C9D0E1F2 /* WebViewScrollGestureArbitrationTests.swift */,
 				802593842FE07057005AF6DF /* PaywallStateStoreTests.swift */,
 				16A9F7B62FAA22D0008E8A4D /* VideoComponentViewTests.swift */,
 				DBD2A16E300E833F0019DB7F /* VideoAudioSessionHandlerTests.swift */,

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
@@ -286,9 +286,9 @@ struct WebViewRepresentable: PlatformViewRepresentable {
         #endif
 
         #if os(iOS)
-        // Nested-scroll arbitration: let JS-panned content (maps, inner overflow scrollers) claim a
-        // drag from the enclosing paywall scroll. Installed before `load` so the document-start probe
-        // is present for the first navigation.
+        // Nested-scroll arbitration: let JS-panned content claim a drag from the enclosing paywall
+        // scroll. Installed before `load` so the document-start probe is present for the first
+        // navigation.
         self.installScrollGestureArbitration(on: webView)
         #endif
 

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
@@ -285,10 +285,30 @@ struct WebViewRepresentable: PlatformViewRepresentable {
         }
         #endif
 
+        #if os(iOS)
+        // Nested-scroll arbitration: let JS-panned content (maps, inner overflow scrollers) claim a
+        // drag from the enclosing paywall scroll. Installed before `load` so the document-start probe
+        // is present for the first navigation.
+        self.installScrollGestureArbitration(on: webView)
+        #endif
+
         self.configureSession(for: webView)
         self.load(webView)
         return webView
     }
+
+    #if os(iOS)
+    @MainActor
+    private func installScrollGestureArbitration(on webView: PlatformWebView) {
+        let recognizer = WebViewScrollOwnershipRecognizer(webView: webView)
+        webView.addGestureRecognizer(recognizer)
+        webView.configuration.userContentController.add(
+            WeakScriptMessageHandler(recognizer),
+            name: WebViewGestureProbe.messageHandlerName
+        )
+        webView.configuration.userContentController.addUserScript(WebViewGestureProbe.userScript)
+    }
+    #endif
 
     @MainActor
     private func update(_ webView: PlatformWebView) {
@@ -324,6 +344,11 @@ struct WebViewRepresentable: PlatformViewRepresentable {
         webView.configuration.userContentController.removeScriptMessageHandler(
             forName: WebViewEnvelope.messageHandlerName
         )
+        #if os(iOS)
+        webView.configuration.userContentController.removeScriptMessageHandler(
+            forName: WebViewGestureProbe.messageHandlerName
+        )
+        #endif
     }
 
     // `WKNavigationDelegate` is `@MainActor`-annotated in the SDK (its `WK_SWIFT_UI_ACTOR` attribute

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
@@ -271,7 +271,7 @@ struct WebViewRepresentable: PlatformViewRepresentable {
         webView.isOpaque = false
         webView.backgroundColor = .clear
         webView.scrollView.isScrollEnabled = true
-        webView.scrollView.bounces = false
+        webView.scrollView.bounces = true
         webView.scrollView.minimumZoomScale = 1
         webView.scrollView.maximumZoomScale = 1
         #endif

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
@@ -241,7 +241,7 @@ struct WebViewRepresentable: PlatformViewRepresentable {
         #else
         webView.isOpaque = false
         webView.backgroundColor = .clear
-        webView.scrollView.isScrollEnabled = false
+        webView.scrollView.isScrollEnabled = true
         webView.scrollView.bounces = false
         webView.scrollView.minimumZoomScale = 1
         webView.scrollView.maximumZoomScale = 1

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewScrollGestureArbitration.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewScrollGestureArbitration.swift
@@ -6,22 +6,17 @@
 //  Created by Antonio Pallares.
 //
 
-// A web_view component embedded in a scrollable paywall competes for vertical drags with the paywall
-// scroll. iOS resolves nested *native* scroll views on its own (the inner web scroll wins when it can
-// scroll), but content that pans via JavaScript — an SVG map with `touch-action: none`, an inner
-// `overflow: auto` list — is invisible to that arbitration, so a drag both pans the content *and*
-// scrolls the paywall ("double scroll").
-//
-// This mirrors purchases-android's approach: a document-start probe reports, per touch, whether the
-// touched element (or an ancestor) consumes the drag, and a custom recognizer on the web view claims
-// the gesture from the enclosing paywall scroll when it does. iOS-only: macOS/tvOS/watchOS use a
-// different (or no) scroll model.
+// A web_view component embedded in a scrollable paywall competes for drag gestures with the paywall
+// scroll — on whichever axis the paywall scrolls (vertical for a typical paywall, horizontal for a
+// paged/carousel container). iOS resolves nested *native* scroll views on its own (the inner web
+// scroll wins when it can scroll), but content that pans via JavaScript — an SVG map with
+// `touch-action: none`, an inner `overflow: auto` list — is invisible to that arbitration, so a drag
+// both pans the content *and* scrolls the paywall ("double scroll").
 
 #if os(iOS) && canImport(WebKit)
 
 import Foundation
 @_spi(Internal) import RevenueCat
-// Importing the subclass submodule re-exports UIKit and unlocks the settable `state` used below.
 import UIKit.UIGestureRecognizerSubclass
 import WebKit
 
@@ -75,8 +70,8 @@ enum WebViewGestureProbe {
 
 /// Whether the web view should claim the drag (else the paywall scroll keeps it). A content `own`
 /// verdict — an inner scroller or `touch-action` map native can't see — wins immediately; otherwise
-/// native root scrollability in the dominant drag direction decides. `direction > 0` means toward the
-/// end (down / trailing), matching Android's `canScroll*` convention.
+/// the web view's own scroll offsets in the dominant drag direction decide. `direction > 0` means
+/// toward the end of the content (scrolling down / trailing), as used by the `canScroll*` closures below.
 @available(iOS 15.0, *)
 // swiftlint:disable:next function_parameter_count
 func shouldWebViewOwnGesture(
@@ -174,8 +169,8 @@ final class WebViewScrollOwnershipRecognizer: UIGestureRecognizer,
         didReceive message: WKScriptMessage
     ) {
         guard message.frameInfo.isMainFrame else { return }
-        let wantsGesture = (message.body as? String) == WebViewGestureProbe.verdictOwn
         guard !self.decided else { return }
+        let wantsGesture = (message.body as? String) == WebViewGestureProbe.verdictOwn
         self.contentWantsGesture = wantsGesture
         // An `own` verdict claims immediately, even within slop. `release` waits for movement so the
         // dominant-axis native-scroll check below can still decide.

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewScrollGestureArbitration.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewScrollGestureArbitration.swift
@@ -46,8 +46,9 @@ enum WebViewGestureProbe {
         let source = """
         (function () {
           function consumesGesture(el) {
-            var node = el && el.nodeType === 1 ? el : (el ? el.parentElement : null);
-            for (var n = node; n && n.nodeType === 1; n = n.parentElement) {
+            var ELEMENT_NODE = Node.ELEMENT_NODE;
+            var node = el && el.nodeType === ELEMENT_NODE ? el : (el ? el.parentElement : null);
+            for (var n = node; n && n.nodeType === ELEMENT_NODE; n = n.parentElement) {
               var s = getComputedStyle(n);
               if (s.touchAction && s.touchAction !== 'auto' && s.touchAction !== 'manipulation') return true;
               if ((s.overflowY === 'auto' || s.overflowY === 'scroll') && n.scrollHeight > n.clientHeight) return true;

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewScrollGestureArbitration.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewScrollGestureArbitration.swift
@@ -1,0 +1,263 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  WebViewScrollGestureArbitration.swift
+//
+//  Created by Antonio Pallares.
+//
+
+// A web_view component embedded in a scrollable paywall competes for vertical drags with the paywall
+// scroll. iOS resolves nested *native* scroll views on its own (the inner web scroll wins when it can
+// scroll), but content that pans via JavaScript — an SVG map with `touch-action: none`, an inner
+// `overflow: auto` list — is invisible to that arbitration, so a drag both pans the content *and*
+// scrolls the paywall ("double scroll").
+//
+// This mirrors purchases-android's approach: a document-start probe reports, per touch, whether the
+// touched element (or an ancestor) consumes the drag, and a custom recognizer on the web view claims
+// the gesture from the enclosing paywall scroll when it does. iOS-only: macOS/tvOS/watchOS use a
+// different (or no) scroll model.
+
+#if os(iOS) && canImport(WebKit)
+
+import Foundation
+@_spi(Internal) import RevenueCat
+// Importing the subclass submodule re-exports UIKit and unlocks the settable `state` used below.
+import UIKit.UIGestureRecognizerSubclass
+import WebKit
+
+// MARK: - Probe
+
+@available(iOS 15.0, *)
+enum WebViewGestureProbe {
+
+    /// Message handler name the probe posts verdicts to. Distinct from the bridge's
+    /// ``WebViewEnvelope/messageHandlerName`` so gesture traffic never touches the app channel.
+    static let messageHandlerName = "rcPaywallGestureProbe"
+
+    static let verdictOwn = "own"
+    static let verdictRelease = "release"
+
+    /// Runs at document start in the main frame. On every `touchstart` it walks from the touched
+    /// element up its ancestors and posts `own` when one declares a non-default `touch-action`
+    /// (JS panning) or is an overflowing `auto`/`scroll` scroller — the per-element signals the
+    /// native scroll-offset checks can't see — otherwise `release`. Passive, so it never blocks
+    /// the page's own handling.
+    static var userScript: WKUserScript {
+        let source = """
+        (function () {
+          function consumesGesture(el) {
+            var node = el && el.nodeType === 1 ? el : (el ? el.parentElement : null);
+            for (var n = node; n && n.nodeType === 1; n = n.parentElement) {
+              var s = getComputedStyle(n);
+              if (s.touchAction && s.touchAction !== 'auto' && s.touchAction !== 'manipulation') return true;
+              if ((s.overflowY === 'auto' || s.overflowY === 'scroll') && n.scrollHeight > n.clientHeight) return true;
+              if ((s.overflowX === 'auto' || s.overflowX === 'scroll') && n.scrollWidth > n.clientWidth) return true;
+            }
+            return false;
+          }
+          function post(verdict) {
+            try {
+              window.webkit.messageHandlers.\(messageHandlerName).postMessage(verdict);
+            } catch (e) {}
+          }
+          document.addEventListener('touchstart', function (event) {
+            post(consumesGesture(event.target) ? '\(verdictOwn)' : '\(verdictRelease)');
+          }, { passive: true, capture: true });
+        })();
+        """
+        return WKUserScript(source: source, injectionTime: .atDocumentStart, forMainFrameOnly: true)
+    }
+
+}
+
+// MARK: - Decision
+
+/// Whether the web view should claim the drag (else the paywall scroll keeps it). A content `own`
+/// verdict — an inner scroller or `touch-action` map native can't see — wins immediately; otherwise
+/// native root scrollability in the dominant drag direction decides. `direction > 0` means toward the
+/// end (down / trailing), matching Android's `canScroll*` convention.
+@available(iOS 15.0, *)
+// swiftlint:disable:next function_parameter_count
+func shouldWebViewOwnGesture(
+    totalDx: CGFloat,
+    totalDy: CGFloat,
+    touchSlop: CGFloat,
+    webContentWantsGesture: Bool?,
+    canScrollHorizontally: (_ direction: Int) -> Bool,
+    canScrollVertically: (_ direction: Int) -> Bool
+) -> Bool {
+    if webContentWantsGesture == true { return true }
+    if abs(totalDx) < touchSlop && abs(totalDy) < touchSlop { return false }
+    if abs(totalDy) >= abs(totalDx) {
+        return canScrollVertically(totalDy < 0 ? 1 : -1)
+    } else {
+        return canScrollHorizontally(totalDx < 0 ? 1 : -1)
+    }
+}
+
+// MARK: - Recognizer
+
+/// Installed on the web view; makes any *ancestor* paywall scroll view wait for it to fail (via
+/// ``gestureRecognizer(_:shouldBeRequiredToFailBy:)``). It recognizes — and so blocks that scroll —
+/// only when the drag belongs to the web content, per ``shouldWebViewOwnGesture(...)`` fed by the
+/// probe verdict and the web view's own scroll offsets. It never cancels touches, so the page still
+/// receives them for panning, taps and links.
+@available(iOS 15.0, *)
+final class WebViewScrollOwnershipRecognizer: UIGestureRecognizer,
+                                              UIGestureRecognizerDelegate,
+                                              WKScriptMessageHandler {
+
+    // Points a finger may drift before we commit to a verdict. Roughly UIKit's own pan slop.
+    private static let touchSlop: CGFloat = 10
+
+    private weak var webView: WKWebView?
+
+    private var startLocation: CGPoint = .zero
+    /// `nil` until the probe reports; `true` == content owns, `false` == release to the paywall.
+    private var contentWantsGesture: Bool?
+    /// Once we pick `.began` or `.failed` for a gesture we don't revisit it (UIKit can't un-fail).
+    private var decided = false
+
+    init(webView: WKWebView) {
+        self.webView = webView
+        super.init(target: nil, action: nil)
+        self.delegate = self
+        // Arbitrate only; let the web view keep every touch so JS panning, taps and links still work.
+        self.cancelsTouchesInView = false
+        self.delaysTouchesBegan = false
+        self.delaysTouchesEnded = false
+    }
+
+    // MARK: Touch tracking
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
+        super.touchesBegan(touches, with: event)
+        self.startLocation = touches.first?.location(in: self.view) ?? .zero
+        self.contentWantsGesture = nil
+        self.decided = false
+        // Stay `.possible`: the ancestor scroll (required to fail by us) waits until we resolve.
+    }
+
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
+        super.touchesMoved(touches, with: event)
+        guard !self.decided, let location = touches.first?.location(in: self.view) else { return }
+        self.evaluate(
+            totalDx: location.x - self.startLocation.x,
+            totalDy: location.y - self.startLocation.y
+        )
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent) {
+        super.touchesEnded(touches, with: event)
+        self.finish(with: self.state == .began || self.state == .changed ? .ended : .failed)
+    }
+
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent) {
+        super.touchesCancelled(touches, with: event)
+        self.finish(with: self.state == .began || self.state == .changed ? .cancelled : .failed)
+    }
+
+    override func reset() {
+        super.reset()
+        self.contentWantsGesture = nil
+        self.decided = false
+    }
+
+    // MARK: Verdict
+
+    /// Receives the probe verdict. May arrive a frame or two after `touchstart`; only useful while the
+    /// gesture is unresolved. A late `own` after we've already failed is dropped (that gesture is lost
+    /// to the paywall — the same async caveat as Android).
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage
+    ) {
+        guard message.frameInfo.isMainFrame else { return }
+        let wantsGesture = (message.body as? String) == WebViewGestureProbe.verdictOwn
+        guard !self.decided else { return }
+        self.contentWantsGesture = wantsGesture
+        // An `own` verdict claims immediately, even within slop. `release` waits for movement so the
+        // dominant-axis native-scroll check below can still decide.
+        if wantsGesture {
+            self.decided = true
+            self.state = .began
+        }
+    }
+
+    // MARK: Arbitration
+
+    private func evaluate(totalDx: CGFloat, totalDy: CGFloat) {
+        let owns = shouldWebViewOwnGesture(
+            totalDx: totalDx,
+            totalDy: totalDy,
+            touchSlop: Self.touchSlop,
+            webContentWantsGesture: self.contentWantsGesture,
+            canScrollHorizontally: { [weak self] in self?.canScroll(horizontally: $0) ?? false },
+            canScrollVertically: { [weak self] in self?.canScroll(vertically: $0) ?? false }
+        )
+
+        if owns {
+            self.decided = true
+            self.state = .began
+        } else if abs(totalDx) >= Self.touchSlop || abs(totalDy) >= Self.touchSlop {
+            // Past slop and not owned: hand the drag to the paywall.
+            self.decided = true
+            self.state = .failed
+        }
+        // Within slop and not owned yet: stay `.possible`, awaiting a verdict or more movement.
+    }
+
+    private func canScroll(vertically direction: Int) -> Bool {
+        guard let scrollView = self.webView?.scrollView else { return false }
+        if direction > 0 {
+            return scrollView.contentOffset.y + scrollView.bounds.height < scrollView.contentSize.height - 0.5
+        } else {
+            return scrollView.contentOffset.y > 0.5
+        }
+    }
+
+    private func canScroll(horizontally direction: Int) -> Bool {
+        guard let scrollView = self.webView?.scrollView else { return false }
+        if direction > 0 {
+            return scrollView.contentOffset.x + scrollView.bounds.width < scrollView.contentSize.width - 0.5
+        } else {
+            return scrollView.contentOffset.x > 0.5
+        }
+    }
+
+    private func finish(with endState: UIGestureRecognizer.State) {
+        self.decided = true
+        self.state = endState
+    }
+
+    // MARK: UIGestureRecognizerDelegate
+
+    /// Make an ancestor paywall scroll view's pan wait for us: it only begins if we fail (release), so
+    /// recognizing (own) blocks it. Scoped to scroll views that actually contain the web view, and not
+    /// the web view's own scroll view.
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        guard otherGestureRecognizer is UIPanGestureRecognizer,
+              let scrollView = otherGestureRecognizer.view as? UIScrollView,
+              let webView = self.webView,
+              scrollView !== webView.scrollView,
+              webView.isDescendant(of: scrollView) else {
+            return false
+        }
+        return true
+    }
+
+    /// Coexist with the web view's own recognizers (its scroll view pan, taps); we only gate the
+    /// ancestor paywall scroll, via the failure requirement above.
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        true
+    }
+
+}
+
+#endif

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewScrollGestureArbitration.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewScrollGestureArbitration.swift
@@ -32,14 +32,17 @@ enum WebViewGestureProbe {
     static let verdictOwn = "own"
     static let verdictRelease = "release"
 
-    /// Runs at document start in the main frame. On every `touchstart` it walks from the touched
-    /// element up its ancestors and posts `own` when one declares `touch-action: none` (JS panning,
-    /// e.g. a map) or is an overflowing `auto`/`scroll` scroller — the per-element signals the
-    /// native scroll-offset checks can't see — otherwise `release`. Passive, so it never blocks
-    /// the page's own handling.
+    /// Runs at document start in the main frame. On the first finger of a `touchstart` it walks from the
+    /// touched element up its ancestors and posts `own` when one declares `touch-action: none` (JS
+    /// panning, e.g. a map) or is an *inner* overflowing `auto`/`scroll` scroller — the per-element
+    /// signals the native scroll-offset checks can't see — otherwise `release`. The root scroller is
+    /// left to those native checks. Passive, so it never blocks the page's own handling.
     static var userScript: WKUserScript {
         let source = """
         (function () {
+          function isRootScroller(n) {
+            return n === document.scrollingElement || n === document.documentElement || n === document.body;
+          }
           function consumesGesture(el) {
             var ELEMENT_NODE = Node.ELEMENT_NODE;
             var node = el && el.nodeType === ELEMENT_NODE ? el : (el ? el.parentElement : null);
@@ -49,6 +52,10 @@ enum WebViewGestureProbe {
               // map). `pan-x`/`pan-y` still let the browser scroll natively on an axis — visible to the
               // `canScroll*` checks — so claiming them would wrongly block the paywall at the scroll edge.
               if (s.touchAction === 'none') return true;
+              // Skip the root scroller: it *is* the web view's scroll view, which the native `canScroll*`
+              // checks already track and hand off to the paywall at the edges. Only inner scrollers are
+              // invisible to them, so claiming the root here would trap the paywall at the content edge.
+              if (isRootScroller(n)) continue;
               if ((s.overflowY === 'auto' || s.overflowY === 'scroll') && n.scrollHeight > n.clientHeight) return true;
               if ((s.overflowX === 'auto' || s.overflowX === 'scroll') && n.scrollWidth > n.clientWidth) return true;
             }
@@ -60,6 +67,9 @@ enum WebViewGestureProbe {
             } catch (e) {}
           }
           document.addEventListener('touchstart', function (event) {
+            // Only the first finger of a sequence: the recognizer tracks the primary touch, so a second
+            // finger's verdict must not overwrite the primary's while the gesture is still undecided.
+            if (event.touches.length > 1) return;
             post(consumesGesture(event.target) ? '\(verdictOwn)' : '\(verdictRelease)');
           }, { passive: true, capture: true });
         })();

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewScrollGestureArbitration.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewScrollGestureArbitration.swift
@@ -288,19 +288,26 @@ final class WebViewScrollOwnershipRecognizer: UIGestureRecognizer,
 
     private func canScroll(vertically direction: Int) -> Bool {
         guard let scrollView = self.webView?.scrollView else { return false }
+        // `adjustedContentInset` widens the offset range (safe area, keyboard, WebKit adjustments): the
+        // resting top offset is `-inset.top` and the max bottom offset gains `inset.bottom`, so raw
+        // `0 ... contentSize - bounds` math would report "at the edge" while the view can still scroll.
+        let inset = scrollView.adjustedContentInset
         if direction > 0 {
-            return scrollView.contentOffset.y + scrollView.bounds.height < scrollView.contentSize.height - 0.5
+            let maxOffsetY = scrollView.contentSize.height + inset.bottom - scrollView.bounds.height
+            return scrollView.contentOffset.y < maxOffsetY - 0.5
         } else {
-            return scrollView.contentOffset.y > 0.5
+            return scrollView.contentOffset.y > -inset.top + 0.5
         }
     }
 
     private func canScroll(horizontally direction: Int) -> Bool {
         guard let scrollView = self.webView?.scrollView else { return false }
+        let inset = scrollView.adjustedContentInset
         if direction > 0 {
-            return scrollView.contentOffset.x + scrollView.bounds.width < scrollView.contentSize.width - 0.5
+            let maxOffsetX = scrollView.contentSize.width + inset.right - scrollView.bounds.width
+            return scrollView.contentOffset.x < maxOffsetX - 0.5
         } else {
-            return scrollView.contentOffset.x > 0.5
+            return scrollView.contentOffset.x > -inset.left + 0.5
         }
     }
 

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewScrollGestureArbitration.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewScrollGestureArbitration.swift
@@ -33,8 +33,8 @@ enum WebViewGestureProbe {
     static let verdictRelease = "release"
 
     /// Runs at document start in the main frame. On every `touchstart` it walks from the touched
-    /// element up its ancestors and posts `own` when one declares a non-default `touch-action`
-    /// (JS panning) or is an overflowing `auto`/`scroll` scroller — the per-element signals the
+    /// element up its ancestors and posts `own` when one declares `touch-action: none` (JS panning,
+    /// e.g. a map) or is an overflowing `auto`/`scroll` scroller — the per-element signals the
     /// native scroll-offset checks can't see — otherwise `release`. Passive, so it never blocks
     /// the page's own handling.
     static var userScript: WKUserScript {
@@ -45,7 +45,10 @@ enum WebViewGestureProbe {
             var node = el && el.nodeType === ELEMENT_NODE ? el : (el ? el.parentElement : null);
             for (var n = node; n && n.nodeType === ELEMENT_NODE; n = n.parentElement) {
               var s = getComputedStyle(n);
-              if (s.touchAction && s.touchAction !== 'auto' && s.touchAction !== 'manipulation') return true;
+              // Only `none` means the browser won't pan this element at all (JS owns every axis, e.g. a
+              // map). `pan-x`/`pan-y` still let the browser scroll natively on an axis — visible to the
+              // `canScroll*` checks — so claiming them would wrongly block the paywall at the scroll edge.
+              if (s.touchAction === 'none') return true;
               if ((s.overflowY === 'auto' || s.overflowY === 'scroll') && n.scrollHeight > n.clientHeight) return true;
               if ((s.overflowX === 'auto' || s.overflowX === 'scroll') && n.scrollWidth > n.clientWidth) return true;
             }

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewScrollGestureArbitration.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewScrollGestureArbitration.swift
@@ -108,11 +108,15 @@ final class WebViewScrollOwnershipRecognizer: UIGestureRecognizer,
 
     private weak var webView: WKWebView?
 
-    private var startLocation: CGPoint = .zero
+    var startLocation: CGPoint = .zero
     /// `nil` until the probe reports; `true` == content owns, `false` == release to the paywall.
-    private var contentWantsGesture: Bool?
+    var contentWantsGesture: Bool?
     /// Once we pick `.began` or `.failed` for a gesture we don't revisit it (UIKit can't un-fail).
-    private var decided = false
+    var decided = false
+    /// `true` while a single touch sequence is being arbitrated: set on the first finger down and
+    /// cleared once the gesture resolves or resets. Guards a second finger from re-initializing state
+    /// mid-gesture, and a late/stale probe verdict from applying between gestures.
+    var isTracking = false
 
     init(webView: WKWebView) {
         self.webView = webView
@@ -128,10 +132,19 @@ final class WebViewScrollOwnershipRecognizer: UIGestureRecognizer,
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
         super.touchesBegan(touches, with: event)
-        self.startLocation = touches.first?.location(in: self.view) ?? .zero
+        self.beginSequence(at: touches.first?.location(in: self.view) ?? .zero)
+        // Stay `.possible`: the ancestor scroll (required to fail by us) waits until we resolve.
+    }
+
+    /// Initialize arbitration state for a new touch sequence. Only the first finger takes effect: a
+    /// second finger landing mid-gesture must not reset `decided` (which could force an illegal
+    /// `.began` -> `.failed` transition) nor re-anchor `startLocation` (which corrupts the drag deltas).
+    func beginSequence(at location: CGPoint) {
+        guard !self.isTracking else { return }
+        self.isTracking = true
+        self.startLocation = location
         self.contentWantsGesture = nil
         self.decided = false
-        // Stay `.possible`: the ancestor scroll (required to fail by us) waits until we resolve.
     }
 
     override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
@@ -155,26 +168,32 @@ final class WebViewScrollOwnershipRecognizer: UIGestureRecognizer,
 
     override func reset() {
         super.reset()
+        self.isTracking = false
         self.contentWantsGesture = nil
         self.decided = false
     }
 
     // MARK: Verdict
 
-    /// Receives the probe verdict. May arrive a frame or two after `touchstart`; only useful while the
-    /// gesture is unresolved. A late `own` after we've already failed is dropped (that gesture is lost
-    /// to the paywall — the same async caveat as Android).
+    /// Receives the probe verdict. May arrive a frame or two after `touchstart`, so `applyProbeVerdict`
+    /// decides whether it's still relevant to the live gesture.
     func userContentController(
         _ userContentController: WKUserContentController,
         didReceive message: WKScriptMessage
     ) {
         guard message.frameInfo.isMainFrame else { return }
-        guard !self.decided else { return }
-        let wantsGesture = (message.body as? String) == WebViewGestureProbe.verdictOwn
-        self.contentWantsGesture = wantsGesture
+        self.applyProbeVerdict(isOwn: (message.body as? String) == WebViewGestureProbe.verdictOwn)
+    }
+
+    /// Apply a probe verdict to the live gesture. Ignored unless a sequence is actively being
+    /// arbitrated and still undecided, so a verdict that arrives after the gesture ended (or was
+    /// handed to the paywall) can't retroactively claim it or leak into the next gesture.
+    func applyProbeVerdict(isOwn: Bool) {
+        guard self.isTracking, !self.decided else { return }
+        self.contentWantsGesture = isOwn
         // An `own` verdict claims immediately, even within slop. `release` waits for movement so the
-        // dominant-axis native-scroll check below can still decide.
-        if wantsGesture {
+        // dominant-axis native-scroll check can still decide.
+        if isOwn {
             self.decided = true
             self.state = .began
         }
@@ -222,6 +241,7 @@ final class WebViewScrollOwnershipRecognizer: UIGestureRecognizer,
     }
 
     private func finish(with endState: UIGestureRecognizer.State) {
+        self.isTracking = false
         self.decided = true
         self.state = endState
     }

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewScrollGestureArbitration.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewScrollGestureArbitration.swift
@@ -289,8 +289,7 @@ final class WebViewScrollOwnershipRecognizer: UIGestureRecognizer,
     private func canScroll(vertically direction: Int) -> Bool {
         guard let scrollView = self.webView?.scrollView else { return false }
         // `adjustedContentInset` widens the offset range (safe area, keyboard, WebKit adjustments): the
-        // resting top offset is `-inset.top` and the max bottom offset gains `inset.bottom`, so raw
-        // `0 ... contentSize - bounds` math would report "at the edge" while the view can still scroll.
+        // resting top offset is `-inset.top` and the max bottom offset gains `inset.bottom`.
         let inset = scrollView.adjustedContentInset
         if direction > 0 {
             let maxOffsetY = scrollView.contentSize.height + inset.bottom - scrollView.bounds.height

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewScrollGestureArbitration.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewScrollGestureArbitration.swift
@@ -91,6 +91,47 @@ func shouldWebViewOwnGesture(
     }
 }
 
+/// The recognizer's resolution for the current movement.
+enum WebViewGestureOutcome: Equatable {
+    /// The web view claims the drag (block the paywall scroll).
+    case own
+    /// Hand the drag to the paywall scroll.
+    case release
+    /// Not enough information yet — keep waiting for more movement or the probe verdict.
+    case pending
+}
+
+/// Resolves the current movement into an outcome. `own` follows ``shouldWebViewOwnGesture``. Otherwise
+/// we only `release` once the probe verdict has arrived (`webContentWantsGesture != nil`): while it is
+/// still `nil` a fast drag past slop stays `pending` rather than releasing, so a late `own` verdict on
+/// JS-panned content (which has no native root scroll to reveal it) isn't preempted by an early hand-off.
+@available(iOS 15.0, *)
+// swiftlint:disable:next function_parameter_count
+func webViewGestureOutcome(
+    totalDx: CGFloat,
+    totalDy: CGFloat,
+    touchSlop: CGFloat,
+    webContentWantsGesture: Bool?,
+    canScrollHorizontally: (_ direction: Int) -> Bool,
+    canScrollVertically: (_ direction: Int) -> Bool
+) -> WebViewGestureOutcome {
+    let owns = shouldWebViewOwnGesture(
+        totalDx: totalDx,
+        totalDy: totalDy,
+        touchSlop: touchSlop,
+        webContentWantsGesture: webContentWantsGesture,
+        canScrollHorizontally: canScrollHorizontally,
+        canScrollVertically: canScrollVertically
+    )
+    if owns { return .own }
+
+    let pastSlop = abs(totalDx) >= touchSlop || abs(totalDy) >= touchSlop
+    // A definitive `release` verdict (or a `nil` verdict that native scrollability already resolved)
+    // lets us hand off; a still-pending verdict must wait so JS-panned content can claim it.
+    if pastSlop && webContentWantsGesture != nil { return .release }
+    return .pending
+}
+
 // MARK: - Recognizer
 
 /// Installed on the web view; makes any *ancestor* paywall scroll view wait for it to fail (via
@@ -117,6 +158,9 @@ final class WebViewScrollOwnershipRecognizer: UIGestureRecognizer,
     /// cleared once the gesture resolves or resets. Guards a second finger from re-initializing state
     /// mid-gesture, and a late/stale probe verdict from applying between gestures.
     var isTracking = false
+    /// The latest drag translation of the current sequence, kept so a probe verdict arriving after the
+    /// finger has already moved can be re-evaluated against where it is now.
+    var latestTranslation: CGSize = .zero
 
     init(webView: WKWebView) {
         self.webView = webView
@@ -143,6 +187,7 @@ final class WebViewScrollOwnershipRecognizer: UIGestureRecognizer,
         guard !self.isTracking else { return }
         self.isTracking = true
         self.startLocation = location
+        self.latestTranslation = .zero
         self.contentWantsGesture = nil
         self.decided = false
     }
@@ -150,10 +195,11 @@ final class WebViewScrollOwnershipRecognizer: UIGestureRecognizer,
     override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
         super.touchesMoved(touches, with: event)
         guard !self.decided, let location = touches.first?.location(in: self.view) else { return }
-        self.evaluate(
-            totalDx: location.x - self.startLocation.x,
-            totalDy: location.y - self.startLocation.y
+        self.latestTranslation = CGSize(
+            width: location.x - self.startLocation.x,
+            height: location.y - self.startLocation.y
         )
+        self.evaluate()
     }
 
     override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent) {
@@ -191,35 +237,39 @@ final class WebViewScrollOwnershipRecognizer: UIGestureRecognizer,
     func applyProbeVerdict(isOwn: Bool) {
         guard self.isTracking, !self.decided else { return }
         self.contentWantsGesture = isOwn
-        // An `own` verdict claims immediately, even within slop. `release` waits for movement so the
-        // dominant-axis native-scroll check can still decide.
+        // An `own` verdict claims immediately, even within slop. A `release` verdict resolves the
+        // pending state, so re-evaluate against the latest movement to hand off promptly if the finger
+        // has already dragged past slop (a fast drag may have moved before the verdict landed).
         if isOwn {
             self.decided = true
             self.state = .began
+        } else {
+            self.evaluate()
         }
     }
 
     // MARK: Arbitration
 
-    private func evaluate(totalDx: CGFloat, totalDy: CGFloat) {
-        let owns = shouldWebViewOwnGesture(
-            totalDx: totalDx,
-            totalDy: totalDy,
+    func evaluate() {
+        switch webViewGestureOutcome(
+            totalDx: self.latestTranslation.width,
+            totalDy: self.latestTranslation.height,
             touchSlop: Self.touchSlop,
             webContentWantsGesture: self.contentWantsGesture,
             canScrollHorizontally: { [weak self] in self?.canScroll(horizontally: $0) ?? false },
             canScrollVertically: { [weak self] in self?.canScroll(vertically: $0) ?? false }
-        )
-
-        if owns {
+        ) {
+        case .own:
             self.decided = true
             self.state = .began
-        } else if abs(totalDx) >= Self.touchSlop || abs(totalDy) >= Self.touchSlop {
-            // Past slop and not owned: hand the drag to the paywall.
+        case .release:
             self.decided = true
             self.state = .failed
+        case .pending:
+            // Within slop, or past slop while the probe verdict is still pending: stay `.possible`,
+            // awaiting the verdict or more movement rather than releasing prematurely.
+            break
         }
-        // Within slop and not owned yet: stay `.possible`, awaiting a verdict or more movement.
     }
 
     private func canScroll(vertically direction: Int) -> Bool {

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewScrollGestureArbitration.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewScrollGestureArbitration.swift
@@ -161,6 +161,10 @@ final class WebViewScrollOwnershipRecognizer: UIGestureRecognizer,
     /// The latest drag translation of the current sequence, kept so a probe verdict arriving after the
     /// finger has already moved can be re-evaluated against where it is now.
     var latestTranslation: CGSize = .zero
+    /// The finger that started the sequence. Arbitration follows only this touch, so a secondary finger
+    /// moving, lifting, or being cancelled can't corrupt the deltas or end the gesture early. Weak: a
+    /// `UITouch` is owned by UIKit and reused, so it must never be retained past its sequence.
+    private weak var trackedTouch: UITouch?
 
     init(webView: WKWebView) {
         self.webView = webView
@@ -176,7 +180,10 @@ final class WebViewScrollOwnershipRecognizer: UIGestureRecognizer,
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
         super.touchesBegan(touches, with: event)
-        self.beginSequence(at: touches.first?.location(in: self.view) ?? .zero)
+        // Only the first finger starts a sequence; a second finger landing mid-gesture is ignored.
+        guard !self.isTracking, let touch = touches.first else { return }
+        self.trackedTouch = touch
+        self.beginSequence(at: touch.location(in: self.view))
         // Stay `.possible`: the ancestor scroll (required to fail by us) waits until we resolve.
     }
 
@@ -194,7 +201,10 @@ final class WebViewScrollOwnershipRecognizer: UIGestureRecognizer,
 
     override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
         super.touchesMoved(touches, with: event)
-        guard !self.decided, let location = touches.first?.location(in: self.view) else { return }
+        // Follow only the tracked finger, measured from its own start, so a second finger can't skew
+        // the deltas.
+        guard !self.decided, let touch = self.trackedTouch, touches.contains(touch) else { return }
+        let location = touch.location(in: self.view)
         self.latestTranslation = CGSize(
             width: location.x - self.startLocation.x,
             height: location.y - self.startLocation.y
@@ -204,17 +214,21 @@ final class WebViewScrollOwnershipRecognizer: UIGestureRecognizer,
 
     override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent) {
         super.touchesEnded(touches, with: event)
+        // Resolve only when the tracked finger lifts; a secondary finger lifting must not end the drag.
+        guard let touch = self.trackedTouch, touches.contains(touch) else { return }
         self.finish(with: self.state == .began || self.state == .changed ? .ended : .failed)
     }
 
     override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent) {
         super.touchesCancelled(touches, with: event)
+        guard let touch = self.trackedTouch, touches.contains(touch) else { return }
         self.finish(with: self.state == .began || self.state == .changed ? .cancelled : .failed)
     }
 
     override func reset() {
         super.reset()
         self.isTracking = false
+        self.trackedTouch = nil
         self.contentWantsGesture = nil
         self.decided = false
     }

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewScrollGestureArbitration.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewScrollGestureArbitration.swift
@@ -178,6 +178,10 @@ final class WebViewScrollOwnershipRecognizer: UIGestureRecognizer,
     /// moving, lifting, or being cancelled can't corrupt the deltas or end the gesture early. Weak: a
     /// `UITouch` is owned by UIKit and reused, so it must never be retained past its sequence.
     private weak var trackedTouch: UITouch?
+    /// The arbitration commit for the current sequence (`own` -> `.began`, `release` -> `.failed`), `nil`
+    /// while undecided. Mirrors the intent behind `state`, which UIKit only honors on a recognizer inside
+    /// a live touch cycle — so `state` is unreliable to observe outside one (notably in tests).
+    private(set) var committedDecision: WebViewGestureOutcome?
 
     init(webView: WKWebView) {
         self.webView = webView
@@ -210,6 +214,7 @@ final class WebViewScrollOwnershipRecognizer: UIGestureRecognizer,
         self.latestTranslation = .zero
         self.contentWantsGesture = nil
         self.decided = false
+        self.committedDecision = nil
     }
 
     override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
@@ -244,6 +249,7 @@ final class WebViewScrollOwnershipRecognizer: UIGestureRecognizer,
         self.trackedTouch = nil
         self.contentWantsGesture = nil
         self.decided = false
+        self.committedDecision = nil
     }
 
     // MARK: Verdict
@@ -268,8 +274,7 @@ final class WebViewScrollOwnershipRecognizer: UIGestureRecognizer,
         // pending state, so re-evaluate against the latest movement to hand off promptly if the finger
         // has already dragged past slop (a fast drag may have moved before the verdict landed).
         if isOwn {
-            self.decided = true
-            self.state = .began
+            self.claimGesture()
         } else {
             self.evaluate()
         }
@@ -287,16 +292,30 @@ final class WebViewScrollOwnershipRecognizer: UIGestureRecognizer,
             canScrollVertically: { [weak self] in self?.canScroll(vertically: $0) ?? false }
         ) {
         case .own:
-            self.decided = true
-            self.state = .began
+            self.claimGesture()
         case .release:
-            self.decided = true
-            self.state = .failed
+            self.releaseGesture()
         case .pending:
             // Within slop, or past slop while the probe verdict is still pending: stay `.possible`,
             // awaiting the verdict or more movement rather than releasing prematurely.
             break
         }
+    }
+
+    /// The web view claims the drag: recognize (`.began`) so the required-to-fail ancestor scroll is
+    /// blocked for this sequence.
+    private func claimGesture() {
+        self.decided = true
+        self.committedDecision = .own
+        self.state = .began
+    }
+
+    /// Hand the drag to the paywall: fail so the ancestor scroll, which was required to fail by us, is
+    /// free to begin.
+    private func releaseGesture() {
+        self.decided = true
+        self.committedDecision = .release
+        self.state = .failed
     }
 
     private func canScroll(vertically direction: Int) -> Bool {

--- a/Tests/RevenueCatUITests/PaywallsV2/WebViewScrollGestureArbitrationTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WebViewScrollGestureArbitrationTests.swift
@@ -1,0 +1,193 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WebViewScrollGestureArbitrationTests.swift
+//
+//  Created by Antonio Pallares.
+
+@testable import RevenueCatUI
+import XCTest
+
+#if os(iOS)
+
+import UIKit
+import WebKit
+
+@available(iOS 15.0, *)
+final class WebViewScrollGestureArbitrationTests: TestCase {
+
+    // Mirrors Android's `DragGestureArbitrationTest` touch-slop value.
+    private let slop: CGFloat = 8
+
+    // MARK: - Decision function (ported 1:1 from purchases-android DragGestureArbitrationTest)
+
+    func testContentVerdictToOwnClaimsImmediatelyEvenWithinTouchSlop() {
+        XCTAssertTrue(shouldOwn(dx: 0, dy: 1, webContentWantsGesture: true))
+    }
+
+    func testContentThatWantsGestureOwnsRegardlessOfNativeScrollability() {
+        XCTAssertTrue(shouldOwn(dx: 0, dy: -50, webContentWantsGesture: true, canScrollDown: false))
+    }
+
+    func testReleaseVerdictStillYieldsToNativeRootScrollWhenThePageCanScroll() {
+        XCTAssertTrue(shouldOwn(dx: 0, dy: -50, webContentWantsGesture: false, canScrollDown: true))
+    }
+
+    func testReleaseVerdictWithNothingToScrollHandsOffToThePaywall() {
+        XCTAssertFalse(shouldOwn(dx: 0, dy: -50, webContentWantsGesture: false, canScrollDown: false))
+    }
+
+    func testNoVerdictYetNativeRootScrollOwnsWhileItCanScrollTheDraggedDirection() {
+        XCTAssertTrue(shouldOwn(dx: 0, dy: -50, webContentWantsGesture: nil, canScrollDown: true))
+    }
+
+    func testNoVerdictYetHandsOffToThePaywallWhenTheRootCannotScroll() {
+        XCTAssertFalse(shouldOwn(dx: 0, dy: -50, webContentWantsGesture: nil, canScrollDown: false))
+    }
+
+    func testMovementWithinTouchSlopDoesNotClaimWithoutAnOwnVerdict() {
+        XCTAssertFalse(shouldOwn(dx: 7, dy: -7, canScrollUp: true))
+    }
+
+    func testDraggingUpAtTheBottomEdgeHandsOffToThePaywall() {
+        XCTAssertFalse(shouldOwn(dx: 0, dy: -50, canScrollDown: false))
+    }
+
+    func testDraggingDownWhileTheRootCanScrollUpIsOwnedByTheWebView() {
+        XCTAssertTrue(shouldOwn(dx: 0, dy: 50, canScrollUp: true))
+    }
+
+    func testHorizontalDominantDragUsesHorizontalScrollability() {
+        XCTAssertTrue(shouldOwn(dx: -50, dy: 10, canScrollRight: true))
+        XCTAssertFalse(shouldOwn(dx: -50, dy: 10, canScrollRight: false))
+    }
+
+    func testVerticalDominantDiagonalDragUsesVerticalScrollability() {
+        XCTAssertTrue(shouldOwn(dx: 30, dy: -50, canScrollDown: true, canScrollLeft: true))
+        XCTAssertFalse(shouldOwn(dx: 30, dy: -50, canScrollDown: false, canScrollLeft: true))
+    }
+
+    // MARK: - Recognizer failure-requirement wiring
+
+    @MainActor
+    func testAncestorPaywallScrollViewIsRequiredToFailByTheRecognizer() {
+        let scrollView = UIScrollView()
+        let webView = WKWebView()
+        scrollView.addSubview(webView)
+        let recognizer = WebViewScrollOwnershipRecognizer(webView: webView)
+
+        XCTAssertTrue(
+            recognizer.gestureRecognizer(recognizer, shouldBeRequiredToFailBy: scrollView.panGestureRecognizer)
+        )
+    }
+
+    @MainActor
+    func testWebViewsOwnScrollViewIsNotGated() {
+        let webView = WKWebView()
+        let recognizer = WebViewScrollOwnershipRecognizer(webView: webView)
+
+        XCTAssertFalse(
+            recognizer.gestureRecognizer(recognizer, shouldBeRequiredToFailBy: webView.scrollView.panGestureRecognizer)
+        )
+    }
+
+    @MainActor
+    func testScrollViewNotContainingTheWebViewIsNotGated() {
+        let unrelatedScrollView = UIScrollView()
+        let webView = WKWebView()
+        let recognizer = WebViewScrollOwnershipRecognizer(webView: webView)
+
+        XCTAssertFalse(
+            recognizer.gestureRecognizer(recognizer, shouldBeRequiredToFailBy: unrelatedScrollView.panGestureRecognizer)
+        )
+    }
+
+    @MainActor
+    func testNonPanRecognizerOnAncestorScrollViewIsNotGated() {
+        let scrollView = UIScrollView()
+        let webView = WKWebView()
+        scrollView.addSubview(webView)
+        let tap = UITapGestureRecognizer()
+        scrollView.addGestureRecognizer(tap)
+        let recognizer = WebViewScrollOwnershipRecognizer(webView: webView)
+
+        XCTAssertFalse(recognizer.gestureRecognizer(recognizer, shouldBeRequiredToFailBy: tap))
+    }
+
+    @MainActor
+    func testPanRecognizerOnANonScrollViewIsNotGated() {
+        let container = UIView()
+        let webView = WKWebView()
+        container.addSubview(webView)
+        let pan = UIPanGestureRecognizer()
+        container.addGestureRecognizer(pan)
+        let recognizer = WebViewScrollOwnershipRecognizer(webView: webView)
+
+        XCTAssertFalse(recognizer.gestureRecognizer(recognizer, shouldBeRequiredToFailBy: pan))
+    }
+
+    @MainActor
+    func testRecognizesSimultaneouslyWithOtherRecognizers() {
+        let scrollView = UIScrollView()
+        let webView = WKWebView()
+        scrollView.addSubview(webView)
+        let recognizer = WebViewScrollOwnershipRecognizer(webView: webView)
+
+        XCTAssertTrue(
+            recognizer.gestureRecognizer(recognizer, shouldRecognizeSimultaneouslyWith: scrollView.panGestureRecognizer)
+        )
+    }
+
+    // MARK: - Probe user script
+
+    @MainActor
+    func testProbeUserScriptRunsAtDocumentStartOnTheMainFrameOnly() {
+        let script = WebViewGestureProbe.userScript
+
+        XCTAssertEqual(script.injectionTime, .atDocumentStart)
+        XCTAssertTrue(script.isForMainFrameOnly)
+    }
+
+    @MainActor
+    func testProbeUserScriptPostsVerdictsToTheDedicatedHandler() {
+        let source = WebViewGestureProbe.userScript.source
+
+        XCTAssertTrue(source.contains("messageHandlers.\(WebViewGestureProbe.messageHandlerName)"))
+        XCTAssertTrue(source.contains("touchstart"))
+        XCTAssertTrue(source.contains("'\(WebViewGestureProbe.verdictOwn)'"))
+        XCTAssertTrue(source.contains("'\(WebViewGestureProbe.verdictRelease)'"))
+    }
+
+    // MARK: - Helpers
+
+    // swiftlint:disable identifier_name
+    private func shouldOwn(
+        dx: CGFloat,
+        dy: CGFloat,
+        webContentWantsGesture: Bool? = nil,
+        canScrollUp: Bool = false,
+        canScrollDown: Bool = false,
+        canScrollLeft: Bool = false,
+        canScrollRight: Bool = false
+    ) -> Bool {
+        // swiftlint:enable identifier_name
+        shouldWebViewOwnGesture(
+            totalDx: dx,
+            totalDy: dy,
+            touchSlop: self.slop,
+            webContentWantsGesture: webContentWantsGesture,
+            // direction > 0 == toward the end (right/bottom), < 0 == toward the start (left/top).
+            canScrollHorizontally: { direction in direction > 0 ? canScrollRight : canScrollLeft },
+            canScrollVertically: { direction in direction > 0 ? canScrollDown : canScrollUp }
+        )
+    }
+
+}
+
+#endif

--- a/Tests/RevenueCatUITests/PaywallsV2/WebViewScrollGestureArbitrationTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WebViewScrollGestureArbitrationTests.swift
@@ -73,6 +73,34 @@ final class WebViewScrollGestureArbitrationTests: TestCase {
         XCTAssertFalse(shouldOwn(dx: 30, dy: -50, canScrollDown: false, canScrollLeft: true))
     }
 
+    // MARK: - Outcome resolution (pending vs release while the probe verdict is in flight)
+
+    func testOwnVerdictResolvesToOwnWithinTouchSlop() {
+        XCTAssertEqual(resolve(dx: 0, dy: 1, webContentWantsGesture: true), .own)
+    }
+
+    func testPendingVerdictPastSlopWithNativeScrollResolvesToOwn() {
+        XCTAssertEqual(resolve(dx: 0, dy: -50, webContentWantsGesture: nil, canScrollDown: true), .own)
+    }
+
+    func testPendingVerdictPastSlopWithoutNativeScrollStaysPending() {
+        // The race the recognizer must not lose: a fast drag on JS-panned content (no native root
+        // scroll) before the `own` verdict lands must wait, not release to the paywall.
+        XCTAssertEqual(resolve(dx: 0, dy: -50, webContentWantsGesture: nil, canScrollDown: false), .pending)
+    }
+
+    func testReleaseVerdictPastSlopWithoutNativeScrollResolvesToRelease() {
+        XCTAssertEqual(resolve(dx: 0, dy: -50, webContentWantsGesture: false, canScrollDown: false), .release)
+    }
+
+    func testWithinTouchSlopWithoutVerdictStaysPending() {
+        XCTAssertEqual(resolve(dx: 7, dy: -7, webContentWantsGesture: nil), .pending)
+    }
+
+    func testReleaseVerdictWithinTouchSlopStaysPending() {
+        XCTAssertEqual(resolve(dx: 3, dy: 3, webContentWantsGesture: false), .pending)
+    }
+
     // MARK: - Recognizer failure-requirement wiring
 
     @MainActor
@@ -209,6 +237,31 @@ final class WebViewScrollGestureArbitrationTests: TestCase {
         XCTAssertNil(recognizer.contentWantsGesture)
     }
 
+    @MainActor
+    func testFastDragPastSlopDoesNotReleaseWhileTheVerdictIsPending() {
+        // A default WKWebView has no scrollable content, so `canScroll` is false in every direction.
+        let recognizer = WebViewScrollOwnershipRecognizer(webView: WKWebView())
+        recognizer.beginSequence(at: .zero)
+        recognizer.latestTranslation = CGSize(width: 0, height: -50) // fast flick up, well past slop
+
+        recognizer.evaluate()
+
+        XCTAssertFalse(recognizer.decided, "Must await the probe verdict instead of releasing early")
+        XCTAssertEqual(recognizer.state, .possible)
+    }
+
+    @MainActor
+    func testReleaseVerdictAfterAFastDragHandsOffToThePaywall() {
+        let recognizer = WebViewScrollOwnershipRecognizer(webView: WKWebView())
+        recognizer.beginSequence(at: .zero)
+        recognizer.latestTranslation = CGSize(width: 0, height: -50)
+
+        recognizer.applyProbeVerdict(isOwn: false)
+
+        XCTAssertTrue(recognizer.decided)
+        XCTAssertEqual(recognizer.state, .failed)
+    }
+
     // MARK: - Probe user script
 
     @MainActor
@@ -248,6 +301,27 @@ final class WebViewScrollGestureArbitrationTests: TestCase {
             touchSlop: self.slop,
             webContentWantsGesture: webContentWantsGesture,
             // direction > 0 == toward the end (right/bottom), < 0 == toward the start (left/top).
+            canScrollHorizontally: { direction in direction > 0 ? canScrollRight : canScrollLeft },
+            canScrollVertically: { direction in direction > 0 ? canScrollDown : canScrollUp }
+        )
+    }
+
+    // swiftlint:disable identifier_name
+    private func resolve(
+        dx: CGFloat,
+        dy: CGFloat,
+        webContentWantsGesture: Bool? = nil,
+        canScrollUp: Bool = false,
+        canScrollDown: Bool = false,
+        canScrollLeft: Bool = false,
+        canScrollRight: Bool = false
+    ) -> WebViewGestureOutcome {
+        // swiftlint:enable identifier_name
+        webViewGestureOutcome(
+            totalDx: dx,
+            totalDy: dy,
+            touchSlop: self.slop,
+            webContentWantsGesture: webContentWantsGesture,
             canScrollHorizontally: { direction in direction > 0 ? canScrollRight : canScrollLeft },
             canScrollVertically: { direction in direction > 0 ? canScrollDown : canScrollUp }
         )

--- a/Tests/RevenueCatUITests/PaywallsV2/WebViewScrollGestureArbitrationTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WebViewScrollGestureArbitrationTests.swift
@@ -247,7 +247,18 @@ final class WebViewScrollGestureArbitrationTests: TestCase {
         recognizer.evaluate()
 
         XCTAssertFalse(recognizer.decided, "Must await the probe verdict instead of releasing early")
-        XCTAssertEqual(recognizer.state, .possible)
+        XCTAssertNil(recognizer.committedDecision)
+    }
+
+    @MainActor
+    func testOwnVerdictClaimsTheGesture() {
+        let recognizer = WebViewScrollOwnershipRecognizer(webView: WKWebView())
+        recognizer.beginSequence(at: .zero)
+
+        recognizer.applyProbeVerdict(isOwn: true)
+
+        XCTAssertTrue(recognizer.decided)
+        XCTAssertEqual(recognizer.committedDecision, .own)
     }
 
     @MainActor
@@ -259,7 +270,7 @@ final class WebViewScrollGestureArbitrationTests: TestCase {
         recognizer.applyProbeVerdict(isOwn: false)
 
         XCTAssertTrue(recognizer.decided)
-        XCTAssertEqual(recognizer.state, .failed)
+        XCTAssertEqual(recognizer.committedDecision, .release)
     }
 
     // MARK: - Probe user script

--- a/Tests/RevenueCatUITests/PaywallsV2/WebViewScrollGestureArbitrationTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WebViewScrollGestureArbitrationTests.swift
@@ -144,6 +144,71 @@ final class WebViewScrollGestureArbitrationTests: TestCase {
         )
     }
 
+    // MARK: - Touch-sequence tracking (multi-touch + stale-verdict hardening)
+
+    @MainActor
+    func testBeginSequenceInitializesTrackingState() {
+        let recognizer = WebViewScrollOwnershipRecognizer(webView: WKWebView())
+
+        recognizer.beginSequence(at: CGPoint(x: 4, y: 9))
+
+        XCTAssertTrue(recognizer.isTracking)
+        XCTAssertEqual(recognizer.startLocation, CGPoint(x: 4, y: 9))
+        XCTAssertFalse(recognizer.decided)
+    }
+
+    @MainActor
+    func testSecondFingerDoesNotResetAnOngoingSequence() {
+        let recognizer = WebViewScrollOwnershipRecognizer(webView: WKWebView())
+        recognizer.beginSequence(at: CGPoint(x: 4, y: 9))
+        recognizer.decided = true // pretend a verdict already committed
+
+        recognizer.beginSequence(at: CGPoint(x: 40, y: 90)) // a second finger lands mid-gesture
+
+        XCTAssertTrue(recognizer.decided, "A mid-gesture second finger must not clear the decision")
+        XCTAssertEqual(
+            recognizer.startLocation,
+            CGPoint(x: 4, y: 9),
+            "startLocation must stay anchored to the first finger"
+        )
+    }
+
+    @MainActor
+    func testProbeVerdictIsIgnoredWhenNoSequenceIsBeingTracked() {
+        let recognizer = WebViewScrollOwnershipRecognizer(webView: WKWebView())
+
+        recognizer.applyProbeVerdict(isOwn: true) // stale verdict arriving between gestures
+
+        XCTAssertEqual(recognizer.state, .possible)
+        XCTAssertFalse(recognizer.decided)
+        XCTAssertNil(recognizer.contentWantsGesture)
+    }
+
+    @MainActor
+    func testReleaseVerdictWhileTrackingRecordsWithoutClaiming() {
+        let recognizer = WebViewScrollOwnershipRecognizer(webView: WKWebView())
+        recognizer.beginSequence(at: .zero)
+
+        recognizer.applyProbeVerdict(isOwn: false)
+
+        XCTAssertEqual(recognizer.contentWantsGesture, false)
+        XCTAssertFalse(recognizer.decided, "A release verdict defers to the movement/scroll check")
+        XCTAssertEqual(recognizer.state, .possible)
+    }
+
+    @MainActor
+    func testResetClearsTrackingSoLaterVerdictsAreIgnored() {
+        let recognizer = WebViewScrollOwnershipRecognizer(webView: WKWebView())
+        recognizer.beginSequence(at: .zero)
+
+        recognizer.reset()
+        recognizer.applyProbeVerdict(isOwn: true)
+
+        XCTAssertFalse(recognizer.isTracking)
+        XCTAssertFalse(recognizer.decided)
+        XCTAssertNil(recognizer.contentWantsGesture)
+    }
+
     // MARK: - Probe user script
 
     @MainActor

--- a/Tests/RevenueCatUITests/PaywallsV2/WebViewScrollGestureArbitrationTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WebViewScrollGestureArbitrationTests.swift
@@ -292,6 +292,19 @@ final class WebViewScrollGestureArbitrationTests: TestCase {
         XCTAssertFalse(source.contains("!== 'manipulation'"))
     }
 
+    @MainActor
+    func testProbeUserScriptSkipsTheRootScrollerAndSecondaryTouches() {
+        let source = WebViewGestureProbe.userScript.source
+
+        // The root scroller is the web view's own scroll view (tracked by `canScroll*`), so the probe
+        // must skip it and only claim inner scrollers.
+        XCTAssertTrue(source.contains("document.scrollingElement"))
+        XCTAssertTrue(source.contains("document.documentElement"))
+        XCTAssertTrue(source.contains("document.body"))
+        // Only the primary finger's verdict is posted so a second finger can't poison the decision.
+        XCTAssertTrue(source.contains("event.touches.length > 1"))
+    }
+
     // MARK: - Helpers
 
     // swiftlint:disable identifier_name

--- a/Tests/RevenueCatUITests/PaywallsV2/WebViewScrollGestureArbitrationTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WebViewScrollGestureArbitrationTests.swift
@@ -282,6 +282,16 @@ final class WebViewScrollGestureArbitrationTests: TestCase {
         XCTAssertTrue(source.contains("'\(WebViewGestureProbe.verdictRelease)'"))
     }
 
+    @MainActor
+    func testProbeUserScriptOnlyClaimsTouchActionNone() {
+        let source = WebViewGestureProbe.userScript.source
+
+        // Only `none` should claim: `pan-x`/`pan-y` still scroll natively and must defer to the
+        // `canScroll*` checks, otherwise the paywall gets stuck at the web view's scroll edge.
+        XCTAssertTrue(source.contains("s.touchAction === 'none'"))
+        XCTAssertFalse(source.contains("!== 'manipulation'"))
+    }
+
     // MARK: - Helpers
 
     // swiftlint:disable identifier_name

--- a/api/revenuecatui-api-ios-simulator.swiftinterface
+++ b/api/revenuecatui-api-ios-simulator.swiftinterface
@@ -16,6 +16,7 @@ import SafariServices
 import StoreKit
 import Swift
 import SwiftUI
+import UIKit.UIGestureRecognizerSubclass
 import UIKit
 import WebKit
 import _AVKit_SwiftUI

--- a/api/revenuecatui-api-ios.swiftinterface
+++ b/api/revenuecatui-api-ios.swiftinterface
@@ -16,6 +16,7 @@ import SafariServices
 import StoreKit
 import Swift
 import SwiftUI
+import UIKit.UIGestureRecognizerSubclass
 import UIKit
 import WebKit
 import _AVKit_SwiftUI


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
A `web_view` whose content pans via JavaScript — a `touch-action` map, an inner `overflow: auto` scroller — is invisible to iOS nested-scroll arbitration, so a drag both pans the content and scrolls the enclosing paywall ("double scroll").

### Description
Mirrors revenuecat/purchases-android#3823. A document-start probe reports, per touch, whether the touched element consumes the drag; a custom recognizer on the web view then claims the gesture from the paywall scroll only when it does, otherwise deferring to native root scrollability. iOS-only (touch-based).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes iOS paywall scroll vs. web view touch arbitration with custom gesture recognizers and injected JS; regressions could affect scrolling or panning UX, though scope is iOS-only and covered by broad unit tests.
> 
> **Overview**
> Fixes **double scroll** on iOS when a paywall `web_view` sits inside a scrollable paywall and page content pans via JavaScript or inner overflow scrollers—gestures UIKit cannot arbitrate against the enclosing scroll view.
> 
> On **iOS only**, `WebViewComponentView` now installs nested-scroll arbitration before the first load: a document-start **JS probe** (`rcPaywallGestureProbe`) reports per-touch whether the target consumes the drag (`touch-action: none` or inner `overflow: auto`/`scroll`), and a **`WebViewScrollOwnershipRecognizer`** on the web view makes ancestor paywall `UIScrollView` pans wait until arbitration resolves. The web view claims the drag when the probe says **own** or when native root scroll offsets can still move in the drag direction; otherwise the paywall scroll gets the gesture. Touches are **not** cancelled, so taps, links, and JS panning still work.
> 
> New logic lives in `WebViewScrollGestureArbitration.swift`, with teardown of the probe script handler on web view dismantle. **`WebViewScrollGestureArbitrationTests`** cover decision/outcome rules (aligned with Android), recognizer wiring, multi-touch, and probe script behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41fdab354d3d66b06d1faab82749fef6270cc3c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->