### PR TITLE
Send `paywall_id`, `workflow_id` and `trace_id` on paywall events

### DIFF
--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -97,8 +97,8 @@ struct PaywallsV2View: View {
     /// standalone paywalls and for workflow steps the backend did not tag (see `stepScreenType`).
     private let workflowScreenType: [String]?
     /// Workflow attribution, `nil` for standalone paywalls. `workflowId` / `stepId` go to the post-receipt
-    /// body as `presented_workflow_id` / `presented_step_id` (#7024); `traceId` goes to the nested `paywall`
-    /// object (#7311) and to the paywall event's `presented_offering_context`. Orthogonal to
+    /// body as `presented_workflow_id` / `presented_step_id`; `traceId` goes to the nested `paywall`
+    /// object and to the paywall event's `presented_offering_context`. Orthogonal to
     /// `workflowScreenType`, which gates whether events fire.
     private let workflowId: String?
     private let stepId: String?
@@ -460,8 +460,8 @@ struct PaywallsV2View: View {
     }
 
     /// Stamps workflow attribution onto a paywall event's data: `workflowId` / `stepId` for the
-    /// post-receipt body (#7024), `traceId` for the post-receipt `paywall` object (#7311) and the
-    /// event's own `presented_offering_context`. Orthogonal to the `screen_type` gate; all are `nil`
+    /// post-receipt body, `traceId` for the post-receipt `paywall` object and the event's own
+    /// `presented_offering_context`. Orthogonal to the `screen_type` gate; all are `nil`
     /// for standalone paywalls.
     static func applyingWorkflowAttribution(
         to data: PaywallEvent.Data,

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -96,8 +96,10 @@ struct PaywallsV2View: View {
     /// The workflow step's `screen_type` classification, used to gate impression reporting. `nil` for
     /// standalone paywalls and for workflow steps the backend did not tag (see `stepScreenType`).
     private let workflowScreenType: [String]?
-    /// Workflow purchase attribution. Orthogonal to `workflowScreenType`: gating decides whether the
-    /// event fires; these identify which workflow traversal and step produced a purchase.
+    /// Workflow attribution, `nil` for standalone paywalls. `workflowId` / `stepId` go to the post-receipt
+    /// body as `presented_workflow_id` / `presented_step_id` (#7024); `traceId` goes to the nested `paywall`
+    /// object (#7311) and to the paywall event's `presented_offering_context`. Orthogonal to
+    /// `workflowScreenType`, which gates whether events fire.
     private let workflowId: String?
     private let stepId: String?
     private let traceId: String?
@@ -457,8 +459,10 @@ struct PaywallsV2View: View {
         )
     }
 
-    /// Stamps workflow purchase attribution onto internal paywall event data. Orthogonal to the
-    /// `screen_type` gate; all values are `nil` for standalone paywalls.
+    /// Stamps workflow attribution onto a paywall event's data: `workflowId` / `stepId` for the
+    /// post-receipt body (#7024), `traceId` for the post-receipt `paywall` object (#7311) and the
+    /// event's own `presented_offering_context`. Orthogonal to the `screen_type` gate; all are `nil`
+    /// for standalone paywalls.
     static func applyingWorkflowAttribution(
         to data: PaywallEvent.Data,
         workflowId: String?,

--- a/Sources/Paywalls/Events/Networking/EventsRequest+Paywall.swift
+++ b/Sources/Paywalls/Events/Networking/EventsRequest+Paywall.swift
@@ -68,21 +68,35 @@ extension FeatureEventsRequest.PaywallEvent {
         var placementIdentifier: String?
         var targetingRevision: Int?
         var targetingRuleId: String?
+        var paywallId: String?
+        var workflowId: String?
+        var traceId: String?
 
-        /// Returns `nil` if all fields are `nil`.
+        /// Returns `nil` unless there is placement, targeting or workflow attribution to report.
+        /// `paywallId` deliberately does not keep the object alive on its own: it is set on essentially
+        /// every paywall event, so including it in the guard would attach a context to standalone paywall
+        /// events that carry `nil` today. It already has its own top-level field and Snowflake column.
         init?(
             placementIdentifier: String?,
             targetingRevision: Int?,
-            targetingRuleId: String?
+            targetingRuleId: String?,
+            paywallId: String?,
+            workflowId: String?,
+            traceId: String?
         ) {
             guard placementIdentifier != nil ||
                     targetingRevision != nil ||
-                    targetingRuleId != nil else {
+                    targetingRuleId != nil ||
+                    workflowId != nil ||
+                    traceId != nil else {
                 return nil
             }
             self.placementIdentifier = placementIdentifier
             self.targetingRevision = targetingRevision
             self.targetingRuleId = targetingRuleId
+            self.paywallId = paywallId
+            self.workflowId = workflowId
+            self.traceId = traceId
         }
 
     }
@@ -116,6 +130,7 @@ extension FeatureEventsRequest.PaywallEvent {
     }
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+    // swiftlint:disable:next function_body_length
     private init(decodedPaywallEvent: PaywallEvent, appUserID: String) {
         let creationData = decodedPaywallEvent.creationData
         let data = decodedPaywallEvent.data
@@ -139,7 +154,10 @@ extension FeatureEventsRequest.PaywallEvent {
             presentedOfferingContext: PresentedOfferingContextData(
                 placementIdentifier: data.placementIdentifier,
                 targetingRevision: data.targetingRevision,
-                targetingRuleId: data.targetingRuleId
+                targetingRuleId: data.targetingRuleId,
+                paywallId: data.paywallIdentifier,
+                workflowId: data.workflowId,
+                traceId: data.traceId
             ),
             exitOfferType: exitOfferData?.exitOfferType,
             exitOfferingID: exitOfferData?.exitOfferingIdentifier,

--- a/Sources/Paywalls/Events/Networking/EventsRequest+Paywall.swift
+++ b/Sources/Paywalls/Events/Networking/EventsRequest+Paywall.swift
@@ -72,10 +72,7 @@ extension FeatureEventsRequest.PaywallEvent {
         var workflowId: String?
         var traceId: String?
 
-        /// Returns `nil` unless there is placement, targeting or workflow attribution to report.
-        /// `paywallId` deliberately does not keep the object alive on its own: it is set on essentially
-        /// every paywall event, so including it in the guard would attach a context to standalone paywall
-        /// events that carry `nil` today. It already has its own top-level field and Snowflake column.
+        /// Returns `nil` if all fields are `nil`.
         init?(
             placementIdentifier: String?,
             targetingRevision: Int?,
@@ -87,6 +84,7 @@ extension FeatureEventsRequest.PaywallEvent {
             guard placementIdentifier != nil ||
                     targetingRevision != nil ||
                     targetingRuleId != nil ||
+                    paywallId != nil ||
                     workflowId != nil ||
                     traceId != nil else {
                 return nil

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
@@ -1202,6 +1202,57 @@ extension WorkflowPaywallViewTests {
         expect(impression.data.paywallIdentifier) == "screen_a"
     }
 
+    /// Re-entering a step mints a fresh paywall session and fires a second `paywall_viewed`
+    /// (`PaywallsV2View.onChangeOf(isActiveWorkflowPage)`). The trace id identifies the presentation, not
+    /// the visit, so it has to survive that. Driven at the `PaywallsV2View` seam because the page's
+    /// activation is the only part of navigation reachable without simulating a tap.
+    @MainActor
+    func testReenteringAWorkflowPageKeepsTheTraceIdOnTheSecondImpression() async throws {
+        let paywallEvents: Atomic<[PaywallEvent]> = .init([])
+        let (_, purchaseHandler) = Self.makeEventRecordingPurchaseHandler(paywallEvents: paywallEvents)
+        let context = try Self.makeContextStartingAt(stepId: "step_a")
+        let screen = try XCTUnwrap(context.workflow.screens["screen_a"])
+        let activation = WorkflowPageActivation(isActive: true)
+
+        let dispose = try WorkflowPageActivationHost(
+            activation: activation,
+            paywallComponents: WorkflowScreenMapper.toPaywallComponents(
+                screen: screen,
+                uiConfig: context.uiConfig
+            ),
+            offering: context.initialOffering,
+            purchaseHandler: purchaseHandler,
+            traceId: Self.reentryTraceId
+        ).addToHierarchy()
+
+        defer { dispose() }
+
+        await expect(Self.impressionData(in: paywallEvents.value)).toEventually(
+            haveCount(1),
+            timeout: .seconds(3)
+        )
+
+        // Navigate away and back. The page stays mounted, it just stops being the current step.
+        // The render pass in between is required, otherwise both flips coalesce into no change at all.
+        activation.isActive = false
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+        activation.isActive = true
+
+        await expect(Self.impressionData(in: paywallEvents.value)).toEventually(
+            haveCount(2),
+            timeout: .seconds(3)
+        )
+
+        let impressions = Self.impressionData(in: paywallEvents.value)
+        expect(impressions.map(\.traceId)) == [Self.reentryTraceId, Self.reentryTraceId]
+
+        let firstVisit = try XCTUnwrap(impressions.first)
+        let secondVisit = try XCTUnwrap(impressions.dropFirst().first)
+        expect(firstVisit.sessionIdentifier) != secondVisit.sessionIdentifier
+    }
+
+    private static let reentryTraceId = "trace_reentry"
+
     private static func isImpression(_ event: PaywallEvent) -> Bool {
         if case .impression = event { return true }
         return false
@@ -1210,6 +1261,10 @@ extension WorkflowPaywallViewTests {
     private static func isStepStarted(_ event: WorkflowEvent) -> Bool {
         if case .stepStarted = event { return true }
         return false
+    }
+
+    private static func impressionData(in events: [PaywallEvent]) -> [PaywallEvent.Data] {
+        return events.filter { Self.isImpression($0) }.map(\.data)
     }
 
     private static func makeEventRecordingPurchaseHandler(
@@ -1229,6 +1284,48 @@ extension WorkflowPaywallViewTests {
             eventTracker: .init(purchases: purchases, eventDispatcher: PaywallEventTrackerTestDispatcher.value)
         )
         return (purchases, purchaseHandler)
+    }
+
+}
+
+/// Lets a test flip a workflow page between current and not-current, the signal
+/// `WorkflowPaywallView` feeds `PaywallsV2View` on every navigation.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private final class WorkflowPageActivation: ObservableObject {
+
+    @Published var isActive: Bool
+
+    init(isActive: Bool) {
+        self.isActive = isActive
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private struct WorkflowPageActivationHost: View {
+
+    @ObservedObject var activation: WorkflowPageActivation
+    let paywallComponents: Offering.PaywallComponents
+    let offering: Offering
+    let purchaseHandler: PurchaseHandler
+    let traceId: String
+
+    var body: some View {
+        PaywallsV2View(
+            paywallComponents: self.paywallComponents,
+            offering: self.offering,
+            purchaseHandler: self.purchaseHandler,
+            introEligibilityChecker: .producing(eligibility: .eligible),
+            showZeroDecimalPlacePrices: false,
+            onDismiss: {},
+            failedToLoadFont: { _ in },
+            colorScheme: .light,
+            isActiveWorkflowPage: self.activation.isActive,
+            workflowScreenType: [WorkflowScreenType.paywall],
+            workflowId: "wf_non_initial_test",
+            stepId: "step_a",
+            traceId: self.traceId
+        )
     }
 
 }

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowStepEventCoordinatorTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowStepEventCoordinatorTests.swift
@@ -64,6 +64,7 @@ final class WorkflowStepEventCoordinatorTests: TestCase {
         expect(self.recorded).to(haveCount(1))
     }
 
+    // `freshTraceId` proves the passthrough surfaces the generated id, not a hardcoded test value.
     func testTraceIdMatchesTheTraceIdStampedOnEmittedWorkflowEvents() throws {
         let workflow = try Self.makeWorkflow()
         let coordinator = self.makeCoordinator(workflow: workflow, freshTraceId: true)

--- a/Tests/UnitTests/Paywalls/Events/PaywallFeatureEventsRequestTests.swift
+++ b/Tests/UnitTests/Paywalls/Events/PaywallFeatureEventsRequestTests.swift
@@ -354,15 +354,12 @@ class PaywallFeatureEventsRequestTests: TestCase {
 
     // MARK: - Workflow Attribution Tests
 
-    func testImpressionEventCarriesWorkflowAttributionInPresentedOfferingContext() throws {
+    func testImpressionEventWithWorkflowAttribution() throws {
         let event = PaywallEvent.impression(Self.eventCreationData, Self.eventDataWithWorkflowAttribution)
         let storedEvent = try Self.createStoredFeatureEvent(from: event)
         let requestEvent: FeatureEventsRequest.PaywallEvent = try XCTUnwrap(.init(storedEvent: storedEvent))
 
-        let context = try XCTUnwrap(requestEvent.presentedOfferingContext)
-        expect(context.paywallId) == "test_paywall_id_1"
-        expect(context.workflowId) == "wf_abc123"
-        expect(context.traceId) == "3F2504E0-4F89-11D3-9A0C-0305E82C3301"
+        assertSnapshot(of: requestEvent, as: .formattedJson)
     }
 
     // The context used to be nil unless placement or targeting was set, which workflow paywalls rarely are.
@@ -375,14 +372,6 @@ class PaywallFeatureEventsRequestTests: TestCase {
         expect(context.placementIdentifier).to(beNil())
         expect(context.targetingRevision).to(beNil())
         expect(context.targetingRuleId).to(beNil())
-    }
-
-    func testImpressionEventWithWorkflowAttribution() throws {
-        let event = PaywallEvent.impression(Self.eventCreationData, Self.eventDataWithWorkflowAttribution)
-        let storedEvent = try Self.createStoredFeatureEvent(from: event)
-        let requestEvent: FeatureEventsRequest.PaywallEvent = try XCTUnwrap(.init(storedEvent: storedEvent))
-
-        assertSnapshot(of: requestEvent, as: .formattedJson)
     }
 
     func testWorkflowAttributionIsNotSentAtTopLevel() throws {

--- a/Tests/UnitTests/Paywalls/Events/PaywallFeatureEventsRequestTests.swift
+++ b/Tests/UnitTests/Paywalls/Events/PaywallFeatureEventsRequestTests.swift
@@ -401,8 +401,32 @@ class PaywallFeatureEventsRequestTests: TestCase {
         expect(json).to(contain("wf_abc123"))
     }
 
-    func testStandalonePaywallEventStillHasNoPresentedOfferingContext() throws {
+    // Matches purchases-android, where `paywallId` also keeps the context alive on its own.
+    func testStandalonePaywallEventCarriesPaywallIdInPresentedOfferingContext() throws {
         let event = PaywallEvent.impression(Self.eventCreationData, Self.eventData)
+        let storedEvent = try Self.createStoredFeatureEvent(from: event)
+        let requestEvent: FeatureEventsRequest.PaywallEvent = try XCTUnwrap(.init(storedEvent: storedEvent))
+
+        let context = try XCTUnwrap(requestEvent.presentedOfferingContext)
+        expect(context.paywallId) == Self.eventData.paywallIdentifier
+        expect(context.placementIdentifier).to(beNil())
+        expect(context.targetingRevision).to(beNil())
+        expect(context.targetingRuleId).to(beNil())
+        expect(context.workflowId).to(beNil())
+        expect(context.traceId).to(beNil())
+    }
+
+    func testPaywallEventWithoutPaywallIdHasNoPresentedOfferingContext() throws {
+        let data = PaywallEvent.Data(
+            paywallIdentifier: nil,
+            offeringIdentifier: "offering",
+            paywallRevision: 0,
+            sessionID: Self.eventData.sessionIdentifier,
+            displayMode: .fullScreen,
+            localeIdentifier: "es_ES",
+            darkMode: true
+        )
+        let event = PaywallEvent.impression(Self.eventCreationData, data)
         let storedEvent = try Self.createStoredFeatureEvent(from: event)
         let requestEvent: FeatureEventsRequest.PaywallEvent = try XCTUnwrap(.init(storedEvent: storedEvent))
 

--- a/Tests/UnitTests/Paywalls/Events/PaywallFeatureEventsRequestTests.swift
+++ b/Tests/UnitTests/Paywalls/Events/PaywallFeatureEventsRequestTests.swift
@@ -352,6 +352,63 @@ class PaywallFeatureEventsRequestTests: TestCase {
         assertSnapshot(of: requestEvent, as: .formattedJson)
     }
 
+    // MARK: - Workflow Attribution Tests
+
+    func testImpressionEventCarriesWorkflowAttributionInPresentedOfferingContext() throws {
+        let event = PaywallEvent.impression(Self.eventCreationData, Self.eventDataWithWorkflowAttribution)
+        let storedEvent = try Self.createStoredFeatureEvent(from: event)
+        let requestEvent: FeatureEventsRequest.PaywallEvent = try XCTUnwrap(.init(storedEvent: storedEvent))
+
+        let context = try XCTUnwrap(requestEvent.presentedOfferingContext)
+        expect(context.paywallId) == "test_paywall_id_1"
+        expect(context.workflowId) == "wf_abc123"
+        expect(context.traceId) == "3F2504E0-4F89-11D3-9A0C-0305E82C3301"
+    }
+
+    // The context used to be nil unless placement or targeting was set, which workflow paywalls rarely are.
+    func testWorkflowAttributionSurvivesWithoutPlacementOrTargeting() throws {
+        let event = PaywallEvent.impression(Self.eventCreationData, Self.eventDataWithWorkflowAttribution)
+        let storedEvent = try Self.createStoredFeatureEvent(from: event)
+        let requestEvent: FeatureEventsRequest.PaywallEvent = try XCTUnwrap(.init(storedEvent: storedEvent))
+
+        let context = try XCTUnwrap(requestEvent.presentedOfferingContext)
+        expect(context.placementIdentifier).to(beNil())
+        expect(context.targetingRevision).to(beNil())
+        expect(context.targetingRuleId).to(beNil())
+    }
+
+    func testImpressionEventWithWorkflowAttribution() throws {
+        let event = PaywallEvent.impression(Self.eventCreationData, Self.eventDataWithWorkflowAttribution)
+        let storedEvent = try Self.createStoredFeatureEvent(from: event)
+        let requestEvent: FeatureEventsRequest.PaywallEvent = try XCTUnwrap(.init(storedEvent: storedEvent))
+
+        assertSnapshot(of: requestEvent, as: .formattedJson)
+    }
+
+    func testWorkflowAttributionIsNotSentAtTopLevel() throws {
+        let event = PaywallEvent.impression(Self.eventCreationData, Self.eventDataWithWorkflowAttribution)
+        let storedEvent = try Self.createStoredFeatureEvent(from: event)
+        let requestEvent: FeatureEventsRequest.PaywallEvent = try XCTUnwrap(.init(storedEvent: storedEvent))
+
+        let encoded = try JSONEncoder.prettyPrinted.encode(requestEvent)
+        let json = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+        let topLevel = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+
+        expect(topLevel.keys.contains("workflow_id")) == false
+        expect(topLevel.keys.contains("trace_id")) == false
+        expect(json).to(contain("wf_abc123"))
+    }
+
+    func testStandalonePaywallEventStillHasNoPresentedOfferingContext() throws {
+        let event = PaywallEvent.impression(Self.eventCreationData, Self.eventData)
+        let storedEvent = try Self.createStoredFeatureEvent(from: event)
+        let requestEvent: FeatureEventsRequest.PaywallEvent = try XCTUnwrap(.init(storedEvent: storedEvent))
+
+        expect(requestEvent.presentedOfferingContext).to(beNil())
+    }
+
     // MARK: - Milliseconds Precision Tests
 
     func testPaywallEventImpressionPreservesMillisecondsInCreationDate() throws {
@@ -542,6 +599,18 @@ private extension PaywallFeatureEventsRequestTests {
             placementIdentifier: nil,
             targetingContext: .init(revision: 3, ruleId: "rule_abc123")
         )
+    )
+
+    static let eventDataWithWorkflowAttribution: PaywallEvent.Data = .init(
+        paywallIdentifier: "test_paywall_id_1",
+        offeringIdentifier: "offering_1",
+        paywallRevision: 5,
+        sessionID: .init(uuidString: "98CC0F1D-7665-4093-9624-1D7308FFF4DB")!,
+        displayMode: .fullScreen,
+        localeIdentifier: "es_ES",
+        darkMode: true,
+        workflowId: "wf_abc123",
+        traceId: "3F2504E0-4F89-11D3-9A0C-0305E82C3301"
     )
 
     static let eventDataWithSource: PaywallEvent.Data = .init(

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS13-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS13-testPostPaywallEventsWithMultipleEvents.1.json
@@ -30,6 +30,9 @@
           "offering_id" : "offering_1",
           "paywall_id" : "test_paywall_id_1",
           "paywall_revision" : 5,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_1"
+          },
           "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694029328000,
           "type" : "paywall_impression",
@@ -44,6 +47,9 @@
           "offering_id" : "offering_2",
           "paywall_id" : "test_paywall_id_2",
           "paywall_revision" : 3,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_2"
+          },
           "session_id" : "10CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694022321000,
           "type" : "paywall_close",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS13-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS13-testPostPaywallEventsWithOneEvent.1.json
@@ -30,6 +30,9 @@
           "offering_id" : "offering_1",
           "paywall_id" : "test_paywall_id_1",
           "paywall_revision" : 5,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_1"
+          },
           "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694029328000,
           "type" : "paywall_impression",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS15-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS15-testPostPaywallEventsWithMultipleEvents.1.json
@@ -34,6 +34,9 @@
           "offering_id" : "offering_1",
           "paywall_id" : "test_paywall_id_1",
           "paywall_revision" : 5,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_1"
+          },
           "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694029328000,
           "type" : "paywall_impression",
@@ -48,6 +51,9 @@
           "offering_id" : "offering_2",
           "paywall_id" : "test_paywall_id_2",
           "paywall_revision" : 3,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_2"
+          },
           "session_id" : "10CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694022321000,
           "type" : "paywall_close",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS15-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS15-testPostPaywallEventsWithOneEvent.1.json
@@ -34,6 +34,9 @@
           "offering_id" : "offering_1",
           "paywall_id" : "test_paywall_id_1",
           "paywall_revision" : 5,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_1"
+          },
           "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694029328000,
           "type" : "paywall_impression",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS15-testPostPaywallEventsWithPlacementAndTargeting.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS15-testPostPaywallEventsWithPlacementAndTargeting.1.json
@@ -35,6 +35,7 @@
           "paywall_id" : "test_paywall_id_1",
           "paywall_revision" : 5,
           "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_1",
             "placement_identifier" : "home_banner",
             "targeting_revision" : 3,
             "targeting_rule_id" : "rule_abc123"

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS16-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS16-testPostPaywallEventsWithMultipleEvents.1.json
@@ -34,6 +34,9 @@
           "offering_id" : "offering_1",
           "paywall_id" : "test_paywall_id_1",
           "paywall_revision" : 5,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_1"
+          },
           "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694029328000,
           "type" : "paywall_impression",
@@ -48,6 +51,9 @@
           "offering_id" : "offering_2",
           "paywall_id" : "test_paywall_id_2",
           "paywall_revision" : 3,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_2"
+          },
           "session_id" : "10CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694022321000,
           "type" : "paywall_close",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS16-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS16-testPostPaywallEventsWithOneEvent.1.json
@@ -34,6 +34,9 @@
           "offering_id" : "offering_1",
           "paywall_id" : "test_paywall_id_1",
           "paywall_revision" : 5,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_1"
+          },
           "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694029328000,
           "type" : "paywall_impression",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS16-testPostPaywallEventsWithPlacementAndTargeting.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS16-testPostPaywallEventsWithPlacementAndTargeting.1.json
@@ -35,6 +35,7 @@
           "paywall_id" : "test_paywall_id_1",
           "paywall_revision" : 5,
           "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_1",
             "placement_identifier" : "home_banner",
             "targeting_revision" : 3,
             "targeting_rule_id" : "rule_abc123"

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS17-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS17-testPostPaywallEventsWithMultipleEvents.1.json
@@ -34,6 +34,9 @@
           "offering_id" : "offering_1",
           "paywall_id" : "test_paywall_id_1",
           "paywall_revision" : 5,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_1"
+          },
           "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694029328000,
           "type" : "paywall_impression",
@@ -48,6 +51,9 @@
           "offering_id" : "offering_2",
           "paywall_id" : "test_paywall_id_2",
           "paywall_revision" : 3,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_2"
+          },
           "session_id" : "10CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694022321000,
           "type" : "paywall_close",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS17-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS17-testPostPaywallEventsWithOneEvent.1.json
@@ -34,6 +34,9 @@
           "offering_id" : "offering_1",
           "paywall_id" : "test_paywall_id_1",
           "paywall_revision" : 5,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_1"
+          },
           "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694029328000,
           "type" : "paywall_impression",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS17-testPostPaywallEventsWithPlacementAndTargeting.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS17-testPostPaywallEventsWithPlacementAndTargeting.1.json
@@ -35,6 +35,7 @@
           "paywall_id" : "test_paywall_id_1",
           "paywall_revision" : 5,
           "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_1",
             "placement_identifier" : "home_banner",
             "targeting_revision" : 3,
             "targeting_rule_id" : "rule_abc123"

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS18-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS18-testPostPaywallEventsWithMultipleEvents.1.json
@@ -34,6 +34,9 @@
           "offering_id" : "offering_1",
           "paywall_id" : "test_paywall_id_1",
           "paywall_revision" : 5,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_1"
+          },
           "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694029328000,
           "type" : "paywall_impression",
@@ -48,6 +51,9 @@
           "offering_id" : "offering_2",
           "paywall_id" : "test_paywall_id_2",
           "paywall_revision" : 3,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_2"
+          },
           "session_id" : "10CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694022321000,
           "type" : "paywall_close",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS18-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS18-testPostPaywallEventsWithOneEvent.1.json
@@ -34,6 +34,9 @@
           "offering_id" : "offering_1",
           "paywall_id" : "test_paywall_id_1",
           "paywall_revision" : 5,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_1"
+          },
           "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694029328000,
           "type" : "paywall_impression",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS18-testPostPaywallEventsWithPlacementAndTargeting.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS18-testPostPaywallEventsWithPlacementAndTargeting.1.json
@@ -35,6 +35,7 @@
           "paywall_id" : "test_paywall_id_1",
           "paywall_revision" : 5,
           "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_1",
             "placement_identifier" : "home_banner",
             "targeting_revision" : 3,
             "targeting_rule_id" : "rule_abc123"

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS26-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS26-testPostPaywallEventsWithMultipleEvents.1.json
@@ -34,6 +34,9 @@
           "offering_id" : "offering_1",
           "paywall_id" : "test_paywall_id_1",
           "paywall_revision" : 5,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_1"
+          },
           "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694029328000,
           "type" : "paywall_impression",
@@ -48,6 +51,9 @@
           "offering_id" : "offering_2",
           "paywall_id" : "test_paywall_id_2",
           "paywall_revision" : 3,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_2"
+          },
           "session_id" : "10CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694022321000,
           "type" : "paywall_close",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS26-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS26-testPostPaywallEventsWithOneEvent.1.json
@@ -34,6 +34,9 @@
           "offering_id" : "offering_1",
           "paywall_id" : "test_paywall_id_1",
           "paywall_revision" : 5,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_1"
+          },
           "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694029328000,
           "type" : "paywall_impression",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS26-testPostPaywallEventsWithPlacementAndTargeting.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/iOS26-testPostPaywallEventsWithPlacementAndTargeting.1.json
@@ -35,6 +35,7 @@
           "paywall_id" : "test_paywall_id_1",
           "paywall_revision" : 5,
           "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_1",
             "placement_identifier" : "home_banner",
             "targeting_revision" : 3,
             "targeting_rule_id" : "rule_abc123"

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/macOS-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/macOS-testPostPaywallEventsWithMultipleEvents.1.json
@@ -33,6 +33,9 @@
           "offering_id" : "offering_1",
           "paywall_id" : "test_paywall_id_1",
           "paywall_revision" : 5,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_1"
+          },
           "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694029328000,
           "type" : "paywall_impression",
