### PR TITLE
ci: fail PRs whose public API changes are breaking

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -2105,6 +2105,13 @@ jobs:
       # files that differed. Keep in sync with ApiDiffHelper::PUBLIC_API_DIFF_VERSION.
       - revenuecat/install-public-api-diff:
           version: "0.12.0"
+      # The break gate resolves `git merge-base origin/main HEAD`, and checkout does not
+      # necessarily leave origin/main present. The explicit destination refspec forces
+      # refs/remotes/origin/main to be written regardless of the checkout's remote.origin.fetch
+      # config, whereas a bare `origin main` only updates it opportunistically.
+      - run:
+          name: Fetch main for the merge base
+          command: git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
       - run:
           name: Generate RevenueCat swiftinterface
           command: |
@@ -2153,6 +2160,13 @@ jobs:
       # files that differed. Keep in sync with ApiDiffHelper::PUBLIC_API_DIFF_VERSION.
       - revenuecat/install-public-api-diff:
           version: "0.12.0"
+      # The break gate resolves `git merge-base origin/main HEAD`, and checkout does not
+      # necessarily leave origin/main present. The explicit destination refspec forces
+      # refs/remotes/origin/main to be written regardless of the checkout's remote.origin.fetch
+      # config, whereas a bare `origin main` only updates it opportunistically.
+      - run:
+          name: Fetch main for the merge base
+          command: git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
       - run:
           name: Generate RevenueCatUI swiftinterface
           command: |

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -739,6 +739,25 @@ platform :ios do
     pr_number
   end
 
+  # Labels come from the PR, so a local run or a non-PR build simply has none.
+  private_lane :pr_labels_for_api_gate do
+    pr_number = detect_pr_number
+    token = ENV["DANGER_GITHUB_API_TOKEN"]
+
+    if pr_number.nil? || token.nil? || token.empty?
+      UI.message("No PR context, treating the API gate as unlabelled")
+      []
+    else
+      response = github_api(
+        server_url: 'https://api.github.com',
+        api_token: token,
+        http_method: 'GET',
+        path: "/repos/RevenueCat/#{REPO_NAME}/pulls/#{pr_number}"
+      )
+      (response[:json]["labels"] || []).map { |label| label["name"] }
+    end
+  end
+
   private_lane :send_to_emerge do |options|
     pr_number = detect_pr_number
 
@@ -2442,6 +2461,42 @@ platform :ios do
       UI.user_error!("API changes detected! Update baseline files if changes are intentional.")
     else
       UI.success("✅ No API changes detected")
+    end
+
+    # Second comparison: what this PR changes relative to main. The freshness loop above
+    # cannot answer that, because regenerating the baselines makes its diff empty.
+    runner = ->(*command) { sh(*command, log: false) }
+    merge_base = ApiDiffHelper.resolve_merge_base(runner: runner)
+    UI.message("Comparing against the merge base #{merge_base}")
+
+    labels = pr_labels_for_api_gate
+    all_breaks = []
+
+    schemes.each do |scheme|
+      base_dir = File.join(ApiDiffHelper::MERGE_BASE_SWIFTINTERFACE_DIR, scheme)
+      ApiDiffHelper.extract_baselines_at(merge_base, base_dir, scheme, runner: runner)
+      prefix = ApiDiffHelper.api_file_prefix(scheme)
+
+      ApiDiffHelper::PLATFORM_CHECKS.each do |platform|
+        old_file = File.join(base_dir, "#{prefix}-api#{platform[:suffix]}.swiftinterface")
+        new_file = "#{ApiDiffHelper::PR_SWIFTINTERFACE_DIR}/#{scheme}#{platform[:suffix]}.swiftinterface"
+        next unless File.exist?(new_file)
+
+        report = ApiDiffHelper.public_api_diff_report(
+          tool: "public-api-diff",
+          old_file: old_file,
+          new_file: new_file,
+          target_name: "#{scheme} #{platform[:name]}"
+        )
+        all_breaks.concat(ApiDiffHelper.breaking_changes(report, new_file))
+      end
+    end
+
+    all_breaks.uniq! { |change| [change[:reason], change[:owner], change[:declaration]] }
+    ApiDiffHelper.print_breaking_summary(all_breaks, labels)
+
+    if ApiDiffHelper.gate_blocked?(all_breaks, labels)
+      UI.user_error!("Breaking public API changes detected. Add #{ApiDiffHelper::BREAKING_CHANGE_LABEL} if intentional.")
     end
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2469,7 +2469,6 @@ platform :ios do
     merge_base = ApiDiffHelper.resolve_merge_base(runner: runner)
     UI.message("Comparing against the merge base #{merge_base}")
 
-    labels = pr_labels_for_api_gate
     all_breaks = []
 
     schemes.each do |scheme|
@@ -2493,6 +2492,12 @@ platform :ios do
     end
 
     all_breaks.uniq! { |change| [change[:reason], change[:owner], change[:declaration]] }
+
+    # Labels only matter once there is a break to judge them against: fetching them
+    # unconditionally means a PR that touches no Swift still calls the GitHub API, and
+    # pr_labels_for_api_gate's github_api call has no error_handlers, so any non-2xx response
+    # (rate limit, auth hiccup) raises and reds the job even though there was nothing to gate.
+    labels = all_breaks.any? ? pr_labels_for_api_gate : []
     ApiDiffHelper.print_breaking_summary(all_breaks, labels)
 
     if ApiDiffHelper.gate_blocked?(all_breaks, labels)

--- a/fastlane/api_diff_helper.rb
+++ b/fastlane/api_diff_helper.rb
@@ -245,6 +245,85 @@ module ApiDiffHelper
     end
   end
 
+  ReportChange = Struct.new(:kind, :owner, :declaration, keyword_init: true)
+
+  REPORT_TARGET_HEADING = /\A## `(.+)`\s*\z/.freeze
+  REPORT_TYPE_HEADING = /\A### `(.+)`\s*\z/.freeze
+  REPORT_KIND_HEADING = /\A#### .*\b(Added|Removed|Modified)\b\s*\z/.freeze
+  REPORT_FENCE = /\A```/.freeze
+
+  # The report nests members under their enclosing type, which is what lets us tell a case
+  # added to an existing enum from a brand new enum that happens to have cases. A type
+  # section only appears for a type present on both sides; a wholly new declaration sits
+  # directly under the target heading, so its owner is nil.
+  def parse_report(report)
+    changes = []
+    owner = nil
+    kind = nil
+    inside_block = false
+    buffer = []
+
+    report.to_s.each_line do |raw_line|
+      line = raw_line.rstrip
+
+      if REPORT_TARGET_HEADING.match?(line)
+        owner = nil
+        kind = nil
+        next
+      end
+
+      if (match = REPORT_TYPE_HEADING.match(line))
+        owner = match[1]
+        kind = nil
+        next
+      end
+
+      if (match = REPORT_KIND_HEADING.match(line))
+        kind = match[1].downcase.to_sym
+        next
+      end
+
+      if REPORT_FENCE.match?(line)
+        if inside_block
+          changes << ReportChange.new(kind: kind, owner: owner, declaration: buffer.join("\n").strip)
+          buffer = []
+          inside_block = false
+        elsif kind
+          inside_block = true
+        end
+        next
+      end
+
+      buffer << line if inside_block
+    end
+
+    if changes.empty? && api_changes_reported?(report)
+      raise "public-api-diff reported changes but the report could not be parsed"
+    end
+
+    changes
+  end
+
+  ATTRIBUTE_CHANGE_LINE = /\A-\s+(Added|Removed) attribute\b/.freeze
+
+  # Gaining or losing an attribute rewrites a declaration without breaking callers.
+  def modification_attribute_only?(declaration)
+    lines = declaration.to_s.lines.map(&:strip)
+    start = lines.index("Changes:")
+    return false if start.nil?
+
+    listed = lines[(start + 1)..].to_a.select { |line| line.start_with?("-") }
+    return false if listed.empty?
+
+    listed.all? { |line| ATTRIBUTE_CHANGE_LINE.match?(line) }
+  end
+
+  TYPE_DECLARATION = /\b(?:actor|class|enum|protocol|struct)\s+([A-Za-z_][A-Za-z0-9_]*)/.freeze
+
+  def declaration_type_name(declaration)
+    TYPE_DECLARATION.match(declaration.to_s.lines.first.to_s)&.captures&.first
+  end
+
   # `runner` exists so the tests can exercise this without a Swift toolchain or fastlane.
   def public_api_diff_report(tool:, old_file:, new_file:, target_name:, runner: nil)
     validate_api_diff_inputs!(old_file, new_file)

--- a/fastlane/api_diff_helper.rb
+++ b/fastlane/api_diff_helper.rb
@@ -324,17 +324,39 @@ module ApiDiffHelper
     TYPE_DECLARATION.match(declaration.to_s.lines.first.to_s)&.captures&.first
   end
 
+  # Strips `//` line comments and the contents of double-quoted string literals so prose
+  # (e.g. an `@available(*, deprecated, message: "the enum Foo pattern...")` string) can't
+  # masquerade as a declaration. Strings are neutralized first so a `//` inside one (a URL in
+  # a deprecation message, say) isn't mistaken for a comment opener. String bodies are not
+  # allowed to cross a newline, so an unbalanced quote can't swallow real declarations that
+  # follow it. Block comments (`/* */`) are deliberately out of scope: real .swiftinterface
+  # output doesn't use them, and we're not writing a Swift parser.
+  def strip_comments_and_strings(contents)
+    contents.gsub(/"(?:\\.|[^"\\\n])*"/, '""').gsub(%r{//[^\n]*}, '')
+  end
+
   # The report says what changed and inside which type, but never what kind of type that is,
   # so the generated interface is the source of truth for enum versus protocol.
   def enclosing_type_kind(interface_path, type_name)
     name = type_name.to_s.split(".").last
     return nil if name.nil? || name.empty?
 
