### PR TITLE
feat(remote-config): health-check-gated API source failover in HTTPClient

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		1DEF75932ECF130500614CB2 /* EmailValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DEF75922ECF130500614CB2 /* EmailValidator.swift */; };
 		1DEF759E2ECF13C000614CB2 /* BackendPostCreateTicketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DEF759D2ECF13C000614CB2 /* BackendPostCreateTicketTests.swift */; };
 		1E2F91722CCFA98C00BDB016 /* WebRedemptionStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E2F91712CCFA98C00BDB016 /* WebRedemptionStrings.swift */; };
+		1E3084B130178A9100236A34 /* BackendAPISourceFailoverIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3084B030178A9100236A34 /* BackendAPISourceFailoverIntegrationTests.swift */; };
 		1E42CC6C2D7F1A0500E0EE8D /* CacheStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E42CC6B2D7F1A0500E0EE8D /* CacheStatus.swift */; };
 		1E473B662AC42D34008B07F9 /* StoreMessagesHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E473B652AC42D34008B07F9 /* StoreMessagesHelper.swift */; };
 		1E473B682AC43254008B07F9 /* StoreMessageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E473B672AC43254008B07F9 /* StoreMessageType.swift */; };
@@ -1690,6 +1691,7 @@
 		1DEF759D2ECF13C000614CB2 /* BackendPostCreateTicketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendPostCreateTicketTests.swift; sourceTree = "<group>"; };
 		1E2F911A2CC918ED00BDB016 /* ContactSupportUtilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactSupportUtilitiesTests.swift; sourceTree = "<group>"; };
 		1E2F91712CCFA98C00BDB016 /* WebRedemptionStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRedemptionStrings.swift; sourceTree = "<group>"; };
+		1E3084B030178A9100236A34 /* BackendAPISourceFailoverIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendAPISourceFailoverIntegrationTests.swift; sourceTree = "<group>"; };
 		1E42CC6B2D7F1A0500E0EE8D /* CacheStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheStatus.swift; sourceTree = "<group>"; };
 		1E473B652AC42D34008B07F9 /* StoreMessagesHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreMessagesHelper.swift; sourceTree = "<group>"; };
 		1E473B672AC43254008B07F9 /* StoreMessageType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreMessageType.swift; sourceTree = "<group>"; };
@@ -5140,6 +5142,7 @@
 			children = (
 				900D27062F96943200D32EDF /* BackendGetRewardVerificationStatusTests.swift */,
 				5796A39727D6C07D00653165 /* __Snapshots__ */,
+				1E3084B030178A9100236A34 /* BackendAPISourceFailoverIntegrationTests.swift */,
 				5796A38927D6B96300653165 /* BackendGetCustomerInfoTests.swift */,
 				5796A38F27D6BCD100653165 /* BackendGetIntroEligibilityTests.swift */,
 				5796A39327D6BD6900653165 /* BackendGetOfferingsTests.swift */,
@@ -7940,6 +7943,7 @@
 				03A98CEF2D1EE048009BCA61 /* FallbackComponentTests.swift in Sources */,
 				573A10D92800ADCD00F976E5 /* StoreKitErrorTests.swift in Sources */,
 				5766AABF283E80B500FA6091 /* BasePurchasesTests.swift in Sources */,
+				1E3084B130178A9100236A34 /* BackendAPISourceFailoverIntegrationTests.swift in Sources */,
 				351B515826D44B3E00BD2BD7 /* MockOfferingsFactory.swift in Sources */,
 				4F0C11562B742F2F00583501 /* PaywallDataMultiTierTests.swift in Sources */,
 				351B51A526D450BC00BD2BD7 /* DateExtensionsTests.swift in Sources */,

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -40,13 +40,21 @@ class Backend {
         apiSourceProvider: RemoteConfigSourceProviderType?,
         dateProvider: DateProvider = DateProvider()
     ) {
+        // Shared by both HTTPClients so their failovers walk one source list and share one
+        // health-check cache; the provider's handle tokens keep concurrent reports from
+        // double-advancing the list.
+        let apiSourceFailover = apiSourceProvider.map {
+            APISourceFailover(dangerousSettings: systemInfo.dangerousSettings,
+                              sourceProvider: $0,
+                              healthChecker: SourceHealthChecker())
+        }
         let httpClient = HTTPClient(systemInfo: systemInfo,
                                     eTagManager: eTagManager,
                                     signing: Signing(apiKey: systemInfo.apiKey, clock: systemInfo.clock),
                                     diagnosticsTracker: diagnosticsTracker,
                                     requestTimeout: httpClientTimeout,
                                     operationDispatcher: OperationDispatcher.default,
-                                    apiSourceProvider: apiSourceProvider)
+                                    apiSourceFailover: apiSourceFailover)
         let config = BackendConfiguration(httpClient: httpClient,
                                           operationDispatcher: operationDispatcher,
                                           operationQueue: QueueProvider.createBackendQueue(),
@@ -59,7 +67,7 @@ class Backend {
                                                eTagManager: eTagManager,
                                                diagnosticsTracker: diagnosticsTracker,
                                                requestTimeout: httpClientTimeout,
-                                               apiSourceProvider: apiSourceProvider),
+                                               apiSourceFailover: apiSourceFailover),
             operationDispatcher: operationDispatcher,
             operationQueue: QueueProvider.createRemoteConfigQueue(),
             diagnosticsQueue: QueueProvider.createDiagnosticsQueue(),