@@ -47,6 +50,9 @@
           "offering_id" : "offering_2",
           "paywall_id" : "test_paywall_id_2",
           "paywall_revision" : 3,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_2"
+          },
           "session_id" : "10CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694022321000,
           "type" : "paywall_close",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/macOS-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/macOS-testPostPaywallEventsWithOneEvent.1.json
@@ -33,6 +33,9 @@
           "offering_id" : "offering_1",
           "paywall_id" : "test_paywall_id_1",
           "paywall_revision" : 5,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_1"
+          },
           "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694029328000,
           "type" : "paywall_impression",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/macOS-testPostPaywallEventsWithPlacementAndTargeting.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/macOS-testPostPaywallEventsWithPlacementAndTargeting.1.json
@@ -34,6 +34,7 @@
           "paywall_id" : "test_paywall_id_1",
           "paywall_revision" : 5,
           "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_1",
             "placement_identifier" : "home_banner",
             "targeting_revision" : 3,
             "targeting_rule_id" : "rule_abc123"

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/tvOS18-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/tvOS18-testPostPaywallEventsWithMultipleEvents.1.json
@@ -34,6 +34,9 @@
           "offering_id" : "offering_1",
           "paywall_id" : "test_paywall_id_1",
           "paywall_revision" : 5,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_1"