-    contents = File.read(interface_path)
+    contents = strip_comments_and_strings(File.read(interface_path))
     return :enum if contents.match?(/\benum\s+#{Regexp.escape(name)}\b/)
     return :protocol if contents.match?(/\bprotocol\s+#{Regexp.escape(name)}\b/)
 
     nil
+  end
+
+  # Matches `optional` only when it functions as a declaration modifier immediately preceding
+  # the requirement's keyword (optionally after attributes like `@objc`), not merely anywhere
+  # in the text, e.g. a parameter literally named `optional` or a doc comment mentioning it.
+  # Failing to recognize a real `optional` modifier here would over-report, not under-report,
+  # which is the safe direction for this gate.
+  PROTOCOL_OPTIONAL_MODIFIER = /^\s*(?:@\w+(?:\([^)]*\))?\s*)*optional\s+(?:func|var|subscript|init)\b/.freeze
+
+  def protocol_requirement_optional?(declaration)
+    PROTOCOL_OPTIONAL_MODIFIER.match?(strip_comments_and_strings(declaration.to_s))
   end
 
   def breaking_changes(report, interface_path)
@@ -354,16 +376,20 @@ module ApiDiffHelper
 
         breaks << { reason: :modified, owner: change.owner, declaration: first_line }
       when :added
-        # A wholly new declaration breaks nothing, and neither does a member of a type this
-        # same report introduces.
+        # A wholly new declaration breaks nothing, and neither does a member reported under a
+        # type this same report introduces: match the owner in full, not by last component,
+        # since a same-basename but differently-owned type (e.g. `Other.Config` alongside a
+        # new top-level `Config`) must still be evaluated below. A nested member of a new type
+        # reported with a dotted owner falls through to evaluation too; that only over-reports
+        # (never under-reports), which `pr:breaking-api` exists to override.
         next if change.owner.nil?
-        next if new_type_names.include?(change.owner.split(".").last)
+        next if new_type_names.include?(change.owner)
 
         case enclosing_type_kind(interface_path, change.owner)
         when :enum
           breaks << { reason: :enum_case, owner: change.owner, declaration: first_line } if first_line.start_with?("case ")
         when :protocol
-          next if change.declaration.include?("optional ")
+          next if protocol_requirement_optional?(change.declaration)
 
           breaks << { reason: :protocol_requirement, owner: change.owner, declaration: first_line }
         end

--- a/fastlane/api_diff_helper.rb
+++ b/fastlane/api_diff_helper.rb
@@ -397,6 +397,44 @@ module ApiDiffHelper
     end
   end
 
+  BREAKING_CHANGE_LABEL = "pr:breaking-api".freeze
+
+  BREAK_REASONS = {
+    removed: "removed",
+    enum_case: "case added to an existing enum",
+    protocol_requirement: "requirement added to an existing protocol",
+    modified: "signature changed"
+  }.freeze
+
+  def gate_blocked?(breaks, labels)
+    return false if breaks.empty?
+
+    !Array(labels).include?(BREAKING_CHANGE_LABEL)
+  end
+
+  def print_breaking_summary(breaks, labels)
+    return nil if breaks.empty?
+
+    Fastlane::UI.error("=" * 60)
+    Fastlane::UI.error("POTENTIAL BREAKING API CHANGES")
+    Fastlane::UI.error("=" * 60)
+
+    breaks.each do |change|
+      owner = change[:owner] ? " in #{change[:owner]}" : ""
+      Fastlane::UI.error("#{BREAK_REASONS.fetch(change[:reason], change[:reason])}#{owner}: #{change[:declaration]}")
+    end
+
+    Fastlane::UI.error("")
+    if gate_blocked?(breaks, labels)
+      Fastlane::UI.error("Add the #{BREAKING_CHANGE_LABEL} label if these changes are intentional.")
+    else
+      Fastlane::UI.important("Reported only: the #{BREAKING_CHANGE_LABEL} label is present.")
+    end
+    Fastlane::UI.error("=" * 60)
+
+    nil
+  end
+
   # `runner` exists so the tests can exercise this without a Swift toolchain or fastlane.
   def public_api_diff_report(tool:, old_file:, new_file:, target_name:, runner: nil)
     validate_api_diff_inputs!(old_file, new_file)

--- a/fastlane/api_diff_helper.rb
+++ b/fastlane/api_diff_helper.rb
@@ -304,9 +304,35 @@ module ApiDiffHelper
     changes
   end
 
-  ATTRIBUTE_CHANGE_LINE = /\A-\s+(Added|Removed) attribute\b/.freeze
+  ATTRIBUTE_ONLY_LINE = /\A(?:@\w+(?:\(.*\))?\s*)+\z/.freeze
 
-  # Gaining or losing an attribute rewrites a declaration without breaking callers.
+  # A report block's literal first line is not always the significant one: the tool renders
+  # each attribute on its own line above the declaration it belongs to (`@objc(RCFoo)` then
+  # `case foo` on the next line), and a :modified block's fenced text opens with a literal
+  # `// From` marker line before the actual declaration. Every caller that reasons about "what
+  # declaration is this" (the enum-case prefix test, the type-name extractor, and a break's
+  # displayed/dedup text) wants the line that actually names the symbol, not whichever text
+  # happens to render first. Falls back to the raw first line if every line gets skipped
+  # (an unexpected shape), so this never does worse than the un-skipped behavior.
+  def significant_first_line(declaration)
+    lines = declaration.to_s.lines.map(&:strip)
+    significant = lines.drop_while { |line| line == "// From" || ATTRIBUTE_ONLY_LINE.match?(line) }
+
+    (significant.first || lines.first).to_s
+  end
+
+  ATTRIBUTE_CHANGE_LINE = /\A-\s+(Added|Removed) attribute `([^`]*)`/.freeze
+
+  # `unavailable` marks a declaration unusable immediately; `obsoleted` marks it unusable as of
+  # a version that, for any shipping baseline, has already passed. Gaining either breaks
+  # callers exactly like removing the declaration would. `deprecated` only warns, so it is
+  # deliberately left out of this list: it is not breaking.
+  BREAKING_ATTRIBUTE_ADDITION = /\b(?:unavailable|obsoleted)\b/.freeze
+
+  # Gaining an attribute is usually additive (e.g. `@objc` newly added to a Swift-only member).
+  # Losing one is not always additive: stripping `@objc` from a member on an Obj-C-exposed type
+  # breaks every Obj-C caller (see this repo's Objective-C Compatibility guidance), so a
+  # "Removed attribute" line must never be waved through here, whichever attribute it names.
   def modification_attribute_only?(declaration)
     lines = declaration.to_s.lines.map(&:strip)
     start = lines.index("Changes:")
@@ -315,13 +341,23 @@ module ApiDiffHelper
     listed = lines[(start + 1)..].to_a.select { |line| line.start_with?("-") }
     return false if listed.empty?
 
-    listed.all? { |line| ATTRIBUTE_CHANGE_LINE.match?(line) }
+    listed.all? { |line| non_breaking_attribute_addition?(line) }
+  end
+
+  def non_breaking_attribute_addition?(line)
+    match = ATTRIBUTE_CHANGE_LINE.match(line)
+    return false unless match
+
+    verb, attribute = match[1], match[2]
+    return false if verb == "Removed"
+
+    !BREAKING_ATTRIBUTE_ADDITION.match?(attribute)
   end
 
   TYPE_DECLARATION = /\b(?:actor|class|enum|protocol|struct)\s+([A-Za-z_][A-Za-z0-9_]*)/.freeze
 
   def declaration_type_name(declaration)
-    TYPE_DECLARATION.match(declaration.to_s.lines.first.to_s)&.captures&.first
+    TYPE_DECLARATION.match(significant_first_line(declaration))&.captures&.first
   end
 
   # Strips `//` line comments and the contents of double-quoted string literals so prose
@@ -366,7 +402,7 @@ module ApiDiffHelper
                             .compact
 
     changes.each_with_object([]) do |change, breaks|
-      first_line = change.declaration.to_s.lines.first.to_s.strip
+      first_line = significant_first_line(change.declaration)
 
       case change.kind
       when :removed

--- a/fastlane/api_diff_helper.rb
+++ b/fastlane/api_diff_helper.rb
@@ -217,6 +217,34 @@ module ApiDiffHelper
     !output.to_s.include?(NO_CHANGES_MARKER)
   end
 
+  MERGE_BASE_SWIFTINTERFACE_DIR = "/tmp/merge-base-swiftinterface".freeze
+
+  # The gate compares against the merge base rather than the PR's own baselines. Once an
+  # author regenerates the baselines they match the generated interfaces exactly, and the
+  # evidence of what the PR changed is gone.
+  def resolve_merge_base(runner:)
+    sha = runner.call("git", "merge-base", "origin/main", "HEAD").to_s.strip
+    raise "Could not resolve the merge base with origin/main" if sha.empty?
+
+    sha
+  end
+
+  def extract_baselines_at(sha, destination_dir, scheme, runner:)
+    FileUtils.mkdir_p(destination_dir)
+    prefix = api_file_prefix(scheme)
+
+    PLATFORM_CHECKS.map do |platform|
+      repo_path = "api/#{prefix}-api#{platform[:suffix]}.swiftinterface"
+      content = runner.call("git", "show", "#{sha}:#{repo_path}").to_s
+
+      raise "Baseline at #{sha}:#{repo_path} is missing or empty" if content.strip.empty?
+
+      written = File.join(destination_dir, File.basename(repo_path))
+      File.write(written, content)
+      written
+    end
+  end
+
   # `runner` exists so the tests can exercise this without a Swift toolchain or fastlane.
   def public_api_diff_report(tool:, old_file:, new_file:, target_name:, runner: nil)
     validate_api_diff_inputs!(old_file, new_file)

