### PR TITLE
ci: post new public API and potential breaks in Slack

### DIFF
--- a/.github/workflows/new-public-api-notification.yml
+++ b/.github/workflows/new-public-api-notification.yml
@@ -1,0 +1,62 @@
+name: New Public API Notification
+
+# Posts to #feed-sdk-new-api when a pull request that adds public API is ready for review.
+# `opened` covers pull requests that never were drafts, which don't emit ready_for_review.
+#
+# The push on main is the backstop: a pull request marked ready before its api/ baselines
+# were regenerated has nothing to report yet, and would otherwise never be announced.
+#
+# `synchronize` and `reopened` are here only so the tests below run on every push; the
+# notify job filters them out.
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize, reopened]
+  push:
+    branches: [main]
+
+# Deny-all baseline: each job must declare its own `permissions:` block.
+permissions: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Run api diff helper unit tests
+        run: ruby fastlane/api_diff_helper_test.rb
+
+  notify:
+    runs-on: ubuntu-latest
+    # Only when a pull request first becomes reviewable, or when something lands on main.
+    if: >-
+      github.event_name == 'push' ||
+      github.event.action == 'ready_for_review' ||
+      (github.event.action == 'opened' && github.event.pull_request.draft == false)
+    # Don't announce anything if the detection itself is broken.
+    needs: test
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          # The detection diffs the pull request against its merge base, so we need history.
+          fetch-depth: 0
+
+      - name: Notify new public API
+        env:
+          # Either secret works: an incoming webhook for the channel, or a bot token that is
+          # a member of it. Nothing is posted while both are unset.
+          SLACK_WEBHOOK_URL: ${{ secrets.SDK_NEW_API_SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SDK_NEW_API_SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL: ${{ vars.SDK_NEW_API_SLACK_CHANNEL }}
+          BASE_SHA: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.head.sha }}
+          # Empty on push, which is what tells the script to report the API as landed.
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: ruby scripts/notify_new_public_api.rb

--- a/fastlane/api_diff_helper.rb
+++ b/fastlane/api_diff_helper.rb
@@ -160,6 +160,340 @@ module ApiDiffHelper
     result
   end
 
