### PR TITLE
fix(remote-config): improve logging when remote config is disabled through to killswitch

### DIFF
--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -30,7 +30,9 @@ enum RemoteConfigStrings {
     case prefetchingBlobCount(Int)
     case receivedConfiguration(activeTopics: [String], changedTopics: [String])
     case refreshing(domain: String, manifestPresent: Bool, isAppBackgrounded: Bool)
+    case disablingRefresh(BackendError)
     case refreshFailed(BackendError)
+    case refreshSkippedDisabled
     case skippingInvalidBlob(String)
     case persistedConfiguration(domain: String, activeTopicCount: Int, referencedBlobCount: Int)
     case sourceUnhealthy(ref: String, hasNextSource: Bool)
@@ -95,8 +97,12 @@ extension RemoteConfigStrings: LogMessage {
         case let .refreshing(domain, manifestPresent, isAppBackgrounded):
             return "Refreshing remote config for domain '\(domain)' " +
                 "(manifestPresent: \(manifestPresent), isAppBackgrounded: \(isAppBackgrounded))."
+        case let .disablingRefresh(error):
+            return "Disabling remote config for this session after receiving a 4xx response. Error: \(error)"
         case let .refreshFailed(error):
             return "Remote config refresh failed. Keeping cached configuration. Error: \(error)"
+        case .refreshSkippedDisabled:
+            return "Remote config is disabled for this session (4xx). Skipping refresh."
         case let .skippingInvalidBlob(ref):
             return "Skipping remote config blob '\(ref)': checksum verification failed."
         case let .persistedConfiguration(domain, activeTopicCount, referencedBlobCount):

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -352,6 +352,11 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     }
 
     func refreshRemoteConfig(fetchContext: RemoteConfigFetchContext, isAppBackgrounded: Bool) {
+        guard !self.isDisabled else {
+            Logger.debug(Strings.remoteConfig.refreshSkippedDisabled)
+            return
+        }
+
         let appUserID = self.currentUserProvider.currentAppUserID
         guard let requestContext = self.prepareRefreshIfNeeded(
             fetchContext: fetchContext,
@@ -362,6 +367,11 @@ final class RemoteConfigManager: RemoteConfigManagerType {
     }
 
     func refreshRemoteConfigIfStale(fetchContext: RemoteConfigFetchContext, isAppBackgrounded: Bool) {
+        guard !self.isDisabled else {
+            Logger.debug(Strings.remoteConfig.refreshSkippedDisabled)
+            return
+        }
+
         let appUserID = self.currentUserProvider.currentAppUserID
         guard let requestContext = self.prepareRefreshIfStale(
             fetchContext: fetchContext,
@@ -739,7 +749,11 @@ private extension RemoteConfigManager {
             self.onRemoteConfigDisabled?()
         }
 
-        Logger.error(Strings.remoteConfig.refreshFailed(error))
+        if shouldDisableRefresh && error.isRemoteConfigDisablingClientError {
+            Logger.error(Strings.remoteConfig.disablingRefresh(error))
+        } else {
+            Logger.error(Strings.remoteConfig.refreshFailed(error))
+        }
     }
 
     func disableRefreshIfNeeded(for error: BackendError) -> Bool {

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -1791,10 +1791,11 @@ final class RemoteConfigManagerTests: TestCase {
         self.diskCache.stubbedRead = Self.persisted(
             manifest: "v1.1710000100.sources:etag1"
         )
+        let error = Self.backendError(statusCode: .invalidRequest)
 
         expect(self.manager.isDisabled) == false
         self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
-        self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .invalidRequest)))
+        self.remoteConfigAPI.complete(with: .failure(error))
         expect(self.manager.isDisabled) == true
         self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
 
@@ -1804,6 +1805,18 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.blobStore.invokedWriteCount) == 0
         expect(self.blobStore.invokedRetainOnlyCount) == 0
         expect(self.blobFetcher.invokedPrefetchCount) == 0
+        self.logger.verifyMessageWasLogged(
+            "Disabling remote config for this session after receiving a 4xx response. Error: \(error)",
+            level: .error
+        )
+        self.logger.verifyMessageWasLogged(
+            "Remote config is disabled for this session (4xx). Skipping refresh.",
+            level: .debug
+        )
+        self.logger.verifyMessageWasNotLogged(
+            "Remote config refresh failed. Keeping cached configuration. Error: \(error)",
+            level: .error
+        )
     }
 
     func testFourHundredResponseNotifiesWhenRemoteConfigIsDisabled() {
@@ -1831,14 +1844,20 @@ final class RemoteConfigManagerTests: TestCase {
     }
 
     func testServerErrorDoesNotDisableRemoteConfig() {
+        let error = Self.backendError(statusCode: .internalServerError)
+
         self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
-        self.remoteConfigAPI.complete(with: .failure(Self.backendError(statusCode: .internalServerError)))
-        self.remoteConfigAPI.completeFallback(with: .failure(Self.backendError(statusCode: .internalServerError)))
+        self.remoteConfigAPI.complete(with: .failure(error))
+        self.remoteConfigAPI.completeFallback(with: .failure(error))
         expect(self.manager.isDisabled) == false
         self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
 
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 2
         expect(self.diskCache.invokedReadCount) == 2
+        self.logger.verifyMessageWasLogged(
+            "Remote config refresh failed. Keeping cached configuration. Error: \(error)",
+            level: .error
+        )
     }
 
     func testFallbackClientErrorDisablesRemoteConfig() {


### PR DESCRIPTION
# Description

When remote config was disabled due to the kill-switch activating (receiving a 4xx from the backend) the error logged was quite misleading. It just mentioned an error was received and that the locally cached data would be used. Which in fact is not true for a 4xx error.

Furthermore subsequent requests did not log anything regarding the feature being disabled.

# Changes
I fixed both by clarifying the error log for the 4xx case (all other (network) error cases still log the previous message) and added a log line for subsequent requests that will not be fired because of the kill-switch

### Before
```
ERROR: 😿‼️ Remote config refresh failed. Keeping cached configuration. Error: Unknown error. API request failed with status code 400
```

### After
```
ERROR: 😿‼️ Disabling remote config for this session after receiving a 4xx response. Error: Unknown error. API request failed with status code 400
```

And on subsequent requests
```
DEBUG: ℹ️ Remote config is disabled for this session (4xx). Skipping refresh.
```

This is now in line with Android https://github.com/RevenueCat/purchases-android/pull/3870

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only changes around existing disable behavior; no changes to auth, networking, or persistence logic.
> 
> **Overview**
> Improves **remote config** logging when the session kill-switch trips on a **4xx** response, without changing disable semantics.
> 
> On the failure that disables refresh, the error log now says remote config is **disabled for the session** instead of implying cached config will keep being used. Other failures still use the existing “refresh failed, keeping cached configuration” message. **`refreshRemoteConfig`** and **`refreshRemoteConfigIfStale`** log a **debug** line when refresh is skipped because the feature is already disabled, so later calls are visible in logs. Unit tests assert the new messages and that the old misleading error is not logged for the 4xx path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba8e75a5c0a8fffb9d65b8f92ae6f1afc070aa38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->