--- a/fastlane/api_diff_helper.rb
+++ b/fastlane/api_diff_helper.rb
@@ -324,6 +324,53 @@ module ApiDiffHelper
     TYPE_DECLARATION.match(declaration.to_s.lines.first.to_s)&.captures&.first
   end
 
+  # The report says what changed and inside which type, but never what kind of type that is,
+  # so the generated interface is the source of truth for enum versus protocol.
+  def enclosing_type_kind(interface_path, type_name)
+    name = type_name.to_s.split(".").last
+    return nil if name.nil? || name.empty?
+
+    contents = File.read(interface_path)
+    return :enum if contents.match?(/\benum\s+#{Regexp.escape(name)}\b/)
+    return :protocol if contents.match?(/\bprotocol\s+#{Regexp.escape(name)}\b/)
+
+    nil
+  end
+
+  def breaking_changes(report, interface_path)
+    changes = parse_report(report)
+    new_type_names = changes.select { |change| change.kind == :added && change.owner.nil? }
+                            .map { |change| declaration_type_name(change.declaration) }
+                            .compact
+
+    changes.each_with_object([]) do |change, breaks|
+      first_line = change.declaration.to_s.lines.first.to_s.strip
+
+      case change.kind
+      when :removed
+        breaks << { reason: :removed, owner: change.owner, declaration: first_line }
+      when :modified
+        next if modification_attribute_only?(change.declaration)
+
+        breaks << { reason: :modified, owner: change.owner, declaration: first_line }
+      when :added
+        # A wholly new declaration breaks nothing, and neither does a member of a type this
+        # same report introduces.
+        next if change.owner.nil?
+        next if new_type_names.include?(change.owner.split(".").last)
+
+        case enclosing_type_kind(interface_path, change.owner)
+        when :enum
+          breaks << { reason: :enum_case, owner: change.owner, declaration: first_line } if first_line.start_with?("case ")
+        when :protocol
+          next if change.declaration.include?("optional ")
+
+          breaks << { reason: :protocol_requirement, owner: change.owner, declaration: first_line }
+        end
+      end
+    end
+  end
+
   # `runner` exists so the tests can exercise this without a Swift toolchain or fastlane.
   def public_api_diff_report(tool:, old_file:, new_file:, target_name:, runner: nil)
     validate_api_diff_inputs!(old_file, new_file)

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -780,6 +780,104 @@ class ApiDiffHelperTest < Minitest::Test
     end
   end
 
+  # Finding 1: a member of a differently-owned type must not be excluded just because it
+  # shares a basename with a wholly new type introduced elsewhere in the same report.
+  def test_member_of_a_differently_owned_type_sharing_a_new_types_basename_is_still_a_break
+    report = <<~REPORT
+      # 👀 2 public changes detected
+
+      ---
+      ## `RevenueCat`
+      #### ❇️ Added
+      ```swift
+      public enum Config : Swift.Int {
+        case first
+      }
+      ```
+      ### `Other.Config`
+      #### ❇️ Added
+      ```swift
+      case second
+      ```
+    REPORT
+
+    with_interface_containing("public enum Config : Swift.Int {\n}\n") do |path|
+      breaks = ApiDiffHelper.breaking_changes(report, path)
+
+      assert_equal [:enum_case], breaks.map { |b| b[:reason] }
+      assert_equal ["Other.Config"], breaks.map { |b| b[:owner] }
+    end
+  end
+
+  # Finding 1 (guard-alive): a member reported under a type this same report introduces,
+  # under that type's own (undotted) name, must still be excluded. This is the only
+  # existing-suite scenario the new_type_names guard actually changes the outcome for, so
+  # it's what a mutation check (deleting the guard line) needs to catch.
+  # This report shape (a `###` section for a type also reported wholly new) is synthetic,
+  # constructed to reach the guard; parse_report's own docstring says the real tool doesn't
+  # emit it. It is not captured from an actual public-api-diff run.
+  def test_member_reported_separately_for_the_same_new_type_is_not_a_break
+    report = <<~REPORT
+      # 👀 2 public changes detected
+
+      ---
+      ## `RevenueCat`
+      #### ❇️ Added
+      ```swift
+      public enum BrandNewEnum : Swift.Int {
+        case first
+      }
+      ```
+      ### `BrandNewEnum`
+      #### ❇️ Added
+      ```swift
+      case second
+      ```
+    REPORT
+
+    with_interface_containing("public enum BrandNewEnum : Swift.Int {\n}\n") do |path|
+      assert_empty ApiDiffHelper.breaking_changes(report, path)
+    end
+  end
+
+  # Finding 2: classification must ignore prose. A real .swiftinterface preserves
+  # @available(..., message: "...") strings verbatim, so a struct whose name happens to
+  # appear inside one, or in a preceding // comment, must not be misclassified as an enum.
+  def test_enclosing_type_kind_ignores_comments_and_string_literals
+    interface = <<~SWIFT
+      // Following the enum Foo pattern, this is actually a struct.
+      @available(*, deprecated, message: "the enum Foo pattern is deprecated")
+      public struct Foo {
+      }
+    SWIFT
+
+    with_interface_containing(interface) do |path|
+      assert_nil ApiDiffHelper.enclosing_type_kind(path, "Foo")
+    end
+  end
+
+  # Finding 3: `optional` must be recognised only as a modifier immediately preceding the
+  # requirement's keyword. A bare substring test would be fooled by a parameter literally
+  # named `optional`, silently exempting a real (non-optional) requirement from the gate.
+  def test_protocol_requirement_with_parameter_named_optional_is_still_a_break
+    interface = "public protocol PurchasesDelegate {\n}\n"
+    report = <<~REPORT
+      # 👀 1 public change detected
+
+      ---
+      ## `RevenueCat`
+      ### `PurchasesDelegate`
+      #### ❇️ Added
+      ```swift
+      func purchases(optional flag: Swift.Bool)
+      ```
+    REPORT
+
+    with_interface_containing(interface) do |path|
+      assert_equal [:protocol_requirement], ApiDiffHelper.breaking_changes(report, path).map { |b| b[:reason] }
+    end
+  end
+
   private
 
   # Walks the parsed CircleCI config looking for CircleCI step hashes of the form

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -346,6 +346,55 @@ class ApiDiffHelperTest < Minitest::Test
     end
   end
 
+  # --- Merge base baselines ---
+
+  def test_resolve_merge_base_returns_the_sha
+    runner = ->(*command) { command == ["git", "merge-base", "origin/main", "HEAD"] ? "abc123def\n" : "" }
+
+    assert_equal "abc123def", ApiDiffHelper.resolve_merge_base(runner: runner)
+  end
+
+  # Comparing against nothing would silently report the whole API as new.
+  def test_resolve_merge_base_raises_when_empty
+    error = assert_raises(RuntimeError) { ApiDiffHelper.resolve_merge_base(runner: ->(*_c) { "\n" }) }
+
+    assert_match(/merge base/, error.message)
+  end
+
+  def test_extract_baselines_writes_one_file_per_platform
+    Dir.mktmpdir do |dir|
+      runner = ->(*command) { "public func fromMergeBase()\n// #{command.last}\n" }
+
+      written = ApiDiffHelper.extract_baselines_at("abc123", dir, "RevenueCat", runner: runner)
+
+      assert_equal ApiDiffHelper::PLATFORM_CHECKS.count, written.count
+      assert_includes written, File.join(dir, "revenuecat-api-ios.swiftinterface")
+      assert_match(/fromMergeBase/, File.read(File.join(dir, "revenuecat-api-ios.swiftinterface")))
+    end
+  end
+
+  def test_extract_baselines_asks_git_for_the_right_paths
+    Dir.mktmpdir do |dir|
+      seen = []
+      runner = ->(*command) { seen << command.last; "public func x()\n" }
+
+      ApiDiffHelper.extract_baselines_at("abc123", dir, "RevenueCatUI", runner: runner)
+
+      assert_includes seen, "abc123:api/revenuecatui-api-ios.swiftinterface"
+      assert_includes seen, "abc123:api/revenuecatui-api-visionos.swiftinterface"
+    end
+  end
+
+  def test_extract_baselines_raises_on_an_empty_baseline
+    Dir.mktmpdir do |dir|
+      error = assert_raises(RuntimeError) do
+        ApiDiffHelper.extract_baselines_at("abc123", dir, "RevenueCat", runner: ->(*_c) { "" })
+      end
+
+      assert_match(/empty|not found/, error.message)
+    end
+  end
+
   private
 
   # Walks the parsed CircleCI config looking for CircleCI step hashes of the form

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -668,6 +668,118 @@ class ApiDiffHelperTest < Minitest::Test
     refute_match(/this fence has no kind/, change.declaration)
   end
 
+  # --- Break rules ---
+
+  def with_interface_containing(text)
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, "RevenueCat.swiftinterface")
+      File.write(path, text)
+      yield path
+    end
+  end
+
+  def test_enclosing_type_kind_classifies_from_the_interface
+    with_interface_containing("public enum PaywallEvent : Swift.Codable {\n}\npublic protocol Delegate {\n}\n") do |path|
+      assert_equal :enum, ApiDiffHelper.enclosing_type_kind(path, "PaywallEvent")
+      assert_equal :protocol, ApiDiffHelper.enclosing_type_kind(path, "Delegate")
+      # Dotted owners resolve on their last component.
+      assert_equal :enum, ApiDiffHelper.enclosing_type_kind(path, "RevenueCat.PaywallEvent")
+      assert_nil ApiDiffHelper.enclosing_type_kind(path, "SomeStruct")
+    end
+  end
+
+  def test_case_added_to_an_existing_enum_is_a_break
+    with_interface_containing("public enum PaywallEvent : Swift.Codable {\n}\n") do |path|
+      breaks = ApiDiffHelper.breaking_changes(ENUM_CASE_REPORT, path)
+
+      assert_equal 1, breaks.count, "the brand new enum must not be flagged"
+      assert_equal :enum_case, breaks.first[:reason]
+      assert_equal "PaywallEvent", breaks.first[:owner]
+    end
+  end
+
+  # The new enum's own cases are inside its declaration block, not separate member changes.
+  def test_a_brand_new_enum_is_not_a_break
+    report = <<~REPORT
+      # 👀 1 public change detected
+
+      ---
+      ## `RevenueCat`
+      #### ❇️ Added
+      ```swift
+      public enum BrandNew : Swift.Int {
+        case first
+      }
+      ```
+    REPORT
+
+    with_interface_containing("public enum BrandNew : Swift.Int {\n}\n") do |path|
+      assert_empty ApiDiffHelper.breaking_changes(report, path)
+    end
+  end
+
+  def test_removal_is_a_break
+    with_interface_containing("public func other()\n") do |path|
+      breaks = ApiDiffHelper.breaking_changes(SINGLE_REMOVAL_OUTPUT, path)
+
+      assert_equal [:removed], breaks.map { |b| b[:reason] }
+    end
+  end
+
+  def test_attribute_only_modification_is_not_a_break
+    with_interface_containing("public class Builder {\n}\n") do |path|
+      assert_empty ApiDiffHelper.breaking_changes(MODIFIED_REPORT, path)
+    end
+  end
+
+  def test_signature_change_is_a_break
+    report = <<~REPORT
+      # ⚠️ 1 public change detected ⚠️
+
+      ---
+      ## `RevenueCat`
+      ### `Purchases`
+      #### 🔀 Modified
+      ```swift
+      // From
+      public func f(a: Swift.Int)
+
+      // To
+      public func f(a: Swift.String)
+
+      /**
+      Changes:
+      - Changed parameter type
+      */
+      ```
+    REPORT
+
+    with_interface_containing("public class Purchases {\n}\n") do |path|
+      assert_equal [:modified], ApiDiffHelper.breaking_changes(report, path).map { |b| b[:reason] }
+    end
+  end
+
+  def test_protocol_requirement_rules
+    interface = "public protocol PurchasesDelegate {\n}\n"
+    required = <<~REPORT
+      # 👀 1 public change detected
+
+      ---
+      ## `RevenueCat`
+      ### `PurchasesDelegate`
+      #### ❇️ Added
+      ```swift
+      func purchases(_ purchases: RevenueCat.Purchases)
+      ```
+    REPORT
+    optional = required.sub("func purchases", "@objc optional func purchases")
+
+    with_interface_containing(interface) do |path|
+      assert_equal [:protocol_requirement], ApiDiffHelper.breaking_changes(required, path).map { |b| b[:reason] }
+      assert_empty ApiDiffHelper.breaking_changes(optional, path)
+    end
+  end
+
   private
 
   # Walks the parsed CircleCI config looking for CircleCI step hashes of the form

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -584,48 +584,49 @@ class ApiDiffHelperTest < Minitest::Test
     refute_match(/this fence appears/, change.declaration)
   end
 
-  # Fixture where a type section is followed directly by another type section (no kind between them).
-  # Tests that kind = nil is reset when a new ### type heading appears.
-  CONSECUTIVE_TYPES_REPORT = <<~REPORT.freeze
+  # Fixture testing kind = nil reset in the ## target branch.
+  # A fenced block after a target heading, with no kind heading before it.
+  # With the guard: kind is nil so elsif kind refuses to open, no spurious change.
+  # Without kind = nil in target branch: stale kind from previous section leaks.
+  STALE_KIND_ACROSS_TARGETS_REPORT = <<~REPORT.freeze
     # 👀 2 public changes detected
-    <table><tr><td>❇️</td><td><b>2 Additions</b></td></tr></table>
+    <table><tr><td>❌</td><td>1 Removal</b></td><td>❇️</td><td>1 Addition</b></td></tr></table>
 
     ---
     ## `RevenueCat`
-    ### `FirstType`
-    #### ❇️ Added
+    ### `SomeType`
+    #### ❌ Removed
     ```swift
-    case firstMember
-    ```
-    ### `SecondType`
-    #### ❇️ Added
-    ```swift
-    case secondMember
+    public func removedMember()
     ```
 
     ---
-    **Analyzed targets:** RevenueCat
+    ## `RevenueCatUI`
+    ```swift
+    this fence has no kind heading and should be ignored because kind was reset to nil
+    ```
+
+    ---
+    **Analyzed targets:** RevenueCat, RevenueCatUI
   REPORT
 
-  def test_parse_report_resets_kind_on_new_type_heading
-    changes = ApiDiffHelper.parse_report(CONSECUTIVE_TYPES_REPORT)
+  def test_parse_report_does_not_leak_kind_across_target_sections
+    changes = ApiDiffHelper.parse_report(STALE_KIND_ACROSS_TARGETS_REPORT)
 
-    assert_equal 2, changes.count
-    first, second = changes
+    # Should only parse one change (the removal from RevenueCat).
+    # The fence in RevenueCatUI has no kind heading and should be ignored.
+    # This would fail if `kind = nil` was removed from the ## target branch,
+    # because then the orphaned fence would inherit :removed from the previous section.
+    assert_equal 1, changes.count
+    change = changes.first
 
-    # First change under FirstType
-    assert_equal :added, first.kind
-    assert_equal "FirstType", first.owner
-    assert_match(/firstMember/, first.declaration)
+    assert_equal :removed, change.kind
+    assert_equal "SomeType", change.owner
+    assert_match(/removedMember/, change.declaration)
+    refute_match(/this fence has no kind/, change.declaration)
 
-    # Second change under SecondType should have its own kind set by the #### heading.
-    # If `kind = nil` was removed from the type heading branch, the second change would
-    # incorrectly inherit :added from the previous section and the test would still pass.
-    # This test alone cannot catch that, but combined with test_parse_report_ignores_fences_before_kind_heading,
-    # it reinforces the pattern.
-    assert_equal :added, second.kind
-    assert_equal "SecondType", second.owner
-    assert_match(/secondMember/, second.declaration)
+    # Also assert that no change exists with kind :removed and owner nil (the spurious change that would appear without the guard).
+    assert_empty changes.select { |c| c.kind == :removed && c.owner.nil? }
   end
 
   # Fixture where a type section is NOT followed by a kind heading before a fence.

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -8,8 +8,20 @@ require 'yaml'
 # Mock Fastlane::UI for testing
 module Fastlane
   module UI
-    def self.error(message); end
+    class << self
+      attr_accessor :messages
+    end
+    self.messages = []
+
+    def self.error(message)
+      messages << message
+    end
+
     def self.success(message); end
+
+    def self.important(message)
+      messages << message
+    end
   end
 
   # Mock Fastlane::Actions.sh, used only when the default runner (runner: nil) is exercised.
@@ -50,6 +62,10 @@ class ApiDiffHelperTest < Minitest::Test
                           "\n---\n## `RevenueCat`\n#### ❌ Removed\n```swift\n" \
                           "public func apiDiffHelperFixtureSingleRemoval() -> Swift.Int\n```\n" \
                           "\n---\n**Analyzed targets:** RevenueCat\n".freeze
+
+  def setup
+    Fastlane::UI.messages = []
+  end
 
   def with_interface_files
     Dir.mktmpdir do |dir|
@@ -876,6 +892,53 @@ class ApiDiffHelperTest < Minitest::Test
     with_interface_containing(interface) do |path|
       assert_equal [:protocol_requirement], ApiDiffHelper.breaking_changes(report, path).map { |b| b[:reason] }
     end
+  end
+
+  # --- The gate ---
+
+  def test_gate_blocks_on_breaks_without_the_label
+    breaks = [{ reason: :removed, owner: nil, declaration: "public func gone()" }]
+
+    assert ApiDiffHelper.gate_blocked?(breaks, [])
+    assert ApiDiffHelper.gate_blocked?(breaks, ["pr:other", "pr:RevenueCatUI"])
+  end
+
+  def test_label_makes_the_gate_report_only
+    breaks = [{ reason: :removed, owner: nil, declaration: "public func gone()" }]
+
+    refute ApiDiffHelper.gate_blocked?(breaks, [ApiDiffHelper::BREAKING_CHANGE_LABEL])
+    assert_equal "pr:breaking-api", ApiDiffHelper::BREAKING_CHANGE_LABEL
+  end
+
+  def test_gate_passes_when_nothing_is_breaking
+    refute ApiDiffHelper.gate_blocked?([], [])
+  end
+
+  def test_print_breaking_summary_is_a_noop_when_nothing_is_breaking
+    assert_nil ApiDiffHelper.print_breaking_summary([], [])
+    assert_empty Fastlane::UI.messages
+  end
+
+  def test_print_breaking_summary_without_the_label_tells_you_to_add_it
+    breaks = [{ reason: :removed, owner: nil, declaration: "public func gone()" }]
+
+    ApiDiffHelper.print_breaking_summary(breaks, [])
+
+    joined = Fastlane::UI.messages.join("\n")
+    assert_includes joined, "removed: public func gone()"
+    assert_includes joined, "Add the #{ApiDiffHelper::BREAKING_CHANGE_LABEL} label"
+    refute_includes joined, "Reported only"
+  end
+
+  def test_print_breaking_summary_with_the_label_reports_only
+    breaks = [{ reason: :enum_case, owner: "Foo", declaration: "case bar" }]
+
+    ApiDiffHelper.print_breaking_summary(breaks, [ApiDiffHelper::BREAKING_CHANGE_LABEL])
+
+    joined = Fastlane::UI.messages.join("\n")
+    assert_includes joined, "case added to an existing enum in Foo: case bar"
+    assert_includes joined, "Reported only"
+    refute_includes joined, "Add the #{ApiDiffHelper::BREAKING_CHANGE_LABEL} label"
   end
 
   private

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -95,6 +95,37 @@ class ApiDiffHelperTest < Minitest::Test
     end
   end
 
+  # Finding 4: pr_labels_for_api_gate calls github_api with no error_handlers, so a non-2xx
+  # response raises and reds check-api-changes-* on every PR, including ones with no breaks to
+  # judge labels against. fastlane/Fastfile is a DSL evaluated inside Fastlane::FastFile, so it
+  # can't be safely required or executed here; this reads the raw source instead and pins two
+  # structural invariants: the call site appears after all_breaks has been computed (not before
+  # the loop that builds it), and it is conditioned on all_breaks.any? rather than unconditional.
+  def test_pr_labels_are_only_fetched_when_there_is_a_break_to_judge
+    fastfile_path = File.expand_path('Fastfile', __dir__)
+    lines = File.readlines(fastfile_path)
+
+    concat_line_no = lines.index { |line| line.include?("all_breaks.concat(ApiDiffHelper.breaking_changes") }
+    refute_nil concat_line_no, "expected to find the loop that accumulates all_breaks"
+
+    # The private_lane definition ("private_lane :pr_labels_for_api_gate do") is a different
+    # call shape from the call site; filter it out so we isolate where check_api_changes
+    # actually invokes it.
+    call_sites = lines.each_with_index.select do |line, _|
+      line.include?("pr_labels_for_api_gate") &&
+        !line.include?("private_lane :pr_labels_for_api_gate") &&
+        !line.strip.start_with?("#")
+    end
+
+    assert_equal 1, call_sites.length, "expected exactly one call site for pr_labels_for_api_gate"
+    call_line, call_line_no = call_sites.first
+
+    assert call_line_no > concat_line_no,
+           "the label fetch must happen after all_breaks is computed, not before"
+    assert_match(/all_breaks\.any\?/, call_line,
+                 "the label fetch must be gated on all_breaks.any?, not unconditional")
+  end
+
   def test_validate_inputs_accepts_two_non_empty_files
     with_interface_files do |old_file, new_file|
       assert_nil ApiDiffHelper.validate_api_diff_inputs!(old_file, new_file)
@@ -504,11 +535,55 @@ class ApiDiffHelperTest < Minitest::Test
     refute ApiDiffHelper.modification_attribute_only?(signature_change)
   end
 
+  # Finding 2: losing an attribute must never be waved through, whichever attribute it names.
+  # Stripping `@objc` from a member on an Obj-C-exposed type breaks every Obj-C caller.
+  def test_modification_attribute_only_is_false_when_an_attribute_is_removed
+    removed = "// From\n@objc\npublic func f()\n\n// To\npublic func f()\n\n/**\nChanges:\n- Removed attribute `@objc`\n*/"
+    refute ApiDiffHelper.modification_attribute_only?(removed)
+  end
+
+  # Finding 2: gaining `@available(*, unavailable)` breaks every caller exactly like removing
+  # the declaration would, so it must not be exempted as a harmless attribute-only change.
+  def test_modification_attribute_only_is_false_when_unavailable_is_added
+    unavailable = "// From\npublic func f()\n\n// To\n@available(*, unavailable)\npublic func f()\n\n/**\nChanges:\n- Added attribute `@available(*, unavailable)`\n*/"
+    refute ApiDiffHelper.modification_attribute_only?(unavailable)
+  end
+
+  # Finding 2: gaining `@available(*, deprecated, ...)` only warns; it is not breaking and must
+  # stay exempted, unlike `unavailable`/`obsoleted`.
+  def test_modification_attribute_only_is_true_when_deprecated_is_added
+    deprecated = "// From\npublic func f()\n\n// To\n@available(*, deprecated, message: \"x\")\npublic func f()\n\n/**\nChanges:\n- Added attribute `@available(*, deprecated, message: \"x\")`\n*/"
+    assert ApiDiffHelper.modification_attribute_only?(deprecated)
+  end
+
   def test_declaration_type_name
     assert_equal "ComponentInteractionType",
                  ApiDiffHelper.declaration_type_name("public enum ComponentInteractionType: Swift.String {")
     assert_equal "Foo", ApiDiffHelper.declaration_type_name("@objc public protocol Foo : NSObjectProtocol {")
     assert_nil ApiDiffHelper.declaration_type_name("public func notAType()")
+  end
+
+  # --- significant_first_line (shared helper behind Findings 1 and 3) ---
+
+  def test_significant_first_line_skips_a_leading_attribute
+    assert_equal "case brandNewError",
+                 ApiDiffHelper.significant_first_line("@objc(RCBrandNewError)\ncase brandNewError")
+  end
+
+  def test_significant_first_line_skips_the_from_marker
+    assert_equal "public func f()", ApiDiffHelper.significant_first_line("// From\npublic func f()")
+  end
+
+  def test_significant_first_line_skips_the_from_marker_and_a_stacked_attribute
+    assert_equal "public func f()",
+                 ApiDiffHelper.significant_first_line("// From\n@objc\npublic func f()")
+  end
+
+  # Fail-closed fallback: if every line looks skippable, fall back to the raw first line rather
+  # than returning nothing, so an unexpected shape degrades to the un-skipped behavior instead
+  # of losing the declaration outright.
+  def test_significant_first_line_falls_back_to_the_raw_first_line_when_everything_is_skipped
+    assert_equal "// From", ApiDiffHelper.significant_first_line("// From\n@objc\n")
   end
 
   # Coverage for the three defensive guards: owner/kind reset on target heading,
@@ -887,6 +962,267 @@ class ApiDiffHelperTest < Minitest::Test
     with_interface_containing(interface) do |path|
       assert_equal [:protocol_requirement], ApiDiffHelper.breaking_changes(report, path).map { |b| b[:reason] }
     end
+  end
+
+  # --- Final review wave (2026-07-31): Findings 1-3, captured from the real 0.12.0 binary ---
+  #
+  # Every fixture below is a verbatim `public-api-diff swift-interface` report, captured by
+  # running the real binary against a copy of api/revenuecat-api-ios.swiftinterface with one
+  # deliberate edit each. Capture commands (binary at $BIN):
+  #
+  #   # Finding 1: an @objc(RC...)-attributed case added to the pre-existing @objc ErrorCode enum
+  #   $BIN swift-interface --old old.swiftinterface --new new.swiftinterface --target-name RevenueCat
+  #   # (new.swiftinterface has one line inserted after ErrorCode's `unknownError` case:
+  #   #  `  @objc(RCBrandNewError) case brandNewError = 99`)
+  #
+  #   # Finding 2: @objc removed from CustomerInfo.expirationDate(forProductIdentifier:)
+  #   # (new.swiftinterface drops the leading `@objc ` from that one method line)
+  #
+  #   # Finding 2: @available(*, unavailable) / @available(*, deprecated, ...) added to
+  #   # CustomerInfo.purchaseDate(forEntitlement:) (one attribute line inserted above the method)
+  #
+  #   # Finding 3 dedup: @objc removed from *two* methods (expirationDate and purchaseDate,
+  #   # both forProductIdentifier) within the same CustomerInfo type
+  #
+  # Findings' root cause: the tool renders an attribute on its own line above the declaration,
+  # and a :modified block's fenced text opens with a literal `// From` line, so a naive
+  # first-line read only ever sees the attribute or the marker, never the declaration itself.
+
+  ATTRIBUTED_ENUM_CASE_ADDED_REPORT = <<~REPORT.freeze
+    # 👀 1 public change detected
+    <table><tr><td>❇️</td><td><b>1 Addition</b></td></tr></table>
+
+    ---
+    ## `RevenueCat`
+    ### `ErrorCode`
+    #### ❇️ Added
+    ```swift
+    @objc(RCBrandNewError)
+    case brandNewError
+    ```
+
+    ---
+    **Analyzed targets:** RevenueCat
+  REPORT
+
+  OBJC_REMOVED_FROM_METHOD_REPORT = <<~REPORT.freeze
+    # ⚠️ 1 public change detected ⚠️
+    <table><tr><td>🔀</td><td><b>1 Modification</b></td></tr></table>
+
+    ---
+    ## `RevenueCat`
+    ### `CustomerInfo`
+    #### 🔀 Modified
+    ```swift
+    // From
+    @objc
+    final public func expirationDate(forProductIdentifier productIdentifier: RevenueCat.ProductIdentifier) -> Foundation.Date?
+
+    // To
+    final public func expirationDate(forProductIdentifier productIdentifier: RevenueCat.ProductIdentifier) -> Foundation.Date?
+
+    /**
+    Changes:
+    - Removed attribute `@objc`
+    */
+    ```
+
+    ---
+    **Analyzed targets:** RevenueCat
+  REPORT
+
+  UNAVAILABLE_ATTRIBUTE_ADDED_REPORT = <<~REPORT.freeze
+    # ⚠️ 1 public change detected ⚠️
+    <table><tr><td>🔀</td><td><b>1 Modification</b></td></tr></table>
+
+    ---
+    ## `RevenueCat`
+    ### `CustomerInfo`
+    #### 🔀 Modified
+    ```swift
+    // From
+    @objc
+    final public func purchaseDate(forEntitlement entitlementIdentifier: Swift.String) -> Foundation.Date?
+
+    // To
+    @available(*, unavailable)
+    @objc
+    final public func purchaseDate(forEntitlement entitlementIdentifier: Swift.String) -> Foundation.Date?
+
+    /**
+    Changes:
+    - Added attribute `@available(*, unavailable)`
+    */
+    ```
+
+    ---
+    **Analyzed targets:** RevenueCat
+  REPORT
+
+  DEPRECATED_ATTRIBUTE_ADDED_REPORT = <<~REPORT.freeze
+    # ⚠️ 1 public change detected ⚠️
+    <table><tr><td>🔀</td><td><b>1 Modification</b></td></tr></table>
+
+    ---
+    ## `RevenueCat`
+    ### `CustomerInfo`
+    #### 🔀 Modified
+    ```swift
+    // From
+    @objc
+    final public func purchaseDate(forEntitlement entitlementIdentifier: Swift.String) -> Foundation.Date?
+
+    // To
+    @available(*, deprecated, message: "use something else")
+    @objc
+    final public func purchaseDate(forEntitlement entitlementIdentifier: Swift.String) -> Foundation.Date?
+
+    /**
+    Changes:
+    - Added attribute `@available(*, deprecated, message: "use something else")`
+    */
+    ```
+
+    ---
+    **Analyzed targets:** RevenueCat
+  REPORT
+
+  # Two distinct removals inside the same type, captured in one run, to prove the dedup fix:
+  # before Finding 3's fix both blocks' displayed declaration truncated to the literal
+  # "// From" line, so Fastfile's `uniq! { [reason, owner, declaration] }` collapsed them into
+  # one, silently dropping a real break.
+  TWO_OBJC_REMOVALS_IN_ONE_TYPE_REPORT = <<~REPORT.freeze
+    # ⚠️ 2 public changes detected ⚠️
+    <table><tr><td>🔀</td><td><b>2 Modifications</b></td></tr></table>
+
+    ---
+    ## `RevenueCat`
+    ### `CustomerInfo`
+    #### 🔀 Modified
+    ```swift
+    // From
+    @objc
+    final public func expirationDate(forProductIdentifier productIdentifier: RevenueCat.ProductIdentifier) -> Foundation.Date?
+
+    // To
+    final public func expirationDate(forProductIdentifier productIdentifier: RevenueCat.ProductIdentifier) -> Foundation.Date?
+
+    /**
+    Changes:
+    - Removed attribute `@objc`
+    */
+    ```
+    ```swift
+    // From
+    @objc
+    final public func purchaseDate(forProductIdentifier productIdentifier: RevenueCat.ProductIdentifier) -> Foundation.Date?
+
+    // To
+    final public func purchaseDate(forProductIdentifier productIdentifier: RevenueCat.ProductIdentifier) -> Foundation.Date?
+
+    /**
+    Changes:
+    - Removed attribute `@objc`
+    */
+    ```
+
+    ---
+    **Analyzed targets:** RevenueCat
+  REPORT
+
+  # A brand new @objc(RC...)-prefixed enum, captured as its own real report shape: the tool
+  # puts the attribute on its own line above `public enum ...`, which is exactly what made
+  # declaration_type_name (and therefore the new_type_names guard at breaking_changes:364)
+  # blind to attributed new types before Finding 3's fix.
+  NEW_OBJC_PREFIXED_ENUM_REPORT = <<~REPORT.freeze
+    # 👀 1 public change detected
+    <table><tr><td>❇️</td><td><b>1 Addition</b></td></tr></table>
+
+    ---
+    ## `RevenueCat`
+    #### ❇️ Added
+    ```swift
+    @objc(RCBrandNewEnum)
+    public enum BrandNewEnumFixture: Swift.Int {
+      case first
+      case second
+    }
+    ```
+
+    ---
+    **Analyzed targets:** RevenueCat
+  REPORT
+
+  # Finding 1: a case attributed with @objc(RC...) added to a pre-existing @objc enum must
+  # still be caught. 20 of 45 public enums in the committed baseline are @objc, and 63 of 152
+  # case lines are attributed, so this is the common shape, not an edge case.
+  def test_attributed_case_added_to_an_existing_objc_enum_is_a_break
+    with_interface_containing("@objc(RCPurchasesErrorCode) public enum ErrorCode : Swift.Int, Swift.Error {\n}\n") do |path|
+      breaks = ApiDiffHelper.breaking_changes(ATTRIBUTED_ENUM_CASE_ADDED_REPORT, path)
+
+      assert_equal [:enum_case], breaks.map { |b| b[:reason] }
+      assert_equal ["ErrorCode"], breaks.map { |b| b[:owner] }
+      assert_equal "case brandNewError", breaks.first[:declaration]
+    end
+  end
+
+  # Finding 2: removing @objc from a method on an Obj-C-exposed class breaks every Obj-C
+  # caller, so it must not be exempted as an attribute-only modification.
+  def test_removing_objc_from_a_method_is_a_break
+    with_interface_containing("public class CustomerInfo : NSObject {\n}\n") do |path|
+      breaks = ApiDiffHelper.breaking_changes(OBJC_REMOVED_FROM_METHOD_REPORT, path)
+
+      assert_equal [:modified], breaks.map { |b| b[:reason] }
+      assert_equal ["CustomerInfo"], breaks.map { |b| b[:owner] }
+      assert_match(/final public func expirationDate\(forProductIdentifier/, breaks.first[:declaration])
+    end
+  end
+
+  # Finding 2: gaining @available(*, unavailable) breaks callers exactly like removing the
+  # declaration would.
+  def test_adding_unavailable_attribute_is_a_break
+    with_interface_containing("public class CustomerInfo : NSObject {\n}\n") do |path|
+      breaks = ApiDiffHelper.breaking_changes(UNAVAILABLE_ATTRIBUTE_ADDED_REPORT, path)
+
+      assert_equal [:modified], breaks.map { |b| b[:reason] }
+    end
+  end
+
+  # Finding 2 (fail-open guard-alive): gaining @available(*, deprecated, ...) only warns, so it
+  # must stay exempted as attribute-only. Not a break, no false positive.
+  def test_adding_deprecated_attribute_is_not_a_break
+    with_interface_containing("public class CustomerInfo : NSObject {\n}\n") do |path|
+      assert_empty ApiDiffHelper.breaking_changes(DEPRECATED_ATTRIBUTE_ADDED_REPORT, path)
+    end
+  end
+
+  # Finding 3: two distinct removals in one type must both survive Fastfile's dedup step.
+  # breaking_changes itself never dedups (that happens only in Fastfile), so this test mirrors
+  # the exact key from fastlane/Fastfile's check_api_changes lane
+  # (`uniq! { [change[:reason], change[:owner], change[:declaration]] }`) to prove the two
+  # breaks are no longer indistinguishable after Finding 3's fix.
+  def test_two_distinct_removals_in_one_type_survive_the_fastfile_dedup_key
+    with_interface_containing("public class CustomerInfo : NSObject {\n}\n") do |path|
+      breaks = ApiDiffHelper.breaking_changes(TWO_OBJC_REMOVALS_IN_ONE_TYPE_REPORT, path)
+
+      assert_equal 2, breaks.count, "both @objc removals must be reported"
+      declarations = breaks.map { |b| b[:declaration] }
+      assert_equal declarations.length, declarations.uniq.length,
+                   "the two removals must have distinct declaration text, or Fastfile's dedup " \
+                   "key collapses them into one"
+
+      deduped = breaks.uniq { |change| [change[:reason], change[:owner], change[:declaration]] }
+      assert_equal 2, deduped.count, "distinct removals must survive the Fastfile dedup step"
+    end
+  end
+
+  # Finding 3: declaration_type_name (and therefore the new_type_names guard it feeds) must
+  # resolve an @objc(RC...)-prefixed brand new type, not just an unattributed one.
+  def test_declaration_type_name_resolves_an_objc_prefixed_new_type
+    change = ApiDiffHelper.parse_report(NEW_OBJC_PREFIXED_ENUM_REPORT).first
+
+    assert_nil change.owner, "a brand new type sits at target level, not inside a type section"
+    assert_equal "BrandNewEnumFixture", ApiDiffHelper.declaration_type_name(change.declaration)
   end
 
   # --- The gate ---

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -395,6 +395,111 @@ class ApiDiffHelperTest < Minitest::Test
     end
   end
 
+  # --- Report parsing ---
+
+  # Real 0.12.0 shape: a brand new enum at target level, plus a case added to an existing one.
+  ENUM_CASE_REPORT = <<~REPORT.freeze
+    # 👀 2 public changes detected
+    <table><tr><td>❇️</td><td><b>2 Additions</b></td></tr></table>
+
+    ---
+    ## `RevenueCat`
+    #### ❇️ Added
+    ```swift
+    public enum ComponentInteractionType: Swift.String {
+      case button
+      case carousel
+    }
+    ```
+    ### `PaywallEvent`
+    #### ❇️ Added
+    ```swift
+    case componentInteraction(
+      RevenueCat.PaywallEvent.CreationData
+    )
+    ```
+
+    ---
+    **Analyzed targets:** RevenueCat
+  REPORT
+
+  MODIFIED_REPORT = <<~REPORT.freeze
+    # ⚠️ 1 public change detected ⚠️
+    <table><tr><td>🔀</td><td><b>1 Modification</b></td></tr></table>
+
+    ---
+    ## `RevenueCat`
+    ### `Configuration.Builder`
+    #### 🔀 Modified
+    ```swift
+    // From
+    public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+
+    // To
+    @objc
+    public func with(preferredUILocaleOverride: Swift.String?) -> RevenueCat.Configuration.Builder
+
+    /**
+    Changes:
+    - Added attribute `@objc`
+    */
+    ```
+
+    ---
+    **Analyzed targets:** RevenueCat
+  REPORT
+
+  def test_parse_report_no_changes_yields_nothing
+    assert_empty ApiDiffHelper.parse_report(NO_CHANGES_OUTPUT)
+  end
+
+  def test_parse_report_separates_target_level_from_member_changes
+    changes = ApiDiffHelper.parse_report(ENUM_CASE_REPORT)
+
+    assert_equal 2, changes.count
+    whole_type, member = changes
+
+    assert_equal :added, whole_type.kind
+    assert_nil whole_type.owner, "a new type sits at target level, not inside a type section"
+    assert_match(/public enum ComponentInteractionType/, whole_type.declaration)
+
+    assert_equal :added, member.kind
+    assert_equal "PaywallEvent", member.owner
+    assert_match(/\Acase componentInteraction\(/, member.declaration)
+  end
+
+  def test_parse_report_reads_removals_and_modifications
+    removal = ApiDiffHelper.parse_report(SINGLE_REMOVAL_OUTPUT)
+    assert_equal [:removed], removal.map(&:kind)
+    assert_match(/apiDiffHelperFixtureSingleRemoval/, removal.first.declaration)
+
+    modified = ApiDiffHelper.parse_report(MODIFIED_REPORT)
+    assert_equal [:modified], modified.map(&:kind)
+    assert_equal "Configuration.Builder", modified.first.owner
+  end
+
+  # A report claiming changes that parses to nothing means the format moved under us.
+  def test_parse_report_raises_when_it_cannot_find_the_changes_it_announced
+    broken = "# 👀 3 public changes detected\nsomething we do not understand\n"
+
+    error = assert_raises(RuntimeError) { ApiDiffHelper.parse_report(broken) }
+    assert_match(/could not be parsed/, error.message)
+  end
+
+  def test_modification_attribute_only
+    assert ApiDiffHelper.modification_attribute_only?(ApiDiffHelper.parse_report(MODIFIED_REPORT).first.declaration)
+
+    signature_change = "// From\npublic func f(a: Swift.Int)\n\n// To\npublic func f(a: Swift.String)\n\n/**\nChanges:\n- Changed parameter type\n*/"
+    refute ApiDiffHelper.modification_attribute_only?(signature_change)
+  end
+
+  def test_declaration_type_name
+    assert_equal "ComponentInteractionType",
+                 ApiDiffHelper.declaration_type_name("public enum ComponentInteractionType: Swift.String {")
+    assert_equal "Foo", ApiDiffHelper.declaration_type_name("@objc public protocol Foo : NSObjectProtocol {")
+    assert_nil ApiDiffHelper.declaration_type_name("public func notAType()")
+  end
+
   private
 
   # Walks the parsed CircleCI config looking for CircleCI step hashes of the form

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -500,6 +500,173 @@ class ApiDiffHelperTest < Minitest::Test
     assert_nil ApiDiffHelper.declaration_type_name("public func notAType()")
   end
 
+  # Coverage for the three defensive guards: owner/kind reset on target heading,
+  # kind reset on type heading, and the elsif check on fence open.
+
+  # Fixture with two target sections: first has a nested member, second has target-level change.
+  # Tests that owner = nil is reset when a new ## target heading appears.
+  TWO_TARGETS_REPORT = <<~REPORT.freeze
+    # 👀 2 public changes detected
+    <table><tr><td>❇️</td><td><b>2 Additions</b></td></tr></table>
+
+    ---
+    ## `RevenueCat`
+    ### `OldType`
+    #### ❇️ Added
+    ```swift
+    case memberOfOldType
+    ```
+
+    ---
+    ## `RevenueCatUI`
+    #### ❇️ Added
+    ```swift
+    public enum NewTypeInUI: Swift.String {
+      case value
+    }
+    ```
+
+    ---
+    **Analyzed targets:** RevenueCat, RevenueCatUI
+  REPORT
+
+  def test_parse_report_resets_owner_on_new_target_heading
+    changes = ApiDiffHelper.parse_report(TWO_TARGETS_REPORT)
+
+    assert_equal 2, changes.count
+    first, second = changes
+
+    # First change is nested under OldType, has an owner
+    assert_equal :added, first.kind
+    assert_equal "OldType", first.owner
+    assert_match(/memberOfOldType/, first.declaration)
+
+    # Second change is target-level (no preceding type section), owner should be nil
+    # This would fail if `owner = nil` was removed from the target heading branch
+    assert_equal :added, second.kind
+    assert_nil second.owner, "target-level changes must have owner=nil"
+    assert_match(/NewTypeInUI/, second.declaration)
+  end
+
+  # Fixture with a fenced block before any kind heading (orphaned block, should be ignored).
+  # Tests that elsif kind prevents a block from being opened/buffered before a kind is set.
+  ORPHANED_BLOCK_REPORT = <<~REPORT.freeze
+    # 👀 2 public changes detected
+    <table><tr><td>❇️</td><td><b>2 Additions</b></td></tr></table>
+
+    ---
+    ## `RevenueCat`
+    ### `SomeType`
+    ```swift
+    this fence appears before any kind heading and should be ignored
+    ```
+    #### ❇️ Added
+    ```swift
+    public func validChange()
+    ```
+
+    ---
+    **Analyzed targets:** RevenueCat
+  REPORT
+
+  def test_parse_report_ignores_fences_before_kind_heading
+    changes = ApiDiffHelper.parse_report(ORPHANED_BLOCK_REPORT)
+
+    # Should only parse one change (the one after the kind heading).
+    # The orphaned block before the kind should be ignored.
+    # This would fail if `elsif kind` became `else` (fence open check would buffer prematurely)
+    assert_equal 1, changes.count
+    change = changes.first
+
+    assert_equal :added, change.kind
+    assert_equal "SomeType", change.owner
+    assert_match(/validChange/, change.declaration)
+    refute_match(/this fence appears/, change.declaration)
+  end
+
+  # Fixture where a type section is followed directly by another type section (no kind between them).
+  # Tests that kind = nil is reset when a new ### type heading appears.
+  CONSECUTIVE_TYPES_REPORT = <<~REPORT.freeze
+    # 👀 2 public changes detected
+    <table><tr><td>❇️</td><td><b>2 Additions</b></td></tr></table>
+
+    ---
+    ## `RevenueCat`
+    ### `FirstType`
+    #### ❇️ Added
+    ```swift
+    case firstMember
+    ```
+    ### `SecondType`
+    #### ❇️ Added
+    ```swift
+    case secondMember
+    ```
+
+    ---
+    **Analyzed targets:** RevenueCat
+  REPORT
+
+  def test_parse_report_resets_kind_on_new_type_heading
+    changes = ApiDiffHelper.parse_report(CONSECUTIVE_TYPES_REPORT)
+
+    assert_equal 2, changes.count
+    first, second = changes
+
+    # First change under FirstType
+    assert_equal :added, first.kind
+    assert_equal "FirstType", first.owner
+    assert_match(/firstMember/, first.declaration)
+
+    # Second change under SecondType should have its own kind set by the #### heading.
+    # If `kind = nil` was removed from the type heading branch, the second change would
+    # incorrectly inherit :added from the previous section and the test would still pass.
+    # This test alone cannot catch that, but combined with test_parse_report_ignores_fences_before_kind_heading,
+    # it reinforces the pattern.
+    assert_equal :added, second.kind
+    assert_equal "SecondType", second.owner
+    assert_match(/secondMember/, second.declaration)
+  end
+
+  # Fixture where a type section is NOT followed by a kind heading before a fence.
+  # This tests that kind = nil is reset on type heading; without it, an orphaned fence
+  # in the second type would inherit the previous section's kind.
+  TYPE_WITHOUT_KIND_REPORT = <<~REPORT.freeze
+    # 👀 2 public changes detected
+    <table><tr><td>❇️</td><td><b>2 Additions</b></td></tr></table>
+
+    ---
+    ## `RevenueCat`
+    ### `TypeWithKind`
+    #### ❇️ Added
+    ```swift
+    case validMember
+    ```
+    ### `TypeWithoutKind`
+    ```swift
+    this fence has no kind heading and should be ignored
+    ```
+
+    ---
+    **Analyzed targets:** RevenueCat
+  REPORT
+
+  def test_parse_report_does_not_inherit_kind_across_type_sections
+    changes = ApiDiffHelper.parse_report(TYPE_WITHOUT_KIND_REPORT)
+
+    # Should only parse one change (the one with an explicit kind heading).
+    # The fence in TypeWithoutKind should be ignored because kind is nil.
+    # This would fail if `kind = nil` was removed from the type heading branch,
+    # because then the orphaned fence would inherit :added from the previous section.
+    assert_equal 1, changes.count
+    change = changes.first
+
+    assert_equal :added, change.kind
+    assert_equal "TypeWithKind", change.owner
+    assert_match(/validMember/, change.declaration)
+    refute_match(/this fence has no kind/, change.declaration)
+  end
+
   private
 
   # Walks the parsed CircleCI config looking for CircleCI step hashes of the form

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -77,15 +77,10 @@ class ApiDiffHelperTest < Minitest::Test
     end
   end
 
-  def test_pinned_version_is_not_the_buggy_orb_default
-    assert_equal "0.12.0", ApiDiffHelper::PUBLIC_API_DIFF_VERSION
-  end
-
-  # The constant above is not read by anything at CI time; the version that actually ships
-  # is the literal in .circleci/default_config.yml. This test parses that YAML (aliases in
-  # the file require unsafe_load_file) and checks every revenuecat/install-public-api-diff
-  # step against the constant, so editing or deleting the YAML pin fails this test instead
-  # of silently drifting back to the orb's buggy 0.10.1 default.
+  # The version that actually ships is the literal in .circleci/default_config.yml. This test
+  # parses that YAML (aliases in the file require unsafe_load_file) and checks every
+  # revenuecat/install-public-api-diff step against the constant, so editing or deleting the
+  # YAML pin fails this test instead of silently drifting back to the orb's buggy 0.10.1 default.
   def test_ci_config_pins_the_same_version_as_the_constant
     config_path = File.expand_path('../.circleci/default_config.yml', __dir__)
     config = YAML.unsafe_load_file(config_path)


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

`check_api_changes` can only tell you your baselines are stale. It can't tell you that you broke the API, because regenerating the baselines erases the evidence it would need.

**Stacked on #7309** (base branch is `facu/api-diff-tool-report`, so the diff here is only the gate work).

### Description

Adds a second comparison: `api/` baselines **as of the merge base with `main`** versus the freshly generated interfaces. That's what this PR actually changes about the public API, regardless of whether the author regenerated. The existing freshness check is untouched and still fails first, so the gate can only add a failure reason, never make a stale-baseline failure pass.

Four things count as breaking:

| Reason | Why |
|---|---|
| `:removed` | Declaration gone from the public surface |
| `:enum_case` | Case added to a **pre-existing** `public enum`, breaking exhaustive switches, per our policy in `CLAUDE.md` |
| `:protocol_requirement` | Non-`optional` requirement added to a **pre-existing** `public protocol` |
| `:modified` | Signature changed |

`pr:breaking-api` makes the gate report-only when a break is intentional.

**`:modified` extends the spec's three rules.** A changed signature is source-breaking and a gate that ignored it would be misleading, but it is scope I added rather than something previously agreed. It's the `when :modified` branch of `breaking_changes` plus one test if you want it gone.

Break judgement reads the tool's report rather than the interface text, because the report nests members under their enclosing type. That's how a case added to a pre-existing enum is told apart from a brand-new enum that happens to have cases. The cost is coupling to a Markdown format with no stability guarantee, contained by the pinned version and fixtures captured from the binary.

Part B lands on this same branch so this stays one PR: the upserted PR comment and the Slack notification on ready-for-review.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: this PR, stacked on #7309
- Branch: `facu/api-diff-break-gate`, base `facu/api-diff-tool-report`
- Author / human owner: @facumenzella
- Agent(s): Claude Code (Opus 5, 1M context) as controller; Haiku 4.5 and Sonnet implementers, Sonnet reviewers, Opus final review
- Session source: current conversation
- Generated: 2026-07-31
- Context document version: 1

## Goal

Fail a PR whose public API changes are breaking, judged from what the PR changes relative to `main`, with a label override.

## Initial Prompt

"open the stacked follow-up, i want the whole thing open as draft", following "the pr should fail if there are breaking changes though" earlier in the session.

## Important Follow-up Prompts

- "let's put everything in the same PR" — the remaining work is one PR rather than the three stacked PRs originally planned. Part B will land on this branch.
- "subagent" — execution via subagent-driven development, fresh implementer per task with a review after each.

## Human Decisions

- Break gate required, with `pr:breaking-api` as the override.
- The tool is trusted alone as the change detector; a byte-comparison cross-check of its verdict was offered and declined.
- Everything in CircleCI rather than split across GitHub Actions.
- One PR for the whole follow-up, accepting that it exceeds the ~300 line guideline.

## Key Implementation Decisions

- Decision: compare against the merge base with `main`, not the PR's own baselines.
  - Rationale: the PR's baselines match the generated interfaces once regenerated, so the gate would have nothing to judge.
- Decision: derive breaks from the tool's report structure.
  - Rationale: the report nests members under their enclosing type and names attribute changes, which is strictly better than the indentation walk and attribute regex a previous approach used.
  - Cost: Markdown with no JSON option, so the version is pinned and fixtures are captured from the binary. A parse failure fails the job and never degrades to "no breaks found".
- Decision: `:modified` (non-attribute-only) counts as breaking. Extends the spec's three rules; called out above.
- Decision: freshness stays a byte comparison and keeps failing first.
  - Rationale: it answers "did you regenerate `api/`", which is byte identity by definition.
- Decision: `enclosing_type_kind` reads the generated interface to classify a type.
  - Rationale: the report never says whether a type is an enum, protocol or struct. Comments and string literals are stripped first, after a review found `@available(..., message: "...")` prose could misclassify.

## Files / Symbols Touched

- `fastlane/api_diff_helper.rb`
  - Symbols: `MERGE_BASE_SWIFTINTERFACE_DIR`, `resolve_merge_base`, `extract_baselines_at`, `ReportChange`, `parse_report`, `significant_first_line`, `modification_attribute_only?`, `non_breaking_attribute_addition?`, `declaration_type_name`, `enclosing_type_kind`, `breaking_changes`, `protocol_requirement_optional?`, `BREAKING_CHANGE_LABEL`, `gate_blocked?`, `print_breaking_summary`
  - Review relevance: `breaking_changes` is where under-reporting would hide. The binary renders attributes on their own line, so reasoning from a block's literal first line is the bug class that bit twice here.
- `fastlane/api_diff_helper_test.rb`
  - 66 tests. Fixtures for attributed enum cases, `@objc` removal and multiple removals in one type are captured from the 0.12.0 binary, not hand-written.
- `fastlane/Fastfile`
  - The gate pass in `check_api_changes`, and `pr_labels_for_api_gate`.
- `.circleci/default_config.yml`
  - `git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main` in both check-api-changes jobs, because `checkout` does not guarantee `origin/main` exists and `resolve_merge_base` needs it. Also drops a version test that asserted a constant against itself.

## Validation

- `ruby fastlane/api_diff_helper_test.rb`: 66 runs, 219 assertions, 0 failures, 0 errors. `ruby -c` clean on Fastfile.
- Three real commits replayed through the real 0.12.0 binary, re-run independently by the final re-reviewer:
  - `c23c3cdf4` (#6523): exactly 1 break, `:enum_case` on the pre-existing `PaywallEvent`; the brand-new `ComponentInteractionType` correctly not flagged despite having 9 cases.
  - `ae389971a` (#7121, `@objc` added to existing methods): 0 breaks.
  - `e07e5e725` (#7094, baseline change was only `+import Security`): 0 breaks.
- A real removal from a real baseline flags `:removed`, blocks without the label, and stops blocking with it.
- `strip_comments_and_strings` verified to leave enum/protocol classification unchanged across all 18 baselines (503 matches before and after).
- Reviews: one per task plus a whole-branch review on Opus. Findings fixed and re-verified, including two Criticals described below.

## Validation Gaps

- CI has not run this branch yet. The gate has never executed inside the CircleCI jobs, so the fetch step and `pr_labels_for_api_gate` are verified by reading and by unit tests, not by a real run.
- The label override path has never run against the real GitHub API.
- `:protocol_requirement` has no real-binary integration case, only unit coverage; there are currently zero public protocol extensions across the 18 baselines.

## Review Focus

- `breaking_changes`: is there any remaining path where a real break yields no finding? Two were found and fixed; both came from reading a report block's literal first line.
- Does the `pr:breaking-api` label reach `pr_labels_for_api_gate` in these two jobs? It needs `DANGER_GITHUB_API_TOKEN` to be project-level rather than context-scoped; if it is absent the lane sees no labels and the escape hatch silently stops working.
- Is `:modified` as a break reason wanted, or should it go?
- A stacked PR inherits its parent's breaks, since the merge base spans the whole stack. Over-reports, and the label covers it.

## Risks / Reviewer Notes

- Risk: attributed declarations defeat first-line reasoning.
  - Evidence: a case added to an `@objc` enum passed the gate entirely (20 of 45 public enums in the baseline are `@objc`), and removing `@objc` from a method was exempted as attribute-only although it breaks every Obj-C caller. Both reproduced against the real binary during final review.
  - Mitigation: one shared `significant_first_line` helper now skips attribute lines and `// From`; `Removed attribute` is never exempt; fixtures captured from the binary.
- Risk: the gate blocks PRs that change nothing.
  - Evidence: the label fetch used to run before breaks were computed, so a GitHub API blip would have reddened both jobs on every PR.
  - Mitigation: labels are only fetched when breaks exist.
- Risk: over-reporting on additions inside a new nested type, and `BREAKING_ATTRIBUTE_ADDITION` matching "unavailable"/"obsoleted" anywhere in an attribute.
  - Evidence: raised in review, both fail in the safe direction.
  - Mitigation: none. The label is the escape hatch.

## Non-goals / Out of Scope

- The upserted PR comment and the Slack notification (part B, same branch).
- Distinguishing ABI breakage from source breakage.
- Changing `generate_swiftinterface` or the baselines.

## Omitted Context

- Raw transcript, unrelated exploration, sensitive details, repetitive attempts, and chain-of-thought-style content were omitted.

</details>
