### PR TITLE
feat(ads): add optional tracking metadata to pollRewardVerification

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1321,6 +1321,7 @@
 		D07F64990C2DD742698ED810 /* PredicateConformanceFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF9988F3464C8BB896E3FE78 /* PredicateConformanceFixture.swift */; };
 		D08C42682FD995C20035A009 /* RewardVerificationToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08C42672FD995C20035A009 /* RewardVerificationToken.swift */; };
 		D0D83AE85FF3400EA30B0BDE /* TabsComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D11B9143D0AA4C0D9A694592 /* TabsComponentTests.swift */; };
+		475702537ED0A302C9D3BE07 /* RewardedAdTrackingMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B845797E663E98145FE7682 /* RewardedAdTrackingMetadata.swift */; };
 		D0DA209A2F23BBEC00BA3B77 /* AdEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DA20992F23BBEC00BA3B77 /* AdEventTests.swift */; };
 		D62A9C83BFD14E5FA0452CC7 /* RemoteConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E35BAD07C46D469D8CC7C396 /* RemoteConfiguration.swift */; };
 		D969194D68D6967E81788B1F /* WebViewComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A2779D02050D28BF369658 /* WebViewComponentView.swift */; };
@@ -3034,6 +3035,7 @@
 		D01244182FD02FC30043B43B /* RewardVerificationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardVerificationResult.swift; sourceTree = "<group>"; };
 		D04D812C75F9E42B66D11A37 /* PredicateConformanceRunner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PredicateConformanceRunner.swift; sourceTree = "<group>"; };
 		D08C42672FD995C20035A009 /* RewardVerificationToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardVerificationToken.swift; sourceTree = "<group>"; };
+		9B845797E663E98145FE7682 /* RewardedAdTrackingMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardedAdTrackingMetadata.swift; sourceTree = "<group>"; };
 		D0A2779D02050D28BF369658 /* WebViewComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewComponentView.swift; sourceTree = "<group>"; };
 		D0DA20992F23BBEC00BA3B77 /* AdEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdEventTests.swift; sourceTree = "<group>"; };
 		D11B9143D0AA4C0D9A694592 /* TabsComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsComponentTests.swift; sourceTree = "<group>"; };
@@ -6237,6 +6239,7 @@
 			isa = PBXGroup;
 			children = (
 				D08C42672FD995C20035A009 /* RewardVerificationToken.swift */,
+				9B845797E663E98145FE7682 /* RewardedAdTrackingMetadata.swift */,
 				D01244152FD02FC30043B43B /* Outcome.swift */,
 				D01244162FD02FC30043B43B /* Poller.swift */,
 				D01244172FD02FC30043B43B /* RewardVerification.swift */,
@@ -7637,6 +7640,7 @@
 				4FC083292A4A35FB00A97089 /* Integer+Extensions.swift in Sources */,
 				F5BE447D269E4ADB00254A30 /* ASIdManagerProxy.swift in Sources */,
 				D08C42682FD995C20035A009 /* RewardVerificationToken.swift in Sources */,
+				475702537ED0A302C9D3BE07 /* RewardedAdTrackingMetadata.swift in Sources */,
 				80E80EF226970E04008F245A /* ReceiptFetcher.swift in Sources */,
 				2DDF41AB24F6F37C005BC22D /* AppleReceipt.swift in Sources */,
 				2DDF41BB24F6F392005BC22D /* UInt8+Extensions.swift in Sources */,

--- a/Sources/Ads/Events/AdRewardEvents.swift
+++ b/Sources/Ads/Events/AdRewardEvents.swift
@@ -73,8 +73,6 @@ import Foundation
     public let adUnitId: String
     public let impressionId: String
     public let rewardVerificationEnabled: Bool
-    public let rewardItem: String?
-    public let rewardAmount: Int?
 
     public init(
         networkName: String?,
@@ -83,9 +81,7 @@ import Foundation
         placement: String?,
         adUnitId: String,
         impressionId: String,
-        rewardVerificationEnabled: Bool,
-        rewardItem: String?,
-        rewardAmount: Int?
+        rewardVerificationEnabled: Bool
     ) {
         self.networkName = networkName
         self.mediatorName = mediatorName
@@ -94,8 +90,6 @@ import Foundation
         self.adUnitId = adUnitId
         self.impressionId = impressionId
         self.rewardVerificationEnabled = rewardVerificationEnabled
-        self.rewardItem = rewardItem
-        self.rewardAmount = rewardAmount
     }
     // swiftlint:enable missing_docs
 

