### PR TITLE
feat(remote-config): send X-RC-Last-Refresh-Time on config requests

### DIFF
--- a/Sources/Networking/HTTPClient/ETagManager.swift
+++ b/Sources/Networking/HTTPClient/ETagManager.swift
@@ -16,7 +16,7 @@ import Foundation
 
 class ETagManager {
     static let eTagRequestHeader = HTTPClient.RequestHeader.eTag
-    static let eTagValidationTimeRequestHeader = HTTPClient.RequestHeader.eTagValidationTime
+    static let lastRefreshTimeRequestHeader = HTTPClient.RequestHeader.lastRefreshTime
     static let eTagResponseHeader = HTTPClient.ResponseHeader.eTag
 
     private let cache: SynchronizedLargeItemCache
@@ -75,7 +75,7 @@ class ETagManager {
 
         return [
             HTTPClient.RequestHeader.eTag.rawValue: etag,
-            HTTPClient.RequestHeader.eTagValidationTime.rawValue: date
+            HTTPClient.RequestHeader.lastRefreshTime.rawValue: date
         ]
             .compactMapValues { $0 }
     }

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -1062,7 +1062,7 @@ extension HTTPRequest {
         if verificationMode.isEnabled,
            self.path.supportsSignatureVerification {
             let headerParametersSignature = HTTPClient.headerParametersForSignatureHeader(
-                with: defaultHeaders,
+                with: result,
                 path: self.path
             )
 

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -1049,7 +1049,7 @@ extension HTTPRequest {
     ) -> HTTPClient.RequestHeaders {
         var result: HTTPClient.RequestHeaders = defaultHeaders
         result += self.path.additionalHeaders
-        result += self.requestBody?.additionalHeaders ?? [:]
+        result += self.additionalHeaders
 
         if self.path.authenticated {
             result += authHeaders

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -1049,6 +1049,7 @@ extension HTTPRequest {
     ) -> HTTPClient.RequestHeaders {
         var result: HTTPClient.RequestHeaders = defaultHeaders
         result += self.path.additionalHeaders
+        result += self.requestBody?.additionalHeaders ?? [:]
 
         if self.path.authenticated {
             result += authHeaders

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -201,7 +201,7 @@ extension HTTPClient {
         case acceptRCElementEncoding = "Accept-RC-Element-Encoding"
         case nonce = "X-Nonce"
         case eTag = "X-RevenueCat-ETag"
-        case eTagValidationTime = "X-RC-Last-Refresh-Time"
+        case lastRefreshTime = "X-RC-Last-Refresh-Time"
         case postParameters = "X-Post-Params-Hash"
         case headerParametersForSignature = "X-Headers-Hash"
         case sandbox = "X-Is-Sandbox"

--- a/Sources/Networking/HTTPClient/HTTPRequest.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequest.swift
@@ -21,6 +21,7 @@ struct HTTPRequest {
     var method: Method
     var path: HTTPRequestPath
     /// Headers that are specific to this request.
+    /// These override default and path headers, and their final values are included when computing header signatures.
     let additionalHeaders: Headers
     /// If present, this will be used by the server to compute a checksum of the response signed with a private key.
     var nonce: Data?

--- a/Sources/Networking/HTTPClient/HTTPRequest.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequest.swift
@@ -20,6 +20,8 @@ struct HTTPRequest {
 
     var method: Method
     var path: HTTPRequestPath
+    /// Headers that are specific to this request.
+    let additionalHeaders: Headers
     /// If present, this will be used by the server to compute a checksum of the response signed with a private key.
     var nonce: Data?
     /// Whether or not this request should be retried by the HTTPClient for certain status codes.
@@ -28,10 +30,17 @@ struct HTTPRequest {
     init(
         method: Method,
         path: HTTPRequest.Path,
+        additionalHeaders: Headers = [:],
         nonce: Data? = nil,
         isRetryable: Bool = false
     ) {
-        self.init(method: method, requestPath: path, nonce: nonce, isRetryable: isRetryable)
+        self.init(
+            method: method,
+            requestPath: path,
+            additionalHeaders: additionalHeaders,
+            nonce: nonce,
+            isRetryable: isRetryable
+        )
     }
 
     init(
@@ -82,6 +91,7 @@ struct HTTPRequest {
     internal init(
         method: Method,
         requestPath: HTTPRequestPath,
+        additionalHeaders: Headers = [:],
         nonce: Data? = nil,
         isRetryable: Bool = false
     ) {
@@ -90,6 +100,7 @@ struct HTTPRequest {
 
         self.method = method
         self.path = requestPath
+        self.additionalHeaders = additionalHeaders
         self.nonce = nonce
         self.isRetryable = isRetryable
     }

--- a/Sources/Networking/HTTPClient/HTTPRequestBody.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestBody.swift
@@ -16,9 +16,6 @@ import Foundation
 /// The content of an `HTTPRequest` for `HTTPRequest.Method.post`
 protocol HTTPRequestBody: Encodable {
 
-    /// Headers that are specific to this request body.
-    var additionalHeaders: HTTPRequest.Headers { get }
-
     /// The keys and values that will be included in the signature.
     /// - Note: this is not `[String: String]` because we need to preserve ordering.
     var contentForSignature: [(key: String, value: String?)] { get }
@@ -26,10 +23,6 @@ protocol HTTPRequestBody: Encodable {
 }
 
 extension HTTPRequestBody {
-
-    var additionalHeaders: HTTPRequest.Headers {
-        return [:]
-    }
 
     // Default implementation for endpoints which don't support signing.
     var contentForSignature: [(key: String, value: String?)] {

--- a/Sources/Networking/HTTPClient/HTTPRequestBody.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestBody.swift
@@ -16,6 +16,9 @@ import Foundation
 /// The content of an `HTTPRequest` for `HTTPRequest.Method.post`
 protocol HTTPRequestBody: Encodable {
 
+    /// Headers that are specific to this request body.
+    var additionalHeaders: HTTPRequest.Headers { get }
+
     /// The keys and values that will be included in the signature.
     /// - Note: this is not `[String: String]` because we need to preserve ordering.
     var contentForSignature: [(key: String, value: String?)] { get }
@@ -23,6 +26,10 @@ protocol HTTPRequestBody: Encodable {
 }
 
 extension HTTPRequestBody {
+
+    var additionalHeaders: HTTPRequest.Headers {
+        return [:]
+    }
 
     // Default implementation for endpoints which don't support signing.
     var contentForSignature: [(key: String, value: String?)] {

--- a/Sources/Networking/Operations/GetRemoteConfigOperation.swift
+++ b/Sources/Networking/Operations/GetRemoteConfigOperation.swift
@@ -91,7 +91,7 @@ struct RemoteConfigRequest: Codable, Equatable, HTTPRequestBody {
         guard let lastRefreshTime else { return [:] }
 
         return [
-            "X-RC-Last-Refresh-Time": lastRefreshTime.millisecondsSince1970.description
+            HTTPClient.RequestHeader.lastRefreshTime.rawValue: lastRefreshTime.millisecondsSince1970.description
         ]
     }
 

--- a/Sources/Networking/Operations/GetRemoteConfigOperation.swift
+++ b/Sources/Networking/Operations/GetRemoteConfigOperation.swift
@@ -52,6 +52,7 @@ struct RemoteConfigRequest: Codable, Equatable, HTTPRequestBody {
     let domain: String
     let manifest: String?
     let prefetchedBlobs: [String]
+    let lastRefreshTime: Date?
 
     private enum CodingKeys: String, CodingKey {
         case fetchContext
@@ -65,13 +66,15 @@ struct RemoteConfigRequest: Codable, Equatable, HTTPRequestBody {
         appUserID: String,
         domain: String = RemoteConfiguration.defaultDomain,
         manifest: String? = nil,
-        prefetchedBlobs: [String] = []
+        prefetchedBlobs: [String] = [],
+        lastRefreshTime: Date? = nil
     ) {
         self.fetchContext = fetchContext
         self.appUserID = appUserID
         self.domain = domain
         self.manifest = manifest
         self.prefetchedBlobs = prefetchedBlobs
+        self.lastRefreshTime = lastRefreshTime
     }
 
     var cacheKey: String {
@@ -79,8 +82,17 @@ struct RemoteConfigRequest: Codable, Equatable, HTTPRequestBody {
             "app_user_id=\(self.appUserID)",
             "domain=\(self.domain)",
             "manifest=\(self.manifest ?? "")",
-            "prefetched_blobs=\(self.prefetchedBlobs.sorted().joined(separator: ","))"
+            "prefetched_blobs=\(self.prefetchedBlobs.sorted().joined(separator: ","))",
+            "last_refresh_time=\(self.lastRefreshTime?.millisecondsSince1970.description ?? "")"
         ].joined(separator: "|")
+    }
+
+    var additionalHeaders: HTTPRequest.Headers {
+        guard let lastRefreshTime else { return [:] }
+
+        return [
+            "X-RC-Last-Refresh-Time": UInt64(lastRefreshTime.timeIntervalSince1970).description
+        ]
     }
 
     func encode(to encoder: Encoder) throws {
@@ -99,6 +111,7 @@ struct RemoteConfigRequest: Codable, Equatable, HTTPRequestBody {
         self.domain = RemoteConfiguration.defaultDomain
         self.manifest = try container.decodeIfPresent(String.self, forKey: .manifest)
         self.prefetchedBlobs = try container.decodeIfPresent([String].self, forKey: .prefetchedBlobs) ?? []
+        self.lastRefreshTime = nil
     }
 
 }

--- a/Sources/Networking/Operations/GetRemoteConfigOperation.swift
+++ b/Sources/Networking/Operations/GetRemoteConfigOperation.swift
@@ -91,7 +91,7 @@ struct RemoteConfigRequest: Codable, Equatable, HTTPRequestBody {
         guard let lastRefreshTime else { return [:] }
 
         return [
-            "X-RC-Last-Refresh-Time": UInt64(lastRefreshTime.timeIntervalSince1970).description
+            "X-RC-Last-Refresh-Time": lastRefreshTime.millisecondsSince1970.description
         ]
     }
 
@@ -124,7 +124,8 @@ private extension GetRemoteConfigOperation {
     func getRemoteConfig(completion: @escaping () -> Void) {
         let request = HTTPRequest(
             method: .post(self.request),
-            path: HTTPRequest.Path.remoteConfig(domain: self.request.domain)
+            path: HTTPRequest.Path.remoteConfig(domain: self.request.domain),
+            additionalHeaders: self.request.additionalHeaders
         )
 
         self.httpClient.perform(request) { (response: VerifiedHTTPResponse<RemoteConfigContainer?>.Result) in

--- a/Sources/Networking/RemoteConfigDiskCache.swift
+++ b/Sources/Networking/RemoteConfigDiskCache.swift
@@ -33,19 +33,22 @@ struct PersistedRemoteConfiguration: Codable, Equatable {
     let activeTopics: [String]
     let prefetchBlobs: [String]
     let topics: RemoteConfiguration.Topics
+    let lastRefreshTimeMilliseconds: UInt64?
 
     init(
         domain: String = RemoteConfiguration.defaultDomain,
         manifest: String,
         activeTopics: [String] = [],
         prefetchBlobs: [String] = [],
-        topics: RemoteConfiguration.Topics = .init()
+        topics: RemoteConfiguration.Topics = .init(),
+        lastRefreshTimeMilliseconds: UInt64? = nil
     ) {
         self.domain = domain
         self.manifest = manifest
         self.activeTopics = activeTopics
         self.prefetchBlobs = prefetchBlobs
         self.topics = topics
+        self.lastRefreshTimeMilliseconds = lastRefreshTimeMilliseconds
     }
 
     init(from decoder: Decoder) throws {
@@ -55,7 +58,11 @@ struct PersistedRemoteConfiguration: Codable, Equatable {
             manifest: try container.decode(String.self, forKey: .manifest),
             activeTopics: try container.decodeIfPresent([String].self, forKey: .activeTopics) ?? [],
             prefetchBlobs: try container.decodeIfPresent([String].self, forKey: .prefetchBlobs) ?? [],
-            topics: try container.decodeIfPresent(RemoteConfiguration.Topics.self, forKey: .topics) ?? .init()
+            topics: try container.decodeIfPresent(RemoteConfiguration.Topics.self, forKey: .topics) ?? .init(),
+            lastRefreshTimeMilliseconds: try container.decodeIfPresent(
+                UInt64.self,
+                forKey: .lastRefreshTimeMilliseconds
+            )
         )
     }
 
@@ -65,6 +72,22 @@ struct PersistedRemoteConfiguration: Codable, Equatable {
         case activeTopics
         case prefetchBlobs
         case topics
+        case lastRefreshTimeMilliseconds
+    }
+
+}
+
+extension PersistedRemoteConfiguration {
+
+    func withLastRefreshTime(_ date: Date) -> Self {
+        return .init(
+            domain: self.domain,
+            manifest: self.manifest,
+            activeTopics: self.activeTopics,
+            prefetchBlobs: self.prefetchBlobs,
+            topics: self.topics,
+            lastRefreshTimeMilliseconds: date.millisecondsSince1970
+        )
     }
 
 }

--- a/Sources/Networking/RemoteConfigDiskCache.swift
+++ b/Sources/Networking/RemoteConfigDiskCache.swift
@@ -33,7 +33,7 @@ struct PersistedRemoteConfiguration: Codable, Equatable {
     let activeTopics: [String]
     let prefetchBlobs: [String]
     let topics: RemoteConfiguration.Topics
-    let lastRefreshTimeMilliseconds: UInt64?
+    private(set) var lastRefreshTimeMilliseconds: UInt64?
 
     init(
         domain: String = RemoteConfiguration.defaultDomain,
@@ -80,14 +80,10 @@ struct PersistedRemoteConfiguration: Codable, Equatable {
 extension PersistedRemoteConfiguration {
 
     func withLastRefreshTime(_ date: Date) -> Self {
-        return .init(
-            domain: self.domain,
-            manifest: self.manifest,
-            activeTopics: self.activeTopics,
-            prefetchBlobs: self.prefetchBlobs,
-            topics: self.topics,
-            lastRefreshTimeMilliseconds: date.millisecondsSince1970
-        )
+        var copy = self
+        copy.lastRefreshTimeMilliseconds = date.millisecondsSince1970
+
+        return copy
     }
 
 }

--- a/Sources/Networking/RemoteConfigDiskCache.swift
+++ b/Sources/Networking/RemoteConfigDiskCache.swift
@@ -79,6 +79,10 @@ struct PersistedRemoteConfiguration: Codable, Equatable {
 
 extension PersistedRemoteConfiguration {
 
+    var lastRefreshTime: Date? {
+        return self.lastRefreshTimeMilliseconds.map(Date.init(millisecondsSince1970:))
+    }
+
     func withLastRefreshTime(_ date: Date) -> Self {
         var copy = self
         copy.lastRefreshTimeMilliseconds = date.millisecondsSince1970

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -259,6 +259,7 @@ final class RemoteConfigManager: RemoteConfigManagerType {
         let epoch: Int
         let requestAppUserID: String
         let fetchContext: RemoteConfigFetchContext
+        let lastRefreshedAt: Date?
     }
 
     /// Runs blocking committed-state reads away from the caller's executor.
@@ -458,7 +459,8 @@ private extension RemoteConfigManager {
             return .init(
                 epoch: self.epoch,
                 requestAppUserID: requestAppUserID,
-                fetchContext: self.fetchContextForRefresh(fetchContext)
+                fetchContext: self.fetchContextForRefresh(fetchContext),
+                lastRefreshedAt: self.lastRefreshedAt
             )
         }
     }
@@ -492,20 +494,28 @@ private extension RemoteConfigManager {
             return .init(
                 epoch: self.epoch,
                 requestAppUserID: requestAppUserID,
-                fetchContext: self.fetchContextForRefresh(fetchContext)
+                fetchContext: self.fetchContextForRefresh(fetchContext),
+                lastRefreshedAt: self.lastRefreshedAt
             )
         }
     }
 
     func startRefresh(isAppBackgrounded: Bool, requestContext: RefreshRequestContext) {
         let persisted = self.diskCache.read()
+        // A refresh time is only meaningful when there is a persisted configuration to associate it with.
+        let lastRefreshTime: Date?
+        if let persisted {
+            lastRefreshTime = requestContext.lastRefreshedAt ?? persisted.lastRefreshTime
+        } else {
+            lastRefreshTime = nil
+        }
         let request = RemoteConfigRequest(
             fetchContext: requestContext.fetchContext,
             appUserID: requestContext.requestAppUserID,
             domain: persisted?.domain ?? Self.defaultDomain,
             manifest: persisted?.manifest,
             prefetchedBlobs: self.cachedPrefetchedBlobRefs(from: persisted),
-            lastRefreshTime: self.lastRefreshTime(from: persisted)
+            lastRefreshTime: lastRefreshTime
         )
 
         Logger.verbose(Strings.remoteConfig.refreshing(
@@ -766,18 +776,6 @@ private extension RemoteConfigManager {
     func markRefreshed(at date: Date) {
         self.hasCommittedInitialConfig = true
         self.lastRefreshedAt = date
-    }
-
-    func lastRefreshTime(from persisted: PersistedRemoteConfiguration?) -> Date? {
-        return self.lock.perform {
-            guard let persisted else { return nil }
-            if let lastRefreshedAt = self.lastRefreshedAt {
-                return lastRefreshedAt
-            }
-            guard let milliseconds = persisted.lastRefreshTimeMilliseconds else { return nil }
-
-            return Date(millisecondsSince1970: milliseconds)
-        }
     }
 
     /// Waits for committed config state to become available for read APIs.

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -770,10 +770,11 @@ private extension RemoteConfigManager {
 
     func lastRefreshTime(from persisted: PersistedRemoteConfiguration?) -> Date? {
         return self.lock.perform {
+            guard let persisted else { return nil }
             if let lastRefreshedAt = self.lastRefreshedAt {
                 return lastRefreshedAt
             }
-            guard let milliseconds = persisted?.lastRefreshTimeMilliseconds else { return nil }
+            guard let milliseconds = persisted.lastRefreshTimeMilliseconds else { return nil }
 
             return Date(millisecondsSince1970: milliseconds)
         }

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -504,7 +504,8 @@ private extension RemoteConfigManager {
             appUserID: requestContext.requestAppUserID,
             domain: persisted?.domain ?? Self.defaultDomain,
             manifest: persisted?.manifest,
-            prefetchedBlobs: self.cachedPrefetchedBlobRefs(from: persisted)
+            prefetchedBlobs: self.cachedPrefetchedBlobRefs(from: persisted),
+            lastRefreshTime: self.lastRefreshTime(from: persisted)
         )
 
         Logger.verbose(Strings.remoteConfig.refreshing(
@@ -579,7 +580,7 @@ private extension RemoteConfigManager {
 
         guard let container = fetchResult.container else {
             Logger.debug(Strings.remoteConfig.notModified)
-            self.markRefreshedIfCurrent(requestEpoch)
+            self.markRefreshedIfCurrent(requestEpoch, previous: previous)
             return
         }
 
@@ -593,14 +594,16 @@ private extension RemoteConfigManager {
 
             self.lock.perform {
                 guard self.epoch == requestEpoch else { return }
+                let refreshedAt = self.dateProvider.now()
                 let didPersist = self.persist(
                     container: container,
                     previous: previous,
-                    response: response
+                    response: response,
+                    refreshedAt: refreshedAt
                 )
                 if didPersist {
                     self.generation += 1
-                    self.markRefreshed()
+                    self.markRefreshed(at: refreshedAt)
                 }
             }
         } catch {
@@ -683,14 +686,16 @@ private extension RemoteConfigManager {
 
         self.lock.perform {
             guard self.epoch == requestEpoch else { return }
+            let refreshedAt = self.dateProvider.now()
             let didPersist = self.persist(
                 container: nil,
                 previous: previous,
-                response: fallbackResult.configuration
+                response: fallbackResult.configuration,
+                refreshedAt: refreshedAt
             )
             if didPersist {
                 self.generation += 1
-                self.markRefreshed()
+                self.markRefreshed(at: refreshedAt)
             }
         }
     }
@@ -741,19 +746,37 @@ private extension RemoteConfigManager {
         }
     }
 
-    func markRefreshedIfCurrent(_ requestEpoch: Int) {
+    func markRefreshedIfCurrent(
+        _ requestEpoch: Int,
+        previous: PersistedRemoteConfiguration?
+    ) {
         self.lock.perform {
             guard self.epoch == requestEpoch else { return }
 
-            self.markRefreshed()
+            let refreshedAt = self.dateProvider.now()
+            if let previous {
+                self.diskCache.write(previous.withLastRefreshTime(refreshedAt))
+            }
+            self.markRefreshed(at: refreshedAt)
         }
     }
 
     /// Records a landed refresh: stamps the refresh time and marks the session's initial config as committed, so
     /// later refreshes stop being forced to `.appStart`. Must be called within `lock`.
-    func markRefreshed() {
+    func markRefreshed(at date: Date) {
         self.hasCommittedInitialConfig = true
-        self.lastRefreshedAt = self.dateProvider.now()
+        self.lastRefreshedAt = date
+    }
+
+    func lastRefreshTime(from persisted: PersistedRemoteConfiguration?) -> Date? {
+        return self.lock.perform {
+            if let lastRefreshedAt = self.lastRefreshedAt {
+                return lastRefreshedAt
+            }
+            guard let milliseconds = persisted?.lastRefreshTimeMilliseconds else { return nil }
+
+            return Date(millisecondsSince1970: milliseconds)
+        }
     }
 
     /// Waits for committed config state to become available for read APIs.
@@ -931,7 +954,8 @@ private extension RemoteConfigManager {
     func persist(
         container: RemoteConfigContainer?,
         previous: PersistedRemoteConfiguration?,
-        response: RemoteConfiguration
+        response: RemoteConfiguration,
+        refreshedAt: Date
     ) -> Bool {
         Logger.debug(Strings.remoteConfig.receivedConfiguration(
             activeTopics: response.activeTopics, changedTopics: Array(response.topics.entries.keys)
@@ -951,7 +975,8 @@ private extension RemoteConfigManager {
             manifest: response.manifest,
             activeTopics: response.activeTopics,
             prefetchBlobs: response.prefetchBlobs,
-            topics: postSyncTopics
+            topics: postSyncTopics,
+            lastRefreshTimeMilliseconds: refreshedAt.millisecondsSince1970
         )
 
         guard self.diskCache.write(persistedConfiguration) else { return false }

--- a/Tests/UnitTests/Mocks/MockETagManager.swift
+++ b/Tests/UnitTests/Mocks/MockETagManager.swift
@@ -33,7 +33,7 @@ class MockETagManager: ETagManager {
     func stubResponseEtag(_ tag: String, validationTime: Date = Date()) {
         self.stubbedETagHeaderResult = [
             ETagManager.eTagRequestHeader.rawValue: tag,
-            ETagManager.eTagValidationTimeRequestHeader.rawValue: validationTime.millisecondsSince1970.description
+            ETagManager.lastRefreshTimeRequestHeader.rawValue: validationTime.millisecondsSince1970.description
         ]
     }
 

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -188,8 +188,8 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         }
 
         expect(self.httpClient.calls.first?.headers[ETagManager.eTagRequestHeader.rawValue]).to(beNil())
-        expect(self.httpClient.calls.first?.headers[ETagManager.eTagValidationTimeRequestHeader.rawValue])
-            == UInt64(lastRefreshTime.timeIntervalSince1970).description
+        expect(self.httpClient.calls.first?.headers["X-RC-Last-Refresh-Time"])
+            == lastRefreshTime.millisecondsSince1970.description
     }
 
     func testGetRemoteConfigFallbackDoesNotSendSignatureRequestHeaders() {

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -168,7 +168,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         }
 
         expect(self.httpClient.calls.first?.headers[ETagManager.eTagRequestHeader.rawValue]).to(beNil())
-        expect(self.httpClient.calls.first?.headers[ETagManager.eTagValidationTimeRequestHeader.rawValue]).to(beNil())
+        expect(self.httpClient.calls.first?.headers[ETagManager.lastRefreshTimeRequestHeader.rawValue]).to(beNil())
     }
 
     func testGetRemoteConfigSendsLastRefreshTimeWithoutETag() {
@@ -188,7 +188,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         }
 
         expect(self.httpClient.calls.first?.headers[ETagManager.eTagRequestHeader.rawValue]).to(beNil())
-        expect(self.httpClient.calls.first?.headers["X-RC-Last-Refresh-Time"])
+        expect(self.httpClient.calls.first?.headers[HTTPClient.RequestHeader.lastRefreshTime.rawValue])
             == lastRefreshTime.millisecondsSince1970.description
     }
 
@@ -206,6 +206,19 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(headers?[HTTPClient.RequestHeader.nonce.rawValue]).to(beNil())
         expect(headers?[HTTPClient.RequestHeader.headerParametersForSignature.rawValue]).to(beNil())
         expect(headers?[HTTPClient.RequestHeader.postParameters.rawValue]).to(beNil())
+    }
+
+    func testGetRemoteConfigFallbackDoesNotSendLastRefreshTimeHeader() {
+        self.mockSuccessfulFallbackResponse()
+
+        waitUntil { completed in
+            self.remoteConfigAPI.getRemoteConfigFallback(
+                domain: "app",
+                isAppBackgrounded: false
+            ) { _ in completed() }
+        }
+
+        expect(self.httpClient.calls.first?.headers[HTTPClient.RequestHeader.lastRefreshTime.rawValue]).to(beNil())
     }
 
     func testGetRemoteConfigDoesNotSendSignatureVerificationHeaders() {

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -171,6 +171,27 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(self.httpClient.calls.first?.headers[ETagManager.eTagValidationTimeRequestHeader.rawValue]).to(beNil())
     }
 
+    func testGetRemoteConfigSendsLastRefreshTimeWithoutETag() {
+        self.mockSuccessfulResponse()
+        let lastRefreshTime = Date(timeIntervalSince1970: 1_785_309_842)
+        let request = RemoteConfigRequest(
+            fetchContext: .appStart,
+            appUserID: Self.appUserID,
+            lastRefreshTime: lastRefreshTime
+        )
+
+        waitUntil { completed in
+            self.remoteConfigAPI.getRemoteConfig(
+                request: request,
+                isAppBackgrounded: false
+            ) { _ in completed() }
+        }
+
+        expect(self.httpClient.calls.first?.headers[ETagManager.eTagRequestHeader.rawValue]).to(beNil())
+        expect(self.httpClient.calls.first?.headers[ETagManager.eTagValidationTimeRequestHeader.rawValue])
+            == UInt64(lastRefreshTime.timeIntervalSince1970).description
+    }
+
     func testGetRemoteConfigFallbackDoesNotSendSignatureRequestHeaders() {
         self.mockSuccessfulFallbackResponse()
 

--- a/Tests/UnitTests/Networking/ETagManagerTests.swift
+++ b/Tests/UnitTests/Networking/ETagManagerTests.swift
@@ -588,7 +588,7 @@ class ETagManagerTests: TestCase {
         let response = self.eTagManager.eTagHeader(for: request, withSignatureVerification: false)
         expect(response) == [
             ETagManager.eTagRequestHeader.rawValue: Self.testETag,
-            ETagManager.eTagValidationTimeRequestHeader.rawValue: validationTime.millisecondsSince1970.description
+            ETagManager.lastRefreshTimeRequestHeader.rawValue: validationTime.millisecondsSince1970.description
         ]
     }
 

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1181,7 +1181,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
 
         stub(condition: isPath(request.path)) { request in
             expect(request.allHTTPHeaderFields?[ETagManager.eTagRequestHeader.rawValue]) == eTag
-            expect(request.allHTTPHeaderFields?[ETagManager.eTagValidationTimeRequestHeader.rawValue])
+            expect(request.allHTTPHeaderFields?[ETagManager.lastRefreshTimeRequestHeader.rawValue])
             == eTagValidationTime.millisecondsSince1970.description
 
             return HTTPStubsResponse(data: responseData,
@@ -1214,7 +1214,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
 
         stub(condition: isPath(path)) { request in
             expect(request.allHTTPHeaderFields?[ETagManager.eTagRequestHeader.rawValue]) == eTag
-            expect(request.allHTTPHeaderFields?[ETagManager.eTagValidationTimeRequestHeader.rawValue])
+            expect(request.allHTTPHeaderFields?[ETagManager.lastRefreshTimeRequestHeader.rawValue])
             == eTagValidationTime.millisecondsSince1970.description
 
             return HTTPStubsResponse(

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -385,4 +385,25 @@ class HTTPRequestTests: TestCase {
         expect(headers[HTTPClient.RequestHeader.acceptRCElementEncoding.rawValue]).to(beNil())
         expect(headers["Accept-Encoding"]).to(beNil())
     }
+
+    func testHeaderSignatureUsesAdditionalHeaderOverride() {
+        let sandboxHeader = HTTPClient.RequestHeader.sandbox.rawValue
+        let request = HTTPRequest(
+            method: .get,
+            path: .getCustomerInfo(appUserID: "user"),
+            additionalHeaders: [sandboxHeader: "false"]
+        )
+
+        let headers = request.headers(
+            with: [:],
+            defaultHeaders: [sandboxHeader: "true"],
+            verificationMode: Signing.verificationMode(with: .informational),
+            internalSettings: DangerousSettings.Internal.default
+        )
+
+        let expectedHash = HTTPRequest.signingParameterHash(["false"])
+        expect(headers[sandboxHeader]) == "false"
+        expect(headers[HTTPClient.RequestHeader.headerParametersForSignature.rawValue])
+            == HTTPRequest.signatureHashHeader(keys: [sandboxHeader], hash: expectedHash)
+    }
 }

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigDiskCacheTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigDiskCacheTests.swift
@@ -73,13 +73,15 @@ final class RemoteConfigDiskCacheTests: TestCase {
             "product_entitlement_mapping": ["default": .init(blobRef: "pemBlob")]
         ])
         let prefetchBlobs = ["blobRefA", "pemBlob"]
+        let lastRefreshTimeMilliseconds: UInt64 = 1_785_309_842_000
 
         self.cache.write(PersistedRemoteConfiguration(
             domain: "app",
             manifest: manifest,
             activeTopics: activeTopics,
             prefetchBlobs: prefetchBlobs,
-            topics: topics
+            topics: topics,
+            lastRefreshTimeMilliseconds: lastRefreshTimeMilliseconds
         ))
         let read = try XCTUnwrap(self.makeCache().read())
 
@@ -88,6 +90,7 @@ final class RemoteConfigDiskCacheTests: TestCase {
         expect(read.activeTopics) == activeTopics
         expect(read.prefetchBlobs) == prefetchBlobs
         expect(read.topics) == topics
+        expect(read.lastRefreshTimeMilliseconds) == lastRefreshTimeMilliseconds
     }
 
     func testInlineOnlyTopicsPersistWithContent() throws {

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigDiskCacheTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigDiskCacheTests.swift
@@ -93,6 +93,26 @@ final class RemoteConfigDiskCacheTests: TestCase {
         expect(read.lastRefreshTimeMilliseconds) == lastRefreshTimeMilliseconds
     }
 
+    func testWithLastRefreshTimeOnlyUpdatesLastRefreshTime() {
+        let original = PersistedRemoteConfiguration(
+            domain: "custom-domain",
+            manifest: "v1.1710000100.sources:etag1",
+            activeTopics: ["sources"],
+            prefetchBlobs: ["blobRefA"],
+            topics: .init(entries: ["sources": ["default": .init(blobRef: "blobRefA")]]),
+            lastRefreshTimeMilliseconds: 1_000
+        )
+
+        let updated = original.withLastRefreshTime(Date(millisecondsSince1970: 123_000))
+
+        expect(updated.domain) == original.domain
+        expect(updated.manifest) == original.manifest
+        expect(updated.activeTopics) == original.activeTopics
+        expect(updated.prefetchBlobs) == original.prefetchBlobs
+        expect(updated.topics) == original.topics
+        expect(updated.lastRefreshTimeMilliseconds) == 123_000
+    }
+
     func testInlineOnlyTopicsPersistWithContent() throws {
         let manifest = "v1.1710000100.sources:etag1"
         let inlineItem = RemoteConfiguration.ConfigItem(
@@ -209,7 +229,7 @@ final class RemoteConfigDiskCacheTests: TestCase {
         expect(self.cache.read()).to(beNil())
     }
 
-    func testReadDefaultsMissingTopicsToEmpty() throws {
+    func testReadDefaultsMissingOptionalFields() throws {
         try FileManager.default.createDirectory(
             at: self.fileURL.deletingLastPathComponent(),
             withIntermediateDirectories: true,
@@ -225,6 +245,7 @@ final class RemoteConfigDiskCacheTests: TestCase {
 
         expect(read.manifest) == "v1.1710000100.sources:etag1"
         expect(read.topics.entries).to(beEmpty())
+        expect(read.lastRefreshTimeMilliseconds).to(beNil())
     }
 
     func testReadIgnoresUnknownFields() throws {

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
@@ -460,20 +460,21 @@ final class RemoteConfigIntegrationTests: TestCase {
 
     func testNoContentResponseAdvancesLastRefreshTimeHeader() async throws {
         let container = try Self.containerData(topics: Self.workflowTopic(ref: "unused"))
+        self.dateProvider.advance(by: 100)
         await self.refresh(with: container)
 
         self.dateProvider.advance(by: 123)
         self.mockRemoteConfigResponse(statusCode: .noContent, body: Data())
         self.manager.refreshRemoteConfig(fetchContext: .foreground, isAppBackgrounded: false)
         await self.waitForRemoteConfigRequestCount(2)
-        await self.waitForStoredRefreshTime(123_000)
+        await self.waitForStoredRefreshTime(223_000)
 
         self.manager.refreshRemoteConfig(fetchContext: .foreground, isAppBackgrounded: false)
         await self.waitForRemoteConfigRequestCount(3)
 
         expect(self.remoteConfigCalls[0].headers[HTTPClient.RequestHeader.lastRefreshTime.rawValue]).to(beNil())
-        expect(self.remoteConfigCalls[1].headers[HTTPClient.RequestHeader.lastRefreshTime.rawValue]) == "0"
-        expect(self.remoteConfigCalls[2].headers[HTTPClient.RequestHeader.lastRefreshTime.rawValue]) == "123000"
+        expect(self.remoteConfigCalls[1].headers[HTTPClient.RequestHeader.lastRefreshTime.rawValue]) == "100000"
+        expect(self.remoteConfigCalls[2].headers[HTTPClient.RequestHeader.lastRefreshTime.rawValue]) == "223000"
     }
 
     func testErrorResponseDoesNotAddLastRefreshTimeHeader() async {

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
@@ -455,7 +455,7 @@ final class RemoteConfigIntegrationTests: TestCase {
 
         expect(self.remoteConfigCalls.first?.headers["X-RC-Last-Refresh-Time"]).to(beNil())
         expect(self.remoteConfigCalls.last?.headers["X-RC-Last-Refresh-Time"])
-            == (storedRefreshTime / 1_000).description
+            == storedRefreshTime.description
     }
 
     func testNoContentResponseAdvancesLastRefreshTimeHeader() async throws {
@@ -473,7 +473,7 @@ final class RemoteConfigIntegrationTests: TestCase {
 
         expect(self.remoteConfigCalls[0].headers["X-RC-Last-Refresh-Time"]).to(beNil())
         expect(self.remoteConfigCalls[1].headers["X-RC-Last-Refresh-Time"]) == "0"
-        expect(self.remoteConfigCalls[2].headers["X-RC-Last-Refresh-Time"]) == "123"
+        expect(self.remoteConfigCalls[2].headers["X-RC-Last-Refresh-Time"]) == "123000"
     }
 
     func testErrorResponseDoesNotAddLastRefreshTimeHeader() async {

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
@@ -440,7 +440,7 @@ final class RemoteConfigIntegrationTests: TestCase {
         self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         await self.waitForRemoteConfigRequestCount(1)
 
-        expect(self.remoteConfigCalls.first?.headers["X-RC-Last-Refresh-Time"]).to(beNil())
+        expect(self.remoteConfigCalls.first?.headers[HTTPClient.RequestHeader.lastRefreshTime.rawValue]).to(beNil())
     }
 
     func testRequestSendsLastRefreshTimeHeaderAfterSuccessfulConfigIsStored() async throws {
@@ -453,8 +453,8 @@ final class RemoteConfigIntegrationTests: TestCase {
         self.manager.refreshRemoteConfig(fetchContext: .foreground, isAppBackgrounded: false)
         await self.waitForRemoteConfigRequestCount(2)
 
-        expect(self.remoteConfigCalls.first?.headers["X-RC-Last-Refresh-Time"]).to(beNil())
-        expect(self.remoteConfigCalls.last?.headers["X-RC-Last-Refresh-Time"])
+        expect(self.remoteConfigCalls.first?.headers[HTTPClient.RequestHeader.lastRefreshTime.rawValue]).to(beNil())
+        expect(self.remoteConfigCalls.last?.headers[HTTPClient.RequestHeader.lastRefreshTime.rawValue])
             == storedRefreshTime.description
     }
 
@@ -471,9 +471,9 @@ final class RemoteConfigIntegrationTests: TestCase {
         self.manager.refreshRemoteConfig(fetchContext: .foreground, isAppBackgrounded: false)
         await self.waitForRemoteConfigRequestCount(3)
 
-        expect(self.remoteConfigCalls[0].headers["X-RC-Last-Refresh-Time"]).to(beNil())
-        expect(self.remoteConfigCalls[1].headers["X-RC-Last-Refresh-Time"]) == "0"
-        expect(self.remoteConfigCalls[2].headers["X-RC-Last-Refresh-Time"]) == "123000"
+        expect(self.remoteConfigCalls[0].headers[HTTPClient.RequestHeader.lastRefreshTime.rawValue]).to(beNil())
+        expect(self.remoteConfigCalls[1].headers[HTTPClient.RequestHeader.lastRefreshTime.rawValue]) == "0"
+        expect(self.remoteConfigCalls[2].headers[HTTPClient.RequestHeader.lastRefreshTime.rawValue]) == "123000"
     }
 
     func testErrorResponseDoesNotAddLastRefreshTimeHeader() async {
@@ -488,8 +488,8 @@ final class RemoteConfigIntegrationTests: TestCase {
         self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         await self.waitForRemoteConfigRequestCount(2)
 
-        expect(self.remoteConfigCalls[0].headers["X-RC-Last-Refresh-Time"]).to(beNil())
-        expect(self.remoteConfigCalls[1].headers["X-RC-Last-Refresh-Time"]).to(beNil())
+        expect(self.remoteConfigCalls[0].headers[HTTPClient.RequestHeader.lastRefreshTime.rawValue]).to(beNil())
+        expect(self.remoteConfigCalls[1].headers[HTTPClient.RequestHeader.lastRefreshTime.rawValue]).to(beNil())
     }
 
     func testInformationalFailedVerificationStillPersistsResponse() async throws {

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
@@ -24,6 +24,7 @@ final class RemoteConfigIntegrationTests: TestCase {
     private var blobStore: RemoteConfigBlobStore!
     private var sourceProvider: RemoteConfigSourceProvider!
     private var downloader: MockIntegrationBlobDownloader!
+    private var dateProvider: MockCurrentDateProvider!
     private var remoteConfigAPI: RemoteConfigAPI!
     private var manager: RemoteConfigManager!
 
@@ -55,6 +56,7 @@ final class RemoteConfigIntegrationTests: TestCase {
         )
         self.sourceProvider = RemoteConfigSourceProvider(topicStore: self.diskCache)
         self.downloader = MockIntegrationBlobDownloader()
+        self.dateProvider = MockCurrentDateProvider()
         self.systemInfo = MockSystemInfo(finishTransactions: false)
         self.httpClient = MockHTTPClient(
             systemInfo: self.systemInfo,
@@ -82,6 +84,7 @@ final class RemoteConfigIntegrationTests: TestCase {
 
         self.manager = nil
         self.remoteConfigAPI = nil
+        self.dateProvider = nil
         self.downloader = nil
         self.sourceProvider = nil
         self.blobStore = nil
@@ -431,6 +434,64 @@ final class RemoteConfigIntegrationTests: TestCase {
         expect(self.blobStore.cachedRefs()).to(beEmpty())
     }
 
+    func testFirstRequestDoesNotSendLastRefreshTimeHeader() async {
+        self.mockRemoteConfigResponse(statusCode: .noContent, body: Data())
+
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
+        await self.waitForRemoteConfigRequestCount(1)
+
+        expect(self.remoteConfigCalls.first?.headers["X-RC-Last-Refresh-Time"]).to(beNil())
+    }
+
+    func testRequestSendsLastRefreshTimeHeaderAfterSuccessfulConfigIsStored() async throws {
+        let container = try Self.containerData(topics: Self.workflowTopic(ref: "unused"))
+
+        await self.refresh(with: container)
+
+        let storedRefreshTime = try XCTUnwrap(self.diskCache.read()?.lastRefreshTimeMilliseconds)
+        self.mockRemoteConfigResponse(statusCode: .noContent, body: Data())
+        self.manager.refreshRemoteConfig(fetchContext: .foreground, isAppBackgrounded: false)
+        await self.waitForRemoteConfigRequestCount(2)
+
+        expect(self.remoteConfigCalls.first?.headers["X-RC-Last-Refresh-Time"]).to(beNil())
+        expect(self.remoteConfigCalls.last?.headers["X-RC-Last-Refresh-Time"])
+            == (storedRefreshTime / 1_000).description
+    }
+
+    func testNoContentResponseAdvancesLastRefreshTimeHeader() async throws {
+        let container = try Self.containerData(topics: Self.workflowTopic(ref: "unused"))
+        await self.refresh(with: container)
+
+        self.dateProvider.advance(by: 123)
+        self.mockRemoteConfigResponse(statusCode: .noContent, body: Data())
+        self.manager.refreshRemoteConfig(fetchContext: .foreground, isAppBackgrounded: false)
+        await self.waitForRemoteConfigRequestCount(2)
+        await self.waitForStoredRefreshTime(123_000)
+
+        self.manager.refreshRemoteConfig(fetchContext: .foreground, isAppBackgrounded: false)
+        await self.waitForRemoteConfigRequestCount(3)
+
+        expect(self.remoteConfigCalls[0].headers["X-RC-Last-Refresh-Time"]).to(beNil())
+        expect(self.remoteConfigCalls[1].headers["X-RC-Last-Refresh-Time"]) == "0"
+        expect(self.remoteConfigCalls[2].headers["X-RC-Last-Refresh-Time"]) == "123"
+    }
+
+    func testErrorResponseDoesNotAddLastRefreshTimeHeader() async {
+        self.mockRemoteConfigError(Self.serverError)
+        self.mockRemoteConfigFallbackError(Self.serverError)
+
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
+        await self.waitForRemoteConfigRequestCount(1)
+        await self.waitForRemoteConfigFallbackRequestCount(1)
+
+        self.mockRemoteConfigResponse(statusCode: .noContent, body: Data())
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
+        await self.waitForRemoteConfigRequestCount(2)
+
+        expect(self.remoteConfigCalls[0].headers["X-RC-Last-Refresh-Time"]).to(beNil())
+        expect(self.remoteConfigCalls[1].headers["X-RC-Last-Refresh-Time"]).to(beNil())
+    }
+
     func testInformationalFailedVerificationStillPersistsResponse() async throws {
         let blob = #"{"workflow":"informational"}"#.asData
         let ref = RCContainerTestData.blobRef(for: blob)
@@ -571,6 +632,13 @@ private extension RemoteConfigIntegrationTests {
         )
     }
 
+    static var serverError: NetworkError {
+        return .errorResponse(
+            .init(code: .unknownError, originalCode: BackendErrorCode.unknownError.rawValue),
+            .internalServerError
+        )
+    }
+
     func createManager(blobStore: RemoteConfigBlobStoreType) -> RemoteConfigManager {
         return RemoteConfigManager(
             remoteConfigAPI: self.remoteConfigAPI,
@@ -581,7 +649,8 @@ private extension RemoteConfigIntegrationTests {
                 sourceProvider: self.sourceProvider,
                 downloader: self.downloader
             ),
-            currentUserProvider: MockCurrentUserProvider(mockAppUserID: "integration-test-user")
+            currentUserProvider: MockCurrentUserProvider(mockAppUserID: "integration-test-user"),
+            dateProvider: self.dateProvider
         )
     }
 
@@ -641,10 +710,21 @@ private extension RemoteConfigIntegrationTests {
         )
     }
 
+    func mockRemoteConfigFallbackError(_ error: NetworkError) {
+        self.httpClient.mock(
+            requestPath: HTTPRequest.FallbackPath.remoteConfig(domain: RemoteConfiguration.defaultDomain),
+            response: .init(error: error)
+        )
+    }
+
     var remoteConfigRequestCount: Int {
+        return self.remoteConfigCalls.count
+    }
+
+    var remoteConfigCalls: [MockHTTPClient.Call] {
         return self.httpClient.calls.filter {
             $0.request.path.url == HTTPRequest.Path.remoteConfig(domain: RemoteConfiguration.defaultDomain).url
-        }.count
+        }
     }
 
     var remoteConfigFallbackRequestCount: Int {
@@ -682,6 +762,15 @@ private extension RemoteConfigIntegrationTests {
     ) async {
         await expect(file: file, line: line, self.diskCache.read()?.manifest)
             .toEventually(equal(manifest), timeout: Self.pollTimeout, pollInterval: Self.pollInterval)
+    }
+
+    func waitForStoredRefreshTime(
+        _ milliseconds: UInt64,
+        file: FileString = #filePath,
+        line: UInt = #line
+    ) async {
+        await expect(file: file, line: line, self.diskCache.read()?.lastRefreshTimeMilliseconds)
+            .toEventually(equal(milliseconds), timeout: Self.pollTimeout, pollInterval: Self.pollInterval)
     }
 
     /// Waits until the blob store reflects the expected refs.

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -362,6 +362,24 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.isAppBackgrounded) == true
     }
 
+    func testClearCacheDropsLastRefreshTime() {
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.sources:etag1",
+            lastRefreshTimeMilliseconds: 123_000
+        )
+
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.lastRefreshTime)
+            == Date(timeIntervalSince1970: 123)
+
+        self.manager.clearCache(forAppUserID: "new-user")
+        self.currentUserProvider.mockAppUserID = "new-user"
+        self.diskCache.stubbedRead = nil
+        self.manager.refreshRemoteConfig(fetchContext: .identityChange, isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.lastRefreshTime).to(beNil())
+    }
+
     func testNoContentResponsePersistsAndSendsSuccessfulPollTime() {
         self.diskCache.stubbedRead = Self.persisted(
             manifest: "v1.1710000100.sources:etag1",
@@ -1565,7 +1583,7 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.blobFetcher.invokedPrefetchCount) == 0
     }
 
-    func testNoContentResponseWithNoPersistedCacheLeavesCacheUntouched() {
+    func testNoContentResponseWithNoPersistedCacheDoesNotSendRefreshTime() {
         self.diskCache.stubbedRead = nil
 
         self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
@@ -1575,6 +1593,10 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.blobStore.invokedWriteCount) == 0
         expect(self.blobStore.invokedRetainOnlyCount) == 0
         expect(self.blobFetcher.invokedPrefetchCount) == 0
+
+        self.manager.refreshRemoteConfig(fetchContext: .foreground, isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.lastRefreshTime).to(beNil())
     }
 
     func testBackendErrorLeavesCacheUntouched() {

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -371,10 +371,12 @@ final class RemoteConfigManagerTests: TestCase {
         self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.lastRefreshTime)
             == Date(timeIntervalSince1970: 123)
+        self.dateProvider.advance(by: 456)
+        self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
 
         self.manager.clearCache(forAppUserID: "new-user")
         self.currentUserProvider.mockAppUserID = "new-user"
-        self.diskCache.stubbedRead = nil
+        self.diskCache.stubbedRead = Self.persisted(manifest: "v1.1710000100.sources:etag2")
         self.manager.refreshRemoteConfig(fetchContext: .identityChange, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.lastRefreshTime).to(beNil())
@@ -396,6 +398,29 @@ final class RemoteConfigManagerTests: TestCase {
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.lastRefreshTime)
             == Date(timeIntervalSince1970: 123)
+    }
+
+    func testNoContentResponseWriteFailureStillMarksRefreshAsFresh() {
+        let manager = RemoteConfigManager(
+            remoteConfigAPI: self.remoteConfigAPI,
+            diskCache: self.diskCache,
+            blobStore: self.blobStore,
+            blobFetcher: self.blobFetcher,
+            currentUserProvider: self.currentUserProvider,
+            dateProvider: self.dateProvider,
+            cacheDurationInSeconds: { _ in 120 }
+        )
+        self.diskCache.stubbedRead = Self.persisted(manifest: "v1.1710000100.sources:etag1")
+        self.diskCache.stubbedWriteResult = false
+
+        manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
+        expect(self.diskCache.invokedWriteCount) == 1
+
+        self.dateProvider.advance(by: Self.refreshAttemptCooldownElapsedInterval)
+        manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
     }
 
     func testAppRestartRefreshesAndAppliesUpdatedConfig() async throws {
@@ -1751,6 +1776,7 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testFallbackConfigSuccessPersistsConfigurationWithoutInlineBlobExtraction() {
+        self.dateProvider.advance(by: 123)
         let prefetchedRef = RCContainerTestData.blobRef(for: #"{"id":"prefetched"}"#.asData)
         let retainedRef = RCContainerTestData.blobRef(for: #"{"id":"retained"}"#.asData)
         let configuration = RemoteConfiguration(
@@ -1769,6 +1795,7 @@ final class RemoteConfigManagerTests: TestCase {
 
         expect(self.diskCache.invokedWriteCount) == 1
         expect(self.diskCache.invokedWriteParameter?.manifest) == "v1.1710000100.workflows:etag2"
+        expect(self.diskCache.invokedWriteParameter?.lastRefreshTimeMilliseconds) == 123_000
         expect(Self.blobRefsByTopic(from: self.diskCache.invokedWriteParameter?.topics)) == [
             "workflows": [retainedRef]
         ]

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -342,12 +342,14 @@ final class RemoteConfigManagerTests: TestCase {
 
     func testSubsequentRunReplaysPersistedManifest() throws {
         let persistedManifest = "v1.1710000100.sources:etag1"
+        let lastRefreshTime = Date(timeIntervalSince1970: 1_785_309_842)
         self.blobStore.stubbedContainsRefs = ["prefetchedBlob"]
         self.diskCache.stubbedRead = Self.persisted(
             domain: "custom",
             manifest: persistedManifest,
             prefetchBlobs: ["prefetchedBlob"],
-            topics: .init()
+            topics: .init(),
+            lastRefreshTimeMilliseconds: lastRefreshTime.millisecondsSince1970
         )
 
         self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: true)
@@ -356,7 +358,26 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.domain) == "custom"
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.manifest) == persistedManifest
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.prefetchedBlobs) == ["prefetchedBlob"]
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.lastRefreshTime) == lastRefreshTime
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.isAppBackgrounded) == true
+    }
+
+    func testNoContentResponsePersistsAndSendsSuccessfulPollTime() {
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.sources:etag1",
+            lastRefreshTimeMilliseconds: 1_000
+        )
+        self.dateProvider.advance(by: 123)
+
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
+
+        expect(self.diskCache.invokedWriteParameter?.lastRefreshTimeMilliseconds) == 123_000
+
+        self.manager.refreshRemoteConfig(fetchContext: .foreground, isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.lastRefreshTime)
+            == Date(timeIntervalSince1970: 123)
     }
 
     func testAppRestartRefreshesAndAppliesUpdatedConfig() async throws {
@@ -1332,6 +1353,7 @@ final class RemoteConfigManagerTests: TestCase {
 
     func testContainerResponsePersistsServerManifestAndChangedTopics() throws {
         self.diskCache.stubbedRead = nil
+        self.dateProvider.advance(by: 123)
         let response = """
         {
           "domain": "app",
@@ -1358,6 +1380,7 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.diskCache.invokedWriteParameter?.activeTopics) == ["sources"]
         expect(self.diskCache.invokedWriteParameter?.prefetchBlobs) == ["newBlob"]
         expect(Self.blobRefsByTopic(from: self.diskCache.invokedWriteParameter?.topics)) == ["sources": ["newBlob"]]
+        expect(self.diskCache.invokedWriteParameter?.lastRefreshTimeMilliseconds) == 123_000
     }
 
     func testContainerResponseDecodesCompressedConfigElement() throws {
@@ -1519,7 +1542,7 @@ final class RemoteConfigManagerTests: TestCase {
         expect(item?.content["priority"]) == 100
     }
 
-    func testNoContentResponseWithPersistedCacheLeavesCacheUntouched() {
+    func testNoContentResponseWithPersistedCacheUpdatesOnlyRefreshTime() {
         let previous = Self.persisted(
             domain: "app",
             manifest: "v1.1710000100.sources:etag1",
@@ -1528,11 +1551,15 @@ final class RemoteConfigManagerTests: TestCase {
             topics: .init(entries: ["sources": ["default": .init(blobRef: "sourceBlob")]])
         )
         self.diskCache.stubbedRead = previous
+        self.dateProvider.advance(by: 123)
 
         self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
 
-        expect(self.diskCache.invokedWriteCount) == 0
+        expect(self.diskCache.invokedWriteCount) == 1
+        expect(self.diskCache.invokedWriteParameter) == previous.withLastRefreshTime(
+            Date(timeIntervalSince1970: 123)
+        )
         expect(self.blobStore.invokedWriteCount) == 0
         expect(self.blobStore.invokedRetainOnlyCount) == 0
         expect(self.blobFetcher.invokedPrefetchCount) == 0
@@ -2784,14 +2811,16 @@ private extension RemoteConfigManagerTests {
         manifest: String,
         activeTopics: [String] = [],
         prefetchBlobs: [String] = [],
-        topics: RemoteConfiguration.Topics = .init()
+        topics: RemoteConfiguration.Topics = .init(),
+        lastRefreshTimeMilliseconds: UInt64? = nil
     ) -> PersistedRemoteConfiguration {
         return PersistedRemoteConfiguration(
             domain: domain,
             manifest: manifest,
             activeTopics: activeTopics,
             prefetchBlobs: prefetchBlobs,
-            topics: topics
+            topics: topics,
+            lastRefreshTimeMilliseconds: lastRefreshTimeMilliseconds
         )
     }
 


### PR DESCRIPTION
## Description
In order to be able to leverage the load shedder functionality, the backend must be able to determine when the request was last refreshed. Other API requests that rely on ETAG caching send the `X-RC-Last-Refresh-Time` header as a unix epoch in milliseconds. With this PR we're doing the same for remote config requests.

## Changes
- After receiving the initial remote config response, we'll now store a `lastRefreshTime: Date` value along with the received config
  - This is only done for successful responses, determined by the `2xx` status code
- In subsequent requests we'll be including this value as a Unix epoch timestamp in milliseconds under the `X-RC-Last-Refresh-Time` header
- After the next successful response we'll update the local value again

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote config request headers and persistence of refresh timestamps; incorrect handling could affect backend load shedding or stale-config behavior, but scope is limited to remote config and header signing with broad test coverage.
> 
> **Overview**
> Remote config refresh requests can now include **`X-RC-Last-Refresh-Time`** (Unix ms), aligned with other cached API calls, so the backend can use load-shedding logic. The header is **not** sent on the first fetch or when there is no persisted config; fallback config GETs still omit it.
> 
> **Persistence and refresh semantics:** Successful config writes store **`lastRefreshTimeMilliseconds`** on `PersistedRemoteConfiguration`. **`204` / not-modified** responses advance the refresh timestamp (disk write via `withLastRefreshTime` when config already exists) without replacing manifest/topics. Failed refreshes do not add a header on the next attempt. **`clearCache`** drops in-memory and persisted refresh time.
> 
> **HTTP plumbing:** `HTTPRequest` gains **`additionalHeaders`**, merged into final headers and included when computing **`X-Headers-Hash`**. `RemoteConfigRequest` maps `lastRefreshTime` to those headers in `GetRemoteConfigOperation`; the value is part of the operation cache key but is not JSON-encoded in the POST body.
> 
> ETag-related code renames the request header enum from **`eTagValidationTime`** to **`lastRefreshTime`** while keeping the same wire name **`X-RC-Last-Refresh-Time`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f23d3d0179a998f885f19d9a6d3379d92e88ec28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->