### PR TITLE
fix(paywalls): apply tab state rules on workflow-backed paywalls

### DIFF
--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowScreenMapper.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowScreenMapper.swift
@@ -29,7 +29,8 @@ enum WorkflowScreenMapper {
             componentsLocalizations: screen.componentsLocalizations,
             revision: screen.revision,
             defaultLocaleIdentifier: screen.defaultLocale,
-            exitOffers: screen.exitOffers
+            exitOffers: screen.exitOffers,
+            stateDeclarations: screen.stateDeclarations
         )
         return .init(uiConfig: uiConfig, data: data)
     }

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -244,9 +244,10 @@ struct WorkflowPaywallView: View {
     @StateObject private var navigator: WorkflowNavigator
     /// One paywall state store per workflow presentation: all screens read and write the same
     /// store, so values survive screen navigation and reset only when the presentation ends
-    /// (this view, and with it the `@StateObject`, is torn down). Seeded empty for now —
-    /// workflow-root `state` declarations arrive with the workflow wire-format follow-up.
-    @StateObject private var stateStore = PaywallStateStore()
+    /// (this view, and with it the `@StateObject`, is torn down). Seeded in `init` from every
+    /// screen's declarations, because `PaywallsV2View` suppresses its own store while a workflow
+    /// injects one: an unseeded store leaves every `state_condition` override permanently unmatched.
+    @StateObject private var stateStore: PaywallStateStore
     // Held via PromoOfferCacheOwner so this view owns one cache shared across all workflow pages
     // without subscribing to its @Published changes: body only forwards the cache to children.
     // Observing it directly would re-render the whole page ForEach + header overlay on each update.
@@ -282,6 +283,9 @@ struct WorkflowPaywallView: View {
         self.displayCloseButton = displayCloseButton
         self.onDismiss = onDismiss
         self._navigator = .init(wrappedValue: WorkflowNavigator(workflow: context.workflow))
+        self._stateStore = .init(
+            wrappedValue: PaywallStateStore(declarations: Self.mergedStateDeclarations(in: context.workflow))
+        )
         self._promoOfferCacheOwner = .init(wrappedValue: PromoOfferCacheOwner(
             cache: promoOfferCache ?? PaywallPromoOfferCache(
                 subscriptionHistoryTracker: purchaseHandler.subscriptionHistoryTracker
@@ -309,6 +313,22 @@ struct WorkflowPaywallView: View {
         )
         self._seenPages = .init(wrappedValue: initialPage.map { [$0] } ?? [])
         self._transitionState = .init(wrappedValue: .init(currentPage: initialPage))
+    }
+
+    /// Every screen's declarations merged into one map, so a key declared on a later screen is
+    /// already seeded when the user navigates to it. Screens are visited in id order and the first
+    /// declaration of a key wins, matching `registerDeclarations`' non-overwriting semantics; the
+    /// sort only makes the outcome deterministic if two screens declare the same key differently.
+    static func mergedStateDeclarations(
+        in workflow: PublishedWorkflow
+    ) -> [String: PaywallComponent.StateDeclaration] {
+        var merged: [String: PaywallComponent.StateDeclaration] = [:]
+        for (_, screen) in workflow.screens.sorted(by: { $0.key < $1.key }) {
+            for (key, declaration) in screen.stateDeclarations ?? [:] where merged[key] == nil {
+                merged[key] = declaration
+            }
+        }
+        return merged
     }
 
     var body: some View {

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -244,9 +244,9 @@ struct WorkflowPaywallView: View {
     @StateObject private var navigator: WorkflowNavigator
     /// One paywall state store per workflow presentation: all screens read and write the same
     /// store, so values survive screen navigation and reset only when the presentation ends
-    /// (this view, and with it the `@StateObject`, is torn down). Seeded in `init` from every
-    /// screen's declarations, because `PaywallsV2View` suppresses its own store while a workflow
-    /// injects one: an unseeded store leaves every `state_condition` override permanently unmatched.
+    /// (this view, and with it the `@StateObject`, is torn down). Seeded from every screen's
+    /// declarations: `PaywallsV2View` suppresses its own store inside a workflow, so nothing else
+    /// seeds this one.
     @StateObject private var stateStore: PaywallStateStore
     // Held via PromoOfferCacheOwner so this view owns one cache shared across all workflow pages
     // without subscribing to its @Published changes: body only forwards the cache to children.
@@ -315,18 +315,15 @@ struct WorkflowPaywallView: View {
         self._transitionState = .init(wrappedValue: .init(currentPage: initialPage))
     }
 
-    /// Every screen's declarations merged into one map, so a key declared on a later screen is
-    /// already seeded when the user navigates to it. Screens are visited in id order and the first
-    /// declaration of a key wins, matching `registerDeclarations`' non-overwriting semantics; the
-    /// sort only makes the outcome deterministic if two screens declare the same key differently.
+    /// Merged across all screens so a key declared on a screen the user has not reached yet is
+    /// already seeded; sorted by id so a key two screens declare differently resolves the same way
+    /// every time.
     static func mergedStateDeclarations(
         in workflow: PublishedWorkflow
     ) -> [String: PaywallComponent.StateDeclaration] {
         var merged: [String: PaywallComponent.StateDeclaration] = [:]
         for (_, screen) in workflow.screens.sorted(by: { $0.key < $1.key }) {
-            for (key, declaration) in screen.stateDeclarations ?? [:] where merged[key] == nil {
-                merged[key] = declaration
-            }
+            merged.merge(screen.stateDeclarations ?? [:]) { first, _ in first }
         }
         return merged
     }

--- a/Sources/Networking/Responses/WorkflowsResponse.swift
+++ b/Sources/Networking/Responses/WorkflowsResponse.swift
@@ -139,6 +139,12 @@ import Foundation
     var config: [String: AnyDecodable]
     public let offeringIdentifier: String?
     public let exitOffers: ExitOffers?
+    /// Unlike `PaywallComponentsData`, which drops malformed entries individually, a malformed map
+    /// here disables state for the whole screen rather than failing the screen's decode.
+    @IgnoreDecodeErrors<[String: PaywallComponent.StateDeclaration]?>
+    // swiftlint:disable:next identifier_name
+    var _stateDeclarations: [String: PaywallComponent.StateDeclaration]?
+    public var stateDeclarations: [String: PaywallComponent.StateDeclaration]? { _stateDeclarations }
 
     // `config` carries backend screen config the renderer doesn't read and is typed with the
     // internal `AnyDecodable`, so it's defaulted rather than exposed.
@@ -151,7 +157,8 @@ import Foundation
         componentsLocalizations: [PaywallComponent.LocaleID: PaywallComponent.LocalizationDictionary],
         defaultLocale: PaywallComponent.LocaleID,
         offeringIdentifier: String?,
-        exitOffers: ExitOffers? = nil
+        exitOffers: ExitOffers? = nil,
+        stateDeclarations: [String: PaywallComponent.StateDeclaration]? = nil
     ) {
         self.name = name
         self.templateName = templateName
@@ -163,6 +170,7 @@ import Foundation
         self.config = [:]
         self.offeringIdentifier = offeringIdentifier
         self.exitOffers = exitOffers
+        self._stateDeclarations = stateDeclarations
     }
 
 }
@@ -288,6 +296,8 @@ extension WorkflowScreen: Codable, Equatable, Sendable {
         case config
         case offeringIdentifier
         case exitOffers
+        // swiftlint:disable:next identifier_name
+        case _stateDeclarations = "stateDeclarations"
     }
 
 }

--- a/Sources/Networking/Responses/WorkflowsResponse.swift
+++ b/Sources/Networking/Responses/WorkflowsResponse.swift
@@ -139,8 +139,8 @@ import Foundation
     var config: [String: AnyDecodable]
     public let offeringIdentifier: String?
     public let exitOffers: ExitOffers?
-    /// Unlike `PaywallComponentsData`, which drops malformed entries individually, a malformed map
-    /// here disables state for the whole screen rather than failing the screen's decode.
+    /// Whole-map fallback to nil; the offerings path drops entries individually via
+    /// `FailableStateDeclaration`.
     @IgnoreDecodeErrors<[String: PaywallComponent.StateDeclaration]?>
     // swiftlint:disable:next identifier_name
     var _stateDeclarations: [String: PaywallComponent.StateDeclaration]?

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
@@ -476,17 +476,20 @@ extension WorkflowPaywallViewTests {
 
     // MARK: - State declarations
 
-    /// Every screen reads through the workflow store (`PaywallsV2View` suppresses its own while a
-    /// workflow injects one) and it is seeded once per presentation, so a key declared on a screen
-    /// the user has not reached yet must already be in the merge.
-    func testMergedStateDeclarationsCollectsKeysFromEveryScreen() throws {
+    func testMergedStateDeclarationsCollectsEveryScreenAndKeepsTheFirstDuplicate() throws {
         let context = try Self.makeContext(
             singleStepFallbackId: "step_terminal",
-            initialScreenJSON: Self.screenJSON(stateDeclarations: """
-            { "on_initial": { "type": "boolean", "default": true } }
+            initialScreenJSON: Self.makeScreenJSON(extraKeysJSON: """
+            "state_declarations": {
+                "on_initial": { "type": "boolean", "default": true },
+                "shared": { "type": "string", "default": "from_initial" }
+            }
             """),
-            terminalScreenJSON: Self.screenJSON(stateDeclarations: """
-            { "on_terminal": { "type": "string", "default": "annual" } }
+            terminalScreenJSON: Self.makeScreenJSON(extraKeysJSON: """
+            "state_declarations": {
+                "on_terminal": { "type": "string", "default": "annual" },
+                "shared": { "type": "string", "default": "from_terminal" }
+            }
             """)
         )
 
@@ -494,22 +497,7 @@ extension WorkflowPaywallViewTests {
 
         expect(merged.keys).to(contain("on_initial", "on_terminal"))
         expect(merged["on_terminal"]?.defaultValue) == .string("annual")
-    }
-
-    func testMergedStateDeclarationsKeepsFirstDeclarationOfADuplicateKey() throws {
-        // Screens merge in id order, so `screen_initial` is seen before `screen_terminal`.
-        let context = try Self.makeContext(
-            singleStepFallbackId: "step_terminal",
-            initialScreenJSON: Self.screenJSON(stateDeclarations: """
-            { "shared": { "type": "string", "default": "from_initial" } }
-            """),
-            terminalScreenJSON: Self.screenJSON(stateDeclarations: """
-            { "shared": { "type": "string", "default": "from_terminal" } }
-            """)
-        )
-
-        let merged = WorkflowPaywallView.mergedStateDeclarations(in: context.workflow)
-
+        // Screens merge in id order, so `screen_initial` wins over `screen_terminal`.
         expect(merged["shared"]?.defaultValue) == .string("from_initial")
     }
 
@@ -638,20 +626,15 @@ private extension WorkflowPaywallViewTests {
         return try JSONDecoder.default.decode(PublishedWorkflow.self, from: data)
     }
 
-    /// A default screen with a `state_declarations` map spliced in, mirroring
-    /// `makeContextWithExitOffer`'s approach of appending a key to the generated screen JSON.
-    static func screenJSON(stateDeclarations: String) -> String {
-        let baseJSON = makeScreenJSON(packages: [], offeringId: "offering_test")
-        return String(baseJSON.dropLast()) + """
-        , "state_declarations": \(stateDeclarations)
-        }
-        """
-    }
-
-    static func makeScreenJSON(packages: [PackageSpec], offeringId: String) -> String {
+    static func makeScreenJSON(
+        packages: [PackageSpec] = [],
+        offeringId: String = "offering_test",
+        extraKeysJSON: String = ""
+    ) -> String {
         let componentsJSON = packages
             .map { packageComponentJSON(id: $0.id, isDefault: $0.isDefault) }
             .joined(separator: ",")
+        let extraKeys = extraKeysJSON.isEmpty ? "" : ",\n    \(extraKeysJSON)"
         return """
         {
             "template_name": "template_v2",
@@ -668,7 +651,7 @@ private extension WorkflowPaywallViewTests {
                         "value": { "light": { "type": "hex", "value": "#220000ff" } }
                     }
                 }
-            }
+            }\(extraKeys)
         }
         """
     }

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowPaywallViewTests.swift
@@ -474,6 +474,51 @@ extension WorkflowPaywallViewTests {
         expect(packageContext.variableContext.mostExpensivePricePerMonth).toNot(beNil())
     }
 
+    // MARK: - State declarations
+
+    /// Every screen reads through the workflow store (`PaywallsV2View` suppresses its own while a
+    /// workflow injects one) and it is seeded once per presentation, so a key declared on a screen
+    /// the user has not reached yet must already be in the merge.
+    func testMergedStateDeclarationsCollectsKeysFromEveryScreen() throws {
+        let context = try Self.makeContext(
+            singleStepFallbackId: "step_terminal",
+            initialScreenJSON: Self.screenJSON(stateDeclarations: """
+            { "on_initial": { "type": "boolean", "default": true } }
+            """),
+            terminalScreenJSON: Self.screenJSON(stateDeclarations: """
+            { "on_terminal": { "type": "string", "default": "annual" } }
+            """)
+        )
+
+        let merged = WorkflowPaywallView.mergedStateDeclarations(in: context.workflow)
+
+        expect(merged.keys).to(contain("on_initial", "on_terminal"))
+        expect(merged["on_terminal"]?.defaultValue) == .string("annual")
+    }
+
+    func testMergedStateDeclarationsKeepsFirstDeclarationOfADuplicateKey() throws {
+        // Screens merge in id order, so `screen_initial` is seen before `screen_terminal`.
+        let context = try Self.makeContext(
+            singleStepFallbackId: "step_terminal",
+            initialScreenJSON: Self.screenJSON(stateDeclarations: """
+            { "shared": { "type": "string", "default": "from_initial" } }
+            """),
+            terminalScreenJSON: Self.screenJSON(stateDeclarations: """
+            { "shared": { "type": "string", "default": "from_terminal" } }
+            """)
+        )
+
+        let merged = WorkflowPaywallView.mergedStateDeclarations(in: context.workflow)
+
+        expect(merged["shared"]?.defaultValue) == .string("from_initial")
+    }
+
+    func testMergedStateDeclarationsIsEmptyWhenNoScreenDeclaresState() throws {
+        let context = try Self.makeContext(singleStepFallbackId: "step_terminal")
+
+        expect(WorkflowPaywallView.mergedStateDeclarations(in: context.workflow)).to(beEmpty())
+    }
+
 }
 
 // MARK: - Helpers for workflowPackageContext tests
@@ -591,6 +636,16 @@ private extension WorkflowPaywallViewTests {
         """
         let data = try XCTUnwrap(json.data(using: .utf8))
         return try JSONDecoder.default.decode(PublishedWorkflow.self, from: data)
+    }
+
+    /// A default screen with a `state_declarations` map spliced in, mirroring
+    /// `makeContextWithExitOffer`'s approach of appending a key to the generated screen JSON.
+    static func screenJSON(stateDeclarations: String) -> String {
+        let baseJSON = makeScreenJSON(packages: [], offeringId: "offering_test")
+        return String(baseJSON.dropLast()) + """
+        , "state_declarations": \(stateDeclarations)
+        }
+        """
     }
 
     static func makeScreenJSON(packages: [PackageSpec], offeringId: String) -> String {

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowScreenMapperTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowScreenMapperTests.swift
@@ -105,8 +105,6 @@ final class WorkflowScreenMapperTests: TestCase {
         expect(result.data.id).to(beNil())
     }
 
-    /// Without these, an undeclared key reads back nil and every `state_condition` override on a
-    /// funnel paywall stays unmatched.
     func testPassesThroughStateDeclarations() throws {
         let screen = try Self.makeScreen(
             stateDeclarationsJSON: """

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowScreenMapperTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowScreenMapperTests.swift
@@ -105,6 +105,32 @@ final class WorkflowScreenMapperTests: TestCase {
         expect(result.data.id).to(beNil())
     }
 
+    /// Without these, an undeclared key reads back nil and every `state_condition` override on a
+    /// funnel paywall stays unmatched.
+    func testPassesThroughStateDeclarations() throws {
+        let screen = try Self.makeScreen(
+            stateDeclarationsJSON: """
+            { "selected_tab": { "type": "string", "default": "monthly" } }
+            """
+        )
+        let uiConfig = try Self.makeUIConfig()
+
+        let result = WorkflowScreenMapper.toPaywallComponents(screen: screen, uiConfig: uiConfig)
+
+        let declaration = try XCTUnwrap(result.data.stateDeclarations?["selected_tab"])
+        expect(declaration.type) == PaywallComponent.StateDeclaration.ValueType.string
+        expect(declaration.defaultValue) == .string("monthly")
+    }
+
+    func testStateDeclarationsAreNilWhenScreenDeclaresNone() throws {
+        let screen = try Self.makeScreen()
+        let uiConfig = try Self.makeUIConfig()
+
+        let result = WorkflowScreenMapper.toPaywallComponents(screen: screen, uiConfig: uiConfig)
+
+        expect(result.data.stateDeclarations).to(beNil())
+    }
+
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
@@ -116,8 +142,15 @@ private extension WorkflowScreenMapperTests {
         assetBaseURL: String = "https://assets.pawwalls.com",
         revision: Int = 3,
         defaultLocale: String = "en_US",
-        exitOfferOfferingId: String? = nil
+        exitOfferOfferingId: String? = nil,
+        stateDeclarationsJSON: String? = nil
     ) throws -> RevenueCat.WorkflowScreen {
+        var stateDeclarationsFragment = ""
+        if let stateDeclarationsJSON {
+            stateDeclarationsFragment = """
+            , "state_declarations": \(stateDeclarationsJSON)
+            """
+        }
         var exitOffersJSON = ""
         if let exitOfferOfferingId {
             exitOffersJSON = """
@@ -157,7 +190,7 @@ private extension WorkflowScreenMapperTests {
                         }
                     }
                 }
-            }\(exitOffersJSON)
+            }\(exitOffersJSON)\(stateDeclarationsFragment)
         }
         """
         let data = try XCTUnwrap(json.data(using: .utf8))


### PR DESCRIPTION
- Tab state rules did nothing on a paywall built on the workflow data model: no `state_condition` override
  could match, because three things had to line up and none did — `WorkflowScreen` didn't decode the
  screen's `state_declarations`, `WorkflowScreenMapper` didn't pass them on, and
  `WorkflowPaywallView` seeded its `PaywallStateStore` empty.
- It failed silently. An undeclared state key is a legitimate "no match", so nothing logged or threw
  and the paywall rendered its base state with tabs switching normally.
- The offerings path was never affected — `PaywallsV2View` seeds its own store from
  `PaywallComponentsData`, and suppresses it only when a workflow injects one.
- The workflow store is seeded once per presentation from every screen's declarations, so a
  `state_condition` can reference a key declared on a screen the user hasn't reached yet.
- Behavior change to note: a screen with no declarations now encodes `"state_declarations": null`
  where the key used to be absent.

Android: https://github.com/RevenueCat/purchases-android/pull/3875

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

<details>
<summary>Agent description</summary>

**Why nothing matched**

- `PaywallsV2View` builds `ownStateStore` from `paywallComponents.data.stateDeclarations` but
  publishes it only when no store is inherited, so inside a workflow the injected store wins.
- That injected store was `PaywallStateStore()` with no declarations, and nothing else seeded it.
- With no declared key, `apply` bails on `guard let declaredType = self.declaredTypes[key]`, so a
  tab's `state_updates` wrote nothing, and the condition read hit
  `guard let actualValue = stateValues[name] ?? stateDefaults[name] else { return false }`.

**Changes**

- `WorkflowScreen` decodes `state_declarations` via `@IgnoreDecodeErrors`, following the existing
  `_revision` shape in the same struct (internal stored property, public computed accessor,
  `CodingKeys` alias) because the wrapper is internal and can't back a public stored property.
- `WorkflowScreenMapper` passes it into `PaywallComponentsData`.
- `WorkflowPaywallView` seeds its store in `init` from `mergedStateDeclarations(in:)`. First
  declaration wins, screens merged in id order so a key two screens declare differently resolves the
  same way every time. Same approach as the web renderer.

**Why seed upfront rather than per screen**

`PaywallStateStore.registerDeclarations` exists for incremental seeding and still has no production
callers, but per-screen registration only seeds screens actually reached, so a condition referencing
another screen's key would not match until that screen was visited. Calling it from a view
initializer also risks publishing changes during a view update.

**Notes**

- Malformed declarations are handled differently from the offerings path: `@IgnoreDecodeErrors` drops
  the whole map, while `PaywallComponentsData` drops entries individually via its private
  `FailableStateDeclaration`. Parity needs that type lifted into a shared generic that is `Codable`
  and `Equatable`, since `WorkflowScreen` is both.
- `Tests/UnitTests` does not compile in my checkout on this branch *or* on clean `main` (13 identical
  `RulesEngine` not-in-scope errors either way; the checked-in project looks out of sync with
  `Sources/RulesEngine`), so `PublishedWorkflowCodableTests` and `WorkflowResponseTests` were not run
  locally. Unrelated to this change, but worth knowing if it reproduces for you.

**Follow-ups**

- Wire `automatically_scale_font_size`, which `WorkflowPaywallView` reads off the mapper output and
  no mapper sets, so workflow-backed paywalls always use the default.
- Collapse `WorkflowScreen` into `PaywallComponentsData`. Cheap here — `PaywallComponentsData(from:)`
  accepts the same decoder — and it would also stop one malformed screen from failing the whole
  workflow decode, since that initializer is resilient where `WorkflowScreen`'s synthesized one throws.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall state and tab/rule matching for workflow presentations only; scope is limited but affects user-visible funnel behavior when state rules are configured.
> 
> **Overview**
> Funnel/workflow paywalls previously used an **empty** `PaywallStateStore`, so tab `state_condition` rules and `state_updates` never matched—behavior looked fine but overrides were ignored. Standalone offerings were unaffected.
> 
> This PR wires **`state_declarations`** through the workflow stack: `WorkflowScreen` decodes them from the API, `WorkflowScreenMapper` passes them into `PaywallComponentsData`, and **`WorkflowPaywallView`** seeds its shared store at init via **`mergedStateDeclarations(in:)`**, merging every screen’s declarations (screen id order, **first wins** on duplicate keys) so conditions can reference keys from steps the user hasn’t visited yet.
> 
> Screens with no declarations may now encode **`state_declarations`: null** instead of omitting the key. Malformed maps on workflow screens can drop the **entire** declaration map (`@IgnoreDecodeErrors`), unlike the offerings path that drops bad entries individually.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa9ffd682d81f0d6152295596eec35511d823025. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
