### PR TITLE
fix: create Local.xcconfig when missing so TUIST_RC_API_KEY isn't dropped

### DIFF
--- a/Projects/PaywallsTester/Project.swift
+++ b/Projects/PaywallsTester/Project.swift
@@ -12,6 +12,12 @@ let paywallsTesterDir = repoRoot
 if let apiKey = Environment.rcApiKey {
     let localXcconfig = repoRoot.appendingPathComponent("Local.xcconfig")
 
+    // Local.xcconfig is gitignored, so it doesn't exist on a fresh checkout. Create an empty
+    // one first so the key isn't silently dropped when TUIST_RC_API_KEY is set.
+    if !fileManager.fileExists(atPath: localXcconfig.path) {
+        try? "".write(to: localXcconfig, atomically: true, encoding: .utf8)
+    }
+
     if fileManager.fileExists(atPath: localXcconfig.path),
        var contents = try? String(contentsOf: localXcconfig, encoding: .utf8) {
         // Replace existing API key or add new one


### PR DESCRIPTION
### Motivation
`TUIST_RC_API_KEY=... tuist generate PaywallsTester` silently dropped the key on a fresh checkout: `Local.xcconfig` is gitignored, and the generator only wrote the key when that file already existed.

### Description
Create an empty `Local.xcconfig` when it's missing before writing the key, so on a clean checkout the key lands in an active (uncommented) line via the existing append path.

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small dev-tooling change in PaywallsTester generation only; no runtime SDK or production behavior.
> 
> **Overview**
> **Fixes silent failure** when `TUIST_RC_API_KEY` is set on a fresh clone: `Local.xcconfig` is gitignored, so the PaywallsTester Tuist `Project.swift` logic never ran and the API key was not written.
> 
> Before updating or appending `REVENUECAT_API_KEY`, the generator now **creates an empty `Local.xcconfig` at the repo root** if the file is missing, so the existing replace/append path runs on clean checkouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0a6dba5258e56d35adffa1700f740232038bde7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->