### PR TITLE
Fix v4 release CI deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1329,6 +1329,7 @@ jobs:
       - run:
           name: Mirror purchases-ios tags to purchases-ios-spm (main not mirrored)
           command: |
+            set -e
             git clone git@github.com:RevenueCat/purchases-ios.git
             cd purchases-ios
             git fetch --tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1322,10 +1322,16 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
-      - install-rubydocker-dependencies
+      - setup-git-credentials
+      - trust-github-key
       - run:
-          name: Clone purchases-ios and push to purchases-ios-spm
-          command: bundle exec fastlane deploy_to_spm
+          name: Mirror purchases-ios tags to purchases-ios-spm (main not mirrored)
+          command: |
+            git clone git@github.com:RevenueCat/purchases-ios.git
+            cd purchases-ios
+            git fetch --tags
+            git remote set-url origin git@github.com:RevenueCat/purchases-ios-spm.git
+            git push --tags
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1012,6 +1012,7 @@ jobs:
     steps:
       - setup-git-credentials
       - checkout
+      - trust-github-key
       - install-bundle-dependencies
       - run:
           name: Build docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1258,6 +1258,7 @@ jobs:
   deploy-purchase-tester:
     executor:
       name: macos-executor
+      xcode_version: "26.5"
     steps:
       - checkout
       - setup-git-credentials

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,10 @@ var dependencies: [Package.Dependency] = [
     .package(url: "git@github.com:pointfreeco/swift-snapshot-testing.git", .upToNextMinor(from: "1.12.0"))
 ]
 if shouldIncludeDocCPlugin {
-    dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"))
+    dependencies.append(.package(
+        url: "https://github.com/apple/swift-docc-plugin",
+        revision: "26ac5758409154cc448d7ab82389c520fa8a8247"
+    ))
 }
 
 // See https://github.com/RevenueCat/purchases-ios/pull/2989

--- a/Package@swift-5.7.swift
+++ b/Package@swift-5.7.swift
@@ -14,7 +14,10 @@ var dependencies: [Package.Dependency] = [
     .package(url: "git@github.com:pointfreeco/swift-snapshot-testing.git", from: "1.11.0")
 ]
 if shouldIncludeDocCPlugin {
-    dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"))
+    dependencies.append(.package(
+        url: "https://github.com/apple/swift-docc-plugin",
+        revision: "26ac5758409154cc448d7ab82389c520fa8a8247"
+    ))
 }
 
 let package = Package(

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -14,7 +14,10 @@ var dependencies: [Package.Dependency] = [
     .package(url: "git@github.com:pointfreeco/swift-snapshot-testing.git", from: "1.11.0")
 ]
 if shouldIncludeDocCPlugin {
-    dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"))
+    dependencies.append(.package(
+        url: "https://github.com/apple/swift-docc-plugin",
+        revision: "26ac5758409154cc448d7ab82389c520fa8a8247"
+    ))
 }
 
 let package = Package(


### PR DESCRIPTION
## Summary

Backports the CI fixes discovered while releasing `4.44.3`.

## Fixes

1. **Fix SPM tag deployment**
   - Adds Git credential and SSH host-trust setup.
   - Mirrors release tags to `purchases-ios-spm` without attempting to update `main`.
   - Commit: [cd8d8259d](https://github.com/RevenueCat/purchases-ios/commit/cd8d8259dc53f9a853e4f0245dc0fd7df1161990)
   - Main equivalent: [#7189](https://github.com/RevenueCat/purchases-ios/pull/7189)

2. **Trust GitHub during documentation deployment**
   - Adds the GitHub host key before the documentation lane clones and pushes to the docs repository.
   - Commit: [5d8660dc8](https://github.com/RevenueCat/purchases-ios/commit/5d8660dc8b867116aa003ca0d197f3d9ae281572)
   - No direct equivalent exists in the current `main` docs job; this is v4-specific hardening based on the release recovery.

3. **Pin the DocC plugin**
   - Prevents Xcode 14.3.1 from resolving incompatible DocC plugin `1.5.0`.
   - Applies `main`'s current pinned revision directly to all three v4 manifests.
   - Commit: [2b6c7def9](https://github.com/RevenueCat/purchases-ios/commit/2b6c7def9cc9c0eef62064fa42e61bb2f7033540)
   - Main history: [#4216](https://github.com/RevenueCat/purchases-ios/pull/4216) introduced the 1.3.0 pin; [#4661](https://github.com/RevenueCat/purchases-ios/pull/4661) converted it to the revision used here.

4. **Build Purchase Tester with Xcode 26.5**
   - Ensures TestFlight uploads use the iOS 26 SDK required by App Store Connect.
   - Commit: [5f649b936](https://github.com/RevenueCat/purchases-ios/commit/5f649b936df68984d09c19c6bd3feea3a7d77363)
   - Main equivalents: [#6441](https://github.com/RevenueCat/purchases-ios/pull/6441), [#6555](https://github.com/RevenueCat/purchases-ios/pull/6555)

## Validation

- CircleCI configuration validates successfully.
- All modified Swift package manifests parse successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release automation (tag mirroring and SSH git pushes) and Xcode pins; mistakes could break SPM consumers or TestFlight uploads, but scope is CI/manifest-only with no runtime SDK logic changes.
> 
> **Overview**
> Backports CI fixes from the **4.44.3** release so v4 deploy workflows can clone/push over SSH and build with the right Xcode/SPM pins.
> 
> **CircleCI:** `docs-deploy` runs **`trust-github-key`** before doc generation. **`deploy-purchase-tester`** pins **`xcode_version: "26.5`** for App Store Connect’s iOS 26 SDK requirement. **`deploy-to-spm`** drops Ruby/bundle setup and the **`deploy_to_spm`** fastlane lane; it uses git credentials + host trust, clones **`purchases-ios`**, fetches tags, and **`git push --tags`** to **`purchases-ios-spm`** (no **`main`** mirror).
> 
> **Package manifests:** When **`INCLUDE_DOCC_PLUGIN`** is set, **`swift-docc-plugin`** is pinned to revision **`26ac575…`** instead of **`from: "1.0.0"`** in **`Package.swift`**, **`Package@swift-5.7.swift`**, and **`Package@swift-5.8.swift`**, avoiding incompatible **1.5.0** resolution on Xcode **14.3.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 893794a8b90348c23d5a1c2656b127f59d20845b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->