### PR TITLE
feat(remote-config): use the server clock for X-RC-Last-Refresh-Time

### DIFF
--- a/Sources/Networking/RemoteConfigAPI.swift
+++ b/Sources/Networking/RemoteConfigAPI.swift
@@ -91,10 +91,12 @@ struct RemoteConfigFetchResult {
     /// container bytes should fail before this result is created.
     let container: RemoteConfigContainer?
     let verificationResult: VerificationResult
+    let requestDate: Date?
 
     init(response: VerifiedHTTPResponse<RemoteConfigContainer?>) {
         self.container = response.body
         self.verificationResult = response.verificationResult
+        self.requestDate = response.requestDate
     }
 
 }

--- a/Sources/Networking/RemoteConfigDiskCache.swift
+++ b/Sources/Networking/RemoteConfigDiskCache.swift
@@ -33,6 +33,10 @@ struct PersistedRemoteConfiguration: Codable, Equatable {
     let activeTopics: [String]
     let prefetchBlobs: [String]
     let topics: RemoteConfiguration.Topics
+
+    /// The most recent `X-RevenueCat-Request-Time` supplied by the main API, stored as epoch milliseconds.
+    ///
+    /// This value is replayed as `X-RC-Last-Refresh-Time` on the next config request.
     private(set) var lastRefreshTimeMilliseconds: UInt64?
 
     init(
@@ -79,10 +83,12 @@ struct PersistedRemoteConfiguration: Codable, Equatable {
 
 extension PersistedRemoteConfiguration {
 
+    /// The persisted main-server request time in the `Date` representation used by the request layer.
     var lastRefreshTime: Date? {
         return self.lastRefreshTimeMilliseconds.map(Date.init(millisecondsSince1970:))
     }
 
+    /// Returns a copy whose replayed refresh time is updated from a successful main-server response.
     func withLastRefreshTime(_ date: Date) -> Self {
         var copy = self
         copy.lastRefreshTimeMilliseconds = date.millisecondsSince1970

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -298,10 +298,15 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     /// ID over the provider value, so a request is either created for the cleared identity or treated as stale later.
     private var identityBoundAppUserID: String?
 
-    /// In-memory staleness marker. Only successful `200` and `204` responses mark the config fresh.
+    /// Client-clock time when this process last completed a successful `200` or `204` refresh.
+    ///
+    /// This is memory-only and is compared with `dateProvider.now()` to decide when the local cache is stale.
     private var lastRefreshedAt: Date?
 
-    /// In-memory attempt marker used to avoid hammering the endpoint when a stale refresh keeps failing.
+    /// Client-clock time when this process last attempted a stale-gated refresh.
+    ///
+    /// This is memory-only and drives the local retry cooldown. The configuration stores its main-server request
+    /// time separately for refresh requests.
     private var lastRefreshAttemptAt: Date?
 
     /// Read callers waiting for the current refresh to finish before rereading committed config state.
@@ -499,13 +504,13 @@ private extension RemoteConfigManager {
 
     func startRefresh(isAppBackgrounded: Bool, requestContext: RefreshRequestContext) {
         let persisted = self.diskCache.read()
-        // The header replays only server-provided time; `lastRefreshedAt` uses the client clock for local staleness.
         let request = RemoteConfigRequest(
             fetchContext: requestContext.fetchContext,
             appUserID: requestContext.requestAppUserID,
             domain: persisted?.domain ?? Self.defaultDomain,
             manifest: persisted?.manifest,
             prefetchedBlobs: self.cachedPrefetchedBlobRefs(from: persisted),
+            // Replay the persisted main-server request date.
             lastRefreshTime: persisted?.lastRefreshTime
         )
 
@@ -599,6 +604,7 @@ private extension RemoteConfigManager {
 
             self.lock.perform {
                 guard self.epoch == requestEpoch else { return }
+                // Prefer this response's main-server request date, carrying forward the persisted value as needed.
                 let lastRefreshTime = fetchResult.requestDate ?? previous?.lastRefreshTime
                 let didPersist = self.persist(
                     container: container,
@@ -691,7 +697,7 @@ private extension RemoteConfigManager {
 
         self.lock.perform {
             guard self.epoch == requestEpoch else { return }
-            // The fallback may use a different host, so its request time must not replace the main API's time.
+            // Keep the persisted refresh time associated with main API responses.
             let didPersist = self.persist(
                 container: nil,
                 previous: previous,
@@ -759,16 +765,18 @@ private extension RemoteConfigManager {
         self.lock.perform {
             guard self.epoch == requestEpoch else { return }
 
-            // Missing server time leaves the previously persisted value untouched.
+            // A response request date advances the persisted main-server time.
             if let previous, let requestDate {
                 self.diskCache.write(previous.withLastRefreshTime(requestDate))
             }
+            // Local staleness starts when this response lands, independently of the server timestamp above.
             self.markRefreshed(at: self.dateProvider.now())
         }
     }
 
-    /// Records a landed refresh: stamps the refresh time and marks the session's initial config as committed, so
-    /// later refreshes stop being forced to `.appStart`. Must be called within `lock`.
+    /// Records a landed refresh using the client clock and marks the session's initial config as committed, so later
+    /// refreshes stop being forced to `.appStart`. This timestamp drives local staleness; the main-server request
+    /// timestamp is persisted separately. Must be called within `lock`.
     func markRefreshed(at date: Date) {
         self.hasCommittedInitialConfig = true
         self.lastRefreshedAt = date

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -259,7 +259,6 @@ final class RemoteConfigManager: RemoteConfigManagerType {
         let epoch: Int
         let requestAppUserID: String
         let fetchContext: RemoteConfigFetchContext
-        let lastRefreshedAt: Date?
     }
 
     /// Runs blocking committed-state reads away from the caller's executor.
@@ -459,8 +458,7 @@ private extension RemoteConfigManager {
             return .init(
                 epoch: self.epoch,
                 requestAppUserID: requestAppUserID,
-                fetchContext: self.fetchContextForRefresh(fetchContext),
-                lastRefreshedAt: self.lastRefreshedAt
+                fetchContext: self.fetchContextForRefresh(fetchContext)
             )
         }
     }
@@ -494,28 +492,21 @@ private extension RemoteConfigManager {
             return .init(
                 epoch: self.epoch,
                 requestAppUserID: requestAppUserID,
-                fetchContext: self.fetchContextForRefresh(fetchContext),
-                lastRefreshedAt: self.lastRefreshedAt
+                fetchContext: self.fetchContextForRefresh(fetchContext)
             )
         }
     }
 
     func startRefresh(isAppBackgrounded: Bool, requestContext: RefreshRequestContext) {
         let persisted = self.diskCache.read()
-        // A refresh time is only meaningful when there is a persisted configuration to associate it with.
-        let lastRefreshTime: Date?
-        if let persisted {
-            lastRefreshTime = requestContext.lastRefreshedAt ?? persisted.lastRefreshTime
-        } else {
-            lastRefreshTime = nil
-        }
+        // The header replays only server-provided time; `lastRefreshedAt` uses the client clock for local staleness.
         let request = RemoteConfigRequest(
             fetchContext: requestContext.fetchContext,
             appUserID: requestContext.requestAppUserID,
             domain: persisted?.domain ?? Self.defaultDomain,
             manifest: persisted?.manifest,
             prefetchedBlobs: self.cachedPrefetchedBlobRefs(from: persisted),
-            lastRefreshTime: lastRefreshTime
+            lastRefreshTime: persisted?.lastRefreshTime
         )
 
         Logger.verbose(Strings.remoteConfig.refreshing(
@@ -590,7 +581,11 @@ private extension RemoteConfigManager {
 
         guard let container = fetchResult.container else {
             Logger.debug(Strings.remoteConfig.notModified)
-            self.markRefreshedIfCurrent(requestEpoch, previous: previous)
+            self.markRefreshedIfCurrent(
+                requestEpoch,
+                previous: previous,
+                requestDate: fetchResult.requestDate
+            )
             return
         }
 
@@ -604,16 +599,16 @@ private extension RemoteConfigManager {
 
             self.lock.perform {
                 guard self.epoch == requestEpoch else { return }
-                let refreshedAt = self.dateProvider.now()
+                let lastRefreshTime = fetchResult.requestDate ?? previous?.lastRefreshTime
                 let didPersist = self.persist(
                     container: container,
                     previous: previous,
                     response: response,
-                    refreshedAt: refreshedAt
+                    lastRefreshTime: lastRefreshTime
                 )
                 if didPersist {
                     self.generation += 1
-                    self.markRefreshed(at: refreshedAt)
+                    self.markRefreshed(at: self.dateProvider.now())
                 }
             }
         } catch {
@@ -696,16 +691,16 @@ private extension RemoteConfigManager {
 
         self.lock.perform {
             guard self.epoch == requestEpoch else { return }
-            let refreshedAt = self.dateProvider.now()
+            // The fallback may use a different host, so its request time must not replace the main API's time.
             let didPersist = self.persist(
                 container: nil,
                 previous: previous,
                 response: fallbackResult.configuration,
-                refreshedAt: refreshedAt
+                lastRefreshTime: previous?.lastRefreshTime
             )
             if didPersist {
                 self.generation += 1
-                self.markRefreshed(at: refreshedAt)
+                self.markRefreshed(at: self.dateProvider.now())
             }
         }
     }
@@ -758,16 +753,17 @@ private extension RemoteConfigManager {
 
     func markRefreshedIfCurrent(
         _ requestEpoch: Int,
-        previous: PersistedRemoteConfiguration?
+        previous: PersistedRemoteConfiguration?,
+        requestDate: Date?
     ) {
         self.lock.perform {
             guard self.epoch == requestEpoch else { return }
 
-            let refreshedAt = self.dateProvider.now()
-            if let previous {
-                self.diskCache.write(previous.withLastRefreshTime(refreshedAt))
+            // Missing server time leaves the previously persisted value untouched.
+            if let previous, let requestDate {
+                self.diskCache.write(previous.withLastRefreshTime(requestDate))
             }
-            self.markRefreshed(at: refreshedAt)
+            self.markRefreshed(at: self.dateProvider.now())
         }
     }
 
@@ -954,7 +950,7 @@ private extension RemoteConfigManager {
         container: RemoteConfigContainer?,
         previous: PersistedRemoteConfiguration?,
         response: RemoteConfiguration,
-        refreshedAt: Date
+        lastRefreshTime: Date?
     ) -> Bool {
         Logger.debug(Strings.remoteConfig.receivedConfiguration(
             activeTopics: response.activeTopics, changedTopics: Array(response.topics.entries.keys)
@@ -975,7 +971,7 @@ private extension RemoteConfigManager {
             activeTopics: response.activeTopics,
             prefetchBlobs: response.prefetchBlobs,
             topics: postSyncTopics,
-            lastRefreshTimeMilliseconds: refreshedAt.millisecondsSince1970
+            lastRefreshTimeMilliseconds: lastRefreshTime?.millisecondsSince1970
         )
 
         guard self.diskCache.write(persistedConfiguration) else { return false }

--- a/Tests/BackendIntegrationTests/ProductionRemoteConfigIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/ProductionRemoteConfigIntegrationTests.swift
@@ -72,6 +72,7 @@ class BaseProductionRemoteConfigIntegrationTests: BaseBackendIntegrationTests {
 
     func verifyContainerResponse(_ result: RemoteConfigFetchResult) throws -> RemoteConfiguration {
         expect(result.verificationResult) == .verified
+        expect(result.requestDate).toNot(beNil())
 
         let container = try XCTUnwrap(result.container)
         let configuration = try self.remoteConfiguration(from: container)
@@ -82,6 +83,7 @@ class BaseProductionRemoteConfigIntegrationTests: BaseBackendIntegrationTests {
 
     func verifyNoContentResponse(_ result: RemoteConfigFetchResult) {
         expect(result.verificationResult) == .verified
+        expect(result.requestDate).toNot(beNil())
         expect(result.container).to(beNil())
     }
 

--- a/Tests/BackendIntegrationTests/ProductionRemoteConfigIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/ProductionRemoteConfigIntegrationTests.swift
@@ -21,13 +21,15 @@ import XCTest
 class BaseProductionRemoteConfigIntegrationTests: BaseBackendIntegrationTests {
 
     private static let domain = RemoteConfiguration.defaultDomain
+    private static let epochMillisecondsFloor = Date(timeIntervalSince1970: 1_700_000_000)
 
     private lazy var remoteConfigAPI = self.createRemoteConfigAPI()
     private lazy var appUserID = self.createAppUserID()
 
     func fetchRemoteConfig(
         fetchContext: RemoteConfigFetchContext,
-        manifest: String? = nil
+        manifest: String? = nil,
+        lastRefreshTime: Date? = nil
     ) async throws -> RemoteConfigFetchResult {
         return try await withCheckedThrowingContinuation { continuation in
             self.remoteConfigAPI.getRemoteConfig(
@@ -36,7 +38,8 @@ class BaseProductionRemoteConfigIntegrationTests: BaseBackendIntegrationTests {
                     appUserID: self.appUserID,
                     domain: Self.domain,
                     manifest: manifest,
-                    prefetchedBlobs: []
+                    prefetchedBlobs: [],
+                    lastRefreshTime: lastRefreshTime
                 ),
                 isAppBackgrounded: false
             ) { result in
@@ -70,20 +73,22 @@ class BaseProductionRemoteConfigIntegrationTests: BaseBackendIntegrationTests {
         expect(configuration.manifest).toNot(beEmpty())
     }
 
-    func verifyContainerResponse(_ result: RemoteConfigFetchResult) throws -> RemoteConfiguration {
+    func verifyContainerResponse(
+        _ result: RemoteConfigFetchResult
+    ) throws -> (configuration: RemoteConfiguration, requestDate: Date) {
         expect(result.verificationResult) == .verified
-        expect(result.requestDate).toNot(beNil())
+        let requestDate = try self.verifyServerRequestDate(result.requestDate)
 
         let container = try XCTUnwrap(result.container)
         let configuration = try self.remoteConfiguration(from: container)
         self.verifyRemoteConfiguration(configuration)
 
-        return configuration
+        return (configuration, requestDate)
     }
 
-    func verifyNoContentResponse(_ result: RemoteConfigFetchResult) {
+    func verifyNoContentResponse(_ result: RemoteConfigFetchResult) throws {
         expect(result.verificationResult) == .verified
-        expect(result.requestDate).toNot(beNil())
+        _ = try self.verifyServerRequestDate(result.requestDate)
         expect(result.container).to(beNil())
     }
 
@@ -91,6 +96,13 @@ class BaseProductionRemoteConfigIntegrationTests: BaseBackendIntegrationTests {
         expect(result.verificationResult) == .verified
 
         self.verifyRemoteConfiguration(result.configuration)
+    }
+
+    private func verifyServerRequestDate(_ requestDate: Date?) throws -> Date {
+        let requestDate = try XCTUnwrap(requestDate)
+        expect(requestDate) > Self.epochMillisecondsFloor
+
+        return requestDate
     }
 
 }
@@ -149,15 +161,18 @@ final class ProductionRemoteConfigIntegrationTests: BaseProductionRemoteConfigIn
     }
 
     func testReplayingManifestReturnsNoContent() async throws {
-        let configuration = try self.verifyContainerResponse(
-            try await self.fetchRemoteConfig(fetchContext: .appStart)
-        )
+        let firstResult = try await self.fetchRemoteConfig(fetchContext: .appStart)
+        let (configuration, requestDate) = try self.verifyContainerResponse(firstResult)
 
         // A `.read` context lets the backend honor the refresh-interval fast path and return no content,
         // whereas `.appStart` would force a full resolve and return the config again.
-        let result = try await self.fetchRemoteConfig(fetchContext: .read, manifest: configuration.manifest)
+        let result = try await self.fetchRemoteConfig(
+            fetchContext: .read,
+            manifest: configuration.manifest,
+            lastRefreshTime: requestDate
+        )
 
-        self.verifyNoContentResponse(result)
+        try self.verifyNoContentResponse(result)
     }
 
     func testCanFetchRemoteConfigFromFallbackURL() async throws {
@@ -181,15 +196,18 @@ final class EnforcedProductionRemoteConfigIntegrationTests: BaseProductionRemote
     }
 
     func testVerifiesNoContentResponseWhenVerificationIsEnforced() async throws {
-        let configuration = try self.verifyContainerResponse(
-            try await self.fetchRemoteConfig(fetchContext: .appStart)
-        )
+        let firstResult = try await self.fetchRemoteConfig(fetchContext: .appStart)
+        let (configuration, requestDate) = try self.verifyContainerResponse(firstResult)
 
         // A `.read` context lets the backend honor the refresh-interval fast path and return no content,
         // whereas `.appStart` would force a full resolve and return the config again.
-        let result = try await self.fetchRemoteConfig(fetchContext: .read, manifest: configuration.manifest)
+        let result = try await self.fetchRemoteConfig(
+            fetchContext: .read,
+            manifest: configuration.manifest,
+            lastRefreshTime: requestDate
+        )
 
-        self.verifyNoContentResponse(result)
+        try self.verifyNoContentResponse(result)
     }
 
     func testVerifiesFallbackResponseWhenVerificationIsEnforced() async throws {

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
@@ -449,14 +449,13 @@ final class RemoteConfigIntegrationTests: TestCase {
 
         await self.refresh(with: container, requestDate: serverRequestTime)
 
-        let storedRefreshTime = try XCTUnwrap(self.diskCache.read()?.lastRefreshTimeMilliseconds)
         self.mockRemoteConfigResponse(statusCode: .noContent, body: Data())
         self.manager.refreshRemoteConfig(fetchContext: .foreground, isAppBackgrounded: false)
         await self.waitForRemoteConfigRequestCount(2)
 
         expect(self.remoteConfigCalls.first?.headers[HTTPClient.RequestHeader.lastRefreshTime.rawValue]).to(beNil())
         expect(self.remoteConfigCalls.last?.headers[HTTPClient.RequestHeader.lastRefreshTime.rawValue])
-            == storedRefreshTime.description
+            == serverRequestTime.millisecondsSince1970.description
     }
 
     func testNoContentResponseAdvancesLastRefreshTimeHeader() async throws {

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
@@ -445,8 +445,9 @@ final class RemoteConfigIntegrationTests: TestCase {
 
     func testRequestSendsLastRefreshTimeHeaderAfterSuccessfulConfigIsStored() async throws {
         let container = try Self.containerData(topics: Self.workflowTopic(ref: "unused"))
+        let serverRequestTime = Date(timeIntervalSince1970: 50)
 
-        await self.refresh(with: container)
+        await self.refresh(with: container, requestDate: serverRequestTime)
 
         let storedRefreshTime = try XCTUnwrap(self.diskCache.read()?.lastRefreshTimeMilliseconds)
         self.mockRemoteConfigResponse(statusCode: .noContent, body: Data())
@@ -460,21 +461,27 @@ final class RemoteConfigIntegrationTests: TestCase {
 
     func testNoContentResponseAdvancesLastRefreshTimeHeader() async throws {
         let container = try Self.containerData(topics: Self.workflowTopic(ref: "unused"))
+        let firstServerRequestTime = Date(timeIntervalSince1970: 50)
         self.dateProvider.advance(by: 100)
-        await self.refresh(with: container)
+        await self.refresh(with: container, requestDate: firstServerRequestTime)
 
+        let secondServerRequestTime = Date(timeIntervalSince1970: 75)
         self.dateProvider.advance(by: 123)
-        self.mockRemoteConfigResponse(statusCode: .noContent, body: Data())
+        self.mockRemoteConfigResponse(
+            statusCode: .noContent,
+            body: Data(),
+            requestDate: secondServerRequestTime
+        )
         self.manager.refreshRemoteConfig(fetchContext: .foreground, isAppBackgrounded: false)
         await self.waitForRemoteConfigRequestCount(2)
-        await self.waitForStoredRefreshTime(223_000)
+        await self.waitForStoredRefreshTime(75_000)
 
         self.manager.refreshRemoteConfig(fetchContext: .foreground, isAppBackgrounded: false)
         await self.waitForRemoteConfigRequestCount(3)
 
         expect(self.remoteConfigCalls[0].headers[HTTPClient.RequestHeader.lastRefreshTime.rawValue]).to(beNil())
-        expect(self.remoteConfigCalls[1].headers[HTTPClient.RequestHeader.lastRefreshTime.rawValue]) == "100000"
-        expect(self.remoteConfigCalls[2].headers[HTTPClient.RequestHeader.lastRefreshTime.rawValue]) == "223000"
+        expect(self.remoteConfigCalls[1].headers[HTTPClient.RequestHeader.lastRefreshTime.rawValue]) == "50000"
+        expect(self.remoteConfigCalls[2].headers[HTTPClient.RequestHeader.lastRefreshTime.rawValue]) == "75000"
     }
 
     func testErrorResponseDoesNotAddLastRefreshTimeHeader() async {
@@ -657,9 +664,14 @@ private extension RemoteConfigIntegrationTests {
 
     func refresh(
         with body: Data,
-        verificationResult: VerificationResult = .verified
+        verificationResult: VerificationResult = .verified,
+        requestDate: Date? = nil
     ) async {
-        self.mockRemoteConfigResponse(body: body, verificationResult: verificationResult)
+        self.mockRemoteConfigResponse(
+            body: body,
+            verificationResult: verificationResult,
+            requestDate: requestDate
+        )
 
         self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         await self.waitForRemoteConfigRequestCount(1)
@@ -685,11 +697,21 @@ private extension RemoteConfigIntegrationTests {
     func mockRemoteConfigResponse(
         statusCode: HTTPStatusCode = .success,
         body: Data,
-        verificationResult: VerificationResult = .verified
+        verificationResult: VerificationResult = .verified,
+        requestDate: Date? = nil
     ) {
+        let responseHeaders: HTTPResponse.Headers = [
+            HTTPClient.ResponseHeader.requestDate.rawValue:
+                requestDate?.millisecondsSince1970.description
+        ].compactMapValues { $0 }
         self.httpClient.mock(
             requestPath: HTTPRequest.Path.remoteConfig(domain: RemoteConfiguration.defaultDomain),
-            response: .init(statusCode: statusCode, body: body, verificationResult: verificationResult)
+            response: .init(
+                statusCode: statusCode,
+                body: body,
+                responseHeaders: responseHeaders,
+                verificationResult: verificationResult
+            )
         )
     }
 

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -387,17 +387,42 @@ final class RemoteConfigManagerTests: TestCase {
             manifest: "v1.1710000100.sources:etag1",
             lastRefreshTimeMilliseconds: 1_000
         )
+        self.diskCache.writeHandler = { configuration in
+            self.diskCache.stubbedRead = configuration
+            return true
+        }
+        self.dateProvider.advance(by: 123)
+        let serverRequestTime = Date(timeIntervalSince1970: 456)
+
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .success(.test(
+            container: nil,
+            requestDate: serverRequestTime
+        )))
+
+        expect(self.diskCache.invokedWriteParameter?.lastRefreshTimeMilliseconds) == 456_000
+
+        self.manager.refreshRemoteConfig(fetchContext: .foreground, isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.lastRefreshTime)
+            == serverRequestTime
+    }
+
+    func testNoContentResponseWithoutServerRequestTimeKeepsPreviousRefreshTime() {
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.sources:etag1",
+            lastRefreshTimeMilliseconds: 1_000
+        )
         self.dateProvider.advance(by: 123)
 
         self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
 
-        expect(self.diskCache.invokedWriteParameter?.lastRefreshTimeMilliseconds) == 123_000
+        expect(self.diskCache.invokedWriteCount) == 0
 
         self.manager.refreshRemoteConfig(fetchContext: .foreground, isAppBackgrounded: false)
-
         expect(self.remoteConfigAPI.invokedGetRemoteConfigParameters?.request.lastRefreshTime)
-            == Date(timeIntervalSince1970: 123)
+            == Date(millisecondsSince1970: 1_000)
     }
 
     func testNoContentResponseWriteFailureStillMarksRefreshAsFresh() {
@@ -414,8 +439,36 @@ final class RemoteConfigManagerTests: TestCase {
         self.diskCache.stubbedWriteResult = false
 
         manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
-        self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
+        self.remoteConfigAPI.complete(with: .success(.test(
+            container: nil,
+            requestDate: Date(timeIntervalSince1970: 10)
+        )))
         expect(self.diskCache.invokedWriteCount) == 1
+
+        self.dateProvider.advance(by: Self.refreshAttemptCooldownElapsedInterval)
+        manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+    }
+
+    func testNoContentResponseUsesClientTimeForStaleness() {
+        let manager = RemoteConfigManager(
+            remoteConfigAPI: self.remoteConfigAPI,
+            diskCache: self.diskCache,
+            blobStore: self.blobStore,
+            blobFetcher: self.blobFetcher,
+            currentUserProvider: self.currentUserProvider,
+            dateProvider: self.dateProvider,
+            cacheDurationInSeconds: { _ in 120 }
+        )
+        self.diskCache.stubbedRead = Self.persisted(manifest: "v1.1710000100.sources:etag1")
+        self.dateProvider.advance(by: 100)
+
+        manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .success(.test(
+            container: nil,
+            requestDate: Date(timeIntervalSince1970: 0)
+        )))
 
         self.dateProvider.advance(by: Self.refreshAttemptCooldownElapsedInterval)
         manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
@@ -1397,6 +1450,7 @@ final class RemoteConfigManagerTests: TestCase {
     func testContainerResponsePersistsServerManifestAndChangedTopics() throws {
         self.diskCache.stubbedRead = nil
         self.dateProvider.advance(by: 123)
+        let serverRequestTime = Date(timeIntervalSince1970: 456)
         let response = """
         {
           "domain": "app",
@@ -1413,7 +1467,10 @@ final class RemoteConfigManagerTests: TestCase {
 
         self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(
-            with: .success(.test(container: try Self.container(config: response)))
+            with: .success(.test(
+                container: try Self.container(config: response),
+                requestDate: serverRequestTime
+            ))
         )
 
         expect(self.diskCache.invokedWriteCount) == 1
@@ -1423,7 +1480,50 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.diskCache.invokedWriteParameter?.activeTopics) == ["sources"]
         expect(self.diskCache.invokedWriteParameter?.prefetchBlobs) == ["newBlob"]
         expect(Self.blobRefsByTopic(from: self.diskCache.invokedWriteParameter?.topics)) == ["sources": ["newBlob"]]
-        expect(self.diskCache.invokedWriteParameter?.lastRefreshTimeMilliseconds) == 123_000
+        expect(self.diskCache.invokedWriteParameter?.lastRefreshTimeMilliseconds) == 456_000
+    }
+
+    func testContainerResponseWithoutServerRequestTimeCarriesPreviousRefreshTimeForward() throws {
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.sources:etag1",
+            lastRefreshTimeMilliseconds: 1_000
+        )
+        self.dateProvider.advance(by: 123)
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.sources:etag2",
+          "active_topics": [],
+          "topics": {}
+        }
+        """
+
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(
+            with: .success(.test(container: try Self.container(config: response)))
+        )
+
+        expect(self.diskCache.invokedWriteParameter?.lastRefreshTimeMilliseconds) == 1_000
+    }
+
+    func testFirstContainerResponseWithoutServerRequestTimeDoesNotPersistClientTime() throws {
+        self.diskCache.stubbedRead = nil
+        self.dateProvider.advance(by: 123)
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.sources:etag1",
+          "active_topics": [],
+          "topics": {}
+        }
+        """
+
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(
+            with: .success(.test(container: try Self.container(config: response)))
+        )
+
+        expect(self.diskCache.invokedWriteParameter?.lastRefreshTimeMilliseconds).to(beNil())
     }
 
     func testContainerResponseDecodesCompressedConfigElement() throws {
@@ -1597,7 +1697,10 @@ final class RemoteConfigManagerTests: TestCase {
         self.dateProvider.advance(by: 123)
 
         self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
-        self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
+        self.remoteConfigAPI.complete(with: .success(.test(
+            container: nil,
+            requestDate: Date(timeIntervalSince1970: 123)
+        )))
 
         expect(self.diskCache.invokedWriteCount) == 1
         expect(self.diskCache.invokedWriteParameter) == previous.withLastRefreshTime(
@@ -1775,8 +1878,9 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.remoteConfigAPI.invokedGetRemoteConfigFallbackCount) == 0
     }
 
-    func testFallbackConfigSuccessPersistsConfigurationWithoutInlineBlobExtraction() {
+    func testFallbackConfigSuccessPersistsConfigurationWithoutRequestTimeOrInlineBlobExtraction() {
         self.dateProvider.advance(by: 123)
+        let serverRequestTime = Date(timeIntervalSince1970: 456)
         let prefetchedRef = RCContainerTestData.blobRef(for: #"{"id":"prefetched"}"#.asData)
         let retainedRef = RCContainerTestData.blobRef(for: #"{"id":"retained"}"#.asData)
         let configuration = RemoteConfiguration(
@@ -1791,11 +1895,14 @@ final class RemoteConfigManagerTests: TestCase {
 
         self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
-        self.remoteConfigAPI.completeFallback(with: .success(.test(configuration: configuration)))
+        self.remoteConfigAPI.completeFallback(with: .success(.test(
+            configuration: configuration,
+            requestDate: serverRequestTime
+        )))
 
         expect(self.diskCache.invokedWriteCount) == 1
         expect(self.diskCache.invokedWriteParameter?.manifest) == "v1.1710000100.workflows:etag2"
-        expect(self.diskCache.invokedWriteParameter?.lastRefreshTimeMilliseconds) == 123_000
+        expect(self.diskCache.invokedWriteParameter?.lastRefreshTimeMilliseconds).to(beNil())
         expect(Self.blobRefsByTopic(from: self.diskCache.invokedWriteParameter?.topics)) == [
             "workflows": [retainedRef]
         ]
@@ -3041,12 +3148,14 @@ private extension RemoteConfigFetchResult {
     /// represents a `204 No Content` response.
     static func test(
         container: RemoteConfigContainer?,
-        verificationResult: VerificationResult = .verified
+        verificationResult: VerificationResult = .verified,
+        requestDate: Date? = nil
     ) -> RemoteConfigFetchResult {
         return RemoteConfigFetchResult(response: .init(
             httpStatusCode: container == nil ? .noContent : .success,
             responseHeaders: [:],
             body: container,
+            requestDate: requestDate,
             verificationResult: verificationResult,
             isLoadShedderResponse: false,
             isFallbackUrlResponse: false
@@ -3059,12 +3168,14 @@ private extension RemoteConfigFallbackFetchResult {
 
     static func test(
         configuration: RemoteConfiguration,
-        verificationResult: VerificationResult = .verified
+        verificationResult: VerificationResult = .verified,
+        requestDate: Date? = nil
     ) -> RemoteConfigFallbackFetchResult {
         return RemoteConfigFallbackFetchResult(response: .init(
             httpStatusCode: .success,
             responseHeaders: [:],
             body: configuration,
+            requestDate: requestDate,
             verificationResult: verificationResult,
             isLoadShedderResponse: false,
             isFallbackUrlResponse: false


### PR DESCRIPTION
iOS equivalent of https://github.com/RevenueCat/purchases-android/pull/3855

Follow up to https://github.com/RevenueCat/purchases-ios/pull/7308, which added sending the `X-RC-Last-Refresh-Time` header, with a timestamp generated by the local device clock. 

This PR updates this logic to use the server provided request timestamp instead, making sure the server can compare the given timestamp against its own clock and avoiding issues like clock drift.

- A response with no such header carries the last server-supplied value forward, rather than substituting local time. Nothing device-derived is ever sent.
- Cache staleness checks stay on the device clock, it measures elapsed local time, so server time there would produce a bogus interval. The two timestamps now use different clocks deliberately.
- The fallback endpoint contributes no refresh time: different host, different clock.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how refresh timestamps are sourced and persisted for the main remote config API, which affects backend fast-path behavior; scope is limited to remote config networking with broad test coverage.
> 
> **Overview**
> **`X-RC-Last-Refresh-Time`** now replays the main API’s **`X-RevenueCat-Request-Time`** from successful responses, not the device clock—so the backend can compare against its own clock and avoid drift.
> 
> `RemoteConfigFetchResult` carries **`requestDate`** from verified HTTP responses. That value is persisted on disk and sent on the next config request. If a response omits the header, the last server-supplied time is carried forward; **nothing device-derived is sent** in that header.
> 
> **Local cache staleness** and **retry cooldown** still use the **client clock** (`lastRefreshedAt` / `lastRefreshAttemptAt`), deliberately separate from the persisted server timestamp. **Fallback** config success does not set or advance the persisted refresh time.
> 
> Integration and unit tests were updated to assert server request dates, header replay, and the split between server time for headers vs client time for staleness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c186e7663f2304a1e0df24a8efd3473a356cf034. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->