### PR TITLE
fix: Add accessibility metadata to paywall close buttons

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -707,6 +707,8 @@ struct LoadedOfferingPaywallView: View {
                 ? Constants.purchaseInProgressButtonOpacity
                 : 1
             )
+            .accessibilityLabel("Dismiss")
+            .accessibilityIdentifier("paywall_close_button")
         }
     }
 

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -331,6 +331,7 @@ struct PaywallsV2View: View {
             : 1
         )
         .accessibilityLabel("Dismiss")
+        .accessibilityIdentifier("paywall_close_button")
     }
 
     private func defaultPaywallView(warning: PaywallWarning) -> some View {

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallsV2ViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallsV2ViewTests.swift
@@ -12,9 +12,129 @@
 import Nimble
 @_spi(Internal) @testable import RevenueCat
 @_spi(Internal) @testable import RevenueCatUI
+import SwiftUI
 import XCTest
 
 #if !os(tvOS)
+
+#if !os(watchOS) && !os(macOS)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@MainActor
+final class PaywallsV2CloseButtonAccessibilityTests: TestCase {
+
+    func testCloseButtonAccessibility() throws {
+        var wasDismissed = false
+        let (window, view) = Self.hostPaywall(displayCloseButton: true) {
+            wasDismissed = true
+        }
+        defer { window.isHidden = true }
+
+        let closeButton = try XCTUnwrap(view.accessibilityElement(identifier: "paywall_close_button"))
+        expect(closeButton.accessibilityLabel) == "Dismiss"
+        expect(closeButton.accessibilityTraits.contains(.button)) == true
+        expect(closeButton.accessibilityActivate()) == true
+        expect(wasDismissed) == true
+    }
+
+    func testCloseButtonAccessibilityWhenHidden() {
+        let (window, view) = Self.hostPaywall(displayCloseButton: false)
+        defer { window.isHidden = true }
+
+        expect(view.accessibilityElement(identifier: "paywall_close_button")).to(beNil())
+    }
+
+    func testDisabledCloseButtonRetainsAccessibilityMetadata() throws {
+        var wasDismissed = false
+        let (window, view) = Self.hostPaywall(
+            displayCloseButton: true,
+            purchaseHandler: .purchasing()
+        ) {
+            wasDismissed = true
+        }
+        defer { window.isHidden = true }
+
+        let closeButton = try XCTUnwrap(view.accessibilityElement(identifier: "paywall_close_button"))
+        expect(closeButton.accessibilityLabel) == "Dismiss"
+        expect(closeButton.accessibilityTraits.contains(.notEnabled)) == true
+        expect(closeButton.accessibilityActivate()) == false
+        expect(wasDismissed) == false
+    }
+
+    private static func hostPaywall(
+        displayCloseButton: Bool,
+        purchaseHandler: PurchaseHandler = .mock(),
+        onDismiss: @escaping () -> Void = {}
+    ) -> (UIWindow, UIView) {
+        return Self.host(
+            PaywallsV2View(
+                paywallComponents: Self.paywallComponents,
+                offering: TestData.offeringWithIntroOffer,
+                purchaseHandler: purchaseHandler,
+                introEligibilityChecker: .producing(eligibility: .eligible),
+                showZeroDecimalPlacePrices: false,
+                displayCloseButton: displayCloseButton,
+                onDismiss: onDismiss,
+                failedToLoadFont: { _ in },
+                colorScheme: .light
+            )
+        )
+    }
+
+    private static func host<Content: View>(_ view: Content) -> (UIWindow, UIView) {
+        let size = BaseSnapshotTest.fullScreenSize
+        let controller = UIHostingController(rootView: view.frame(width: size.width, height: size.height))
+        let window = UIWindow(frame: CGRect(origin: .zero, size: size))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        controller.view.layoutIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+
+        return (window, controller.view)
+    }
+
+    private static let paywallComponents: Offering.PaywallComponents = {
+        var data = PaywallComponentsData(
+            templateName: "components",
+            assetBaseURL: URL(fileURLWithPath: "/"),
+            componentsConfig: .init(
+                base: .init(
+                    stack: .init(components: []),
+                    stickyFooter: nil,
+                    background: .color(.init(light: .hex("#ffffff")))
+                )
+            ),
+            componentsLocalizations: ["en_US": [:]],
+            revision: 1,
+            defaultLocaleIdentifier: "en_US"
+        )
+        data.errorInfo = ["test": .init(PaywallError.noCurrentOffering)]
+
+        return .init(uiConfig: PreviewUIConfig.make(), data: data)
+    }()
+
+}
+
+private extension UIView {
+
+    func accessibilityElement(identifier: String) -> NSObject? {
+        if self.accessibilityIdentifier == identifier {
+            return self
+        }
+
+        for element in self.accessibilityElements ?? [] {
+            if let identifiable = element as? UIAccessibilityIdentification,
+               identifiable.accessibilityIdentifier == identifier {
+                return element as? NSObject
+            }
+        }
+
+        return self.subviews.lazy.compactMap { $0.accessibilityElement(identifier: identifier) }.first
+    }
+
+}
+
+#endif
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 final class IntroEligibilityPackagesTests: TestCase {

--- a/Tests/RevenueCatUITests/Templates/OtherPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/Templates/OtherPaywallViewTests.swift
@@ -9,11 +9,51 @@ import Nimble
 import RevenueCat
 @testable import RevenueCatUI
 import SnapshotTesting
+import SwiftUI
+import XCTest
 
 #if !os(watchOS) && !os(macOS)
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 class OtherPaywallViewTests: BaseSnapshotTest {
+
+    func testCloseButtonAccessibility() throws {
+        var wasDismissed = false
+        let (window, view) = Self.hostPaywall(displayCloseButton: true) {
+            wasDismissed = true
+        }
+        defer { window.isHidden = true }
+
+        let closeButton = try XCTUnwrap(view.accessibilityElement(identifier: "paywall_close_button"))
+        expect(closeButton.accessibilityLabel) == "Dismiss"
+        expect(closeButton.accessibilityTraits.contains(.button)) == true
+        expect(closeButton.accessibilityActivate()) == true
+        expect(wasDismissed) == true
+    }
+
+    func testCloseButtonAccessibilityWhenHidden() {
+        let (window, view) = Self.hostPaywall(displayCloseButton: false)
+        defer { window.isHidden = true }
+
+        expect(view.accessibilityElement(identifier: "paywall_close_button")).to(beNil())
+    }
+
+    func testDisabledCloseButtonRetainsAccessibilityMetadata() throws {
+        var wasDismissed = false
+        let (window, view) = Self.hostPaywall(
+            displayCloseButton: true,
+            purchaseHandler: .purchasing()
+        ) {
+            wasDismissed = true
+        }
+        defer { window.isHidden = true }
+
+        let closeButton = try XCTUnwrap(view.accessibilityElement(identifier: "paywall_close_button"))
+        expect(closeButton.accessibilityLabel) == "Dismiss"
+        expect(closeButton.accessibilityTraits.contains(.notEnabled)) == true
+        expect(closeButton.accessibilityActivate()) == false
+        expect(wasDismissed) == false
+    }
 
     func testLoadingPaywallView() {
         LoadingPaywallView(mode: .fullScreen, displayCloseButton: false, shimmer: false)
@@ -28,6 +68,57 @@ class OtherPaywallViewTests: BaseSnapshotTest {
     func testLoadingCondensedFooterPaywallView() {
         LoadingPaywallView(mode: .condensedFooter, displayCloseButton: false, shimmer: false)
             .recordSnapshot(size: Self.footerSize)
+    }
+
+    private static func hostPaywall(
+        displayCloseButton: Bool,
+        purchaseHandler: PurchaseHandler = .mock(),
+        onDismiss: @escaping () -> Void = {}
+    ) -> (UIWindow, UIView) {
+        let view = PaywallView(
+            configuration: .init(
+                offering: TestData.offeringWithIntroOffer.withLocalImages,
+                customerInfo: TestData.customerInfo,
+                displayCloseButton: displayCloseButton,
+                introEligibility: .producing(eligibility: .eligible),
+                purchaseHandler: purchaseHandler
+            ),
+            paywallViewOwnsPurchaseHandler: false
+        )
+        .onRequestedDismissal(onDismiss)
+
+        return Self.host(view)
+    }
+
+    private static func host<Content: View>(_ view: Content) -> (UIWindow, UIView) {
+        let size = Self.fullScreenSize
+        let controller = UIHostingController(rootView: view.frame(width: size.width, height: size.height))
+        let window = UIWindow(frame: CGRect(origin: .zero, size: size))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        controller.view.layoutIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+
+        return (window, controller.view)
+    }
+
+}
+
+private extension UIView {
+
+    func accessibilityElement(identifier: String) -> NSObject? {
+        if self.accessibilityIdentifier == identifier {
+            return self
+        }
+
+        for element in self.accessibilityElements ?? [] {
+            if let identifiable = element as? UIAccessibilityIdentification,
+               identifiable.accessibilityIdentifier == identifier {
+                return element as? NSObject
+            }
+        }
+
+        return self.subviews.lazy.compactMap { $0.accessibilityElement(identifier: identifier) }.first
     }
 
 }


### PR DESCRIPTION
### Checklist

- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids
  Not run: no test command resolved in this workspace, so nothing was executed to pass.

### Motivation

Add a "Dismiss" accessibility label and a stable `paywall_close_button` accessibility identifier to the legacy toolbar button in `LoadedOfferingPaywallView`, attaching the modifiers to the `Button` so assistive technologies expose the control's action rather than its SF Symbol. Add the same identifier to the existing V2 close button while retaining its current "Dismiss" label, giving hybrid and native UI tests one selector regardless of which paywall renderer an offering uses. Extend the existing legacy and V2 view test suites to render each path with `displayCloseButton` enabled and inspect the resulting accessibility tree for the expected button label and identifier.

RevenueCatUI's legacy paywall toolbar renders its close action as an `xmark` image without an accessibility label or identifier, so VoiceOver cannot communicate the action and UI tests cannot select it reliably. The same public `displayCloseButton` option routes V2 paywalls through a separate close-button implementation; that path already supplies the "Dismiss" label but still lacks an identifier. Customer Center demonstrates the intended SwiftUI accessibility-modifier pattern, while the paywall paths should use a paywall-specific identifier rather than Customer Center's `circled_close_button`. The fix must cover both shipped full-screen paywall renderers without changing dismissal callbacks, disabled state, styling, or public API.

Fixes #7348

### Description

Add a "Dismiss" accessibility label and a stable `paywall_close_button` accessibility identifier to the legacy toolbar button in `LoadedOfferingPaywallView`, attaching the modifiers to the `Button` so assistive technologies expose the control's action rather than its SF Symbol. Add the same identifier to the existing V2 close button while retaining its current "Dismiss" label, giving hybrid and native UI tests one selector regardless of which paywall renderer an offering uses. Extend the existing legacy and V2 view test suites to render each path with `displayCloseButton` enabled and inspect the resulting accessibility tree for the expected button label and identifier.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small SwiftUI accessibility additions on close buttons with no API or dismissal behavior changes; coverage added via UI tests.
> 
> **Overview**
> Adds **Dismiss** labeling and a shared **`paywall_close_button`** accessibility identifier on paywall close controls so VoiceOver and UI tests can target them reliably.
> 
> The legacy full-screen paywall toolbar close button (`LoadedOfferingPaywallView`) now gets both modifiers on the `Button` (not only the `xmark` image). The V2 close button in `PaywallsV2View` keeps its existing **Dismiss** label and gains the same identifier, so one selector works for legacy and V2 renderers.
> 
> New UI-hosted tests in the legacy and V2 paywall test suites assert the identifier and label when the button is shown, absent when `displayCloseButton` is false, and still correct when the button is disabled during an in-progress purchase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a821b371e46eb0a820e1455f185693ebb22aa2ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->