### PR TITLE
Bounce web_view scroll at its content edges on iOS

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
@@ -271,7 +271,7 @@ struct WebViewRepresentable: PlatformViewRepresentable {
         webView.isOpaque = false
         webView.backgroundColor = .clear
         webView.scrollView.isScrollEnabled = true
-        webView.scrollView.bounces = false
+        webView.scrollView.bounces = true
         webView.scrollView.minimumZoomScale = 1
         webView.scrollView.maximumZoomScale = 1
         #endif


### PR DESCRIPTION
### Motivation
An overflowing `web_view` custom component (Fill/Fixed height) scrolls internally but stops abruptly at its edges, which feels unnatural on iOS.

### Description
Enables rubber-banding on the web view's scroll view. No effect on fit-height content, which has no overflow to bounce against.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line iOS scroll UX tweak in web view setup with no auth, data, or payment logic changes.
> 
> **Overview**
> On iOS, Paywall V2 **`web_view`** components now use **`scrollView.bounces = true`** when the `WKWebView` is configured, replacing the previous **`false`** setting.
> 
> Overflowing content in **Fill** or **Fixed** height web views gets standard rubber-banding at scroll edges instead of stopping abruptly. **Fit** height layouts are unchanged when there is no internal overflow to bounce against. macOS configuration is untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e03f2c5fa234bd2d1887f4f7f41dc9129b523af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->