### PR TITLE
feat(remote-config): add health checker and API source failover components

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1E30849C30178A2100236A34 /* SourceHealthChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E30849B30178A2100236A34 /* SourceHealthChecker.swift */; };
+		1E30849D30178A2100236A34 /* APISourceFailover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E30849A30178A2100236A34 /* APISourceFailover.swift */; };
+		1E3084A430178A6E00236A34 /* MockSourceHealthChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3084A330178A6E00236A34 /* MockSourceHealthChecker.swift */; };
+		1E3084A530178A6E00236A34 /* MockSourceHealthChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3084A330178A6E00236A34 /* MockSourceHealthChecker.swift */; };
+		1E3084A830178A9100236A34 /* APISourceFailoverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3084A630178A9100236A34 /* APISourceFailoverTests.swift */; };
+		1E3084A930178A9100236A34 /* SourceHealthCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3084A730178A9100236A34 /* SourceHealthCheckerTests.swift */; };
 		02F84B23216242A7B8CDAB4A /* ErrorCode+Conformances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F92C8B490F4B78AC8B1AAF /* ErrorCode+Conformances.swift */; };
 		030890812D2B764D0069677B /* VariableHandlerV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030890802D2B76450069677B /* VariableHandlerV2.swift */; };
 		030F918A2D55C1D20085103F /* LocaleFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030F91892D55C1AB0085103F /* LocaleFinder.swift */; };
@@ -1533,6 +1539,11 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1E30849A30178A2100236A34 /* APISourceFailover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APISourceFailover.swift; sourceTree = "<group>"; };
+		1E30849B30178A2100236A34 /* SourceHealthChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceHealthChecker.swift; sourceTree = "<group>"; };
+		1E3084A330178A6E00236A34 /* MockSourceHealthChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSourceHealthChecker.swift; sourceTree = "<group>"; };
+		1E3084A630178A9100236A34 /* APISourceFailoverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APISourceFailoverTests.swift; sourceTree = "<group>"; };
+		1E3084A730178A9100236A34 /* SourceHealthCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceHealthCheckerTests.swift; sourceTree = "<group>"; };
 		019BA4A7731BC93FEC1A74FA /* PaywallScrollEnvironment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaywallScrollEnvironment.swift; path = RevenueCatUI/Templates/V2/Layout/PaywallScrollEnvironment.swift; sourceTree = SOURCE_ROOT; };
 		030890802D2B76450069677B /* VariableHandlerV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariableHandlerV2.swift; sourceTree = "<group>"; };
 		030890832D2B77E20069677B /* VariableHandlerV2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariableHandlerV2Tests.swift; sourceTree = "<group>"; };
@@ -4212,6 +4223,7 @@
 		2DDF41DD24F6F4F9005BC22D /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				1E3084A330178A6E00236A34 /* MockSourceHealthChecker.swift */,
 				900D27022F96929800D32EDF /* MockAdsAPI.swift */,
 				1699BC6C2EEC6EAF002001FB /* MockUnderlyingSynchronizedFileCache.swift */,
 				903A065F2EB4B728009B9CE4 /* MockEventsManager.swift */,
