### PR TITLE
refactor: model ForceServerErrorStrategy interception as a single Action enum

### DIFF
--- a/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/RcMaestroApp.swift
+++ b/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/RcMaestroApp.swift
@@ -20,46 +20,41 @@ struct RcMaestroApp: App {
                 .with(dangerousSettings: .init(
                     autoSyncPurchases: true,
                     internalSettings: DangerousSettings.Internal(
-                        forceServerErrorStrategy: .init(
-                            // For `remoteConfigNetworkError`, route forced-error requests to an unreachable
-                            // host so they fail with a transport error (simulating no network), instead of
-                            // the default endpoint that returns a server error.
-                            serverErrorURL: forceServerErrorStrategy == .remoteConfigNetworkError
-                                ? URL(string: "http://127.0.0.1:1")!
-                                : ForceServerErrorStrategy.defaultServerErrorURL,
-                            fakeResponseWithoutPerformingRequest: { request in
+                        forceServerErrorStrategy: .init { request in
+                            switch forceServerErrorStrategy {
+                            case .never:
+                                return .performRequest
+
+                            case .remoteConfigNotFound:
                                 // Simulate a 4xx on the /v1/config endpoint (its session kill-switch),
                                 // so we can exercise the classic-paywall fallback for workflow offerings.
-                                guard case .remoteConfigNotFound = forceServerErrorStrategy,
-                                      request.path.contains("config/"),
+                                guard request.path.contains("config/"),
                                       let url = URL(string: "https://api.revenuecat.com"),
                                       let response = HTTPURLResponse(url: url,
                                                                      statusCode: 404,
                                                                      httpVersion: nil,
                                                                      headerFields: nil) else {
-                                    return nil
+                                    return .performRequest
                                 }
-                                return (response, Data("{}".utf8))
-                            },
-                            shouldForceServerError: { request in
-                                switch forceServerErrorStrategy {
-                                case .never, .remoteConfigNotFound:
-                                    return false
-                                case .primaryBackendDown:
-                                    // Remote config uses a separate request path whose primary URL is already
-                                    // the fallback backend, so it does not have a fallbackUrlIndex.
-                                    if let fallbackPath = request.httpRequest.path as? HTTPRequest.FallbackPath,
-                                       case .remoteConfig = fallbackPath {
-                                        return false
-                                    }
-                                    return request.fallbackUrlIndex == nil
-                                case .remoteConfigNetworkError:
-                                    // No network for /v1/config only; offerings still resolve so a paywall
-                                    // is presentable and can degrade to the classic paywall.
-                                    return request.path.contains("config/")
+                                return .fakeResponse(response, Data("{}".utf8))
+
+                            case .primaryBackendDown:
+                                // Remote config uses a separate request path whose primary URL is already
+                                // the fallback backend, so it does not have a fallbackUrlIndex.
+                                if let fallbackPath = request.httpRequest.path as? HTTPRequest.FallbackPath,
+                                   case .remoteConfig = fallbackPath {
+                                    return .performRequest
                                 }
+                                return request.fallbackUrlIndex == nil ? .defaultServerError : .performRequest
+
+                            case .remoteConfigNetworkError:
+                                // No network for /v1/config only; offerings still resolve so a paywall
+                                // is presentable and can degrade to the classic paywall. The unreachable
+                                // host makes the request fail with a transport error.
+                                guard request.path.contains("config/") else { return .performRequest }
+                                return .serverErrorURL(URL(string: "http://127.0.0.1:1")!)
                             }
-                        )
+                        }
                     ),
                     // Workflows (multipage paywalls) read through remote config; this internal flag
                     // is the runtime gate (no compile flag needed for the Maestro app).

--- a/Sources/Logging/Strings/NetworkStrings.swift
+++ b/Sources/Logging/Strings/NetworkStrings.swift
@@ -56,8 +56,8 @@ enum NetworkStrings {
     case request_handled_by_load_shedder(HTTPRequestPath)
 
     #if DEBUG
-    case api_request_forcing_server_error(HTTPRequest)
-    case api_request_faking_error_response(HTTPRequest)
+    case api_request_forcing_server_error(HTTPRequest, serverErrorURL: URL)
+    case api_request_faking_response(HTTPRequest, statusCode: Int)
     case api_request_forcing_signature_failure(HTTPRequest)
     case api_request_disabling_header_parameter_signature_verification(HTTPRequest)
     case api_request_response_both_fallback_and_load_shedder(HTTPRequest)
@@ -169,11 +169,13 @@ extension NetworkStrings: LogMessage {
             return "Request \(httpMethod) \(path) failed all \(retryCount) retries."
 
         #if DEBUG
-        case let .api_request_forcing_server_error(request):
-            return "Forcing server error for request \(request.description)"
+        case let .api_request_forcing_server_error(request, serverErrorURL):
+            return "Forcing server error for request \(request.description) " +
+            "by routing it to \(serverErrorURL.absoluteString)"
 
-        case let .api_request_faking_error_response(request):
-            return "Faking error response for request \(request.description)"
+        case let .api_request_faking_response(request, statusCode):
+            return "Faking response with status code \(statusCode) " +
+            "for request \(request.description)"
 
         case let .api_request_forcing_signature_failure(request):
             return "Returning fake signature verification failure for '\(request.description)'"

--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -193,8 +193,7 @@ internal protocol InternalDangerousSettingsType: Sendable {
     /// The strategy for the `HTTPClient` to fake server errors. Meant for tests only.
     /// `nil` means no server errors are forced.
     ///
-    /// This is done by routing the requests to https://api.revenuecat.com/force-server-failure,
-    /// which returns a 502 status code with a HTML response body.
+    /// See `ForceServerErrorStrategy.Action` for the ways a request can be intercepted.
     var forceServerErrorStrategy: ForceServerErrorStrategy? { get }
 
     /// Whether `HTTPClient` will fake invalid signatures.
@@ -215,29 +214,30 @@ internal protocol InternalDangerousSettingsType: Sendable {
 
 struct ForceServerErrorStrategy {
 
+    /// What the `HTTPClient` does with a request.
+    enum Action {
+
+        /// The request is not performed, and this response is returned instead.
+        case fakeResponse(HTTPURLResponse, Data)
+
+        /// The request is performed against this URL instead of its original one.
+        case serverErrorURL(URL)
+
+        /// The request is performed as usual, without interception.
+        case performRequest
+
+        /// Routes the request to `ForceServerErrorStrategy.defaultServerErrorURL`.
+        static var defaultServerError: Self {
+            return .serverErrorURL(ForceServerErrorStrategy.defaultServerErrorURL)
+        }
+
+    }
+
+    /// Returns a 502 status code with an HTML response body.
     // swiftlint:disable:next force_unwrapping
     static let defaultServerErrorURL = URL(string: "https://api.revenuecat.com/force-server-failure")!
 
-    let serverErrorURL: URL
-
-    /// If this returns a non-nil pair of `(HTTPURLResponse, Data)`, the `HTTPClient` will not perform the request
-    /// and will just return the fake response.
-    ///
-    /// Takes precedence over `shouldForceServerError`.
-    let fakeResponseWithoutPerformingRequest: (HTTPClient.Request) -> (HTTPURLResponse, Data)?
-
-    /// If this returns `true`, the `HTTPClient` will route the request to `forceServerErrorURL`.
-    let shouldForceServerError: (HTTPClient.Request) -> Bool
-
-    init(
-        serverErrorURL: URL = Self.defaultServerErrorURL,
-        fakeResponseWithoutPerformingRequest: @escaping (HTTPClient.Request) -> (HTTPURLResponse, Data)? = { _ in nil },
-        shouldForceServerError: @escaping (HTTPClient.Request) -> Bool
-    ) {
-        self.serverErrorURL = serverErrorURL
-        self.fakeResponseWithoutPerformingRequest = fakeResponseWithoutPerformingRequest
-        self.shouldForceServerError = shouldForceServerError
-    }
+    let action: (HTTPClient.Request) -> Action
 
 }
 

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -759,7 +759,8 @@ private extension HTTPClient {
                 // might be empty if called immediately after `Product.purchase()`.
                 // This introduces a delay to simulate a real API request, and avoid that race condition.
 
-                Logger.warn(Strings.network.api_request_faking_error_response(request.httpRequest))
+                Logger.warn(Strings.network.api_request_faking_response(request.httpRequest,
+                                                                        statusCode: fakeResponse.statusCode))
                 DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(300)) {
                     self.handle(urlResponse: fakeResponse,
                                 request: request,
@@ -771,7 +772,8 @@ private extension HTTPClient {
                 return
 
             case let .serverErrorURL(serverErrorURL):
-                Logger.warn(Strings.network.api_request_forcing_server_error(request.httpRequest))
+                Logger.warn(Strings.network.api_request_forcing_server_error(request.httpRequest,
+                                                                             serverErrorURL: serverErrorURL))
                 finalURLRequest = URLRequest(url: serverErrorURL)
 
             case .performRequest:

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -753,9 +753,8 @@ private extension HTTPClient {
         #if DEBUG
         // Meant only for testing error handling behavior of the SDK.
         if let forceErrorStrategy = self.systemInfo.dangerousSettings.internalSettings.forceServerErrorStrategy {
-
-            if let (fakeResponse, fakeData) = forceErrorStrategy.fakeResponseWithoutPerformingRequest(request) {
-
+            switch forceErrorStrategy.action(request) {
+            case let .fakeResponse(fakeResponse, fakeData):
                 // `FB13133387`: when computing offline CustomerInfo, `StoreKit.Transaction.unfinished`
                 // might be empty if called immediately after `Product.purchase()`.
                 // This introduces a delay to simulate a real API request, and avoid that race condition.
@@ -770,11 +769,13 @@ private extension HTTPClient {
                                 requestStartTime: requestStartTime)
                 }
                 return
-            }
 
-            if forceErrorStrategy.shouldForceServerError(request) {
+            case let .serverErrorURL(serverErrorURL):
                 Logger.warn(Strings.network.api_request_forcing_server_error(request.httpRequest))
-                finalURLRequest = URLRequest(url: forceErrorStrategy.serverErrorURL)
+                finalURLRequest = URLRequest(url: serverErrorURL)
+
+            case .performRequest:
+                break
             }
         }
         #endif

--- a/Tests/BackendIntegrationTests/CachedOfferingsUsageIntegrationTest.swift
+++ b/Tests/BackendIntegrationTests/CachedOfferingsUsageIntegrationTest.swift
@@ -44,21 +44,18 @@ class CachedOfferingsUsageIntegrationTest: BaseStoreKitIntegrationTests {
     func testCachedOfferingsAreNotUsedWhenCachedOfferingsExistsServerReturns4xx() async throws {
         _ = try await Purchases.shared.offerings()
 
-        self.forceServerErrorStrategy = ForceServerErrorStrategy(
-            fakeResponseWithoutPerformingRequest: { (request: HTTPClient.Request) -> (HTTPURLResponse, Data)? in
-                guard case HTTPRequest.Path.getOfferings(appUserID: _) = request.httpRequest.path else {
-                    return nil
-                }
-                return (
-                    HTTPURLResponse(url: request.httpRequest.path.url!,
-                                    statusCode: 401,
-                                    httpVersion: nil,
-                                    headerFields: nil)!,
-                    Data()
-                )
-            },
-            shouldForceServerError: { _ in true}
-        )
+        self.forceServerErrorStrategy = ForceServerErrorStrategy { (request: HTTPClient.Request) in
+            guard case HTTPRequest.Path.getOfferings(appUserID: _) = request.httpRequest.path else {
+                return .defaultServerError
+            }
+            return .fakeResponse(
+                HTTPURLResponse(url: request.httpRequest.path.url!,
+                                statusCode: 401,
+                                httpVersion: nil,
+                                headerFields: nil)!,
+                Data()
+            )
+        }
         await resetSingleton()
 
         do {

--- a/Tests/BackendIntegrationTests/WorkflowComponentsIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/WorkflowComponentsIntegrationTests.swift
@@ -25,12 +25,9 @@ final class WorkflowComponentsIntegrationTests: BaseStoreKitIntegrationTests {
     private let remoteConfigFake = RemoteConfigKillSwitchFake()
 
     override func setUp() async throws {
-        self.forceServerErrorStrategy = ForceServerErrorStrategy(
-            fakeResponseWithoutPerformingRequest: { [remoteConfigFake] request in
-                remoteConfigFake.response(for: request)
-            },
-            shouldForceServerError: { _ in false }
-        )
+        self.forceServerErrorStrategy = ForceServerErrorStrategy { [remoteConfigFake] request in
+            remoteConfigFake.action(for: request)
+        }
 
         try await super.setUp()
     }
@@ -70,36 +67,36 @@ private final class RemoteConfigKillSwitchFake: @unchecked Sendable {
 
     var disableRemoteConfig = false
 
-    func response(for request: HTTPClient.Request) -> (HTTPURLResponse, Data)? {
+    func action(for request: HTTPClient.Request) -> ForceServerErrorStrategy.Action {
         guard case HTTPRequest.Path.remoteConfig = request.httpRequest.path else {
-            return nil
+            return .performRequest
         }
 
         if self.disableRemoteConfig {
-            return self.response(
+            return self.fakeResponse(
                 statusCode: 400,
                 data: Data(#"{"code":7000,"message":"remote config disabled for test"}"#.utf8),
                 request: request
             )
         } else {
-            return self.response(statusCode: 204, data: Data(), request: request)
+            return self.fakeResponse(statusCode: 204, data: Data(), request: request)
         }
     }
 
-    private func response(
+    private func fakeResponse(
         statusCode: Int,
         data: Data,
         request: HTTPClient.Request
-    ) -> (HTTPURLResponse, Data)? {
+    ) -> ForceServerErrorStrategy.Action {
         guard let url = request.httpRequest.path.url,
               let response = HTTPURLResponse(url: url,
                                              statusCode: statusCode,
                                              httpVersion: nil,
                                              headerFields: nil) else {
-            return nil
+            return .performRequest
         }
 
-        return (response, data)
+        return .fakeResponse(response, data)
     }
 
 }

--- a/Tests/UnitTests/Misc/TestCase.swift
+++ b/Tests/UnitTests/Misc/TestCase.swift
@@ -101,12 +101,18 @@ extension ForceServerErrorStrategy {
 
     /// Forces server error in all requests, including requests made to the fallback API hosts.
     static let allServersDown: ForceServerErrorStrategy = .init { _ in
-        return true // All requests fail
+        return .defaultServerError
     }
 
     /// Forces server error in all requests except those made to the fallback API hosts.
     static let failExceptFallbackUrls: ForceServerErrorStrategy = .init { (request: HTTPClient.Request) in
-        return !request.isRequestToFallbackUrl
+        return request.isRequestToFallbackUrl ? .performRequest : .defaultServerError
+    }
+
+    /// Forces server error by pointing all requests to an unreachable address.
+    static let noNetwork: ForceServerErrorStrategy = .init { _ in
+        // swiftlint:disable:next force_unwrapping
+        return .serverErrorURL(URL(string: "http://localhost:100/unreachable-address")!)
     }
 
 }
@@ -116,12 +122,5 @@ extension HTTPClient.Request {
     var isRequestToFallbackUrl: Bool {
         return self.fallbackUrlIndex != nil
     }
-
-    /// Forces server error by pointing to an unreachable address.
-    static let noNetwork = ForceServerErrorStrategy(
-        // swiftlint:disable:next force_unwrapping
-        serverErrorURL: URL(string: "http://localhost:100/unreachable-address")!,
-        shouldForceServerError: { _ in true }
-    )
 
 }

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -2879,7 +2879,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
         expect(response).to(beSuccess())
     }
 
-    func testforceServerErrorStrategyAlwaysFalseCallsTheOriginalPath() throws {
+    func testforceServerErrorStrategyPerformingRequestCallsTheOriginalPath() throws {
         let path: HTTPRequest.Path = .logIn
 
         let mockedResponse = BodyWithDate(data: "test", requestDate: Date())
@@ -2905,7 +2905,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
                 dangerousSettings: .init(
                     autoSyncPurchases: true,
                     internalSettings: DangerousSettings.Internal(forceServerErrorStrategy: .init { _ in
-                        return false
+                        return .performRequest
                     })
                 ),
                 preferredLocalesProvider: .mock()


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Groundwork for forcing errors on the remote config endpoint. `ForceServerErrorStrategy` took two independent closures plus a URL, and the fact that a fake response silently won over routing to the error URL was documented only in a comment.

### Description
Each request now resolves to exactly one `Action`: `.fakeResponse`, `.serverErrorURL`, or `.performRequest`. `DEBUG`-only type used by tests and the Maestro sample app; no behavior change at any existing call site.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> DEBUG-only test/Maestro plumbing with no production networking behavior change; risk is limited to test error simulation correctness.
> 
> **Overview**
> Replaces the DEBUG-only `ForceServerErrorStrategy` shape (separate URL, fake-response closure, and `shouldForceServerError` closure with implicit precedence) with **one closure** that returns a single `Action`: `.fakeResponse`, `.serverErrorURL`, or `.performRequest`, plus `.defaultServerError` for the standard force-failure host.
> 
> `HTTPClient` now handles those actions in one `switch` instead of checking fake response first then routing. **NetworkStrings** log messages include the routed error URL or faked status code.
> 
> Maestro E2E configuration, integration tests, and unit test helpers are updated to the new API; the PR description states **no behavior change** at existing call sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b050d24073764b4bce59c2aa80542e339d7ffaed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->