### PR TITLE
fix(remote-config): clear last attempt timestamp for cooldown after successful response

### DIFF
--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -780,6 +780,7 @@ private extension RemoteConfigManager {
     func markRefreshed(at date: Date) {
         self.hasCommittedInitialConfig = true
         self.lastRefreshedAt = date
+        self.lastRefreshAttemptAt = nil
     }
 
     /// Waits for committed config state to become available for read APIs.

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -205,6 +205,16 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
     }
 
+    func testSuccessfulRefreshDoesNotApplyFailureCooldown() {
+        self.manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
+        self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
+
+        self.dateProvider.advance(by: 6)
+        self.manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
+    }
+
     func testFailureDoesNotMarkRefreshAsFresh() {
         self.manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
         self.remoteConfigAPI.complete(with: .failure(.networkError(.networkError(NSError(domain: "test", code: 1)))))
@@ -241,12 +251,18 @@ final class RemoteConfigManagerTests: TestCase {
 
         self.manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
 
-        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
+        self.remoteConfigAPI.complete(with: .success(.test(container: nil)))
 
-        self.dateProvider.advance(by: Self.refreshAttemptCooldownElapsedInterval)
-        self.manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: false)
+        self.dateProvider.advance(by: 6)
+        self.manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: true)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
+
+        self.dateProvider.advance(by: 5)
+        self.manager.refreshRemoteConfigIfStale(fetchContext: .foreground, isAppBackgrounded: true)
+
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 3
     }
 
     func testClearCacheClearsRefreshAttemptCooldown() {


### PR DESCRIPTION
The `lastRefreshAttemptAt` cooldown functionality was designed to ensure that the `RemoteConfigManager` would not immediately allow another request to be sent if a request failed, because the cache wouldn't be updated and thus still be stale. 

However `lastRefreshAttemptAt` was never reset on a successful response, which caused the logic to also kick in after successful responses. This was fine in production code, since the cache was only considered stale after 5 minutes, and the cooldown was just 1 minute. 

However during manual testing (in which I lowered the cache staleness expiration time) this means that we can never really lower the value below the cooldown time (1 minute)

Also added test coverage for this, because this should've been caught really.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line state reset on an existing success path in RemoteConfigManager; behavior change is limited to refresh scheduling after successful responses, with added unit tests.
> 
> **Overview**
> Clears **`lastRefreshAttemptAt`** in **`markRefreshed(at:)`** when a stale-gated refresh completes successfully (200/204 or persisted fallback), so the **60s failure retry cooldown** no longer blocks later refreshes after a good response.
> 
> That cooldown was meant only for failed attempts where the cache stays stale; leaving the timestamp set after success could still throttle **`refreshRemoteConfigIfStale`** when cache staleness is shorter than the cooldown (e.g. in tests or tuned durations).
> 
> **Tests** add **`testSuccessfulRefreshDoesNotApplyFailureCooldown`** and extend foreground/background staleness coverage so a second refresh can run once only staleness—not the attempt cooldown—gates it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 904e99c6ead38a06d16d7adb61e1ea675c551585. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->