### PR TITLE
Send `paywall_id` and `trace_id` on post receipt

### DIFF
--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -624,7 +624,8 @@ extension PurchaseHandler {
 
         let paywallComponents = WorkflowScreenMapper.toPaywallComponents(
             screen: screen,
-            uiConfig: uiConfig
+            uiConfig: uiConfig,
+            paywallId: WorkflowScreenMapper.paywallId(from: baseOffering)
         )
 
         let initialOffering = baseOffering.withPaywallComponents(paywallComponents)

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -625,7 +625,7 @@ extension PurchaseHandler {
         let paywallComponents = WorkflowScreenMapper.toPaywallComponents(
             screen: screen,
             uiConfig: uiConfig,
-            paywallId: WorkflowScreenMapper.paywallId(from: baseOffering)
+            paywallId: screenID
         )
 
         let initialOffering = baseOffering.withPaywallComponents(paywallComponents)

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -624,7 +624,8 @@ extension PurchaseHandler {
 
         let paywallComponents = WorkflowScreenMapper.toPaywallComponents(
             screen: screen,
-            uiConfig: uiConfig
+            uiConfig: uiConfig,
+            paywallId: screenID
         )
 
         let initialOffering = baseOffering.withPaywallComponents(paywallComponents)

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -96,11 +96,11 @@ struct PaywallsV2View: View {
     /// The workflow step's `screen_type` classification, used to gate impression reporting. `nil` for
     /// standalone paywalls and for workflow steps the backend did not tag (see `stepScreenType`).
     private let workflowScreenType: [String]?
-    /// Workflow attribution for the impression event (`presented_workflow_id` / `presented_step_id` in
-    /// the post-receipt body, see #7024). Orthogonal to `workflowScreenType`: gating decides whether the
-    /// event fires; these identify which workflow step it came from. `nil` for standalone paywalls.
+    /// Workflow purchase attribution. Orthogonal to `workflowScreenType`: gating decides whether the
+    /// event fires; these identify which workflow traversal and step produced a purchase.
     private let workflowId: String?
     private let stepId: String?
+    private let traceId: String?
     /// Whether this workflow step is the workflow's `singleStepFallbackId`. Only consulted for untagged
     /// steps (`nil` `screen_type`), where it restores the structural rule of reporting on the fallback
     /// step alone. Irrelevant for standalone paywalls and tagged steps.
@@ -143,6 +143,7 @@ struct PaywallsV2View: View {
         workflowScreenType: [String]? = nil,
         workflowId: String? = nil,
         stepId: String? = nil,
+        traceId: String? = nil,
         isWorkflowSingleStepFallback: Bool = false
     ) {
         let uiConfigProvider = UIConfigProvider(
@@ -166,6 +167,7 @@ struct PaywallsV2View: View {
         self.workflowScreenType = workflowScreenType
         self.workflowId = workflowId
         self.stepId = stepId
+        self.traceId = traceId
         self.isWorkflowSingleStepFallback = isWorkflowSingleStepFallback
         self._paywallPromoOfferCache = .init(wrappedValue: promoOfferCache ?? PaywallPromoOfferCache(
             subscriptionHistoryTracker: purchaseHandler.subscriptionHistoryTracker
@@ -455,18 +457,18 @@ struct PaywallsV2View: View {
         )
     }
 
-    /// Stamps workflow attribution onto a paywall event's data so the post-receipt body can send
-    /// `presented_workflow_id` / `presented_step_id` (#7024). Orthogonal to the `screen_type` gate
-    /// (``shouldTrackPaywallEvents`` decides whether the event fires at all); both are `nil` for
-    /// standalone paywalls. Mirrors Android's `PaywallEvent.Data.withCurrentWorkflowMetadata`.
+    /// Stamps workflow purchase attribution onto internal paywall event data. Orthogonal to the
+    /// `screen_type` gate; all values are `nil` for standalone paywalls.
     static func applyingWorkflowAttribution(
         to data: PaywallEvent.Data,
         workflowId: String?,
-        stepId: String?
+        stepId: String?,
+        traceId: String?
     ) -> PaywallEvent.Data {
         var data = data
         data.workflowId = workflowId
         data.stepId = stepId
+        data.traceId = traceId
         return data
     }
 
@@ -554,7 +556,12 @@ struct PaywallsV2View: View {
             darkMode: self.colorScheme == .dark,
             source: self.paywallSource
         )
-        return Self.applyingWorkflowAttribution(to: data, workflowId: self.workflowId, stepId: self.stepId)
+        return Self.applyingWorkflowAttribution(
+            to: data,
+            workflowId: self.workflowId,
+            stepId: self.stepId,
+            traceId: self.traceId
+        )
     }
 
 }

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowScreenMapper.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowScreenMapper.swift
@@ -16,6 +16,9 @@
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 enum WorkflowScreenMapper {
 
+    /// `paywallId` is the screen's key in `workflow.screens`, which is the paywall's own id. It cannot be
+    /// read off the offering: workflows imply remote config is active, and that prunes the offering's
+    /// paywall components payload (see `OfferingsManager.shouldCreatePaywallComponents`).
     static func toPaywallComponents(
         screen: WorkflowScreen,
         uiConfig: UIConfig,
@@ -32,12 +35,6 @@ enum WorkflowScreenMapper {
             exitOffers: screen.exitOffers
         )
         return .init(uiConfig: uiConfig, data: data)
-    }
-
-    /// A paywall is always one of a workflow's screens, so the step's offering is the one whose paywall
-    /// id we need. Mirrors Android's `offering.paywall?.id ?: offering.paywallComponents?.data?.id`.
-    static func paywallId(from offering: Offering) -> String? {
-        offering.paywall?.id ?? offering.internalPaywallComponents?.data.id
     }
 
 }

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowScreenMapper.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowScreenMapper.swift
@@ -18,9 +18,11 @@ enum WorkflowScreenMapper {
 
     static func toPaywallComponents(
         screen: WorkflowScreen,
-        uiConfig: UIConfig
+        uiConfig: UIConfig,
+        paywallId: String? = nil
     ) -> Offering.PaywallComponents {
         let data = PaywallComponentsData(
+            id: paywallId,
             templateName: screen.templateName,
             assetBaseURL: screen.assetBaseURL,
             componentsConfig: screen.componentsConfig,
@@ -30,6 +32,12 @@ enum WorkflowScreenMapper {
             exitOffers: screen.exitOffers
         )
         return .init(uiConfig: uiConfig, data: data)
+    }
+
+    /// A paywall is always one of a workflow's screens, so the step's offering is the one whose paywall
+    /// id we need. Mirrors Android's `offering.paywall?.id ?: offering.paywallComponents?.data?.id`.
+    static func paywallId(from offering: Offering) -> String? {
+        offering.paywall?.id ?? offering.internalPaywallComponents?.data.id
     }
 
 }

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowScreenMapper.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowScreenMapper.swift
@@ -18,9 +18,11 @@ enum WorkflowScreenMapper {
 
     static func toPaywallComponents(
         screen: WorkflowScreen,
-        uiConfig: UIConfig
+        uiConfig: UIConfig,
+        paywallId: String? = nil
     ) -> Offering.PaywallComponents {
         let data = PaywallComponentsData(
+            id: paywallId,
             templateName: screen.templateName,
             assetBaseURL: screen.assetBaseURL,
             componentsConfig: screen.componentsConfig,

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowStepEventCoordinator.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowStepEventCoordinator.swift
@@ -27,6 +27,8 @@ final class WorkflowStepEventCoordinator {
     private var hasTrackedTerminalCompletion = false
     private var hasTrackedAbandonment = false
 
+    var traceId: String { self.tracker.traceId }
+
     init(workflow: PublishedWorkflow, traceId: String, sink: @escaping (WorkflowEvent) -> Void) {
         self.tracker = WorkflowStepEventTracker(workflow: workflow, traceId: traceId, sink: sink)
     }

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowStepEventTracker.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowStepEventTracker.swift
@@ -32,7 +32,7 @@ struct WorkflowStepEventTracker {
     }
 
     private let workflow: PublishedWorkflow
-    private let traceId: String
+    let traceId: String
     private let sink: (WorkflowEvent) -> Void
 
     init(

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -464,9 +464,10 @@ struct WorkflowPaywallView: View {
             // Gates paywall events: steps tagged as paywalls report; untagged steps fall back to the
             // single-step-fallback rule.
             workflowScreenType: page.screenType,
-            // Workflow attribution on the impression event (#7024), orthogonal to the screen_type gate.
+            // Workflow purchase attribution, orthogonal to the screen_type gate.
             workflowId: self.context.workflow.id,
             stepId: page.stepId,
+            traceId: self.stepEventCoordinator.traceId,
             isWorkflowSingleStepFallback: page.isSingleStepFallback
         )
         .environment(\.workflowPackageContext, page.effectiveWorkflowPackageContext)

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -705,7 +705,8 @@ struct WorkflowPaywallView: View {
 
         let paywallComponents = WorkflowScreenMapper.toPaywallComponents(
             screen: screen,
-            uiConfig: context.uiConfig
+            uiConfig: context.uiConfig,
+            paywallId: WorkflowScreenMapper.paywallId(from: offering)
         )
 
         return .init(

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -706,7 +706,7 @@ struct WorkflowPaywallView: View {
         let paywallComponents = WorkflowScreenMapper.toPaywallComponents(
             screen: screen,
             uiConfig: context.uiConfig,
-            paywallId: WorkflowScreenMapper.paywallId(from: offering)
+            paywallId: screenId
         )
 
         return .init(

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -705,7 +705,8 @@ struct WorkflowPaywallView: View {
 
         let paywallComponents = WorkflowScreenMapper.toPaywallComponents(
             screen: screen,
-            uiConfig: context.uiConfig
+            uiConfig: context.uiConfig,
+            paywallId: screenId
         )
 
         return .init(

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -178,6 +178,9 @@ extension PostReceiptDataOperation {
         var workflowId: String?
         var stepId: String?
 
+        /// Encoded inside the nested paywall object for transaction attribution.
+        var traceId: String?
+
     }
 
     struct AppliedTargetingRule {
@@ -244,7 +247,8 @@ private extension PurchasedTransactionData {
                      localeIdentifier: paywall.data.localeIdentifier,
                      source: paywall.data.source,
                      workflowId: paywall.data.workflowId,
-                     stepId: paywall.data.stepId)
+                     stepId: paywall.data.stepId,
+                     traceId: paywall.data.traceId)
     }
 }
 
@@ -371,6 +375,7 @@ extension PostReceiptDataOperation.Paywall: Codable {
         case darkMode
         case localeIdentifier = "locale"
         case source
+        case traceId
 
     }
 }

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -178,6 +178,11 @@ extension PostReceiptDataOperation {
         var workflowId: String?
         var stepId: String?
 
+        /// Unlike `workflowId`/`stepId`, this rides inside the nested `paywall` object: the backend's
+        /// post-receipt body model rejects unknown top-level keys, so a `presented_trace_id` sibling
+        /// would fail the request until the backend adds it.
+        var traceId: String?
+
     }
 
     struct AppliedTargetingRule {
@@ -244,7 +249,8 @@ private extension PurchasedTransactionData {
                      localeIdentifier: paywall.data.localeIdentifier,
                      source: paywall.data.source,
                      workflowId: paywall.data.workflowId,
-                     stepId: paywall.data.stepId)
+                     stepId: paywall.data.stepId,
+                     traceId: paywall.data.traceId)
     }
 }
 
@@ -371,6 +377,7 @@ extension PostReceiptDataOperation.Paywall: Codable {
         case darkMode
         case localeIdentifier = "locale"
         case source
+        case traceId
 
     }
 }

--- a/Sources/Paywalls/Events/PaywallEvent.swift
+++ b/Sources/Paywalls/Events/PaywallEvent.swift
@@ -157,6 +157,7 @@ extension PaywallEvent {
         var errorMessage: String?
         @_spi(Internal) public var workflowId: String?
         @_spi(Internal) public var stepId: String?
+        @_spi(Internal) public var traceId: String?
 
         #if !os(tvOS) // For Paywalls V2
         @_spi(Internal)
@@ -268,7 +269,8 @@ extension PaywallEvent {
             errorCode: Int? = nil,
             errorMessage: String? = nil,
             workflowId: String? = nil,
-            stepId: String? = nil
+            stepId: String? = nil,
+            traceId: String? = nil
         ) {
             self.paywallIdentifier = paywallIdentifier
             self.offeringIdentifier = offeringIdentifier
@@ -287,6 +289,7 @@ extension PaywallEvent {
             self.errorMessage = errorMessage
             self.workflowId = workflowId
             self.stepId = stepId
+            self.traceId = traceId
         }
 
     }

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallsV2ViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallsV2ViewTests.swift
@@ -233,17 +233,18 @@ final class ApplyingWorkflowAttributionTests: TestCase {
         )
     }
 
-    // The seam #7024 wires and the screen_type work removed: a workflow paywall step's impression event
-    // must carry the workflow + step so the post-receipt body sends presented_workflow_id/step_id.
+    // A workflow paywall step's purchase attribution must carry the workflow, step, and traversal.
     func testStampsWorkflowAndStepIdOnWorkflowStep() {
         let result = PaywallsV2View.applyingWorkflowAttribution(
             to: self.makeData(),
             workflowId: "wf_test",
-            stepId: "step_1"
+            stepId: "step_1",
+            traceId: "trace_1"
         )
 
         expect(result.workflowId) == "wf_test"
         expect(result.stepId) == "step_1"
+        expect(result.traceId) == "trace_1"
     }
 
     // Standalone paywalls (and untagged steps with no IDs) carry no attribution, so the post-receipt
@@ -252,11 +253,13 @@ final class ApplyingWorkflowAttributionTests: TestCase {
         let result = PaywallsV2View.applyingWorkflowAttribution(
             to: self.makeData(workflowId: "stale", stepId: "stale"),
             workflowId: nil,
-            stepId: nil
+            stepId: nil,
+            traceId: nil
         )
 
         expect(result.workflowId).to(beNil())
         expect(result.stepId).to(beNil())
+        expect(result.traceId).to(beNil())
     }
 
 }

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
@@ -1145,6 +1145,74 @@ extension WorkflowPaywallViewTests {
 
 }
 
+// MARK: - Trace id wiring
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension WorkflowPaywallViewTests {
+
+    /// `PaywallsV2View`'s `traceId` defaults to `nil`, so dropping the argument would compile silently.
+    @MainActor
+    func testPaywallEventCarriesTheSameTraceIdAsTheWorkflowEvent() async throws {
+        let paywallEvents: Atomic<[PaywallEvent]> = .init([])
+        let workflowEvents: Atomic<[WorkflowEvent]> = .init([])
+        let (purchases, purchaseHandler) = Self.makeEventRecordingPurchaseHandler(paywallEvents: paywallEvents)
+        purchases.trackWorkflowEventBlock = { event in
+            workflowEvents.modify { $0.append(event) }
+        }
+        let context = try Self.makeContextStartingAt(stepId: "step_a")
+
+        let dispose = try WorkflowPurchaseObserver(purchaseHandler: purchaseHandler, context: context)
+            .addToHierarchy()
+        defer { dispose() }
+
+        await expect(paywallEvents.value).toEventually(
+            containElementSatisfying { Self.isImpression($0) },
+            timeout: .seconds(3)
+        )
+        await expect(workflowEvents.value).toEventually(
+            containElementSatisfying { Self.isStepStarted($0) },
+            timeout: .seconds(3)
+        )
+
+        let impression = try XCTUnwrap(paywallEvents.value.first { Self.isImpression($0) })
+        let stepStarted = try XCTUnwrap(workflowEvents.value.first { Self.isStepStarted($0) })
+
+        let paywallTraceId = try XCTUnwrap(impression.data.traceId, "paywall event carried no trace id")
+        let workflowTraceId = try XCTUnwrap(stepStarted.data.traceId, "workflow event carried no trace id")
+        expect(paywallTraceId) == workflowTraceId
+    }
+
+    private static func isImpression(_ event: PaywallEvent) -> Bool {
+        if case .impression = event { return true }
+        return false
+    }
+
+    private static func isStepStarted(_ event: WorkflowEvent) -> Bool {
+        if case .stepStarted = event { return true }
+        return false
+    }
+
+    private static func makeEventRecordingPurchaseHandler(
+        paywallEvents: Atomic<[PaywallEvent]>
+    ) -> (MockPurchases, PurchaseHandler) {
+        let purchases = MockPurchases { _, _, _ in
+            return (transaction: nil, customerInfo: TestData.customerInfo, userCancelled: false)
+        } restorePurchases: {
+            return TestData.customerInfo
+        } trackEvent: { event in
+            paywallEvents.modify { $0.append(event) }
+        } customerInfo: {
+            return TestData.customerInfo
+        }
+        let purchaseHandler = PurchaseHandler(
+            purchases: purchases,
+            eventTracker: .init(purchases: purchases, eventDispatcher: PaywallEventTrackerTestDispatcher.value)
+        )
+        return (purchases, purchaseHandler)
+    }
+
+}
+
 // MARK: - Callback test helpers
 
 /// Mirrors the @StateObject role that PaywallView plays in production:

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
@@ -1010,6 +1010,47 @@ extension WorkflowPaywallViewTests {
 
 }
 
+// MARK: - Paywall impression event carries the offering's paywall id
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension WorkflowPaywallViewTests {
+
+    @MainActor
+    func testPaywallImpressionCarriesThePaywallIdFromTheOffering() throws {
+        let trackedEvents: Atomic<[PaywallEvent]> = .init([])
+        let purchases = MockPurchases(
+            purchase: { _, _, _ in
+                (transaction: nil, customerInfo: TestData.customerInfo, userCancelled: false)
+            },
+            restorePurchases: { TestData.customerInfo },
+            trackEvent: { event in trackedEvents.modify { $0.append(event) } },
+            customerInfo: { TestData.customerInfo }
+        )
+        let purchaseHandler = PurchaseHandler(
+            purchases: purchases,
+            eventTracker: .init(purchases: purchases, eventDispatcher: PaywallEventTrackerTestDispatcher.value)
+        )
+        let context = try Self.makeContextStartingAt(stepId: "step_a", paywallId: "offering_paywall_id")
+
+        let dispose = try WorkflowPurchaseObserver(purchaseHandler: purchaseHandler, context: context)
+            .addToHierarchy()
+        defer { dispose() }
+
+        expect(trackedEvents.value.contains(where: {
+            if case .impression = $0 { return true }
+            return false
+        })).toEventually(beTrue(), timeout: .seconds(2))
+
+        let impressionEvent = try XCTUnwrap(trackedEvents.value.first(where: {
+            if case .impression = $0 { return true }
+            return false
+        }))
+
+        expect(impressionEvent.data.paywallIdentifier) == "offering_paywall_id"
+    }
+
+}
+
 // MARK: - Callback tests (non-initial step)
 // These tests verify that purchase/restore callbacks fire when the workflow renders
 // a non-initial step. WorkflowPaywallView uses a shared purchaseHandler across all
@@ -1341,7 +1382,7 @@ private extension WorkflowPaywallViewTests {
 
     /// Creates a two-step workflow (step_a, step_b) with initial_step_id set to stepId.
     /// Use this to exercise callbacks from a non-initial step without requiring navigation.
-    static func makeContextStartingAt(stepId: String) throws -> WorkflowContext {
+    static func makeContextStartingAt(stepId: String, paywallId: String? = nil) throws -> WorkflowContext {
         let offeringId = "offering_test"
         let workflowJSON = """
         {
@@ -1370,11 +1411,16 @@ private extension WorkflowPaywallViewTests {
             makePackage(identifier: TestData.annualPackage.identifier, offeringId: offeringId),
             makePackage(identifier: TestData.monthlyPackage.identifier, offeringId: offeringId)
         ]
+        var paywall: PaywallData?
+        if let paywallId {
+            paywall = TestData.paywallWithIntroOffer
+            paywall?.id = paywallId
+        }
         let offering = Offering(
             identifier: offeringId,
             serverDescription: "Test",
             metadata: [:],
-            paywall: nil,
+            paywall: paywall,
             availablePackages: packages,
             webCheckoutUrl: nil
         )

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
@@ -1182,6 +1182,25 @@ extension WorkflowPaywallViewTests {
         expect(paywallTraceId) == workflowTraceId
     }
 
+    @MainActor
+    func testPaywallImpressionCarriesThePaywallIdFromTheScreen() async throws {
+        let paywallEvents: Atomic<[PaywallEvent]> = .init([])
+        let (_, purchaseHandler) = Self.makeEventRecordingPurchaseHandler(paywallEvents: paywallEvents)
+        let context = try Self.makeContextStartingAt(stepId: "step_a")
+
+        let dispose = try WorkflowPurchaseObserver(purchaseHandler: purchaseHandler, context: context)
+            .addToHierarchy()
+        defer { dispose() }
+
+        await expect(paywallEvents.value).toEventually(
+            containElementSatisfying { Self.isImpression($0) },
+            timeout: .seconds(3)
+        )
+
+        let impression = try XCTUnwrap(paywallEvents.value.first { Self.isImpression($0) })
+        expect(impression.data.paywallIdentifier) == "screen_a"
+    }
+
     private static func isImpression(_ event: PaywallEvent) -> Bool {
         if case .impression = event { return true }
         return false

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
@@ -1010,13 +1010,16 @@ extension WorkflowPaywallViewTests {
 
 }
 
-// MARK: - Paywall impression event carries the offering's paywall id
+// MARK: - Paywall impression event carries the screen's paywall id
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension WorkflowPaywallViewTests {
 
+    // The offering here carries no paywall and no paywall components, which is what production looks
+    // like: workflows imply remote config is active, and that prunes the offering's components payload.
+    // The id has to come from the step's screen key instead.
     @MainActor
-    func testPaywallImpressionCarriesThePaywallIdFromTheOffering() throws {
+    func testPaywallImpressionCarriesThePaywallIdFromTheScreen() throws {
         let trackedEvents: Atomic<[PaywallEvent]> = .init([])
         let purchases = MockPurchases(
             purchase: { _, _, _ in
@@ -1030,7 +1033,7 @@ extension WorkflowPaywallViewTests {
             purchases: purchases,
             eventTracker: .init(purchases: purchases, eventDispatcher: PaywallEventTrackerTestDispatcher.value)
         )
-        let context = try Self.makeContextStartingAt(stepId: "step_a", paywallId: "offering_paywall_id")
+        let context = try Self.makeContextStartingAt(stepId: "step_a")
 
         let dispose = try WorkflowPurchaseObserver(purchaseHandler: purchaseHandler, context: context)
             .addToHierarchy()
@@ -1046,7 +1049,7 @@ extension WorkflowPaywallViewTests {
             return false
         }))
 
-        expect(impressionEvent.data.paywallIdentifier) == "offering_paywall_id"
+        expect(impressionEvent.data.paywallIdentifier) == "screen_a"
     }
 
 }
@@ -1382,7 +1385,7 @@ private extension WorkflowPaywallViewTests {
 
     /// Creates a two-step workflow (step_a, step_b) with initial_step_id set to stepId.
     /// Use this to exercise callbacks from a non-initial step without requiring navigation.
-    static func makeContextStartingAt(stepId: String, paywallId: String? = nil) throws -> WorkflowContext {
+    static func makeContextStartingAt(stepId: String) throws -> WorkflowContext {
         let offeringId = "offering_test"
         let workflowJSON = """
         {
@@ -1411,16 +1414,11 @@ private extension WorkflowPaywallViewTests {
             makePackage(identifier: TestData.annualPackage.identifier, offeringId: offeringId),
             makePackage(identifier: TestData.monthlyPackage.identifier, offeringId: offeringId)
         ]
-        var paywall: PaywallData?
-        if let paywallId {
-            paywall = TestData.paywallWithIntroOffer
-            paywall?.id = paywallId
-        }
         let offering = Offering(
             identifier: offeringId,
             serverDescription: "Test",
             metadata: [:],
-            paywall: paywall,
+            paywall: nil,
             availablePackages: packages,
             webCheckoutUrl: nil
         )

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowScreenMapperTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowScreenMapperTests.swift
@@ -83,6 +83,28 @@ final class WorkflowScreenMapperTests: TestCase {
         expect(result.data.exitOffers).to(beNil())
     }
 
+    func testCarriesThePaywallIdItWasGiven() throws {
+        let screen = try Self.makeScreen()
+        let uiConfig = try Self.makeUIConfig()
+
+        let result = WorkflowScreenMapper.toPaywallComponents(
+            screen: screen,
+            uiConfig: uiConfig,
+            paywallId: "paywall_123"
+        )
+
+        expect(result.data.id) == "paywall_123"
+    }
+
+    func testIdIsNilWhenNotGiven() throws {
+        let screen = try Self.makeScreen()
+        let uiConfig = try Self.makeUIConfig()
+
+        let result = WorkflowScreenMapper.toPaywallComponents(screen: screen, uiConfig: uiConfig)
+
+        expect(result.data.id).to(beNil())
+    }
+
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowScreenMapperTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowScreenMapperTests.swift
@@ -105,50 +105,6 @@ final class WorkflowScreenMapperTests: TestCase {
         expect(result.data.id).to(beNil())
     }
 
-    // Workflow paywalls are Paywalls V2, so this is the branch that fires in production.
-    func testPaywallIdFallsBackToTheComponentsIdWhenThereIsNoV1Paywall() throws {
-        let offering = try Self.makeOffering(paywall: nil, componentsPaywallId: "components_id")
-
-        expect(WorkflowScreenMapper.paywallId(from: offering)) == "components_id"
-    }
-
-    func testPaywallIdPrefersTheV1PaywallId() throws {
-        var paywall = TestData.paywallWithIntroOffer
-        paywall.id = "v1_id"
-        let offering = try Self.makeOffering(paywall: paywall, componentsPaywallId: "components_id")
-
-        expect(WorkflowScreenMapper.paywallId(from: offering)) == "v1_id"
-    }
-
-    func testPaywallIdIsNilWhenTheOfferingHasNoPaywall() throws {
-        let offering = try Self.makeOffering(paywall: nil, componentsPaywallId: nil)
-
-        expect(WorkflowScreenMapper.paywallId(from: offering)).to(beNil())
-    }
-
-    private static func makeOffering(
-        paywall: PaywallData?,
-        componentsPaywallId: String?
-    ) throws -> Offering {
-        let offering = Offering(
-            identifier: "offering_id",
-            serverDescription: "Test",
-            metadata: [:],
-            paywall: paywall,
-            availablePackages: [],
-            webCheckoutUrl: nil
-        )
-
-        guard let componentsPaywallId else { return offering }
-
-        let components = WorkflowScreenMapper.toPaywallComponents(
-            screen: try Self.makeScreen(),
-            uiConfig: try Self.makeUIConfig(),
-            paywallId: componentsPaywallId
-        )
-        return offering.withPaywallComponents(components)
-    }
-
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowScreenMapperTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowScreenMapperTests.swift
@@ -83,6 +83,72 @@ final class WorkflowScreenMapperTests: TestCase {
         expect(result.data.exitOffers).to(beNil())
     }
 
+    func testCarriesThePaywallIdItWasGiven() throws {
+        let screen = try Self.makeScreen()
+        let uiConfig = try Self.makeUIConfig()
+
+        let result = WorkflowScreenMapper.toPaywallComponents(
+            screen: screen,
+            uiConfig: uiConfig,
+            paywallId: "paywall_123"
+        )
+
+        expect(result.data.id) == "paywall_123"
+    }
+
+    func testIdIsNilWhenNotGiven() throws {
+        let screen = try Self.makeScreen()
+        let uiConfig = try Self.makeUIConfig()
+
+        let result = WorkflowScreenMapper.toPaywallComponents(screen: screen, uiConfig: uiConfig)
+
+        expect(result.data.id).to(beNil())
+    }
+
+    // Workflow paywalls are Paywalls V2, so this is the branch that fires in production.
+    func testPaywallIdFallsBackToTheComponentsIdWhenThereIsNoV1Paywall() throws {
+        let offering = try Self.makeOffering(paywall: nil, componentsPaywallId: "components_id")
+
+        expect(WorkflowScreenMapper.paywallId(from: offering)) == "components_id"
+    }
+
+    func testPaywallIdPrefersTheV1PaywallId() throws {
+        var paywall = TestData.paywallWithIntroOffer
+        paywall.id = "v1_id"
+        let offering = try Self.makeOffering(paywall: paywall, componentsPaywallId: "components_id")
+
+        expect(WorkflowScreenMapper.paywallId(from: offering)) == "v1_id"
+    }
+
+    func testPaywallIdIsNilWhenTheOfferingHasNoPaywall() throws {
+        let offering = try Self.makeOffering(paywall: nil, componentsPaywallId: nil)
+
+        expect(WorkflowScreenMapper.paywallId(from: offering)).to(beNil())
+    }
+
+    private static func makeOffering(
+        paywall: PaywallData?,
+        componentsPaywallId: String?
+    ) throws -> Offering {
+        let offering = Offering(
+            identifier: "offering_id",
+            serverDescription: "Test",
+            metadata: [:],
+            paywall: paywall,
+            availablePackages: [],
+            webCheckoutUrl: nil
+        )
+
+        guard let componentsPaywallId else { return offering }
+
+        let components = WorkflowScreenMapper.toPaywallComponents(
+            screen: try Self.makeScreen(),
+            uiConfig: try Self.makeUIConfig(),
+            paywallId: componentsPaywallId
+        )
+        return offering.withPaywallComponents(components)
+    }
+
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowStepEventCoordinatorTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowStepEventCoordinatorTests.swift
@@ -64,6 +64,17 @@ final class WorkflowStepEventCoordinatorTests: TestCase {
         expect(self.recorded).to(haveCount(1))
     }
 
+    func testTraceIdMatchesTheTraceIdStampedOnEmittedWorkflowEvents() throws {
+        let workflow = try Self.makeWorkflow()
+        let coordinator = self.makeCoordinator(workflow: workflow, freshTraceId: true)
+        let step = try XCTUnwrap(workflow.steps["step_1"])
+
+        coordinator.trackInitialStep(step, hasRenderedPage: true)
+
+        let data = try XCTUnwrap(Self.startedData(self.recorded[0]))
+        expect(coordinator.traceId) == data.traceId
+    }
+
     // MARK: - Forward / back transitions
 
     func testForwardTransitionEmitsCompletedThenStartedInOrder() throws {

--- a/Tests/UnitTests/Networking/Backend/PostReceiptDataOperationFactoryTests.swift
+++ b/Tests/UnitTests/Networking/Backend/PostReceiptDataOperationFactoryTests.swift
@@ -487,6 +487,69 @@ class PostReceiptDataOperationFactoryTests: TestCase {
         expect(paywall["step_id"]).to(beNil())
     }
 
+    // trace_id rides inside the nested paywall object, unlike workflow_id/step_id: the backend's
+    // post-receipt body model forbids unknown top-level keys, so a `presented_trace_id` sibling would
+    // fail the whole request, while the nested paywall model ignores keys it does not know yet.
+    // Encoded with JSONEncoder.default because that is what production uses — a bare JSONEncoder()
+    // skips convertToSnakeCase and would report `traceId` instead.
+    func testTraceIdIsSentInsideTheNestedPaywallObject() throws {
+        let json = try self.encodedBody(forPaywall: Self.paywallData(traceId: "trace-456"))
+
+        let paywall = try XCTUnwrap(json["paywall"] as? [String: Any])
+        expect(paywall["trace_id"] as? String) == "trace-456"
+
+        expect(json["trace_id"]).to(beNil())
+        expect(json["presented_trace_id"]).to(beNil())
+    }
+
+    func testTraceIdIsOmittedWhenThePaywallHasNone() throws {
+        let json = try self.encodedBody(forPaywall: Self.paywallData(traceId: nil))
+
+        let paywall = try XCTUnwrap(json["paywall"] as? [String: Any])
+        expect(paywall.keys.contains("trace_id")) == false
+    }
+
+    private static func paywallData(traceId: String?) -> PaywallEvent.Data {
+        return .init(
+            paywallIdentifier: "paywall-abc",
+            offeringIdentifier: "offering-1",
+            paywallRevision: 1,
+            sessionID: UUID(),
+            displayMode: .fullScreen,
+            localeIdentifier: "en_US",
+            darkMode: false,
+            workflowId: "workflow-xyz",
+            stepId: "step-123",
+            traceId: traceId
+        )
+    }
+
+    private func encodedBody(forPaywall paywallData: PaywallEvent.Data) throws -> [String: Any] {
+        let transactionData = PurchasedTransactionData(
+            presentedOfferingContext: nil,
+            presentedPaywall: .impression(.init(), paywallData),
+            unsyncedAttributes: nil,
+            storeCountry: nil
+        )
+
+        let postData = PostReceiptDataOperation.PostData(
+            transactionData: transactionData,
+            postReceiptSource: .init(isRestore: false, initiationSource: .purchase),
+            appUserID: self.appUserID,
+            productData: nil,
+            receipt: self.receipt,
+            observerMode: false,
+            purchaseCompletedBy: .revenueCat,
+            testReceiptIdentifier: nil,
+            appTransaction: nil,
+            transactionId: nil,
+            containsAttributionData: false
+        )
+
+        let data = try JSONEncoder.default.encode(postData)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
     func testPresentedWorkflowIdAndStepIdAreAbsentWhenNoPaywall() throws {
         let transactionData = PurchasedTransactionData(
             presentedOfferingContext: nil,
@@ -573,7 +636,8 @@ class PostReceiptDataOperationFactoryTests: TestCase {
             localeIdentifier: "en_US",
             darkMode: false,
             workflowId: "workflow-xyz",
-            stepId: "step-123"
+            stepId: "step-123",
+            traceId: "trace-456"
         )
 
         let config = self.createConfig()

--- a/Tests/UnitTests/Networking/Backend/PostReceiptDataOperationFactoryTests.swift
+++ b/Tests/UnitTests/Networking/Backend/PostReceiptDataOperationFactoryTests.swift
@@ -487,6 +487,63 @@ class PostReceiptDataOperationFactoryTests: TestCase {
         expect(paywall["step_id"]).to(beNil())
     }
 
+    func testTraceIdIsSentInsideTheNestedPaywallObject() throws {
+        let json = try self.encodedBody(forPaywall: Self.paywallData(traceId: "trace-456"))
+
+        let paywall = try XCTUnwrap(json["paywall"] as? [String: Any])
+        expect(paywall["trace_id"] as? String) == "trace-456"
+        expect(json["trace_id"]).to(beNil())
+        expect(json["presented_trace_id"]).to(beNil())
+    }
+
+    func testTraceIdIsOmittedWhenThePaywallHasNone() throws {
+        let json = try self.encodedBody(forPaywall: Self.paywallData(traceId: nil))
+
+        let paywall = try XCTUnwrap(json["paywall"] as? [String: Any])
+        expect(paywall.keys.contains("trace_id")) == false
+    }
+
+    private static func paywallData(traceId: String?) -> PaywallEvent.Data {
+        return .init(
+            paywallIdentifier: "paywall-abc",
+            offeringIdentifier: "offering-1",
+            paywallRevision: 1,
+            sessionID: UUID(),
+            displayMode: .fullScreen,
+            localeIdentifier: "en_US",
+            darkMode: false,
+            workflowId: "workflow-xyz",
+            stepId: "step-123",
+            traceId: traceId
+        )
+    }
+
+    private func encodedBody(forPaywall paywallData: PaywallEvent.Data) throws -> [String: Any] {
+        let transactionData = PurchasedTransactionData(
+            presentedOfferingContext: nil,
+            presentedPaywall: .impression(.init(), paywallData),
+            unsyncedAttributes: nil,
+            storeCountry: nil
+        )
+
+        let postData = PostReceiptDataOperation.PostData(
+            transactionData: transactionData,
+            postReceiptSource: .init(isRestore: false, initiationSource: .purchase),
+            appUserID: self.appUserID,
+            productData: nil,
+            receipt: self.receipt,
+            observerMode: false,
+            purchaseCompletedBy: .revenueCat,
+            testReceiptIdentifier: nil,
+            appTransaction: nil,
+            transactionId: nil,
+            containsAttributionData: false
+        )
+
+        let data = try JSONEncoder.default.encode(postData)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
     func testPresentedWorkflowIdAndStepIdAreAbsentWhenNoPaywall() throws {
         let transactionData = PurchasedTransactionData(
             presentedOfferingContext: nil,


### PR DESCRIPTION
Workflow paywall purchases need the workflow trace and paywall ids in the post-receipt body so [khepri#23285](https://github.com/RevenueCat/khepri/pull/23285) can save them on the transaction.

Use the workflow screen key as the paywall id. Carry the workflow trace id through purchase attribution and send it inside the nested `paywall` object in the post-receipt body.

This does not add the trace id to paywall event requests.

Equivalent Android PR https://github.com/RevenueCat/purchases-android/pull/3858 . Android was already sending `paywall_id`

```
 "paywall": {
    "trace_id": "44CB0863-E780-4FA2-8E8C-DA641A7C57C1",
    "revision": 18,
    "display_mode": "full_screen",
    "dark_mode": false,
    "session_id": "344C08E3-DE02-4126-9D71-9AF880846508",
    "paywall_id": "pw388ec5f023b94a11",
    "locale": "en_ES"
  },
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ca0acdea500d0bf83fd6a743025a49741e3960dd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->