### PR TITLE
DO NOT MERGE: CI probe for public-api-diff invocation path

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1880,6 +1880,9 @@ jobs:
             bundle exec fastlane run swiftlint raise_if_swiftlint_error:true strict:true \
             reporter:junit output_file:fastlane/test_output/swiftlint/junit.xml
           no_output_timeout: 5m
+      - run:
+          name: Run api diff helper unit tests
+          command: ruby fastlane/api_diff_helper_test.rb
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:
@@ -2098,6 +2101,10 @@ jobs:
     steps:
       - checkout
       - install-dependencies
+      # Pinned: the orb default is 0.10.1, whose consolidator bug reported no changes for
+      # files that differed. Keep in sync with ApiDiffHelper::PUBLIC_API_DIFF_VERSION.
+      - revenuecat/install-public-api-diff:
+          version: "0.12.0"
       - run:
           name: Generate RevenueCat swiftinterface
           command: |
@@ -2142,6 +2149,10 @@ jobs:
     steps:
       - checkout
       - install-dependencies
+      # Pinned: the orb default is 0.10.1, whose consolidator bug reported no changes for
+      # files that differed. Keep in sync with ApiDiffHelper::PUBLIC_API_DIFF_VERSION.
+      - revenuecat/install-public-api-diff:
+          version: "0.12.0"
       - run:
           name: Generate RevenueCatUI swiftinterface
           command: |

