### PR TITLE
Improve fallback paywall error description

### DIFF
--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -221,15 +221,21 @@ struct PaywallsV2View: View {
         self._selectedPackageContext = .init(wrappedValue: selectedPackageContext)
     }
 
+    /// Maximum length of the fallback error message shown on screen, to avoid flooding it.
+    private static let maxFallbackErrorLength = 400
+
     public var body: some View {
         self.addPaywallModifiers(to:
             VStack(spacing: 0) {
                 if let errorInfo = self.paywallComponentsData.errorInfo, !errorInfo.isEmpty {
+                    // Cap the message for display so a verbose (or long list of) error(s) can't
+                    // flood the screen, adding an ellipsis to indicate that it was truncated.
+                    let message = PaywallFallbackError(errorInfo: errorInfo).description
+                    let displayMessage = message.count > Self.maxFallbackErrorLength
+                        ? "\(message.prefix(Self.maxFallbackErrorLength))…"
+                        : message
                     self.defaultPaywallView(
-                        warning: .from(error: PaywallFallbackError(
-                            // Trim up the error value to not flood the screen with too much content
-                            reason: String("\(errorInfo)".prefix(130))
-                        ))
+                        warning: .from(error: PaywallFallbackError.Display(description: displayMessage))
                     )
                 } else {
                     switch self.paywallStateManager.state {
@@ -834,8 +840,30 @@ extension PaywallsV2View {
 
 }
 
-private struct PaywallFallbackError: Error {
-    let reason: String
+private struct PaywallFallbackError: Error, CustomStringConvertible {
+
+    /// Per-field decoding errors, keyed by the name of the field that failed to decode.
+    let errorInfo: [String: PaywallComponentsData.EquatableError]?
+
+    /// The complete, untruncated error message. Callers that need to fit it into a
+    /// constrained space (e.g. the fallback paywall) are responsible for capping it.
+    var description: String {
+        guard let errorInfo, !errorInfo.isEmpty else {
+            return "Unknown error"
+        }
+
+        return errorInfo
+            .sorted { $0.key < $1.key }
+            .map { key, error in "\(key): \(error.description)" }
+            .joined(separator: "\n\n")
+    }
+
+    /// A display-ready, possibly-truncated form of a `PaywallFallbackError`, surfaced through
+    /// `PaywallWarning`. The original error's `description` always stays complete.
+    struct Display: Error, CustomStringConvertible {
+        let description: String
+    }
+
 }
 
 #endif

--- a/Sources/Networking/Responses/RevenueCatUI/PaywallComponentsData.swift
+++ b/Sources/Networking/Responses/RevenueCatUI/PaywallComponentsData.swift
@@ -296,15 +296,39 @@ private extension PaywallComponentsData {
 
 @_spi(Internal) extension PaywallComponentsData {
 
-    public struct EquatableError: Equatable, Sendable {
-        let description: String
+    public struct EquatableError: Equatable, Sendable, CustomStringConvertible {
+        public let description: String
 
         init(_ error: Error) {
-            self.description = String(describing: error)
+            // For decoding errors, prefer the concise underlying message over the full
+            // `String(describing:)` dump (which also includes the type and coding path).
+            if let decodingError = error as? DecodingError {
+                self.description = decodingError.debugMessage
+            } else {
+                self.description = String(describing: error)
+            }
         }
 
         public static func == (lhs: EquatableError, rhs: EquatableError) -> Bool {
             return lhs.description == rhs.description
+        }
+    }
+
+}
+
+private extension DecodingError {
+
+    /// The concise, human-readable message from the error's context (e.g.
+    /// `Failed to decode unknown type "web_view"`), without the type or coding path noise.
+    var debugMessage: String {
+        switch self {
+        case let .typeMismatch(_, context),
+             let .valueNotFound(_, context),
+             let .keyNotFound(_, context),
+             let .dataCorrupted(context):
+            return context.debugDescription
+        @unknown default:
+            return String(describing: self)
         }
     }
 


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
When paywall components fail to decode, the fallback paywall showed a raw `String(describing:)` dump that was hard to read while debugging.

### Description
The fallback paywall now shows a readable `key: message` list per failed field, and uses the concise underlying message for decoding errors. `PaywallFallbackError.description` stays complete; the view caps it for display and appends an ellipsis when truncated.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/RevenueCat/purchases-ios/pallares/pr-assets/.pr-assets/paywall-fallback-error-before.png" width="300"> | <img src="https://raw.githubusercontent.com/RevenueCat/purchases-ios/pallares/pr-assets/.pr-assets/paywall-fallback-error.png" width="300"> |