### PR TITLE
[PoC] Checkpoints APIs + demo app

### DIFF
--- a/Examples/CheckpointTester/CheckpointTester/Resources/Demo/hard_paywall.json
+++ b/Examples/CheckpointTester/CheckpointTester/Resources/Demo/hard_paywall.json
@@ -1,0 +1,49 @@
+{
+  "id": "hard_paywall",
+  "presentation": {
+    "dismissible": false
+  },
+  "pages": [
+    {
+      "components": [
+        {
+          "type": "image",
+          "system_name": "lock.shield.fill"
+        },
+        {
+          "type": "title",
+          "text": "Unlock to continue"
+        },
+        {
+          "type": "body",
+          "text": "This hard paywall cannot be swiped away. Choose an outcome below."
+        },
+        {
+          "type": "feature",
+          "text": "Unlimited checkpoint experiments"
+        },
+        {
+          "type": "feature",
+          "text": "Advanced targeting insights"
+        }
+      ],
+      "actions": [
+        {
+          "title": "Purchased",
+          "type": "purchase",
+          "style": "primary"
+        },
+        {
+          "title": "Restored",
+          "type": "restore",
+          "style": "secondary"
+        },
+        {
+          "title": "Simulate error",
+          "type": "error",
+          "style": "destructive"
+        }
+      ]
+    }
+  ]
+}

--- a/Examples/CheckpointTester/CheckpointTester/Resources/Demo/onboarding.json
+++ b/Examples/CheckpointTester/CheckpointTester/Resources/Demo/onboarding.json
@@ -1,0 +1,87 @@
+{
+  "id": "onboarding",
+  "presentation": {
+    "dismissible": true
+  },
+  "pages": [
+    {
+      "components": [
+        {
+          "type": "image",
+          "system_name": "hand.wave.fill"
+        },
+        {
+          "type": "title",
+          "text": "Welcome"
+        },
+        {
+          "type": "body",
+          "text": "This checkpoint loaded a multi-step onboarding workflow from JSON."
+        }
+      ],
+      "actions": [
+        {
+          "title": "Continue",
+          "type": "next",
+          "style": "primary"
+        }
+      ]
+    },
+    {
+      "components": [
+        {
+          "type": "image",
+          "system_name": "slider.horizontal.3"
+        },
+        {
+          "type": "title",
+          "text": "Personalize"
+        },
+        {
+          "type": "body",
+          "text": "A real workflow could collect preferences and customize the next experience."
+        }
+      ],
+      "actions": [
+        {
+          "title": "Back",
+          "type": "previous",
+          "style": "secondary"
+        },
+        {
+          "title": "Continue",
+          "type": "next",
+          "style": "primary"
+        }
+      ]
+    },
+    {
+      "components": [
+        {
+          "type": "image",
+          "system_name": "checkmark.seal.fill"
+        },
+        {
+          "type": "title",
+          "text": "You're ready"
+        },
+        {
+          "type": "body",
+          "text": "The current UI result has no onboarding-completed case, so this PoC reports Dismissed."
+        }
+      ],
+      "actions": [
+        {
+          "title": "Back",
+          "type": "previous",
+          "style": "secondary"
+        },
+        {
+          "title": "Finish onboarding",
+          "type": "complete",
+          "style": "primary"
+        }
+      ]
+    }
+  ]
+}

--- a/Examples/CheckpointTester/CheckpointTester/Resources/Demo/result_picker.json
+++ b/Examples/CheckpointTester/CheckpointTester/Resources/Demo/result_picker.json
@@ -1,0 +1,46 @@
+{
+  "id": "result_picker",
+  "presentation": {
+    "dismissible": true
+  },
+  "pages": [
+    {
+      "components": [
+        {
+          "type": "image",
+          "system_name": "point.3.connected.trianglepath.dotted"
+        },
+        {
+          "type": "title",
+          "text": "Mock checkpoint UI"
+        },
+        {
+          "type": "body",
+          "text": "Choose the terminal result reported to the checkpoint listener."
+        }
+      ],
+      "actions": [
+        {
+          "title": "Purchased",
+          "type": "purchase",
+          "style": "primary"
+        },
+        {
+          "title": "Restored",
+          "type": "restore",
+          "style": "secondary"
+        },
+        {
+          "title": "Dismissed",
+          "type": "dismiss",
+          "style": "secondary"
+        },
+        {
+          "title": "Simulate error",
+          "type": "error",
+          "style": "destructive"
+        }
+      ]
+    }
+  ]
+}

--- a/Examples/CheckpointTester/CheckpointTester/Resources/Demo/soft_paywall.json
+++ b/Examples/CheckpointTester/CheckpointTester/Resources/Demo/soft_paywall.json
@@ -1,0 +1,53 @@
+{
+  "id": "soft_paywall",
+  "presentation": {
+    "dismissible": true
+  },
+  "pages": [
+    {
+      "components": [
+        {
+          "type": "image",
+          "system_name": "wand.and.stars"
+        },
+        {
+          "type": "title",
+          "text": "Try Cat Pro"
+        },
+        {
+          "type": "body",
+          "text": "This soft paywall can be dismissed and the app continues normally."
+        },
+        {
+          "type": "feature",
+          "text": "Unlimited checkpoint experiments"
+        },
+        {
+          "type": "feature",
+          "text": "Advanced targeting insights"
+        },
+        {
+          "type": "feature",
+          "text": "Priority support for every cat"
+        }
+      ],
+      "actions": [
+        {
+          "title": "Purchased",
+          "type": "purchase",
+          "style": "primary"
+        },
+        {
+          "title": "Restored",
+          "type": "restore",
+          "style": "secondary"
+        },
+        {
+          "title": "Not now",
+          "type": "dismiss",
+          "style": "secondary"
+        }
+      ]
+    }
+  ]
+}

