### PR TITLE
feat(ads): admob adapter support for reward tracking

### DIFF
--- a/AdapterSDKs/RevenueCatAdMob/Examples/AdMobIntegrationSample/Sources/AdManagers/VerifiedRewardedAdManager.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Examples/AdMobIntegrationSample/Sources/AdManagers/VerifiedRewardedAdManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import GoogleMobileAds
+@_spi(Experimental) import RevenueCat
 @_spi(Experimental) import RevenueCatAdMob
 
 final class VerifiedRewardedAdManager: NSObject, ObservableObject {

--- a/AdapterSDKs/RevenueCatAdMob/Examples/AdMobIntegrationSample/Sources/AdManagers/VerifiedRewardedInterstitialAdManager.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Examples/AdMobIntegrationSample/Sources/AdManagers/VerifiedRewardedInterstitialAdManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import GoogleMobileAds
+@_spi(Experimental) import RevenueCat
 @_spi(Experimental) import RevenueCatAdMob
 
 final class VerifiedRewardedInterstitialAdManager: NSObject, ObservableObject {

--- a/AdapterSDKs/RevenueCatAdMob/Examples/AdMobIntegrationSample/Sources/Support/Messages.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Examples/AdMobIntegrationSample/Sources/Support/Messages.swift
@@ -29,6 +29,10 @@ struct Message: Equatable {
     ✅ Verified
     ⚠️ Unsupported reward
     """
+    private static let verificationEntitlementGrantedTemplate = """
+    ✅ Verified
+    🎁 Reward granted: entitlement %@
+    """
     private static let verificationUnhandledRewardTypeText = """
     ✅ Verified
     ⚠️ Unhandled reward type
@@ -75,6 +79,12 @@ struct Message: Equatable {
                     "\(virtualCurrency.amount)",
                     virtualCurrency.code
                 ),
+                severity: .success,
+                isLoading: false
+            )
+        } else if let entitlement = reward.entitlement {
+            return .init(
+                text: String(format: Self.verificationEntitlementGrantedTemplate, entitlement.identifier),
                 severity: .success,
                 isLoading: false
             )

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardedAds+RewardVerification.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/RewardVerification/RewardedAds+RewardVerification.swift
@@ -163,13 +163,15 @@ internal extension RewardVerification.CapableAd {
     /// reward-verification result through the one-shot guard on the main actor.
     ///
     /// - Parameter pollRewardVerification: For unit tests; pass `nil` in production to use
-    ///   `Purchases.shared.pollRewardVerification(clientTransactionID:)`. Virtual-currency cache
-    ///   invalidation happens inside the core call.
+    ///   `Purchases.shared.pollRewardVerification(clientTransactionID:trackingMetadata:captureMethod:)`.
+    ///   Virtual-currency cache invalidation happens inside the core call.
     @MainActor
     func createUserDidEarnRewardHandler(
         rewardVerificationStarted: (@MainActor () -> Void)?,
         rewardVerificationCompleted: (@MainActor (RewardVerificationResult) -> Void)?,
-        pollRewardVerification: (@Sendable (String) async -> RewardVerificationResult)? = nil
+        pollRewardVerification: (
+            @Sendable (String, RewardedAdTrackingMetadata?) async -> RewardVerificationResult
+        )? = nil
     ) -> (() -> Void) {
         let state = RewardVerification.Setup.verificationState(for: self)
 
@@ -193,14 +195,24 @@ internal extension RewardVerification.CapableAd {
                 return
             }
 
-            let poll = pollRewardVerification ?? { clientTransactionID in
-                await Purchases.shared.pollRewardVerification(clientTransactionID: clientTransactionID)
+            let trackingMetadata = Tracking.Adapter.shared.fullScreenDelegateStore
+                .retrieve(for: self)?
+                .rewardTrackingMetadata()
+
+            let poll = pollRewardVerification ?? { clientTransactionID, trackingMetadata in
+                await Purchases.shared.pollRewardVerification(
+                    clientTransactionID: clientTransactionID,
+                    trackingMetadata: trackingMetadata,
+                    captureMethod: .adapter
+                )
             }
 
             RewardVerification.Dispatcher.dispatch(
                 clientTransactionID: state.clientTransactionID,
                 state: state,
-                pollRewardVerification: poll,
+                pollRewardVerification: { clientTransactionID in
+                    await poll(clientTransactionID, trackingMetadata)
+                },
                 resultHandler: { result in rewardVerificationCompleted(result) }
             )
         }

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/Tracking/Adapter.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/Tracking/Adapter.swift
@@ -224,7 +224,7 @@ internal extension Tracking {
 
         // MARK: - Helpers
 
-        private static func networkName(from responseInfo: GoogleMobileAds.ResponseInfo?) -> String {
+        static func networkName(from responseInfo: GoogleMobileAds.ResponseInfo?) -> String {
             responseInfo?.loadedAdNetworkResponseInfo?.adNetworkClassName ?? self.fallbackValue
         }
 

--- a/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/Tracking/FullScreenContentDelegate.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Sources/RevenueCatAdMob/Tracking/FullScreenContentDelegate.swift
@@ -41,6 +41,18 @@ internal extension Tracking {
             self.responseInfoProvider = responseInfoProvider
         }
 
+        func rewardTrackingMetadata() -> RewardedAdTrackingMetadata {
+            let responseInfo = self.responseInfoProvider()
+            return RewardedAdTrackingMetadata(
+                networkName: Tracking.Adapter.networkName(from: responseInfo),
+                mediatorName: .adMob,
+                adFormat: self.adFormat,
+                placement: self.placement,
+                adUnitId: self.adUnitID,
+                impressionId: Tracking.Adapter.impressionID(from: responseInfo)
+            )
+        }
+
         func adDidRecordImpression(_ presentingAd: any GoogleMobileAds.FullScreenPresentingAd) {
             let responseInfo = self.responseInfoProvider()
             self.adapter.trackDisplayed(

--- a/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentRewardVerificationTests.swift
+++ b/AdapterSDKs/RevenueCatAdMob/Tests/RevenueCatAdMobTests/PresentRewardVerificationTests.swift
@@ -40,7 +40,7 @@ final class PresentRewardVerificationTests: AdapterTestCase {
                 receivedResult = result
                 expectation.fulfill()
             },
-            pollRewardVerification: { _ in .verified(.unsupportedReward) }
+            pollRewardVerification: { _, _ in .verified(.unsupportedReward) }
         )
 
         handler()
@@ -62,7 +62,7 @@ final class PresentRewardVerificationTests: AdapterTestCase {
                 receivedResult = result
                 expectation.fulfill()
             },
-            pollRewardVerification: { _ in .failed }
+            pollRewardVerification: { _, _ in .failed }
         )
 
         handler()
@@ -84,12 +84,45 @@ final class PresentRewardVerificationTests: AdapterTestCase {
                 events.append("result")
                 expectation.fulfill()
             },
-            pollRewardVerification: { _ in .verified(.noReward) }
+            pollRewardVerification: { _, _ in .verified(.noReward) }
         )
 
         handler()
         self.wait(for: [expectation], timeout: 2.0)
         XCTAssertEqual(events, ["started", "result"])
+    }
+
+    func testCreateUserDidEarnRewardHandlerPassesNoTrackingMetadataWhenAdWasNotTracked() throws {
+        let fakeAd = FakeCapableAd()
+        RewardVerification.Setup.install(on: fakeAd, token: Self.testToken)
+
+        let metadata = try self.pollTrackingMetadata(for: fakeAd)
+        XCTAssertNil(metadata)
+    }
+
+    func testCreateUserDidEarnRewardHandlerPassesTrackingMetadataFromTheTrackingDelegate() throws {
+        let fakeAd = FakeCapableAd()
+        RewardVerification.Setup.install(on: fakeAd, token: Self.testToken)
+        self.installTrackingDelegate(on: fakeAd, placement: "load_time_placement")
+
+        let metadata = try XCTUnwrap(self.pollTrackingMetadata(for: fakeAd))
+        XCTAssertEqual(metadata.mediatorName, .adMob)
+        XCTAssertEqual(metadata.adFormat, .rewarded)
+        XCTAssertEqual(metadata.placement, "load_time_placement")
+        XCTAssertEqual(metadata.adUnitId, "ad_unit_id")
+        XCTAssertEqual(metadata.impressionId, "response_id")
+        XCTAssertEqual(metadata.networkName, "")
+    }
+
+    func testCreateUserDidEarnRewardHandlerPassesTrackingMetadataWithTheShowTimePlacement() throws {
+        let fakeAd = FakeCapableAd()
+        RewardVerification.Setup.install(on: fakeAd, token: Self.testToken)
+        self.installTrackingDelegate(on: fakeAd, placement: "load_time_placement")
+
+        Tracking.setShowTimePlacement("show_time_placement", on: fakeAd)
+
+        let metadata = try XCTUnwrap(self.pollTrackingMetadata(for: fakeAd))
+        XCTAssertEqual(metadata.placement, "show_time_placement")
     }
 
     func testCreateUserDidEarnRewardHandlerAssertsWhenResultCallbackProvidedWithoutVerificationState() {
@@ -102,6 +135,38 @@ final class PresentRewardVerificationTests: AdapterTestCase {
             )
         }.to(throwAssertion())
     }
+
+    // MARK: - Helpers
+
+    private func installTrackingDelegate(on fakeAd: FakeCapableAd, placement: String?) {
+        let trackingDelegate = Tracking.FullScreenContentDelegate(
+            delegate: nil,
+            placement: placement,
+            adUnitID: "ad_unit_id",
+            adFormat: .rewarded,
+            responseInfoProvider: { fakeAd.responseInfo }
+        )
+        Tracking.Adapter.shared.fullScreenDelegateStore.set(trackingDelegate, for: fakeAd)
+    }
+
+    /// Runs the reward handler and returns the tracking metadata the adapter handed to the poll call.
+    private func pollTrackingMetadata(for fakeAd: FakeCapableAd) throws -> RewardedAdTrackingMetadata? {
+        let expectation = self.expectation(description: "poll called")
+        let received = Box<RewardedAdTrackingMetadata?>(nil)
+        let handler = fakeAd.createUserDidEarnRewardHandler(
+            rewardVerificationStarted: nil,
+            rewardVerificationCompleted: { _ in },
+            pollRewardVerification: { _, trackingMetadata in
+                received.value = trackingMetadata
+                expectation.fulfill()
+                return .verified(.noReward)
+            }
+        )
+
+        handler()
+        self.wait(for: [expectation], timeout: 2.0)
+        return received.value
+    }
 }
 
 // MARK: - Test doubles
@@ -109,7 +174,31 @@ final class PresentRewardVerificationTests: AdapterTestCase {
 @available(iOS 15.0, *)
 private final class FakeCapableAd: RewardVerification.CapableAd {
     var serverSideVerificationOptions: GoogleMobileAds.ServerSideVerificationOptions?
-    let responseInfo = GoogleMobileAds.ResponseInfo()
+    let responseInfo: GoogleMobileAds.ResponseInfo = unsafeBitCast(
+        FakeResponseInfo(),
+        to: GoogleMobileAds.ResponseInfo.self
+    )
+}
+
+@available(iOS 15.0, *)
+private final class FakeResponseInfo: NSObject {
+    @objc var responseIdentifier: String? { "response_id" }
+    @objc var loadedAdNetworkResponseInfo: AnyObject? { nil }
+}
+
+/// Minimal box so the poll closure can hand its argument back to the test body.
+private final class Box<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: Value
+
+    init(_ value: Value) {
+        self.storage = value
+    }
+
+    var value: Value {
+        get { self.lock.withLock { self.storage } }
+        set { self.lock.withLock { self.storage = newValue } }
+    }
 }
 
 #endif


### PR DESCRIPTION
## Description

This change wires up the ad reward tracking with the admob adapter, so tracking is enabled automatically for adapter users.

It constructs the `RewardedAdTrackingMetadata` automatically based on the ad - and passes it to the polling, while marking the tracking source as `.adapter`. It is using the existing mechanism to look up ad data from the associated object store.

I had to open `networkName` helper to public so we can reuse the network name resolution.

Tested with the sample rewarded app, and also had to fix an import there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the reward-verification polling path and analytics metadata for adapter users; scoped to the AdMob adapter but affects how rewarded ad events are attributed.
> 
> **Overview**
> **Reward verification** in the AdMob adapter now sends **reward tracking metadata** when polling RevenueCat, with **`captureMethod: .adapter`**, so adapter users get tracking without building metadata themselves.
> 
> On earn-reward, the handler reads the stored full-screen tracking delegate and builds **`RewardedAdTrackingMetadata`** (network, placement, ad unit, impression id, etc.) via a new **`rewardTrackingMetadata()`** on the delegate wrapper. Show-time placement overrides still apply. If the ad was never loaded through **`loadAndTrack`**, metadata is **`nil`**.
> 
> **`Tracking.Adapter.networkName`** is exposed for shared network-name resolution. The sample app adds the RevenueCat import and shows entitlement grants in verification messages. Tests cover metadata passing (missing delegate, load vs show placement).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 683c5562207c11a612a4eec4df888667efd7e697. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->