### PR TITLE
fix(12mo commitments): use commitmentTotalDisplayPrice for localizedPriceString for 12mo commitment products

### DIFF
--- a/Sources/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -12,6 +12,8 @@
 // Created by Andrés Boedo on 7/16/21.
 //
 
+// swiftlint:disable file_length
+
 import Foundation
 import StoreKit
 

--- a/Sources/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -87,7 +87,16 @@ internal typealias SK2BillingPlanType = StoreKit.Product.SubscriptionInfo.Billin
         }
     }
 
-    @objc public var localizedPriceString: String { self.product.localizedPriceString}
+    @objc public var localizedPriceString: String {
+        if #available(iOS 26.4, tvOS 26.4, watchOS 26.4, macOS 26.4, visionOS 26.4, *),
+           let installmentsInfo {
+            // This product represents a billing plan, so use the billing plan's
+            // total commitment price
+            return installmentsInfo.commitmentTotalDisplayPrice
+        } else {
+            return self.product.localizedPriceString
+        }
+    }
 
     @objc public var productIdentifier: String { self.product.productIdentifier }
 

--- a/Tests/StoreKitUnitTests/StoreProductTests.swift
+++ b/Tests/StoreKitUnitTests/StoreProductTests.swift
@@ -592,6 +592,54 @@ extension StoreProductTests {
         expect(storeProduct.price) == 11.97
     }
 
+    func testLocalizedPriceStringUsesProductPriceStringWhenInstallmentsInfoIsNil() {
+        let localizedPriceString = "$3.99"
+        let storeProduct = Self.testProduct(
+            productIdentifier: "com.revenuecat.product",
+            localizedPriceString: localizedPriceString,
+            installmentsInfo: nil
+        )
+
+        expect(storeProduct.localizedPriceString) == localizedPriceString
+    }
+
+    func testLocalizedPriceStringUsesProductPriceStringBelowIOS264EvenWithInstallmentsInfo() throws {
+        // InstallmentsInfo shouldn't be populated below iOS 26.4, but it's a good thing to check
+        // just in case.
+        try AvailabilityChecks.iOS264APINotAvailableOrSkipTest()
+
+        let localizedPriceString = "$3.99"
+        let storeProduct = Self.testProduct(
+            productIdentifier: "com.revenuecat.product",
+            localizedPriceString: localizedPriceString,
+            installmentsInfo: Self.installmentsInfo(
+                commitmentInstallmentsCount: 12,
+                commitmentTotalPrice: 11.97,
+                commitmentTotalDisplayPrice: "$11.97"
+            )
+        )
+
+        expect(storeProduct.localizedPriceString) == localizedPriceString
+    }
+
+    @available(iOS 26.4, tvOS 26.4, macOS 26.4, watchOS 26.4, visionOS 26.4, *)
+    func testLocalizedPriceStringUsesCommitmentTotalDisplayPriceOnIOS264WhenInstallmentsInfoIsPresent() throws {
+        try AvailabilityChecks.iOS264APIAvailableOrSkipTest()
+        let commitmentTotalDisplayPrice = "$11.97"
+
+        let storeProduct = Self.testProduct(
+            productIdentifier: "com.revenuecat.product",
+            localizedPriceString: "$3.99",
+            installmentsInfo: Self.installmentsInfo(
+                commitmentInstallmentsCount: 12,
+                commitmentTotalPrice: 11.97,
+                commitmentTotalDisplayPrice: commitmentTotalDisplayPrice
+            )
+        )
+
+        expect(storeProduct.localizedPriceString) == commitmentTotalDisplayPrice
+    }
+
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testIdReturnsProductIdentifierForSK2ProductWithoutInstallmentsInfo() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
@@ -690,13 +738,14 @@ private extension StoreProductTests {
     static func testProduct(
         productIdentifier: String,
         price: Decimal = 3.99,
+        localizedPriceString: String = "$3.99",
         installmentsInfo: InstallmentsInfo?
     ) -> StoreProduct {
         return TestStoreProduct(
             localizedTitle: "product",
             price: price,
             currencyCode: "USD",
-            localizedPriceString: "$3.99",
+            localizedPriceString: localizedPriceString,
             productIdentifier: productIdentifier,
             productType: .autoRenewableSubscription,
             localizedDescription: "",
@@ -709,6 +758,7 @@ private extension StoreProductTests {
     static func installmentsInfo(
         commitmentInstallmentsCount: Int,
         commitmentTotalPrice: Decimal? = nil,
+        commitmentTotalDisplayPrice: String? = nil,
         billingPlanType: BillingPlanType = .monthly
     ) -> InstallmentsInfo {
         return InstallmentsInfo(
@@ -718,7 +768,8 @@ private extension StoreProductTests {
             installmentBillingDisplayPrice: "$3.99",
             commitmentTotalPeriod: SubscriptionPeriod(value: commitmentInstallmentsCount, unit: .month),
             commitmentTotalPrice: commitmentTotalPrice ?? Decimal(commitmentInstallmentsCount) * 3.99,
-            commitmentTotalDisplayPrice: "$\(commitmentInstallmentsCount * 399 / 100).99",
+            commitmentTotalDisplayPrice: commitmentTotalDisplayPrice
+                ?? "$\(commitmentInstallmentsCount * 399 / 100).99",
             billingPlanType: billingPlanType
         )
     }


### PR DESCRIPTION
### Description
https://github.com/RevenueCat/purchases-ios/pull/6910 set `StoreProduct.price` to be equal to the total commitment price for SK2 12mo commitment subscriptions. However, it did not update `StoreProduct.localizedPriceString`, creating conflicting values between `price` and `localizedPriceString` for 12mo commitment products.

This PR resolves this issue by using `commitmentTotalDisplayPrice` for `SK2Product.localizedPriceString` for 12 month commitment products.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized display-only change aligned with existing commitment pricing logic; scope is narrow with added unit tests.
> 
> **Overview**
> Fixes a mismatch where **12‑month commitment** `StoreProduct` instances already exposed total commitment via `price` but still showed the per‑installment string on `localizedPriceString`.
> 
> On **iOS 26.4+**, when `installmentsInfo` is set, `StoreProduct.localizedPriceString` now returns `installmentsInfo.commitmentTotalDisplayPrice`, matching the same billing‑plan branch used for `price`. Products without installments or on older OS versions keep the underlying product’s localized price string.
> 
> Unit tests cover nil installments, pre‑26.4 behavior, and the 26.4 commitment display path; test helpers accept custom `localizedPriceString` and `commitmentTotalDisplayPrice` for those cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 061377983741184b7b73507c1b85633c64b030b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->