--- a/api/revenuecat-api-ios-simulator.swiftinterface
+++ b/api/revenuecat-api-ios-simulator.swiftinterface
@@ -2254,7 +2254,6 @@ extension RevenueCat.Purchases {
   public static let paywallImageDownloadSession: Foundation.URLSession
 }
 extension RevenueCat.Purchases {
-  @objc final public func overridePreferredUILocale(_ locale: Swift.String?)
 }
 extension RevenueCat.Purchases {
   @discardableResult

--- a/api/revenuecat-api-ios.swiftinterface
+++ b/api/revenuecat-api-ios.swiftinterface
@@ -2254,7 +2254,6 @@ extension RevenueCat.Purchases {
   public static let paywallImageDownloadSession: Foundation.URLSession
 }
 extension RevenueCat.Purchases {
-  @objc final public func overridePreferredUILocale(_ locale: Swift.String?)
 }
 extension RevenueCat.Purchases {
   @discardableResult

--- a/api/revenuecat-api-macos.swiftinterface
+++ b/api/revenuecat-api-macos.swiftinterface
@@ -2193,7 +2193,6 @@ extension RevenueCat.Purchases {
   public static let paywallImageDownloadSession: Foundation.URLSession
 }
 extension RevenueCat.Purchases {
-  @objc final public func overridePreferredUILocale(_ locale: Swift.String?)
 }
 extension RevenueCat.Purchases {
   @discardableResult

--- a/api/revenuecat-api-tvos-simulator.swiftinterface
+++ b/api/revenuecat-api-tvos-simulator.swiftinterface
@@ -2185,7 +2185,6 @@ extension RevenueCat.Purchases {
   public static let paywallImageDownloadSession: Foundation.URLSession
 }
 extension RevenueCat.Purchases {
-  @objc final public func overridePreferredUILocale(_ locale: Swift.String?)
 }
 extension RevenueCat.Purchases {
   @discardableResult

--- a/api/revenuecat-api-tvos.swiftinterface
+++ b/api/revenuecat-api-tvos.swiftinterface
@@ -2185,7 +2185,6 @@ extension RevenueCat.Purchases {
   public static let paywallImageDownloadSession: Foundation.URLSession
 }
 extension RevenueCat.Purchases {
-  @objc final public func overridePreferredUILocale(_ locale: Swift.String?)
 }
 extension RevenueCat.Purchases {
   @discardableResult

--- a/api/revenuecat-api-visionos-simulator.swiftinterface
+++ b/api/revenuecat-api-visionos-simulator.swiftinterface
@@ -2254,7 +2254,6 @@ extension RevenueCat.Purchases {
   public static let paywallImageDownloadSession: Foundation.URLSession
 }
 extension RevenueCat.Purchases {
-  @objc final public func overridePreferredUILocale(_ locale: Swift.String?)
 }
 extension RevenueCat.Purchases {
   @discardableResult

--- a/api/revenuecat-api-visionos.swiftinterface
+++ b/api/revenuecat-api-visionos.swiftinterface
@@ -2254,7 +2254,6 @@ extension RevenueCat.Purchases {
   public static let paywallImageDownloadSession: Foundation.URLSession
 }
 extension RevenueCat.Purchases {
-  @objc final public func overridePreferredUILocale(_ locale: Swift.String?)
 }
 extension RevenueCat.Purchases {
   @discardableResult

--- a/api/revenuecat-api-watchos-simulator.swiftinterface
+++ b/api/revenuecat-api-watchos-simulator.swiftinterface
@@ -2186,7 +2186,6 @@ extension RevenueCat.Purchases {
   public static let paywallImageDownloadSession: Foundation.URLSession
 }
 extension RevenueCat.Purchases {
-  @objc final public func overridePreferredUILocale(_ locale: Swift.String?)
 }
 extension RevenueCat.Purchases {
   @discardableResult

--- a/api/revenuecat-api-watchos.swiftinterface
+++ b/api/revenuecat-api-watchos.swiftinterface
@@ -2186,7 +2186,6 @@ extension RevenueCat.Purchases {
   public static let paywallImageDownloadSession: Foundation.URLSession
 }
 extension RevenueCat.Purchases {
-  @objc final public func overridePreferredUILocale(_ locale: Swift.String?)
 }
 extension RevenueCat.Purchases {
   @discardableResult

--- a/fastlane/api_diff_helper.rb
+++ b/fastlane/api_diff_helper.rb
@@ -1,6 +1,8 @@
 # Helper module for API diff functionality
 # Used by generate_swiftinterface and check_api_changes lanes
 
+require 'fileutils'
+
 module ApiDiffHelper
   MODULES = ["RevenueCat", "RevenueCatUI"].freeze
 
@@ -169,8 +171,8 @@ module ApiDiffHelper
       result[:diff] = if api_changes_reported?(report)
                         report
                       else
-                        "The baselines differ from the generated interface without any public API change " \
-                        "(the compiler version comment, for example). Regenerate them."
+                        "public-api-diff reported no public API changes, but the baseline file differs " \
+                        "from the generated interface at the byte level. Regenerate the baselines."
                       end
     rescue StandardError => e
       # The check has already failed on bytes; surface why the explanation is missing.
@@ -187,7 +189,7 @@ module ApiDiffHelper
 
   NO_CHANGES_MARKER = "✅ No changes detected".freeze
 
-  CHANGES_HEADER_PATTERN = /^#\s.*\d+ public changes detected/.freeze
+  CHANGES_HEADER_PATTERN = /^#\s.*\d+ public changes? detected/.freeze
 
   def validate_api_diff_inputs!(old_file, new_file)
     [old_file, new_file].each do |path|
@@ -202,7 +204,7 @@ module ApiDiffHelper
   # so its report is the only signal we have. Silence means the tool did not run, which is
   # not the same as the API being unchanged.
   def validate_api_diff_output!(output, old_file, new_file)
-    report = output.to_s.strip
+    report = output.to_s.encode("UTF-8", invalid: :replace, undef: :replace).strip
 
     raise "public-api-diff produced no output comparing #{old_file} to #{new_file}" if report.empty?
     return nil if report.include?(NO_CHANGES_MARKER)
@@ -219,13 +221,30 @@ module ApiDiffHelper
   def public_api_diff_report(tool:, old_file:, new_file:, target_name:, runner: nil)
     validate_api_diff_inputs!(old_file, new_file)
 
-    runner ||= ->(*command) { Fastlane::Actions.sh(*command, log: false) }
+    runner ||= lambda do |*command|
+      captured_output = nil
+      begin
+        Fastlane::Actions.sh(
+          *command,
+          log: false,
+          error_callback: ->(sh_output) { captured_output = sh_output }
+        )
+      rescue StandardError => e
+        # log: false keeps the raw report out of the CI log. If fastlane still raises
+        # (rather than routing through error_callback), fold the captured output back in
+        # so the failure is not just a bare exit status.
+        raise "#{e.message}\n#{captured_output}".strip
+      end
+    end
     output = runner.call(
       tool, "swift-interface",
       "--old", old_file,
       "--new", new_file,
       "--target-name", target_name
     )
+    # Sanitize before this string flows any further: it gets substring-matched and
+    # stored in the result, not just validated, and invalid bytes would raise there too.
+    output = output.to_s.encode("UTF-8", invalid: :replace, undef: :replace)
 
     validate_api_diff_output!(output, old_file, new_file)
     output

--- a/fastlane/api_diff_helper.rb
+++ b/fastlane/api_diff_helper.rb
@@ -130,7 +130,7 @@ module ApiDiffHelper
     end
   end
 
-  def run_api_diff(old_file, new_file, platform_name)
+  def run_api_diff(old_file, new_file, platform_name, tool: "public-api-diff", runner: nil)
     result = {
       platform: platform_name,
       success: false,
@@ -152,9 +152,29 @@ module ApiDiffHelper
     if FileUtils.identical?(old_file, new_file)
       Fastlane::UI.success("✅ No API changes for #{platform_name}")
       result[:success] = true
-    else
-      Fastlane::UI.error("❌ API changes detected for #{platform_name}")
-      result[:diff] = `diff -u "#{old_file}" "#{new_file}"`.encode('UTF-8', invalid: :replace, undef: :replace)
+      return result
+    end
+
+    Fastlane::UI.error("❌ API changes detected for #{platform_name}")
+
+    begin
+      report = public_api_diff_report(
+        tool: tool,
+        old_file: old_file,
+        new_file: new_file,
+        target_name: platform_name,
+        runner: runner
+      )
+
+      result[:diff] = if api_changes_reported?(report)
+                        report
+                      else
+                        "The baselines differ from the generated interface without any public API change " \
+                        "(the compiler version comment, for example). Regenerate them."
+                      end
+    rescue StandardError => e
+      # The check has already failed on bytes; surface why the explanation is missing.
+      result[:diff] = "public-api-diff failed: #{e.message}"
     end
 
     result

--- a/fastlane/api_diff_helper.rb
+++ b/fastlane/api_diff_helper.rb
@@ -160,6 +160,41 @@ module ApiDiffHelper
     result
   end
 
+  # Pinned deliberately: the orb command defaults to 0.10.1, the release whose
+  # SwiftInterfaceChangeConsolidator bug reported "no changes detected" for files that
+  # differed. Fixed upstream in 0.11.0.
+  PUBLIC_API_DIFF_VERSION = "0.12.0".freeze
+
+  NO_CHANGES_MARKER = "✅ No changes detected".freeze
+
+  CHANGES_HEADER_PATTERN = /^#\s.*\d+ public changes detected/.freeze
+
+  def validate_api_diff_inputs!(old_file, new_file)
+    [old_file, new_file].each do |path|
+      raise "Interface file not found: #{path}" unless File.exist?(path)
+      raise "Interface file is empty: #{path}" if File.size(path).zero?
+    end
+
+    nil
+  end
+
+  # public-api-diff exits 0 for changes, for no changes, and even for a missing input file,
+  # so its report is the only signal we have. Silence means the tool did not run, which is
+  # not the same as the API being unchanged.
+  def validate_api_diff_output!(output, old_file, new_file)
+    report = output.to_s.strip
+
+    raise "public-api-diff produced no output comparing #{old_file} to #{new_file}" if report.empty?
+    return nil if report.include?(NO_CHANGES_MARKER)
+    return nil if CHANGES_HEADER_PATTERN.match?(report)
+
+    raise "Unrecognized public-api-diff output comparing #{old_file} to #{new_file}: #{report.lines.first.to_s.strip}"
+  end
+
+  def api_changes_reported?(output)
+    !output.to_s.include?(NO_CHANGES_MARKER)
+  end
+
   def print_failure_summary(failed_platforms)
     Fastlane::UI.error("=" * 60)
     Fastlane::UI.error("API CHANGES DETECTED")

--- a/fastlane/api_diff_helper.rb
+++ b/fastlane/api_diff_helper.rb
@@ -195,6 +195,22 @@ module ApiDiffHelper
     !output.to_s.include?(NO_CHANGES_MARKER)
   end
 
+  # `runner` exists so the tests can exercise this without a Swift toolchain or fastlane.
+  def public_api_diff_report(tool:, old_file:, new_file:, target_name:, runner: nil)
+    validate_api_diff_inputs!(old_file, new_file)
+
+    runner ||= ->(*command) { Fastlane::Actions.sh(*command, log: false) }
+    output = runner.call(
+      tool, "swift-interface",
+      "--old", old_file,
+      "--new", new_file,
+      "--target-name", target_name
+    )
+
+    validate_api_diff_output!(output, old_file, new_file)
+    output
+  end
+
   def print_failure_summary(failed_platforms)
     Fastlane::UI.error("=" * 60)
     Fastlane::UI.error("API CHANGES DETECTED")

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -80,4 +80,62 @@ class ApiDiffHelperTest < Minitest::Test
     assert ApiDiffHelper.api_changes_reported?(ADDITIONS_OUTPUT)
     assert ApiDiffHelper.api_changes_reported?(MODIFICATIONS_OUTPUT)
   end
+
+  # --- Tool invocation ---
+
+  def test_report_passes_expected_arguments_to_the_tool
+    with_interface_files do |old_file, new_file|
+      received = nil
+      runner = ->(*command) { received = command; ADDITIONS_OUTPUT }
+
+      report = ApiDiffHelper.public_api_diff_report(
+        tool: "public-api-diff",
+        old_file: old_file,
+        new_file: new_file,
+        target_name: "RevenueCat",
+        runner: runner
+      )
+
+      assert_equal ADDITIONS_OUTPUT, report
+      assert_equal [
+        "public-api-diff", "swift-interface",
+        "--old", old_file,
+        "--new", new_file,
+        "--target-name", "RevenueCat"
+      ], received
+    end
+  end
+
+  def test_report_raises_when_the_tool_prints_nothing
+    with_interface_files do |old_file, new_file|
+      runner = ->(*_command) { "" }
+
+      error = assert_raises(RuntimeError) do
+        ApiDiffHelper.public_api_diff_report(
+          tool: "public-api-diff", old_file: old_file, new_file: new_file,
+          target_name: "RevenueCat", runner: runner
+        )
+      end
+      assert_match(/no output/, error.message)
+    end
+  end
+
+  def test_report_validates_inputs_before_invoking_the_tool
+    with_interface_files do |_old_file, new_file, dir|
+      invoked = false
+      runner = ->(*_command) { invoked = true; ADDITIONS_OUTPUT }
+
+      assert_raises(RuntimeError) do
+        ApiDiffHelper.public_api_diff_report(
+          tool: "public-api-diff",
+          old_file: File.join(dir, "gone.swiftinterface"),
+          new_file: new_file,
+          target_name: "RevenueCat",
+          runner: runner
+        )
+      end
+
+      refute invoked, "the tool must not run when an input file is missing"
+    end
+  end
 end

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -3,6 +3,15 @@
 
 require 'minitest/autorun'
 require 'tmpdir'
+
+# Mock Fastlane::UI for testing
+module Fastlane
+  module UI
+    def self.error(message); end
+    def self.success(message); end
+  end
+end
+
 require_relative 'api_diff_helper'
 
 class ApiDiffHelperTest < Minitest::Test
@@ -136,6 +145,76 @@ class ApiDiffHelperTest < Minitest::Test
       end
 
       refute invoked, "the tool must not run when an input file is missing"
+    end
+  end
+
+  # --- Failure output ---
+
+  def test_identical_files_succeed_without_running_the_tool
+    Dir.mktmpdir do |dir|
+      old_file = File.join(dir, "old.swiftinterface")
+      new_file = File.join(dir, "new.swiftinterface")
+      File.write(old_file, "public func a()\n")
+      File.write(new_file, "public func a()\n")
+
+      invoked = false
+      result = ApiDiffHelper.run_api_diff(
+        old_file, new_file, "RevenueCat iOS",
+        runner: ->(*_command) { invoked = true; ADDITIONS_OUTPUT }
+      )
+
+      assert result[:success]
+      assert_nil result[:diff]
+      refute invoked, "no need to explain a difference that does not exist"
+    end
+  end
+
+  def test_differing_files_report_the_tool_output
+    with_interface_files do |old_file, new_file|
+      result = ApiDiffHelper.run_api_diff(
+        old_file, new_file, "RevenueCat iOS",
+        runner: ->(*_command) { ADDITIONS_OUTPUT }
+      )
+
+      refute result[:success]
+      assert_equal "RevenueCat iOS", result[:platform]
+      assert_includes result[:diff], "4 public changes detected"
+    end
+  end
+
+  # Baselines routinely differ only in the compiler-version comment. Saying so beats
+  # printing a report that lists nothing.
+  def test_differing_files_with_no_api_change_explain_why
+    with_interface_files do |old_file, new_file|
+      result = ApiDiffHelper.run_api_diff(
+        old_file, new_file, "RevenueCat iOS",
+        runner: ->(*_command) { NO_CHANGES_OUTPUT }
+      )
+
+      refute result[:success]
+      assert_includes result[:diff], "without any public API change"
+    end
+  end
+
+  def test_tool_failure_is_surfaced_and_still_fails
+    with_interface_files do |old_file, new_file|
+      result = ApiDiffHelper.run_api_diff(
+        old_file, new_file, "RevenueCat iOS",
+        runner: ->(*_command) { "" }
+      )
+
+      refute result[:success]
+      assert_includes result[:diff], "public-api-diff failed"
+      assert_includes result[:diff], "no output"
+    end
+  end
+
+  def test_missing_baseline_keeps_its_existing_wording
+    with_interface_files do |_old_file, new_file, dir|
+      result = ApiDiffHelper.run_api_diff(File.join(dir, "gone.swiftinterface"), new_file, "RevenueCat iOS")
+
+      refute result[:success]
+      assert_equal "Baseline file missing", result[:diff]
     end
   end
 end

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -3,12 +3,29 @@
 
 require 'minitest/autorun'
 require 'tmpdir'
+require 'yaml'
 
 # Mock Fastlane::UI for testing
 module Fastlane
   module UI
     def self.error(message); end
     def self.success(message); end
+  end
+
+  # Mock Fastlane::Actions.sh, used only when the default runner (runner: nil) is exercised.
+  # Mirrors fastlane 2.237.0's sh_control_output: when error_callback is given, a non-zero
+  # exit does not raise, it calls error_callback with the output and returns that output.
+  module Actions
+    class << self
+      attr_accessor :last_sh_call
+    end
+
+    def self.sh(*command, log: true, error_callback: nil)
+      self.last_sh_call = { command: command, log: log, error_callback: error_callback }
+      output = "boom: bad interface\n"
+      error_callback.call(output) if error_callback
+      output
+    end
   end
 end
 
@@ -18,6 +35,21 @@ class ApiDiffHelperTest < Minitest::Test
   NO_CHANGES_OUTPUT = "# ✅ No changes detected\n\n---\n**Analyzed targets:** RevenueCat\n".freeze
   ADDITIONS_OUTPUT = "# 👀 4 public changes detected\n<table><tr><td>❇️</td><td><b>4 Additions</b></td></tr></table>\n".freeze
   MODIFICATIONS_OUTPUT = "# ⚠️ 2 public changes detected ⚠️\n<table><tr><td>🔀</td><td><b>2 Modifications</b></td></tr></table>\n".freeze
+
+  # Captured verbatim from the real 0.12.0 public-api-diff binary run against
+  # api/revenuecat-api-ios.swiftinterface with exactly one public declaration added/removed,
+  # to prove the singular header (finding: CHANGES_HEADER_PATTERN required "changes", plural
+  # only) is a real shape the tool emits, not a hypothetical one.
+  SINGLE_ADDITION_OUTPUT = "# \u{1F440} 1 public change detected\n" \
+                           "<table><tr><td>❇️</td><td><b>1 Addition</b></td></tr></table>\n" \
+                           "\n---\n## `RevenueCat`\n#### ❇️ Added\n```swift\n" \
+                           "public func apiDiffHelperFixtureSingleAddition() -> Swift.Int\n```\n" \
+                           "\n---\n**Analyzed targets:** RevenueCat\n".freeze
+  SINGLE_REMOVAL_OUTPUT = "# ⚠️ 1 public change detected ⚠️\n" \
+                          "<table><tr><td>❌</td><td><b>1 Removal</b></td></tr></table>\n" \
+                          "\n---\n## `RevenueCat`\n#### ❌ Removed\n```swift\n" \
+                          "public func apiDiffHelperFixtureSingleRemoval() -> Swift.Int\n```\n" \
+                          "\n---\n**Analyzed targets:** RevenueCat\n".freeze
 
   def with_interface_files
     Dir.mktmpdir do |dir|
@@ -31,6 +63,25 @@ class ApiDiffHelperTest < Minitest::Test
 
   def test_pinned_version_is_not_the_buggy_orb_default
     assert_equal "0.12.0", ApiDiffHelper::PUBLIC_API_DIFF_VERSION
+  end
+
+  # The constant above is not read by anything at CI time; the version that actually ships
+  # is the literal in .circleci/default_config.yml. This test parses that YAML (aliases in
+  # the file require unsafe_load_file) and checks every revenuecat/install-public-api-diff
+  # step against the constant, so editing or deleting the YAML pin fails this test instead
+  # of silently drifting back to the orb's buggy 0.10.1 default.
+  def test_ci_config_pins_the_same_version_as_the_constant
+    config_path = File.expand_path('../.circleci/default_config.yml', __dir__)
+    config = YAML.unsafe_load_file(config_path)
+
+    versions = find_install_public_api_diff_versions(config)
+
+    assert_equal 2, versions.length,
+                 "expected exactly two revenuecat/install-public-api-diff steps in .circleci/default_config.yml, " \
+                 "found #{versions.length}"
+    versions.each do |version|
+      assert_equal ApiDiffHelper::PUBLIC_API_DIFF_VERSION, version
+    end
   end
 
   def test_validate_inputs_accepts_two_non_empty_files
@@ -61,7 +112,10 @@ class ApiDiffHelperTest < Minitest::Test
   end
 
   def test_validate_output_accepts_recognised_reports
-    [NO_CHANGES_OUTPUT, ADDITIONS_OUTPUT, MODIFICATIONS_OUTPUT].each do |output|
+    [
+      NO_CHANGES_OUTPUT, ADDITIONS_OUTPUT, MODIFICATIONS_OUTPUT,
+      SINGLE_ADDITION_OUTPUT, SINGLE_REMOVAL_OUTPUT
+    ].each do |output|
       assert_nil ApiDiffHelper.validate_api_diff_output!(output, "old.swiftinterface", "new.swiftinterface")
     end
   end
@@ -182,8 +236,62 @@ class ApiDiffHelperTest < Minitest::Test
     end
   end
 
+  # Regression coverage for the singular header ("1 public change detected"). The tool
+  # pluralizes its own title, and the previous CHANGES_HEADER_PATTERN required "changes",
+  # so a single addition or single removal was rejected as unrecognised output and the
+  # report was discarded in favor of a generic failure message.
+  def test_single_addition_report_is_recognised_and_surfaced
+    with_interface_files do |old_file, new_file|
+      result = ApiDiffHelper.run_api_diff(
+        old_file, new_file, "RevenueCat iOS",
+        runner: ->(*_command) { SINGLE_ADDITION_OUTPUT }
+      )
+
+      refute result[:success]
+      assert_includes result[:diff], "1 public change detected"
+      refute_includes result[:diff], "public-api-diff failed"
+    end
+  end
+
+  # Invalid bytes in the tool output must not blow up `.include?`/pattern matching
+  # downstream. The old `diff -u` path guarded against this with
+  # `.encode('UTF-8', invalid: :replace, undef: :replace)`; that guard was dropped when
+  # the tool was swapped in. Without it this raises ArgumentError instead of surfacing
+  # the report, and the exercise must go through run_api_diff (not just the validator)
+  # because the sanitized string has to be what gets stored in result[:diff].
+  def test_invalid_bytes_in_the_report_do_not_crash_validation
+    with_interface_files do |old_file, new_file|
+      dirty_output = "#{SINGLE_ADDITION_OUTPUT}\xFF\xFE".dup.force_encoding("UTF-8")
+      refute dirty_output.valid_encoding?, "the fixture must actually contain invalid bytes"
+
+      result = ApiDiffHelper.run_api_diff(
+        old_file, new_file, "RevenueCat iOS",
+        runner: ->(*_command) { dirty_output }
+      )
+
+      refute result[:success]
+      assert_includes result[:diff], "1 public change detected"
+      refute_includes result[:diff], "public-api-diff failed"
+      assert result[:diff].valid_encoding?
+    end
+  end
+
+  def test_single_removal_report_is_recognised_and_surfaced
+    with_interface_files do |old_file, new_file|
+      result = ApiDiffHelper.run_api_diff(
+        old_file, new_file, "RevenueCat iOS",
+        runner: ->(*_command) { SINGLE_REMOVAL_OUTPUT }
+      )
+
+      refute result[:success]
+      assert_includes result[:diff], "1 public change detected"
+      refute_includes result[:diff], "public-api-diff failed"
+    end
+  end
+
   # Baselines routinely differ only in the compiler-version comment. Saying so beats
-  # printing a report that lists nothing.
+  # printing a report that lists nothing, but the message should only claim what the
+  # tool actually proved: it saw no public API changes; it did not diagnose the cause.
   def test_differing_files_with_no_api_change_explain_why
     with_interface_files do |old_file, new_file|
       result = ApiDiffHelper.run_api_diff(
@@ -192,7 +300,8 @@ class ApiDiffHelperTest < Minitest::Test
       )
 
       refute result[:success]
-      assert_includes result[:diff], "without any public API change"
+      assert_includes result[:diff], "reported no public API changes"
+      assert_includes result[:diff], "Regenerate the baselines"
     end
   end
 
@@ -209,6 +318,25 @@ class ApiDiffHelperTest < Minitest::Test
     end
   end
 
+  # The default runner (used whenever run_api_diff/public_api_diff_report is called without
+  # an explicit `runner:`) must pass an error_callback to Fastlane::Actions.sh so the tool's
+  # output survives a non-zero exit instead of being replaced by a bare exit-status message.
+  # Every other test in this file injects `runner:` and never touches this code path, so
+  # without this test the error_callback could be deleted and the suite would stay green.
+  def test_default_runner_keeps_log_quiet_but_surfaces_output_via_error_callback
+    with_interface_files do |old_file, new_file|
+      Fastlane::Actions.last_sh_call = nil
+
+      result = ApiDiffHelper.run_api_diff(old_file, new_file, "RevenueCat iOS")
+
+      call = Fastlane::Actions.last_sh_call
+      refute_nil call, "the default runner must invoke Fastlane::Actions.sh"
+      assert_equal false, call[:log], "the raw report must stay out of the normal CI log"
+      refute_nil call[:error_callback], "an error_callback must be passed so failure output is not lost"
+      assert_includes result[:diff], "boom: bad interface"
+    end
+  end
+
   def test_missing_baseline_keeps_its_existing_wording
     with_interface_files do |_old_file, new_file, dir|
       result = ApiDiffHelper.run_api_diff(File.join(dir, "gone.swiftinterface"), new_file, "RevenueCat iOS")
@@ -216,5 +344,27 @@ class ApiDiffHelperTest < Minitest::Test
       refute result[:success]
       assert_equal "Baseline file missing", result[:diff]
     end
+  end
+
+  private
+
+  # Walks the parsed CircleCI config looking for CircleCI step hashes of the form
+  # `{"revenuecat/install-public-api-diff" => {"version" => "..."}}` and collects the
+  # pinned version from each one found, at any depth.
+  def find_install_public_api_diff_versions(node, found = [])
+    case node
+    when Hash
+      node.each do |key, value|
+        if key == "revenuecat/install-public-api-diff"
+          found << (value.is_a?(Hash) ? value["version"] : nil)
+        else
+          find_install_public_api_diff_versions(value, found)
+        end
+      end
+    when Array
+      node.each { |item| find_install_public_api_diff_versions(item, found) }
+    end
+
+    found
   end
 end

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -1,0 +1,83 @@
+# Unit tests for ApiDiffHelper's public-api-diff integration.
+# Run with: ruby fastlane/api_diff_helper_test.rb
+
+require 'minitest/autorun'
+require 'tmpdir'
+require_relative 'api_diff_helper'
+
+class ApiDiffHelperTest < Minitest::Test
+  NO_CHANGES_OUTPUT = "# ✅ No changes detected\n\n---\n**Analyzed targets:** RevenueCat\n".freeze
+  ADDITIONS_OUTPUT = "# 👀 4 public changes detected\n<table><tr><td>❇️</td><td><b>4 Additions</b></td></tr></table>\n".freeze
+  MODIFICATIONS_OUTPUT = "# ⚠️ 2 public changes detected ⚠️\n<table><tr><td>🔀</td><td><b>2 Modifications</b></td></tr></table>\n".freeze
+
+  def with_interface_files
+    Dir.mktmpdir do |dir|
+      old_file = File.join(dir, "old.swiftinterface")
+      new_file = File.join(dir, "new.swiftinterface")
+      File.write(old_file, "public func a()\n")
+      File.write(new_file, "public func b()\n")
+      yield old_file, new_file, dir
+    end
+  end
+
+  def test_pinned_version_is_not_the_buggy_orb_default
+    assert_equal "0.12.0", ApiDiffHelper::PUBLIC_API_DIFF_VERSION
+  end
+
+  def test_validate_inputs_accepts_two_non_empty_files
+    with_interface_files do |old_file, new_file|
+      assert_nil ApiDiffHelper.validate_api_diff_inputs!(old_file, new_file)
+    end
+  end
+
+  def test_validate_inputs_rejects_missing_file
+    with_interface_files do |old_file, new_file, dir|
+      missing = File.join(dir, "gone.swiftinterface")
+      error = assert_raises(RuntimeError) { ApiDiffHelper.validate_api_diff_inputs!(missing, new_file) }
+      assert_match(/not found/, error.message)
+      assert_match(/gone.swiftinterface/, error.message)
+      # Also rejected when it is the new side.
+      assert_raises(RuntimeError) { ApiDiffHelper.validate_api_diff_inputs!(old_file, missing) }
+    end
+  end
+
+  # An empty baseline makes the tool report every declaration as an addition.
+  def test_validate_inputs_rejects_empty_file
+    with_interface_files do |old_file, new_file, dir|
+      empty = File.join(dir, "empty.swiftinterface")
+      File.write(empty, "")
+      error = assert_raises(RuntimeError) { ApiDiffHelper.validate_api_diff_inputs!(empty, new_file) }
+      assert_match(/empty/, error.message)
+    end
+  end
+
+  def test_validate_output_accepts_recognised_reports
+    [NO_CHANGES_OUTPUT, ADDITIONS_OUTPUT, MODIFICATIONS_OUTPUT].each do |output|
+      assert_nil ApiDiffHelper.validate_api_diff_output!(output, "old.swiftinterface", "new.swiftinterface")
+    end
+  end
+
+  # The tool prints nothing and still exits 0 when an input path is wrong. The previous
+  # integration treated empty output as "no changes", which passed CI silently.
+  def test_validate_output_rejects_empty_output
+    ["", "   \n\n"].each do |output|
+      error = assert_raises(RuntimeError) do
+        ApiDiffHelper.validate_api_diff_output!(output, "old.swiftinterface", "new.swiftinterface")
+      end
+      assert_match(/no output/, error.message)
+    end
+  end
+
+  def test_validate_output_rejects_unrecognised_output
+    error = assert_raises(RuntimeError) do
+      ApiDiffHelper.validate_api_diff_output!("Segmentation fault: 11\n", "old.swiftinterface", "new.swiftinterface")
+    end
+    assert_match(/Unrecognized/, error.message)
+  end
+
+  def test_api_changes_reported
+    refute ApiDiffHelper.api_changes_reported?(NO_CHANGES_OUTPUT)
+    assert ApiDiffHelper.api_changes_reported?(ADDITIONS_OUTPUT)
+    assert ApiDiffHelper.api_changes_reported?(MODIFICATIONS_OUTPUT)
+  end
+end


### PR DESCRIPTION
Throwaway probe for #7309, to be closed as soon as the evidence is captured. **Do not merge, do not review.**

Removes one public declaration from the RevenueCat `api/` baselines so the generated interface differs by exactly one addition. That makes `check-api-changes-revenuecat` fail on purpose, which is the only way to reach the `public-api-diff` invocation path: on a green branch the tool is never invoked, because it only runs when bytes differ.

Checking two things #7309 cannot show on its own:
- that `public-api-diff` resolves on PATH inside the fastlane step, via the orb's BASH_ENV mechanism
- that the grouped report reaches the CircleCI log through `print_failure_summary`

The single-declaration case is deliberate: it produces the singular `1 public change detected` header, which was a Critical finding on #7309.