--- a/Examples/CheckpointTester/CheckpointTester/Sources/CheckpointTesterApp.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/CheckpointTesterApp.swift
@@ -44,6 +44,9 @@ struct CheckpointTesterApp: App {
 
     // MARK: - New checkpoint public API implementation
 
+    // This section is the app-side setup for the new public API. Everything below the
+    // `setCheckpointWorkflowData` call is demo infrastructure that stands in for workflows
+    // the SDK will fetch from RevenueCat's server in production.
     private static func configurePurchases(analyticsTracker: GlobalCheckpointAnalyticsTracker) {
         guard let apiKey = Bundle.main.object(forInfoDictionaryKey: "REVENUECAT_API_KEY") as? String,
               apiKey.hasPrefix("appl_"),
@@ -55,6 +58,9 @@ struct CheckpointTesterApp: App {
             ? Purchases.shared
             : Purchases.configure(withAPIKey: apiKey)
         purchases.checkpointListener = analyticsTracker
+
+        // Demo-only: production SDKs fetch these workflow documents from RevenueCat's server.
+        purchases.setCheckpointWorkflowData(DemoWorkflowLoader.loadBundledWorkflowData())
     }
 
 }

--- a/Examples/CheckpointTester/CheckpointTester/Sources/Demo/DemoWorkflowLoader.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/Demo/DemoWorkflowLoader.swift
@@ -1,3 +1,17 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  DemoWorkflowLoader.swift
+//
+//  Created by Rick van der Linden.
+//
+
 import Foundation
 
 /// Demo-only workflow loading. Production workflows are fetched from RevenueCat's server.

--- a/Examples/CheckpointTester/CheckpointTester/Sources/Demo/DemoWorkflowLoader.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/Demo/DemoWorkflowLoader.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Demo-only workflow loading. Production workflows are fetched from RevenueCat's server.
+enum DemoWorkflowLoader {
+
+    private static let workflowIdentifiers = [
+        "result_picker",
+        "soft_paywall",
+        "hard_paywall",
+        "onboarding"
+    ]
+
+    static func loadBundledWorkflowData() -> [String: Data] {
+        return Dictionary(
+            uniqueKeysWithValues: Self.workflowIdentifiers.compactMap { identifier in
+                guard let url = Bundle.main.url(forResource: identifier, withExtension: "json"),
+                      let data = try? Data(contentsOf: url) else {
+                    return nil
+                }
+                return (identifier, data)
+            }
+        )
+    }
+
+}

--- a/Examples/CheckpointTester/CheckpointTester/Sources/Demo/README.md
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/Demo/README.md
@@ -1,0 +1,4 @@
+# Demo workflow support
+
+This directory contains app-only support for loading the bundled JSON workflow fixtures. A
+production app does not bundle these files; the SDK fetches workflow data from RevenueCat.

--- a/Examples/CheckpointTester/Project.swift
+++ b/Examples/CheckpointTester/Project.swift
@@ -39,6 +39,7 @@ let project = Project(
                 ]
             ),
             sources: ["CheckpointTester/Sources/**/*.swift"],
