### PR TITLE
fix(paywalls): stop media backgrounds from swallowing taps

### DIFF
--- a/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift
@@ -111,6 +111,9 @@ fileprivate extension View {
                     }
                 }
                 .ignoresSafeAreaIfNeeded(edges: ignoresSafeAreaEdges)
+                // The mask clips drawing only, so a "fill" image overflowing its container would
+                // still swallow taps on the components it overlaps.
+                .allowsHitTesting(false)
             }
         case let .video(viewModel, colorOverlay):
             self.background(alignment: alignment) {
@@ -129,6 +132,8 @@ fileprivate extension View {
                     }
                 }
                 .ignoresSafeAreaIfNeeded(edges: ignoresSafeAreaEdges)
+                // Same reason as the image background above.
+                .allowsHitTesting(false)
             }
         }
     }


### PR DESCRIPTION
### Motivation

A close button placed at the Paywall layer (or in a header) is not tappable under certain conditions.
Reported on an exit offer paywall, but  any paywall with this layout is affected by this bug.

https://github.com/user-attachments/assets/2d78937c-af55-4237-943a-7bf8b1ea6201
https://github.com/user-attachments/assets/b237a377-b2c7-42d5-945c-9acd6b9c6d3a


<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: this PR
- Branch: `facu/fix-media-background-hit-testing`
- Author / human owner: facumenzella
- Agent(s): Claude Code (Claude Opus 5, 1M context); Codex (gpt-5.x via codex-rescue) consulted twice for alternatives
- Session source: current conversation
- Generated: 2026-07-27
- Context document version: 1

## Goal

Diagnose and fix DSE ticket 81376: the close button on an exit offer paywall does nothing when placed at the Paywall layer, while the same `navigate_back` button works in the sticky footer.

## Initial Prompt

Investigate a bug report for the Kooki project: "Close Button on Exit Offer is not working if added right at the `Paywall` layer, both within a `Header` and out. Works fine if added in other parts of the paywall (e.g `Footer`)", with a Loom recording, dashboard links, and a DSE-made reproduction in the Paywalls Support project. Use `mafdet` where needed.

## Important Follow-up Prompts

- "have you tested it using paywalls tester?" — rejected a claimed fix that had only been validated by a unit-level hit-test assertion, and forced end-to-end validation on a simulator. This overturned the first proposed fix.
- "use the teststore key" — unblocked PaywallsTester setup after `mafdet paywalls-tester ios spin-up` failed with "No Apple app found in this project".
- "Run all this through codex" and later "have you run all this with codex?" — brought in an independent review; Codex's ranked candidate (b) is the fix that shipped.
- "let's keep testing until we understand the reason" — mandated continuing to root cause rather than stopping at a plausible story.
- "Just rewatched the loom. What's not closeable tapping X is the exit offer paywall, not the first paywall" plus two screenshots — the decisive input. The main paywall has the same Paywall-layer close button but no image background and works; only the exit offer has the overflowing image. This isolated the cause and disproved a spurious second blocker.

## Agent Contribution

- Fetched and diffed the reported configurations with `mafdet paywall components` / `localizations` / `versions`; established that the image is a stack **background** (`base.stack.components[1].components[0]`, `fill x fixed(450)`, `fit_mode: fill`, source 1200x2149), not an image component, and that `header` is `null` in the repro.
- Established the discriminator: the main paywall (`pwe3731e8a52f74046`) has the same Paywall-layer `navigate_back` button and **no** image background anywhere.
- Set up PaywallsTester against the Test Store key and drove real taps with Maestro; built a reliable detector (temporary `NSLog` at the top of `ButtonComponentView.performAction()`).
- Traced tap propagation with temporary `simultaneousGesture` probes to show the tap reaching the media wrapper and stopping, versus reaching the button and firing when the background image is absent.
- Implemented the fix and produced before/after screen recordings.

## Human Decisions

- Rejected the first "fix + passing test" report and required PaywallsTester validation. This was correct: the fix was wrong and the test was invalid.
- Directed the Codex consultations that produced the shipped candidate.
- Supplied the Loom re-watch and screenshots that isolated the real cause.
- Requested a draft PR with a demonstration video.

## Key Implementation Decisions

- Decision: `.allowsHitTesting(false)` on the image and video **background containers** in `BackgroundStyleModifier.apply`.
  - Rationale: a decorative background must never intercept taps outside the view it decorates. Confirmed by real taps in both sheet and fullscreen.
  - Rejected: the same modifier on the `RemoteImage` chain (verified not to work); `.clipped()` instead of the mask; `.contentShape(Rectangle())` on the image; pinning the background to the measured `size` (also regressed layout); a rect-only mask; making the root stack non-scrollable.
