### PR TITLE
test(paywalls): drop the nested background landscape test

### DIFF
--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
@@ -593,14 +593,10 @@ private extension WorkflowPaywallViewTests {
         return try JSONDecoder.default.decode(PublishedWorkflow.self, from: data)
     }
 
-    static func makeScreenJSON(
-        packages: [PackageSpec],
-        offeringId: String,
-        extraComponentsJSON: [String] = []
-    ) -> String {
-        let componentsJSON = (
-            packages.map { packageComponentJSON(id: $0.id, isDefault: $0.isDefault) } + extraComponentsJSON
-        ).joined(separator: ",")
+    static func makeScreenJSON(packages: [PackageSpec], offeringId: String) -> String {
+        let componentsJSON = packages
+            .map { packageComponentJSON(id: $0.id, isDefault: $0.isDefault) }
+            .joined(separator: ",")
         return """
         {
             "template_name": "template_v2",
@@ -1278,10 +1274,6 @@ final class WorkflowLandscapeSafeAreaTests: TestCase {
     /// The fixture screen's root background: `#220000ff`.
     fileprivate static let backgroundColor = PixelColor(red: 0x22, green: 0x00, blue: 0x00)
 
-    /// The nested stack's own background. Different from the root, so the edge samples show which
-    /// of the two reached the edge.
-    fileprivate static let nestedBackgroundColor = PixelColor(red: 0x00, green: 0x22, blue: 0x00)
-
     /// Sliding by only `size.width` leaves part of the off-screen page inside the clip mask, so a
     /// strip of the wrong page shows at the edge while the animation runs. Both roles and both
     /// directions, since each is a separate call into the same offset code.
@@ -1377,23 +1369,6 @@ final class WorkflowLandscapeSafeAreaTests: TestCase {
         )
     }
 
-    /// `BackgroundStyleModifier` is also used by stacks, text and badges, not just the page root. A
-    /// nested background has to reach the edge mid-animation the same way it does at rest, or the
-    /// paywall jumps when the animation starts and stops.
-    @MainActor
-    func testComponentBackgroundReachesHorizontalScreenEdgesWhileTransitioning() throws {
-        try Self.expectBackgroundAtEdges(
-            of: try Self.renderScreenInLandscape(
-                isTransitioning: true,
-                screenJSON: Self.nestedComponentBackgroundScreenJSON(),
-                settled: Self.nestedBackgroundColor
-            ),
-            axis: .horizontal,
-            label: "nested component background, mid-transition",
-            expected: Self.nestedBackgroundColor
-        )
-    }
-
     /// The mask grows on all four edges. The other tests use a zero top inset and sample the middle
     /// row, so they would not catch a mistake in the top or bottom growth.
     @MainActor
@@ -1435,12 +1410,8 @@ private extension WorkflowLandscapeSafeAreaTests {
 
     /// Samples both edges along `axis`, halfway along the other one. Both have to be the paywall's
     /// background; anything else means it stopped at the safe area and the view behind shows.
-    static func expectBackgroundAtEdges(
-        of image: UIImage,
-        axis: Axis,
-        label: String,
-        expected: PixelColor = WorkflowLandscapeSafeAreaTests.backgroundColor
-    ) throws {
+    static func expectBackgroundAtEdges(of image: UIImage, axis: Axis, label: String) throws {
+        let expected = Self.backgroundColor
         let pixels = try PixelSampler(image: image)
         let midColumn = pixels.width / 2
         let midRow = pixels.height / 2
@@ -1485,12 +1456,8 @@ private extension WorkflowLandscapeSafeAreaTests {
 
     /// The fixture screen without the workflow container, optionally with the transition flag set.
     @MainActor
-    static func renderScreenInLandscape(
-        isTransitioning: Bool,
-        screenJSON: String? = nil,
-        settled: PixelColor = WorkflowLandscapeSafeAreaTests.backgroundColor
-    ) throws -> UIImage {
-        let context = try Self.makeLandscapeContext(screenJSON: screenJSON)
+    static func renderScreenInLandscape(isTransitioning: Bool) throws -> UIImage {
+        let context = try Self.makeLandscapeContext()
         let screen = try XCTUnwrap(context.workflow.screens[Self.landscapeScreenId])
         let offering = try XCTUnwrap(context.offering(for: screen.offeringIdentifier))
 
@@ -1518,8 +1485,7 @@ private extension WorkflowLandscapeSafeAreaTests {
                     )
                 )
             ),
-            safeArea: Landscape.symmetricSafeArea,
-            settled: settled
+            safeArea: Landscape.symmetricSafeArea
         )
     }
 
@@ -1544,11 +1510,7 @@ private extension WorkflowLandscapeSafeAreaTests {
     /// Puts `view` in a landscape-sized window with the given safe area insets and draws it at
     /// scale 1, so one pixel is one point.
     @MainActor
-    static func renderInLandscape(
-        _ view: some View,
-        safeArea: UIEdgeInsets,
-        settled: PixelColor = WorkflowLandscapeSafeAreaTests.backgroundColor
-    ) throws -> UIImage {
+    static func renderInLandscape(_ view: some View, safeArea: UIEdgeInsets) throws -> UIImage {
         UIView.setAnimationsEnabled(false)
 
         let controller = UIHostingController(rootView: view)
@@ -1589,7 +1551,7 @@ private extension WorkflowLandscapeSafeAreaTests {
               (try? PixelSampler(image: image).color(
                   column: Int(Landscape.size.width / 2),
                   row: Int(Landscape.size.height / 2)
-              )) != settled {
+              )) != Self.backgroundColor {
             RunLoop.main.run(until: Date().addingTimeInterval(0.05))
             image = render()
         }
@@ -1603,41 +1565,11 @@ private extension WorkflowLandscapeSafeAreaTests {
 
     /// The screen id `makeContext` gives the workflow's first step.
     static let landscapeScreenId = "screen_initial"
-    static let landscapeOfferingId = "offering_test"
 
-    /// A workflow whose first screen is `screenJSON`, defaulting to a flat `#220000ff` stack that
-    /// fills the screen, so edge pixels are easy to check.
-    static func makeLandscapeContext(screenJSON: String? = nil) throws -> WorkflowContext {
-        return try WorkflowPaywallViewTests.makeContext(
-            singleStepFallbackId: nil,
-            initialScreenJSON: screenJSON
-        )
-    }
-
-    /// The flat fixture plus a child stack that fills the screen and has its own background, so the
-    /// sampled edges come from a component rather than the page root.
-    static func nestedComponentBackgroundScreenJSON() -> String {
-        let childStack = """
-        {
-            "type": "stack",
-            "components": [],
-            "dimension": { "type": "vertical", "alignment": "center", "distribution": "center" },
-            "size": { "width": { "type": "fill" }, "height": { "type": "fill" } },
-            "margin": {},
-            "padding": {},
-            "spacing": 0,
-            "background": {
-                "type": "color",
-                "value": { "light": { "type": "hex", "value": "#002200ff" } }
-            }
-        }
-        """
-
-        return WorkflowPaywallViewTests.makeScreenJSON(
-            packages: [],
-            offeringId: Self.landscapeOfferingId,
-            extraComponentsJSON: [childStack]
-        )
+    /// A workflow whose first screen is a flat `#220000ff` stack that fills the screen, so edge
+    /// pixels are easy to check.
+    static func makeLandscapeContext() throws -> WorkflowContext {
+        return try WorkflowPaywallViewTests.makeContext(singleStepFallbackId: nil)
     }
 
 }


### PR DESCRIPTION
### Motivation

`testComponentBackgroundReachesHorizontalScreenEdgesWhileTransitioning`, added in #7310, fails on iOS 15 and doesn't actually guard the fix it shipped with. Removing it instead of carrying a version gate.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: this one (removal); related: #7310 (origin of the test), #7316 (release carrying the gate)
- Branch: `facu/remove-nested-background-landscape-test`
- Author / human owner: @facumenzella
- Agent(s): Claude Code, Opus 5 (1M context)
- Session source: current conversation
- Generated: 2026-07-30
- Context document version: 1

## Goal

Triage a `spm-revenuecat-ui-ios-15` failure on release PR #7316, determine whether it was flaky, then act on it.

## Initial Prompt

Check https://github.com/RevenueCat/purchases-ios/pull/7316, then: "`WorkflowLandscapeSafeAreaTests.testComponentBackgroundReachesHorizontalScreenEdgesWhileTransitioning` is failing. is it flaky?" followed by "it only fails for ios15".

## Important Follow-up Prompts

- "can you push that in the release pr?" -> the iOS 16 gate was committed and pushed to `release/5.82.0` (commit `e2524b647`), not to `main`.
- "Do you think the test it is worth it? Maybe we can remove it all together?" -> triggered the redundancy analysis that led here.
- "open a PR against main removing the test" -> scope of this PR.

## Agent Contribution

- Established the failure is deterministic, not flaky: 6 identical assertion failures (2 assertions x 3 fastlane retries) in each of three independent runs, jobs 694728 (release PR head), 694487 (`main` at the #7310 merge), and 694833 (manual rerun by @facumenzella).
- Found the test never ran on #7310: `spm-revenuecat-ui-ios-15` sits behind `approve-full-tests`, so the only RevenueCatUI job on that PR was `run-revenuecat-ui-ios-26`.
- Established the behaviour is not a regression: `git grep` confirmed `WorkflowLandscapeSafeAreaTests` is absent before #7310, so "green on `ca0b6813f`" means the test did not exist, not that iOS 15 worked.
- Established `isTransitioning` no longer reaches the background path post-#7310: the only remaining consumer is `TransitionModifier.shouldRenderContentImmediately`, and the fixture configures no component transitions. Therefore the failure cannot be transition-specific.
- Wrote the iOS 16 gate now on `release/5.82.0`, then this removal.

## Human Decisions

- Decided to remove the test rather than keep the gate on `main`. The agent's recommendation was to keep a renamed version; @facumenzella chose removal.
- Reran `spm-revenuecat-ui-ios-15` manually to check the flakiness hypothesis.
- Chose to gate on the release branch first to unblock 5.82.0.

## Key Implementation Decisions

- Decision: delete the test rather than gate it on `main`.
  - Rationale: the assertion's only unique variable is nesting depth, which `BackgroundStyleModifier` does not branch on, so it characterises SwiftUI rather than SDK code. The #7310 fix stays covered by the root-background mid-transition test, the two `renderWorkflowInLandscape` tests, and the offset math tests.
  - Rejected: keeping it gated to iOS 16 and renamed (agent's preference, would have preserved narrow coverage of "nested backgrounds bleed"); fixing iOS 15 via negative padding from `\.safeAreaInsets` in `BackgroundStyleModifier`, rejected for a release branch because that call site is every Paywalls V2 paywall on every OS version.
- Decision: also remove the parameters that became always-default.
  - Rationale: parameters no caller varies are a misleading seam in a test helper.
  - Rejected: minimum-diff removal of only the test body and its two exclusive fixtures. Called out in the description as reversible on request.

## Files / Symbols Touched

- `Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift`
  - Why: remove the test and everything that became dead with it.
  - Symbols: removed `WorkflowLandscapeSafeAreaTests.testComponentBackgroundReachesHorizontalScreenEdgesWhileTransitioning`, `nestedBackgroundColor`, `nestedComponentBackgroundScreenJSON()`; narrowed `renderScreenInLandscape(isTransitioning:)`, `renderInLandscape(_:safeArea:)`, `expectBackgroundAtEdges(of:axis:label:)`, `makeLandscapeContext()`, `makeScreenJSON(packages:offeringId:)`.
  - Review relevance: confirm no remaining caller needed the dropped parameters, and that the settle loop still targets `Self.backgroundColor`.

## Dependencies / Config / Migrations

- None. Test-only change, no production source touched.

## Validation

- Commands run:
  - `xcodebuild test -workspace . -scheme RevenueCatUI -destination 'platform=iOS Simulator,name=iPhone 14 Pro,OS=16.4' -sdk iphonesimulator -testPlan CI-RevenueCatUI -only-testing:RevenueCatUITests/WorkflowPaywallViewTests -only-testing:RevenueCatUITests/WorkflowLandscapeSafeAreaTests`: `** TEST SUCCEEDED **`, 59 tests, 0 failures.
  - `swiftlint lint --quiet Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift`: no violations.
- Manual verification:
  - Both test classes run because the change also narrows `makeScreenJSON`, which the non-landscape tests share.
- CI:
  - Not captured at the time of writing.

## Validation Gaps

- Not verified on an iOS 15 runtime. Only iOS 16.4 and newer simulator runtimes are installed locally; `spm-revenuecat-ui-ios-15` needs Xcode 14.3.1 / iOS 15.5. That job is gated behind `approve-full-tests`, so it may need a manual trigger on this PR.
- The mechanism behind the iOS 15 behaviour (that SwiftUI 3 treats the safe-area region as consumed by the first view expanding into it, leaving nothing for descendants) is inferred from observed behaviour, not from documentation or a probe on an iOS 15 runtime. What is measured: the root background bleeds on 15, a nested one does not, and both do on 16.4 and up.
- No at-rest nested control test was ever written, so the suite never distinguished "iOS 15 never propagates to nested" from "only during transitions". The code path argument above settles it, a test does not.

## Review Focus

- Is the #7310 fix still adequately covered? Check `testWorkflowPageBackgroundReachesHorizontalScreenEdgesWhileTransitioning` (root background, `isTransitioning: true`) against the deleted `ignoresSafeAreaEdges` conditional.
- Is dropping `extraComponentsJSON` from `makeScreenJSON` acceptable, or is it worth keeping as an extension point for future fixtures?
- Merge order versus #7316, which gates the same test on the same lines.

## Risks / Reviewer Notes

- Risk: losing coverage of "a nested component background bleeds into the safe area" on iOS 16+.
  - Evidence: real, though narrow. It would only regress if a future change put a background under a container that consumes the safe area, in which case nested breaks while the root keeps working.
  - Mitigation: none in this PR. Deliberate call, the assertion tests SwiftUI's behaviour rather than a seam in SDK code.
- Risk: nested component backgrounds genuinely stop at the safe area in landscape on iOS 15, and this PR removes the only signal about it.
  - Evidence: confirmed by three CI runs before removal.
  - Mitigation: no follow-up filed yet. A fix would mean negative padding from `\.safeAreaInsets` in `BackgroundStyleModifier`, which affects every Paywalls V2 paywall on every OS version.

## Non-goals / Out of Scope

- Fixing the iOS 15 nested-background behaviour.
- Touching `BackgroundStyleModifier` or any production source.
- Reverting the iOS 16 gate on `release/5.82.0`.

## Omitted Context

- Raw transcript, unrelated exploration, sensitive details, repetitive attempts, and chain-of-thought-style content were omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2aba5936cc704111e552001694fba8fb83b42f48. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->