### PR TITLE
Add copy button for the fallback paywall error

### DIFF
--- a/RevenueCatUI/Helpers/PaywallWarning.swift
+++ b/RevenueCatUI/Helpers/PaywallWarning.swift
@@ -130,4 +130,24 @@ enum PaywallWarning {
         }
         return .other(error)
     }
+
+    /// The complete, untruncated text for this warning that is worth copying, if any.
+    ///
+    /// `bodyText` may be capped to fit on screen, so this exposes the full content (e.g. a
+    /// verbose decoding error) so it can be copied to the pasteboard while debugging.
+    var copyableText: String? {
+        switch self {
+        case .other(let error):
+            return (error as? CopyableWarningError)?.copyableText
+        default:
+            return nil
+        }
+    }
+}
+
+/// Adopted by errors whose `bodyText` is truncated for display but that can provide a full,
+/// copyable representation.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+protocol CopyableWarningError {
+    var copyableText: String { get }
 }

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -235,7 +235,10 @@ struct PaywallsV2View: View {
                         ? "\(message.prefix(Self.maxFallbackErrorLength))…"
                         : message
                     self.defaultPaywallView(
-                        warning: .from(error: PaywallFallbackError.Display(description: displayMessage))
+                        warning: .from(error: PaywallFallbackError.Display(
+                            description: displayMessage,
+                            copyableText: message
+                        ))
                     )
                 } else {
                     switch self.paywallStateManager.state {
@@ -859,9 +862,11 @@ private struct PaywallFallbackError: Error, CustomStringConvertible {
     }
 
     /// A display-ready, possibly-truncated form of a `PaywallFallbackError`, surfaced through
-    /// `PaywallWarning`. The original error's `description` always stays complete.
-    struct Display: Error, CustomStringConvertible {
+    /// `PaywallWarning`. The original error's `description` always stays complete, and the full
+    /// message remains available via `copyableText` so it can be copied while debugging.
+    struct Display: Error, CustomStringConvertible, CopyableWarningError {
         let description: String
+        let copyableText: String
     }
 
 }

--- a/RevenueCatUI/Views/DefaultPaywall/DefaultPaywallWarning.swift
+++ b/RevenueCatUI/Views/DefaultPaywall/DefaultPaywallWarning.swift
@@ -71,7 +71,7 @@ struct DefaultPaywallWarning: View {
         } label: {
             Label(self.didCopy ? "Copied" : "Copy error details",
                   systemImage: self.didCopy ? "checkmark" : "doc.on.doc")
-                .bold()
+                .font(.body.bold())
         }.buttonStyle(.bordered)
 
         if #available(watchOS 9.0, *) {

--- a/RevenueCatUI/Views/DefaultPaywall/DefaultPaywallWarning.swift
+++ b/RevenueCatUI/Views/DefaultPaywall/DefaultPaywallWarning.swift
@@ -14,9 +14,17 @@
 import RevenueCat
 import SwiftUI
 
+#if os(iOS) || os(visionOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
+#endif
+
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct DefaultPaywallWarning: View {
     let warning: PaywallWarning
+
+    @State private var didCopy = false
 
     var body: some View {
         VStack(alignment: .center, spacing: 16) {
@@ -44,7 +52,57 @@ struct DefaultPaywallWarning: View {
                 }
             }
 
+            if let copyableText = warning.copyableText, Pasteboard.isAvailable {
+                self.copyButton(for: copyableText)
+            }
+
         }
         .multilineTextAlignment(.center)
     }
+
+    @ViewBuilder
+    private func copyButton(for text: String) -> some View {
+        let button = Button {
+            Pasteboard.copy(text)
+            withAnimation { self.didCopy = true }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                withAnimation { self.didCopy = false }
+            }
+        } label: {
+            Label(self.didCopy ? "Copied" : "Copy error details",
+                  systemImage: self.didCopy ? "checkmark" : "doc.on.doc")
+                .bold()
+        }.buttonStyle(.bordered)
+
+        if #available(watchOS 9.0, *) {
+            button.tint(.revenueCatBrandRed)
+        } else {
+            button.foregroundStyle(Color.revenueCatBrandRed)
+        }
+    }
+}
+
+/// Small cross-platform wrapper around the system pasteboard.
+///
+/// tvOS and watchOS don't provide a pasteboard, so `isAvailable` is `false` there and
+/// `copy(_:)` is a no-op. Callers should check `isAvailable` before offering copy affordances.
+enum Pasteboard {
+
+    static var isAvailable: Bool {
+        #if os(iOS) || os(visionOS) || os(macOS)
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    static func copy(_ string: String) {
+        #if os(iOS) || os(visionOS)
+        UIPasteboard.general.string = string
+        #elseif os(macOS)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(string, forType: .string)
+        #endif
+    }
+
 }

--- a/RevenueCatUI/Views/DefaultPaywall/DefaultPaywallWarning.swift
+++ b/RevenueCatUI/Views/DefaultPaywall/DefaultPaywallWarning.swift
@@ -38,6 +38,13 @@ struct DefaultPaywallWarning: View {
                     .bold()
                 Text(warning.bodyText)
                     .font(.subheadline)
+
+                if let copyableText = warning.copyableText, Pasteboard.isAvailable {
+                    HStack {
+                        Spacer()
+                        self.copyButton(for: copyableText)
+                    }
+                }
             }
             if let url = warning.helpURL {
                 let link = Link(destination: url) {
@@ -52,33 +59,25 @@ struct DefaultPaywallWarning: View {
                 }
             }
 
-            if let copyableText = warning.copyableText, Pasteboard.isAvailable {
-                self.copyButton(for: copyableText)
-            }
-
         }
         .multilineTextAlignment(.center)
     }
 
     @ViewBuilder
     private func copyButton(for text: String) -> some View {
-        let button = Button {
+        Button {
             Pasteboard.copy(text)
             withAnimation { self.didCopy = true }
             DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                 withAnimation { self.didCopy = false }
             }
         } label: {
-            Label(self.didCopy ? "Copied" : "Copy error details",
-                  systemImage: self.didCopy ? "checkmark" : "doc.on.doc")
-                .font(.body.bold())
-        }.buttonStyle(.bordered)
-
-        if #available(watchOS 9.0, *) {
-            button.tint(.revenueCatBrandRed)
-        } else {
-            button.foregroundStyle(Color.revenueCatBrandRed)
+            Image(systemName: self.didCopy ? "checkmark" : "doc.on.doc")
+                .imageScale(.medium)
+                .foregroundStyle(.secondary)
         }
+        .buttonStyle(.plain)
+        .accessibilityLabel(self.didCopy ? "Copied" : "Copy error details")
     }
 }
 


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
The fallback paywall can cap verbose decoding errors for display, so the full message may not be recoverable from the screen while debugging.

### Description
- Adds a discreet, icon-only copy button that puts the complete error message on the pasteboard.
- It only appears for warnings that opt in by exposing a full copyable representation (via a `CopyableWarningError` protocol) — currently just the Paywalls V2 fallback decoding error. Other warnings don't show it.
- Hidden on platforms without a pasteboard (tvOS, watchOS).

> Stacked on #7288.