- Decision: leave color backgrounds hit-testable.
  - Rationale: a `Color` fills exactly the bounds it is offered, so it cannot overflow its container and cannot intercept taps on a sibling. No bug to fix, so no change made.
- Decision: no unit test.
  - Rationale: a `UIWindow.hitTest` assertion passes while the bug is intact, because SwiftUI does not route taps through the returned UIKit view. Documented rather than shipped as false assurance.

## Files / Symbols Touched

- `RevenueCatUI/Templates/V2/ViewHelpers/BackgroundStyle.swift`
  - Why: the only place image/video backgrounds are composed.
  - Symbols: `View.apply(backgroundStyle:colorScheme:alignment:ignoresSafeAreaEdges:size:)`, `.image` and `.video` cases
  - Review relevance: whether disabling hit testing on a decorative background can shrink any legitimate tap target. Color backgrounds are untouched. Not verified: whether any interactive element relies on an image/video background as its only tap surface.

## Dependencies / Config / Migrations

- None. No public API change, no new types, no config.

## Validation

- Commands run:
  - `xcodebuild build -scheme PaywallsTester -destination 'platform=iOS Simulator,id=<iPhone 16 Pro, iOS 18.4>'`: BUILD SUCCEEDED on current `origin/main` base
  - `maestro test flows/demo-green.yaml` (full customer path): passes with the fix
  - same flow without the fix: exit offer stays open, final assertion fails
  - `swiftlint`: clean
- Manual verification:
  - Full path with real taps: present main paywall, tap its close button, exit offer appears, tap the exit offer's close button. Without fix: 1 `performAction` (main only). With fix: 2, and the paywall dismisses.
  - Exit offer close button verified in both Sheet and Fullscreen presentation.
  - Footer "No, thank you" still fires after the fix.
  - Before/after screen recordings attached to this PR.
- CI:
  - Not captured at time of writing.

## Validation Gaps

- The ticket's "within a `Header`" arm was never reproduced: the repro config has `header: null`. The same mechanism predicts it, but it is unverified.
- The `.video` branch change is by symmetry only, untested.
- No automated regression test. A Maestro flow is the viable option and is not included.
- Full `RevenueCatUITests` was last run on the earlier (wrong) fix, not on this one. Locally, all V1 Template snapshot classes fail regardless because `Tests/RevenueCatUITests/Templates/__Snapshots__` is gitignored and records on first run.

## Review Focus

- Can any paywall rely on an **image or video** background as the only tap surface of an interactive element? Evidence says no, since the stack's `shape` modifier provides the tap area, but this is the main behavioral risk.
- Is the container level the right place, given the same modifier one level deeper provably does not work? Do not "simplify" this to `.contentShape` or `.clipped`; both were tested and fail.
- Should the video branch ship without its own verification, or be split out?
- Adjacent latent issue deliberately not touched: `ImageComponentView.swift` and `VideoComponentView.swift` use `.clipped()`, which has the same drawing-only clipping property. Those are content rather than decoration, so changing them would alter in-bounds behavior.

## Risks / Reviewer Notes

- Risk: shrinking a legitimate tap target on a paywall whose interactive element uses an image or video background as its only tap surface.
  - Evidence: not established either way. Color backgrounds are unchanged, and the reported paywall's buttons still work post-fix, but no sweep was done for image-backed buttons.
  - Mitigation: footer and close buttons re-verified post-fix; broader paywall interaction not exhaustively swept.
- Risk: no automated test guards this regression.
  - Evidence: a unit-level hit-test assertion was shown to pass while broken.
  - Mitigation: Maestro flow as follow-up.

## Non-goals / Out of Scope

- Changing `ImageComponentView` / `VideoComponentView` clipping.
- Any change to exit-offer presentation or `ExitOfferPresenter`.
- Adding the Maestro regression flow.

## Omitted Context

- Raw transcript, unrelated exploration, sensitive details, repetitive attempts, and chain-of-thought-style content were omitted. Several intermediate wrong diagnoses and two self-inflicted measurement confounds are summarized rather than reproduced; the corrections that matter are captured under Human Decisions and Key Implementation Decisions.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized SwiftUI hit-testing change on decorative backgrounds; color backgrounds untouched and interactive elements still get hit areas from their own shape modifiers.
> 
> **Overview**
> Paywalls with **fill**-mode **image** or **video** stack backgrounds could block taps on overlapping controls (e.g. a Paywall-layer close button on exit offers). The background uses a **mask** so overflow is hidden visually, but that clipping does not remove hit testing on the invisible overflow.
> 
> This change applies **`allowsHitTesting(false)`** on the image and video background **`ZStack`** containers in `BackgroundStyleModifier.apply`, so decorative media no longer intercept taps. **Color** backgrounds are unchanged and remain hit-testable where needed for CTAs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81483738b74b691e3f61e0944f49633853f4d5fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->