### PR TITLE
fix(maestro): tap the relabeled Continue buttons in the workflow flows

### DIFF
--- a/Examples/rc-maestro/maestro/workflows/navigate_workflow_back.yaml
+++ b/Examples/rc-maestro/maestro/workflows/navigate_workflow_back.yaml
@@ -29,7 +29,7 @@ env:
     visible: "Start Your Free Week And Reclaim 30+ Minutes Daily"
     timeout: 15000
 - tapOn:
-    text: "Continue"
+    text: "Continue 1/3"
 
 # Screen 2
 - extendedWaitUntil:

--- a/Examples/rc-maestro/maestro/workflows/open_workflow.yaml
+++ b/Examples/rc-maestro/maestro/workflows/open_workflow.yaml
@@ -31,7 +31,7 @@ env:
     timeout: 15000
 - takeScreenshot: "open_workflow - screen 1"
 - tapOn:
-    text: "Continue"
+    text: "Continue 1/3"
 
 # Screen 2
 - extendedWaitUntil:
@@ -39,7 +39,7 @@ env:
     timeout: 15000
 - takeScreenshot: "open_workflow - screen 2"
 - tapOn:
-    text: "Continue"
+    text: "Continue 2/3"
 
 # Paywall screen (Yearly is preselected); the last Continue starts the purchase.
 - extendedWaitUntil:
@@ -47,7 +47,7 @@ env:
     timeout: 15000
 - takeScreenshot: "open_workflow - paywall screen"
 - tapOn:
-    text: "Continue"
+    text: "Continue 3/3"
 
 - runFlow:
     file: ../utils/confirm_purchase.yaml

--- a/Examples/rc-maestro/maestro/workflows/workflow_exit_offer_on_last_page.yaml
+++ b/Examples/rc-maestro/maestro/workflows/workflow_exit_offer_on_last_page.yaml
@@ -21,11 +21,11 @@ env:
 - extendedWaitUntil:
     visible: "Start Your Free Week And Reclaim 30+ Minutes Daily"
     timeout: 15000
-- tapOn: { text: "Continue" }
+- tapOn: { text: "Continue 1/3" }
 - extendedWaitUntil:
     visible: "Most People Feel Calmer After Just 3 Sessions"
     timeout: 15000
-- tapOn: { text: "Continue" }
+- tapOn: { text: "Continue 2/3" }
 - extendedWaitUntil:
     visible: "People Who Meditate Daily Sleep 40% Better"
     timeout: 15000


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

The `default_workflows` CTAs were relabeled to `Continue 1/3`, `2/3` and `3/3` in the dashboard, and Maestro matches `text` against the whole string, so every flow tapping `Continue` fails. That leaves `run-workflow-maestro-tests` red on every PR.

### Description

- Tap labels only; the screen assertions are untouched.
- The `e2e_tests` flows keep tapping `Continue`, since they drive the `default` and Paywall V2 offerings, whose buttons didn't change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Maestro workflow YAML label updates with no production or SDK code changes.
> 
> **Overview**
> Updates Maestro workflow flows under `Examples/rc-maestro/maestro/workflows/` so taps match the dashboard relabel of `default_workflows` CTAs from plain **Continue** to **Continue 1/3**, **Continue 2/3**, and **Continue 3/3**. Maestro matches the full button text, so unchanged `tapOn: "Continue"` steps were failing and breaking `run-workflow-maestro-tests`.
> 
> **`open_workflow.yaml`** advances all three screens with the numbered labels before purchase. **`navigate_workflow_back.yaml`** uses **Continue 1/3** on screen 1. **`workflow_exit_offer_on_last_page.yaml`** uses **Continue 1/3** and **Continue 2/3** to reach the last page. Screen visibility assertions are unchanged; only tap targets were updated. **`e2e_tests`** flows still tap **Continue** for default and Paywall V2 offerings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4d172172b2007b91eb5587e2b712e2a0e8a68e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->