+  # Every changed line in a swiftinterface is treated as API except known noise, so a
+  # declaration form we didn't anticipate still gets reported.
+  # Comments cover the compiler-version header, which churns on every Xcode bump.
+  IGNORED_LINE_PREFIXES = ["//", "import ", "#if", "#else", "#elseif", "#endif"].freeze
+
+  # Accessors and lone punctuation travel with the declaration that owns them.
+  ACCESSOR_OR_PUNCTUATION_LINE = /\A(?:get|set|_modify|_read|yield|mutating get|nonmutating set|[{}()\[\],;:]+)\z/.freeze
+
+  # A single attribute, with its optional argument list.
+  ATTRIBUTE_PATTERN = /\A@[A-Za-z_][A-Za-z0-9_]*(?:\([^)]*\))?\s*/.freeze
+
+  DIFF_METADATA_PREFIXES = [
+    "+++", "---", "@@", "index ", "new file", "deleted file", "similarity ", "rename ", "Binary "
+  ].freeze
+
+  # Declarations listed per module before the Slack message truncates.
+  MAX_DECLARATIONS_PER_MODULE = 10
+
+  def module_for_api_file(path)
+    case File.basename(path.to_s)
+    when /\Arevenuecatui-api/ then "RevenueCatUI"
+    when /\Arevenuecat-api/ then "RevenueCat"
+    end
+  end
+
+  def api_declaration?(line)
+    stripped = line.strip
+    return false if stripped.empty?
+    return false if IGNORED_LINE_PREFIXES.any? { |prefix| stripped.start_with?(prefix) }
+    return false if ACCESSOR_OR_PUNCTUATION_LINE.match?(stripped)
+
+    !attributes_only?(stripped)
+  end
+
+  # True for lines that are nothing but attributes, e.g. a standalone `@available(...)`.
+  # `@objc public func foo()` keeps the declaration after the attribute, so it isn't one.
+  def attributes_only?(line)
+    rest = line
+    matched = false
+
+    while (match = ATTRIBUTE_PATTERN.match(rest))
+      rest = match.post_match
+      matched = true
+    end
+
+    matched && rest.empty?
+  end
+
+  # Added lines with their position in the new file, per api/ file, so a declaration can
+  # later be attributed to whatever encloses it.
+  def added_lines_by_file(diff_text)
+    added = {}
+    current_path = nil
+    line_number = 0
+
+    diff_text.to_s.each_line do |line|
+      if line.start_with?("diff --git ")
+        current_path = line.split(" ").last.to_s.sub(%r{\Ab/}, "").chomp
+        next
+      end
+
+      next if current_path.nil?
+
+      if (hunk = line.match(/\A@@ -\d+(?:,\d+)? \+(\d+)/))
+        line_number = hunk[1].to_i
+        next
+      end
+
+      next if DIFF_METADATA_PREFIXES.any? { |prefix| line.start_with?(prefix) }
+
+      if line.start_with?("+")
+        (added[current_path] ||= []) << { line_number: line_number, text: line[1..].to_s.chomp }
+        line_number += 1
+      elsif line.start_with?(" ")
+        line_number += 1
+      end
+    end
+
+    added
+  end
+
+  # The declaration a line sits inside, found by walking up to the closest line indented
+  # less than it. Nested types resolve to the type that owns them, not the outermost one.
+  def enclosing_declaration(lines, line_number)
+    index = line_number - 1
+    return nil if index <= 0 || index >= lines.length
+
+    indentation = indentation_of(lines[index])
+
+    (index - 1).downto(0) do |candidate_index|
+      candidate = lines[candidate_index]
+      next unless api_declaration?(candidate)
+      next unless indentation_of(candidate) < indentation
+
+      return candidate.strip
+    end
+
+    nil
+  end
+
+  def indentation_of(line)
+    line[/\A[ \t]*/].length
+  end
+
+  def declaration_owner(declaration, keyword)
+    declaration[/\b#{keyword}\s+([A-Za-z_][A-Za-z0-9_]*)/, 1]
+  end
+
+  # Additions that can break existing code even though nothing was removed: a case added to
+  # an existing public enum breaks exhaustive switches, and a requirement added to an
+  # existing public protocol breaks outside conformers. Both are fine when the enclosing
+  # type is itself new, hence the check against everything the diff adds.
+  #
+  # Takes a block that returns the new version of an api/ file as an array of lines.
+  def breaking_additions(diff_text)
+    added_declarations = parse_api_diff(diff_text).transform_values { |changes| changes[:added] }
+    breaks = {}
+
+    added_lines_by_file(diff_text).each do |path, lines|
+      module_name = module_for_api_file(path)
+      next if module_name.nil?
+
+      new_file_lines = yield(path)
+
+      lines.each do |added_line|
+        declaration = added_line[:text].strip
+        next unless api_declaration?(declaration)
+
+        owner = enclosing_declaration(new_file_lines, added_line[:line_number])
+        next if owner.nil?
+        # The whole type is new, so nothing existing can break.
+        next if added_declarations.fetch(module_name, []).include?(owner)
+
+        kind = breaking_addition_kind(declaration, owner)
+        next if kind.nil?
+
+        (breaks[module_name] ||= []) << {
+          kind: kind,
+          owner: declaration_owner(owner, kind == :enum_case ? "enum" : "protocol"),
+          text: declaration
+        }
+      end
+    end
+
+    breaks.each_value(&:uniq!)
+    breaks
+  end
+
+  def breaking_addition_kind(declaration, owner)
+    return :enum_case if owner.match?(/\benum\b/) && declaration.start_with?("case ")
+    # An optional Objective-C requirement doesn't force conformers to do anything.
+    return :protocol_requirement if owner.match?(/\bprotocol\b/) && !declaration.match?(/\boptional\b/)
+
+    nil
+  end
+
+  # Groups a `git diff` over api/*.swiftinterface into added/removed declarations per
+  # module. The same declaration shows up in every platform file, so results are
+  # deduplicated and indentation is stripped.
+  def parse_api_diff(diff_text)
+    changes = {}
+    current_module = nil
+
+    diff_text.to_s.each_line do |line|
+      if line.start_with?("diff --git ")
+        current_module = module_for_api_file(line.split(" ").last.to_s.sub(%r{\Ab/}, ""))
+        next
+      end
+
+      next if current_module.nil?
+      next if DIFF_METADATA_PREFIXES.any? { |prefix| line.start_with?(prefix) }
+
+      bucket = if line.start_with?("+")
+                 :added
+               elsif line.start_with?("-")
+                 :removed
+               end
+      next if bucket.nil?
+
+      declaration = line[1..].to_s.strip
+      next unless api_declaration?(declaration)
+
+      changes[current_module] ||= { added: [], removed: [] }
+      changes[current_module][bucket] << declaration
+    end
+
+    changes.each_value do |module_changes|
+      module_changes[:added].uniq!
+      module_changes[:removed].uniq!
+    end
+
+    changes
+  end
+
+  # A declaration that shows up as both added and removed is a move or a re-indent in
+  # some platform file, not an API change, so both sides cancel out.
+  #
+  # Gaining or losing an attribute rewrites the line without removing the declaration
+  # (exposing something to Objective-C with @objc, deprecating it with @available), so the
+  # removal is dropped while the new form is still announced.
+  def new_api_changes(diff_text)
+    parse_api_diff(diff_text).each_with_object({}) do |(module_name, module_changes), result|
+      added = module_changes[:added] - module_changes[:removed]
+      removed = module_changes[:removed] - module_changes[:added]
+
+      added_without_attributes = added.map { |declaration| declaration_without_attributes(declaration) }
+      removed = removed.reject do |declaration|
+        added_without_attributes.include?(declaration_without_attributes(declaration))
+      end
+
+      next if added.empty? && removed.empty?
+
+      result[module_name] = { new: added.sort, removed: removed.sort }
+    end
+  end
+
+  def declaration_without_attributes(declaration)
+    rest = declaration
+
+    while (match = ATTRIBUTE_PATTERN.match(rest))
+      rest = match.post_match
+    end
+
+    rest
+  end
+
+  def new_api?(changes_by_module)
+    changes_by_module.any? { |_, changes| !changes[:new].empty? }
+  end
+
+  def pull_request_link(number:, title:, repo_url:)
+    "<#{repo_url}/pull/#{number}|##{number}> #{title}".strip
+  end
+
+  # Slack link to the PR that introduced the change, falling back to the commit when the
+  # subject has no PR number (only squash merges carry one).
+  def source_link(subject:, sha:, repo_url:)
+    pr_number = subject[/\(#(\d+)\)\s*\z/, 1]
+    return "<#{repo_url}/commit/#{sha}|#{sha}> #{subject}" if pr_number.nil?
+
+    "<#{repo_url}/pull/#{pr_number}|##{pr_number}> #{subject.sub(/\s*\(#\d+\)\s*\z/, '')}"
+  end
+
+  # A pull request notification and the post-merge one can both fire for the same API, so
+  # the headline says which moment this is. A change that only breaks leads with the
+  # warning instead of announcing new API that isn't there.
+  HEADLINES = {
+    up_for_review: { new_api: "New public API up for review", breaks: "Potential API breaks up for review" },
+    landed: { new_api: "New public API landed on `main`", breaks: "Potential API breaks landed on `main`" }
+  }.freeze
+
+  HEADLINE_ICONS = { new_api: ":sparkles:", breaks: ":warning:" }.freeze
+
+  def reportable?(changes_by_module, breaks_by_module = {})
+    new_api?(changes_by_module) || !break_entries(changes_by_module, breaks_by_module).empty?
+  end
+
+  # Removals and breaking additions, as the lines they'll take in the message.
+  def break_entries(changes_by_module, breaks_by_module = {})
+    entries = {}
+
+    changes_by_module.each do |module_name, changes|
+      changes[:removed].each do |declaration|
+        (entries[module_name] ||= []) << "- removed: #{declaration}"
+      end
+    end
+
+    breaks_by_module.each do |module_name, module_breaks|
+      module_breaks.each do |module_break|
+        label = module_break[:kind] == :enum_case ? "new case in" : "new requirement in"
+        (entries[module_name] ||= []) << "+ #{label} #{module_break[:owner]}: #{module_break[:text]}"
+      end
+    end
+
+    entries
+  end
+
+  def api_report_message(changes_by_module, breaks_by_module: {}, source: nil, status: :up_for_review)
+    new_api_by_module = changes_by_module.reject { |_, changes| changes[:new].empty? }
+    breaks = break_entries(changes_by_module, breaks_by_module)
+    kind = new_api_by_module.empty? ? :breaks : :new_api
+
+    module_names = (new_api_by_module.keys + breaks.keys).uniq.sort
+    lines = ["#{HEADLINE_ICONS.fetch(kind)} *#{HEADLINES.fetch(status).fetch(kind)}* in #{module_names.join(', ')}"]
+    lines << source unless source.to_s.empty?
+
+    new_api_by_module.keys.sort.each do |module_name|
+      lines << ""
+      lines << "*#{module_name}*"
+      lines << declaration_block(new_api_by_module[module_name][:new].map { |declaration| "+ #{declaration}" })
+    end
+
+    unless breaks.empty?
+      lines << ""
+      lines << ":warning: *Potential API breaks*"
+
+      breaks.keys.sort.each do |module_name|
+        lines << "*#{module_name}*"
+        lines << declaration_block(breaks[module_name])
+      end
+    end
+
+    lines.join("\n")
+  end
+
+  # Either an incoming webhook, which carries its own channel, or a bot token with an
+  # explicit channel, so the notification can use whichever Slack credential the CI system
+  # already has. Returns nil when neither is configured.
+  def slack_post_request(message, webhook_url: nil, bot_token: nil, channel: nil)
+    unless webhook_url.to_s.empty?
+      return {
+        url: webhook_url,
+        headers: { "Content-Type" => "application/json" },
+        body: { text: message }
+      }
+    end
+
+    return nil if bot_token.to_s.empty? || channel.to_s.empty?
+
+    {
+      url: "https://slack.com/api/chat.postMessage",
+      headers: { "Content-Type" => "application/json", "Authorization" => "Bearer #{bot_token}" },
+      body: { channel: channel, text: message }
+    }
+  end
+
+  def declaration_block(entries)
+    shown = entries.first(MAX_DECLARATIONS_PER_MODULE)
+    remaining = entries.count - shown.count
+    shown += ["... and #{remaining} more"] if remaining > 0
+
+    "```\n#{shown.join("\n")}\n```"
+  end
+
   def print_failure_summary(failed_platforms)
     Fastlane::UI.error("=" * 60)
     Fastlane::UI.error("API CHANGES DETECTED")

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -1,0 +1,377 @@
+# Unit tests for ApiDiffHelper's new-public-API detection.
+# Run with: ruby fastlane/api_diff_helper_test.rb
+
+require 'minitest/autorun'
+require_relative 'api_diff_helper'
+
+class ApiDiffHelperTest < Minitest::Test
+  REPO_URL = "https://github.com/RevenueCat/purchases-ios".freeze
+
+  def test_detects_new_declaration_across_platform_files
+    diff = <<~DIFF
+      diff --git a/api/revenuecat-api-ios.swiftinterface b/api/revenuecat-api-ios.swiftinterface
+      index 1111111..2222222 100644
+      --- a/api/revenuecat-api-ios.swiftinterface
+      +++ b/api/revenuecat-api-ios.swiftinterface
+      @@ -100,0 +101 @@ extension RevenueCat.Purchases {
+      +  public func newThing(with identifier: Swift.String) async throws
+      diff --git a/api/revenuecat-api-macos.swiftinterface b/api/revenuecat-api-macos.swiftinterface
+      index 3333333..4444444 100644
+      --- a/api/revenuecat-api-macos.swiftinterface
+      +++ b/api/revenuecat-api-macos.swiftinterface
+      @@ -90,0 +91 @@ extension RevenueCat.Purchases {
+      +    public func newThing(with identifier: Swift.String) async throws
+    DIFF
+
+    changes = ApiDiffHelper.new_api_changes(diff)
+
+    assert ApiDiffHelper.new_api?(changes)
+    # Same declaration in two platform files, reported once, indentation stripped.
+    assert_equal ["public func newThing(with identifier: Swift.String) async throws"],
+                 changes["RevenueCat"][:new]
+    assert_empty changes["RevenueCat"][:removed]
+  end
+
+  def test_ignores_noise_that_is_not_api
+    diff = <<~DIFF
+      diff --git a/api/revenuecat-api-ios.swiftinterface b/api/revenuecat-api-ios.swiftinterface
+      @@ -1,3 +1,4 @@
+      -// swift-compiler-version: Apple Swift version 6.3.1
+      +// swift-compiler-version: Apple Swift version 6.3.2
+      +import AdServices
+      +#if compiler(>=5.3) && $NoncopyableGenerics
+      +@available(iOS 15.0, *)
+      +@_hasMissingDesignatedInitializers
+      +    get
+      +  }
+    DIFF
+
+    assert_empty ApiDiffHelper.new_api_changes(diff)
+  end
+
+  def test_keeps_declarations_that_carry_inline_attributes
+    diff = <<~DIFF
+      diff --git a/api/revenuecat-api-ios.swiftinterface b/api/revenuecat-api-ios.swiftinterface
+      @@ -10,0 +11,2 @@
+      +  @objc final public func purchase(product: RevenueCat.StoreProduct)
+      +@objc(RCNewThing) public enum NewThing : Swift.Int {
+    DIFF
+
+    assert_equal [
+      "@objc final public func purchase(product: RevenueCat.StoreProduct)",
+      "@objc(RCNewThing) public enum NewThing : Swift.Int {"
+    ], ApiDiffHelper.new_api_changes(diff)["RevenueCat"][:new]
+  end
+
+  # The point of blacklisting noise instead of whitelisting known keywords: a declaration
+  # form we never anticipated still gets reported.
+  def test_reports_unanticipated_declaration_forms
+    diff = <<~DIFF
+      diff --git a/api/revenuecat-api-ios.swiftinterface b/api/revenuecat-api-ios.swiftinterface
+      @@ -10,0 +11 @@
+      +  public macro SomethingBrandNew() = #externalMacro(module: "X", type: "Y")
+    DIFF
+
+    assert_equal ['public macro SomethingBrandNew() = #externalMacro(module: "X", type: "Y")'],
+                 ApiDiffHelper.new_api_changes(diff)["RevenueCat"][:new]
+  end
+
+  def test_moved_declaration_is_not_reported_as_new
+    diff = <<~DIFF
+      diff --git a/api/revenuecatui-api-ios.swiftinterface b/api/revenuecatui-api-ios.swiftinterface
+      @@ -10 +10 @@
+      -  public var body: some SwiftUI.View
+      @@ -40,0 +41 @@
+      +  public var body: some SwiftUI.View
+    DIFF
+
+    assert_empty ApiDiffHelper.new_api_changes(diff)
+  end
+
+  def test_reports_removals_alongside_additions
+    diff = <<~DIFF
+      diff --git a/api/revenuecatui-api-ios.swiftinterface b/api/revenuecatui-api-ios.swiftinterface
+      @@ -10 +10 @@
+      -  public init(offering: RevenueCat.Offering)
+      +  public init(offering: RevenueCat.Offering, displayCloseButton: Swift.Bool)
+    DIFF
+
+    changes = ApiDiffHelper.new_api_changes(diff)
+
+    assert_equal ["public init(offering: RevenueCat.Offering, displayCloseButton: Swift.Bool)"],
+                 changes["RevenueCatUI"][:new]
+    assert_equal ["public init(offering: RevenueCat.Offering)"], changes["RevenueCatUI"][:removed]
+  end
+
+  def test_only_removals_is_not_new_api
+    diff = <<~DIFF
+      diff --git a/api/revenuecat-api-ios.swiftinterface b/api/revenuecat-api-ios.swiftinterface
+      @@ -10 +9 @@
+      -  public func goneMethod()
+    DIFF
+
+    changes = ApiDiffHelper.new_api_changes(diff)
+
+    refute ApiDiffHelper.new_api?(changes)
+    assert_equal ["public func goneMethod()"], changes["RevenueCat"][:removed]
+  end
+
+  def test_ignores_files_outside_the_api_baselines
+    diff = <<~DIFF
+      diff --git a/Sources/Purchasing/Purchases.swift b/Sources/Purchasing/Purchases.swift
+      @@ -10,0 +11 @@
+      +  public func newThing()
+    DIFF
+
+    assert_empty ApiDiffHelper.new_api_changes(diff)
+  end
+
+  def test_module_attribution_distinguishes_revenuecat_and_revenuecatui
+    assert_equal "RevenueCat", ApiDiffHelper.module_for_api_file("api/revenuecat-api-ios.swiftinterface")
+    assert_equal "RevenueCatUI", ApiDiffHelper.module_for_api_file("api/revenuecatui-api-ios.swiftinterface")
+    assert_nil ApiDiffHelper.module_for_api_file("api/something-else.txt")
+  end
+
+  def test_source_link_uses_pr_number_from_squash_commit_subject
+    link = ApiDiffHelper.source_link(
+      subject: "feat: add new thing (#7290)",
+      sha: "ad49327",
+      repo_url: REPO_URL
+    )
+
+    assert_equal "<#{REPO_URL}/pull/7290|#7290> feat: add new thing", link
+  end
+
+  def test_source_link_falls_back_to_commit_without_pr_number
+    link = ApiDiffHelper.source_link(subject: "feat: add new thing", sha: "ad49327", repo_url: REPO_URL)
+
+    assert_equal "<#{REPO_URL}/commit/ad49327|ad49327> feat: add new thing", link
+  end
+
+  # --- Slack credentials ---
+
+  def test_webhook_credential_posts_to_the_webhook_url
+    request = ApiDiffHelper.slack_post_request("hello", webhook_url: "https://hooks.example/abc")
+
+    assert_equal "https://hooks.example/abc", request[:url]
+    assert_equal({ text: "hello" }, request[:body])
+  end
+
+  # Lets us reuse an existing bot token instead of creating a channel-bound webhook.
+  def test_bot_token_credential_posts_to_chat_post_message
+    request = ApiDiffHelper.slack_post_request("hello", bot_token: "xoxb-token", channel: "C0123456789")
+
+    assert_equal "https://slack.com/api/chat.postMessage", request[:url]
+    assert_equal({ channel: "C0123456789", text: "hello" }, request[:body])
+    assert_equal "Bearer xoxb-token", request[:headers]["Authorization"]
+  end
+
+  def test_webhook_wins_when_both_credentials_are_present
+    request = ApiDiffHelper.slack_post_request("hello", webhook_url: "https://hooks.example/abc",
+                                                        bot_token: "xoxb-token", channel: "C1")
+
+    assert_equal "https://hooks.example/abc", request[:url]
+  end
+
+  def test_no_credential_means_no_request
+    assert_nil ApiDiffHelper.slack_post_request("hello")
+    # A bot token without a channel has nowhere to post.
+    assert_nil ApiDiffHelper.slack_post_request("hello", bot_token: "xoxb-token")
+  end
+
+  # --- Potential API breaks ---
+
+  # Exposing an existing declaration to Objective-C rewrites the line, but removes nothing.
+  def test_gaining_an_attribute_is_not_a_break
+    diff = <<~DIFF
+      diff --git a/api/revenuecat-api-ios.swiftinterface b/api/revenuecat-api-ios.swiftinterface
+      @@ -10 +10 @@
+      -  final public func overridePreferredUILocale(_ locale: Swift.String?)
+      +  @objc final public func overridePreferredUILocale(_ locale: Swift.String?)
+    DIFF
+
+    changes = ApiDiffHelper.new_api_changes(diff)
+
+    assert_equal ["@objc final public func overridePreferredUILocale(_ locale: Swift.String?)"],
+                 changes["RevenueCat"][:new]
+    assert_empty changes["RevenueCat"][:removed]
+    assert_empty ApiDiffHelper.break_entries(changes)
+  end
+
+  def test_deprecating_a_declaration_is_not_a_break
+    diff = <<~DIFF
+      diff --git a/api/revenuecat-api-ios.swiftinterface b/api/revenuecat-api-ios.swiftinterface
+      @@ -10 +10 @@
+      -  final public var hasPaywall: Swift.Bool
+      +  @available(*, deprecated, message: "Use somethingElse") final public var hasPaywall: Swift.Bool
+    DIFF
+
+    assert_empty ApiDiffHelper.new_api_changes(diff)["RevenueCat"][:removed]
+  end
+
+  def test_flags_case_added_to_an_existing_enum
+    diff = <<~DIFF
+      diff --git a/api/revenuecat-api-ios.swiftinterface b/api/revenuecat-api-ios.swiftinterface
+      @@ -3,0 +4 @@
+      +  case tenjin = 4
+    DIFF
+    new_file = <<~SWIFT.lines
+      @objc(RCAttributionNetwork) public enum AttributionNetwork : Swift.Int {
+        case appleSearchAds = 0
+        case adjust = 1
+        case tenjin = 4
+      }
+    SWIFT
+
+    breaks = ApiDiffHelper.breaking_additions(diff) { new_file }
+
+    assert_equal [{ kind: :enum_case, owner: "AttributionNetwork", text: "case tenjin = 4" }],
+                 breaks["RevenueCat"]
+  end
+
+  # A brand new enum can't break an exhaustive switch that nobody has written yet.
+  def test_does_not_flag_cases_of_a_brand_new_enum
+    diff = <<~DIFF
+      diff --git a/api/revenuecat-api-ios.swiftinterface b/api/revenuecat-api-ios.swiftinterface
+      @@ -0,0 +1,3 @@
+      +public enum BrandNew : Swift.Int {
+      +  case first = 0
+      +  case second = 1
+    DIFF
+    new_file = <<~SWIFT.lines
+      public enum BrandNew : Swift.Int {
+        case first = 0
+        case second = 1
+      }
+    SWIFT
+
+    assert_empty ApiDiffHelper.breaking_additions(diff) { new_file }
+  end
+
+  def test_flags_requirement_added_to_an_existing_protocol
+    diff = <<~DIFF
+      diff --git a/api/revenuecat-api-ios.swiftinterface b/api/revenuecat-api-ios.swiftinterface
+      @@ -2,0 +3 @@
+      +  func purchases(_ purchases: RevenueCat.Purchases, didChange: Swift.Bool)
+    DIFF
+    new_file = <<~SWIFT.lines
+      @objc public protocol PurchasesDelegate : ObjectiveC.NSObjectProtocol {
+        @objc optional func existing()
+        func purchases(_ purchases: RevenueCat.Purchases, didChange: Swift.Bool)
+      }
+    SWIFT
+
+    breaks = ApiDiffHelper.breaking_additions(diff) { new_file }
+
+    assert_equal :protocol_requirement, breaks["RevenueCat"].first[:kind]
+    assert_equal "PurchasesDelegate", breaks["RevenueCat"].first[:owner]
+  end
+
+  def test_does_not_flag_optional_protocol_requirement_or_extension_default
+    diff = <<~DIFF
+      diff --git a/api/revenuecat-api-ios.swiftinterface b/api/revenuecat-api-ios.swiftinterface
+      @@ -1,0 +2 @@
+      +  @objc optional func newOptional()
+      @@ -5,0 +6 @@
+      +  public func convenience()
+    DIFF
+    new_file = <<~SWIFT.lines
+      @objc public protocol PurchasesDelegate : ObjectiveC.NSObjectProtocol {
+        @objc optional func newOptional()
+        func existing()
+      }
+      extension RevenueCat.PurchasesDelegate {
+        public func convenience()
+      }
+    SWIFT
+
+    assert_empty ApiDiffHelper.breaking_additions(diff) { new_file }
+  end
+
+  def test_resolves_the_innermost_enclosing_type_for_nested_enums
+    diff = <<~DIFF
+      diff --git a/api/revenuecat-api-ios.swiftinterface b/api/revenuecat-api-ios.swiftinterface
+      @@ -4,0 +5 @@
+      +    case newMode = 2
+    DIFF
+    new_file = <<~SWIFT.lines
+      extension RevenueCat.Purchases {
+        public struct Wrapper {
+        }
+        public enum Mode : Swift.Int {
+          case newMode = 2
+        }
+      }
+    SWIFT
+
+    breaks = ApiDiffHelper.breaking_additions(diff) { new_file }
+
+    assert_equal "Mode", breaks["RevenueCat"].first[:owner]
+  end
+
+  def test_removal_only_change_reports_as_a_break
+    changes = { "RevenueCat" => { new: [], removed: ["public func goneMethod()"] } }
+
+    assert ApiDiffHelper.reportable?(changes)
+    message = ApiDiffHelper.api_report_message(changes, status: :landed)
+
+    assert_includes message, ":warning: *Potential API breaks landed on `main`* in RevenueCat"
+    assert_includes message, "- removed: public func goneMethod()"
+  end
+
+  def test_message_lists_breaks_below_new_api
+    changes = { "RevenueCat" => { new: ["public func added()"], removed: ["public func gone()"] } }
+    breaks = { "RevenueCat" => [{ kind: :enum_case, owner: "AttributionNetwork", text: "case tenjin = 4" }] }
+
+    message = ApiDiffHelper.api_report_message(changes, breaks_by_module: breaks)
+
+    assert_includes message, ":sparkles: *New public API up for review* in RevenueCat"
+    assert_includes message, "+ public func added()"
+    assert_includes message, ":warning: *Potential API breaks*"
+    assert_includes message, "- removed: public func gone()"
+    assert_includes message, "+ new case in AttributionNetwork: case tenjin = 4"
+  end
+
+  def test_nothing_to_report_when_there_are_no_changes
+    refute ApiDiffHelper.reportable?({}, {})
+  end
+
+  def test_message_includes_source_declarations_and_removal_count
+    changes = {
+      "RevenueCat" => { new: ["public func a()"], removed: [] },
+      "RevenueCatUI" => { new: ["public struct B"], removed: ["public struct C"] }
+    }
+
+    message = ApiDiffHelper.api_report_message(
+      changes,
+      source: "<#{REPO_URL}/pull/7290|#7290> feat: add new thing"
+    )
+
+    assert_includes message, ":sparkles: *New public API up for review* in RevenueCat, RevenueCatUI"
+    assert_includes message, "<#{REPO_URL}/pull/7290|#7290> feat: add new thing"
+    assert_includes message, "+ public func a()"
+    assert_includes message, "- removed: public struct C"
+  end
+
+  def test_landed_message_distinguishes_itself_from_the_review_one
+    changes = { "RevenueCat" => { new: ["public func a()"], removed: [] } }
+
+    message = ApiDiffHelper.api_report_message(changes, status: :landed)
+
+    assert_includes message, ":sparkles: *New public API landed on `main`* in RevenueCat"
+  end
+
+  def test_pull_request_link
+    assert_equal "<#{REPO_URL}/pull/7290|#7290> Add a new thing",
+                 ApiDiffHelper.pull_request_link(number: "7290", title: "Add a new thing", repo_url: REPO_URL)
+  end
+
+  def test_message_truncates_long_declaration_lists
+    new_declarations = (1..15).map { |index| "public func method#{index}()" }
+    message = ApiDiffHelper.api_report_message({ "RevenueCat" => { new: new_declarations, removed: [] } })
+
+    assert_includes message, "+ public func method10()"
+    refute_includes message, "+ public func method11()"
+    assert_includes message, "... and 5 more"
+  end
+end

--- a/scripts/notify_new_public_api.rb
+++ b/scripts/notify_new_public_api.rb
@@ -1,0 +1,88 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Posts a Slack message listing public API added to the api/ baselines between two refs.
+# Exits quietly when there's nothing new. Prints the message without posting when
+# SLACK_WEBHOOK_URL is unset, which makes it safe to run locally.
+#
+# Usage: BASE_SHA=<sha> HEAD_SHA=<sha> ruby scripts/notify_new_public_api.rb
+
+require 'json'
+require 'net/http'
+require 'uri'
+require_relative '../fastlane/api_diff_helper'
+
+REPO_URL = ENV.fetch("REPO_URL", "https://github.com/RevenueCat/purchases-ios")
+
+def git(*args)
+  output = IO.popen(["git", *args], &:read)
+  raise "git #{args.join(' ')} failed" unless $?.success?
+
+  output
+end
+
+def source_link
+  pr_number = ENV["PR_NUMBER"].to_s
+  return ApiDiffHelper.pull_request_link(number: pr_number, title: ENV["PR_TITLE"].to_s, repo_url: REPO_URL) unless pr_number.empty?
+
+  head = ENV.fetch("HEAD_SHA", "HEAD")
+  ApiDiffHelper.source_link(
+    subject: git("log", "-1", "--pretty=%s", head).strip,
+    sha: git("rev-parse", "--short", head).strip,
+    repo_url: REPO_URL
+  )
+end
+
+def post_to_slack(request)
+  response = Net::HTTP.post(URI.parse(request[:url]), request[:body].to_json, request[:headers])
+  raise "Slack returned #{response.code}: #{response.body}" unless response.is_a?(Net::HTTPSuccess)
+
+  # chat.postMessage reports its own failures with a 200 and ok: false.
+  body = JSON.parse(response.body) rescue nil
+  raise "Slack rejected the message: #{body['error']}" if body.is_a?(Hash) && body["ok"] == false
+end
+
+head = ENV.fetch("HEAD_SHA", "HEAD")
+
+# A force push or a brand new branch reports an all-zero or unknown base, so fall back to
+# the previous commit rather than failing the run.
+def resolve_base(base, head)
+  return "#{head}^" if base.empty? || base.match?(/\A0+\z/)
+  return base if system("git", "cat-file", "-e", "#{base}^{commit}", out: File::NULL, err: File::NULL)
+
+  warn "Base #{base} is not available, falling back to #{head}^"
+  "#{head}^"
+end
+
+base = resolve_base(ENV.fetch("BASE_SHA", "HEAD^"), head)
+
+# Three dots so a pull request is compared against its merge base, not the tip of main.
+diff = git("diff", "--unified=0", "#{base}...#{head}", "--", "api")
+changes = ApiDiffHelper.new_api_changes(diff)
+breaks = ApiDiffHelper.breaking_additions(diff) { |path| git("show", "#{head}:#{path}").lines }
+
+unless ApiDiffHelper.reportable?(changes, breaks)
+  puts "No public API changes between #{base} and #{head}, nothing to notify"
+  exit 0
+end
+
+# A pull request number is only set for pull request events; a push to main has none.
+status = ENV["PR_NUMBER"].to_s.empty? ? :landed : :up_for_review
+message = ApiDiffHelper.api_report_message(changes, breaks_by_module: breaks, source: source_link, status: status)
+puts message
+
+request = ApiDiffHelper.slack_post_request(
+  message,
+  webhook_url: ENV["SLACK_WEBHOOK_URL"],
+  bot_token: ENV["SLACK_BOT_TOKEN"],
+  channel: ENV["SLACK_CHANNEL"]
+)
+
+if request.nil?
+  puts "\nNo Slack credential configured (SLACK_WEBHOOK_URL, or SLACK_BOT_TOKEN with " \
+       "SLACK_CHANNEL), skipping the notification"
+  exit 0
+end
+
+post_to_slack(request)
+puts "\nPosted to Slack"


### PR DESCRIPTION
### Motivation

We detect API changes in CI, but some changes might go unnoticed 😓 
This posts it to #feed-sdk-new-api while there's still time to weigh in.

### Description

It flags potential breaks: removed declarations, a case added to an existing `public enum`, and a requirement added to an existing `public protocol`. A PR that only removes API leads with the warning instead.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: this PR
- Branch: `facu/notify-new-public-api`
- Author / human owner: @facumenzella
- Agent(s): Claude Code (Opus 5, 1M context)
- Session source: current conversation
- Generated: 2026-07-27
- Context document version: 1

## Goal

Post a Slack message to #feed-sdk-new-api when a PR introduces new public API, and flag potential API breaks. Simple message: PR link plus enough context to judge.

## Initial Prompt

"We have thing on the CI that detects api changes. Would it be too much to ask for a slack message whenever there's a NEW api? #feed-sdk-new-api is the new channel"

## Important Follow-up Prompts

- "simple message with the PR link, and maybe some useful info" — set the message scope.
- "whats DECLARATION_KEYWORDS? can't you detect a new thing? from the diff?" — rejected the keyword whitelist in the first draft; replaced with a noise blacklist.
- "is this the best way to detect it? doesn't the tool provide anything useful?" (clarified: the existing diff tool) — forced an evaluation of what the current tooling exposes and of `swift-api-digester`.
- "can we run this whenever the pr is ready for review?" — moved the trigger from post-merge to ready-for-review.
- "we should flag potential api breaks" — added the break detection.
- Asked whether an existing Slack credential could be reused — led to supporting a bot token plus channel alongside the webhook.

## Agent Contribution

- Surveyed the existing API-diff path: `ApiDiffHelper.run_api_diff`, the `check-api-changes-*` CircleCI jobs, and the `release-or-main` / `run-all-tests` workflows.
- Established that the existing check cannot be the trigger: it compares baseline vs freshly built, so it fails when baselines are stale and is silent exactly when API is intentionally added.
- Implemented detection, break classification, and Slack message building in `fastlane/api_diff_helper.rb`; entry point in `scripts/notify_new_public_api.rb` (stdlib only); trigger in `.github/workflows/new-public-api-notification.yml`.
- Wrote 29 unit tests, run by a `test` job in the same workflow that the notification depends on.
- Replayed real merged commits through the script as end-to-end validation, and removed two false-positive classes found that way.

## Human Decisions

- Decision: keep both triggers (ready-for-review + `main` backstop), chosen over ready-for-review only and post-merge only, after being shown that ready-for-review can miss a PR whose baselines are regenerated later.
- Rejected the initial `DECLARATION_KEYWORDS` whitelist as a detection mechanism.
- Asked for break flagging, which was not in the original scope.

## Key Implementation Decisions

- Decision: diff the committed `api/*.swiftinterface` baselines between two refs.
  - Rationale: they are already the canonical public-API artifact in this repo and are updated in the same PR; costs ~1s in a docker runner.
  - Rejected: `swift-api-digester -dump-sdk`, which reads our committed interfaces and emits structured JSON with `usr`/kind/`printedName` (verified working locally, ~16s per interface). 18 invocations on a macOS runner was disproportionate for a notification. This is the upgrade path if declaration kinds or breaking-change classification are wanted later.
  - Rejected: triggering from the existing `check_api_changes` lane (signal is inverted, see above).
- Decision: report every changed line except known non-API noise (comments, imports, `#if`, accessors, lone punctuation, attribute-only lines).
  - Rationale: a whitelist silently drops declaration forms it doesn't enumerate; for a notifier, a false negative is worse than a visible noise line.
  - Rejected: keyword whitelist (`func|var|class|…`).
- Decision: both triggers live in one GitHub Actions workflow.
  - Rationale: Actions is the only place that sees `ready_for_review`; putting the `main` backstop there too means one secret, one code path, and no fastlane lane. An earlier CircleCI job + fastlane lane were written and then removed.
- Decision: cancel added/removed pairs by attribute-stripped identity.
  - Rationale: gaining `@objc` or an `@available` deprecation rewrites the line without removing anything. Found via #7121, which produced two bogus "removed" flags before this.
- Decision: resolve each added line to its innermost enclosing declaration by reading the new file version.
  - Rationale: needed to tell a case added to an existing enum from a case of a brand-new enum. Rejected relying on `git diff` hunk-header context (git's default funcname pattern skips lines starting with `@`, so attributed enums resolve wrong) and a `.gitattributes` diff driver (needs runner-side git config).

## Files / Symbols Touched

- `fastlane/api_diff_helper.rb`
  - Why: detection, break classification, message building, alongside the existing API-diff helpers.
  - Symbols: `new_api_changes`, `parse_api_diff`, `added_lines_by_file`, `enclosing_declaration`, `breaking_additions`, `breaking_addition_kind`, `declaration_without_attributes`, `api_report_message`, `break_entries`, `reportable?`, `api_declaration?`, `attributes_only?`
  - Review relevance: the noise blacklist and the break classification are where false positives/negatives live.
- `scripts/notify_new_public_api.rb`
  - Why: entry point; stdlib only (`Net::HTTP`, `JSON`), no bundler, so it runs in seconds.
  - Symbols: `resolve_base`, `source_link`, `post_to_slack`
  - Review relevance: three-dot diff against the merge base; all-zero/unknown base falls back to `HEAD^`; exits 0 when the webhook is unset.
- `.github/workflows/new-public-api-notification.yml`
  - Why: both triggers plus the unit tests. `test` runs on every pull request push; `notify` runs on `opened` / `ready_for_review` / `push: main` and `needs: test`, so nothing is announced when detection is broken.
  - Review relevance: `synchronize` and `reopened` are in the trigger list only to run the tests, and the `notify` `if` filters them out; the guard names `push` explicitly rather than relying on `draft == false` being falsy on push, and applies the draft check only to `opened` since `ready_for_review` fires after the conversion; PR title passed via `env:`, not interpolated into `run:`.

## Dependencies / Config / Migrations

- A Slack credential is required in GitHub Actions: `SDK_NEW_API_SLACK_WEBHOOK_URL`, or `SDK_NEW_API_SLACK_BOT_TOKEN` with the `SDK_NEW_API_SLACK_CHANNEL` variable. The webhook wins when both are set. Absent both, the script prints and exits 0.
- Note the existing `SLACK_URL_*` / `SLACK_ACCESS_TOKEN_*` values live in CircleCI contexts, which GitHub Actions cannot read, so the value has to be copied into Actions secrets either way. The `SLACK_URL_*` webhooks are channel-bound and cannot target a new channel; only the bot token can.
- No new gems. `minitest` and `Net::HTTP` are stdlib.
- `actions/checkout` pinned to the same SHA as `actionlint.yml` (`34e1148…`, v4.3.1).

## Validation

- Commands run:
  - `ruby fastlane/api_diff_helper_test.rb`: 29 runs, 77 assertions, 0 failures, 0 errors.
  - Replayed real merged commits through `scripts/notify_new_public_api.rb` (dry run, webhook unset):
    - #7049 (added two `@objc let`s): both reported, no break. Correct.
    - #6523 (40+ declarations, 10 enum cases): one break flagged, `case componentInteraction` on the pre-existing `PaywallEvent`. Correct.
    - #7121 (added `@objc` to existing methods): reported as new API, no break, after the attribute-pairing fix. Correct.
    - #7244 (deprecation, `let` became a computed `var`): reported plus a break flag. Deliberate, see Risks.
    - #7094 (`api/` change was only `+import Security`): silent. Correct.
    - `ad493275a` (no `api/` change): silent. Correct.
  - `git show c23c3cdf4^:api/revenuecat-api-ios.swiftinterface | grep -cE "enum PaywallEvent"` → 1, and `ComponentInteractionType` → 0: independently confirms the enclosing-enum attribution in the #6523 case.
  - `xcrun swift-api-digester -dump-sdk -module RevenueCat -I <dir> …`: succeeded from a committed baseline in ~16s, producing 2.4 MB of JSON. Used to price the rejected alternative.
  - YAML parse check on both changed/added YAML files, and `ruby -c` on both Ruby files: OK.
- Manual verification:
  - No Slack message has actually been delivered. The webhook secret does not exist yet, so the posting path (`post_to_slack`) has never run.
- CI:
  - Not captured at time of writing; this is the first push of the branch.

## Validation Gaps

- `post_to_slack` is unexercised: no webhook configured, so Slack's rendering of the message (mrkdwn, code blocks, `<url|label>` links) is unverified.
- Neither trigger has fired in GitHub Actions. Event wiring (`github.event.before` on push, the `if` guard on both event types) is verified only by reading, not by a run.
- `actionlint` was not run locally (not installed); the repo's `actionlint` job will cover it. The `notify` job's `if` expression in particular is verified by reading only.
- The `MAX_DECLARATIONS_PER_MODULE` cap (10) is tested but has not been seen against a real oversized diff in Slack.

## Review Focus

- Is the noise blacklist in `api_declaration?` right? Anything not comment/import/`#if`/accessor/punctuation/attribute-only is reported, so a swiftinterface line shape we haven't seen becomes a message line rather than being dropped.
- `breaking_addition_kind` treats any non-`optional` addition inside a `public protocol` as a break. Is that too aggressive for our delegate protocols?
- `enclosing_declaration` walks up to the first line indented less than the added line. Does that hold for every nesting shape in these baselines?
- Two messages per API change (review + merge) — acceptable for the channel, or should the `main` backstop be dropped?
- `ATTRIBUTE_PATTERN` uses `\([^)]*\)`, so an attribute argument containing `)` (e.g. `renamed: "foo(bar:)"`) strips only partially and may show as a break. Acceptable?

## Risks / Reviewer Notes

- Risk: a modified declaration reads as new API.
  - Evidence: #7244 deprecated `Offering.paywallComponents` by turning a stored `let` into a computed `var`; the new line appears under "New public API" and the old one under breaks.
  - Mitigation: none. Distinguishing add-from-change needs declaration-name matching, deliberately left out. The stored-to-computed change is arguably worth flagging anyway.
- Risk: a PR marked ready before its baselines are regenerated is not announced at review time.
  - Evidence: `create_swiftinterface_pr` opens the baseline PR against the *feature branch*, so timing is up to the author.
  - Mitigation: the `push: main` backstop, which is the reason both triggers exist.
- Risk: repeated messages if a PR is re-drafted and marked ready again.
  - Evidence: `ready_for_review` fires per transition; there is no dedup state.
  - Mitigation: none.
- Risk: force-push to `main` sends an all-zero `github.event.before`.
  - Evidence: handled in `resolve_base`, which falls back to `HEAD^` for zero or unresolvable bases.
  - Mitigation: covered by reading, not by a test.

## Non-goals / Out of Scope

- Failing CI or blocking a merge on API breaks. This only notifies; `check-api-changes-*` remains the gate.
- Classifying breaks by severity, or distinguishing source-breaking from ABI-breaking.
- Touching the existing `check_api_changes` / `generate_swiftinterface` lanes or the `api/` baselines themselves.
- Notifying about `@_spi(Internal)` API, which these baselines exclude by construction.

## Omitted Context

- Raw transcript, unrelated exploration, sensitive details, repetitive attempts, and chain-of-thought-style content were omitted.

</details>