+          },
           "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694029328000,
           "type" : "paywall_impression",
@@ -48,6 +51,9 @@
           "offering_id" : "offering_2",
           "paywall_id" : "test_paywall_id_2",
           "paywall_revision" : 3,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_2"
+          },
           "session_id" : "10CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694022321000,
           "type" : "paywall_close",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/tvOS18-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/tvOS18-testPostPaywallEventsWithOneEvent.1.json
@@ -34,6 +34,9 @@
           "offering_id" : "offering_1",
           "paywall_id" : "test_paywall_id_1",
           "paywall_revision" : 5,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_1"
+          },
           "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694029328000,
           "type" : "paywall_impression",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/tvOS18-testPostPaywallEventsWithPlacementAndTargeting.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/tvOS18-testPostPaywallEventsWithPlacementAndTargeting.1.json
@@ -35,6 +35,7 @@
           "paywall_id" : "test_paywall_id_1",
           "paywall_revision" : 5,
           "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_1",
             "placement_identifier" : "home_banner",
             "targeting_revision" : 3,
             "targeting_rule_id" : "rule_abc123"

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/watchOS-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/watchOS-testPostPaywallEventsWithMultipleEvents.1.json
@@ -34,6 +34,9 @@
           "offering_id" : "offering_1",
           "paywall_id" : "test_paywall_id_1",
           "paywall_revision" : 5,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_1"
