### PR TITLE
DO NOT MERGE: demo run for the public API diff report

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1865,26 +1865,6 @@ extension Purchases {
     ///
     /// Setting this will affect the display of RevenueCat UI components, such as the Paywalls.
     /// - Important: This method only takes effect after `Purchases` has been configured.
-    @objc public func overridePreferredUILocale(_ locale: String?) {
-        guard locale != self.systemInfo.preferredLocaleOverride else {
-            return
-        }
-
-        self.systemInfo.overridePreferredLocale(locale)
-
-        if self.overridePreferredUILocaleRateLimiter.shouldProceed() {
-            // Refetches new offerings with preferred locale
-            self.offeringsManager.clearInMemoryOfferingsCache()
-            self.getOfferings(fetchPolicy: .default) { _, _ in
-                // No-op
-            }
-        } else {
-            Logger.debug(Strings.offering.override_preferred_locale_rate_limited(
-                maxCalls: self.overridePreferredUILocaleRateLimiter.maxCalls,
-                periodSeconds: Int(self.overridePreferredUILocaleRateLimiter.period)
-            ))
-        }
-    }
 }
 
 // MARK: Configuring Purchases

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1854,6 +1854,11 @@ extension Purchases {
 // MARK: - Preferred locale
 
 extension Purchases {
+    /// Demo-only API used to verify the public API diff report in CI. Do not merge.
+    @objc public func apiDiffDemoPing() -> String {
+        "pong"
+    }
+
     /// Overrides the preferred locale for RevenueCatUI components.
     /// - Parameter locale: A locale string in the format "language_region" (e.g., "en_US").
     /// Use `nil` to remove the override and use the default user locale determined by the system.


### PR DESCRIPTION
Throwaway demo for #7309, to be closed once we have seen the output. **Do not merge, do not review.**

Adds one `@objc public func apiDiffDemoPing()` to `Purchases` so CI exercises the whole reporting path against a real public API change:

- the **PR comment** should appear on this PR, listing the addition, and be rewritten in place on any later push
- the **Slack summary** should post to #feed-sdk-new-api as `:sparkles: New public API`, or log that no credential is configured
- the **gate** should NOT block: an added method on an existing class is not breaking
- the **freshness check** should fail, because the baselines were deliberately not regenerated. That is the realistic shape of a first push, and the report is published before that failure is raised.