### PR TITLE
Build CircleCI trigger payload with jq

### DIFF
--- a/.github/workflows/rcgitbot_please_test.yml
+++ b/.github/workflows/rcgitbot_please_test.yml
@@ -203,10 +203,15 @@ jobs:
         run: |
           PROJECT_SLUG="gh/RevenueCat/purchases-ios"
 
+          # Build the payload with jq rather than string interpolation: branch names come
+          # from the PR head ref and may contain characters that need JSON escaping.
+          BODY_JSON=$(jq -n --arg branch "$BRANCH" --arg jobs "$JOB_NAMES" \
+            '{branch: $branch, parameters: {requested_jobs: $jobs}}')
+
           RESPONSE=$(curl -s --max-time 15 -w "\n%{http_code}" -X POST \
             -H "Circle-Token: $CCI_TOKEN" \
             -H "Content-Type: application/json" \
-            -d "{\"branch\": \"$BRANCH\", \"parameters\": {\"requested_jobs\": \"$JOB_NAMES\"}}" \
+            -d "$BODY_JSON" \
             "https://circleci.com/api/v2/project/$PROJECT_SLUG/pipeline")
 
           HTTP_STATUS=$(echo "$RESPONSE" | tail -1)


### PR DESCRIPTION
### Motivation

The `run-specific-jobs` job spliced the PR head branch name into a hand-written JSON string when triggering the CircleCI pipeline. Head refs are attacker-influenceable on fork PRs and may contain `"`, so a crafted branch name could inject extra top-level keys into the payload (e.g. a second `branch` key redirecting the pipeline to another ref).

### Description

Impact is bounded: the real `parameters` object comes last and wins, and CircleCI rejects undeclared parameters, so this is hardening rather than a fix for a proven escalation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only the GitHub Actions workflow changes; no runtime app or security-critical product code is touched.
> 
> **Overview**
> Hardens the **`run-specific-jobs`** CircleCI trigger in `rcgitbot_please_test.yml` by building the POST body with **`jq`** instead of embedding **`BRANCH`** and **`JOB_NAMES`** in a hand-written JSON string.
> 
> PR head branch names (and job names) can include quotes or other characters that break or manipulate naive string interpolation; **`jq`** applies proper JSON escaping so the payload stays a single well-formed object with **`branch`** and **`parameters.requested_jobs`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9b44edef3dfd2e6a67f17df8e2049813128d820. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->