+          },
           "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694029328000,
           "type" : "paywall_impression",
@@ -48,6 +51,9 @@
           "offering_id" : "offering_2",
           "paywall_id" : "test_paywall_id_2",
           "paywall_revision" : 3,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_2"
+          },
           "session_id" : "10CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694022321000,
           "type" : "paywall_close",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/watchOS-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/watchOS-testPostPaywallEventsWithOneEvent.1.json
@@ -34,6 +34,9 @@
           "offering_id" : "offering_1",
           "paywall_id" : "test_paywall_id_1",
           "paywall_revision" : 5,
+          "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_1"
+          },
           "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 1694029328000,
           "type" : "paywall_impression",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/watchOS-testPostPaywallEventsWithPlacementAndTargeting.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/BackendPaywallEventTests/watchOS-testPostPaywallEventsWithPlacementAndTargeting.1.json
@@ -35,6 +35,7 @@
           "paywall_id" : "test_paywall_id_1",
           "paywall_revision" : 5,
           "presented_offering_context" : {
+            "paywall_id" : "test_paywall_id_1",
             "placement_identifier" : "home_banner",
             "targeting_revision" : 3,
             "targeting_rule_id" : "rule_abc123"

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testCanInitFromDeserializedEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testCanInitFromDeserializedEvent.1.json
@@ -7,6 +7,9 @@
   "offering_id" : "offeringIdentifier",
   "paywall_id" : "test_paywall_id",
   "paywall_revision" : 0,
+  "presented_offering_context" : {
+    "paywall_id" : "test_paywall_id"
+  },
   "session_id" : "73616D70-6C65-2073-7472-696E67000000",
   "timestamp" : 1694029328000,
   "type" : "paywall_impression",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testCanInitFromDeserializedEventWithPlacementAndTargeting.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testCanInitFromDeserializedEventWithPlacementAndTargeting.1.json
@@ -8,6 +8,7 @@
   "paywall_id" : "test_paywall_id_1",
   "paywall_revision" : 5,
   "presented_offering_context" : {
+    "paywall_id" : "test_paywall_id_1",
     "placement_identifier" : "home_banner",
     "targeting_revision" : 3,
     "targeting_rule_id" : "rule_abc123"

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testCancelEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testCancelEvent.1.json
@@ -7,6 +7,9 @@
   "offering_id" : "offering",
   "paywall_id" : "test_paywall_id",
   "paywall_revision" : 0,
+  "presented_offering_context" : {
+    "paywall_id" : "test_paywall_id"
+  },
   "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
   "timestamp" : 1694029328000,
   "type" : "paywall_cancel",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testCloseEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testCloseEvent.1.json
@@ -7,6 +7,9 @@
   "offering_id" : "offering",
   "paywall_id" : "test_paywall_id",
   "paywall_revision" : 0,
+  "presented_offering_context" : {
+    "paywall_id" : "test_paywall_id"
+  },
   "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
   "timestamp" : 1694029328000,
   "type" : "paywall_close",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testImpressionEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testImpressionEvent.1.json
@@ -7,6 +7,9 @@
   "offering_id" : "offering",
   "paywall_id" : "test_paywall_id",
   "paywall_revision" : 0,
+  "presented_offering_context" : {
+    "paywall_id" : "test_paywall_id"
+  },
   "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
   "timestamp" : 1694029328000,
   "type" : "paywall_impression",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testImpressionEventWithPlacementAndTargeting.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testImpressionEventWithPlacementAndTargeting.1.json
@@ -8,6 +8,7 @@
   "paywall_id" : "test_paywall_id_1",
   "paywall_revision" : 5,
   "presented_offering_context" : {
+    "paywall_id" : "test_paywall_id_1",
     "placement_identifier" : "home_banner",
     "targeting_revision" : 3,
     "targeting_rule_id" : "rule_abc123"

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testImpressionEventWithPlacementOnly.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testImpressionEventWithPlacementOnly.1.json
@@ -8,6 +8,7 @@
   "paywall_id" : "test_paywall_id_1",
   "paywall_revision" : 5,
   "presented_offering_context" : {
+    "paywall_id" : "test_paywall_id_1",
     "placement_identifier" : "home_banner"
   },
   "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testImpressionEventWithSource.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testImpressionEventWithSource.1.json
@@ -7,6 +7,9 @@
   "offering_id" : "offering",
   "paywall_id" : "test_paywall_id",
   "paywall_revision" : 0,
+  "presented_offering_context" : {
+    "paywall_id" : "test_paywall_id"
+  },
   "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
   "source" : "customer_center",
   "timestamp" : 1694029328000,

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testImpressionEventWithTargetingOnly.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testImpressionEventWithTargetingOnly.1.json
@@ -8,6 +8,7 @@
   "paywall_id" : "test_paywall_id_1",
   "paywall_revision" : 5,
   "presented_offering_context" : {
+    "paywall_id" : "test_paywall_id_1",
     "targeting_revision" : 3,
     "targeting_rule_id" : "rule_abc123"
   },

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testImpressionEventWithWorkflowAttribution.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallFeatureEventsRequestTests/testImpressionEventWithWorkflowAttribution.1.json
@@ -1,0 +1,19 @@
+{
+  "app_user_id" : "Jack Shepard",
+  "dark_mode" : true,
+  "display_mode" : "full_screen",
+  "id" : "72164C05-2BDC-4807-8918-A4105F727DEB",
+  "locale" : "es_ES",
+  "offering_id" : "offering_1",
+  "paywall_id" : "test_paywall_id_1",
+  "paywall_revision" : 5,
+  "presented_offering_context" : {
+    "paywall_id" : "test_paywall_id_1",
+    "trace_id" : "3F2504E0-4F89-11D3-9A0C-0305E82C3301",
+    "workflow_id" : "wf_abc123"
+  },
+  "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
+  "timestamp" : 1694029328000,
+  "type" : "paywall_impression",
+  "version" : 1
+}


### PR DESCRIPTION
Re-lands #7304 (reverted in #7313) and adds `paywall_id` next to `workflow_id` and `trace_id`, so all three arrive  inside `presented_offering_context` rather than having to be inferred in the backend.

android [here](https://github.com/RevenueCat/purchases-android/pull/3860)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shape of paywall event payloads sent to the backend (new nested fields and more events carrying `presented_offering_context`), which can affect analytics and downstream consumers if they assumed the old encoding.
> 
> **Overview**
> Paywall events sent to the paywalls API now populate **`presented_offering_context`** with **`paywall_id`**, **`workflow_id`**, and **`trace_id`** (aligned with purchases-android), instead of leaving workflow paywalls without that object when placement/targeting are absent.
> 
> **`paywall_id`** is duplicated into the nested context whenever a paywall id exists on the event, so standalone impressions include a context object even with no placement or targeting. **`workflow_id`** and **`trace_id`** are encoded only inside **`presented_offering_context`**, not as top-level event fields.
> 
> Comments in **`PaywallsV2View`** clarify how **`workflowId`**, **`stepId`**, and **`traceId`** map to post-receipt vs event payloads. Tests cover workflow attribution snapshots, re-entering a workflow page (same trace id, new session), and updated backend JSON snapshots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b17edad0564c84a14a369f747a7b26b3fb0d998. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->