@@ -299,7 +307,7 @@ private extension HTTPClient {
         eTagManager: ETagManager,
         diagnosticsTracker: DiagnosticsTrackerType?,
         requestTimeout: TimeInterval,
-        apiSourceProvider: RemoteConfigSourceProviderType?
+        apiSourceFailover: APISourceFailoverType?
     ) -> HTTPClient {
         HTTPClient(systemInfo: systemInfo,
                    eTagManager: eTagManager,
@@ -307,7 +315,7 @@ private extension HTTPClient {
                    diagnosticsTracker: diagnosticsTracker,
                    requestTimeout: requestTimeout,
                    operationDispatcher: OperationDispatcher.default,
-                   apiSourceProvider: apiSourceProvider)
+                   apiSourceFailover: apiSourceFailover)
     }
 
 }

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -44,7 +44,8 @@ class Backend {
         // health-check cache; the provider's handle tokens keep concurrent reports from
         // double-advancing the list.
         let apiSourceFailover = apiSourceProvider.map {
-            APISourceFailover(dangerousSettings: systemInfo.dangerousSettings,
+            APISourceFailover(usesRemoteConfigAPISources:
+                                systemInfo.dangerousSettings.internalSettings.usesRemoteConfigAPISources,
                               sourceProvider: $0,
                               healthChecker: SourceHealthChecker())
         }

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -35,13 +35,17 @@ class HTTPClient {
     private let retriableStatusCodes: Set<HTTPStatusCode>
     private let operationDispatcher: OperationDispatcher
     private let requestTimeoutManager: HTTPRequestTimeoutManagerType
-    private let apiSourceProvider: RemoteConfigSourceProviderType?
+    private let apiSourceFailover: APISourceFailoverType?
 
     private let retryBackoffIntervals: [TimeInterval] = [
         TimeInterval(0),
         TimeInterval(0.75),
         TimeInterval(3)
     ]
+
+    /// Defensive cap on API source attempts within one logical request, in case the source list is
+    /// re-armed (topic rebuild or interval restart) while a request is walking it.
+    private static let maxAPISourceAttempts = 5
 
     init(systemInfo: SystemInfo,
          eTagManager: ETagManager,
@@ -52,7 +56,7 @@ class HTTPClient {
          requestTimeout: TimeInterval = Configuration.networkTimeoutDefault,
          dateProvider: DateProvider = DateProvider(),
          operationDispatcher: OperationDispatcher,
-         apiSourceProvider: RemoteConfigSourceProviderType?,
+         apiSourceFailover: APISourceFailoverType?,
          timeoutManager: HTTPRequestTimeoutManagerType? = nil
     ) {
         let config = URLSessionConfiguration.ephemeral
@@ -73,7 +77,7 @@ class HTTPClient {
         self.authHeaders = HTTPClient.authorizationHeader(withAPIKey: systemInfo.apiKey)
         self.dateProvider = dateProvider
         self.operationDispatcher = operationDispatcher
-        self.apiSourceProvider = apiSourceProvider
+        self.apiSourceFailover = apiSourceFailover
         self.requestTimeoutManager = timeoutManager ?? HTTPRequestTimeoutManager(
             defaultTimeout: timeout,
             dateProvider: dateProvider
@@ -283,6 +287,19 @@ internal extension HTTPClient {
             return self.fallbackUrlIndex != nil
         }
 
+        /// The API source this request targets, if it resolved one. Carried on the request so a
+        /// failure can report the exact handle unhealthy, and so retries of any kind (ETag refresh,
+        /// status-code backoff) keep targeting the same host.
+        private(set) var apiSource: APISourceFailover.ResolvedSource?
+
+        /// Whether source resolution already ran for this logical request (distinguishes "not yet
+        /// resolved" from "resolved to no source").
+        private(set) var apiSourceResolved: Bool = false
+
+        /// Attempts made on API sources for this logical request: 1 when a source is first resolved,
+        /// +1 per failover to the next source.
+        private(set) var apiSourceAttemptCount: Int = 0
+
         init<Value: HTTPResponseBody>(httpRequest: HTTPRequest,
                                       authHeaders: HTTPClient.RequestHeaders,
                                       defaultHeaders: HTTPClient.RequestHeaders,
@@ -325,6 +342,26 @@ internal extension HTTPClient {
             return copy
         }
 
+        /// Resolves the API source once per logical request. Retries of any kind keep the carried
+        /// source instead of re-resolving, so they deterministically target the same host.
+        mutating func resolveAPISourceIfNeeded(with failover: APISourceFailoverType?) {
+            guard !self.apiSourceResolved else { return }
+            self.apiSourceResolved = true
+            guard let source = failover?.currentSource(for: self.httpRequest.path,
+                                                       isFallbackAttempt: self.isFallbackURLRequest) else {
+                return
+            }
+            self.apiSource = source
+            self.apiSourceAttemptCount = 1
+        }
+
+        func requestWith(nextAPISource: APISourceFailover.ResolvedSource) -> Self {
+            var copy = self
+            copy.apiSource = nextAPISource
+            copy.apiSourceAttemptCount += 1
+            return copy
+        }
+
         func requestWithNextFallbackHost(proxyURL: URL?) -> Self? {
             guard proxyURL == nil else {
                 // Don't fallback to next host if proxyURL is set
@@ -332,6 +369,9 @@ internal extension HTTPClient {
             }
             var copy = self
             copy.fallbackUrlIndex = self.fallbackUrlIndex?.advanced(by: 1) ?? 0
+            // The static fallback walk drops the API source: fallback attempts pin their own host and
+            // must not re-enter source failover.
+            copy.apiSource = nil
             guard copy.getCurrentRequestURL(proxyURL: nil, apiSourceURL: nil) != nil else {
                 // No more fallback hosts available
                 return nil
@@ -508,7 +548,6 @@ private extension HTTPClient {
 
         if let response = response {
             let httpURLResponse = urlResponse as? HTTPURLResponse
-            var retryScheduled = false
 
             switch response {
             case let .success(response):
@@ -529,9 +568,14 @@ private extension HTTPClient {
                     requestTimeoutResult = .successOnMainBackend
                 }
 
-            case let .failure(error):
-                let httpURLResponse = urlResponse as? HTTPURLResponse
+                self.finish(request: request,
+                            response: .success(response),
+                            retryScheduled: false,
+                            requestTimeoutResult: requestTimeoutResult,
+                            urlRequest: urlRequest,
+                            requestStartTime: requestStartTime)
 
+            case let .failure(error):
                 Logger.debug(Strings.network.api_request_failed(request.httpRequest,
                                                                 httpCode: httpURLResponse?.httpStatusCode,
                                                                 error: error,
@@ -548,17 +592,44 @@ private extension HTTPClient {
                     requestTimeoutResult = .timeoutOnMainBackendForFallbackSupportedEndpoint
                 }
 
-                retryScheduled = self.retryRequestWithNextFallbackHostIfNeeded(request: request,
-                                                                               error: error)
+                // A failure that points at the host (never a device-connectivity error or a 4xx) on a
+                // request targeting an API source may fail over to the next source, but only after the
+                // current source's health check fails. The decision is asynchronous: the serial pipeline
+                // stays stalled (as if the request were still in flight) until it completes.
+                if let source = request.apiSource,
+                   request.apiSourceAttemptCount < Self.maxAPISourceAttempts,
+                   error.isAllowedToRetryWithFallbackHost,
+                   let apiSourceFailover = self.apiSourceFailover {
+                    let requestTimeoutResult = requestTimeoutResult
+                    apiSourceFailover.onRequestFailure(source) { decision in
+                        let retryScheduled = self.handleAPISourceFailureDecision(decision,
+                                                                                 request: request,
+                                                                                 error: error,
+                                                                                 httpURLResponse: httpURLResponse)
+                        self.finish(request: request,
+                                    response: .failure(error),
+                                    retryScheduled: retryScheduled,
+                                    requestTimeoutResult: requestTimeoutResult,
+                                    urlRequest: urlRequest,
+                                    requestStartTime: requestStartTime)
+                    }
+                    return
+                }
+
+                var retryScheduled = self.retryRequestWithNextFallbackHostIfNeeded(request: request,
+                                                                                   error: error)
 
                 if !retryScheduled {
                     retryScheduled = self.retryRequestIfNeeded(request: request,
                                                                httpURLResponse: httpURLResponse)
                 }
-            }
 
-            if !retryScheduled {
-                request.completionHandler?(response)
+                self.finish(request: request,
+                            response: .failure(error),
+                            retryScheduled: retryScheduled,
+                            requestTimeoutResult: requestTimeoutResult,
+                            urlRequest: urlRequest,
+                            requestStartTime: requestStartTime)
             }
         } else {
             Logger.debug(Strings.network.retrying_request(httpMethod: request.method.httpMethod, path: request.path))
@@ -566,6 +637,52 @@ private extension HTTPClient {
             self.state.modify {
                 $0.queuedRequests.insert(request.retriedRequest(), at: 0)
             }
+
+            self.finish(request: request,
+                        response: nil,
+                        retryScheduled: true,
+                        requestTimeoutResult: requestTimeoutResult,
+                        urlRequest: urlRequest,
+                        requestStartTime: requestStartTime)
+        }
+    }
+
+    /// Schedules the retry (if any) that a failover `decision` calls for, returning whether one was
+    /// scheduled. A source that failed its health check is retried on the next source; otherwise the
+    /// pre-existing chain runs: the static fallback host walk, then the status-code backoff retry.
+    private func handleAPISourceFailureDecision(_ decision: APISourceFailover.FailureDecision,
+                                                request: Request,
+                                                error: NetworkError,
+                                                httpURLResponse: HTTPURLResponse?) -> Bool {
+        switch decision {
+        case let .retryNextSource(nextSource):
+            Logger.debug(Strings.network.retrying_request_with_next_api_source(
+                httpMethod: request.method.httpMethod,
+                path: request.path,
+                host: nextSource.handle.url
+            ))
+            self.state.modify {
+                $0.queuedRequests.insert(request.requestWith(nextAPISource: nextSource), at: 0)
+            }
+            return true
+
+        case .sourceHealthy, .sourcesExhausted:
+            return self.retryRequestWithNextFallbackHostIfNeeded(request: request, error: error)
+                || self.retryRequestIfNeeded(request: request, httpURLResponse: httpURLResponse)
+        }
+    }
+
+    /// The shared tail of `handle(...)`: completes the request (unless a retry was scheduled), records
+    /// timeout bookkeeping and diagnostics for the attempt, and unblocks the serial pipeline.
+    // swiftlint:disable:next function_parameter_count
+    private func finish(request: Request,
+                        response: VerifiedHTTPResponse<Data>.Result?,
+                        retryScheduled: Bool,
+                        requestTimeoutResult: HTTPRequestTimeoutManager.RequestResult,
+                        urlRequest: URLRequest,
+                        requestStartTime: Date) {
+        if !retryScheduled, let response = response {
+            request.completionHandler?(response)
         }
 
         self.requestTimeoutManager.recordRequestResult(requestTimeoutResult)
@@ -595,6 +712,9 @@ private extension HTTPClient {
     }
 
     func start(request: Request) {
+        var request = request
+        request.resolveAPISourceIfNeeded(with: self.apiSourceFailover)
+
         let urlRequest = self.convert(request: request)
 
         guard let urlRequest = urlRequest else {
@@ -660,7 +780,7 @@ private extension HTTPClient {
     func convert(request: Request) -> URLRequest? {
         guard let requestURL = request.getCurrentRequestURL(
             proxyURL: SystemInfo.proxyURL,
-            apiSourceURL: self.apiSourceURL(for: request)
+            apiSourceURL: request.apiSource?.url
         ) else {
             return nil
         }
@@ -676,24 +796,6 @@ private extension HTTPClient {
         }
 
         return urlRequest
-    }
-
-    /// The API base source URL to use for `request`, or `nil` to fall back to the path's `serverHostURL`.
-    ///
-    /// API sources apply only when: the `usesRemoteConfigAPISources` dangerous setting is enabled, no proxy
-    /// is configured (a proxy pins every request to itself), the request is not already targeting an endpoint
-    /// fallback host, the path opts in via `usesAPISources`, and `SystemInfo.apiBaseURL` still holds its
-    /// default (an override pins the host, e.g. in tests).
-    private func apiSourceURL(for request: Request) -> URL? {
-        guard self.systemInfo.dangerousSettings.internalSettings.usesRemoteConfigAPISources,
-              SystemInfo.proxyURL == nil,
-              !request.isFallbackURLRequest,
-              request.httpRequest.path.usesAPISources,
-              SystemInfo.apiBaseURL == SystemInfo.defaultApiBaseURL,
-              let source = self.apiSourceProvider?.currentAPISource() else {
-            return nil
-        }
-        return URL(string: source.url)
     }
 
     private func headers(for request: Request, urlRequest: URLRequest) -> HTTPClient.RequestHeaders {

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -684,6 +684,8 @@ private extension HTTPClient {
             return true
 
         case .sourceHealthy, .sourcesExhausted:
+            // Declining to switch sources doesn't disable the pre-existing static fallback: the
+            // request still failed, so endpoints with fallback hosts keep retrying there as before.
             return self.retryRequestWithNextFallbackHostIfNeeded(request: request, error: error)
                 || self.retryRequestIfNeeded(request: request, httpURLResponse: httpURLResponse)
         }

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -613,8 +613,8 @@ private extension HTTPClient {
                 // request targeting an API source may fail over to the next source, but only after the
                 // current source's health check fails. The decision is asynchronous: the serial pipeline
                 // stays stalled (as if the request were still in flight) until it completes.
-                if let source = request.apiSourceState.source,
-                   request.apiSourceState.attemptCount < Self.maxAPISourceAttempts,
+                if case let .source(source, attemptCount) = request.apiSourceState,
+                   attemptCount < Self.maxAPISourceAttempts,
                    error.isAllowedToRetryWithFallbackHost,
                    let apiSourceFailover = self.apiSourceFailover {
                     let requestTimeoutResult = requestTimeoutResult

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -266,6 +266,33 @@ internal extension HTTPClient {
         static let initial: Self = .init(queuedRequests: [], currentSerialRequest: nil)
     }
 
+    /// The API-source resolution state of a request, modeled as one value so an inconsistent
+    /// combination (e.g. a targeted source without an attempt count) is unrepresentable.
+    enum APISourceState {
+
+        /// Source resolution hasn't run yet for this logical request.
+        case unresolved
+
+        /// Resolution ran and API sources don't apply (setting disabled, proxy or overridden
+        /// base URL, endpoint fallback attempt, opted-out path, or an exhausted source list).
+        case noSource
+
+        /// The request targets `source`; `attemptCount` is the number of source attempts made
+        /// by this logical request so far (1 when a source is first resolved, +1 per failover).
+        case source(APISourceFailover.ResolvedSource, attemptCount: Int)
+
+        var source: APISourceFailover.ResolvedSource? {
+            guard case let .source(source, _) = self else { return nil }
+            return source
+        }
+
+        var attemptCount: Int {
+            guard case let .source(_, attemptCount) = self else { return 0 }
+            return attemptCount
+        }
+
+    }
+
     struct Request: CustomStringConvertible {
 
         var httpRequest: HTTPRequest
@@ -287,18 +314,9 @@ internal extension HTTPClient {
             return self.fallbackUrlIndex != nil
         }
 
-        /// The API source this request targets, if it resolved one. Carried on the request so a
-        /// failure can report the exact handle unhealthy, and so retries of any kind (ETag refresh,
-        /// status-code backoff) keep targeting the same host.
-        private(set) var apiSource: APISourceFailover.ResolvedSource?
-
-        /// Whether source resolution already ran for this logical request (distinguishes "not yet
-        /// resolved" from "resolved to no source").
-        private(set) var apiSourceResolved: Bool = false
-
-        /// Attempts made on API sources for this logical request: 1 when a source is first resolved,
-        /// +1 per failover to the next source.
-        private(set) var apiSourceAttemptCount: Int = 0
+        /// Carried on the request so a failure can report the exact handle unhealthy, and so
+        /// retries of any kind (ETag refresh, status-code backoff) keep targeting the same host.
+        private(set) var apiSourceState: APISourceState = .unresolved
 
         init<Value: HTTPResponseBody>(httpRequest: HTTPRequest,
                                       authHeaders: HTTPClient.RequestHeaders,
@@ -345,20 +363,19 @@ internal extension HTTPClient {
         /// Resolves the API source once per logical request. Retries of any kind keep the carried
         /// source instead of re-resolving, so they deterministically target the same host.
         mutating func resolveAPISourceIfNeeded(with failover: APISourceFailoverType?) {
-            guard !self.apiSourceResolved else { return }
-            self.apiSourceResolved = true
-            guard let source = failover?.currentSource(for: self.httpRequest.path,
-                                                       isFallbackAttempt: self.isFallbackURLRequest) else {
-                return
+            guard case .unresolved = self.apiSourceState else { return }
+            if let source = failover?.currentSource(for: self.httpRequest.path,
+                                                    isFallbackAttempt: self.isFallbackURLRequest) {
+                self.apiSourceState = .source(source, attemptCount: 1)
+            } else {
+                self.apiSourceState = .noSource
             }
-            self.apiSource = source
-            self.apiSourceAttemptCount = 1
         }
 
         func requestWith(nextAPISource: APISourceFailover.ResolvedSource) -> Self {
             var copy = self
-            copy.apiSource = nextAPISource
-            copy.apiSourceAttemptCount += 1
+            copy.apiSourceState = .source(nextAPISource,
+                                          attemptCount: self.apiSourceState.attemptCount + 1)
             return copy
         }
 
@@ -371,7 +388,7 @@ internal extension HTTPClient {
             copy.fallbackUrlIndex = self.fallbackUrlIndex?.advanced(by: 1) ?? 0
             // The static fallback walk drops the API source: fallback attempts pin their own host and
             // must not re-enter source failover.
-            copy.apiSource = nil
+            copy.apiSourceState = .noSource
             guard copy.getCurrentRequestURL(proxyURL: nil, apiSourceURL: nil) != nil else {
                 // No more fallback hosts available
                 return nil
@@ -596,8 +613,8 @@ private extension HTTPClient {
                 // request targeting an API source may fail over to the next source, but only after the
                 // current source's health check fails. The decision is asynchronous: the serial pipeline
                 // stays stalled (as if the request were still in flight) until it completes.
-                if let source = request.apiSource,
-                   request.apiSourceAttemptCount < Self.maxAPISourceAttempts,
+                if let source = request.apiSourceState.source,
+                   request.apiSourceState.attemptCount < Self.maxAPISourceAttempts,
                    error.isAllowedToRetryWithFallbackHost,
                    let apiSourceFailover = self.apiSourceFailover {
                     let requestTimeoutResult = requestTimeoutResult
@@ -780,7 +797,7 @@ private extension HTTPClient {
     func convert(request: Request) -> URLRequest? {
         guard let requestURL = request.getCurrentRequestURL(
             proxyURL: SystemInfo.proxyURL,
-            apiSourceURL: request.apiSource?.url
+            apiSourceURL: request.apiSourceState.source?.url
         ) else {
             return nil
         }

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -286,11 +286,6 @@ internal extension HTTPClient {
             return source
         }
 
-        var attemptCount: Int {
-            guard case let .source(_, attemptCount) = self else { return 0 }
-            return attemptCount
-        }
-
     }
 
     struct Request: CustomStringConvertible {
@@ -372,10 +367,15 @@ internal extension HTTPClient {
             }
         }
 
+        /// Only meaningful on a request that is already targeting a source (a failover decision can
+        /// only come from one); the previous attempt count carries over and increments.
         func requestWith(nextAPISource: APISourceFailover.ResolvedSource) -> Self {
+            guard case let .source(_, attemptCount) = self.apiSourceState else {
+                assertionFailure("Retrying on a next API source requires a current one")
+                return self
+            }
             var copy = self
-            copy.apiSourceState = .source(nextAPISource,
-                                          attemptCount: self.apiSourceState.attemptCount + 1)
+            copy.apiSourceState = .source(nextAPISource, attemptCount: attemptCount + 1)
             return copy
         }
 

--- a/Sources/Networking/RemoteConfigSourceProvider.swift
+++ b/Sources/Networking/RemoteConfigSourceProvider.swift
@@ -111,7 +111,8 @@ final class RemoteConfigSourceProvider: RemoteConfigSourceProviderType {
         RemoteConfigSource(url: "https://api.rc-backup.com/", priority: 100_001, weight: 1)
     ]
 
-    private static let apiFailoverRestartInterval: TimeInterval = 600
+    // Visible for tests.
+    static let apiFailoverRestartInterval: TimeInterval = 2 * 60 * 60
 
     private let topicStore: RemoteConfigTopicStoreType?
     private let randomizer: WeightedSourceRandomizer?

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -97,7 +97,7 @@ class MockHTTPClient: HTTPClient {
                    dnsChecker: dnsChecker,
                    requestTimeout: requestTimeout,
                    operationDispatcher: MockOperationDispatcher(),
-                   apiSourceProvider: nil)
+                   apiSourceFailover: nil)
     }
 
     /// Disables snapshot testing for this mock HTTP client.

--- a/Tests/UnitTests/Networking/Backend/BackendAPISourceFailoverIntegrationTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendAPISourceFailoverIntegrationTests.swift
@@ -186,6 +186,46 @@ final class BackendAPISourceFailoverIntegrationTests: TestCase {
         expect(sourceB.value).to(beEmpty())
     }
 
+    func testBothHTTPClientLanesShareTheSameFailover() {
+        // Backend builds one APISourceFailover for both the main HTTPClient and the dedicated
+        // remote-config lane: a failover triggered by one lane must advance the source list (and
+        // reuse the health-check verdict) for the other.
+        let sourceA = self.stubSource(host: Self.sourceAHost,
+                                      endpoint: { Self.response(500) },
+                                      health: { Self.response(503) })
+        let sourceB: Atomic<[String]> = .init([])
+        stub(condition: isHost(Self.sourceBHost)) { request in
+            let path = request.url?.path ?? ""
+            sourceB.modify { $0.append(path) }
+            if path.hasPrefix("/v1/config") {
+                return HTTPStubsResponse(data: Data(), statusCode: 204, headers: nil)
+            }
+            return Self.customerInfoResponse()
+        }
+        let backend = Self.createBackend(sources: [Self.sourceAHost, Self.sourceBHost])
+
+        // The main lane fails over A -> B.
+        let result = self.fetchCustomerInfo(backend)
+
+        expect(result).to(beSuccess())
+        expect(sourceA.value) == [Self.customerInfoPath, Self.healthPath]
+        expect(sourceB.value) == [Self.customerInfoPath]
+
+        // The remote-config lane starts directly on B: no request or probe ever reaches A again.
+        let configResult: Result<RemoteConfigFetchResult, BackendError>? = waitUntilValue { completion in
+            backend.remoteConfigAPI.getRemoteConfig(
+                request: .init(fetchContext: .appStart, appUserID: Self.appUserID),
+                isAppBackgrounded: false,
+                completion: completion
+            )
+        }
+
+        expect(configResult).to(beSuccess())
+        expect(sourceA.value) == [Self.customerInfoPath, Self.healthPath]
+        expect(sourceB.value.count) == 2
+        expect(sourceB.value.last).to(beginWith("/v1/config"))
+    }
+
     // MARK: - Helpers
 
     /// Wires the production stack: the `Backend` convenience init builds the real `HTTPClient`s, the

--- a/Tests/UnitTests/Networking/Backend/BackendAPISourceFailoverIntegrationTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendAPISourceFailoverIntegrationTests.swift
@@ -1,0 +1,294 @@
+//
+//  BackendAPISourceFailoverIntegrationTests.swift
+//  RevenueCat
+//
+//  Created by Toni Rico on 27/07/2026.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Nimble
+import OHHTTPStubs
+import OHHTTPStubsSwift
+import XCTest
+
+@testable import RevenueCat
+
+/// End-to-end coverage of API source failover through a real `Backend.getCustomerInfo` request: the
+/// production wiring built by the `Backend` convenience init (real `HTTPClient`s, one shared
+/// `APISourceFailover`, real `SourceHealthChecker` whose probes go over the URL loading system) and a
+/// real `RemoteConfigSourceProvider` fed by an in-memory `sources` topic. OHHTTPStubs stands in for
+/// the source hosts, routing each host's API endpoint and its `/v1/health/connectivity` endpoint by
+/// path and recording the exact request order, mirroring purchases-android's
+/// `BackendAPISourceFailoverIntegrationTest`.
+final class BackendAPISourceFailoverIntegrationTests: TestCase {
+
+    private static let appUserID = "integration-test-user"
+    private static let customerInfoPath = "/v1/subscribers/integration-test-user"
+    private static let healthPath = "/v1/health/connectivity"
+
+    private static let sourceAHost = "source-a.rc-test.com"
+    private static let sourceBHost = "source-b.rc-test.com"
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        #if os(watchOS)
+        // See https://github.com/AliSoftware/OHHTTPStubs/issues/287
+        try XCTSkipIf(true, "OHHTTPStubs does not currently support watchOS")
+        #endif
+    }
+
+    override func tearDown() {
+        HTTPStubs.removeAllStubs()
+
+        super.tearDown()
+    }
+
+    func testGetCustomerInfoSucceedsOnThePrimarySourceWithoutHealthChecks() {
+        let sourceA = self.stubSource(host: Self.sourceAHost, endpoint: Self.customerInfoResponse)
+        let sourceB = self.stubSource(host: Self.sourceBHost, endpoint: Self.customerInfoResponse)
+        let backend = Self.createBackend(sources: [Self.sourceAHost, Self.sourceBHost])
+
+        let result = self.fetchCustomerInfo(backend)
+
+        expect(result).to(beSuccess())
+        expect(sourceA.value) == [Self.customerInfoPath]
+        expect(sourceB.value).to(beEmpty())
+    }
+
+    func testGetCustomerInfoSurfacesA5xxWithoutFailingOverWhenTheSourceIsHealthy() {
+        let sourceA = self.stubSource(host: Self.sourceAHost,
+                                      endpoint: { Self.response(500) },
+                                      health: { Self.response(200) })
+        let sourceB = self.stubSource(host: Self.sourceBHost, endpoint: Self.customerInfoResponse)
+        let backend = Self.createBackend(sources: [Self.sourceAHost, Self.sourceBHost])
+
+        let result = self.fetchCustomerInfo(backend)
+
+        expect(result).to(beFailure())
+        expect(self.isServerError(result)) == true
+        expect(sourceA.value) == [Self.customerInfoPath, Self.healthPath]
+        expect(sourceB.value).to(beEmpty())
+    }
+
+    func testGetCustomerInfoFailsOverOnA5xxWhenTheSourceIsUnhealthyAndStaysFailedOver() {
+        let sourceA = self.stubSource(host: Self.sourceAHost,
+                                      endpoint: { Self.response(500) },
+                                      health: { Self.response(503) })
+        let sourceB = self.stubSource(host: Self.sourceBHost, endpoint: Self.customerInfoResponse)
+        let backend = Self.createBackend(sources: [Self.sourceAHost, Self.sourceBHost])
+
+        let result = self.fetchCustomerInfo(backend)
+
+        expect(result).to(beSuccess())
+        expect(sourceA.value) == [Self.customerInfoPath, Self.healthPath]
+        expect(sourceB.value) == [Self.customerInfoPath]
+
+        // The provider advanced, so a subsequent request goes straight to the second source.
+        let secondResult = self.fetchCustomerInfo(backend)
+
+        expect(secondResult).to(beSuccess())
+        expect(sourceA.value) == [Self.customerInfoPath, Self.healthPath]
+        expect(sourceB.value) == [Self.customerInfoPath, Self.customerInfoPath]
+    }
+
+    func testGetCustomerInfoFailsOverWhenTheSourceIsUnreachable() {
+        // Both the API request and the health probe fail at the connection level, like a host whose
+        // port refuses connections.
+        let sourceA = self.stubSource(host: Self.sourceAHost,
+                                      endpoint: Self.connectionRefused,
+                                      health: Self.connectionRefused)
+        let sourceB = self.stubSource(host: Self.sourceBHost, endpoint: Self.customerInfoResponse)
+        let backend = Self.createBackend(sources: [Self.sourceAHost, Self.sourceBHost])
+
+        let result = self.fetchCustomerInfo(backend)
+
+        expect(result).to(beSuccess())
+        expect(sourceA.value) == [Self.customerInfoPath, Self.healthPath]
+        expect(sourceB.value) == [Self.customerInfoPath]
+    }
+
+    func testGetCustomerInfoSurfacesAConnectionErrorWithoutFailingOverWhenTheSourceIsHealthy() {
+        let sourceA = self.stubSource(host: Self.sourceAHost,
+                                      endpoint: Self.connectionRefused,
+                                      health: { Self.response(200) })
+        let sourceB = self.stubSource(host: Self.sourceBHost, endpoint: Self.customerInfoResponse)
+        let backend = Self.createBackend(sources: [Self.sourceAHost, Self.sourceBHost])
+
+        let result = self.fetchCustomerInfo(backend)
+
+        expect(result).to(beFailure())
+        expect(self.isServerError(result)) == false
+        // The health check ran and passed, and we still never failed over to the second source.
+        expect(sourceA.value) == [Self.customerInfoPath, Self.healthPath]
+        expect(sourceB.value).to(beEmpty())
+    }
+
+    func testGetCustomerInfoSurfacesTheErrorOnceEverySourceIsUnhealthy() {
+        let sourceA = self.stubSource(host: Self.sourceAHost,
+                                      endpoint: { Self.response(500) },
+                                      health: { Self.response(503) })
+        let sourceB = self.stubSource(host: Self.sourceBHost,
+                                      endpoint: { Self.response(500) },
+                                      health: { Self.response(503) })
+        let backend = Self.createBackend(sources: [Self.sourceAHost, Self.sourceBHost])
+
+        let result = self.fetchCustomerInfo(backend)
+
+        expect(result).to(beFailure())
+        expect(self.isServerError(result)) == true
+        expect(sourceA.value) == [Self.customerInfoPath, Self.healthPath]
+        expect(sourceB.value) == [Self.customerInfoPath, Self.healthPath]
+    }
+
+    func testGetCustomerInfoDoesNotFailOverOrHealthCheckOnA4xx() {
+        let sourceA = self.stubSource(host: Self.sourceAHost,
+                                      endpoint: { Self.response(404) },
+                                      health: { Self.response(200) })
+        let sourceB = self.stubSource(host: Self.sourceBHost, endpoint: Self.customerInfoResponse)
+        let backend = Self.createBackend(sources: [Self.sourceAHost, Self.sourceBHost])
+
+        let result = self.fetchCustomerInfo(backend)
+
+        expect(result).to(beFailure())
+        expect(self.isServerError(result)) == false
+        expect(sourceA.value) == [Self.customerInfoPath]
+        expect(sourceB.value).to(beEmpty())
+    }
+
+    func testGetCustomerInfoDoesNotFailOverOrHealthCheckOnADeviceConnectivityError() {
+        // iOS-specific behavior with no Android counterpart: the device being offline is
+        // distinguishable from a host outage, so the SDK fails directly without probing the source.
+        let sourceA = self.stubSource(host: Self.sourceAHost,
+                                      endpoint: { HTTPStubsResponse(error: URLError(.notConnectedToInternet)) },
+                                      health: { Self.response(200) })
+        let sourceB = self.stubSource(host: Self.sourceBHost, endpoint: Self.customerInfoResponse)
+        let backend = Self.createBackend(sources: [Self.sourceAHost, Self.sourceBHost])
+
+        let result = self.fetchCustomerInfo(backend)
+
+        expect(result).to(beFailure())
+        expect(sourceA.value) == [Self.customerInfoPath]
+        expect(sourceB.value).to(beEmpty())
+    }
+
+    func testGetCustomerInfoIgnoresSourcesWhenTheDangerousSettingIsDisabled() {
+        let sourceA = self.stubSource(host: Self.sourceAHost, endpoint: Self.customerInfoResponse)
+        let sourceB = self.stubSource(host: Self.sourceBHost, endpoint: Self.customerInfoResponse)
+        let defaultHost = self.stubSource(host: "api.revenuecat.com", endpoint: Self.customerInfoResponse)
+        let backend = Self.createBackend(sources: [Self.sourceAHost, Self.sourceBHost],
+                                         usesRemoteConfigAPISources: false)
+
+        let result = self.fetchCustomerInfo(backend)
+
+        expect(result).to(beSuccess())
+        expect(defaultHost.value) == [Self.customerInfoPath]
+        expect(sourceA.value).to(beEmpty())
+        expect(sourceB.value).to(beEmpty())
+    }
+
+    // MARK: - Helpers
+
+    /// Wires the production stack: the `Backend` convenience init builds the real `HTTPClient`s, the
+    /// shared `APISourceFailover` and the real `SourceHealthChecker`; sources come from an in-memory
+    /// `sources` topic pointing at `sources` in order.
+    private static func createBackend(sources: [String], usesRemoteConfigAPISources: Bool = true) -> Backend {
+        let systemInfo = MockSystemInfo(
+            finishTransactions: true,
+            dangerousSettings: DangerousSettings(
+                autoSyncPurchases: true,
+                internalSettings: DangerousSettings.Internal(
+                    usesRemoteConfigAPISources: usesRemoteConfigAPISources
+                )
+            )
+        )
+        return Backend(
+            systemInfo: systemInfo,
+            eTagManager: MockETagManager(),
+            operationDispatcher: OperationDispatcher(),
+            attributionFetcher: AttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
+                                                   systemInfo: systemInfo),
+            offlineCustomerInfoCreator: nil,
+            diagnosticsTracker: nil,
+            apiSourceProvider: RemoteConfigSourceProvider(
+                topicStore: APISourceTopicStore(urls: sources.map { "https://\($0)/" })
+            )
+        )
+    }
+
+    private func fetchCustomerInfo(_ backend: Backend) -> Result<CustomerInfo, BackendError>? {
+        return waitUntilValue { completion in
+            backend.getCustomerInfo(appUserID: Self.appUserID,
+                                    isAppBackgrounded: false,
+                                    allowComputingOffline: false) {
+                completion($0)
+            }
+        }
+    }
+
+    private func isServerError(_ result: Result<CustomerInfo, BackendError>?) -> Bool {
+        guard case let .failure(.networkError(networkError)) = result else { return false }
+        return networkError.isServerDown
+    }
+
+    /// Stubs `host`, routing its health endpoint and its API endpoint by path (like Android's
+    /// path-routing MockWebServer dispatcher) and recording every request's path in order.
+    private func stubSource(
+        host: String,
+        endpoint: @escaping () -> HTTPStubsResponse,
+        health: @escaping () -> HTTPStubsResponse = {
+            BackendAPISourceFailoverIntegrationTests.response(200)
+        }
+    ) -> Atomic<[String]> {
+        let recordedPaths: Atomic<[String]> = .init([])
+        stub(condition: isHost(host)) { request in
+            let path = request.url?.path ?? ""
+            recordedPaths.modify { $0.append(path) }
+            return path == Self.healthPath ? health() : endpoint()
+        }
+        return recordedPaths
+    }
+
+    private static func response(_ statusCode: Int32) -> HTTPStubsResponse {
+        return HTTPStubsResponse(jsonObject: BaseBackendTests.serverErrorResponse,
+                                 statusCode: statusCode,
+                                 headers: nil)
+    }
+
+    private static func customerInfoResponse() -> HTTPStubsResponse {
+        return HTTPStubsResponse(jsonObject: BaseBackendTests.validCustomerResponse,
+                                 statusCode: 200,
+                                 headers: nil)
+    }
+
+    /// A connection-level failure with the same `NSURLErrorDomain` classification as a real host
+    /// whose port refuses connections.
+    private static func connectionRefused() -> HTTPStubsResponse {
+        return HTTPStubsResponse(error: URLError(.cannotConnectToHost))
+    }
+
+}
+
+/// A minimal `sources` topic store exposing API sources in order (priority = index), matching the
+/// backend topic shape.
+private final class APISourceTopicStore: RemoteConfigTopicStoreType {
+
+    private let urls: [String]
+
+    init(urls: [String]) {
+        self.urls = urls
+    }
+
+    func topic(_ topic: RemoteConfigTopic) -> RemoteConfiguration.ConfigTopic? {
+        guard topic == .sources else { return nil }
+        return ["api": RemoteConfiguration.ConfigItem(content: [
+            "sources": .array(self.urls.enumerated().map { priority, url in
+                .object([
+                    "url": .string(url),
+                    "priority": .int(priority),
+                    "weight": .int(1)
+                ])
+            })
+        ])]
+    }
+
+}

--- a/Tests/UnitTests/Networking/Backend/BackendRemoteConfigLaneTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendRemoteConfigLaneTests.swift
@@ -130,7 +130,7 @@ final class BackendRemoteConfigLaneParallelTests: TestCase {
                               diagnosticsTracker: nil,
                               requestTimeout: 30,
                               operationDispatcher: OperationDispatcher(),
-                              apiSourceProvider: nil)
+                              apiSourceFailover: nil)
         }
 
         func makeConfig(_ client: HTTPClient, _ queue: OperationQueue) -> BackendConfiguration {

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -78,7 +78,8 @@ class BaseHTTPClientTests<ETag: ETagManager, TimeoutManager: HTTPRequestTimeoutM
         // The real `SourceHealthChecker` default keeps health probes visible to OHHTTPStubs; tests
         // that need a fixed health result inject a `MockSourceHealthChecker` instead.
         let apiSourceFailover = apiSourceProvider.map {
-            APISourceFailover(dangerousSettings: systemInfo.dangerousSettings,
+            APISourceFailover(usesRemoteConfigAPISources:
+                                systemInfo.dangerousSettings.internalSettings.usesRemoteConfigAPISources,
                               sourceProvider: $0,
                               healthChecker: sourceHealthChecker)
         }

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -72,8 +72,16 @@ class BaseHTTPClientTests<ETag: ETagManager, TimeoutManager: HTTPRequestTimeoutM
     fileprivate final func createClient(
         _ systemInfo: SystemInfo,
         operationDispatcher: OperationDispatcher = MockOperationDispatcher(),
-        apiSourceProvider: RemoteConfigSourceProviderType? = nil
+        apiSourceProvider: RemoteConfigSourceProviderType? = nil,
+        sourceHealthChecker: SourceHealthCheckerType = SourceHealthChecker()
     ) -> HTTPClient {
+        // The real `SourceHealthChecker` default keeps health probes visible to OHHTTPStubs; tests
+        // that need a fixed health result inject a `MockSourceHealthChecker` instead.
+        let apiSourceFailover = apiSourceProvider.map {
+            APISourceFailover(dangerousSettings: systemInfo.dangerousSettings,
+                              sourceProvider: $0,
+                              healthChecker: sourceHealthChecker)
+        }
         return HTTPClient(systemInfo: systemInfo,
                           eTagManager: self.eTagManager,
                           signing: self.signing,
@@ -81,7 +89,7 @@ class BaseHTTPClientTests<ETag: ETagManager, TimeoutManager: HTTPRequestTimeoutM
                           dnsChecker: MockDNSChecker.self,
                           requestTimeout: defaultRequestTimeout,
                           operationDispatcher: operationDispatcher,
-                          apiSourceProvider: apiSourceProvider,
+                          apiSourceFailover: apiSourceFailover,
                           timeoutManager: timeoutManager)
     }
 }
@@ -255,6 +263,260 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
 
         expect(result).to(beSuccess())
         expect(apiSourceRequests.value) == 2
+    }
+
+    // MARK: - API source failover
+
+    private static let healthCheckPath = "/v1/health/connectivity"
+
+    /// Stubs `host`, counting and answering its health probes and its regular requests separately.
+    private func stubHost(
+        _ host: String,
+        healthStatusCode: Int32 = 200,
+        response: @escaping () -> HTTPStubsResponse
+    ) -> (healthChecks: Atomic<Int>, requests: Atomic<Int>) {
+        let healthChecks: Atomic<Int> = .init(0)
+        let requests: Atomic<Int> = .init(0)
+        stub(condition: isHost(host) && isPath(Self.healthCheckPath)) { _ in
+            healthChecks.modify { $0 += 1 }
+            return HTTPStubsResponse(data: Data(), statusCode: healthStatusCode, headers: nil)
+        }
+        stub(condition: isHost(host) && !isPath(Self.healthCheckPath)) { _ in
+            requests.modify { $0 += 1 }
+            return response()
+        }
+        return (healthChecks, requests)
+    }
+
+    func testFallsBackToNextAPISourceWhenCurrentSourceFails() {
+        let firstHost = "first-api.rc-test.com"
+        let secondHost = "second-api.rc-test.com"
+        let client = self.createClient(
+            self.systemInfoUsingAPISources(),
+            apiSourceProvider: Self.apiSourceProvider(hosts: [firstHost, secondHost])
+        )
+
+        let first = self.stubHost(firstHost, healthStatusCode: 500) { .serverDownResponse() }
+        let second = self.stubHost(secondHost) { .emptySuccessResponse() }
+
+        let result: EmptyResponse? = waitUntilValue { completion in
+            client.perform(.init(method: .get, path: .mockPath)) { completion($0) }
+        }
+
+        expect(result).to(beSuccess())
+        expect(first.requests.value) == 1
+        expect(first.healthChecks.value) == 1
+        expect(second.requests.value) == 1
+    }
+
+    func testDoesNotFailOverWhenSourceIsHealthyDespiteServerError() {
+        let firstHost = "first-api.rc-test.com"
+        let secondHost = "second-api.rc-test.com"
+        let client = self.createClient(
+            self.systemInfoUsingAPISources(),
+            apiSourceProvider: Self.apiSourceProvider(hosts: [firstHost, secondHost])
+        )
+
+        let first = self.stubHost(firstHost, healthStatusCode: 200) { .serverDownResponse() }
+        let second = self.stubHost(secondHost) { .emptySuccessResponse() }
+
+        let result: EmptyResponse? = waitUntilValue { completion in
+            client.perform(.init(method: .get, path: .mockPath)) { completion($0) }
+        }
+
+        // The source is healthy, so the request failure was not a source outage: the original
+        // error surfaces without switching hosts.
+        expect(result).to(beFailure())
+        expect(first.requests.value) == 1
+        expect(first.healthChecks.value) == 1
+        expect(second.requests.value) == 0
+    }
+
+    func test4xxDoesNotFailOverAndDoesNotHealthCheck() {
+        let firstHost = "first-api.rc-test.com"
+        let secondHost = "second-api.rc-test.com"
+        let client = self.createClient(
+            self.systemInfoUsingAPISources(),
+            apiSourceProvider: Self.apiSourceProvider(hosts: [firstHost, secondHost])
+        )
+
+        let first = self.stubHost(firstHost) {
+            HTTPStubsResponse(data: Data(), statusCode: 400, headers: nil)
+        }
+        let second = self.stubHost(secondHost) { .emptySuccessResponse() }
+
+        let result: EmptyResponse? = waitUntilValue { completion in
+            client.perform(.init(method: .get, path: .mockPath)) { completion($0) }
+        }
+
+        expect(result).to(beFailure())
+        expect(first.requests.value) == 1
+        expect(first.healthChecks.value) == 0
+        expect(second.requests.value) == 0
+    }
+
+    func testFailsOverOnConnectionFailureWhenHealthCheckFails() {
+        let firstHost = "first-api.rc-test.com"
+        let secondHost = "second-api.rc-test.com"
+        let client = self.createClient(
+            self.systemInfoUsingAPISources(),
+            apiSourceProvider: Self.apiSourceProvider(hosts: [firstHost, secondHost])
+        )
+
+        let first = self.stubHost(firstHost, healthStatusCode: 500) {
+            HTTPStubsResponse(error: URLError(.cannotConnectToHost))
+        }
+        let second = self.stubHost(secondHost) { .emptySuccessResponse() }
+
+        let result: EmptyResponse? = waitUntilValue { completion in
+            client.perform(.init(method: .get, path: .mockPath)) { completion($0) }
+        }
+
+        expect(result).to(beSuccess())
+        expect(first.requests.value) == 1
+        expect(second.requests.value) == 1
+    }
+
+    func testDoesNotFailOverOnConnectionFailureWhenSourceIsHealthy() {
+        let firstHost = "first-api.rc-test.com"
+        let secondHost = "second-api.rc-test.com"
+        let client = self.createClient(
+            self.systemInfoUsingAPISources(),
+            apiSourceProvider: Self.apiSourceProvider(hosts: [firstHost, secondHost])
+        )
+
+        let first = self.stubHost(firstHost, healthStatusCode: 200) {
+            HTTPStubsResponse(error: URLError(.cannotConnectToHost))
+        }
+        let second = self.stubHost(secondHost) { .emptySuccessResponse() }
+
+        let result: EmptyResponse? = waitUntilValue { completion in
+            client.perform(.init(method: .get, path: .mockPath)) { completion($0) }
+        }
+
+        expect(result).to(beFailure())
+        expect(first.healthChecks.value) == 1
+        expect(second.requests.value) == 0
+    }
+
+    func testDoesNotHealthCheckOrFailOverOnDeviceConnectivityError() {
+        // Unlike Android, iOS can tell a device-connectivity failure apart from a host outage using
+        // the original request's URLError code. Switching hosts can't fix a device without
+        // connectivity, so the health check endpoint must not even be probed.
+        let firstHost = "first-api.rc-test.com"
+        let secondHost = "second-api.rc-test.com"
+        let client = self.createClient(
+            self.systemInfoUsingAPISources(),
+            apiSourceProvider: Self.apiSourceProvider(hosts: [firstHost, secondHost])
+        )
+
+        let first = self.stubHost(firstHost) {
+            HTTPStubsResponse(error: URLError(.notConnectedToInternet))
+        }
+        let second = self.stubHost(secondHost) { .emptySuccessResponse() }
+
+        let result: EmptyResponse? = waitUntilValue { completion in
+            client.perform(.init(method: .get, path: .mockPath)) { completion($0) }
+        }
+
+        expect(result).to(beFailure())
+        expect(first.requests.value) == 1
+        expect(first.healthChecks.value) == 0
+        expect(second.requests.value) == 0
+    }
+
+    func testSurfacesOriginalErrorOnceSourcesAreExhausted() {
+        let firstHost = "first-api.rc-test.com"
+        let secondHost = "second-api.rc-test.com"
+        let client = self.createClient(
+            self.systemInfoUsingAPISources(),
+            apiSourceProvider: Self.apiSourceProvider(hosts: [firstHost, secondHost])
+        )
+
+        let first = self.stubHost(firstHost, healthStatusCode: 500) { .serverDownResponse() }
+        let second = self.stubHost(secondHost, healthStatusCode: 500) { .serverDownResponse() }
+
+        let result: EmptyResponse? = waitUntilValue { completion in
+            client.perform(.init(method: .get, path: .mockPath)) { completion($0) }
+        }
+
+        expect(result).to(beFailure())
+        expect(first.requests.value) == 1
+        expect(second.requests.value) == 1
+    }
+
+    func testUsesStaticFallbackHostOnceSourcesAreExhausted() {
+        let firstHost = "first-api.rc-test.com"
+        let secondHost = "second-api.rc-test.com"
+        let client = self.createClient(
+            self.systemInfoUsingAPISources(),
+            apiSourceProvider: Self.apiSourceProvider(hosts: [firstHost, secondHost])
+        )
+
+        let first = self.stubHost(firstHost, healthStatusCode: 500) { .serverDownResponse() }
+        let second = self.stubHost(secondHost, healthStatusCode: 500) { .serverDownResponse() }
+        let fallback = self.stubHost("api-production.8-lives-cat.io") { .emptySuccessResponse() }
+
+        let result: EmptyResponse? = waitUntilValue { completion in
+            client.perform(.init(method: .get, path: .mockPathWithFallbacks)) { completion($0) }
+        }
+
+        // The static per-endpoint fallback host stays the last resort once every source declined.
+        expect(result).to(beSuccess())
+        expect(first.requests.value) == 1
+        expect(second.requests.value) == 1
+        expect(fallback.requests.value) == 1
+    }
+
+    func testPostRetriesWithItsBodyOnTheNextAPISource() throws {
+        let firstHost = "first-api.rc-test.com"
+        let secondHost = "second-api.rc-test.com"
+        let client = self.createClient(
+            self.systemInfoUsingAPISources(),
+            apiSourceProvider: Self.apiSourceProvider(hosts: [firstHost, secondHost])
+        )
+
+        let body = AnyEncodableRequestBody(["arg": "value"])
+        let bodyData = try JSONEncoder.default.encode(body)
+
+        let first = self.stubHost(firstHost, healthStatusCode: 500) { .serverDownResponse() }
+        let secondHostBodyCorrect: Atomic<Bool> = false
+        stub(condition: isHost(secondHost) && hasBody(bodyData)) { _ in
+            secondHostBodyCorrect.value = true
+            return .emptySuccessResponse()
+        }
+
+        let result: EmptyResponse? = waitUntilValue { completion in
+            client.perform(.init(method: .post(body), path: .mockPath)) { completion($0) }
+        }
+
+        expect(result).to(beSuccess())
+        expect(first.requests.value) == 1
+        expect(secondHostBodyCorrect.value) == true
+    }
+
+    func testCapsAPISourceAttemptsWhenTheListKeepsRearming() {
+        let firstHost = "first-api.rc-test.com"
+        let secondHost = "second-api.rc-test.com"
+        // A provider that re-arms its exhausted list on every read, simulating a topic rebuild or
+        // interval restart happening while a request walks the list.
+        let provider = AlwaysRearmingSourceProvider(
+            wrapping: Self.apiSourceProvider(hosts: [firstHost, secondHost])
+        )
+        let client = self.createClient(
+            self.systemInfoUsingAPISources(),
+            apiSourceProvider: provider
+        )
+
+        let first = self.stubHost(firstHost, healthStatusCode: 500) { .serverDownResponse() }
+        let second = self.stubHost(secondHost, healthStatusCode: 500) { .serverDownResponse() }
+
+        let result: EmptyResponse? = waitUntilValue { completion in
+            client.perform(.init(method: .get, path: .mockPath)) { completion($0) }
+        }
+
+        expect(result).to(beFailure())
+        expect(first.requests.value + second.requests.value) == 5
     }
 
     func testPassesHeaders() {
@@ -4175,7 +4437,15 @@ extension HTTPClientTests {
     /// A real `RemoteConfigSourceProvider` whose only API source is `https://<host>/`, so the resolved
     /// base host is unambiguously provider-driven rather than the default `serverHostURL`.
     fileprivate static func apiSourceProvider(host: String) -> RemoteConfigSourceProvider {
-        return RemoteConfigSourceProvider(topicStore: SingleAPISourceTopicStore(url: "https://\(host)/"))
+        return self.apiSourceProvider(hosts: [host])
+    }
+
+    /// A real `RemoteConfigSourceProvider` whose API sources are `https://<host>/` in the given
+    /// (priority) order.
+    fileprivate static func apiSourceProvider(hosts: [String]) -> RemoteConfigSourceProvider {
+        return RemoteConfigSourceProvider(
+            topicStore: APISourceTopicStore(urls: hosts.map { "https://\($0)/" })
+        )
     }
 
     /// A `MockSystemInfo` with the `usesRemoteConfigAPISources` dangerous setting enabled, so API source
@@ -4193,25 +4463,57 @@ extension HTTPClientTests {
 
 }
 
-/// A minimal `sources` topic store exposing a single API source, matching the backend topic shape.
-private final class SingleAPISourceTopicStore: RemoteConfigTopicStoreType {
+/// Re-arms the wrapped provider's exhausted list on every read, simulating a topic rebuild or
+/// interval restart happening while a request walks the list. Used to exercise the API source
+/// attempt cap.
+private final class AlwaysRearmingSourceProvider: RemoteConfigSourceProviderType {
 
-    private let url: String
+    private let wrapped: RemoteConfigSourceProvider
 
-    init(url: String) {
-        self.url = url
+    init(wrapping provider: RemoteConfigSourceProvider) {
+        self.wrapped = provider
+    }
+
+    func getCurrent(for purpose: RemoteConfigSourceHandle.Purpose) -> RemoteConfigSourceHandle? {
+        self.wrapped.restartIfExhausted(for: purpose)
+        return self.wrapped.getCurrent(for: purpose)
+    }
+
+    func reportUnhealthy(_ handle: RemoteConfigSourceHandle) {
+        self.wrapped.reportUnhealthy(handle)
+    }
+
+    func restart(for purpose: RemoteConfigSourceHandle.Purpose) {
+        self.wrapped.restart(for: purpose)
+    }
+
+    @discardableResult
+    func restartIfExhausted(for purpose: RemoteConfigSourceHandle.Purpose) -> Bool {
+        return self.wrapped.restartIfExhausted(for: purpose)
+    }
+
+}
+
+/// A minimal `sources` topic store exposing API sources in order (priority = index), matching the
+/// backend topic shape.
+private final class APISourceTopicStore: RemoteConfigTopicStoreType {
+
+    private let urls: [String]
+
+    init(urls: [String]) {
+        self.urls = urls
     }
 
     func topic(_ topic: RemoteConfigTopic) -> RemoteConfiguration.ConfigTopic? {
         guard topic == .sources else { return nil }
         return ["api": RemoteConfiguration.ConfigItem(content: [
-            "sources": .array([
+            "sources": .array(self.urls.enumerated().map { priority, url in
                 .object([
-                    "url": .string(self.url),
-                    "priority": .int(0),
+                    "url": .string(url),
+                    "priority": .int(priority),
                     "weight": .int(1)
                 ])
-            ])
+            })
         ])]
     }
 

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -520,6 +520,54 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
         expect(first.requests.value + second.requests.value) == 5
     }
 
+    func testRequestQueuedDuringAHealthCheckRunsAfterTheFailoverRetry() {
+        // While the probe is in flight the serial pipeline stays stalled, and the failover retry is
+        // requeued at the front: a request enqueued during the probe must run only after the retry.
+        let firstHost = "first-api.rc-test.com"
+        let secondHost = "second-api.rc-test.com"
+        let client = self.createClient(
+            self.systemInfoUsingAPISources(),
+            apiSourceProvider: Self.apiSourceProvider(hosts: [firstHost, secondHost])
+        )
+
+        let endpointHits: Atomic<[String]> = .init([])
+
+        stub(condition: isHost(firstHost) && isPath(Self.healthCheckPath)) { _ in
+            HTTPStubsResponse(data: Data(), statusCode: 503, headers: nil)
+                .responseTime(0.3)
+        }
+        stub(condition: isHost(firstHost) && !isPath(Self.healthCheckPath)) { request in
+            endpointHits.modify { $0.append("first:\(request.url?.path ?? "")") }
+            return .serverDownResponse()
+        }
+        stub(condition: isHost(secondHost) && !isPath(Self.healthCheckPath)) { request in
+            endpointHits.modify { $0.append("second:\(request.url?.path ?? "")") }
+            return .emptySuccessResponse()
+        }
+
+        let firstRequestPath = HTTPRequest.Path.mockPath.relativePath
+        let queuedRequestPath = HTTPRequest.Path.getCustomerInfo(appUserID: "queued-user").relativePath
+
+        let firstRequestCompleted: Atomic<Bool> = false
+        client.perform(.init(method: .get, path: .mockPath)) { (_: EmptyResponse) in
+            firstRequestCompleted.value = true
+        }
+        // Enqueued while the first request's attempt/probe is in flight.
+        let queuedResult: EmptyResponse? = waitUntilValue(timeout: .seconds(5)) { completion in
+            client.perform(.init(method: .get, path: .getCustomerInfo(appUserID: "queued-user"))) {
+                completion($0)
+            }
+        }
+
+        expect(queuedResult).to(beSuccess())
+        expect(firstRequestCompleted.value) == true
+        expect(endpointHits.value) == [
+            "first:\(firstRequestPath)",
+            "second:\(firstRequestPath)",
+            "second:\(queuedRequestPath)"
+        ]
+    }
+
     func testPassesHeaders() {
         let headerPresent: Atomic<Bool> = false
 

--- a/Tests/UnitTests/Networking/RemoteConfigSourceProviderTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfigSourceProviderTests.swift
@@ -376,6 +376,8 @@ final class RemoteConfigSourceProviderTests: TestCase {
 
     // MARK: - API restart interval (TTL re-arm)
 
+    private static let restartInterval = RemoteConfigSourceProvider.apiFailoverRestartInterval
+
     func testAdvancedAPIListRestartsFromTheTopAfterTheRestartInterval() {
         let dateProvider = MockCurrentDateProvider()
         let provider = Self.apiProvider([Self.source("a"), Self.source("b")], dateProvider: dateProvider)
@@ -383,7 +385,7 @@ final class RemoteConfigSourceProviderTests: TestCase {
         provider.reportUnhealthy(provider.getCurrent(for: .api)!) // a -> b
         expect(provider.getCurrent(for: .api)?.url) == Self.url("b")
 
-        dateProvider.advance(by: 600)
+        dateProvider.advance(by: Self.restartInterval)
         expect(provider.getCurrent(for: .api)?.url) == Self.url("a")
     }
 
@@ -393,7 +395,7 @@ final class RemoteConfigSourceProviderTests: TestCase {
 
         provider.reportUnhealthy(provider.getCurrent(for: .api)!) // a -> b
 
-        dateProvider.advance(by: 599)
+        dateProvider.advance(by: Self.restartInterval - 1)
         expect(provider.getCurrent(for: .api)?.url) == Self.url("b")
     }
 
@@ -405,7 +407,7 @@ final class RemoteConfigSourceProviderTests: TestCase {
         provider.reportUnhealthy(provider.getCurrent(for: .api)!) // b -> exhausted
         expect(provider.getCurrent(for: .api)).to(beNil())
 
-        dateProvider.advance(by: 599)
+        dateProvider.advance(by: Self.restartInterval - 1)
         expect(provider.getCurrent(for: .api)).to(beNil())
 
         dateProvider.advance(by: 1)
@@ -422,10 +424,10 @@ final class RemoteConfigSourceProviderTests: TestCase {
         )
 
         provider.reportUnhealthy(provider.getCurrent(for: .api)!) // a -> b, timer starts
-        dateProvider.advance(by: 500)
+        dateProvider.advance(by: Self.restartInterval - 100)
         provider.reportUnhealthy(provider.getCurrent(for: .api)!) // b -> c, timer unchanged
 
-        dateProvider.advance(by: 100) // 600s since the first advance
+        dateProvider.advance(by: 100) // a full interval since the first advance
         expect(provider.getCurrent(for: .api)?.url) == Self.url("a")
     }
 
@@ -437,7 +439,7 @@ final class RemoteConfigSourceProviderTests: TestCase {
         let stale = provider.getCurrent(for: .api)
         expect(stale?.url) == Self.url("b")
 
-        dateProvider.advance(by: 600)
+        dateProvider.advance(by: Self.restartInterval)
         expect(provider.getCurrent(for: .api)?.url) == Self.url("a")
 
         // The pre-restart handle belongs to the previous cycle, so it must not advance the list.
@@ -450,11 +452,11 @@ final class RemoteConfigSourceProviderTests: TestCase {
         let provider = Self.apiProvider([Self.source("a"), Self.source("b")], dateProvider: dateProvider)
 
         provider.reportUnhealthy(provider.getCurrent(for: .api)!) // a -> b
-        dateProvider.advance(by: 600)
+        dateProvider.advance(by: Self.restartInterval)
         expect(provider.getCurrent(for: .api)?.url) == Self.url("a")
 
         provider.reportUnhealthy(provider.getCurrent(for: .api)!) // a -> b, new timer
-        dateProvider.advance(by: 599)
+        dateProvider.advance(by: Self.restartInterval - 1)
         expect(provider.getCurrent(for: .api)?.url) == Self.url("b")
 
         dateProvider.advance(by: 1)
@@ -466,11 +468,12 @@ final class RemoteConfigSourceProviderTests: TestCase {
         let provider = Self.apiProvider([Self.source("a"), Self.source("b")], dateProvider: dateProvider)
 
         provider.reportUnhealthy(provider.getCurrent(for: .api)!) // a -> b, timer starts
-        dateProvider.advance(by: 500)
+        dateProvider.advance(by: Self.restartInterval - 100)
         provider.restart(for: .api) // timer cleared
 
         provider.reportUnhealthy(provider.getCurrent(for: .api)!) // a -> b, fresh timer
-        dateProvider.advance(by: 599) // over 600s since the ORIGINAL advance, under since the fresh one
+        // Over a full interval since the ORIGINAL advance, under since the fresh one.
+        dateProvider.advance(by: Self.restartInterval - 1)
         expect(provider.getCurrent(for: .api)?.url) == Self.url("b")
     }
 
@@ -484,12 +487,12 @@ final class RemoteConfigSourceProviderTests: TestCase {
         )
 
         provider.reportUnhealthy(provider.getCurrent(for: .api)!) // a -> b, timer starts
-        dateProvider.advance(by: 500)
+        dateProvider.advance(by: Self.restartInterval - 100)
 
         store.sources = Self.sourcesTopic(api: [Self.source("x"), Self.source("y")], blob: [])
         provider.reportUnhealthy(provider.getCurrent(for: .api)!) // x -> y, fresh timer
 
-        dateProvider.advance(by: 599)
+        dateProvider.advance(by: Self.restartInterval - 1)
         expect(provider.getCurrent(for: .api)?.url) == Self.url("y")
 
         dateProvider.advance(by: 1)
@@ -505,7 +508,7 @@ final class RemoteConfigSourceProviderTests: TestCase {
         )
 
         provider.reportUnhealthy(provider.getCurrent(for: .blob)!) // blob1 -> blob2
-        dateProvider.advance(by: 600)
+        dateProvider.advance(by: Self.restartInterval)
         expect(provider.getCurrent(for: .blob)?.url) == Self.url("blob2")
     }
 


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Second of two stacked PRs adding health-check-gated API source failover, completing the feature behind the `usesRemoteConfigAPISources` dangerous setting (still internal and defaulting to false, so released behavior is unchanged). Stacked on #7293.

Android equivalent: https://github.com/RevenueCat/purchases-android/pull/3812

### Description
- Requests resolve their API source once and carry the handle, so a failure can report the exact source unhealthy, and ETag/backoff retries keep targeting the same host.
- On a failure that points at the host, the source is health-checked before failing over: a healthy source surfaces the original error, an unhealthy one is reported and the request transparently retries on the next source (capped at 5 source attempts per request). 4xx responses never fail over. The static per-endpoint fallback hosts stay the last resort.
- Both Backend HTTPClients share one `APISourceFailover`, so they walk one source list and share one health-check cache.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core networking retry and host selection for all API traffic when the internal `usesRemoteConfigAPISources` flag is enabled; behavior is gated behind a dangerous setting defaulting to false, but mistakes in failover or health-check logic could affect request routing and error surfacing.
> 
> **Overview**
> **HTTPClient** now drives API host selection through a shared **`APISourceFailover`** instead of reading **`RemoteConfigSourceProvider`** directly. Each logical request resolves its remote-config API source once, keeps that handle on **`APISourceState`** for ETag/backoff retries, and caps source walks at five attempts per request.
> 
> On host-level failures (not 4xx or device offline), the client **health-checks** the current source asynchronously while the serial pipeline stays stalled. Unhealthy sources trigger a transparent retry on the next source; healthy sources surface the original error. Static per-endpoint fallback hosts still run after failover declines or exhausts sources.
> 
> **Backend** builds **one** **`APISourceFailover`** (with **`SourceHealthChecker`**) and passes it to both the main and dedicated remote-config **`HTTPClient`** lanes so they share one source list and health-check cache.
> 
> **`RemoteConfigSourceProvider.apiFailoverRestartInterval`** is now **two hours** (was 600s in tests). New integration and **`HTTPClient`** unit tests cover failover, health gating, shared lanes, and queue ordering during probes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81114887d4e93c32eb1b12e1164c3c68a97495a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->