### PR TITLE
Re-resolve pruned offerings when the config kill switch trips

### DIFF
--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -134,6 +134,7 @@ enum Strings {
     case paywall_workflow_trigger_not_handled(componentName: String?)
     case workflow_package_context_unresolvable(stepId: String)
     case workflow_fetch_failed_falling_back_to_offerings_paywall(offeringIdentifier: String, error: Error)
+    case restored_paywall_components_for_disabled_remote_config(offeringIdentifier: String)
 
 }
 
@@ -432,6 +433,9 @@ extension Strings: CustomStringConvertible {
         case let .workflow_fetch_failed_falling_back_to_offerings_paywall(offeringIdentifier, error):
             return "Failed to fetch workflow for offering '\(offeringIdentifier)' (\(error)). " +
             "Falling back to the offerings-provided paywall."
+        case let .restored_paywall_components_for_disabled_remote_config(offeringIdentifier):
+            return "Remote config is disabled, so offering '\(offeringIdentifier)' was re-resolved to restore " +
+            "its offerings-provided paywall."
         }
     }
 

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -343,10 +343,16 @@ extension PurchaseHandler {
         remoteConfigEnabled: Bool
     ) -> ResolvedPaywallViewData? {
         if !remoteConfigEnabled {
-            return self.cachedInitialOffering(
+            // A pruned offering has nothing to render, so don't seed it: falling through leaves the async
+            // path to re-resolve it against the offerings cache.
+            guard let offering = self.cachedInitialOffering(
                 for: content,
                 remoteConfigEnabled: remoteConfigEnabled
-            ).map { .init(offering: $0, workflowContext: nil) }
+            ), !offering.hasPrunedPaywallComponents else {
+                return nil
+            }
+
+            return .init(offering: offering, workflowContext: nil)
         }
 
         guard let cachedOfferings = self.purchases.cachedOfferings,
@@ -538,7 +544,13 @@ extension PurchaseHandler {
         remoteConfigEnabled: Bool
     ) async throws -> ResolvedPaywallViewData {
         guard remoteConfigEnabled, offering.paywall == nil else {
-            return .init(offering: offering, workflowContext: nil)
+            return .init(
+                offering: await self.restoringPrunedPaywallComponents(
+                    offering,
+                    remoteConfigEnabled: remoteConfigEnabled
+                ),
+                workflowContext: nil
+            )
         }
 
         do {
@@ -550,12 +562,20 @@ extension PurchaseHandler {
 
             return .init(offering: context.initialOffering, workflowContext: context)
         } catch {
+            // This very fetch may be what disabled remote config (the kill switch trips on a 4xx), so read
+            // the gate again rather than reusing the caller's snapshot: the offering's own components become
+            // restorable at that point.
+            let fallbackOffering = await self.restoringPrunedPaywallComponents(
+                offering,
+                remoteConfigEnabled: self.remoteConfigEnabled
+            )
+
             // Fall back to rendering the offering when there are components to show, or when the
             // offering simply has no workflow attached (render the default paywall, matching the
             // legacy path). Other failures with no components — including a mapped workflow whose item
             // or blob failed to resolve — still propagate so a broken rollout surfaces.
             guard error.isWorkflowFetchFallbackEligible,
-                  offering.internalPaywallComponents != nil || error.isOfferingWithoutWorkflowError else {
+                  fallbackOffering.internalPaywallComponents != nil || error.isOfferingWithoutWorkflowError else {
                 throw error
             }
 
@@ -566,7 +586,41 @@ extension PurchaseHandler {
                 )
             )
 
-            return .init(offering: offering, workflowContext: nil)
+            return .init(offering: fallbackOffering, workflowContext: nil)
+        }
+    }
+
+    /// Re-resolves an offering whose paywall components the SDK pruned while remote config was active.
+    ///
+    /// Under workflows, offerings retain only the components marker because components are served by
+    /// `/v1/config`, so an offering captured then — including one the app holds and passes back in — can no
+    /// longer render once the kill switch disables remote config mid-session. `OfferingsManager` restores the
+    /// components in its own cache on disable, so reading offerings again yields a renderable offering.
+    /// Returns the offering untouched when there is nothing to restore.
+    private func restoringPrunedPaywallComponents(
+        _ offering: Offering,
+        remoteConfigEnabled: Bool
+    ) async -> Offering {
+        guard !remoteConfigEnabled, offering.hasPrunedPaywallComponents else { return offering }
+
+        do {
+            guard let restored = try await self.purchases.offerings().offering(identifier: offering.identifier),
+                  !restored.hasPrunedPaywallComponents else {
+                return offering
+            }
+
+            Logger.debug(
+                Strings.restored_paywall_components_for_disabled_remote_config(
+                    offeringIdentifier: offering.identifier
+                )
+            )
+
+            guard let presentedOfferingContext = offering.presentedOfferingContext else { return restored }
+
+            return restored.withPresentedOfferingContext(presentedOfferingContext)
+        } catch {
+            Logger.warning(Strings.errorFetchingOfferings(error))
+            return offering
         }
     }
 

--- a/Sources/Purchasing/Offering.swift
+++ b/Sources/Purchasing/Offering.swift
@@ -316,6 +316,14 @@ public extension Offering {
         return availablePackages.first?.presentedOfferingContext
     }
 
+    /// Whether the backend served paywall components that this offering doesn't carry. Offerings parsed
+    /// while remote config is active keep only the marker, since workflows resolve components from
+    /// `/v1/config`. Such an offering can't render on its own once remote config is disabled, so callers
+    /// must re-resolve it against the offerings cache instead of rendering it as-is.
+    var hasPrunedPaywallComponents: Bool {
+        return hasPaywallComponents && internalPaywallComponents == nil
+    }
+
     /// Copies the Offering and sets the given `presentedOfferingContext` on all `availablePackages`
     func withPresentedOfferingContext(_ presentedOfferingContext: PresentedOfferingContext) -> Self {
         return Self(

--- a/Tests/RevenueCatUITests/Data/PaywallViewConfigurationTests.swift
+++ b/Tests/RevenueCatUITests/Data/PaywallViewConfigurationTests.swift
@@ -311,6 +311,138 @@ final class PaywallViewConfigurationTests: TestCase {
         expect(result.workflowContext).to(beNil())
     }
 
+    func testResolvePaywallViewDataRestoresPrunedComponentsWhenRemoteConfigDisabled() async throws {
+        // An offering the app captured while workflows were active carries only the components marker.
+        // Once the kill switch disables remote config, rendering it as-is would show the default paywall,
+        // so it must be re-resolved against the offerings cache that has the components back.
+        let identifier = "offering_a"
+        let paywallComponents = try Self.createPaywallComponents(offeringIdentifier: identifier)
+        let prunedOffering = Self.createPrunedOffering(identifier: identifier)
+        let purchases = Self.createMockPurchases()
+        let handler = Self.createPurchaseHandler(purchases: purchases)
+
+        purchases.offeringsBlock = {
+            Self.createOfferings(
+                [Self.createOffering(identifier: identifier, paywall: nil)
+                    .withPaywallComponents(paywallComponents)],
+                currentOfferingID: identifier
+            )
+        }
+
+        let result = try await handler.resolvePaywallViewData(
+            for: .offering(prunedOffering),
+            remoteConfigEnabled: false
+        )
+
+        expect(result.offering.identifier) == identifier
+        expect(result.offering.paywallComponents?.data) == paywallComponents.data
+        expect(result.workflowContext).to(beNil())
+    }
+
+    func testResolvePaywallViewDataRestoringPrunedComponentsKeepsPresentedOfferingContext() async throws {
+        let identifier = "offering_a"
+        let presentedOfferingContext = Self.createPresentedOfferingContext(offeringIdentifier: identifier)
+        let paywallComponents = try Self.createPaywallComponents(offeringIdentifier: identifier)
+        let prunedOffering = Self.createPrunedOffering(identifier: identifier)
+            .withPresentedOfferingContext(presentedOfferingContext)
+        let purchases = Self.createMockPurchases()
+        let handler = Self.createPurchaseHandler(purchases: purchases)
+
+        purchases.offeringsBlock = {
+            Self.createOfferings(
+                [Self.createOffering(identifier: identifier, paywall: nil)
+                    .withPaywallComponents(paywallComponents)],
+                currentOfferingID: identifier
+            )
+        }
+
+        let result = try await handler.resolvePaywallViewData(
+            for: .offering(prunedOffering),
+            remoteConfigEnabled: false
+        )
+
+        expect(result.offering.paywallComponents?.data) == paywallComponents.data
+        expect(result.offering.presentedOfferingContext?.placementIdentifier)
+            == presentedOfferingContext.placementIdentifier
+        expect(result.offering.presentedOfferingContext?.targetingContext?.ruleId)
+            == presentedOfferingContext.targetingContext?.ruleId
+    }
+
+    func testResolvePaywallViewDataKeepsPrunedOfferingWhenOfferingsCacheIsStillPruned() async throws {
+        // Nothing to restore (the refreshed offerings are pruned too), so the offering is returned
+        // untouched instead of failing.
+        let identifier = "offering_a"
+        let prunedOffering = Self.createPrunedOffering(identifier: identifier)
+        let purchases = Self.createMockPurchases()
+        let handler = Self.createPurchaseHandler(purchases: purchases)
+
+        purchases.offeringsBlock = {
+            Self.createOfferings([prunedOffering], currentOfferingID: identifier)
+        }
+
+        let result = try await handler.resolvePaywallViewData(
+            for: .offering(prunedOffering),
+            remoteConfigEnabled: false
+        )
+
+        expect(result.offering) === prunedOffering
+        expect(result.workflowContext).to(beNil())
+    }
+
+    func testResolvePaywallViewDataRestoresPrunedComponentsWhenKillSwitchTripsDuringWorkflowFetch() async throws {
+        // The workflow fetch is what trips the kill switch (a 4xx on `/v1/config`), so the gate has to be
+        // re-read on failure: the offerings-provided paywall only becomes restorable at that point.
+        let identifier = "offering_a"
+        let paywallComponents = try Self.createPaywallComponents(offeringIdentifier: identifier)
+        let prunedOffering = Self.createPrunedOffering(identifier: identifier)
+        let purchases = Self.createMockPurchases()
+        let handler = Self.createPurchaseHandler(purchases: purchases)
+
+        purchases.remoteConfigEnabled = true
+        purchases.offeringsBlock = {
+            Self.createOfferings(
+                [Self.createOffering(identifier: identifier, paywall: nil)
+                    .withPaywallComponents(paywallComponents)],
+                currentOfferingID: identifier
+            )
+        }
+        purchases.workflowBlock = { [weak purchases] offeringIdentifier in
+            purchases?.remoteConfigEnabled = false
+            throw BackendError.offeringHasNoWorkflow(offeringId: offeringIdentifier)
+        }
+
+        let result = try await handler.resolvePaywallViewData(
+            for: .offering(prunedOffering),
+            remoteConfigEnabled: true
+        )
+
+        expect(result.offering.identifier) == identifier
+        expect(result.offering.paywallComponents?.data) == paywallComponents.data
+        expect(result.workflowContext).to(beNil())
+    }
+
+    func testCachedInitialPaywallViewDataReturnsNilForPrunedOfferingWhenRemoteConfigDisabled() {
+        // Seeding a pruned offering would render the default paywall and skip the async path that can
+        // restore its components, so the cached seed must miss instead.
+        let prunedOffering = Self.createPrunedOffering(identifier: "offering_a")
+        let purchases = Self.createMockPurchases()
+        let handler = Self.createPurchaseHandler(purchases: purchases)
+
+        purchases.cachedOfferings = Self.createOfferings(
+            [prunedOffering],
+            currentOfferingID: prunedOffering.identifier
+        )
+
+        expect(handler.cachedInitialPaywallViewData(
+            for: .offering(prunedOffering),
+            remoteConfigEnabled: false
+        )).to(beNil())
+        expect(handler.cachedInitialPaywallViewData(
+            for: .defaultOffering,
+            remoteConfigEnabled: false
+        )).to(beNil())
+    }
+
     func testResolvePaywallViewDataThrowsWhenWorkflowScreenOfferingMissingEvenWithFallbackAvailable() async throws {
         // A structural workflow misconfiguration (unlike a fetch failure) must still surface, even
         // with a fallback available: mirrors isWorkflowFetchFallbackEligible's PaywallError exclusion.
@@ -631,6 +763,21 @@ private extension PaywallViewConfigurationTests {
             serverDescription: "Offering \(identifier)",
             metadata: [:],
             paywall: paywall,
+            availablePackages: TestData.packages,
+            webCheckoutUrl: nil
+        )
+    }
+
+    /// An offering as parsed while remote config is active: the backend served paywall components, but the
+    /// payload isn't retained because workflows resolve components from `/v1/config`.
+    static func createPrunedOffering(identifier: String) -> Offering {
+        return Offering(
+            identifier: identifier,
+            serverDescription: "Offering \(identifier)",
+            metadata: [:],
+            paywall: nil,
+            paywallComponents: nil,
+            hasPaywallComponents: true,
             availablePackages: TestData.packages,
             webCheckoutUrl: nil
         )


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

Flipping the config-endpoint [kill switch](https://revenuecat.slack.com/archives/C0AK23U9DBN/p1785403887489019) mid-session rendered the default paywall on iOS instead of falling back to the single-page paywall. A fresh launch was unaffected, which is what made this look like a caching problem.

### Description

Offerings parsed while remote config is active keep only a paywall-components marker, since workflows serve components from `/v1/config`. `OfferingsManager` restores them in its own cache once the kill switch disables remote config, but an offering the app already holds and passes into `PaywallView` was still rendered as-is — with nothing left to render. Such an offering is now re-resolved against the refreshed offerings cache, including when the kill switch trips during the workflow fetch itself, which is the common case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall resolution and caching when remote config is disabled mid-session; scope is limited to pruned-offering fallback with strong test coverage, but incorrect restoration could still show the wrong paywall.
> 
> **Overview**
> Fixes mid-session **default paywall** when the remote config kill switch disables workflows after the app already held an offering parsed under remote config (components marker only, payload pruned).
> 
> **`PurchaseHandler`** now re-resolves such offerings from the refreshed offerings cache via **`restoringPrunedPaywallComponents`**, including on the legacy path, workflow fetch fallback, and when the kill switch trips **during** the workflow fetch (re-reads `remoteConfigEnabled` after failure). **`cachedInitialPaywallViewData`** no longer seeds a pruned offering when remote config is off, so the async path can restore components. **`Offering.hasPrunedPaywallComponents`** identifies offerings that need this path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10ca190c99dfaa34454067f832682638048281a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->