+            resources: ["CheckpointTester/Resources/**/*.json"],
             dependencies: [
                 .revenueCat,
                 .revenueCatUI,

--- a/Examples/CheckpointTester/README.md
+++ b/Examples/CheckpointTester/README.md
@@ -2,12 +2,30 @@
 
 `CheckpointTester` is a Tuist-generated example for the experimental checkpoint APIs.
 
-This base app demonstrates the application-facing integration:
+It demonstrates the core checkpoint cases:
 
-- configuring `Purchases` and installing a global `CheckpointListener`;
-- calling a checkpoint with custom properties;
-- handling checkpoint result subclasses and paywall outcomes;
-- displaying call results and a live analytics event log.
+- a checkpoint that presents UI;
+- a checkpoint with no matching experience;
+- a simulated checkpoint error;
+- purchased, restored, dismissed, and error UI outcomes.
+
+It also includes soft paywall, hard paywall, and onboarding examples. Every presented
+experience is defined by a JSON document in `CheckpointTester/Resources` and rendered by
+the experimental server-driven workflow presenter in RevenueCatUI.
+
+At launch, the app reads the JSON files into a `[workflowID: Data]` dictionary and supplies it
+to the SDK using the temporary `setCheckpointWorkflowData` SPI. Each demo checkpoint identifier
+selects the workflow with the same identifier. Calls include `name: "Rick"` as an example custom
+property that could be used by targeting configuration from RevenueCat's backend. The core SDK
+passes the JSON unchanged to RevenueCatUI, where it is decoded and rendered.
+
+The deliberately small JSON schema supports:
+
+- dismissible and non-dismissible presentation;
+- multi-page workflows;
+- image, title, body, and feature components;
+- next, previous, purchase, restore, dismiss, complete, and error actions;
+- primary, secondary, and destructive button styles.
 
 Generate the project from the repository root:
 
@@ -15,5 +33,5 @@ Generate the project from the repository root:
 TUIST_RC_API_KEY=appl_your_key tuist generate CheckpointTester --no-open
 ```
 
-The app configures RevenueCat before showing its root screen, so generation requires a valid public
-iOS API key.
+The app configures RevenueCat before showing its root screen, so generation requires a valid
+public iOS API key.

--- a/RevenueCatUI/Checkpoints/CheckpointPresenterFactory.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointPresenterFactory.swift
@@ -19,7 +19,8 @@ enum CheckpointPresenterFactory {
 
     static func makePresenter() -> CheckpointEnginePresenter? {
         if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
-            return CheckpointWorkflowPresenter()
+            // PoC-only: render the bundled JSON registered by CheckpointTester.
+            return DemoCheckpointWorkflowPresenter()
         } else {
             return nil
         }

--- a/RevenueCatUI/Checkpoints/Demo/CheckpointWorkflow.swift
+++ b/RevenueCatUI/Checkpoints/Demo/CheckpointWorkflow.swift
@@ -1,0 +1,71 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CheckpointWorkflow.swift
+//
+//  Created by Rick van der Linden.
+//
+
+import Foundation
+
+struct CheckpointWorkflow: Decodable {
+
+    let id: String
+    let presentation: DemoWorkflowPresentation
+    let pages: [CheckpointWorkflowPage]
+
+}
+
+struct DemoWorkflowPresentation: Decodable {
+    let dismissible: Bool
+}
+
+struct CheckpointWorkflowPage: Decodable {
+    let components: [CheckpointWorkflowComponent]
+    let actions: [CheckpointWorkflowAction]
+}
+
+struct CheckpointWorkflowComponent: Decodable {
+
+    enum Kind: String, Decodable {
+        case image
+        case title
+        case body
+        case feature
+    }
+
+    let type: Kind
+    let text: String?
+    let systemName: String?
+
+}
+
+struct CheckpointWorkflowAction: Decodable {
+
+    enum Kind: String, Decodable {
+        case next
+        case previous
+        case purchase
+        case restore
+        case dismiss
+        case complete
+        case error
+    }
+
+    enum Style: String, Decodable {
+        case primary
+        case secondary
+        case destructive
+    }
+
+    let title: String
+    let type: Kind
+    let style: Style
+
+}

--- a/RevenueCatUI/Checkpoints/Demo/CheckpointWorkflowView.swift
+++ b/RevenueCatUI/Checkpoints/Demo/CheckpointWorkflowView.swift
@@ -1,0 +1,148 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CheckpointWorkflowView.swift
+//
+//  Created by Rick van der Linden.
+//
+
+import Foundation
+@_spi(Internal) import RevenueCat
+import SwiftUI
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct CheckpointWorkflowView: View {
+
+    let presentedWorkflow: DemoCheckpointWorkflowPresenter.PresentedWorkflow
+    let presenter: DemoCheckpointWorkflowPresenter
+
+    @State private var pageIndex = 0
+
+    var body: some View {
+        let workflow = self.presentedWorkflow.workflow
+        let page = workflow.pages[self.pageIndex]
+
+        ScrollView {
+            VStack(spacing: 18) {
+                Spacer(minLength: 24)
+
+                ForEach(Array(page.components.enumerated()), id: \.offset) { _, component in
+                    self.componentView(component)
+                }
+
+                if workflow.pages.count > 1 {
+                    SwiftUI.ProgressView(
+                        value: Double(self.pageIndex + 1),
+                        total: Double(workflow.pages.count)
+                    )
+                    .padding(.vertical, 8)
+                }
+
+                ForEach(Array(page.actions.enumerated()), id: \.offset) { _, action in
+                    self.actionButton(action, workflow: workflow)
+                }
+
+                Spacer(minLength: 24)
+            }
+            .frame(maxWidth: 560)
+            .padding(24)
+            .frame(maxWidth: .infinity)
+        }
+    }
+
+    @ViewBuilder
+    private func componentView(_ component: CheckpointWorkflowComponent) -> some View {
+        switch component.type {
+        case .image:
+            if let systemName = component.systemName {
+                Image(systemName: systemName)
+                    .font(.system(size: 58))
+                    .foregroundStyle(.tint)
+            }
+        case .title:
+            if let text = component.text {
+                Text(text)
+                    .font(.largeTitle.bold())
+                    .multilineTextAlignment(.center)
+            }
+        case .body:
+            if let text = component.text {
+                Text(text)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+        case .feature:
+            if let text = component.text {
+                Label(text, systemImage: component.systemName ?? "checkmark.circle.fill")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func actionButton(
+        _ action: CheckpointWorkflowAction,
+        workflow: CheckpointWorkflow
+    ) -> some View {
+        switch action.style {
+        case .primary:
+            self.button(action, workflow: workflow)
+                .buttonStyle(.borderedProminent)
+        case .secondary:
+            self.button(action, workflow: workflow)
+                .buttonStyle(.bordered)
+        case .destructive:
+            self.button(action, workflow: workflow)
+                .buttonStyle(.bordered)
+                .foregroundStyle(.red)
+        }
+    }
+
+    private func button(
+        _ action: CheckpointWorkflowAction,
+        workflow: CheckpointWorkflow
+    ) -> some View {
+        Button(action.title) {
+            self.perform(action, workflow: workflow)
+        }
+        .controlSize(.large)
+        .frame(maxWidth: .infinity)
+    }
+
+    private func perform(
+        _ action: CheckpointWorkflowAction,
+        workflow: CheckpointWorkflow
+    ) {
+        switch action.type {
+        case .next:
+            self.pageIndex = min(self.pageIndex + 1, workflow.pages.count - 1)
+        case .previous:
+            self.pageIndex = max(self.pageIndex - 1, 0)
+        case .purchase:
+            self.presenter.finishWithCustomerInfo(restored: false)
+        case .restore:
+            self.presenter.finishWithCustomerInfo(restored: true)
+        case .dismiss, .complete:
+            self.presenter.finish(with: .dismissed)
+        case .error:
+            self.presenter.finish(
+                with: .error(
+                    NSError(
+                        domain: "RevenueCatUI.CheckpointWorkflow",
+                        code: 1,
+                        userInfo: [
+                            NSLocalizedDescriptionKey: "Server-driven workflow simulated an error."
+                        ]
+                    )
+                )
+            )
+        }
+    }
+
+}

--- a/RevenueCatUI/Checkpoints/Demo/CheckpointWorkflowView.swift
+++ b/RevenueCatUI/Checkpoints/Demo/CheckpointWorkflowView.swift
@@ -129,11 +129,11 @@ struct CheckpointWorkflowView: View {
         case .restore:
             self.presenter.finishWithCustomerInfo(restored: true)
         case .dismiss, .complete:
-            self.presenter.finish(with: .dismissed)
+            self.presenter.finish(with: CheckpointPaywallDismissedOutcome.shared)
         case .error:
             self.presenter.finish(
-                with: .error(
-                    NSError(
+                with: CheckpointPaywallErrorOutcome(
+                    error: NSError(
                         domain: "RevenueCatUI.CheckpointWorkflow",
                         code: 1,
                         userInfo: [

--- a/RevenueCatUI/Checkpoints/Demo/DemoCheckpointWorkflowPresenter.swift
+++ b/RevenueCatUI/Checkpoints/Demo/DemoCheckpointWorkflowPresenter.swift
@@ -1,0 +1,242 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  DemoCheckpointWorkflowPresenter.swift
+//
+//  Created by Rick van der Linden.
+//
+
+import Foundation
+@_spi(Internal) import RevenueCat
+import SwiftUI
+
+#if canImport(UIKit) && !os(tvOS) && !os(watchOS)
+import UIKit
+#endif
+
+/// PoC-only renderer for the JSON workflows bundled with CheckpointTester.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@MainActor
+final class DemoCheckpointWorkflowPresenter: NSObject, CheckpointEnginePresenter {
+
+    struct PresentedWorkflow: Identifiable {
+        let id: String
+        let checkpoint: CheckpointEngineInfo
+        let workflow: CheckpointWorkflow
+        let delegate: CheckpointEnginePresenterDelegate
+    }
+
+    private var activeWorkflow: PresentedWorkflow?
+    private var isFinishing = false
+    private let presentationHandler: ((PresentedWorkflow) -> Bool)?
+
+    #if canImport(UIKit) && !os(tvOS) && !os(watchOS)
+    private weak var presentedViewController: UIViewController?
+    #endif
+
+    override init() {
+        self.presentationHandler = nil
+        super.init()
+    }
+
+    init(presentationHandler: @escaping (PresentedWorkflow) -> Bool) {
+        self.presentationHandler = presentationHandler
+        super.init()
+    }
+
+    func present(
+        callID: String,
+        presentation: CheckpointEnginePresentation,
+        delegate: CheckpointEnginePresenterDelegate
+    ) {
+        guard let presentation = presentation as? DemoCheckpointWorkflowPresentation else {
+            delegate.onCheckpointPaywallFinished(
+                callID: callID,
+                outcome: .error(WorkflowError.invalidPresentation as NSError)
+            )
+            return
+        }
+
+        do {
+            let decoder = JSONDecoder()
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            let workflow = try decoder.decode(CheckpointWorkflow.self, from: presentation.workflowData)
+            guard !workflow.pages.isEmpty else {
+                throw WorkflowError.emptyWorkflow
+            }
+
+            let presentedWorkflow = PresentedWorkflow(
+                id: callID,
+                checkpoint: presentation.checkpoint,
+                workflow: workflow,
+                delegate: delegate
+            )
+            self.activeWorkflow = presentedWorkflow
+
+            let didBeginPresentation = self.presentationHandler?(presentedWorkflow)
+                ?? self.presentAutomatically(presentedWorkflow)
+            guard didBeginPresentation else {
+                throw WorkflowError.noPresentationContext
+            }
+        } catch {
+            self.finish(with: .error(error as NSError), fallback: (callID, delegate))
+        }
+    }
+
+    func finish(with outcome: CheckpointEnginePaywallOutcome) {
+        self.finish(with: outcome, fallback: nil)
+    }
+
+    func finishWithCustomerInfo(restored: Bool) {
+        guard self.activeWorkflow != nil, !self.isFinishing else {
+            return
+        }
+        self.isFinishing = true
+
+        Task { @MainActor in
+            do {
+                let customerInfo = try await Purchases.shared.customerInfo()
+                if restored {
+                    self.finish(with: .restored(customerInfo))
+                } else {
+                    self.finish(with: .purchased(customerInfo))
+                }
+            } catch {
+                self.finish(with: .error(error as NSError))
+            }
+        }
+    }
+
+    func presentationDidDismiss() {
+        self.finish(with: .dismissed)
+    }
+
+    private func finish(
+        with outcome: CheckpointEnginePaywallOutcome,
+        fallback: (String, CheckpointEnginePresenterDelegate)?
+    ) {
+        let activeWorkflow = self.activeWorkflow
+        self.activeWorkflow = nil
+        self.isFinishing = false
+
+        #if canImport(UIKit) && !os(tvOS) && !os(watchOS)
+        let viewController = self.presentedViewController
+        self.presentedViewController = nil
+        if viewController?.presentingViewController != nil {
+            viewController?.dismiss(animated: true)
+        }
+        #endif
+
+        if let activeWorkflow {
+            activeWorkflow.delegate.onCheckpointPaywallFinished(
+                callID: activeWorkflow.id,
+                outcome: outcome
+            )
+        } else if let fallback {
+            fallback.1.onCheckpointPaywallFinished(callID: fallback.0, outcome: outcome)
+        }
+    }
+
+    private func presentAutomatically(_ presentedWorkflow: PresentedWorkflow) -> Bool {
+        #if canImport(UIKit) && !os(tvOS) && !os(watchOS)
+        guard let presentationContext = UIApplication.demoCheckpointPresentationViewController else {
+            return false
+        }
+
+        let rootView = CheckpointWorkflowView(
+            presentedWorkflow: presentedWorkflow,
+            presenter: self
+        )
+        .interactiveDismissDisabled(!presentedWorkflow.workflow.presentation.dismissible)
+        let viewController = UIHostingController(rootView: rootView)
+        self.presentedViewController = viewController
+        presentationContext.present(viewController, animated: true)
+        viewController.presentationController?.delegate = self
+        return true
+        #else
+        return false
+        #endif
+    }
+
+}
+
+private enum WorkflowError: LocalizedError {
+
+    case emptyWorkflow
+    case invalidPresentation
+    case noPresentationContext
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyWorkflow:
+            return "The checkpoint workflow contains no pages."
+        case .invalidPresentation:
+            return "The checkpoint did not resolve to a demo JSON workflow."
+        case .noPresentationContext:
+            return "Unable to locate a view controller for checkpoint presentation."
+        }
+    }
+
+}
+
+#if canImport(UIKit) && !os(tvOS) && !os(watchOS)
+
+@available(iOS 15.0, macOS 12.0, *)
+extension DemoCheckpointWorkflowPresenter: UIAdaptivePresentationControllerDelegate {
+
+    func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
+        return self.activeWorkflow?.workflow.presentation.dismissible == true
+    }
+
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        self.presentationDidDismiss()
+    }
+
+}
+
+private extension UIApplication {
+
+    static var demoCheckpointPresentationViewController: UIViewController? {
+        return self.extensionSafeApplication?
+            .connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .filter { $0.activationState == .foregroundActive }
+            .flatMap(\.windows)
+            .sorted { left, right in left.isKeyWindow && !right.isKeyWindow }
+            .compactMap(\.rootViewController)
+            .first?
+            .demoCheckpointTopMostViewController
+    }
+
+}
+
+private extension UIViewController {
+
+    var demoCheckpointTopMostViewController: UIViewController {
+        if let presentedViewController {
+            return presentedViewController.demoCheckpointTopMostViewController
+        }
+        if let navigationController = self as? UINavigationController {
+            return navigationController.visibleViewController?.demoCheckpointTopMostViewController
+                ?? navigationController
+        }
+        if let tabBarController = self as? UITabBarController {
+            return tabBarController.selectedViewController?.demoCheckpointTopMostViewController
+                ?? tabBarController
+        }
+        if let splitViewController = self as? UISplitViewController,
+           let lastViewController = splitViewController.viewControllers.last {
+            return lastViewController.demoCheckpointTopMostViewController
+        }
+        return self
+    }
+
+}
+
+#endif

--- a/RevenueCatUI/Checkpoints/Demo/DemoCheckpointWorkflowPresenter.swift
+++ b/RevenueCatUI/Checkpoints/Demo/DemoCheckpointWorkflowPresenter.swift
@@ -27,13 +27,13 @@ final class DemoCheckpointWorkflowPresenter: NSObject, CheckpointEnginePresenter
 
     struct PresentedWorkflow: Identifiable {
         let id: String
-        let checkpoint: CheckpointEngineInfo
+        let checkpoint: CheckpointInfo
         let workflow: CheckpointWorkflow
         let delegate: CheckpointEnginePresenterDelegate
     }
 
     private var activeWorkflow: PresentedWorkflow?
-    private var stagedOutcome: CheckpointEnginePaywallOutcome = .dismissed
+    private var stagedOutcome: CheckpointPaywallOutcome = CheckpointPaywallDismissedOutcome.shared
     private var isFinishing = false
     private let presentationHandler: ((PresentedWorkflow) -> Bool)?
 
@@ -59,7 +59,7 @@ final class DemoCheckpointWorkflowPresenter: NSObject, CheckpointEnginePresenter
         guard let presentation = presentation as? DemoCheckpointWorkflowPresentation else {
             delegate.onCheckpointPaywallFinished(
                 callID: callID,
-                outcome: .error(WorkflowError.invalidPresentation as NSError)
+                outcome: CheckpointPaywallErrorOutcome(error: WorkflowError.invalidPresentation as NSError)
             )
             return
         }
@@ -79,7 +79,7 @@ final class DemoCheckpointWorkflowPresenter: NSObject, CheckpointEnginePresenter
                 delegate: delegate
             )
             self.activeWorkflow = presentedWorkflow
-            self.stagedOutcome = .dismissed
+            self.stagedOutcome = CheckpointPaywallDismissedOutcome.shared
 
             let didBeginPresentation = self.presentationHandler?(presentedWorkflow)
                 ?? self.presentAutomatically(presentedWorkflow)
@@ -87,11 +87,14 @@ final class DemoCheckpointWorkflowPresenter: NSObject, CheckpointEnginePresenter
                 throw WorkflowError.noPresentationContext
             }
         } catch {
-            self.finish(with: .error(error as NSError), fallback: (callID, delegate))
+            self.finish(
+                with: CheckpointPaywallErrorOutcome(error: error as NSError),
+                fallback: (callID, delegate)
+            )
         }
     }
 
-    func finish(with outcome: CheckpointEnginePaywallOutcome) {
+    func finish(with outcome: CheckpointPaywallOutcome) {
         self.finish(with: outcome, fallback: nil)
     }
 
@@ -105,12 +108,12 @@ final class DemoCheckpointWorkflowPresenter: NSObject, CheckpointEnginePresenter
             do {
                 let customerInfo = try await Purchases.shared.customerInfo()
                 if restored {
-                    self.finish(with: .restored(customerInfo))
+                    self.finish(with: CheckpointPaywallRestoredOutcome(customerInfo: customerInfo))
                 } else {
-                    self.finish(with: .purchased(customerInfo))
+                    self.finish(with: CheckpointPaywallPurchasedOutcome(customerInfo: customerInfo))
                 }
             } catch {
-                self.finish(with: .error(error as NSError))
+                self.finish(with: CheckpointPaywallErrorOutcome(error: error as NSError))
             }
         }
     }
@@ -120,7 +123,7 @@ final class DemoCheckpointWorkflowPresenter: NSObject, CheckpointEnginePresenter
     }
 
     private func finish(
-        with outcome: CheckpointEnginePaywallOutcome,
+        with outcome: CheckpointPaywallOutcome,
         fallback: (String, CheckpointEnginePresenterDelegate)?
     ) {
         guard self.activeWorkflow != nil else {

--- a/RevenueCatUI/Checkpoints/Demo/DemoCheckpointWorkflowPresenter.swift
+++ b/RevenueCatUI/Checkpoints/Demo/DemoCheckpointWorkflowPresenter.swift
@@ -33,6 +33,7 @@ final class DemoCheckpointWorkflowPresenter: NSObject, CheckpointEnginePresenter
     }
 
     private var activeWorkflow: PresentedWorkflow?
+    private var stagedOutcome: CheckpointEnginePaywallOutcome = .dismissed
     private var isFinishing = false
     private let presentationHandler: ((PresentedWorkflow) -> Bool)?
 
@@ -78,6 +79,7 @@ final class DemoCheckpointWorkflowPresenter: NSObject, CheckpointEnginePresenter
                 delegate: delegate
             )
             self.activeWorkflow = presentedWorkflow
+            self.stagedOutcome = .dismissed
 
             let didBeginPresentation = self.presentationHandler?(presentedWorkflow)
                 ?? self.presentAutomatically(presentedWorkflow)
@@ -114,33 +116,48 @@ final class DemoCheckpointWorkflowPresenter: NSObject, CheckpointEnginePresenter
     }
 
     func presentationDidDismiss() {
-        self.finish(with: .dismissed)
+        self.complete()
     }
 
     private func finish(
         with outcome: CheckpointEnginePaywallOutcome,
         fallback: (String, CheckpointEnginePresenterDelegate)?
     ) {
-        let activeWorkflow = self.activeWorkflow
-        self.activeWorkflow = nil
-        self.isFinishing = false
+        guard self.activeWorkflow != nil else {
+            if let fallback {
+                fallback.1.onCheckpointPaywallFinished(callID: fallback.0, outcome: outcome)
+            }
+            return
+        }
+
+        self.stagedOutcome = outcome
 
         #if canImport(UIKit) && !os(tvOS) && !os(watchOS)
         let viewController = self.presentedViewController
-        self.presentedViewController = nil
         if viewController?.presentingViewController != nil {
-            viewController?.dismiss(animated: true)
+            viewController?.dismiss(animated: true) { [weak self] in
+                self?.complete()
+            }
+            return
         }
         #endif
 
-        if let activeWorkflow {
-            activeWorkflow.delegate.onCheckpointPaywallFinished(
-                callID: activeWorkflow.id,
-                outcome: outcome
-            )
-        } else if let fallback {
-            fallback.1.onCheckpointPaywallFinished(callID: fallback.0, outcome: outcome)
-        }
+        self.complete()
+    }
+
+    private func complete() {
+        guard let activeWorkflow = self.activeWorkflow else { return }
+
+        self.activeWorkflow = nil
+        self.isFinishing = false
+        #if canImport(UIKit) && !os(tvOS) && !os(watchOS)
+        self.presentedViewController = nil
+        #endif
+
+        activeWorkflow.delegate.onCheckpointPaywallFinished(
+            callID: activeWorkflow.id,
+            outcome: self.stagedOutcome
+        )
     }
 
     private func presentAutomatically(_ presentedWorkflow: PresentedWorkflow) -> Bool {

--- a/RevenueCatUI/Checkpoints/Demo/README.md
+++ b/RevenueCatUI/Checkpoints/Demo/README.md
@@ -1,0 +1,5 @@
+# Checkpoint workflow PoC
+
+This folder contains the temporary JSON decoder and renderer used only by CheckpointTester.
+Production checkpoint presentation uses the published workflow model and RevenueCatUI's existing
+workflow paywall renderer.

--- a/Sources/Checkpoints/Demo/DemoCheckpointWorkflowPresentation.swift
+++ b/Sources/Checkpoints/Demo/DemoCheckpointWorkflowPresentation.swift
@@ -1,0 +1,28 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  DemoCheckpointWorkflowPresentation.swift
+//
+//  Created by Rick van der Linden.
+//
+
+import Foundation
+
+/// Demo-only presentation containing a bundled JSON workflow document.
+@_spi(Internal) public final class DemoCheckpointWorkflowPresentation: CheckpointEnginePresentation {
+
+    /// JSON data consumed by the PoC renderer in RevenueCatUI.
+    public let workflowData: Data
+
+    init(checkpoint: CheckpointEngineInfo, workflowData: Data) {
+        self.workflowData = workflowData
+        super.init(checkpoint: checkpoint)
+    }
+
+}

--- a/Sources/Checkpoints/Demo/DemoCheckpointWorkflowPresentation.swift
+++ b/Sources/Checkpoints/Demo/DemoCheckpointWorkflowPresentation.swift
@@ -20,7 +20,7 @@ import Foundation
     /// JSON data consumed by the PoC renderer in RevenueCatUI.
     public let workflowData: Data
 
-    init(checkpoint: CheckpointEngineInfo, workflowData: Data) {
+    init(checkpoint: CheckpointInfo, workflowData: Data) {
         self.workflowData = workflowData
         super.init(checkpoint: checkpoint)
     }

--- a/Sources/Checkpoints/Demo/RegisteredWorkflowCheckpointResolver.swift
+++ b/Sources/Checkpoints/Demo/RegisteredWorkflowCheckpointResolver.swift
@@ -1,0 +1,50 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  RegisteredWorkflowCheckpointResolver.swift
+//
+//  Created by Rick van der Linden.
+//
+
+import Foundation
+
+/// Demo-only resolver for the bundled JSON workflows registered by CheckpointTester.
+final class RegisteredWorkflowCheckpointResolver: CheckpointWorkflowResolver {
+
+    private let workflowDataByIdentifier: [String: Data]
+
+    init(workflowDataByIdentifier: [String: Data]) {
+        self.workflowDataByIdentifier = workflowDataByIdentifier
+    }
+
+    func resolve(checkpoint: CheckpointEngineInfo) async -> CheckpointWorkflowResolution {
+        if checkpoint.identifier == Self.simulatedErrorCheckpointIdentifier {
+            return .failed(
+                ErrorUtils.configurationError(message: "Simulated error: checkpoint UI not presentable.")
+            )
+        }
+
+        guard !self.workflowDataByIdentifier.isEmpty else {
+            return .noMatch(.configurationUnavailable)
+        }
+        guard let workflowData = self.workflowDataByIdentifier[checkpoint.identifier] else {
+            return .noMatch(.noMatch)
+        }
+
+        return .matched(
+            DemoCheckpointWorkflowPresentation(
+                checkpoint: checkpoint,
+                workflowData: workflowData
+            )
+        )
+    }
+
+    private static let simulatedErrorCheckpointIdentifier = "error_checkpoint"
+
+}

--- a/Sources/Checkpoints/Demo/RegisteredWorkflowCheckpointResolver.swift
+++ b/Sources/Checkpoints/Demo/RegisteredWorkflowCheckpointResolver.swift
@@ -23,7 +23,7 @@ final class RegisteredWorkflowCheckpointResolver: CheckpointWorkflowResolver {
         self.workflowDataByIdentifier = workflowDataByIdentifier
     }
 
-    func resolve(checkpoint: CheckpointEngineInfo) async -> CheckpointWorkflowResolution {
+    func resolve(checkpoint: CheckpointInfo) async -> CheckpointWorkflowResolution {
         if checkpoint.identifier == Self.simulatedErrorCheckpointIdentifier {
             return .failed(
                 ErrorUtils.configurationError(message: "Simulated error: checkpoint UI not presentable.")

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -130,6 +130,15 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         set { self.purchasesOrchestrator.checkpointListenerInternal = newValue }
     }
 
+    /// Supplies JSON workflow data for checkpoint presentation.
+    ///
+    /// This temporary API exists only for CheckpointTester. Production checkpoint workflows are fetched
+    /// from RevenueCat configuration and rendered by RevenueCatUI's existing workflow renderer.
+    @_spi(Internal)
+    public func setCheckpointWorkflowData(_ workflowDataByIdentifier: [String: Data]) {
+        self.purchasesOrchestrator.setCheckpointWorkflowData(workflowDataByIdentifier)
+    }
+
     private let operationDispatcher: OperationDispatcher
 
     /**

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -282,6 +282,14 @@ final class PurchasesOrchestrator {
         set { self.checkpointsManager.checkpointListener = newValue }
     }
 
+    func setCheckpointWorkflowData(_ workflowDataByIdentifier: [String: Data]) {
+        self.checkpointsManager.setResolver(
+            RegisteredWorkflowCheckpointResolver(
+                workflowDataByIdentifier: workflowDataByIdentifier
+            )
+        )
+    }
+
     func checkpoint(
         identifier: String,
         params: CheckpointParams,

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointWorkflowPresenterTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointWorkflowPresenterTests.swift
@@ -21,7 +21,7 @@ import XCTest
 final class CheckpointWorkflowPresenterTests: TestCase {
 
     func testFactoryCreatesPresenterDirectly() {
-        XCTAssertTrue(CheckpointPresenterFactory.makePresenter() is CheckpointWorkflowPresenter)
+        XCTAssertTrue(CheckpointPresenterFactory.makePresenter() is DemoCheckpointWorkflowPresenter)
     }
 
     func testPresenterRejectsAnUnresolvedPresentation() {

--- a/Tests/RevenueCatUITests/Checkpoints/Demo/DemoCheckpointWorkflowTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/Demo/DemoCheckpointWorkflowTests.swift
@@ -61,7 +61,7 @@ final class DemoCheckpointWorkflowTests: TestCase {
     func testPresenterReportsResultWhenWorkflowFinishes() {
         let presenter = DemoCheckpointWorkflowPresenter(presentationHandler: { _ in true })
         let delegate = DemoMockCheckpointPresenterDelegate()
-        let checkpoint = CheckpointEngineInfo(identifier: "test_checkpoint", params: .init())
+        let checkpoint = CheckpointInfo(identifier: "test_checkpoint", params: .init())
 
         presenter.present(
             callID: "call-id",
@@ -71,10 +71,10 @@ final class DemoCheckpointWorkflowTests: TestCase {
             ),
             delegate: delegate
         )
-        presenter.finish(with: .dismissed)
+        presenter.finish(with: CheckpointPaywallDismissedOutcome.shared)
 
         XCTAssertEqual(delegate.finishedCallID, "call-id")
-        guard case .dismissed = delegate.outcome else {
+        guard delegate.outcome is CheckpointPaywallDismissedOutcome else {
             return XCTFail("Expected a dismissed outcome")
         }
     }
@@ -99,9 +99,9 @@ final class DemoCheckpointWorkflowTests: TestCase {
 private final class DemoMockCheckpointPresenterDelegate: CheckpointEnginePresenterDelegate {
 
     private(set) var finishedCallID: String?
-    private(set) var outcome: CheckpointEnginePaywallOutcome?
+    private(set) var outcome: CheckpointPaywallOutcome?
 
-    func onCheckpointPaywallFinished(callID: String, outcome: CheckpointEnginePaywallOutcome) {
+    func onCheckpointPaywallFinished(callID: String, outcome: CheckpointPaywallOutcome) {
         self.finishedCallID = callID
         self.outcome = outcome
     }

--- a/Tests/RevenueCatUITests/Checkpoints/Demo/DemoCheckpointWorkflowTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/Demo/DemoCheckpointWorkflowTests.swift
@@ -1,0 +1,109 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  DemoCheckpointWorkflowTests.swift
+//
+//  Created by Rick van der Linden.
+//
+
+@_spi(Internal) @testable import RevenueCat
+@_spi(Internal) @testable import RevenueCatUI
+import XCTest
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@MainActor
+final class DemoCheckpointWorkflowTests: TestCase {
+
+    func testDecodesMultiPageWorkflow() throws {
+        let data = Data(
+            #"""
+            {
+              "id": "onboarding",
+              "presentation": { "dismissible": true },
+              "pages": [
+                {
+                  "components": [
+                    { "type": "title", "text": "Welcome" },
+                    { "type": "image", "system_name": "hand.wave.fill" }
+                  ],
+                  "actions": [
+                    { "title": "Continue", "type": "next", "style": "primary" }
+                  ]
+                },
+                {
+                  "components": [{ "type": "body", "text": "Done" }],
+                  "actions": [
+                    { "title": "Finish", "type": "complete", "style": "primary" }
+                  ]
+                }
+              ]
+            }
+            """#.utf8
+        )
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+        let workflow = try decoder.decode(CheckpointWorkflow.self, from: data)
+
+        XCTAssertEqual(workflow.id, "onboarding")
+        XCTAssertTrue(workflow.presentation.dismissible)
+        XCTAssertEqual(workflow.pages.count, 2)
+        XCTAssertEqual(workflow.pages[0].components[1].systemName, "hand.wave.fill")
+        XCTAssertEqual(workflow.pages[1].actions[0].type, .complete)
+    }
+
+    func testPresenterReportsResultImmediatelyWhenWorkflowFinishes() {
+        let presenter = DemoCheckpointWorkflowPresenter(presentationHandler: { _ in true })
+        let delegate = DemoMockCheckpointPresenterDelegate()
+        let checkpoint = CheckpointEngineInfo(identifier: "test_checkpoint", params: .init())
+
+        presenter.present(
+            callID: "call-id",
+            presentation: DemoCheckpointWorkflowPresentation(
+                checkpoint: checkpoint,
+                workflowData: Self.validWorkflowData
+            ),
+            delegate: delegate
+        )
+        presenter.finish(with: .dismissed)
+
+        XCTAssertEqual(delegate.finishedCallID, "call-id")
+        guard case .dismissed = delegate.outcome else {
+            return XCTFail("Expected a dismissed outcome")
+        }
+    }
+
+    private static let validWorkflowData = Data(
+        #"""
+        {
+          "id": "workflow",
+          "presentation": { "dismissible": true },
+          "pages": [
+            {
+              "components": [{ "type": "title", "text": "Title" }],
+              "actions": [{ "title": "Done", "type": "dismiss", "style": "primary" }]
+            }
+          ]
+        }
+        """#.utf8
+    )
+
+}
+
+private final class DemoMockCheckpointPresenterDelegate: CheckpointEnginePresenterDelegate {
+
+    private(set) var finishedCallID: String?
+    private(set) var outcome: CheckpointEnginePaywallOutcome?
+
+    func onCheckpointPaywallFinished(callID: String, outcome: CheckpointEnginePaywallOutcome) {
+        self.finishedCallID = callID
+        self.outcome = outcome
+    }
+
+}

--- a/Tests/RevenueCatUITests/Checkpoints/Demo/DemoCheckpointWorkflowTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/Demo/DemoCheckpointWorkflowTests.swift
@@ -58,7 +58,7 @@ final class DemoCheckpointWorkflowTests: TestCase {
         XCTAssertEqual(workflow.pages[1].actions[0].type, .complete)
     }
 
-    func testPresenterReportsResultImmediatelyWhenWorkflowFinishes() {
+    func testPresenterReportsResultWhenWorkflowFinishes() {
         let presenter = DemoCheckpointWorkflowPresenter(presentationHandler: { _ in true })
         let delegate = DemoMockCheckpointPresenterDelegate()
         let checkpoint = CheckpointEngineInfo(identifier: "test_checkpoint", params: .init())


### PR DESCRIPTION
# Description
Adds the current proposed public APIs for implementing checkpoints in an app. Also adds a demo app that implements checkpoints and demos some common use cases. 

# APIs

<details>
<summary>Public API signatures</summary>

#### Calling a checkpoint

```swift
// async/await
func checkpoint(
    _ identifier: String,
    params: CheckpointParams = .init()
) async throws -> CheckpointResult

// completion based
func checkpoint(
    _ identifier: String,
    params: CheckpointParams = .init(),
    completion: @escaping (
        Result<CheckpointResult, PublicError>
    ) -> Void
)
```

#### Using a global listener

```swift
var checkpointListener: CheckpointListener? { get set }

class MyCheckpointListener: CheckpointListener {
    func onCheckpointRegistered(_ checkpoint: CheckpointInfo)

    func onCheckpointResolved(
        _ checkpoint: CheckpointInfo,
        result: CheckpointResult
    )

    func onCheckpointUIFinished(
        _ checkpoint: CheckpointInfo,
        result: CheckpointUIResult
    )
}
```

#### `CheckpointResult`

```swift
class CheckpointResult {
    let checkpoint: CheckpointInfo
}

final class CheckpointUIPresentedResult: CheckpointResult {
    let result: CheckpointUIResult
}

final class CheckpointNoActionResult: CheckpointResult {
    let reason: CheckpointNoActionReason
}
```

#### UI result

```swift
class CheckpointUIResult {}

final class CheckpointDismissedResult: CheckpointUIResult {}

final class CheckpointPurchasedResult: CheckpointUIResult {
    let customerInfo: CustomerInfo
}

final class CheckpointRestoredResult: CheckpointUIResult {
    let customerInfo: CustomerInfo
}

final class CheckpointErrorResult: CheckpointUIResult {
    let error: PublicError
}
```

#### No-action reason

```swift
struct CheckpointNoActionReason {
    let value: String

    static let noMatch: Self
    static let holdout: Self
    static let frequencyCapped: Self
    static let configurationUnavailable: Self
    static let disabled: Self
}
```

</details>

### Open (design) questions / considerations

#### `registerCheckpoint` naming
We may go with just `checkpoint()` but in the listener that could look a bit inconsistent between
- `onCheckpoint()`
- `onCheckpointResolved()`
- `onCheckpointUIFinished()`

Maybe go with `onCheckpointHit()` there?

#### Listener ordering
Currently `onCheckpointUIFinished` is received before `onCheckpointResolved`, which makes the naming a bit confusing imo.

#### Returning the UI result directly
[Android](https://github.com/RevenueCat/purchases-android/pull/3863) currently returns `UIPresented(checkpoint)` while the UI result is only sent through the global listener. Could we return the UI result directly as well? If not is it ok to have this discrepancy?

#### Automatic discovery of the RevenueCatUI module. 
We're currently discovering the necessary UI component `RCCheckpointPresenterProvider` through `NSClassFromString`. However there is a slight risk that this class may be stripped out of the final binary if it's not used (according to the linker). We could try to cover this well in CI tests, but there is always a risk of developer Xcode / project / optimization / linker settings still causing this class to be stripped from the final binary.

##### There are some (lesser) alternatives though.

<details>
<summary><strong>1. Explicit RevenueCatUI registration</strong></summary>

```swift
Purchases.configure(withAPIKey: apiKey)
RevenueCatUI.enableCheckpointPresentation()
```

Checkpoint calls would remain unchanged:

```swift
try await Purchases.shared.checkpoint("soft_paywall")
```

This creates a reliable linker reference, but adds setup that developers must remember.

</details>

<details>
<summary><strong>2. RevenueCatUI-specific overload</strong></summary>

```swift
try await Purchases.shared.checkpoint(
    "soft_paywall",
    params: params,
    presentation: .automatic
)
```

RevenueCatUI would implement this overload and internally call core. It is reliable with static linking, but developers must choose a separate UI-enabled signature.

</details>

<details>
<summary><strong>3. Linker anchor</strong></summary>

Keep the current runtime lookup, but force the provider to remain linked using an anchor symbol, `-ObjC`, `-force_load`, or another packaging rule.

This preserves the ideal call site:

```swift
try await Purchases.shared.checkpoint("soft_paywall")
```

However, it introduces linker- and package-manager-specific behavior.

</details>


<img width="603" height="1311" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-31 at 14 51 09" src="https://github.com/user-attachments/assets/85bf814b-39fa-4d7d-949e-f53e3d7db943" />