--- a/Sources/Ads/Events/Networking/AdEventsRequest.swift
+++ b/Sources/Ads/Events/Networking/AdEventsRequest.swift
@@ -63,8 +63,6 @@ extension AdEventsRequest {
         var mediatorErrorCode: Int?
         // For reward earned (unverified) events only:
         var rewardVerificationEnabled: Bool?
-        var rewardItem: String?
-        var rewardAmount: Int?
         // For reward granted events only:
         var rewardType: String?
         var rewardVirtualCurrencyCode: String?
@@ -124,8 +122,6 @@ extension AdEventsRequest.AdEventRequest {
                 precision: adEvent.revenueData?.precision.rawValue,
                 mediatorErrorCode: adEvent.mediatorErrorCode,
                 rewardVerificationEnabled: adEvent.rewardEarnedUnverifiedData?.rewardVerificationEnabled,
-                rewardItem: adEvent.rewardEarnedUnverifiedData?.rewardItem,
-                rewardAmount: adEvent.rewardEarnedUnverifiedData?.rewardAmount,
                 rewardType: adEvent.rewardGrantedData?.reward.kindRawValue,
                 rewardVirtualCurrencyCode: adEvent.rewardGrantedData?.reward.virtualCurrency?.code,
                 rewardVirtualCurrencyAmount: adEvent.rewardGrantedData?.reward.virtualCurrency?.amount,
@@ -190,8 +186,6 @@ extension AdEventsRequest.AdEventRequest: Encodable {
         case precision
         case mediatorErrorCode
         case rewardVerificationEnabled
-        case rewardItem
-        case rewardAmount
         case rewardType
         case rewardVirtualCurrencyCode
         case rewardVirtualCurrencyAmount

--- a/Sources/Ads/RewardVerification/Outcome.swift
+++ b/Sources/Ads/RewardVerification/Outcome.swift
@@ -60,12 +60,12 @@ internal extension RewardVerification {
 
 internal extension RewardVerification.FailureReason {
 
-    /// Maps this internal diagnostic classification to the coarser reason reported on the
+    /// Maps this internal diagnostic classification to the reason reported on the
     /// ``AdRewardFailedToVerify`` tracking event.
     var trackingFailureReason: AdRewardFailureReason {
         switch self {
-        case .backendRejected:
-            return .backendError
+        case .backendRejected(let reason, _):
+            return .backendError(reason: reason)
         case .exhaustedPending:
             return .timeout
         case .exhaustedTransient, .terminalError:
@@ -73,7 +73,7 @@ internal extension RewardVerification.FailureReason {
         case .unexpectedResponse:
             return .unknown
         case .cancelled:
-            return .unknown
+            return .cancelled
         }
     }
 }

--- a/Sources/Ads/RewardVerification/Outcome.swift
+++ b/Sources/Ads/RewardVerification/Outcome.swift
@@ -57,3 +57,23 @@ internal extension RewardVerification {
         case cancelled
     }
 }
+
+internal extension RewardVerification.FailureReason {
+
+    /// Maps this internal diagnostic classification to the coarser reason reported on the
+    /// ``AdRewardFailedToVerify`` tracking event.
+    var trackingFailureReason: AdRewardFailureReason {
+        switch self {
+        case .backendRejected:
+            return .backendError
+        case .exhaustedPending:
+            return .timeout
+        case .exhaustedTransient, .terminalError:
+            return .networkError
+        case .unexpectedResponse:
+            return .unknown
+        case .cancelled:
+            return .unknown
+        }
+    }
+}

--- a/Sources/Ads/RewardVerification/RewardedAdTrackingMetadata.swift
+++ b/Sources/Ads/RewardVerification/RewardedAdTrackingMetadata.swift
@@ -1,0 +1,46 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  RewardedAdTrackingMetadata.swift
+//
+
+import Foundation
+
+/// Ad metadata for a rewarded ad events while polling reward verification.
+///
+/// Pass this to ``pollRewardVerification(clientTransactionID:trackingMetadata:)`` to have the
+/// SDK automatically track those events.
+@_spi(Experimental) public struct RewardedAdTrackingMetadata: Sendable {
+
+    // swiftlint:disable missing_docs
+    public let networkName: String?
+    public let mediatorName: MediatorName
+    public let adFormat: AdFormat
+    public let placement: String?
+    public let adUnitId: String
+    public let impressionId: String
+
+    public init(
+        networkName: String?,
+        mediatorName: MediatorName,
+        adFormat: AdFormat,
+        placement: String?,
+        adUnitId: String,
+        impressionId: String
+    ) {
+        self.networkName = networkName
+        self.mediatorName = mediatorName
+        self.adFormat = adFormat
+        self.placement = placement
+        self.adUnitId = adUnitId
+        self.impressionId = impressionId
+    }
+    // swiftlint:enable missing_docs
+
+}

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1793,10 +1793,13 @@ extension Purchases {
     /// Polls the backend until reward verification completes or the attempt budget is exhausted.
     ///
     /// Call when your ad network's reward callback fires, passing the `clientTransactionID` returned by
-    /// ``generateRewardVerificationToken(impressionId:)``.
+    /// ``generateRewardVerificationToken(impressionId:)``. Pass `trackingMetadata` to have the SDK
+    /// automatically track the reward events as verification progresses
+    ///
     /// Refreshes local reward state before returning verified rewards.
     @_spi(Experimental) public func pollRewardVerification(
-        clientTransactionID: String
+        clientTransactionID: String,
+        trackingMetadata: RewardedAdTrackingMetadata? = nil
     ) async -> RewardVerificationResult {
         await self.pollRewardVerification(
             clientTransactionID: clientTransactionID,

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1831,7 +1831,6 @@ extension Purchases {
         poller: RewardVerification.Poller
     ) async -> RewardVerificationResult {
         self.trackRewardEarnedUnverified(
-            clientTransactionID: clientTransactionID,
             trackingMetadata: trackingMetadata,
             captureMethod: captureMethod
         )
@@ -1839,7 +1838,6 @@ extension Purchases {
         let outcome = await poller.run(clientTransactionID: clientTransactionID)
         self.trackRewardOutcome(
             outcome,
-            clientTransactionID: clientTransactionID,
             trackingMetadata: trackingMetadata,
             captureMethod: captureMethod
         )
@@ -1854,7 +1852,6 @@ extension Purchases {
 
     /// Tracks the "earned, not yet verified" moment.
     private func trackRewardEarnedUnverified(
-        clientTransactionID: String,
         trackingMetadata: RewardedAdTrackingMetadata?,
         captureMethod: AdEventCaptureMethod
     ) {
@@ -1867,9 +1864,7 @@ extension Purchases {
             placement: trackingMetadata.placement,
             adUnitId: trackingMetadata.adUnitId,
             impressionId: trackingMetadata.impressionId,
-            rewardVerificationEnabled: true,
-            rewardItem: nil,
-            rewardAmount: nil
+            rewardVerificationEnabled: true
         )
         self.adTracker.trackAdRewardEarnedUnverified(data, captureMethod: captureMethod)
     }
@@ -1878,7 +1873,6 @@ extension Purchases {
     /// event per non-empty reward.
     private func trackRewardOutcome(
         _ outcome: RewardVerification.Outcome,
-        clientTransactionID: String,
         trackingMetadata: RewardedAdTrackingMetadata?,
         captureMethod: AdEventCaptureMethod
     ) {

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1803,21 +1803,132 @@ extension Purchases {
     ) async -> RewardVerificationResult {
         await self.pollRewardVerification(
             clientTransactionID: clientTransactionID,
+            trackingMetadata: trackingMetadata,
+            captureMethod: .manual,
+            poller: RewardVerification.Poller.makeDefault()
+        )
+    }
+
+    /// Adapter entry point: identical to the public overload, but lets an official RevenueCat
+    /// ad-network adapter stamp `captureMethod: .adapter` on the tracked events instead of `.manual`.
+    @_spi(Internal) public func pollRewardVerification(
+        clientTransactionID: String,
+        trackingMetadata: RewardedAdTrackingMetadata?,
+        captureMethod: AdEventCaptureMethod
+    ) async -> RewardVerificationResult {
+        await self.pollRewardVerification(
+            clientTransactionID: clientTransactionID,
+            trackingMetadata: trackingMetadata,
+            captureMethod: captureMethod,
             poller: RewardVerification.Poller.makeDefault()
         )
     }
 
     internal func pollRewardVerification(
         clientTransactionID: String,
+        trackingMetadata: RewardedAdTrackingMetadata? = nil,
+        captureMethod: AdEventCaptureMethod = .manual,
         poller: RewardVerification.Poller
     ) async -> RewardVerificationResult {
+        self.trackRewardEarnedUnverified(
+            clientTransactionID: clientTransactionID,
+            trackingMetadata: trackingMetadata,
+            captureMethod: captureMethod
+        )
+
         let outcome = await poller.run(clientTransactionID: clientTransactionID)
+        self.trackRewardOutcome(
+            outcome,
+            clientTransactionID: clientTransactionID,
+            trackingMetadata: trackingMetadata,
+            captureMethod: captureMethod
+        )
+
         let result = await self.rewardVerificationResult(for: outcome, clientTransactionID: clientTransactionID)
         Logger.info(AdsStrings.reward_verification_completed(
             result: result,
             transactionID: clientTransactionID
         ))
         return result
+    }
+
+    /// Tracks the "earned, not yet verified" moment.
+    private func trackRewardEarnedUnverified(
+        clientTransactionID: String,
+        trackingMetadata: RewardedAdTrackingMetadata?,
+        captureMethod: AdEventCaptureMethod
+    ) {
+        guard let trackingMetadata else { return }
+        let data = AdRewardEarnedUnverified(
+            networkName: trackingMetadata.networkName,
+            mediatorName: trackingMetadata.mediatorName,
+            adFormat: trackingMetadata.adFormat,
+            placement: trackingMetadata.placement,
+            adUnitId: trackingMetadata.adUnitId,
+            impressionId: trackingMetadata.impressionId,
+            rewardVerificationEnabled: true,
+            rewardItem: nil,
+            rewardAmount: nil
+        )
+        self.trackRewardAdEvent(.rewardEarnedUnverified(.init(captureMethod: captureMethod), data))
+    }
+
+    /// Tracks the terminal verification outcome: one verified/failed-to-verify event, plus one granted
+    /// event per non-empty reward.
+    private func trackRewardOutcome(
+        _ outcome: RewardVerification.Outcome,
+        clientTransactionID: String,
+        trackingMetadata: RewardedAdTrackingMetadata?,
+        captureMethod: AdEventCaptureMethod
+    ) {
+        guard let trackingMetadata else { return }
+
+        switch outcome {
+        case let .verified(reward, moreRewards):
+            let verified = AdRewardVerified(
+                networkName: trackingMetadata.networkName,
+                mediatorName: trackingMetadata.mediatorName,
+                adFormat: trackingMetadata.adFormat,
+                placement: trackingMetadata.placement,
+                adUnitId: trackingMetadata.adUnitId,
+                impressionId: trackingMetadata.impressionId,
+                reward: reward
+            )
+            self.trackRewardAdEvent(.rewardVerified(.init(captureMethod: captureMethod), verified))
+
+            for grant in ([reward] + moreRewards) where grant != .noReward {
+                let granted = AdRewardGranted(
+                    networkName: trackingMetadata.networkName,
+                    mediatorName: trackingMetadata.mediatorName,
+                    adFormat: trackingMetadata.adFormat,
+                    placement: trackingMetadata.placement,
+                    adUnitId: trackingMetadata.adUnitId,
+                    impressionId: trackingMetadata.impressionId,
+                    reward: grant
+                )
+                self.trackRewardAdEvent(.rewardGranted(.init(captureMethod: captureMethod), granted))
+            }
+        case .failed(.cancelled):
+            break
+        case let .failed(reason):
+            let failed = AdRewardFailedToVerify(
+                networkName: trackingMetadata.networkName,
+                mediatorName: trackingMetadata.mediatorName,
+                adFormat: trackingMetadata.adFormat,
+                placement: trackingMetadata.placement,
+                adUnitId: trackingMetadata.adUnitId,
+                impressionId: trackingMetadata.impressionId,
+                failureReason: reason.trackingFailureReason
+            )
+            self.trackRewardAdEvent(.rewardFailedToVerify(.init(captureMethod: captureMethod), failed))
+        }
+    }
+
+    private func trackRewardAdEvent(_ event: AdEvent) {
+        guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) else { return }
+        Task {
+            await self.eventsManager?.track(adEvent: event)
+        }
     }
 
     /// Applies local side effects before building the result delivered to the caller.

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1891,8 +1891,7 @@ extension Purchases {
                 adFormat: trackingMetadata.adFormat,
                 placement: trackingMetadata.placement,
                 adUnitId: trackingMetadata.adUnitId,
-                impressionId: trackingMetadata.impressionId,
-                reward: reward
+                impressionId: trackingMetadata.impressionId
             )
             self.trackRewardAdEvent(.rewardVerified(.init(captureMethod: captureMethod), verified))
 
@@ -1908,8 +1907,6 @@ extension Purchases {
                 )
                 self.trackRewardAdEvent(.rewardGranted(.init(captureMethod: captureMethod), granted))
             }
-        case .failed(.cancelled):
-            break
         case let .failed(reason):
             let failed = AdRewardFailedToVerify(
                 networkName: trackingMetadata.networkName,

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1858,7 +1858,8 @@ extension Purchases {
         trackingMetadata: RewardedAdTrackingMetadata?,
         captureMethod: AdEventCaptureMethod
     ) {
-        guard let trackingMetadata else { return }
+        guard let trackingMetadata,
+              #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) else { return }
         let data = AdRewardEarnedUnverified(
             networkName: trackingMetadata.networkName,
             mediatorName: trackingMetadata.mediatorName,
@@ -1870,7 +1871,7 @@ extension Purchases {
             rewardItem: nil,
             rewardAmount: nil
         )
-        self.trackRewardAdEvent(.rewardEarnedUnverified(.init(captureMethod: captureMethod), data))
+        self.adTracker.trackAdRewardEarnedUnverified(data, captureMethod: captureMethod)
     }
 
     /// Tracks the terminal verification outcome: one verified/failed-to-verify event, plus one granted
@@ -1881,7 +1882,8 @@ extension Purchases {
         trackingMetadata: RewardedAdTrackingMetadata?,
         captureMethod: AdEventCaptureMethod
     ) {
-        guard let trackingMetadata else { return }
+        guard let trackingMetadata,
+              #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) else { return }
 
         switch outcome {
         case let .verified(reward, moreRewards):
@@ -1893,7 +1895,7 @@ extension Purchases {
                 adUnitId: trackingMetadata.adUnitId,
                 impressionId: trackingMetadata.impressionId
             )
-            self.trackRewardAdEvent(.rewardVerified(.init(captureMethod: captureMethod), verified))
+            self.adTracker.trackAdRewardVerified(verified, captureMethod: captureMethod)
 
             for grant in ([reward] + moreRewards) where grant != .noReward {
                 let granted = AdRewardGranted(
@@ -1905,7 +1907,7 @@ extension Purchases {
                     impressionId: trackingMetadata.impressionId,
                     reward: grant
                 )
-                self.trackRewardAdEvent(.rewardGranted(.init(captureMethod: captureMethod), granted))
+                self.adTracker.trackAdRewardGranted(granted, captureMethod: captureMethod)
             }
         case let .failed(reason):
             let failed = AdRewardFailedToVerify(
@@ -1917,14 +1919,7 @@ extension Purchases {
                 impressionId: trackingMetadata.impressionId,
                 failureReason: reason.trackingFailureReason
             )
-            self.trackRewardAdEvent(.rewardFailedToVerify(.init(captureMethod: captureMethod), failed))
-        }
-    }
-
-    private func trackRewardAdEvent(_ event: AdEvent) {
-        guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) else { return }
-        Task {
-            await self.eventsManager?.track(adEvent: event)
+            self.adTracker.trackAdRewardFailedToVerify(failed, captureMethod: captureMethod)
         }
     }
 

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/PurchasesAPI.swift
@@ -396,6 +396,17 @@ private func checkAsyncMethods(purchases: Purchases) async {
         )
 
         let _: RewardVerificationResult = await purchases.pollRewardVerification(clientTransactionID: "")
+        let _: RewardVerificationResult = await purchases.pollRewardVerification(
+            clientTransactionID: "",
+            trackingMetadata: RewardedAdTrackingMetadata(
+                networkName: nil,
+                mediatorName: .adMob,
+                adFormat: .rewarded,
+                placement: nil,
+                adUnitId: "",
+                impressionId: ""
+            )
+        )
     } catch {}
 }
 

--- a/Tests/UnitTests/Ads/Events/AdEventTests.swift
+++ b/Tests/UnitTests/Ads/Events/AdEventTests.swift
@@ -264,7 +264,7 @@ class AdEventTests: TestCase {
 
     // MARK: - AdRewardEarnedUnverified Equality
 
-    func testAdRewardEarnedUnverifiedEqualityWithDifferentRewardAmount() {
+    func testAdRewardEarnedUnverifiedEqualityWithDifferentRewardVerificationEnabled() {
         let event1 = AdRewardEarnedUnverified(
             networkName: "AdMob",
             mediatorName: .adMob,
@@ -272,9 +272,7 @@ class AdEventTests: TestCase {
             placement: "home_screen",
             adUnitId: "ca-app-pub-123",
             impressionId: "impression-123",
-            rewardVerificationEnabled: true,
-            rewardItem: "coins",
-            rewardAmount: 10
+            rewardVerificationEnabled: true
         )
 
         let event2 = AdRewardEarnedUnverified(
@@ -284,9 +282,7 @@ class AdEventTests: TestCase {
             placement: "home_screen",
             adUnitId: "ca-app-pub-123",
             impressionId: "impression-123",
-            rewardVerificationEnabled: true,
-            rewardItem: "coins",
-            rewardAmount: 20
+            rewardVerificationEnabled: false
         )
 
         expect(event1) != event2
@@ -300,9 +296,7 @@ class AdEventTests: TestCase {
             placement: "home_screen",
             adUnitId: "ca-app-pub-123",
             impressionId: "impression-123",
-            rewardVerificationEnabled: true,
-            rewardItem: "coins",
-            rewardAmount: 10
+            rewardVerificationEnabled: true
         )
 
         let event2 = AdRewardEarnedUnverified(
@@ -312,30 +306,10 @@ class AdEventTests: TestCase {
             placement: "home_screen",
             adUnitId: "ca-app-pub-123",
             impressionId: "impression-123",
-            rewardVerificationEnabled: true,
-            rewardItem: "coins",
-            rewardAmount: 10
+            rewardVerificationEnabled: true
         )
 
         expect(event1) == event2
-    }
-
-    func testAdRewardEarnedUnverifiedAllowsNilRewardFields() {
-        let event = AdRewardEarnedUnverified(
-            networkName: nil,
-            mediatorName: .adMob,
-            adFormat: .rewardedInterstitial,
-            placement: nil,
-            adUnitId: "ca-app-pub-123",
-            impressionId: "",
-            rewardVerificationEnabled: false,
-            rewardItem: nil,
-            rewardAmount: nil as Int?
-        )
-
-        expect(event.rewardItem).to(beNil())
-        expect(event.rewardAmount).to(beNil())
-        expect(event.rewardVerificationEnabled) == false
     }
 
     // MARK: - AdRewardVerified Equality
@@ -456,9 +430,7 @@ class AdEventTests: TestCase {
             placement: "home_screen",
             adUnitId: "ca-app-pub-123",
             impressionId: "impression-123",
-            rewardVerificationEnabled: true,
-            rewardItem: "coins",
-            rewardAmount: 10
+            rewardVerificationEnabled: true
         )
 
         let data = try JSONEncoder.default.encode(original)

--- a/Tests/UnitTests/Ads/Events/AdEventsRequestTests.swift
+++ b/Tests/UnitTests/Ads/Events/AdEventsRequestTests.swift
@@ -409,9 +409,7 @@ private extension AdFeatureEventsRequestTests {
         placement: "home_screen",
         adUnitId: "ca-app-pub-123456789",
         impressionId: "impression-123",
-        rewardVerificationEnabled: true,
-        rewardItem: "coins",
-        rewardAmount: 10
+        rewardVerificationEnabled: true
     )
 
     static let rewardVerifiedData: AdRewardVerified = .init(

--- a/Tests/UnitTests/Ads/Events/PurchasesAdEventsTests.swift
+++ b/Tests/UnitTests/Ads/Events/PurchasesAdEventsTests.swift
@@ -185,9 +185,7 @@ class PurchasesAdEventsTests: BasePurchasesTests {
             placement: "home_screen",
             adUnitId: "ca-app-pub-123",
             impressionId: "impression-123",
-            rewardVerificationEnabled: true,
-            rewardItem: "coins",
-            rewardAmount: 10
+            rewardVerificationEnabled: true
         )
 
         self.purchases.adTracker.trackAdRewardEarnedUnverified(data, captureMethod: .adapter)
@@ -208,8 +206,6 @@ class PurchasesAdEventsTests: BasePurchasesTests {
         expect(eventData.adUnitId) == "ca-app-pub-123"
         expect(eventData.impressionId) == "impression-123"
         expect(eventData.rewardVerificationEnabled) == true
-        expect(eventData.rewardItem) == "coins"
-        expect(eventData.rewardAmount) == 10
     }
 
     func testTrackAdRewardVerifiedStoresEvent() async throws {

--- a/Tests/UnitTests/Ads/Events/__Snapshots__/AdEventsRequestTests/testRewardEarnedUnverifiedEvent.1.json
+++ b/Tests/UnitTests/Ads/Events/__Snapshots__/AdEventsRequestTests/testRewardEarnedUnverifiedEvent.1.json
@@ -9,8 +9,6 @@
   "mediator_name" : "AdMob",
   "network_name" : "AdMob",
   "placement" : "home_screen",
-  "reward_amount" : 10,
-  "reward_item" : "coins",
   "reward_verification_enabled" : true,
   "timestamp_ms" : 1694029328000,
   "type" : "rc_ads_ad_reward_sdk_earned",

--- a/Tests/UnitTests/Ads/RewardVerification/RewardVerificationOutcomeTests.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/RewardVerificationOutcomeTests.swift
@@ -74,4 +74,32 @@ final class RewardVerificationOutcomeTests: TestCase {
         XCTAssertEqual(moreRewards.count, 1)
         XCTAssertEqual(moreRewards.first?.entitlement, entitlement)
     }
+
+    // MARK: - trackingFailureReason
+
+    func testTrackingFailureReasonMapsBackendRejectedToBackendError() {
+        let reason = RewardVerification.FailureReason.backendRejected(reason: "no_access", message: "nope")
+        XCTAssertEqual(reason.trackingFailureReason, .backendError)
+    }
+
+    func testTrackingFailureReasonMapsExhaustedPendingToTimeout() {
+        XCTAssertEqual(RewardVerification.FailureReason.exhaustedPending.trackingFailureReason, .timeout)
+    }
+
+    func testTrackingFailureReasonMapsExhaustedTransientToNetworkError() {
+        XCTAssertEqual(RewardVerification.FailureReason.exhaustedTransient.trackingFailureReason, .networkError)
+    }
+
+    func testTrackingFailureReasonMapsTerminalErrorToNetworkError() {
+        let reason = RewardVerification.FailureReason.terminalError(error: "boom")
+        XCTAssertEqual(reason.trackingFailureReason, .networkError)
+    }
+
+    func testTrackingFailureReasonMapsUnexpectedResponseToUnknown() {
+        XCTAssertEqual(RewardVerification.FailureReason.unexpectedResponse.trackingFailureReason, .unknown)
+    }
+
+    func testTrackingFailureReasonMapsCancelledToUnknown() {
+        XCTAssertEqual(RewardVerification.FailureReason.cancelled.trackingFailureReason, .unknown)
+    }
 }

--- a/Tests/UnitTests/Ads/RewardVerification/RewardVerificationOutcomeTests.swift
+++ b/Tests/UnitTests/Ads/RewardVerification/RewardVerificationOutcomeTests.swift
@@ -77,9 +77,14 @@ final class RewardVerificationOutcomeTests: TestCase {
 
     // MARK: - trackingFailureReason
 
-    func testTrackingFailureReasonMapsBackendRejectedToBackendError() {
+    func testTrackingFailureReasonCarriesTheBackendReasonCode() {
         let reason = RewardVerification.FailureReason.backendRejected(reason: "no_access", message: "nope")
-        XCTAssertEqual(reason.trackingFailureReason, .backendError)
+        XCTAssertEqual(reason.trackingFailureReason, .backendError(reason: "no_access"))
+    }
+
+    func testTrackingFailureReasonMapsBackendRejectedWithoutReasonToBackendError() {
+        let reason = RewardVerification.FailureReason.backendRejected(reason: nil, message: "nope")
+        XCTAssertEqual(reason.trackingFailureReason, .backendError(reason: nil))
     }
 
     func testTrackingFailureReasonMapsExhaustedPendingToTimeout() {
@@ -99,7 +104,7 @@ final class RewardVerificationOutcomeTests: TestCase {
         XCTAssertEqual(RewardVerification.FailureReason.unexpectedResponse.trackingFailureReason, .unknown)
     }
 
-    func testTrackingFailureReasonMapsCancelledToUnknown() {
-        XCTAssertEqual(RewardVerification.FailureReason.cancelled.trackingFailureReason, .unknown)
+    func testTrackingFailureReasonMapsCancelledToCancelled() {
+        XCTAssertEqual(RewardVerification.FailureReason.cancelled.trackingFailureReason, .cancelled)
     }
 }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesRewardVerificationTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesRewardVerificationTests.swift
@@ -297,6 +297,7 @@ extension PurchasesRewardVerificationTests {
     }
 
     func testPollRewardVerificationWithNilTrackingMetadataTracksNothing() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
         let reward = try XCTUnwrap(VirtualCurrencyReward(code: "coins", amount: 3))
         let poller = self.makeStubPoller(statuses: [.verified(.virtualCurrency(reward))])
 
@@ -332,6 +333,7 @@ extension PurchasesRewardVerificationTests {
     }
 
     func testPollRewardVerificationTracksVerifiedAndGrantedEventsOnVirtualCurrencyReward() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
         let reward = try XCTUnwrap(VirtualCurrencyReward(code: "coins", amount: 3))
         let poller = self.makeStubPoller(statuses: [.verified(.virtualCurrency(reward))])
 
@@ -355,6 +357,7 @@ extension PurchasesRewardVerificationTests {
     }
 
     func testPollRewardVerificationDoesNotTrackGrantedEventOnNoReward() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
         let poller = self.makeStubPoller(statuses: [.verified(.noReward)])
 
         _ = await self.purchases.pollRewardVerification(
@@ -370,6 +373,7 @@ extension PurchasesRewardVerificationTests {
     }
 
     func testPollRewardVerificationTracksOneGrantedEventPerRewardOnMultiGrant() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
         let virtualCurrency = try XCTUnwrap(VirtualCurrencyReward(code: "coins", amount: 5))
         let entitlement = try XCTUnwrap(EntitlementReward(identifier: "pro", expiresAt: Date()))
         let poller = self.makeStubPoller(statuses: [
@@ -396,6 +400,7 @@ extension PurchasesRewardVerificationTests {
     }
 
     func testPollRewardVerificationTracksFailedToVerifyEvent() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
         let poller = self.makeStubPoller(statuses: [.failed(reason: "no_reward_rule", message: "nope")])
 
         _ = await self.purchases.pollRewardVerification(
@@ -414,6 +419,7 @@ extension PurchasesRewardVerificationTests {
     }
 
     func testPollRewardVerificationTracksCancellation() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
         let poller = self.makeStubPoller(statuses: [.pending, .verified(.noReward)])
 
         let task = Task {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesRewardVerificationTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesRewardVerificationTests.swift
@@ -390,7 +390,9 @@ extension PurchasesRewardVerificationTests {
             return data
         }
         expect(grantedEvents.count) == 2
-        expect(grantedEvents.map(\.reward)) == [.virtualCurrency(virtualCurrency), .entitlement(entitlement)]
+        let grantedRewards = grantedEvents.map(\.reward)
+        expect(grantedRewards).to(contain(.virtualCurrency(virtualCurrency)))
+        expect(grantedRewards).to(contain(.entitlement(entitlement)))
     }
 
     func testPollRewardVerificationTracksFailedToVerifyEvent() async throws {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesRewardVerificationTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesRewardVerificationTests.swift
@@ -344,10 +344,9 @@ extension PurchasesRewardVerificationTests {
         await expect { try await self.mockEventsManager.trackedAdEvents }.toEventually(haveCount(3))
 
         let trackedEvents = try await self.mockEventsManager.trackedAdEvents // earned, verified, granted
-        guard case let .rewardVerified(_, verifiedData) = trackedEvents[1] else {
+        guard case .rewardVerified = trackedEvents[1] else {
             return fail("Expected AdEvent.rewardVerified but got \(trackedEvents[1])")
         }
-        expect(verifiedData.reward.virtualCurrency?.code) == "coins"
 
         guard case let .rewardGranted(_, grantedData) = trackedEvents[2] else {
             return fail("Expected AdEvent.rewardGranted but got \(trackedEvents[2])")
@@ -409,7 +408,29 @@ extension PurchasesRewardVerificationTests {
         guard case let .rewardFailedToVerify(_, failedData) = trackedEvents[1] else {
             return fail("Expected AdEvent.rewardFailedToVerify but got \(trackedEvents[1])")
         }
-        expect(failedData.failureReason) == .backendError
+        expect(failedData.failureReason) == .backendError(reason: "no_reward_rule")
+    }
+
+    func testPollRewardVerificationTracksCancellation() async throws {
+        let poller = self.makeStubPoller(statuses: [.pending, .verified(.noReward)])
+
+        let task = Task {
+            await self.purchases.pollRewardVerification(
+                clientTransactionID: "tx-1",
+                trackingMetadata: self.makeTrackingMetadata(),
+                poller: poller
+            )
+        }
+        task.cancel()
+        _ = await task.value
+
+        await expect { try await self.mockEventsManager.trackedAdEvents }.toEventually(haveCount(2))
+
+        let trackedEvents = try await self.mockEventsManager.trackedAdEvents // earned, failed-to-verify
+        guard case let .rewardFailedToVerify(_, failedData) = trackedEvents[1] else {
+            return fail("Expected AdEvent.rewardFailedToVerify but got \(trackedEvents[1])")
+        }
+        expect(failedData.failureReason) == .cancelled
     }
 
 }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesRewardVerificationTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesRewardVerificationTests.swift
@@ -280,6 +280,140 @@ extension PurchasesRewardVerificationTests {
 
 }
 
+// MARK: - pollRewardVerification tracking
+
+@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+extension PurchasesRewardVerificationTests {
+
+    private func makeTrackingMetadata() -> RewardedAdTrackingMetadata {
+        .init(
+            networkName: "AdMob",
+            mediatorName: .adMob,
+            adFormat: .rewarded,
+            placement: "home_screen",
+            adUnitId: "ca-app-pub-123",
+            impressionId: "impression-123"
+        )
+    }
+
+    func testPollRewardVerificationWithNilTrackingMetadataTracksNothing() async throws {
+        let reward = try XCTUnwrap(VirtualCurrencyReward(code: "coins", amount: 3))
+        let poller = self.makeStubPoller(statuses: [.verified(.virtualCurrency(reward))])
+
+        _ = await self.purchases.pollRewardVerification(clientTransactionID: "tx-1", poller: poller)
+
+        await expect { try await self.mockEventsManager.trackedAdEvents }.toEventually(beEmpty())
+    }
+
+    func testPollRewardVerificationTracksEarnedUnverifiedEvent() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        let reward = try XCTUnwrap(VirtualCurrencyReward(code: "coins", amount: 3))
+        let poller = self.makeStubPoller(statuses: [.verified(.virtualCurrency(reward))])
+
+        _ = await self.purchases.pollRewardVerification(
+            clientTransactionID: "tx-1",
+            trackingMetadata: self.makeTrackingMetadata(),
+            poller: poller
+        )
+
+        await expect { try await self.mockEventsManager.trackedAdEvents }.toEventually(haveCount(3))
+
+        let trackedEvents = try await self.mockEventsManager.trackedAdEvents // earned, verified, granted
+        guard case let .rewardEarnedUnverified(_, eventData) = trackedEvents.first else {
+            return fail("Expected AdEvent.rewardEarnedUnverified but got \(String(describing: trackedEvents.first))")
+        }
+        expect(eventData.networkName) == "AdMob"
+        expect(eventData.mediatorName) == .adMob
+        expect(eventData.adFormat) == .rewarded
+        expect(eventData.placement) == "home_screen"
+        expect(eventData.adUnitId) == "ca-app-pub-123"
+        expect(eventData.impressionId) == "impression-123"
+        expect(eventData.rewardVerificationEnabled) == true
+    }
+
+    func testPollRewardVerificationTracksVerifiedAndGrantedEventsOnVirtualCurrencyReward() async throws {
+        let reward = try XCTUnwrap(VirtualCurrencyReward(code: "coins", amount: 3))
+        let poller = self.makeStubPoller(statuses: [.verified(.virtualCurrency(reward))])
+
+        _ = await self.purchases.pollRewardVerification(
+            clientTransactionID: "tx-1",
+            trackingMetadata: self.makeTrackingMetadata(),
+            poller: poller
+        )
+
+        await expect { try await self.mockEventsManager.trackedAdEvents }.toEventually(haveCount(3))
+
+        let trackedEvents = try await self.mockEventsManager.trackedAdEvents // earned, verified, granted
+        guard case let .rewardVerified(_, verifiedData) = trackedEvents[1] else {
+            return fail("Expected AdEvent.rewardVerified but got \(trackedEvents[1])")
+        }
+        expect(verifiedData.reward.virtualCurrency?.code) == "coins"
+
+        guard case let .rewardGranted(_, grantedData) = trackedEvents[2] else {
+            return fail("Expected AdEvent.rewardGranted but got \(trackedEvents[2])")
+        }
+        expect(grantedData.reward.virtualCurrency?.code) == "coins"
+    }
+
+    func testPollRewardVerificationDoesNotTrackGrantedEventOnNoReward() async throws {
+        let poller = self.makeStubPoller(statuses: [.verified(.noReward)])
+
+        _ = await self.purchases.pollRewardVerification(
+            clientTransactionID: "tx-1",
+            trackingMetadata: self.makeTrackingMetadata(),
+            poller: poller
+        )
+
+        await expect { try await self.mockEventsManager.trackedAdEvents }.toEventually(haveCount(2))
+
+        let trackedEvents = try await self.mockEventsManager.trackedAdEvents // earned, verified — no granted
+        expect(trackedEvents.contains { if case .rewardGranted = $0 { return true }; return false }) == false
+    }
+
+    func testPollRewardVerificationTracksOneGrantedEventPerRewardOnMultiGrant() async throws {
+        let virtualCurrency = try XCTUnwrap(VirtualCurrencyReward(code: "coins", amount: 5))
+        let entitlement = try XCTUnwrap(EntitlementReward(identifier: "pro", expiresAt: Date()))
+        let poller = self.makeStubPoller(statuses: [
+            .verified(reward: .virtualCurrency(virtualCurrency), moreRewards: [.entitlement(entitlement)])
+        ])
+
+        _ = await self.purchases.pollRewardVerification(
+            clientTransactionID: "tx-1",
+            trackingMetadata: self.makeTrackingMetadata(),
+            poller: poller
+        )
+
+        await expect { try await self.mockEventsManager.trackedAdEvents }.toEventually(haveCount(4))
+
+        let trackedEvents = try await self.mockEventsManager.trackedAdEvents
+        let grantedEvents = trackedEvents.compactMap { event -> AdRewardGranted? in
+            guard case let .rewardGranted(_, data) = event else { return nil }
+            return data
+        }
+        expect(grantedEvents.count) == 2
+        expect(grantedEvents.map(\.reward)) == [.virtualCurrency(virtualCurrency), .entitlement(entitlement)]
+    }
+
+    func testPollRewardVerificationTracksFailedToVerifyEvent() async throws {
+        let poller = self.makeStubPoller(statuses: [.failed(reason: "no_reward_rule", message: "nope")])
+
+        _ = await self.purchases.pollRewardVerification(
+            clientTransactionID: "tx-1",
+            trackingMetadata: self.makeTrackingMetadata(),
+            poller: poller
+        )
+
+        await expect { try await self.mockEventsManager.trackedAdEvents }.toEventually(haveCount(2))
+
+        let trackedEvents = try await self.mockEventsManager.trackedAdEvents // earned, failed-to-verify
+        guard case let .rewardFailedToVerify(_, failedData) = trackedEvents[1] else {
+            return fail("Expected AdEvent.rewardFailedToVerify but got \(trackedEvents[1])")
+        }
+        expect(failedData.failureReason) == .backendError
+    }
+
+}
+
 // MARK: - generateRewardVerificationToken
 
 extension PurchasesRewardVerificationTests {


### PR DESCRIPTION
## Description

This change actually adds tracking to the manual rewarded ads feature (not yet for the admob adapter - that will come in a separate PR).

Ad tracking carries a range of ad related properties. Since we do not have the ad at hand when we are doing manual ad reward handling, we created a `RewardedAdTrackingMetadata` struct to be the descriptor object. This can be passed to the polling function so it can track. 
This also implicitly drives rewarded ad tracking opt-in: unlike existing tracking, we do not require the user to directly call tracking, so this is the decision point (so it is optional).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public experimental API and ad event wire format (removed reward fields on unverified events); tracking is opt-in via metadata but affects analytics contracts for manual rewarded flows.
> 
> **Overview**
> Adds **optional automatic ad reward tracking** during manual `pollRewardVerification`, so integrators can pass ad context without calling tracking APIs themselves.
> 
> Introduces **`RewardedAdTrackingMetadata`** (network, mediator, format, placement, ad unit, impression) as an optional parameter on the public `pollRewardVerification` API. When provided, the SDK emits **earned-unverified** before polling, then **verified** / **granted** (per non-`noReward` grant) or **failed-to-verify** after the outcome. A **`@_spi(Internal)`** overload lets official adapters set **`captureMethod: .adapter`** instead of `.manual`.
> 
> **`AdRewardEarnedUnverified`** and the ad events request payload **drop `rewardItem` and `rewardAmount`**; unverified events only carry `rewardVerificationEnabled`. **`RewardVerification.FailureReason`** gains **`trackingFailureReason`** mapping to **`AdRewardFailureReason`** for failed-to-verify events.
> 
> Tests and API snapshots are updated; new coverage exercises nil metadata (no events), multi-grant, cancellation, and failure mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3a939e4c20ed1b2e4620853bb3966dd114f7092. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->