### PR TITLE
Use internalPaywallComponents property in tests

### DIFF
--- a/Tests/BackendIntegrationTests/WorkflowComponentsIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/WorkflowComponentsIntegrationTests.swift
@@ -35,7 +35,7 @@ final class WorkflowComponentsIntegrationTests: BaseStoreKitIntegrationTests {
         let phase1Current = try await self.currentOffering
         expect(phase1Current.identifier) == "default"
         expect(phase1Current.hasPaywall) == true
-        expect(phase1Current.paywallComponents).to(beNil())
+        expect(phase1Current.internalPaywallComponents).to(beNil())
 
         self.remoteConfigFake.disableRemoteConfig = true
         _ = try? await self.purchases.logIn("integration-test-workflows-\(UUID().uuidString)")
@@ -43,14 +43,14 @@ final class WorkflowComponentsIntegrationTests: BaseStoreKitIntegrationTests {
         let phase2Current = try await self.currentOfferingWithComponents()
         expect(phase2Current.identifier) == "default"
         expect(phase2Current.hasPaywall) == true
-        expect(phase2Current.paywallComponents).toNot(beNil())
-        expect(phase2Current.paywallComponents?.data).toNot(beNil())
+        expect(phase2Current.internalPaywallComponents).toNot(beNil())
+        expect(phase2Current.internalPaywallComponents?.data).toNot(beNil())
     }
 
     private func currentOfferingWithComponents() async throws -> Offering {
         for _ in 0..<20 {
             let current = try await self.currentOffering
-            if current.paywallComponents != nil {
+            if current.internalPaywallComponents != nil {
                 return current
             }
 

--- a/Tests/RevenueCatUITests/Data/PaywallViewConfigurationTests.swift
+++ b/Tests/RevenueCatUITests/Data/PaywallViewConfigurationTests.swift
@@ -187,7 +187,7 @@ final class PaywallViewConfigurationTests: TestCase {
         )
 
         expect(result.offering.identifier) == workflowOffering.identifier
-        expect(result.offering.paywallComponents).toNot(beNil())
+        expect(result.offering.internalPaywallComponents).toNot(beNil())
         expect(result.workflowContext?.initialOffering.identifier) == workflowOffering.identifier
         expect(result.workflowContext?.presentedOfferingContext?.offeringIdentifier) == initialOffering.identifier
 
@@ -222,7 +222,7 @@ final class PaywallViewConfigurationTests: TestCase {
         )
 
         expect(result?.offering.identifier) == workflowOffering.identifier
-        expect(result?.offering.paywallComponents).toNot(beNil())
+        expect(result?.offering.internalPaywallComponents).toNot(beNil())
         expect(result?.workflowContext?.initialOffering.identifier) == workflowOffering.identifier
         expect(result?.workflowContext?.presentedOfferingContext?.offeringIdentifier) == initialOffering.identifier
     }
@@ -252,7 +252,7 @@ final class PaywallViewConfigurationTests: TestCase {
         )
 
         expect(result.offering.identifier) == workflowOffering.identifier
-        expect(result.offering.paywallComponents).toNot(beNil())
+        expect(result.offering.internalPaywallComponents).toNot(beNil())
         expect(result.workflowContext?.initialOffering.identifier) == workflowOffering.identifier
         expect(result.workflowContext?.presentedOfferingContext?.offeringIdentifier) == initialOffering.identifier
 
@@ -283,7 +283,7 @@ final class PaywallViewConfigurationTests: TestCase {
         )
 
         expect(result.offering.identifier) == workflowOffering.identifier
-        expect(result.offering.paywallComponents).toNot(beNil())
+        expect(result.offering.internalPaywallComponents).toNot(beNil())
         expect(result.workflowContext?.initialOffering.identifier) == workflowOffering.identifier
         expect(result.workflowContext?.presentedOfferingContext?.offeringIdentifier) == initialOffering.identifier
         expect(result.workflowContext?.workflow.initialStepId) == "step_1"
@@ -307,7 +307,7 @@ final class PaywallViewConfigurationTests: TestCase {
 
         expect(workflowFetchAttempted) == true
         expect(result.offering.identifier) == offering.identifier
-        expect(result.offering.paywallComponents?.data) == paywallComponents.data
+        expect(result.offering.internalPaywallComponents?.data) == paywallComponents.data
         expect(result.workflowContext).to(beNil())
     }
 
@@ -335,7 +335,7 @@ final class PaywallViewConfigurationTests: TestCase {
         )
 
         expect(result.offering.identifier) == identifier
-        expect(result.offering.paywallComponents?.data) == paywallComponents.data
+        expect(result.offering.internalPaywallComponents?.data) == paywallComponents.data
         expect(result.workflowContext).to(beNil())
     }
 
@@ -361,7 +361,7 @@ final class PaywallViewConfigurationTests: TestCase {
             remoteConfigEnabled: false
         )
 
-        expect(result.offering.paywallComponents?.data) == paywallComponents.data
+        expect(result.offering.internalPaywallComponents?.data) == paywallComponents.data
         expect(result.offering.presentedOfferingContext?.placementIdentifier)
             == presentedOfferingContext.placementIdentifier
         expect(result.offering.presentedOfferingContext?.targetingContext?.ruleId)
@@ -417,7 +417,7 @@ final class PaywallViewConfigurationTests: TestCase {
         )
 
         expect(result.offering.identifier) == identifier
-        expect(result.offering.paywallComponents?.data) == paywallComponents.data
+        expect(result.offering.internalPaywallComponents?.data) == paywallComponents.data
         expect(result.workflowContext).to(beNil())
     }
 

--- a/Tests/RevenueCatUITests/PaywallsV2/TakeScreenshot.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/TakeScreenshot.swift
@@ -42,7 +42,7 @@ class TakeScreenshotTests: BaseSnapshotTest {
         for offering in paywallPreviewsResourceLoader.allOfferings {
             let offeringId = offering.id
 
-            if offering.paywallComponents != nil {
+            if offering.internalPaywallComponents != nil {
                 let view = Self.createPaywall(offering: offering)
                     .frame(width: 450, height: 1000)
                 self.snapshotAndSave(view: view,

--- a/Tests/RevenueCatUITests/Purchasing/WorkflowPreviewTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/WorkflowPreviewTests.swift
@@ -28,7 +28,7 @@ final class WorkflowPreviewTests: TestCase {
 
         // The rendered offering is the screen's offering with the workflow screen's components applied.
         expect(context.initialOffering.identifier) == "offering_a"
-        expect(context.initialOffering.paywallComponents).toNot(beNil())
+        expect(context.initialOffering.internalPaywallComponents).toNot(beNil())
         expect(context.workflow.id) == "wf_test"
     }
 

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -1125,7 +1125,7 @@ extension OfferingsManagerTests {
 
         expect(result).to(beSuccess())
         expect(self.mockOfferings.invokedGetOfferingsForAppUserID) == true
-        expect(result?.value?.offering(identifier: "paywall_components")?.paywallComponents).toNot(beNil())
+        expect(result?.value?.offering(identifier: "paywall_components")?.internalPaywallComponents).toNot(beNil())
     }
 
     func testGetOfferingsRefetchesIfRemoteConfigDisablesBeforeReadinessDelivery() throws {
@@ -1166,7 +1166,7 @@ extension OfferingsManagerTests {
             .withPaywallComponents
         ]
         let deliveredOffering = deliveredResult.value?.value?.offering(identifier: "paywall_components")
-        expect(deliveredOffering?.paywallComponents).toNot(beNil())
+        expect(deliveredOffering?.internalPaywallComponents).toNot(beNil())
     }
 
     func testGetOfferingsCarriesFullResponseDataToDiskCacheWhenRemoteConfigManagerIsEnabled() throws {
@@ -1212,7 +1212,7 @@ extension OfferingsManagerTests {
         }
 
         expect(result).to(beSuccess())
-        expect(result?.value?.offering(identifier: "paywall_components")?.paywallComponents).to(beNil())
+        expect(result?.value?.offering(identifier: "paywall_components")?.internalPaywallComponents).to(beNil())
         expect(self.mockDeviceCache.latestCachedOfferingsContents?.response.offerings.first?.paywallComponents)
             .to(beNil())
         expect(self.mockDeviceCache.latestCachedOfferingsContents?.response.offerings.first?.hasPaywallComponents)
@@ -1545,7 +1545,7 @@ extension OfferingsManagerTests {
 
         expect(result).to(beSuccess())
         expect(result?.value?.loadedFromDiskCache) == true
-        expect(result?.value?.offering(identifier: "paywall_components")?.paywallComponents).toNot(beNil())
+        expect(result?.value?.offering(identifier: "paywall_components")?.internalPaywallComponents).toNot(beNil())
         expect(self.mockOfferings.invokedGetOfferingsForAppUserIDCount) == 1
     }
 
@@ -1581,7 +1581,7 @@ extension OfferingsManagerTests {
         expect(self.mockDeviceCache.clearCachedOfferingsCount) == 0
         expect(self.mockDeviceCache.stubbedOfferings?.loadedFromDiskCache) == true
         expect(self.mockDeviceCache.stubbedOfferings?.offering(identifier: "paywall_components")?
-            .paywallComponents).toNot(beNil())
+            .internalPaywallComponents).toNot(beNil())
     }
 
     func testRemoteConfigDisableDoesNotAllowOlderPrunedRequestToOverwriteFullCache() throws {

--- a/Tests/UnitTests/Purchasing/OfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsTests.swift
@@ -806,7 +806,7 @@ class OfferingsTests: TestCase {
             )
 
         expect(offering.paywall).to(beNil())
-        expect(offering.paywallComponents).to(beNil())
+        expect(offering.internalPaywallComponents).to(beNil())
         expect(offering.hasPaywall) == false
     }
 
@@ -833,7 +833,7 @@ class OfferingsTests: TestCase {
             )
 
         expect(offering.paywall).toNot(beNil())
-        expect(offering.paywallComponents).to(beNil())
+        expect(offering.internalPaywallComponents).to(beNil())
         expect(offering.hasPaywall) == true
     }
 
@@ -858,7 +858,7 @@ class OfferingsTests: TestCase {
             )
 
         expect(offering.paywall).to(beNil())
-        expect(offering.paywallComponents).toNot(beNil())
+        expect(offering.internalPaywallComponents).toNot(beNil())
         expect(offering.hasPaywall) == true
     }
 
@@ -884,7 +884,7 @@ class OfferingsTests: TestCase {
             )
 
         expect(offering.paywall).to(beNil())
-        expect(offering.paywallComponents).to(beNil())
+        expect(offering.internalPaywallComponents).to(beNil())
         expect(offering.hasPaywall) == true
     }
 
@@ -906,7 +906,7 @@ class OfferingsTests: TestCase {
         let offering = try XCTUnwrap(offerings.offering(identifier: "paywall_components"))
 
         expect(offering.paywall).to(beNil())
-        expect(offering.paywallComponents).to(beNil())
+        expect(offering.internalPaywallComponents).to(beNil())
         expect(offering.hasPaywall) == true
         expect(offerings.response.offerings.first?.paywallComponents).to(beNil())
         expect(offerings.response.offerings.first?.hasPaywallComponents) == true
@@ -937,7 +937,7 @@ class OfferingsTests: TestCase {
         )
         let offering = try XCTUnwrap(rebuiltOfferings.offering(identifier: "paywall_components"))
 
-        expect(offering.paywallComponents).to(beNil())
+        expect(offering.internalPaywallComponents).to(beNil())
         expect(offering.hasPaywall) == true
         expect(rebuiltOfferings.response.offerings.first?.paywallComponents).to(beNil())
         expect(rebuiltOfferings.response.offerings.first?.hasPaywallComponents) == true
@@ -964,7 +964,7 @@ class OfferingsTests: TestCase {
             )
 
         expect(offering.paywall).to(beNil())
-        expect(offering.paywallComponents).to(beNil())
+        expect(offering.internalPaywallComponents).to(beNil())
         expect(offering.hasPaywall) == false
     }
 


### PR DESCRIPTION
# Description
In several tests we were still using the deprecated `paywallComponents`, resulting in a lot of deprecation warnings. Since these tests `@testable import` they can use the internal property `internalPaywallComponents`. So I've updated these occurrences.

# Changes
Updated the use of `paywallComponents` in tests with `internalPaywallComponents`, fixing the deprecation warnings

```
[13:34:18]: ▸ ⚠️  /Users/distiller/purchases-ios/Tests/RevenueCatUITests/Data/PaywallViewConfigurationTests.swift:310:32: 'paywallComponents' is deprecated: Use hasPaywall to check whether the Offering has a paywall.
[13:34:18]: ▸ expect(result.offering.paywallComponents?.data) == paywallComponents.data
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only renames with no runtime or public API changes; behavior under test is identical.
> 
> **Overview**
> Replaces **`paywallComponents`** with **`internalPaywallComponents`** across integration, UI, and unit tests that `@testable import` RevenueCat. Assertions and helpers are unchanged; only the property name updates so tests no longer trigger the deprecation on **`Offering.paywallComponents`** (public API now directs callers to **`hasPaywall`**).
> 
> Touches workflow/paywall configuration tests, screenshot generation, offerings manager cache behavior, and offering factory tests—no production code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fec9df2ae8902ee3b15d70102f21b5a1e295cf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->