@@ -4607,6 +4619,8 @@
 		35D832CB262A5B3400E60AC5 /* Networking */ = {
 			isa = PBXGroup;
 			children = (
+				1E30849A30178A2100236A34 /* APISourceFailover.swift */,
+				1E30849B30178A2100236A34 /* SourceHealthChecker.swift */,
 				B34605A1279A6E380031CA74 /* Caching */,
 				B378156E285A978A000A7B93 /* HTTPClient */,
 				B34605AA279A6E380031CA74 /* Operations */,
@@ -4650,6 +4664,8 @@
 		35D832FE262FAD6900E60AC5 /* Networking */ = {
 			isa = PBXGroup;
 			children = (
+				1E3084A630178A9100236A34 /* APISourceFailoverTests.swift */,
+				1E3084A730178A9100236A34 /* SourceHealthCheckerTests.swift */,
 				75D9DE062D79FC0E0068554F /* Requests */,
 				5796A38427D6B83C00653165 /* Backend */,
 				5774F9BF2805EA1200997128 /* Responses */,
@@ -6985,6 +7001,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1E3084A430178A6E00236A34 /* MockSourceHealthChecker.swift in Sources */,
 				2D9C5ECA26F2805C0057FC45 /* ProductsManagerTests.swift in Sources */,
 				75A3B2B22F16B458001C4CA7 /* MockLargeItemCache.swift in Sources */,
 				3543914526F926D900E669DF /* SKProductSubscriptionDurationExtensions.swift in Sources */,
@@ -7124,6 +7141,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1E30849C30178A2100236A34 /* SourceHealthChecker.swift in Sources */,
+				1E30849D30178A2100236A34 /* APISourceFailover.swift in Sources */,
 				2C9107E02CE2E33400189565 /* StoredFeatureEvent.swift in Sources */,
 				751192E02E39149200E583CC /* WebBillingAPI.swift in Sources */,
 				B3A36AAE26BC76340059EDEA /* CustomerInfoManager.swift in Sources */,
@@ -7615,6 +7634,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1E3084A830178A9100236A34 /* APISourceFailoverTests.swift in Sources */,
+				1E3084A930178A9100236A34 /* SourceHealthCheckerTests.swift in Sources */,
+				1E3084A530178A6E00236A34 /* MockSourceHealthChecker.swift in Sources */,
 				576C8A9227D27DDD0058FA6E /* SnapshotTesting+Extensions.swift in Sources */,
 				5791FBD2299184EF00F1FEDA /* MockAsyncSequence.swift in Sources */,
 				4FA4C9732A16D3AC007D2803 /* MockBackendConfiguration.swift in Sources */,

--- a/Sources/Logging/Strings/NetworkStrings.swift
+++ b/Sources/Logging/Strings/NetworkStrings.swift
@@ -44,6 +44,11 @@ enum NetworkStrings {
     case starting_request(httpMethod: String, path: String)
     case retrying_request(httpMethod: String, path: String)
     case retrying_request_with_fallback_path(httpMethod: String, path: String)
+    case retrying_request_with_next_api_source(httpMethod: String, path: String, host: String)
+    case api_source_healthy_despite_failure(host: String)
+    case skipping_malformed_api_source_url(url: String)
+    case api_source_health_check_completed(url: URL, statusCode: Int, isHealthy: Bool)
+    case api_source_health_check_failed_to_connect(url: URL, error: Error)
     case failing_url_resolved_to_host(url: URL, resolvedHost: String)
     case blocked_network(url: URL, newHost: String?)
     case api_request_redirect(from: URL, to: URL)
@@ -124,6 +129,21 @@ extension NetworkStrings: LogMessage {
 
         case let .retrying_request_with_fallback_path(httpMethod, path):
             return "Retrying request using fallback host: \(httpMethod) \(path)"
+
+        case let .retrying_request_with_next_api_source(httpMethod, path, host):
+            return "Retrying request \(httpMethod) \(path) using next API source host \(host)"
+
+        case let .api_source_healthy_despite_failure(host):
+            return "API source \(host) is healthy despite the request failing; not failing over."
+
+        case let .skipping_malformed_api_source_url(url):
+            return "Skipping API source with malformed url \(url)"
+
+        case let .api_source_health_check_completed(url, statusCode, isHealthy):
+            return "Health check for \(url.absoluteString) returned \(statusCode) (healthy=\(isHealthy))"
+
+        case let .api_source_health_check_failed_to_connect(url, error):
+            return "Health check for \(url.absoluteString) failed to connect: \(error)"
 
         case let .failing_url_resolved_to_host(url, resolvedHost):
             return "Failing url '\(url)' resolved to host '\(resolvedHost)'"

--- a/Sources/Networking/APISourceFailover.swift
+++ b/Sources/Networking/APISourceFailover.swift
@@ -1,0 +1,113 @@
+//
+//  APISourceFailover.swift
+//  RevenueCat
+//
+//  Created by Toni Rico on 27/07/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+
+protocol APISourceFailoverType: AnyObject, Sendable {
+
+    /// The source a request to `path` should target, or `nil` to keep using the path's default host.
+    func currentSource(for path: HTTPRequestPath, isFallbackAttempt: Bool) -> APISourceFailover.ResolvedSource?
+
+    /// Decides what to do after a request to `source` failed in a way that may indicate a source
+    /// outage, health-checking the source to tell an outage apart from anything else.
+    func onRequestFailure(_ source: APISourceFailover.ResolvedSource,
+                          completion: @escaping @Sendable (APISourceFailover.FailureDecision) -> Void)
+
+}
+
+/// Decides which API source a request should target and whether a failed request should fail over to
+/// the next source. Only failures that point at the host (connection-level failures and 5xx
+/// responses, never device-connectivity errors or 4xx — the caller gates on
+/// `NetworkError.isAllowedToRetryWithFallbackHost`) can trigger a failover, and only after a health
+/// check against the current source fails: a 2xx health response means the source is healthy (the
+/// request failure was something else, e.g. endpoint-specific), so the original error surfaces
+/// without switching hosts. A source whose health check returns non-2xx or cannot complete is
+/// reported unhealthy and the next one takes over.
+final class APISourceFailover: APISourceFailoverType {
+
+    /// A source handle plus its parsed base URL; only parseable sources are ever handed out.
+    struct ResolvedSource {
+
+        let handle: RemoteConfigSourceHandle
+        let url: URL
+
+    }
+
+    enum FailureDecision {
+
+        /// The current source failed its health check; retry the request on the associated source.
+        case retryNextSource(ResolvedSource)
+
+        /// The current source is healthy, so failing over is pointless: surface the original error.
+        case sourceHealthy
+
+        /// Every source has been reported unhealthy; surface the original error.
+        case sourcesExhausted
+
+    }
+
+    private let dangerousSettings: DangerousSettings
+    private let sourceProvider: RemoteConfigSourceProviderType
+    private let healthChecker: SourceHealthCheckerType
+
+    init(dangerousSettings: DangerousSettings,
+         sourceProvider: RemoteConfigSourceProviderType,
+         healthChecker: SourceHealthCheckerType) {
+        self.dangerousSettings = dangerousSettings
+        self.sourceProvider = sourceProvider
+        self.healthChecker = healthChecker
+    }
+
+    /// The source a request to `path` should target, or `nil` to keep using the path's default host.
+    ///
+    /// API sources apply only when: the `usesRemoteConfigAPISources` dangerous setting is enabled, no
+    /// proxy is configured (a proxy pins every request to itself), this is not an endpoint
+    /// fallback-host attempt, the path opts in via `usesAPISources`, and `SystemInfo.apiBaseURL`
+    /// still holds its default (an override pins the host, e.g. in tests).
+    func currentSource(for path: HTTPRequestPath, isFallbackAttempt: Bool) -> ResolvedSource? {
+        guard self.dangerousSettings.internalSettings.usesRemoteConfigAPISources,
+              SystemInfo.proxyURL == nil,
+              !isFallbackAttempt,
+              path.usesAPISources,
+              SystemInfo.apiBaseURL == SystemInfo.defaultApiBaseURL else {
+            return nil
+        }
+        return self.currentResolvedSource()
+    }
+
+    func onRequestFailure(_ source: ResolvedSource,
+                          completion: @escaping @Sendable (FailureDecision) -> Void) {
+        self.healthChecker.checkHealth(ofSourceBaseURL: source.url) { isHealthy in
+            if isHealthy {
+                Logger.debug(Strings.network.api_source_healthy_despite_failure(host: source.handle.url))
+                completion(.sourceHealthy)
+                return
+            }
+            self.sourceProvider.reportUnhealthy(source.handle)
+            completion(self.currentResolvedSource().map(FailureDecision.retryNextSource) ?? .sourcesExhausted)
+        }
+    }
+
+    /// The provider's current source with its URL parsed. Sources with malformed URLs are reported
+    /// unhealthy and skipped, so they participate in failover instead of silently pinning requests to
+    /// the default host. The walk ends when the provider runs out of sources.
+    private func currentResolvedSource() -> ResolvedSource? {
+        while let handle = self.sourceProvider.currentAPISource() {
+            if let url = URL(string: handle.url) {
+                return ResolvedSource(handle: handle, url: url)
+            }
+            Logger.warn(Strings.network.skipping_malformed_api_source_url(url: handle.url))
+            self.sourceProvider.reportUnhealthy(handle)
+        }
+        return nil
+    }
+
+}
+
+// @unchecked because the compiler can't verify it: all dependencies are themselves thread-safe and
+// this class holds no mutable state.
+extension APISourceFailover: @unchecked Sendable {}

--- a/Sources/Networking/APISourceFailover.swift
+++ b/Sources/Networking/APISourceFailover.swift
@@ -50,14 +50,16 @@ final class APISourceFailover: APISourceFailoverType {
 
     }
 
-    private let dangerousSettings: DangerousSettings
+    private let usesRemoteConfigAPISources: Bool
     private let sourceProvider: RemoteConfigSourceProviderType
     private let healthChecker: SourceHealthCheckerType
 
-    init(dangerousSettings: DangerousSettings,
+    /// - Parameter usesRemoteConfigAPISources: the `usesRemoteConfigAPISources` dangerous setting.
+    /// Taken as a plain value because the whole settings chain is immutable per SDK instance.
+    init(usesRemoteConfigAPISources: Bool,
          sourceProvider: RemoteConfigSourceProviderType,
          healthChecker: SourceHealthCheckerType) {
-        self.dangerousSettings = dangerousSettings
+        self.usesRemoteConfigAPISources = usesRemoteConfigAPISources
         self.sourceProvider = sourceProvider
         self.healthChecker = healthChecker
     }
@@ -69,7 +71,7 @@ final class APISourceFailover: APISourceFailoverType {
     /// fallback-host attempt, the path opts in via `usesAPISources`, and `SystemInfo.apiBaseURL`
     /// still holds its default (an override pins the host, e.g. in tests).
     func currentSource(for path: HTTPRequestPath, isFallbackAttempt: Bool) -> ResolvedSource? {
-        guard self.dangerousSettings.internalSettings.usesRemoteConfigAPISources,
+        guard self.usesRemoteConfigAPISources,
               SystemInfo.proxyURL == nil,
               !isFallbackAttempt,
               path.usesAPISources,
@@ -97,13 +99,25 @@ final class APISourceFailover: APISourceFailoverType {
     /// the default host. The walk ends when the provider runs out of sources.
     private func currentResolvedSource() -> ResolvedSource? {
         while let handle = self.sourceProvider.currentAPISource() {
-            if let url = URL(string: handle.url) {
+            if let url = Self.parseAbsoluteURL(handle.url) {
                 return ResolvedSource(handle: handle, url: url)
             }
             Logger.warn(Strings.network.skipping_malformed_api_source_url(url: handle.url))
             self.sourceProvider.reportUnhealthy(handle)
         }
         return nil
+    }
+
+    /// Parses `string` as an absolute base URL. `URL(string:)` alone is too lenient (on modern
+    /// Foundation almost any string parses, e.g. scheme-less hosts or relative paths), so a scheme
+    /// and a host are additionally required — anything less would build requests that can only fail.
+    private static func parseAbsoluteURL(_ string: String) -> URL? {
+        guard let url = URL(string: string),
+              url.scheme != nil,
+              url.host != nil else {
+            return nil
+        }
+        return url
     }
 
 }

--- a/Sources/Networking/RemoteConfigSourceProvider.swift
+++ b/Sources/Networking/RemoteConfigSourceProvider.swift
@@ -86,6 +86,12 @@ extension RemoteConfigSourceProviderType {
 /// embedded default: they are only useful alongside a fetched config, which carries its own. Sources
 /// are deduped by url and ordered via `WeightedSourceSelector`.
 ///
+/// The api list additionally restarts on its own once `apiFailoverRestartInterval` has elapsed since
+/// it first advanced past the top, so the SDK periodically returns to the primary source (or re-arms
+/// an exhausted list) instead of sticking on a backup forever. During a persistent outage this
+/// retries the primary at most once per interval. Blob failover has no such timer: it is restarted
+/// per fetch cycle by its callers.
+///
 /// - Note: Thread-safe.
 final class RemoteConfigSourceProvider: RemoteConfigSourceProviderType {
 
@@ -105,8 +111,11 @@ final class RemoteConfigSourceProvider: RemoteConfigSourceProviderType {
         RemoteConfigSource(url: "https://api.rc-backup.com/", priority: 100_001, weight: 1)
     ]
 
+    private static let apiFailoverRestartInterval: TimeInterval = 600
+
     private let topicStore: RemoteConfigTopicStoreType?
     private let randomizer: WeightedSourceRandomizer?
+    private let dateProvider: DateProvider
     private let lock = Lock()
 
     /// Topic the current failovers were built from. `nil` means there is no sources topic (absent, or
@@ -115,12 +124,19 @@ final class RemoteConfigSourceProvider: RemoteConfigSourceProviderType {
     private var api: SourceFailover
     private var blob: SourceFailover
 
+    /// When the api failover first advanced past the top of its list, or `nil` while it sits at the
+    /// top. Stamped on the first advance (not the latest) so a flapping source can't postpone the
+    /// periodic return to the primary indefinitely.
+    private var apiFailoverStartedAt: Date?
+
     init(
         topicStore: RemoteConfigTopicStoreType?,
-        randomizer: WeightedSourceRandomizer? = nil
+        randomizer: WeightedSourceRandomizer? = nil,
+        dateProvider: DateProvider = DateProvider()
     ) {
         self.topicStore = topicStore
         self.randomizer = randomizer
+        self.dateProvider = dateProvider
         self.api = SourceFailover(
             purpose: .api,
             sources: Self.dedupe(Self.sources(from: nil, for: .api)),
@@ -136,6 +152,7 @@ final class RemoteConfigSourceProvider: RemoteConfigSourceProviderType {
     func getCurrent(for purpose: RemoteConfigSourceHandle.Purpose) -> RemoteConfigSourceHandle? {
         return self.lock.perform {
             self.rebuildIfNeeded()
+            self.restartAPIIfExpired()
             return self.failover(for: purpose).current
         }
     }
@@ -143,8 +160,12 @@ final class RemoteConfigSourceProvider: RemoteConfigSourceProviderType {
     func reportUnhealthy(_ handle: RemoteConfigSourceHandle) {
         self.lock.perform {
             // Rebuild happened, no need to report unhealthy
-            if !self.rebuildIfNeeded() {
-                self.failover(for: handle.purpose).reportUnhealthy(handle)
+            if self.rebuildIfNeeded() { return }
+            self.restartAPIIfExpired()
+
+            let advanced = self.failover(for: handle.purpose).reportUnhealthy(handle)
+            if advanced, handle.purpose == .api, self.apiFailoverStartedAt == nil {
+                self.apiFailoverStartedAt = self.dateProvider.now()
             }
         }
     }
@@ -154,6 +175,9 @@ final class RemoteConfigSourceProvider: RemoteConfigSourceProviderType {
             // Rebuild happened, no need to restart
             if !self.rebuildIfNeeded() {
                 self.failover(for: purpose).restart()
+                if purpose == .api {
+                    self.apiFailoverStartedAt = nil
+                }
             }
         }
     }
@@ -164,13 +188,30 @@ final class RemoteConfigSourceProvider: RemoteConfigSourceProviderType {
             if self.rebuildIfNeeded() {
                 return true
             }
+            self.restartAPIIfExpired()
 
             let failover = self.failover(for: purpose)
             guard failover.current == nil else { return false }
 
             failover.restart()
+            if purpose == .api {
+                self.apiFailoverStartedAt = nil
+            }
             return true
         }
+    }
+
+    /// Restarts the api failover once `apiFailoverRestartInterval` has elapsed since it first
+    /// advanced, so a backup (or an exhausted list) periodically retries the primary source. The
+    /// restart bumps the token, so handles from before it can no longer advance the list. Callers
+    /// must hold `lock`.
+    private func restartAPIIfExpired() {
+        guard let startedAt = self.apiFailoverStartedAt,
+              self.dateProvider.now().timeIntervalSince(startedAt) >= Self.apiFailoverRestartInterval else {
+            return
+        }
+        self.api.restart()
+        self.apiFailoverStartedAt = nil
     }
 
     private func failover(for purpose: RemoteConfigSourceHandle.Purpose) -> SourceFailover {
@@ -203,6 +244,7 @@ final class RemoteConfigSourceProvider: RemoteConfigSourceProviderType {
             initialToken: nextToken
         )
         self.sourcesTopic = topic
+        self.apiFailoverStartedAt = nil
         return true
     }
 
@@ -302,10 +344,13 @@ private final class SourceFailover {
         }
     }
 
-    func reportUnhealthy(_ handle: RemoteConfigSourceHandle) {
-        guard handle.token == self.token else { return }
+    /// Advances past the handle's source, returning whether it did (stale reports are ignored).
+    @discardableResult
+    func reportUnhealthy(_ handle: RemoteConfigSourceHandle) -> Bool {
+        guard handle.token == self.token else { return false }
         self.selector.advance()
         self.token += 1
+        return true
     }
 
     func restart() {

--- a/Sources/Networking/SourceHealthChecker.swift
+++ b/Sources/Networking/SourceHealthChecker.swift
@@ -1,0 +1,122 @@
+//
+//  SourceHealthChecker.swift
+//  RevenueCat
+//
+//  Created by Toni Rico on 27/07/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+
+protocol SourceHealthCheckerType: AnyObject, Sendable {
+
+    /// Probes `<sourceBaseURL>/v1/health/connectivity`. Only a 2xx response is healthy; any other
+    /// response or a connection failure is not. `completion` may be invoked synchronously (on a
+    /// cache hit) or on a background queue.
+    func checkHealth(ofSourceBaseURL url: URL, completion: @escaping @Sendable (Bool) -> Void)
+
+}
+
+/// Checks whether a source is healthy by hitting its `/v1/health/connectivity` endpoint: only a 2xx
+/// response counts as healthy; any other response or a connection failure does not. Checks are
+/// on-demand only (callers probe after a request to the source has already failed, never proactively).
+///
+/// Thread-safe: concurrent checks for the same source share a single request (joiners are completed
+/// with the owner's result), and results are cached briefly so a burst of failing requests fires
+/// one probe.
+final class SourceHealthChecker: SourceHealthCheckerType {
+
+    private static let healthPath = "v1/health/connectivity"
+    private static let resultValidity: TimeInterval = 10
+    private static let requestTimeout: TimeInterval = 5
+
+    private struct CachedResult {
+        let timestamp: Date
+        let isHealthy: Bool
+    }
+
+    private struct State {
+        /// A non-nil entry means a probe for that URL is in flight; joiners append their completions.
+        var pendingCompletions: [URL: [@Sendable (Bool) -> Void]] = [:]
+        var cachedResults: [URL: CachedResult] = [:]
+    }
+
+    private let state: Atomic<State> = .init(.init())
+    private let session: URLSession
+    private let dateProvider: DateProvider
+
+    init(dateProvider: DateProvider = DateProvider()) {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = Self.requestTimeout
+        configuration.timeoutIntervalForResource = Self.requestTimeout
+        configuration.urlCache = nil
+        self.session = URLSession(configuration: configuration)
+        self.dateProvider = dateProvider
+    }
+
+    func checkHealth(ofSourceBaseURL url: URL, completion: @escaping @Sendable (Bool) -> Void) {
+        let healthURL = Self.healthURL(forSourceBaseURL: url)
+
+        enum Action {
+            case complete(isHealthy: Bool)
+            case joined
+            case probe
+        }
+
+        let action: Action = self.state.modify { state in
+            if let cached = state.cachedResults[healthURL],
+               self.dateProvider.now().timeIntervalSince(cached.timestamp) < Self.resultValidity {
+                return .complete(isHealthy: cached.isHealthy)
+            }
+            if state.pendingCompletions[healthURL] != nil {
+                state.pendingCompletions[healthURL]?.append(completion)
+                return .joined
+            }
+            state.pendingCompletions[healthURL] = [completion]
+            return .probe
+        }
+
+        switch action {
+        case let .complete(isHealthy):
+            completion(isHealthy)
+        case .joined:
+            break
+        case .probe:
+            self.performProbe(healthURL: healthURL)
+        }
+    }
+
+    private func performProbe(healthURL: URL) {
+        let task = self.session.dataTask(with: healthURL) { _, response, error in
+            let isHealthy: Bool
+            if let error = error {
+                Logger.verbose(Strings.network.api_source_health_check_failed_to_connect(url: healthURL,
+                                                                                         error: error))
+                isHealthy = false
+            } else {
+                let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+                isHealthy = (200..<300).contains(statusCode)
+                Logger.verbose(Strings.network.api_source_health_check_completed(url: healthURL,
+                                                                                 statusCode: statusCode,
+                                                                                 isHealthy: isHealthy))
+            }
+
+            let completions: [@Sendable (Bool) -> Void] = self.state.modify { state in
+                state.cachedResults[healthURL] = CachedResult(timestamp: self.dateProvider.now(),
+                                                              isHealthy: isHealthy)
+                return state.pendingCompletions.removeValue(forKey: healthURL) ?? []
+            }
+            completions.forEach { $0(isHealthy) }
+        }
+        task.resume()
+    }
+
+    /// `https://host/` and `https://host` both map to `https://host/v1/health/connectivity`.
+    private static func healthURL(forSourceBaseURL url: URL) -> URL {
+        return url.appendingPathComponent(Self.healthPath)
+    }
+
+}
+
+// @unchecked because the compiler can't verify the hand-rolled synchronization:
+// all mutable state is guarded by `Atomic`.
+extension SourceHealthChecker: @unchecked Sendable {}

--- a/Tests/UnitTests/Mocks/MockSourceHealthChecker.swift
+++ b/Tests/UnitTests/Mocks/MockSourceHealthChecker.swift
@@ -1,0 +1,22 @@
+//
+//  MockSourceHealthChecker.swift
+//  RevenueCat
+//
+//  Created by Toni Rico on 27/07/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+@testable import RevenueCat
+
+/// Completes synchronously with `stubbedIsHealthy`, recording every probed source URL.
+final class MockSourceHealthChecker: SourceHealthCheckerType, @unchecked Sendable {
+
+    let stubbedIsHealthy: Atomic<Bool> = .init(true)
+    let checkedSourceURLs: Atomic<[URL]> = .init([])
+
+    func checkHealth(ofSourceBaseURL url: URL, completion: @escaping @Sendable (Bool) -> Void) {
+        self.checkedSourceURLs.modify { $0.append(url) }
+        completion(self.stubbedIsHealthy.value)
+    }
+
+}

--- a/Tests/UnitTests/Networking/APISourceFailoverTests.swift
+++ b/Tests/UnitTests/Networking/APISourceFailoverTests.swift
@@ -74,19 +74,29 @@ final class APISourceFailoverTests: TestCase {
     }
 
     func testCurrentSourceSkipsAndReportsSourcesWithMalformedURLs() {
-        let provider = RecordingSourceProvider(urls: ["", "https://b.revenuecat.com/"])
+        let provider = RecordingSourceProvider(urls: ["not a url", "https://b.revenuecat.com/"])
         let source = Self.failover(provider).currentSource(for: Self.eligiblePath, isFallbackAttempt: false)
 
         expect(source?.url) == URL(string: "https://b.revenuecat.com/")
-        expect(provider.unhealthyReports.value) == [""]
+        expect(provider.unhealthyReports.value) == ["not a url"]
+    }
+
+    func testCurrentSourceSkipsAndReportsSourcesWithSchemelessURLs() {
+        // `URL(string:)` parses these fine as relative URLs, so they need explicit rejection:
+        // a request built against a base without a scheme and host can only fail.
+        let provider = RecordingSourceProvider(urls: ["a.revenuecat.com/", "https://b.revenuecat.com/"])
+        let source = Self.failover(provider).currentSource(for: Self.eligiblePath, isFallbackAttempt: false)
+
+        expect(source?.url) == URL(string: "https://b.revenuecat.com/")
+        expect(provider.unhealthyReports.value) == ["a.revenuecat.com/"]
     }
 
     func testCurrentSourceIsNilWhenEverySourceURLIsMalformed() {
-        let provider = RecordingSourceProvider(urls: [""])
+        let provider = RecordingSourceProvider(urls: ["not a url", "a.revenuecat.com/"])
 
         expect(Self.failover(provider).currentSource(for: Self.eligiblePath, isFallbackAttempt: false))
             .to(beNil())
-        expect(provider.unhealthyReports.value) == [""]
+        expect(provider.unhealthyReports.value) == ["not a url", "a.revenuecat.com/"]
     }
 
     // MARK: - onRequestFailure
@@ -159,12 +169,7 @@ final class APISourceFailoverTests: TestCase {
         healthChecker: SourceHealthCheckerType = MockSourceHealthChecker()
     ) -> APISourceFailover {
         return APISourceFailover(
-            dangerousSettings: DangerousSettings(
-                autoSyncPurchases: true,
-                internalSettings: DangerousSettings.Internal(
-                    usesRemoteConfigAPISources: usesRemoteConfigAPISources
-                )
-            ),
+            usesRemoteConfigAPISources: usesRemoteConfigAPISources,
             sourceProvider: provider,
             healthChecker: healthChecker
         )

--- a/Tests/UnitTests/Networking/APISourceFailoverTests.swift
+++ b/Tests/UnitTests/Networking/APISourceFailoverTests.swift
@@ -1,0 +1,241 @@
+//
+//  APISourceFailoverTests.swift
+//  RevenueCat
+//
+//  Created by Toni Rico on 27/07/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+import Nimble
+@testable import RevenueCat
+import XCTest
+
+final class APISourceFailoverTests: TestCase {
+
+    private static let eligiblePath: HTTPRequestPath = HTTPRequest.Path.getCustomerInfo(appUserID: "test-user-id")
+
+    // MARK: - currentSource eligibility
+
+    func testCurrentSourceResolvesTheProvidersCurrentSourceWhenEligible() {
+        let provider = RecordingSourceProvider(urls: ["https://a.revenuecat.com/"])
+        let source = Self.failover(provider).currentSource(for: Self.eligiblePath, isFallbackAttempt: false)
+
+        expect(source?.url) == URL(string: "https://a.revenuecat.com/")
+        expect(source?.handle.url) == "https://a.revenuecat.com/"
+    }
+
+    func testCurrentSourceIsNilWhenTheDangerousSettingIsDisabled() {
+        let provider = RecordingSourceProvider(urls: ["https://a.revenuecat.com/"])
+        let failover = Self.failover(provider, usesRemoteConfigAPISources: false)
+
+        expect(failover.currentSource(for: Self.eligiblePath, isFallbackAttempt: false)).to(beNil())
+    }
+
+    func testCurrentSourceIsNilForEndpointFallbackAttempts() {
+        let provider = RecordingSourceProvider(urls: ["https://a.revenuecat.com/"])
+
+        expect(Self.failover(provider).currentSource(for: Self.eligiblePath, isFallbackAttempt: true))
+            .to(beNil())
+    }
+
+    func testCurrentSourceIsNilForPathsThatDoNotUseAPISources() {
+        let provider = RecordingSourceProvider(urls: ["https://a.revenuecat.com/"])
+        let path: HTTPRequestPath = HTTPRequest.DiagnosticsPath.postDiagnostics
+
+        expect(Self.failover(provider).currentSource(for: path, isFallbackAttempt: false)).to(beNil())
+    }
+
+    func testCurrentSourceIsNilWhenProxyURLIsSet() throws {
+        SystemInfo.proxyURL = try XCTUnwrap(URL(string: "https://proxy.rc-test.com"))
+        defer { SystemInfo.proxyURL = nil }
+
+        let provider = RecordingSourceProvider(urls: ["https://a.revenuecat.com/"])
+
+        expect(Self.failover(provider).currentSource(for: Self.eligiblePath, isFallbackAttempt: false))
+            .to(beNil())
+    }
+
+    func testCurrentSourceIsNilWhenTheAPIBaseURLIsOverridden() throws {
+        SystemInfo.apiBaseURL = try XCTUnwrap(URL(string: "https://pinned-api.rc-test.com"))
+        defer { SystemInfo.apiBaseURL = SystemInfo.defaultApiBaseURL }
+
+        let provider = RecordingSourceProvider(urls: ["https://a.revenuecat.com/"])
+
+        expect(Self.failover(provider).currentSource(for: Self.eligiblePath, isFallbackAttempt: false))
+            .to(beNil())
+    }
+
+    func testCurrentSourceIsNilWhenTheProviderIsExhausted() {
+        let provider = RecordingSourceProvider(urls: ["https://a.revenuecat.com/"])
+        provider.reportUnhealthy(provider.currentAPISource()!)
+
+        expect(Self.failover(provider).currentSource(for: Self.eligiblePath, isFallbackAttempt: false))
+            .to(beNil())
+    }
+
+    func testCurrentSourceSkipsAndReportsSourcesWithMalformedURLs() {
+        let provider = RecordingSourceProvider(urls: ["", "https://b.revenuecat.com/"])
+        let source = Self.failover(provider).currentSource(for: Self.eligiblePath, isFallbackAttempt: false)
+
+        expect(source?.url) == URL(string: "https://b.revenuecat.com/")
+        expect(provider.unhealthyReports.value) == [""]
+    }
+
+    func testCurrentSourceIsNilWhenEverySourceURLIsMalformed() {
+        let provider = RecordingSourceProvider(urls: [""])
+
+        expect(Self.failover(provider).currentSource(for: Self.eligiblePath, isFallbackAttempt: false))
+            .to(beNil())
+        expect(provider.unhealthyReports.value) == [""]
+    }
+
+    // MARK: - onRequestFailure
+
+    func testOnRequestFailureDoesNotFailOverWhenTheSourcesHealthCheckPasses() throws {
+        let provider = RecordingSourceProvider(urls: ["https://a.revenuecat.com/", "https://b.revenuecat.com/"])
+        let healthChecker = MockSourceHealthChecker()
+        healthChecker.stubbedIsHealthy.value = true
+        let failover = Self.failover(provider, healthChecker: healthChecker)
+
+        let source = try XCTUnwrap(failover.currentSource(for: Self.eligiblePath, isFallbackAttempt: false))
+        let decision = self.decision(of: failover, for: source)
+
+        guard case .sourceHealthy = decision else {
+            fail("Expected sourceHealthy, got \(String(describing: decision))")
+            return
+        }
+        expect(provider.unhealthyReports.value).to(beEmpty())
+    }
+
+    func testOnRequestFailureFailsOverWhenTheHealthCheckFails() throws {
+        let provider = RecordingSourceProvider(urls: ["https://a.revenuecat.com/", "https://b.revenuecat.com/"])
+        let healthChecker = MockSourceHealthChecker()
+        healthChecker.stubbedIsHealthy.value = false
+        let failover = Self.failover(provider, healthChecker: healthChecker)
+
+        let source = try XCTUnwrap(failover.currentSource(for: Self.eligiblePath, isFallbackAttempt: false))
+        let decision = self.decision(of: failover, for: source)
+
+        guard case let .retryNextSource(next) = decision else {
+            fail("Expected retryNextSource, got \(String(describing: decision))")
+            return
+        }
+        expect(next.url) == URL(string: "https://b.revenuecat.com/")
+        expect(provider.unhealthyReports.value) == ["https://a.revenuecat.com/"]
+    }
+
+    func testOnRequestFailureReportsExhaustionOnceTheLastSourceFailsItsHealthCheck() throws {
+        let provider = RecordingSourceProvider(urls: ["https://a.revenuecat.com/"])
+        let healthChecker = MockSourceHealthChecker()
+        healthChecker.stubbedIsHealthy.value = false
+        let failover = Self.failover(provider, healthChecker: healthChecker)
+
+        let source = try XCTUnwrap(failover.currentSource(for: Self.eligiblePath, isFallbackAttempt: false))
+        let decision = self.decision(of: failover, for: source)
+
+        guard case .sourcesExhausted = decision else {
+            fail("Expected sourcesExhausted, got \(String(describing: decision))")
+            return
+        }
+        expect(provider.unhealthyReports.value) == ["https://a.revenuecat.com/"]
+    }
+
+    func testOnRequestFailureHealthChecksTheFailedSource() throws {
+        let provider = RecordingSourceProvider(urls: ["https://a.revenuecat.com/", "https://b.revenuecat.com/"])
+        let healthChecker = MockSourceHealthChecker()
+        let failover = Self.failover(provider, healthChecker: healthChecker)
+
+        let source = try XCTUnwrap(failover.currentSource(for: Self.eligiblePath, isFallbackAttempt: false))
+        _ = self.decision(of: failover, for: source)
+
+        expect(healthChecker.checkedSourceURLs.value) == [URL(string: "https://a.revenuecat.com/")]
+    }
+
+    // MARK: - Helpers
+
+    private static func failover(
+        _ provider: RemoteConfigSourceProviderType,
+        usesRemoteConfigAPISources: Bool = true,
+        healthChecker: SourceHealthCheckerType = MockSourceHealthChecker()
+    ) -> APISourceFailover {
+        return APISourceFailover(
+            dangerousSettings: DangerousSettings(
+                autoSyncPurchases: true,
+                internalSettings: DangerousSettings.Internal(
+                    usesRemoteConfigAPISources: usesRemoteConfigAPISources
+                )
+            ),
+            sourceProvider: provider,
+            healthChecker: healthChecker
+        )
+    }
+
+    /// The mock health checker completes synchronously, so the decision is available on return.
+    private func decision(
+        of failover: APISourceFailover,
+        for source: APISourceFailover.ResolvedSource
+    ) -> APISourceFailover.FailureDecision? {
+        let decision: Atomic<APISourceFailover.FailureDecision?> = .init(nil)
+        failover.onRequestFailure(source) { decision.value = $0 }
+        return decision.value
+    }
+
+}
+
+/// A real `RemoteConfigSourceProvider` over the given API source urls (in priority order), wrapped to
+/// record every `reportUnhealthy` call. `RemoteConfigSourceHandle` can only be created by the real
+/// provider, so tests drive it instead of faking handles.
+private final class RecordingSourceProvider: RemoteConfigSourceProviderType {
+
+    let unhealthyReports: Atomic<[String]> = .init([])
+
+    private let wrapped: RemoteConfigSourceProvider
+
+    init(urls: [String]) {
+        self.wrapped = RemoteConfigSourceProvider(topicStore: APISourceTopicStore(urls: urls))
+    }
+
+    func getCurrent(for purpose: RemoteConfigSourceHandle.Purpose) -> RemoteConfigSourceHandle? {
+        return self.wrapped.getCurrent(for: purpose)
+    }
+
+    func reportUnhealthy(_ handle: RemoteConfigSourceHandle) {
+        self.unhealthyReports.modify { $0.append(handle.url) }
+        self.wrapped.reportUnhealthy(handle)
+    }
+
+    func restart(for purpose: RemoteConfigSourceHandle.Purpose) {
+        self.wrapped.restart(for: purpose)
+    }
+
+    @discardableResult
+    func restartIfExhausted(for purpose: RemoteConfigSourceHandle.Purpose) -> Bool {
+        return self.wrapped.restartIfExhausted(for: purpose)
+    }
+
+}
+
+/// A minimal `sources` topic store exposing the given API sources in order (priority = index), matching
+/// the backend topic shape.
+private final class APISourceTopicStore: RemoteConfigTopicStoreType {
+
+    private let urls: [String]
+
+    init(urls: [String]) {
+        self.urls = urls
+    }
+
+    func topic(_ topic: RemoteConfigTopic) -> RemoteConfiguration.ConfigTopic? {
+        guard topic == .sources else { return nil }
+        return ["api": RemoteConfiguration.ConfigItem(content: [
+            "sources": .array(self.urls.enumerated().map { index, url in
+                .object([
+                    "url": .string(url),
+                    "priority": .int(index),
+                    "weight": .int(1)
+                ])
+            })
+        ])]
+    }
+
+}

--- a/Tests/UnitTests/Networking/RemoteConfigSourceProviderTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfigSourceProviderTests.swift
@@ -374,6 +374,141 @@ final class RemoteConfigSourceProviderTests: TestCase {
         expect(provider.getCurrent(for: .api)?.url) == Self.url("a")
     }
 
+    // MARK: - API restart interval (TTL re-arm)
+
+    func testAdvancedAPIListRestartsFromTheTopAfterTheRestartInterval() {
+        let dateProvider = MockCurrentDateProvider()
+        let provider = Self.apiProvider([Self.source("a"), Self.source("b")], dateProvider: dateProvider)
+
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!) // a -> b
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("b")
+
+        dateProvider.advance(by: 600)
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("a")
+    }
+
+    func testAdvancedAPIListKeepsItsPositionJustUnderTheRestartInterval() {
+        let dateProvider = MockCurrentDateProvider()
+        let provider = Self.apiProvider([Self.source("a"), Self.source("b")], dateProvider: dateProvider)
+
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!) // a -> b
+
+        dateProvider.advance(by: 599)
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("b")
+    }
+
+    func testExhaustedAPIListReArmsAfterTheRestartInterval() {
+        let dateProvider = MockCurrentDateProvider()
+        let provider = Self.apiProvider([Self.source("a"), Self.source("b")], dateProvider: dateProvider)
+
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!) // a -> b
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!) // b -> exhausted
+        expect(provider.getCurrent(for: .api)).to(beNil())
+
+        dateProvider.advance(by: 599)
+        expect(provider.getCurrent(for: .api)).to(beNil())
+
+        dateProvider.advance(by: 1)
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("a")
+    }
+
+    func testTheRestartIntervalCountsFromTheFirstAdvanceNotTheLatest() {
+        // A flapping list must not postpone the periodic return to the primary: advancing again
+        // mid-interval does not reset the timer.
+        let dateProvider = MockCurrentDateProvider()
+        let provider = Self.apiProvider(
+            [Self.source("a"), Self.source("b"), Self.source("c")],
+            dateProvider: dateProvider
+        )
+
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!) // a -> b, timer starts
+        dateProvider.advance(by: 500)
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!) // b -> c, timer unchanged
+
+        dateProvider.advance(by: 100) // 600s since the first advance
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("a")
+    }
+
+    func testHandleFromBeforeTheIntervalRestartIsStale() {
+        let dateProvider = MockCurrentDateProvider()
+        let provider = Self.apiProvider([Self.source("a"), Self.source("b")], dateProvider: dateProvider)
+
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!) // a -> b
+        let stale = provider.getCurrent(for: .api)
+        expect(stale?.url) == Self.url("b")
+
+        dateProvider.advance(by: 600)
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("a")
+
+        // The pre-restart handle belongs to the previous cycle, so it must not advance the list.
+        provider.reportUnhealthy(stale!)
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("a")
+    }
+
+    func testANewFailoverCycleAfterAnIntervalRestartNeedsAFullIntervalAgain() {
+        let dateProvider = MockCurrentDateProvider()
+        let provider = Self.apiProvider([Self.source("a"), Self.source("b")], dateProvider: dateProvider)
+
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!) // a -> b
+        dateProvider.advance(by: 600)
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("a")
+
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!) // a -> b, new timer
+        dateProvider.advance(by: 599)
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("b")
+
+        dateProvider.advance(by: 1)
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("a")
+    }
+
+    func testExplicitRestartResetsTheIntervalTimer() {
+        let dateProvider = MockCurrentDateProvider()
+        let provider = Self.apiProvider([Self.source("a"), Self.source("b")], dateProvider: dateProvider)
+
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!) // a -> b, timer starts
+        dateProvider.advance(by: 500)
+        provider.restart(for: .api) // timer cleared
+
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!) // a -> b, fresh timer
+        dateProvider.advance(by: 599) // over 600s since the ORIGINAL advance, under since the fresh one
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("b")
+    }
+
+    func testAChangedSourcesTopicResetsTheIntervalTimer() {
+        let dateProvider = MockCurrentDateProvider()
+        let store = FakeTopicStore(Self.sourcesTopic(api: [Self.source("a"), Self.source("b")], blob: []))
+        let provider = RemoteConfigSourceProvider(
+            topicStore: store,
+            randomizer: FakeRandomizer(0),
+            dateProvider: dateProvider
+        )
+
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!) // a -> b, timer starts
+        dateProvider.advance(by: 500)
+
+        store.sources = Self.sourcesTopic(api: [Self.source("x"), Self.source("y")], blob: [])
+        provider.reportUnhealthy(provider.getCurrent(for: .api)!) // x -> y, fresh timer
+
+        dateProvider.advance(by: 599)
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("y")
+
+        dateProvider.advance(by: 1)
+        expect(provider.getCurrent(for: .api)?.url) == Self.url("x")
+    }
+
+    func testBlobProgressIsUnaffectedByElapsedTime() {
+        let dateProvider = MockCurrentDateProvider()
+        let provider = Self.provider(
+            api: [Self.source("api1")],
+            blob: [Self.source("blob1", priority: 0), Self.source("blob2", priority: 10)],
+            dateProvider: dateProvider
+        )
+
+        provider.reportUnhealthy(provider.getCurrent(for: .blob)!) // blob1 -> blob2
+        dateProvider.advance(by: 600)
+        expect(provider.getCurrent(for: .blob)?.url) == Self.url("blob2")
+    }
+
     // MARK: - Threading
 
     func testConcurrentReportsOfSameSourceAdvanceExactlyOnce() {
@@ -425,17 +560,22 @@ final class RemoteConfigSourceProviderTests: TestCase {
         return RemoteConfigSource(url: url(host), priority: priority, weight: weight)
     }
 
-    private static func apiProvider(_ sources: [RemoteConfigSource]) -> RemoteConfigSourceProvider {
-        return provider(api: sources, blob: [])
+    private static func apiProvider(
+        _ sources: [RemoteConfigSource],
+        dateProvider: DateProvider = DateProvider()
+    ) -> RemoteConfigSourceProvider {
+        return provider(api: sources, blob: [], dateProvider: dateProvider)
     }
 
     private static func provider(
         api: [RemoteConfigSource],
-        blob: [RemoteConfigSource]
+        blob: [RemoteConfigSource],
+        dateProvider: DateProvider = DateProvider()
     ) -> RemoteConfigSourceProvider {
         return RemoteConfigSourceProvider(
             topicStore: FakeTopicStore(sourcesTopic(api: api, blob: blob)),
-            randomizer: FakeRandomizer(0)
+            randomizer: FakeRandomizer(0),
+            dateProvider: dateProvider
         )
     }
 

--- a/Tests/UnitTests/Networking/SourceHealthCheckerTests.swift
+++ b/Tests/UnitTests/Networking/SourceHealthCheckerTests.swift
@@ -1,0 +1,186 @@
+//
+//  SourceHealthCheckerTests.swift
+//  RevenueCat
+//
+//  Created by Toni Rico on 27/07/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Nimble
+import OHHTTPStubs
+import OHHTTPStubsSwift
+import XCTest
+
+@testable import RevenueCat
+
+final class SourceHealthCheckerTests: TestCase {
+
+    private static let sourceBaseURL = URL(string: "https://api.revenuecat.com/")!
+    private static let healthPath = "/v1/health/connectivity"
+
+    private var dateProvider: MockCurrentDateProvider!
+    private var checker: SourceHealthChecker!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        #if os(watchOS)
+        // See https://github.com/AliSoftware/OHHTTPStubs/issues/287
+        try XCTSkipIf(true, "OHHTTPStubs does not currently support watchOS")
+        #endif
+
+        self.dateProvider = MockCurrentDateProvider()
+        self.checker = SourceHealthChecker(dateProvider: self.dateProvider)
+    }
+
+    override func tearDown() {
+        HTTPStubs.removeAllStubs()
+
+        super.tearDown()
+    }
+
+    func test2xxResponsesAreHealthy() {
+        for statusCode in [200, 204, 299] as [Int32] {
+            HTTPStubs.removeAllStubs()
+            let checker = SourceHealthChecker(dateProvider: self.dateProvider)
+            self.stubHealthEndpoint { HTTPStubsResponse(data: Data(), statusCode: statusCode, headers: nil) }
+
+            expect(self.checkHealth(with: checker))
+                .to(beTrue(), description: "Expected \(statusCode) to be healthy")
+        }
+    }
+
+    func testNon2xxResponsesAreNotHealthy() {
+        for statusCode in [301, 404, 500, 503] as [Int32] {
+            HTTPStubs.removeAllStubs()
+            let checker = SourceHealthChecker(dateProvider: self.dateProvider)
+            self.stubHealthEndpoint { HTTPStubsResponse(data: Data(), statusCode: statusCode, headers: nil) }
+
+            expect(self.checkHealth(with: checker))
+                .to(beFalse(), description: "Expected \(statusCode) to not be healthy")
+        }
+    }
+
+    func testConnectionFailureIsNotHealthy() {
+        self.stubHealthEndpoint { HTTPStubsResponse(error: URLError(.cannotConnectToHost)) }
+
+        expect(self.checkHealth()) == false
+    }
+
+    func testChecksTheHealthConnectivityPathOfTheSource() {
+        let requestedPaths: Atomic<[String]> = .init([])
+        stub(condition: isHost("api.revenuecat.com")) { request in
+            requestedPaths.modify { $0.append(request.url?.path ?? "") }
+            return HTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
+        }
+
+        expect(self.checkHealth()) == true
+        expect(requestedPaths.value) == [Self.healthPath]
+    }
+
+    func testBuildsTheHealthURLForABaseURLWithoutATrailingSlash() {
+        let requestedPaths: Atomic<[String]> = .init([])
+        stub(condition: isHost("api.revenuecat.com")) { request in
+            requestedPaths.modify { $0.append(request.url?.path ?? "") }
+            return HTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
+        }
+
+        expect(self.checkHealth(of: URL(string: "https://api.revenuecat.com")!)) == true
+        expect(requestedPaths.value) == [Self.healthPath]
+    }
+
+    func testCachesTheResultWithinItsValidityWindow() {
+        let requestCount: Atomic<Int> = .init(0)
+        self.stubHealthEndpoint {
+            requestCount.modify { $0 += 1 }
+            return HTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
+        }
+
+        expect(self.checkHealth()) == true
+        self.dateProvider.advance(by: 9)
+        expect(self.checkHealth()) == true
+        expect(requestCount.value) == 1
+    }
+
+    func testCachesUnhealthyResultsToo() {
+        let requestCount: Atomic<Int> = .init(0)
+        self.stubHealthEndpoint {
+            requestCount.modify { $0 += 1 }
+            return HTTPStubsResponse(data: Data(), statusCode: 500, headers: nil)
+        }
+
+        expect(self.checkHealth()) == false
+        expect(self.checkHealth()) == false
+        expect(requestCount.value) == 1
+    }
+
+    func testChecksAgainOnceTheCachedResultExpires() {
+        let requestCount: Atomic<Int> = .init(0)
+        self.stubHealthEndpoint {
+            requestCount.modify { $0 += 1 }
+            return HTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
+        }
+
+        expect(self.checkHealth()) == true
+        self.dateProvider.advance(by: 10)
+        expect(self.checkHealth()) == true
+        expect(requestCount.value) == 2
+    }
+
+    func testCachesResultsPerSource() {
+        stub(condition: isHost("api.revenuecat.com") && isPath(Self.healthPath)) { _ in
+            HTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
+        }
+        stub(condition: isHost("api.rc-backup.com") && isPath(Self.healthPath)) { _ in
+            HTTPStubsResponse(data: Data(), statusCode: 503, headers: nil)
+        }
+
+        expect(self.checkHealth()) == true
+        expect(self.checkHealth(of: URL(string: "https://api.rc-backup.com/")!)) == false
+    }
+
+    func testConcurrentChecksForTheSameSourceShareOneRequest() {
+        let requestCount: Atomic<Int> = .init(0)
+        self.stubHealthEndpoint {
+            requestCount.modify { $0 += 1 }
+            return HTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
+                .responseTime(0.2)
+        }
+
+        let results: Atomic<[Bool]> = .init([])
+        let group = DispatchGroup()
+        for _ in 0..<2 {
+            group.enter()
+            self.checker.checkHealth(ofSourceBaseURL: Self.sourceBaseURL) { isHealthy in
+                results.modify { $0.append(isHealthy) }
+                group.leave()
+            }
+        }
+        expect(group.wait(timeout: .now() + 5)) == .success
+
+        expect(results.value) == [true, true]
+        expect(requestCount.value) == 1
+    }
+
+    // MARK: - Helpers
+
+    private func stubHealthEndpoint(_ response: @escaping () -> HTTPStubsResponse) {
+        stub(condition: isHost("api.revenuecat.com") && isPath(Self.healthPath)) { _ in response() }
+    }
+
+    /// Blocks until the (possibly asynchronous) health check completes and returns its result.
+    private func checkHealth(
+        of url: URL = SourceHealthCheckerTests.sourceBaseURL,
+        with checker: SourceHealthChecker? = nil
+    ) -> Bool? {
+        let result: Atomic<Bool?> = .init(nil)
+        let group = DispatchGroup()
+        group.enter()
+        (checker ?? self.checker).checkHealth(ofSourceBaseURL: url) { isHealthy in
+            result.value = isHealthy
+            group.leave()
+        }
+        guard group.wait(timeout: .now() + 5) == .success else { return nil }
+        return result.value
+    }
+
+}


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
First of two stacked PRs adding health-check-gated API source failover. This one adds the standalone pieces; nothing consumes them yet, so released behavior is unchanged.

Android equivalent: https://github.com/RevenueCat/purchases-android/pull/3812

### Description
- `SourceHealthChecker`: probes `<source>/v1/health/connectivity`; only a 2xx is healthy. Concurrent checks per source share one request and results are cached for 10s.
- `APISourceFailover`: the decision layer. After a failed request, the current source is health-checked: a 2xx health response means the source is healthy and the original error should surface instead of switching hosts; otherwise the source is reported unhealthy and the next one takes over. Malformed source URLs are reported unhealthy and skipped.
- `RemoteConfigSourceProvider`: the API failover list restarts from the top 10 minutes after it first advances, so the SDK periodically retries the primary source (and re-arms an exhausted list) instead of sticking on a backup forever.

The HTTPClient integration (and the iOS-specific device-connectivity handling) lands in the [follow-up PR](https://github.com/RevenueCat/purchases-ios/pull/7294).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New networking code is not integrated into request handling yet; only `RemoteConfigSourceProvider` timing/token behavior changes in code paths that already existed, with broad test coverage.
> 
> **Overview**
> Adds **standalone** building blocks for health-check-gated API source failover; nothing in the HTTP client consumes them yet, so shipped behavior is unchanged until the follow-up PR.
> 
> **`SourceHealthChecker`** probes each source’s `/v1/health/connectivity` (2xx = healthy), deduplicates concurrent probes per URL, and caches results for 10 seconds.
> 
> **`APISourceFailover`** picks the remote-config API host when the dangerous setting and path gates allow, and on eligible request failures runs a health check before marking a source unhealthy and advancing to the next one; malformed URLs are skipped and reported unhealthy.
> 
> **`RemoteConfigSourceProvider`** now **re-arms the API failover list every 600 seconds** after the first advance past the primary (timer anchored on first advance, cleared on explicit restart or topic rebuild); blob failover is unchanged.
> 
> Network log strings and unit tests cover the new components and TTL behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e4de93a281cd17097a86686cb8e77966b23d3e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->