### PR TITLE
Fix `fastlane setup_dev` in submodule checkouts and with PATH-installed swiftlint

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -173,20 +173,28 @@ platform :ios do
 
   desc "Setup development environment"
   lane :setup_dev do |options|
-    begin
-      sh("brew install swiftlint")
-    rescue => exception
-      UI.error("❌ Please install homebrew and then re-run this lane: /bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"")
-      raise exception
+    if system("command -v swiftlint > /dev/null")
+      UI.message("swiftlint already installed ✅")
+    else
+      begin
+        sh("brew install swiftlint")
+      rescue => exception
+        UI.error("❌ Please install homebrew and then re-run this lane: /bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"")
+        raise exception
+      end
     end
 
-    pre_commit_link = "../.git/hooks/pre-commit"
-    if File.exist?(pre_commit_link) || File.symlink?(pre_commit_link)
-      UI.message("pre-commit script already linked ✅")
-    else
-      UI.message("Linking pre-commit script 🔗")
-      Dir.chdir ".." do
-        sh("ln -s -f ../../scripts/pre-commit.sh .git/hooks/pre-commit")
+    Dir.chdir ".." do
+      # .git is a file when this repo is checked out as a submodule, so ask git for the real hooks dir
+      hooks_dir = sh("git", "rev-parse", "--git-path", "hooks", log: false).strip
+      pre_commit_link = File.join(hooks_dir, "pre-commit")
+
+      if File.exist?(pre_commit_link) || File.symlink?(pre_commit_link)
+        UI.message("pre-commit script already linked ✅")
+      else
+        UI.message("Linking pre-commit script 🔗")
+        FileUtils.mkdir_p(hooks_dir)
+        FileUtils.ln_sf(File.expand_path("scripts/pre-commit.sh"), pre_commit_link)
       end
     end
   end

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -21,13 +21,27 @@ DIM='\033[2m'
 BOLD='\033[1m'
 NC='\033[0m' # No Color
 
-# Figure out where swiftlint is
-HOMEBREW_BINARY_DESTINATION="/opt/homebrew/bin"
-SWIFT_LINT="${HOMEBREW_BINARY_DESTINATION}/swiftlint"
+# Figure out where swiftlint is. PATH first (mise, asdf, ...), since GUI clients run hooks with a
+# minimal PATH where mise isn't active: ask mise directly before falling back to homebrew, so both
+# paths use the version pinned in mise.toml.
+SWIFT_LINT=$(command -v swiftlint)
 
-if ! test -d $HOMEBREW_BINARY_DESTINATION; then
-  # X86_64 macs have this destination
-  SWIFT_LINT="/usr/local/bin/swiftlint"
+if [[ -z "$SWIFT_LINT" ]]; then
+  for mise in "$HOME/.local/bin/mise" /opt/homebrew/bin/mise /usr/local/bin/mise; do
+    if [[ -x "$mise" ]]; then
+      SWIFT_LINT=$("$mise" which swiftlint 2>/dev/null)
+      [[ -n "$SWIFT_LINT" ]] && break
+    fi
+  done
+fi
+
+if [[ -z "$SWIFT_LINT" ]]; then
+  for candidate in /opt/homebrew/bin/swiftlint /usr/local/bin/swiftlint; do
+    if [[ -x "$candidate" ]]; then
+      SWIFT_LINT="$candidate"
+      break
+    fi
+  done
 fi
 
 # Start timer
@@ -80,8 +94,8 @@ verify_no_included_apikeys() {
 }
 
 # Check if SwiftLint is installed
-if [[ ! -e "$SWIFT_LINT" ]]; then
-  print_error "$SWIFT_LINT is not installed. Please install it via: fastlane setup_dev"
+if [[ -z "$SWIFT_LINT" ]]; then
+  print_error "swiftlint is not installed. Please install it via: fastlane setup_dev"
   exit 1
 fi
 


### PR DESCRIPTION
In submodules, `.git` is a text file pointing to a submodule folder in the parent `.git` directory. The correct way to get the git hooks dir is via `rev-parse`. This fixes `setup_dev` so that it can work in both situations.

Additionally, skip `swiftlint` install in `setup_dev` if already present (e.g. installed via `mise`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect developer tooling (Fastlane setup and git hooks), not the SDK runtime or release artifacts.
> 
> **Overview**
> Improves **local dev setup** and **pre-commit** so swiftlint and git hooks work when the repo is a submodule or swiftlint comes from **mise** instead of Homebrew.
> 
> **`fastlane setup_dev`** skips `brew install swiftlint` when `swiftlint` is already on PATH, and links the pre-commit hook using **`git rev-parse --git-path hooks`** (with `FileUtils`) instead of assuming `.git/hooks` is a directory—fixing submodule layouts where `.git` is a file.
> 
> **`scripts/pre-commit.sh`** resolves swiftlint via PATH, then **`mise which swiftlint`**, then common Homebrew paths, so GUI git clients with a minimal PATH still use the version pinned in **mise.toml**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88cf864c0f5f08b41abff14b5c2f47ec71676b7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->