### PR TITLE
Ingest the checkpoints config topic

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1442,6 +1442,10 @@
 		FEDA000000000000000000B2 /* WeightedSourceSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA000000000000000000A2 /* WeightedSourceSelector.swift */; };
 		FEDA000000000000000000D1 /* RemoteConfigSourceProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA000000000000000000C1 /* RemoteConfigSourceProviderTests.swift */; };
 		FEDA000000000000000000D2 /* RemoteConfigSourceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA000000000000000000C2 /* RemoteConfigSourceProvider.swift */; };
+		FEDA000000000000000000D3 /* CheckpointRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA000000000000000000C3 /* CheckpointRules.swift */; };
+		FEDA000000000000000000D4 /* CheckpointsConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA000000000000000000C4 /* CheckpointsConfigProvider.swift */; };
+		FEDA000000000000000000D5 /* CheckpointRulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA000000000000000000C5 /* CheckpointRulesTests.swift */; };
+		FEDA000000000000000000D6 /* CheckpointsConfigProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA000000000000000000C6 /* CheckpointsConfigProviderTests.swift */; };
 		FEDA000000000000000000E1 /* MockRemoteConfigSourceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA000000000000000000E0 /* MockRemoteConfigSourceProvider.swift */; };
 		FEDA000000000000000000E2 /* MockRemoteConfigSourceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA000000000000000000E0 /* MockRemoteConfigSourceProvider.swift */; };
 		FEDA0000000000000000F0A2 /* GetRemoteConfigFallbackOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA0000000000000000F0A1 /* GetRemoteConfigFallbackOperation.swift */; };
@@ -3112,6 +3116,10 @@
 		FEDA000000000000000000A2 /* WeightedSourceSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightedSourceSelector.swift; sourceTree = "<group>"; };
 		FEDA000000000000000000C1 /* RemoteConfigSourceProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigSourceProviderTests.swift; sourceTree = "<group>"; };
 		FEDA000000000000000000C2 /* RemoteConfigSourceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigSourceProvider.swift; sourceTree = "<group>"; };
+		FEDA000000000000000000C3 /* CheckpointRules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckpointRules.swift; sourceTree = "<group>"; };
+		FEDA000000000000000000C4 /* CheckpointsConfigProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckpointsConfigProvider.swift; sourceTree = "<group>"; };
+		FEDA000000000000000000C5 /* CheckpointRulesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckpointRulesTests.swift; sourceTree = "<group>"; };
+		FEDA000000000000000000C6 /* CheckpointsConfigProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckpointsConfigProviderTests.swift; sourceTree = "<group>"; };
 		FEDA000000000000000000E0 /* MockRemoteConfigSourceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRemoteConfigSourceProvider.swift; sourceTree = "<group>"; };
 		FEDA0000000000000000F0A1 /* GetRemoteConfigFallbackOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetRemoteConfigFallbackOperation.swift; sourceTree = "<group>"; };
 		FFB683A085B695768EAB9AA5 /* WorkflowsConfigProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowsConfigProviderTests.swift; sourceTree = "<group>"; };
@@ -4677,6 +4685,8 @@
 				A1B2C3D42FE9000000000001 /* GenerationGuardedCache.swift */,
 				DB021C52E3CCC5EB17FFF795 /* UiConfigProvider.swift */,
 				4C390BBAC430231B23B4B5F8 /* WorkflowsConfigProvider.swift */,
+				FEDA000000000000000000C3 /* CheckpointRules.swift */,
+				FEDA000000000000000000C4 /* CheckpointsConfigProvider.swift */,
 				A1B2C3D42FE7000000000001 /* RemoteConfigTopic.swift */,
 				A1B2C3D42FE1000000000011 /* RemoteConfigSignatureContextProvider.swift */,
 			);
@@ -4708,6 +4718,8 @@
 				A1B2C3D42FE9000000000003 /* GenerationGuardedCacheTests.swift */,
 				371E0615EDF883698273BC59 /* UiConfigProviderTests.swift */,
 				FFB683A085B695768EAB9AA5 /* WorkflowsConfigProviderTests.swift */,
+				FEDA000000000000000000C5 /* CheckpointRulesTests.swift */,
+				FEDA000000000000000000C6 /* CheckpointsConfigProviderTests.swift */,
 				5733B1A927FFBCF900EC2045 /* BaseErrorTests.swift */,
 				DB7EA7752F964CA200BCC082 /* Workflows */,
 			);
@@ -7286,6 +7298,8 @@
 				A1B2C3D42FE9000000000002 /* GenerationGuardedCache.swift in Sources */,
 				B8EF700CBF25815EC2BF1253 /* UiConfigProvider.swift in Sources */,
 				49B8016629C29C4691C0774A /* WorkflowsConfigProvider.swift in Sources */,
+				FEDA000000000000000000D3 /* CheckpointRules.swift in Sources */,
+				FEDA000000000000000000D4 /* CheckpointsConfigProvider.swift in Sources */,
 				A1B2C3D42FE2000000000006 /* RemoteConfigStrings.swift in Sources */,
 				A1B2C3D42FE7000000000002 /* RemoteConfigTopic.swift in Sources */,
 				A1B2C3D42FE1000000000010 /* RemoteConfigSignatureContextProvider.swift in Sources */,
@@ -7913,6 +7927,8 @@
 				A1B2C3D42FE9000000000004 /* GenerationGuardedCacheTests.swift in Sources */,
 				AD787D4FC44F9C3638DCDEF9 /* UiConfigProviderTests.swift in Sources */,
 				E48EFFFF5FF27ECC25F4E308 /* WorkflowsConfigProviderTests.swift in Sources */,
+				FEDA000000000000000000D5 /* CheckpointRulesTests.swift in Sources */,
+				FEDA000000000000000000D6 /* CheckpointsConfigProviderTests.swift in Sources */,
 				03A98D362D244329009BCA61 /* UIConfigDecodingTests.swift in Sources */,
 				7559DF072E38B05F0050C5B4 /* WebProductToStoreProductConversionTests.swift in Sources */,
 				351B515626D44B2300BD2BD7 /* MockNotificationCenter.swift in Sources */,

--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -10,7 +10,7 @@ import Foundation
 enum RemoteConfigStrings {
 
     case cacheURLNotAvailable
-    case checkpointRuleSkipped(checkpoint: String, reason: String)
+    case checkpointRuleSkipped(reason: String)
     case failedToClearBlobStore(Error)
     case failedToDeleteBlob(String, Error)
     case failedToReadBlob(String, Error)
@@ -50,8 +50,8 @@ extension RemoteConfigStrings: LogMessage {
         switch self {
         case .cacheURLNotAvailable:
             return "Remote config cache URL is not available."
-        case let .checkpointRuleSkipped(checkpoint, reason):
-            return "Skipping malformed rule for checkpoint '\(checkpoint)': \(reason)."
+        case let .checkpointRuleSkipped(reason):
+            return "Skipping malformed checkpoint rule: \(reason)."
         case let .failedToClearBlobStore(error):
             return "Failed to clear remote config blob store: \(error.localizedDescription)"
         case let .failedToDeleteBlob(ref, error):

--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -10,6 +10,7 @@ import Foundation
 enum RemoteConfigStrings {
 
     case cacheURLNotAvailable
+    case checkpointRuleSkipped(checkpoint: String, reason: String)
     case failedToClearBlobStore(Error)
     case failedToDeleteBlob(String, Error)
     case failedToReadBlob(String, Error)
@@ -49,6 +50,8 @@ extension RemoteConfigStrings: LogMessage {
         switch self {
         case .cacheURLNotAvailable:
             return "Remote config cache URL is not available."
+        case let .checkpointRuleSkipped(checkpoint, reason):
+            return "Skipping malformed rule for checkpoint '\(checkpoint)': \(reason)."
         case let .failedToClearBlobStore(error):
             return "Failed to clear remote config blob store: \(error.localizedDescription)"
         case let .failedToDeleteBlob(ref, error):

--- a/Sources/Networking/CheckpointRules.swift
+++ b/Sources/Networking/CheckpointRules.swift
@@ -10,13 +10,10 @@ import Foundation
 /// One checkpoint's rules, which decide whether it resolves to a workflow. Parsed only, not evaluated.
 struct CheckpointRuleSet: Equatable, Sendable {
 
-    /// The checkpoint's backend id, as opposed to its name, which is the topic item key.
-    let id: String?
     /// Served in priority order, first match wins. Never re-sorted here.
     let rules: [CheckpointRule]
 
-    init(id: String? = nil, rules: [CheckpointRule]) {
-        self.id = id
+    init(rules: [CheckpointRule]) {
         self.rules = rules
     }
 
@@ -43,7 +40,6 @@ struct CheckpointRule: Equatable, Sendable {
 extension CheckpointRuleSet: Decodable {
 
     private enum CodingKeys: String, CodingKey {
-        case id
         case rules
     }
 
@@ -52,7 +48,6 @@ extension CheckpointRuleSet: Decodable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        self.id = try container.decodeIfPresent(String.self, forKey: .id)
         self.rules = (try container.decodeIfPresent([SkippableRule].self, forKey: .rules) ?? [])
             .compactMap(\.rule)
     }
@@ -63,7 +58,7 @@ extension CheckpointRule: Decodable {
 
     private enum CodingKeys: String, CodingKey {
         case id
-        case audienceId = "audience"
+        case audienceId
         case workflowId
     }
 

--- a/Sources/Networking/CheckpointRules.swift
+++ b/Sources/Networking/CheckpointRules.swift
@@ -28,40 +28,23 @@ struct CheckpointRuleSet: Equatable, Sendable {
 struct CheckpointRule: Equatable, Sendable {
 
     let id: String?
-    /// Reference to the targeted audience, whose predicate arrives in a separate topic. `nil` targets everyone.
-    let audienceId: String?
+    /// Reference to the targeted audience, whose predicate arrives in a separate topic. Required, so a rule
+    /// can never end up targeting everyone by omission.
+    let audienceId: Int
     let workflowId: String
-    let frequencyCap: CheckpointFrequencyCap?
     /// Rules are published ahead of their start date, so this window is resolved on device.
     let schedule: CheckpointRuleSchedule?
 
     init(
         id: String? = nil,
-        audienceId: String? = nil,
+        audienceId: Int,
         workflowId: String,
-        frequencyCap: CheckpointFrequencyCap? = nil,
         schedule: CheckpointRuleSchedule? = nil
     ) {
         self.id = id
         self.audienceId = audienceId
         self.workflowId = workflowId
-        self.frequencyCap = frequencyCap
         self.schedule = schedule
-    }
-
-}
-
-/// `type` stays the raw wire value: frequency capping is out of V1 scope and its vocabulary isn't settled.
-struct CheckpointFrequencyCap: Equatable, Sendable {
-
-    let type: String
-    let count: Int?
-    let window: String?
-
-    init(type: String, count: Int? = nil, window: String? = nil) {
-        self.type = type
-        self.count = count
-        self.window = window
     }
 
 }
@@ -136,40 +119,25 @@ extension CheckpointRuleSet {
             return nil
         }
 
+        guard case let .int(audienceId)? = fields[Self.audienceKey] else {
+            Logger.warn(Strings.remoteConfig.checkpointRuleSkipped(
+                checkpoint: checkpoint,
+                reason: "missing '\(Self.audienceKey)'"
+            ))
+            return nil
+        }
+
         var id: String?
         if case let .string(value)? = fields[Self.idKey] {
             id = value
-        }
-        var audienceId: String?
-        if case let .string(value)? = fields[Self.audienceKey] {
-            audienceId = value
         }
 
         return CheckpointRule(
             id: id,
             audienceId: audienceId,
             workflowId: workflowId,
-            frequencyCap: Self.parseFrequencyCap(fields[Self.frequencyCapKey]),
             schedule: Self.parseSchedule(fields[Self.scheduleKey])
         )
-    }
-
-    private static func parseFrequencyCap(_ field: AnyDecodable?) -> CheckpointFrequencyCap? {
-        guard case let .object(fields)? = field,
-              case let .string(type)? = fields[Self.typeKey] else {
-            return nil
-        }
-
-        var count: Int?
-        if case let .int(value)? = fields[Self.countKey] {
-            count = value
-        }
-        var window: String?
-        if case let .string(value)? = fields[Self.windowKey] {
-            window = value
-        }
-
-        return CheckpointFrequencyCap(type: type, count: count, window: window)
     }
 
     /// Dropped rather than kept as open-ended, which would run the rule outside its dates.
@@ -201,10 +169,6 @@ extension CheckpointRuleSet {
     private static let rulesKey = "rules"
     private static let audienceKey = "audience"
     private static let workflowIdKey = "workflow_id"
-    private static let frequencyCapKey = "frequency_cap"
-    private static let typeKey = "type"
-    private static let countKey = "count"
-    private static let windowKey = "window"
     private static let scheduleKey = "schedule"
     private static let startKey = "start"
     private static let endKey = "end"

--- a/Sources/Networking/CheckpointRules.swift
+++ b/Sources/Networking/CheckpointRules.swift
@@ -29,33 +29,11 @@ struct CheckpointRule: Equatable, Sendable {
     /// can never end up targeting everyone by omission.
     let audienceId: String
     let workflowId: String
-    /// Rules are published ahead of their start date, so this window is resolved on device.
-    let schedule: CheckpointRuleSchedule?
 
-    init(
-        id: String? = nil,
-        audienceId: String,
-        workflowId: String,
-        schedule: CheckpointRuleSchedule? = nil
-    ) {
+    init(id: String? = nil, audienceId: String, workflowId: String) {
         self.id = id
         self.audienceId = audienceId
         self.workflowId = workflowId
-        self.schedule = schedule
-    }
-
-}
-
-/// Either bound absent means open-ended on that side. A bound that's present but unparseable fails the whole
-/// rule rather than reading as open-ended, which would run it outside its dates.
-struct CheckpointRuleSchedule: Equatable, Sendable {
-
-    let start: Date?
-    let end: Date?
-
-    init(start: Date? = nil, end: Date? = nil) {
-        self.start = start
-        self.end = end
     }
 
 }
@@ -87,12 +65,9 @@ extension CheckpointRule: Decodable {
         case id
         case audienceId = "audience"
         case workflowId
-        case schedule
     }
 
 }
-
-extension CheckpointRuleSchedule: Decodable {}
 
 /// Turns a rule that fails to decode into `nil` instead of failing its enclosing array.
 private struct SkippableRule: Decodable {

--- a/Sources/Networking/CheckpointRules.swift
+++ b/Sources/Networking/CheckpointRules.swift
@@ -10,15 +10,12 @@ import Foundation
 /// One checkpoint's rules, which decide whether it resolves to a workflow. Parsed only, not evaluated.
 struct CheckpointRuleSet: Equatable, Sendable {
 
-    /// The checkpoint name, which is also the topic item key.
-    let identifier: String
-    /// The checkpoint's backend id, as opposed to its name.
+    /// The checkpoint's backend id, as opposed to its name, which is the topic item key.
     let id: String?
     /// Served in priority order, first match wins. Never re-sorted here.
     let rules: [CheckpointRule]
 
-    init(identifier: String, id: String? = nil, rules: [CheckpointRule]) {
-        self.identifier = identifier
+    init(id: String? = nil, rules: [CheckpointRule]) {
         self.id = id
         self.rules = rules
     }
@@ -49,7 +46,8 @@ struct CheckpointRule: Equatable, Sendable {
 
 }
 
-/// Either bound absent means open-ended on that side.
+/// Either bound absent means open-ended on that side. A bound that's present but unparseable fails the whole
+/// rule rather than reading as open-ended, which would run it outside its dates.
 struct CheckpointRuleSchedule: Equatable, Sendable {
 
     let start: Date?
@@ -62,115 +60,52 @@ struct CheckpointRuleSchedule: Equatable, Sendable {
 
 }
 
-// MARK: - Parsing
+// MARK: - Decodable
 
-extension CheckpointRuleSet {
+extension CheckpointRuleSet: Decodable {
 
-    /// `nil` when the bytes aren't a JSON object.
-    static func parse(identifier: String, blob data: Data) -> CheckpointRuleSet? {
-        guard let fields = Self.fields(fromBlob: data) else { return nil }
-        return Self.parse(identifier: identifier, fields: fields)
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case rules
     }
 
-    /// A malformed rule is skipped rather than failing the checkpoint, and unknown fields are ignored so the
-    /// backend can extend the schema without a client release.
-    static func parse(identifier: String, fields: [String: AnyDecodable]) -> CheckpointRuleSet {
-        var id: String?
-        if case let .string(value)? = fields[Self.idKey] {
-            id = value
-        }
+    /// A rule the SDK can't make sense of is skipped rather than failing the checkpoint, so one bad rule
+    /// can't take out the rest.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        return CheckpointRuleSet(
-            identifier: identifier,
-            id: id,
-            rules: Self.parseRules(from: fields, checkpoint: identifier)
-        )
+        self.id = try container.decodeIfPresent(String.self, forKey: .id)
+        self.rules = (try container.decodeIfPresent([SkippableRule].self, forKey: .rules) ?? [])
+            .compactMap(\.rule)
     }
 
-    private static func parseRules(
-        from fields: [String: AnyDecodable],
-        checkpoint: String
-    ) -> [CheckpointRule] {
-        guard let rules = fields[Self.rulesKey] else { return [] }
-        guard case let .array(entries) = rules else {
-            Logger.warn(Strings.remoteConfig.checkpointRuleSkipped(
-                checkpoint: checkpoint,
-                reason: "expected '\(Self.rulesKey)' to be an array"
-            ))
-            return []
-        }
+}
 
-        return entries.compactMap { Self.parseRule($0, checkpoint: checkpoint) }
+extension CheckpointRule: Decodable {
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case audienceId = "audience"
+        case workflowId
+        case schedule
     }
 
-    private static func parseRule(_ entry: AnyDecodable, checkpoint: String) -> CheckpointRule? {
-        guard case let .object(fields) = entry else {
-            Logger.warn(Strings.remoteConfig.checkpointRuleSkipped(
-                checkpoint: checkpoint,
-                reason: "expected each rule to be an object"
-            ))
-            return nil
-        }
-        guard case let .string(workflowId)? = fields[Self.workflowIdKey], !workflowId.isEmpty else {
-            Logger.warn(Strings.remoteConfig.checkpointRuleSkipped(
-                checkpoint: checkpoint,
-                reason: "missing '\(Self.workflowIdKey)'"
-            ))
-            return nil
-        }
+}
 
-        guard case let .int(audienceId)? = fields[Self.audienceKey] else {
-            Logger.warn(Strings.remoteConfig.checkpointRuleSkipped(
-                checkpoint: checkpoint,
-                reason: "missing '\(Self.audienceKey)'"
-            ))
-            return nil
-        }
+extension CheckpointRuleSchedule: Decodable {}
 
-        var id: String?
-        if case let .string(value)? = fields[Self.idKey] {
-            id = value
-        }
+/// Turns a rule that fails to decode into `nil` instead of failing its enclosing array.
+private struct SkippableRule: Decodable {
 
-        return CheckpointRule(
-            id: id,
-            audienceId: audienceId,
-            workflowId: workflowId,
-            schedule: Self.parseSchedule(fields[Self.scheduleKey])
-        )
-    }
+    let rule: CheckpointRule?
 
-    /// Dropped rather than kept as open-ended, which would run the rule outside its dates.
-    private static func parseSchedule(_ field: AnyDecodable?) -> CheckpointRuleSchedule? {
-        guard case let .object(fields)? = field else { return nil }
-
-        let start = Self.parseDate(fields[Self.startKey])
-        let end = Self.parseDate(fields[Self.endKey])
-        guard start != nil || end != nil else { return nil }
-
-        return CheckpointRuleSchedule(start: start, end: end)
-    }
-
-    private static func parseDate(_ field: AnyDecodable?) -> Date? {
-        guard case let .string(value)? = field else { return nil }
-        return ISO8601DateFormatter.default.date(from: value)
-    }
-
-    private static func fields(fromBlob data: Data) -> [String: AnyDecodable]? {
+    init(from decoder: Decoder) throws {
         do {
-            return try JSONDecoder.default.decode([String: AnyDecodable].self, from: data)
+            self.rule = try CheckpointRule(from: decoder)
         } catch {
-            Logger.error(Strings.codable.decoding_error(error, [String: AnyDecodable].self))
-            return nil
+            Logger.warn(Strings.remoteConfig.checkpointRuleSkipped(reason: "\(error)"))
+            self.rule = nil
         }
     }
-
-    private static let idKey = "id"
-    private static let rulesKey = "rules"
-    private static let audienceKey = "audience"
-    private static let workflowIdKey = "workflow_id"
-    private static let scheduleKey = "schedule"
-    private static let startKey = "start"
-    private static let endKey = "end"
 
 }

--- a/Sources/Networking/CheckpointRules.swift
+++ b/Sources/Networking/CheckpointRules.swift
@@ -12,10 +12,9 @@ struct CheckpointRuleSet: Equatable, Sendable {
 
     /// The checkpoint name, which is also the topic item key.
     let identifier: String
-    /// The checkpoint's backend id, absent when the backend doesn't send one.
+    /// The checkpoint's backend id, as opposed to its name.
     let id: String?
-    /// Served in priority order: evaluated top to bottom, first match wins. Not re-sorted here, since the
-    /// wire order *is* the order.
+    /// Served in priority order, first match wins. Never re-sorted here.
     let rules: [CheckpointRule]
 
     init(identifier: String, id: String? = nil, rules: [CheckpointRule]) {
@@ -26,17 +25,14 @@ struct CheckpointRuleSet: Equatable, Sendable {
 
 }
 
-/// One rule at a checkpoint: who it applies to, and the workflow it resolves to.
 struct CheckpointRule: Equatable, Sendable {
 
     let id: String?
-    /// The audience this rule targets, as a reference. The audience's own predicate is expected to arrive in
-    /// a separate topic, so nothing here evaluates it. `nil` targets every user.
+    /// Reference to the targeted audience, whose predicate arrives in a separate topic. `nil` targets everyone.
     let audienceId: String?
     let workflowId: String
     let frequencyCap: CheckpointFrequencyCap?
-    /// When the rule is live. Rules are published on creation, ahead of their start date, so a scheduled
-    /// window has to be resolved on device.
+    /// Rules are published ahead of their start date, so this window is resolved on device.
     let schedule: CheckpointRuleSchedule?
 
     init(
@@ -55,8 +51,7 @@ struct CheckpointRule: Equatable, Sendable {
 
 }
 
-/// How often a rule may fire. `type` stays the raw wire value: frequency capping is out of V1 scope and its
-/// vocabulary isn't settled, so this carries what was sent instead of interpreting it.
+/// `type` stays the raw wire value: frequency capping is out of V1 scope and its vocabulary isn't settled.
 struct CheckpointFrequencyCap: Equatable, Sendable {
 
     let type: String
@@ -71,7 +66,7 @@ struct CheckpointFrequencyCap: Equatable, Sendable {
 
 }
 
-/// A rule's scheduled window. Either bound can be absent, meaning open-ended on that side.
+/// Either bound absent means open-ended on that side.
 struct CheckpointRuleSchedule: Equatable, Sendable {
 
     let start: Date?
@@ -88,19 +83,14 @@ struct CheckpointRuleSchedule: Equatable, Sendable {
 
 extension CheckpointRuleSet {
 
-    /// Parses a checkpoint's blob payload. Returns `nil` when the bytes aren't a JSON object.
+    /// `nil` when the bytes aren't a JSON object.
     static func parse(identifier: String, blob data: Data) -> CheckpointRuleSet? {
         guard let fields = Self.fields(fromBlob: data) else { return nil }
         return Self.parse(identifier: identifier, fields: fields)
     }
 
-    /// Parses one checkpoint's id and rules from its decoded payload. A malformed rule is skipped rather than
-    /// failing the checkpoint, and unknown fields are ignored so the backend can extend the schema without a
-    /// client release.
-    ///
-    /// Keys are read at their wire spelling (`workflow_id`, `frequency_cap`): the payload is decoded as a
-    /// dictionary, and `.convertFromSnakeCase` only renames keys read through a keyed container. That holds at
-    /// every depth here, unlike an item's `content`, whose own keys `ConfigItem.init(from:)` does camelCase.
+    /// A malformed rule is skipped rather than failing the checkpoint, and unknown fields are ignored so the
+    /// backend can extend the schema without a client release.
     static func parse(identifier: String, fields: [String: AnyDecodable]) -> CheckpointRuleSet {
         var id: String?
         if case let .string(value)? = fields[Self.idKey] {
@@ -182,8 +172,7 @@ extension CheckpointRuleSet {
         return CheckpointFrequencyCap(type: type, count: count, window: window)
     }
 
-    /// A schedule with neither bound parseable is dropped, so an unparseable window can't be mistaken for
-    /// an open-ended one.
+    /// Dropped rather than kept as open-ended, which would run the rule outside its dates.
     private static func parseSchedule(_ field: AnyDecodable?) -> CheckpointRuleSchedule? {
         guard case let .object(fields)? = field else { return nil }
 

--- a/Sources/Networking/CheckpointRules.swift
+++ b/Sources/Networking/CheckpointRules.swift
@@ -27,14 +27,14 @@ struct CheckpointRule: Equatable, Sendable {
     let id: String?
     /// Reference to the targeted audience, whose predicate arrives in a separate topic. Required, so a rule
     /// can never end up targeting everyone by omission.
-    let audienceId: Int
+    let audienceId: String
     let workflowId: String
     /// Rules are published ahead of their start date, so this window is resolved on device.
     let schedule: CheckpointRuleSchedule?
 
     init(
         id: String? = nil,
-        audienceId: Int,
+        audienceId: String,
         workflowId: String,
         schedule: CheckpointRuleSchedule? = nil
     ) {

--- a/Sources/Networking/CheckpointRules.swift
+++ b/Sources/Networking/CheckpointRules.swift
@@ -1,0 +1,223 @@
+//
+//  CheckpointRules.swift
+//  RevenueCat
+//
+//  Created by Facundo Menzella.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+
+/// One checkpoint's rules, which decide whether it resolves to a workflow. Parsed only, not evaluated.
+struct CheckpointRuleSet: Equatable, Sendable {
+
+    /// The checkpoint name, which is also the topic item key.
+    let identifier: String
+    /// The checkpoint's backend id, absent when the backend doesn't send one.
+    let id: String?
+    /// Served in priority order: evaluated top to bottom, first match wins. Not re-sorted here, since the
+    /// wire order *is* the order.
+    let rules: [CheckpointRule]
+
+    init(identifier: String, id: String? = nil, rules: [CheckpointRule]) {
+        self.identifier = identifier
+        self.id = id
+        self.rules = rules
+    }
+
+}
+
+/// One rule at a checkpoint: who it applies to, and the workflow it resolves to.
+struct CheckpointRule: Equatable, Sendable {
+
+    let id: String?
+    /// The audience this rule targets, as a reference. The audience's own predicate is expected to arrive in
+    /// a separate topic, so nothing here evaluates it. `nil` targets every user.
+    let audienceId: String?
+    let workflowId: String
+    let frequencyCap: CheckpointFrequencyCap?
+    /// When the rule is live. Rules are published on creation, ahead of their start date, so a scheduled
+    /// window has to be resolved on device.
+    let schedule: CheckpointRuleSchedule?
+
+    init(
+        id: String? = nil,
+        audienceId: String? = nil,
+        workflowId: String,
+        frequencyCap: CheckpointFrequencyCap? = nil,
+        schedule: CheckpointRuleSchedule? = nil
+    ) {
+        self.id = id
+        self.audienceId = audienceId
+        self.workflowId = workflowId
+        self.frequencyCap = frequencyCap
+        self.schedule = schedule
+    }
+
+}
+
+/// How often a rule may fire. `type` stays the raw wire value: frequency capping is out of V1 scope and its
+/// vocabulary isn't settled, so this carries what was sent instead of interpreting it.
+struct CheckpointFrequencyCap: Equatable, Sendable {
+
+    let type: String
+    let count: Int?
+    let window: String?
+
+    init(type: String, count: Int? = nil, window: String? = nil) {
+        self.type = type
+        self.count = count
+        self.window = window
+    }
+
+}
+
+/// A rule's scheduled window. Either bound can be absent, meaning open-ended on that side.
+struct CheckpointRuleSchedule: Equatable, Sendable {
+
+    let start: Date?
+    let end: Date?
+
+    init(start: Date? = nil, end: Date? = nil) {
+        self.start = start
+        self.end = end
+    }
+
+}
+
+// MARK: - Parsing
+
+extension CheckpointRuleSet {
+
+    /// Parses a checkpoint's blob payload. Returns `nil` when the bytes aren't a JSON object.
+    static func parse(identifier: String, blob data: Data) -> CheckpointRuleSet? {
+        guard let fields = Self.fields(fromBlob: data) else { return nil }
+        return Self.parse(identifier: identifier, fields: fields)
+    }
+
+    /// Parses one checkpoint's id and rules from its decoded payload. A malformed rule is skipped rather than
+    /// failing the checkpoint, and unknown fields are ignored so the backend can extend the schema without a
+    /// client release.
+    ///
+    /// Keys are read at their wire spelling (`workflow_id`, `frequency_cap`): the payload is decoded as a
+    /// dictionary, and `.convertFromSnakeCase` only renames keys read through a keyed container. That holds at
+    /// every depth here, unlike an item's `content`, whose own keys `ConfigItem.init(from:)` does camelCase.
+    static func parse(identifier: String, fields: [String: AnyDecodable]) -> CheckpointRuleSet {
+        var id: String?
+        if case let .string(value)? = fields[Self.idKey] {
+            id = value
+        }
+
+        return CheckpointRuleSet(
+            identifier: identifier,
+            id: id,
+            rules: Self.parseRules(from: fields, checkpoint: identifier)
+        )
+    }
+
+    private static func parseRules(
+        from fields: [String: AnyDecodable],
+        checkpoint: String
+    ) -> [CheckpointRule] {
+        guard let rules = fields[Self.rulesKey] else { return [] }
+        guard case let .array(entries) = rules else {
+            Logger.warn(Strings.remoteConfig.checkpointRuleSkipped(
+                checkpoint: checkpoint,
+                reason: "expected '\(Self.rulesKey)' to be an array"
+            ))
+            return []
+        }
+
+        return entries.compactMap { Self.parseRule($0, checkpoint: checkpoint) }
+    }
+
+    private static func parseRule(_ entry: AnyDecodable, checkpoint: String) -> CheckpointRule? {
+        guard case let .object(fields) = entry else {
+            Logger.warn(Strings.remoteConfig.checkpointRuleSkipped(
+                checkpoint: checkpoint,
+                reason: "expected each rule to be an object"
+            ))
+            return nil
+        }
+        guard case let .string(workflowId)? = fields[Self.workflowIdKey], !workflowId.isEmpty else {
+            Logger.warn(Strings.remoteConfig.checkpointRuleSkipped(
+                checkpoint: checkpoint,
+                reason: "missing '\(Self.workflowIdKey)'"
+            ))
+            return nil
+        }
+
+        var id: String?
+        if case let .string(value)? = fields[Self.idKey] {
+            id = value
+        }
+        var audienceId: String?
+        if case let .string(value)? = fields[Self.audienceKey] {
+            audienceId = value
+        }
+
+        return CheckpointRule(
+            id: id,
+            audienceId: audienceId,
+            workflowId: workflowId,
+            frequencyCap: Self.parseFrequencyCap(fields[Self.frequencyCapKey]),
+            schedule: Self.parseSchedule(fields[Self.scheduleKey])
+        )
+    }
+
+    private static func parseFrequencyCap(_ field: AnyDecodable?) -> CheckpointFrequencyCap? {
+        guard case let .object(fields)? = field,
+              case let .string(type)? = fields[Self.typeKey] else {
+            return nil
+        }
+
+        var count: Int?
+        if case let .int(value)? = fields[Self.countKey] {
+            count = value
+        }
+        var window: String?
+        if case let .string(value)? = fields[Self.windowKey] {
+            window = value
+        }
+
+        return CheckpointFrequencyCap(type: type, count: count, window: window)
+    }
+
+    /// A schedule with neither bound parseable is dropped, so an unparseable window can't be mistaken for
+    /// an open-ended one.
+    private static func parseSchedule(_ field: AnyDecodable?) -> CheckpointRuleSchedule? {
+        guard case let .object(fields)? = field else { return nil }
+
+        let start = Self.parseDate(fields[Self.startKey])
+        let end = Self.parseDate(fields[Self.endKey])
+        guard start != nil || end != nil else { return nil }
+
+        return CheckpointRuleSchedule(start: start, end: end)
+    }
+
+    private static func parseDate(_ field: AnyDecodable?) -> Date? {
+        guard case let .string(value)? = field else { return nil }
+        return ISO8601DateFormatter.default.date(from: value)
+    }
+
+    private static func fields(fromBlob data: Data) -> [String: AnyDecodable]? {
+        do {
+            return try JSONDecoder.default.decode([String: AnyDecodable].self, from: data)
+        } catch {
+            Logger.error(Strings.codable.decoding_error(error, [String: AnyDecodable].self))
+            return nil
+        }
+    }
+
+    private static let idKey = "id"
+    private static let rulesKey = "rules"
+    private static let audienceKey = "audience"
+    private static let workflowIdKey = "workflow_id"
+    private static let frequencyCapKey = "frequency_cap"
+    private static let typeKey = "type"
+    private static let countKey = "count"
+    private static let windowKey = "window"
+    private static let scheduleKey = "schedule"
+    private static let startKey = "start"
+    private static let endKey = "end"
+
+}

--- a/Sources/Networking/CheckpointRules.swift
+++ b/Sources/Networking/CheckpointRules.swift
@@ -67,6 +67,25 @@ extension CheckpointRule: Decodable {
         case workflowId
     }
 
+    /// An empty reference is treated the same as a missing one: it can't resolve to anything, so the rule is
+    /// better dropped at ingest than left to fail later.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.id = try container.decodeIfPresent(String.self, forKey: .id)
+        self.audienceId = try container.decode(String.self, forKey: .audienceId)
+        self.workflowId = try container.decode(String.self, forKey: .workflowId)
+
+        for (key, value) in [(CodingKeys.audienceId, self.audienceId), (.workflowId, self.workflowId)]
+        where value.isEmpty {
+            throw DecodingError.dataCorruptedError(
+                forKey: key,
+                in: container,
+                debugDescription: "'\(key.rawValue)' is empty"
+            )
+        }
+    }
+
 }
 
 /// Turns a rule that fails to decode into `nil` instead of failing its enclosing array.

--- a/Sources/Networking/CheckpointsConfigProvider.swift
+++ b/Sources/Networking/CheckpointsConfigProvider.swift
@@ -1,0 +1,45 @@
+//
+//  CheckpointsConfigProvider.swift
+//  RevenueCat
+//
+//  Created by Facundo Menzella.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+
+protocol CheckpointsConfigProviderType: AnyObject {
+
+    /// The rules configured for `identifier`, or `nil` when there are none the SDK can read.
+    func getCheckpoint(_ identifier: String) async -> CheckpointRuleSet?
+
+}
+
+/// The topic-specific front door for checkpoints, reading through `RemoteConfigManager`'s `checkpoints` topic.
+/// It knows only the topic name and how to parse a ``CheckpointRuleSet``; everything else is delegated to
+/// `RemoteConfigManager`.
+///
+/// Items are keyed by checkpoint name, so a checkpoint resolves with a single `blobData` read: it needs no
+/// topic-index scan, and `blobData` already resolves a blob whether its bytes arrived inlined with the config
+/// response or have to be downloaded, and already invalidates on an identity change.
+final class CheckpointsConfigProvider: CheckpointsConfigProviderType {
+
+    private let manager: RemoteConfigManagerType
+
+    init(manager: RemoteConfigManagerType) {
+        self.manager = manager
+    }
+
+    /// Returns `nil` when the checkpoint has no item in the topic, its payload can't be resolved, or remote
+    /// config is disabled. Those are indistinguishable here, and all mean the same thing to a caller: there
+    /// are no rules to run.
+    func getCheckpoint(_ identifier: String) async -> CheckpointRuleSet? {
+        guard let data = await self.manager.blobData(for: .checkpoints, itemKey: identifier) else {
+            return nil
+        }
+
+        return CheckpointRuleSet.parse(identifier: identifier, blob: data)
+    }
+
+}
+
+extension CheckpointsConfigProvider: @unchecked Sendable {}

--- a/Sources/Networking/CheckpointsConfigProvider.swift
+++ b/Sources/Networking/CheckpointsConfigProvider.swift
@@ -13,7 +13,7 @@ protocol CheckpointsConfigProviderType {
 
 }
 
-/// The topic-specific front door for checkpoints, reading through `RemoteConfigManager`'s `checkpoints` topic.
+/// The topic-specific front door for checkpoints, reading through `RemoteConfigManager`'s `checkpoint_rules` topic.
 ///
 /// Items are keyed by checkpoint name, so a checkpoint resolves with a single `blobData` read: no topic-index
 /// scan, and `blobData` already handles inlined versus downloaded blobs and identity invalidation.

--- a/Sources/Networking/CheckpointsConfigProvider.swift
+++ b/Sources/Networking/CheckpointsConfigProvider.swift
@@ -28,7 +28,7 @@ final class CheckpointsConfigProvider: CheckpointsConfigProviderType {
     /// `nil` covers no item, an unresolvable payload and remote config being disabled: indistinguishable here,
     /// and all mean there are no rules to run.
     func getCheckpoint(_ identifier: String) async -> CheckpointRuleSet? {
-        guard let data = await self.manager.blobData(for: .checkpoints, itemKey: identifier) else {
+        guard let data = await self.manager.blobData(for: .checkpointRules, itemKey: identifier) else {
             return nil
         }
 

--- a/Sources/Networking/CheckpointsConfigProvider.swift
+++ b/Sources/Networking/CheckpointsConfigProvider.swift
@@ -25,14 +25,19 @@ final class CheckpointsConfigProvider: CheckpointsConfigProviderType {
         self.manager = manager
     }
 
-    /// `nil` covers no item, an unresolvable payload and remote config being disabled: indistinguishable here,
-    /// and all mean there are no rules to run.
+    /// `nil` covers no item, an unresolvable or undecodable payload and remote config being disabled:
+    /// indistinguishable here, and all mean there are no rules to run.
     func getCheckpoint(_ identifier: String) async -> CheckpointRuleSet? {
-        guard let data = await self.manager.blobData(for: .checkpointRules, itemKey: identifier) else {
+        do {
+            return try await self.manager.blobData(
+                for: .checkpointRules,
+                itemKey: identifier,
+                as: CheckpointRuleSet.self
+            )
+        } catch {
+            Logger.error(Strings.codable.decoding_error(error, CheckpointRuleSet.self))
             return nil
         }
-
-        return CheckpointRuleSet.parse(identifier: identifier, blob: data)
     }
 
 }

--- a/Sources/Networking/CheckpointsConfigProvider.swift
+++ b/Sources/Networking/CheckpointsConfigProvider.swift
@@ -7,20 +7,16 @@
 
 import Foundation
 
-protocol CheckpointsConfigProviderType: AnyObject {
+protocol CheckpointsConfigProviderType {
 
-    /// The rules configured for `identifier`, or `nil` when there are none the SDK can read.
     func getCheckpoint(_ identifier: String) async -> CheckpointRuleSet?
 
 }
 
 /// The topic-specific front door for checkpoints, reading through `RemoteConfigManager`'s `checkpoints` topic.
-/// It knows only the topic name and how to parse a ``CheckpointRuleSet``; everything else is delegated to
-/// `RemoteConfigManager`.
 ///
-/// Items are keyed by checkpoint name, so a checkpoint resolves with a single `blobData` read: it needs no
-/// topic-index scan, and `blobData` already resolves a blob whether its bytes arrived inlined with the config
-/// response or have to be downloaded, and already invalidates on an identity change.
+/// Items are keyed by checkpoint name, so a checkpoint resolves with a single `blobData` read: no topic-index
+/// scan, and `blobData` already handles inlined versus downloaded blobs and identity invalidation.
 final class CheckpointsConfigProvider: CheckpointsConfigProviderType {
 
     private let manager: RemoteConfigManagerType
@@ -29,9 +25,8 @@ final class CheckpointsConfigProvider: CheckpointsConfigProviderType {
         self.manager = manager
     }
 
-    /// Returns `nil` when the checkpoint has no item in the topic, its payload can't be resolved, or remote
-    /// config is disabled. Those are indistinguishable here, and all mean the same thing to a caller: there
-    /// are no rules to run.
+    /// `nil` covers no item, an unresolvable payload and remote config being disabled: indistinguishable here,
+    /// and all mean there are no rules to run.
     func getCheckpoint(_ identifier: String) async -> CheckpointRuleSet? {
         guard let data = await self.manager.blobData(for: .checkpoints, itemKey: identifier) else {
             return nil

--- a/Sources/Networking/RemoteConfigTopic.swift
+++ b/Sources/Networking/RemoteConfigTopic.swift
@@ -16,7 +16,7 @@ enum RemoteConfigTopic: String {
     case workflows
     case uiConfig = "ui_config"
     case sources
-    case checkpoints
+    case checkpointRules = "checkpoint_rules"
 
     var wireName: String {
         return self.rawValue

--- a/Sources/Networking/RemoteConfigTopic.swift
+++ b/Sources/Networking/RemoteConfigTopic.swift
@@ -16,6 +16,7 @@ enum RemoteConfigTopic: String {
     case workflows
     case uiConfig = "ui_config"
     case sources
+    case checkpoints
 
     var wireName: String {
         return self.rawValue

--- a/Tests/UnitTests/Networking/CheckpointRulesTests.swift
+++ b/Tests/UnitTests/Networking/CheckpointRulesTests.swift
@@ -27,16 +27,14 @@ final class CheckpointRulesTests: TestCase {
           "rules": [
             {
               "id": "rule-1",
-              "audience": "audience-1",
+              "audience": 4412,
               "workflow_id": "wf-1",
-              "frequency_cap": { "type": "once" },
               "schedule": { "start": "2026-11-25T00:00:00Z", "end": "2026-11-30T00:00:00Z" }
             },
             {
               "id": "rule-2",
-              "audience": "audience-2",
-              "workflow_id": "wf-2",
-              "frequency_cap": { "type": "every" }
+              "audience": 4419,
+              "workflow_id": "wf-2"
             }
           ]
         }
@@ -49,31 +47,30 @@ final class CheckpointRulesTests: TestCase {
 
         let first = try XCTUnwrap(ruleSet.rules.first)
         expect(first.id) == "rule-1"
-        expect(first.audienceId) == "audience-1"
-        expect(first.frequencyCap) == CheckpointFrequencyCap(type: "once")
+        expect(first.audienceId) == 4412
         expect(first.schedule?.start) == Self.date("2026-11-25T00:00:00Z")
         expect(first.schedule?.end) == Self.date("2026-11-30T00:00:00Z")
 
         let second = try XCTUnwrap(ruleSet.rules.last)
-        expect(second.frequencyCap) == CheckpointFrequencyCap(type: "every")
+        expect(second.audienceId) == 4419
         expect(second.schedule).to(beNil())
     }
 
     func testKeepsPayloadKeysVerbatimWhileItemMetadataIsCamelCased() throws {
-        let blob = Data(#"{ "rules": [{ "workflow_id": "wf-1", "frequency_cap": { "type": "once" } }] }"#.utf8)
+        let blob = Data(#"{ "rules": [{ "workflow_id": "wf-1", "audience": 4412 }] }"#.utf8)
         let ruleSet = try XCTUnwrap(CheckpointRuleSet.parse(identifier: "app_open", blob: blob))
 
         let rule = try XCTUnwrap(ruleSet.rules.onlyElement)
         expect(rule.workflowId) == "wf-1"
-        expect(rule.frequencyCap) == CheckpointFrequencyCap(type: "once")
+        expect(rule.audienceId) == 4412
 
         let payload = """
         {
           "domain": "app",
-          "manifest": "v1.1710000100.checkpoints:etag",
-          "active_topics": ["checkpoints"],
+          "manifest": "v1.1710000100.checkpoint_rules:etag",
+          "active_topics": ["checkpoint_rules"],
           "topics": {
-            "checkpoints": {
+            "checkpoint_rules": {
               "app_open": { "blob_ref": "app-open-ref", "prefetch": true, "first_seen": "2026-06-17T08:44:26Z" }
             }
           }
@@ -81,7 +78,7 @@ final class CheckpointRulesTests: TestCase {
         """
         let response = try JSONDecoder.default.decode(RemoteConfiguration.self, from: Data(payload.utf8))
         let item = try XCTUnwrap(
-            response.topics.entries[RemoteConfigTopic.checkpoints.wireName]?["app_open"]
+            response.topics.entries[RemoteConfigTopic.checkpointRules.wireName]?["app_open"]
         )
 
         expect(item.blobRef) == "app-open-ref"
@@ -118,11 +115,20 @@ final class CheckpointRulesTests: TestCase {
 
     // MARK: - Malformed data
 
+    func testSkipsRulesMissingAnAudience() {
+        let ruleSet = Self.ruleSet(["rules": .array([
+            .object(["workflow_id": .string("wf-no-audience")]),
+            Self.rule(workflowId: "wf-valid")
+        ])])
+
+        expect(ruleSet.rules.map(\.workflowId)) == ["wf-valid"]
+    }
+
     func testSkipsRulesMissingAWorkflowId() {
         let ruleSet = Self.ruleSet(["rules": .array([
-            .object(["id": .string("rule-1")]),
+            .object(["id": .string("rule-1"), "audience": .int(4412)]),
             Self.rule(workflowId: "wf-valid"),
-            .object(["workflow_id": .string("")])
+            .object(["workflow_id": .string(""), "audience": .int(4412)])
         ])])
 
         expect(ruleSet.rules.map(\.workflowId)) == ["wf-valid"]
@@ -155,6 +161,7 @@ final class CheckpointRulesTests: TestCase {
             "rules": .array([
                 .object([
                     "workflow_id": .string("wf-a"),
+                    "audience": .int(4412),
                     "state": .string("active"),
                     "something_else_new": .bool(true)
                 ])
@@ -166,40 +173,11 @@ final class CheckpointRulesTests: TestCase {
 
     // MARK: - Optional rule fields
 
-    func testTreatsAnAbsentAudienceAsTargetingEveryone() {
-        let ruleSet = Self.ruleSet(["rules": .array([Self.rule(workflowId: "wf-a")])])
-
-        expect(ruleSet.rules.onlyElement?.audienceId).to(beNil())
-    }
-
-    func testIgnoresAFrequencyCapWithoutAType() {
-        let ruleSet = Self.ruleSet(["rules": .array([
-            .object(["workflow_id": .string("wf-a"), "frequency_cap": .object(["count": .int(3)])])
-        ])])
-
-        expect(ruleSet.rules.onlyElement?.frequencyCap).to(beNil())
-    }
-
-    func testParsesACustomFrequencyCap() {
-        let ruleSet = Self.ruleSet(["rules": .array([
-            .object([
-                "workflow_id": .string("wf-a"),
-                "frequency_cap": .object([
-                    "type": .string("custom"),
-                    "count": .int(3),
-                    "window": .string("P7D")
-                ])
-            ])
-        ])])
-
-        expect(ruleSet.rules.onlyElement?.frequencyCap)
-            == CheckpointFrequencyCap(type: "custom", count: 3, window: "P7D")
-    }
-
     func testParsesAScheduleWithOnlyOneBound() {
         let ruleSet = Self.ruleSet(["rules": .array([
             .object([
                 "workflow_id": .string("wf-a"),
+                "audience": .int(4412),
                 "schedule": .object(["start": .string("2026-11-25T00:00:00Z")])
             ])
         ])])
@@ -213,6 +191,7 @@ final class CheckpointRulesTests: TestCase {
         let ruleSet = Self.ruleSet(["rules": .array([
             .object([
                 "workflow_id": .string("wf-a"),
+                "audience": .int(4412),
                 "schedule": .object(["start": .string("not-a-date"), "end": .string("nope")])
             ])
         ])])
@@ -225,6 +204,7 @@ final class CheckpointRulesTests: TestCase {
         let ruleSet = Self.ruleSet(["rules": .array([
             .object([
                 "workflow_id": .string("wf-a"),
+                "audience": .int(4412),
                 "schedule": .object(["start": .string("2026-11-25T00:00:00.251Z")])
             ])
         ])])
@@ -239,7 +219,7 @@ final class CheckpointRulesTests: TestCase {
     }
 
     private static func rule(workflowId: String) -> AnyDecodable {
-        return .object(["workflow_id": .string(workflowId)])
+        return .object(["workflow_id": .string(workflowId), "audience": .int(4412)])
     }
 
     private static func date(_ string: String) -> Date? {

--- a/Tests/UnitTests/Networking/CheckpointRulesTests.swift
+++ b/Tests/UnitTests/Networking/CheckpointRulesTests.swift
@@ -113,6 +113,19 @@ final class CheckpointRulesTests: TestCase {
         expect(ruleSet.rules.map(\.workflowId)) == ["wf-valid"]
     }
 
+    /// An empty reference can't resolve to anything, so it's dropped at ingest like a missing one.
+    func testSkipsRulesWithAnEmptyReference() throws {
+        let ruleSet = try Self.decode("""
+        { "rules": [
+            { "audience": "aud_4412", "workflow_id": "" },
+            { "audience": "", "workflow_id": "wf-no-audience" },
+            \(Self.rule("wf-valid"))
+        ] }
+        """)
+
+        expect(ruleSet.rules.map(\.workflowId)) == ["wf-valid"]
+    }
+
     func testSkipsRuleEntriesThatArentObjects() throws {
         let ruleSet = try Self.decode("""
         { "rules": ["not-a-rule", \(Self.rule("wf-valid"))] }

--- a/Tests/UnitTests/Networking/CheckpointRulesTests.swift
+++ b/Tests/UnitTests/Networking/CheckpointRulesTests.swift
@@ -29,19 +29,18 @@ final class CheckpointRulesTests: TestCase {
           "rules": [
             {
               "id": "chkptrule_1a2b3c4d5e6f7a8b",
-              "audience": "aud_4412",
+              "audience_id": "aud_4412",
               "workflow_id": "wf-1"
             },
             {
               "id": "chkptrule_9z8y7x6w5v4u3t2s",
-              "audience": "aud_4419",
+              "audience_id": "aud_4419",
               "workflow_id": "wf-2"
             }
           ]
         }
         """)
 
-        expect(ruleSet.id) == "chkpt_a1b2c3d4e5f6a7b8"
         expect(ruleSet.rules.map(\.workflowId)) == ["wf-1", "wf-2"]
 
         let first = try XCTUnwrap(ruleSet.rules.first)
@@ -52,10 +51,7 @@ final class CheckpointRulesTests: TestCase {
     }
 
     func testDecodesACheckpointWithNoRules() throws {
-        let ruleSet = try Self.decode(#"{ "id": "chkpt_abc" }"#)
-
-        expect(ruleSet.id) == "chkpt_abc"
-        expect(ruleSet.rules).to(beEmpty())
+        expect(try Self.decode(#"{ "id": "chkpt_abc" }"#).rules).to(beEmpty())
     }
 
     func testIgnoresUnknownFields() throws {
@@ -63,7 +59,7 @@ final class CheckpointRulesTests: TestCase {
         {
           "id": "chkpt_abc",
           "something_the_backend_added_later": true,
-          "rules": [{ "audience": "aud_4412", "workflow_id": "wf-a", "state": "active", "frequency_cap": null }]
+          "rules": [{ "audience_id": "aud_4412", "workflow_id": "wf-a", "state": "active", "frequency_cap": null }]
         }
         """)
 
@@ -91,7 +87,7 @@ final class CheckpointRulesTests: TestCase {
     /// One bad rule shouldn't take out the whole checkpoint, and it shouldn't shift the others either.
     func testSkipsAMalformedRuleAndKeepsTheRest() throws {
         let ruleSet = try Self.decode("""
-        { "rules": [\(Self.rule("wf-a")), { "audience": "aud_4412" }, \(Self.rule("wf-b"))] }
+        { "rules": [\(Self.rule("wf-a")), { "audience_id": "aud_4412" }, \(Self.rule("wf-b"))] }
         """)
 
         expect(ruleSet.rules.map(\.workflowId)) == ["wf-a", "wf-b"]
@@ -107,7 +103,7 @@ final class CheckpointRulesTests: TestCase {
 
     func testSkipsRulesMissingAWorkflowId() throws {
         let ruleSet = try Self.decode("""
-        { "rules": [{ "audience": "aud_4412" }, \(Self.rule("wf-valid"))] }
+        { "rules": [{ "audience_id": "aud_4412" }, \(Self.rule("wf-valid"))] }
         """)
 
         expect(ruleSet.rules.map(\.workflowId)) == ["wf-valid"]
@@ -117,8 +113,8 @@ final class CheckpointRulesTests: TestCase {
     func testSkipsRulesWithAnEmptyReference() throws {
         let ruleSet = try Self.decode("""
         { "rules": [
-            { "audience": "aud_4412", "workflow_id": "" },
-            { "audience": "", "workflow_id": "wf-no-audience" },
+            { "audience_id": "aud_4412", "workflow_id": "" },
+            { "audience_id": "", "workflow_id": "wf-no-audience" },
             \(Self.rule("wf-valid"))
         ] }
         """)
@@ -141,7 +137,7 @@ final class CheckpointRulesTests: TestCase {
     }
 
     private static func rule(_ workflowId: String) -> String {
-        return #"{ "audience": "aud_4412", "workflow_id": "\#(workflowId)" }"#
+        return #"{ "audience_id": "aud_4412", "workflow_id": "\#(workflowId)" }"#
     }
 
 }

--- a/Tests/UnitTests/Networking/CheckpointRulesTests.swift
+++ b/Tests/UnitTests/Networking/CheckpointRulesTests.swift
@@ -16,37 +16,37 @@ import Nimble
 @testable import RevenueCat
 import XCTest
 
+/// Decoding tests for a checkpoint's payload, run through `JSONDecoder.default` so the key and date
+/// strategies the topic manager uses are exercised for real.
 final class CheckpointRulesTests: TestCase {
 
     // MARK: - Wire contract
 
-    func testParsesTheDocumentedExamplePayload() throws {
-        let blob = Data("""
+    func testDecodesTheDocumentedExamplePayload() throws {
+        let ruleSet = try Self.decode("""
         {
-          "id": "checkpoint-abc",
+          "id": "chkpt_a1b2c3d4e5f6a7b8",
           "rules": [
             {
-              "id": "rule-1",
+              "id": "chkptrule_1a2b3c4d5e6f7a8b",
               "audience": 4412,
               "workflow_id": "wf-1",
               "schedule": { "start": "2026-11-25T00:00:00Z", "end": "2026-11-30T00:00:00Z" }
             },
             {
-              "id": "rule-2",
+              "id": "chkptrule_9z8y7x6w5v4u3t2s",
               "audience": 4419,
               "workflow_id": "wf-2"
             }
           ]
         }
-        """.utf8)
-        let ruleSet = try XCTUnwrap(CheckpointRuleSet.parse(identifier: "app_open", blob: blob))
+        """)
 
-        expect(ruleSet.identifier) == "app_open"
-        expect(ruleSet.id) == "checkpoint-abc"
+        expect(ruleSet.id) == "chkpt_a1b2c3d4e5f6a7b8"
         expect(ruleSet.rules.map(\.workflowId)) == ["wf-1", "wf-2"]
 
         let first = try XCTUnwrap(ruleSet.rules.first)
-        expect(first.id) == "rule-1"
+        expect(first.id) == "chkptrule_1a2b3c4d5e6f7a8b"
         expect(first.audienceId) == 4412
         expect(first.schedule?.start) == Self.date("2026-11-25T00:00:00Z")
         expect(first.schedule?.end) == Self.date("2026-11-30T00:00:00Z")
@@ -56,170 +56,120 @@ final class CheckpointRulesTests: TestCase {
         expect(second.schedule).to(beNil())
     }
 
-    func testKeepsPayloadKeysVerbatimWhileItemMetadataIsCamelCased() throws {
-        let blob = Data(#"{ "rules": [{ "workflow_id": "wf-1", "audience": 4412 }] }"#.utf8)
-        let ruleSet = try XCTUnwrap(CheckpointRuleSet.parse(identifier: "app_open", blob: blob))
+    func testDecodesACheckpointWithNoRules() throws {
+        let ruleSet = try Self.decode(#"{ "id": "chkpt_abc" }"#)
 
-        let rule = try XCTUnwrap(ruleSet.rules.onlyElement)
-        expect(rule.workflowId) == "wf-1"
-        expect(rule.audienceId) == 4412
-
-        let payload = """
-        {
-          "domain": "app",
-          "manifest": "v1.1710000100.checkpoint_rules:etag",
-          "active_topics": ["checkpoint_rules"],
-          "topics": {
-            "checkpoint_rules": {
-              "app_open": { "blob_ref": "app-open-ref", "prefetch": true, "first_seen": "2026-06-17T08:44:26Z" }
-            }
-          }
-        }
-        """
-        let response = try JSONDecoder.default.decode(RemoteConfiguration.self, from: Data(payload.utf8))
-        let item = try XCTUnwrap(
-            response.topics.entries[RemoteConfigTopic.checkpointRules.wireName]?["app_open"]
-        )
-
-        expect(item.blobRef) == "app-open-ref"
-        expect(item.prefetch) == true
-        expect(item.content.keys.sorted()) == ["firstSeen"]
-    }
-
-    func testReturnsNilForAPayloadThatIsntAJSONObject() {
-        expect(CheckpointRuleSet.parse(identifier: "app_open", blob: Data("not-json".utf8))).to(beNil())
-        expect(CheckpointRuleSet.parse(identifier: "app_open", blob: Data(#"["an", "array"]"#.utf8))).to(beNil())
-    }
-
-    // MARK: - Ordering
-
-    func testPreservesTheServedRuleOrder() {
-        let ruleSet = Self.ruleSet(["rules": .array([
-            Self.rule(workflowId: "wf-c"),
-            Self.rule(workflowId: "wf-a"),
-            Self.rule(workflowId: "wf-b")
-        ])])
-
-        expect(ruleSet.rules.map(\.workflowId)) == ["wf-c", "wf-a", "wf-b"]
-    }
-
-    func testKeepsServedOrderWhenARuleInTheMiddleIsSkipped() {
-        let ruleSet = Self.ruleSet(["rules": .array([
-            Self.rule(workflowId: "wf-a"),
-            .object(["id": .string("no-workflow")]),
-            Self.rule(workflowId: "wf-b")
-        ])])
-
-        expect(ruleSet.rules.map(\.workflowId)) == ["wf-a", "wf-b"]
-    }
-
-    // MARK: - Malformed data
-
-    func testSkipsRulesMissingAnAudience() {
-        let ruleSet = Self.ruleSet(["rules": .array([
-            .object(["workflow_id": .string("wf-no-audience")]),
-            Self.rule(workflowId: "wf-valid")
-        ])])
-
-        expect(ruleSet.rules.map(\.workflowId)) == ["wf-valid"]
-    }
-
-    func testSkipsRulesMissingAWorkflowId() {
-        let ruleSet = Self.ruleSet(["rules": .array([
-            .object(["id": .string("rule-1"), "audience": .int(4412)]),
-            Self.rule(workflowId: "wf-valid"),
-            .object(["workflow_id": .string(""), "audience": .int(4412)])
-        ])])
-
-        expect(ruleSet.rules.map(\.workflowId)) == ["wf-valid"]
-    }
-
-    func testSkipsRuleEntriesThatArentObjects() {
-        let ruleSet = Self.ruleSet(["rules": .array([
-            .string("not-a-rule"),
-            Self.rule(workflowId: "wf-valid")
-        ])])
-
-        expect(ruleSet.rules.map(\.workflowId)) == ["wf-valid"]
-    }
-
-    func testKeepsCheckpointWithNoRulesWhenRulesArentAnArray() {
-        expect(Self.ruleSet(["rules": .string("nope")]).rules).to(beEmpty())
-    }
-
-    func testKeepsCheckpointWithNoRulesKeyAtAll() {
-        let ruleSet = Self.ruleSet(["id": .string("checkpoint-xyz")])
-
-        expect(ruleSet.identifier) == "app_open"
-        expect(ruleSet.id) == "checkpoint-xyz"
+        expect(ruleSet.id) == "chkpt_abc"
         expect(ruleSet.rules).to(beEmpty())
     }
 
-    func testIgnoresUnknownFields() {
-        let ruleSet = Self.ruleSet([
-            "something_the_backend_added_later": .bool(true),
-            "rules": .array([
-                .object([
-                    "workflow_id": .string("wf-a"),
-                    "audience": .int(4412),
-                    "state": .string("active"),
-                    "something_else_new": .bool(true)
-                ])
-            ])
-        ])
+    func testIgnoresUnknownFields() throws {
+        let ruleSet = try Self.decode("""
+        {
+          "id": "chkpt_abc",
+          "something_the_backend_added_later": true,
+          "rules": [{ "audience": 4412, "workflow_id": "wf-a", "state": "active", "frequency_cap": null }]
+        }
+        """)
 
         expect(ruleSet.rules.map(\.workflowId)) == ["wf-a"]
     }
 
-    // MARK: - Optional rule fields
-
-    func testParsesAScheduleWithOnlyOneBound() {
-        let ruleSet = Self.ruleSet(["rules": .array([
-            .object([
-                "workflow_id": .string("wf-a"),
-                "audience": .int(4412),
-                "schedule": .object(["start": .string("2026-11-25T00:00:00Z")])
-            ])
-        ])])
-
-        expect(ruleSet.rules.onlyElement?.schedule?.start) == Self.date("2026-11-25T00:00:00Z")
-        expect(ruleSet.rules.onlyElement?.schedule?.end).to(beNil())
+    func testThrowsForAPayloadThatIsntAJSONObject() {
+        expect { try Self.decode("not-json") }.to(throwError())
+        expect { try Self.decode(#"["an", "array"]"#) }.to(throwError())
     }
 
-    /// Dropped rather than kept as open-ended, which would run the rule outside its dates.
-    func testDropsAScheduleWhoseDatesCantBeParsed() {
-        let ruleSet = Self.ruleSet(["rules": .array([
-            .object([
-                "workflow_id": .string("wf-a"),
-                "audience": .int(4412),
-                "schedule": .object(["start": .string("not-a-date"), "end": .string("nope")])
-            ])
-        ])])
+    // MARK: - Ordering
 
-        expect(ruleSet.rules.onlyElement?.workflowId) == "wf-a"
-        expect(ruleSet.rules.onlyElement?.schedule).to(beNil())
+    /// Rules are served in priority order, so decoding must not reorder them.
+    func testPreservesTheServedRuleOrder() throws {
+        let ruleSet = try Self.decode("""
+        { "rules": [\(Self.rule("wf-c")), \(Self.rule("wf-a")), \(Self.rule("wf-b"))] }
+        """)
+
+        expect(ruleSet.rules.map(\.workflowId)) == ["wf-c", "wf-a", "wf-b"]
     }
 
-    func testParsesFractionalSecondsInASchedule() {
-        let ruleSet = Self.ruleSet(["rules": .array([
-            .object([
-                "workflow_id": .string("wf-a"),
-                "audience": .int(4412),
-                "schedule": .object(["start": .string("2026-11-25T00:00:00.251Z")])
-            ])
-        ])])
+    // MARK: - Skipping malformed rules
+
+    /// One bad rule shouldn't take out the whole checkpoint, and it shouldn't shift the others either.
+    func testSkipsAMalformedRuleAndKeepsTheRest() throws {
+        let ruleSet = try Self.decode("""
+        { "rules": [\(Self.rule("wf-a")), { "audience": 4412 }, \(Self.rule("wf-b"))] }
+        """)
+
+        expect(ruleSet.rules.map(\.workflowId)) == ["wf-a", "wf-b"]
+    }
+
+    func testSkipsRulesMissingAnAudience() throws {
+        let ruleSet = try Self.decode("""
+        { "rules": [{ "workflow_id": "wf-no-audience" }, \(Self.rule("wf-valid"))] }
+        """)
+
+        expect(ruleSet.rules.map(\.workflowId)) == ["wf-valid"]
+    }
+
+    func testSkipsRulesMissingAWorkflowId() throws {
+        let ruleSet = try Self.decode("""
+        { "rules": [{ "audience": 4412 }, \(Self.rule("wf-valid"))] }
+        """)
+
+        expect(ruleSet.rules.map(\.workflowId)) == ["wf-valid"]
+    }
+
+    func testSkipsRuleEntriesThatArentObjects() throws {
+        let ruleSet = try Self.decode("""
+        { "rules": ["not-a-rule", \(Self.rule("wf-valid"))] }
+        """)
+
+        expect(ruleSet.rules.map(\.workflowId)) == ["wf-valid"]
+    }
+
+    // MARK: - Schedule
+
+    func testDecodesAScheduleWithOnlyOneBound() throws {
+        let ruleSet = try Self.decode("""
+        { "rules": [{ "audience": 4412, "workflow_id": "wf-a",
+                      "schedule": { "start": "2026-11-25T00:00:00Z" } }] }
+        """)
+
+        let schedule = try XCTUnwrap(ruleSet.rules.onlyElement?.schedule)
+        expect(schedule.start) == Self.date("2026-11-25T00:00:00Z")
+        expect(schedule.end).to(beNil())
+    }
+
+    func testDecodesFractionalSecondsInASchedule() throws {
+        let ruleSet = try Self.decode("""
+        { "rules": [{ "audience": 4412, "workflow_id": "wf-a",
+                      "schedule": { "start": "2026-11-25T00:00:00.251Z" } }] }
+        """)
 
         expect(ruleSet.rules.onlyElement?.schedule?.start) == Self.date("2026-11-25T00:00:00.251Z")
     }
 
-    // MARK: - Helpers
+    /// A bound that's present but unparseable drops the whole rule. Letting it read as `nil` would widen the
+    /// window and run the rule outside the dates it was scheduled for.
+    func testSkipsARuleWhoseScheduleHasAnUnparseableBound() throws {
+        let ruleSet = try Self.decode("""
+        { "rules": [
+            { "audience": 4412, "workflow_id": "wf-broken",
+              "schedule": { "start": "not-a-date", "end": "2026-11-30T00:00:00Z" } },
+            \(Self.rule("wf-valid"))
+        ] }
+        """)
 
-    private static func ruleSet(_ fields: [String: AnyDecodable]) -> CheckpointRuleSet {
-        return CheckpointRuleSet.parse(identifier: "app_open", fields: fields)
+        expect(ruleSet.rules.map(\.workflowId)) == ["wf-valid"]
     }
 
-    private static func rule(workflowId: String) -> AnyDecodable {
-        return .object(["workflow_id": .string(workflowId), "audience": .int(4412)])
+    // MARK: - Helpers
+
+    private static func decode(_ json: String) throws -> CheckpointRuleSet {
+        return try JSONDecoder.default.decode(CheckpointRuleSet.self, from: Data(json.utf8))
+    }
+
+    private static func rule(_ workflowId: String) -> String {
+        return #"{ "audience": 4412, "workflow_id": "\#(workflowId)" }"#
     }
 
     private static func date(_ string: String) -> Date? {

--- a/Tests/UnitTests/Networking/CheckpointRulesTests.swift
+++ b/Tests/UnitTests/Networking/CheckpointRulesTests.swift
@@ -29,13 +29,13 @@ final class CheckpointRulesTests: TestCase {
           "rules": [
             {
               "id": "chkptrule_1a2b3c4d5e6f7a8b",
-              "audience": 4412,
+              "audience": "aud_4412",
               "workflow_id": "wf-1",
               "schedule": { "start": "2026-11-25T00:00:00Z", "end": "2026-11-30T00:00:00Z" }
             },
             {
               "id": "chkptrule_9z8y7x6w5v4u3t2s",
-              "audience": 4419,
+              "audience": "aud_4419",
               "workflow_id": "wf-2"
             }
           ]
@@ -47,12 +47,12 @@ final class CheckpointRulesTests: TestCase {
 
         let first = try XCTUnwrap(ruleSet.rules.first)
         expect(first.id) == "chkptrule_1a2b3c4d5e6f7a8b"
-        expect(first.audienceId) == 4412
+        expect(first.audienceId) == "aud_4412"
         expect(first.schedule?.start) == Self.date("2026-11-25T00:00:00Z")
         expect(first.schedule?.end) == Self.date("2026-11-30T00:00:00Z")
 
         let second = try XCTUnwrap(ruleSet.rules.last)
-        expect(second.audienceId) == 4419
+        expect(second.audienceId) == "aud_4419"
         expect(second.schedule).to(beNil())
     }
 
@@ -68,7 +68,7 @@ final class CheckpointRulesTests: TestCase {
         {
           "id": "chkpt_abc",
           "something_the_backend_added_later": true,
-          "rules": [{ "audience": 4412, "workflow_id": "wf-a", "state": "active", "frequency_cap": null }]
+          "rules": [{ "audience": "aud_4412", "workflow_id": "wf-a", "state": "active", "frequency_cap": null }]
         }
         """)
 
@@ -96,7 +96,7 @@ final class CheckpointRulesTests: TestCase {
     /// One bad rule shouldn't take out the whole checkpoint, and it shouldn't shift the others either.
     func testSkipsAMalformedRuleAndKeepsTheRest() throws {
         let ruleSet = try Self.decode("""
-        { "rules": [\(Self.rule("wf-a")), { "audience": 4412 }, \(Self.rule("wf-b"))] }
+        { "rules": [\(Self.rule("wf-a")), { "audience": "aud_4412" }, \(Self.rule("wf-b"))] }
         """)
 
         expect(ruleSet.rules.map(\.workflowId)) == ["wf-a", "wf-b"]
@@ -112,7 +112,7 @@ final class CheckpointRulesTests: TestCase {
 
     func testSkipsRulesMissingAWorkflowId() throws {
         let ruleSet = try Self.decode("""
-        { "rules": [{ "audience": 4412 }, \(Self.rule("wf-valid"))] }
+        { "rules": [{ "audience": "aud_4412" }, \(Self.rule("wf-valid"))] }
         """)
 
         expect(ruleSet.rules.map(\.workflowId)) == ["wf-valid"]
@@ -130,7 +130,7 @@ final class CheckpointRulesTests: TestCase {
 
     func testDecodesAScheduleWithOnlyOneBound() throws {
         let ruleSet = try Self.decode("""
-        { "rules": [{ "audience": 4412, "workflow_id": "wf-a",
+        { "rules": [{ "audience": "aud_4412", "workflow_id": "wf-a",
                       "schedule": { "start": "2026-11-25T00:00:00Z" } }] }
         """)
 
@@ -141,7 +141,7 @@ final class CheckpointRulesTests: TestCase {
 
     func testDecodesFractionalSecondsInASchedule() throws {
         let ruleSet = try Self.decode("""
-        { "rules": [{ "audience": 4412, "workflow_id": "wf-a",
+        { "rules": [{ "audience": "aud_4412", "workflow_id": "wf-a",
                       "schedule": { "start": "2026-11-25T00:00:00.251Z" } }] }
         """)
 
@@ -153,7 +153,7 @@ final class CheckpointRulesTests: TestCase {
     func testSkipsARuleWhoseScheduleHasAnUnparseableBound() throws {
         let ruleSet = try Self.decode("""
         { "rules": [
-            { "audience": 4412, "workflow_id": "wf-broken",
+            { "audience": "aud_4412", "workflow_id": "wf-broken",
               "schedule": { "start": "not-a-date", "end": "2026-11-30T00:00:00Z" } },
             \(Self.rule("wf-valid"))
         ] }
@@ -169,7 +169,7 @@ final class CheckpointRulesTests: TestCase {
     }
 
     private static func rule(_ workflowId: String) -> String {
-        return #"{ "audience": 4412, "workflow_id": "\#(workflowId)" }"#
+        return #"{ "audience": "aud_4412", "workflow_id": "\#(workflowId)" }"#
     }
 
     private static func date(_ string: String) -> Date? {

--- a/Tests/UnitTests/Networking/CheckpointRulesTests.swift
+++ b/Tests/UnitTests/Networking/CheckpointRulesTests.swift
@@ -16,14 +16,10 @@ import Nimble
 @testable import RevenueCat
 import XCTest
 
-/// Parsing-level tests for a checkpoint's payload. The first two go through real JSON bytes so the key
-/// contract is exercised end to end; the rest build the decoded fields directly to keep each case focused.
 final class CheckpointRulesTests: TestCase {
 
     // MARK: - Wire contract
 
-    /// The example payload from the "Storing and serving checkpoint rules" proposal, with its placeholder ids
-    /// filled in, as it would arrive in a checkpoint's blob.
     func testParsesTheDocumentedExamplePayload() throws {
         let blob = Data("""
         {
@@ -63,8 +59,6 @@ final class CheckpointRulesTests: TestCase {
         expect(second.schedule).to(beNil())
     }
 
-    /// A payload is decoded as a dictionary, so `.convertFromSnakeCase` leaves every key alone at every
-    /// depth. An item's own `content` keys are the exception, and those carry metadata, not rules.
     func testKeepsPayloadKeysVerbatimWhileItemMetadataIsCamelCased() throws {
         let blob = Data(#"{ "rules": [{ "workflow_id": "wf-1", "frequency_cap": { "type": "once" } }] }"#.utf8)
         let ruleSet = try XCTUnwrap(CheckpointRuleSet.parse(identifier: "app_open", blob: blob))
@@ -102,7 +96,6 @@ final class CheckpointRulesTests: TestCase {
 
     // MARK: - Ordering
 
-    /// Rules are served in priority order, so parsing must not reorder them.
     func testPreservesTheServedRuleOrder() {
         let ruleSet = Self.ruleSet(["rules": .array([
             Self.rule(workflowId: "wf-c"),
@@ -148,7 +141,6 @@ final class CheckpointRulesTests: TestCase {
         expect(Self.ruleSet(["rules": .string("nope")]).rules).to(beEmpty())
     }
 
-    /// A payload carrying only the checkpoint's own id is still a known checkpoint with no rules.
     func testKeepsCheckpointWithNoRulesKeyAtAll() {
         let ruleSet = Self.ruleSet(["id": .string("checkpoint-xyz")])
 
@@ -216,8 +208,7 @@ final class CheckpointRulesTests: TestCase {
         expect(ruleSet.rules.onlyElement?.schedule?.end).to(beNil())
     }
 
-    /// Dropped rather than kept as an open-ended window, which would run a rule outside the dates it was
-    /// scheduled for.
+    /// Dropped rather than kept as open-ended, which would run the rule outside its dates.
     func testDropsAScheduleWhoseDatesCantBeParsed() {
         let ruleSet = Self.ruleSet(["rules": .array([
             .object([

--- a/Tests/UnitTests/Networking/CheckpointRulesTests.swift
+++ b/Tests/UnitTests/Networking/CheckpointRulesTests.swift
@@ -1,0 +1,258 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CheckpointRulesTests.swift
+//
+//  Created by Facundo Menzella.
+
+import Foundation
+import Nimble
+@testable import RevenueCat
+import XCTest
+
+/// Parsing-level tests for a checkpoint's payload. The first two go through real JSON bytes so the key
+/// contract is exercised end to end; the rest build the decoded fields directly to keep each case focused.
+final class CheckpointRulesTests: TestCase {
+
+    // MARK: - Wire contract
+
+    /// The example payload from the "Storing and serving checkpoint rules" proposal, with its placeholder ids
+    /// filled in, as it would arrive in a checkpoint's blob.
+    func testParsesTheDocumentedExamplePayload() throws {
+        let blob = Data("""
+        {
+          "id": "checkpoint-abc",
+          "rules": [
+            {
+              "id": "rule-1",
+              "audience": "audience-1",
+              "workflow_id": "wf-1",
+              "frequency_cap": { "type": "once" },
+              "schedule": { "start": "2026-11-25T00:00:00Z", "end": "2026-11-30T00:00:00Z" }
+            },
+            {
+              "id": "rule-2",
+              "audience": "audience-2",
+              "workflow_id": "wf-2",
+              "frequency_cap": { "type": "every" }
+            }
+          ]
+        }
+        """.utf8)
+        let ruleSet = try XCTUnwrap(CheckpointRuleSet.parse(identifier: "app_open", blob: blob))
+
+        expect(ruleSet.identifier) == "app_open"
+        expect(ruleSet.id) == "checkpoint-abc"
+        expect(ruleSet.rules.map(\.workflowId)) == ["wf-1", "wf-2"]
+
+        let first = try XCTUnwrap(ruleSet.rules.first)
+        expect(first.id) == "rule-1"
+        expect(first.audienceId) == "audience-1"
+        expect(first.frequencyCap) == CheckpointFrequencyCap(type: "once")
+        expect(first.schedule?.start) == Self.date("2026-11-25T00:00:00Z")
+        expect(first.schedule?.end) == Self.date("2026-11-30T00:00:00Z")
+
+        let second = try XCTUnwrap(ruleSet.rules.last)
+        expect(second.frequencyCap) == CheckpointFrequencyCap(type: "every")
+        expect(second.schedule).to(beNil())
+    }
+
+    /// A payload is decoded as a dictionary, so `.convertFromSnakeCase` leaves every key alone at every
+    /// depth. An item's own `content` keys are the exception, and those carry metadata, not rules.
+    func testKeepsPayloadKeysVerbatimWhileItemMetadataIsCamelCased() throws {
+        let blob = Data(#"{ "rules": [{ "workflow_id": "wf-1", "frequency_cap": { "type": "once" } }] }"#.utf8)
+        let ruleSet = try XCTUnwrap(CheckpointRuleSet.parse(identifier: "app_open", blob: blob))
+
+        let rule = try XCTUnwrap(ruleSet.rules.onlyElement)
+        expect(rule.workflowId) == "wf-1"
+        expect(rule.frequencyCap) == CheckpointFrequencyCap(type: "once")
+
+        let payload = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.checkpoints:etag",
+          "active_topics": ["checkpoints"],
+          "topics": {
+            "checkpoints": {
+              "app_open": { "blob_ref": "app-open-ref", "prefetch": true, "first_seen": "2026-06-17T08:44:26Z" }
+            }
+          }
+        }
+        """
+        let response = try JSONDecoder.default.decode(RemoteConfiguration.self, from: Data(payload.utf8))
+        let item = try XCTUnwrap(
+            response.topics.entries[RemoteConfigTopic.checkpoints.wireName]?["app_open"]
+        )
+
+        expect(item.blobRef) == "app-open-ref"
+        expect(item.prefetch) == true
+        expect(item.content.keys.sorted()) == ["firstSeen"]
+    }
+
+    func testReturnsNilForAPayloadThatIsntAJSONObject() {
+        expect(CheckpointRuleSet.parse(identifier: "app_open", blob: Data("not-json".utf8))).to(beNil())
+        expect(CheckpointRuleSet.parse(identifier: "app_open", blob: Data(#"["an", "array"]"#.utf8))).to(beNil())
+    }
+
+    // MARK: - Ordering
+
+    /// Rules are served in priority order, so parsing must not reorder them.
+    func testPreservesTheServedRuleOrder() {
+        let ruleSet = Self.ruleSet(["rules": .array([
+            Self.rule(workflowId: "wf-c"),
+            Self.rule(workflowId: "wf-a"),
+            Self.rule(workflowId: "wf-b")
+        ])])
+
+        expect(ruleSet.rules.map(\.workflowId)) == ["wf-c", "wf-a", "wf-b"]
+    }
+
+    func testKeepsServedOrderWhenARuleInTheMiddleIsSkipped() {
+        let ruleSet = Self.ruleSet(["rules": .array([
+            Self.rule(workflowId: "wf-a"),
+            .object(["id": .string("no-workflow")]),
+            Self.rule(workflowId: "wf-b")
+        ])])
+
+        expect(ruleSet.rules.map(\.workflowId)) == ["wf-a", "wf-b"]
+    }
+
+    // MARK: - Malformed data
+
+    func testSkipsRulesMissingAWorkflowId() {
+        let ruleSet = Self.ruleSet(["rules": .array([
+            .object(["id": .string("rule-1")]),
+            Self.rule(workflowId: "wf-valid"),
+            .object(["workflow_id": .string("")])
+        ])])
+
+        expect(ruleSet.rules.map(\.workflowId)) == ["wf-valid"]
+    }
+
+    func testSkipsRuleEntriesThatArentObjects() {
+        let ruleSet = Self.ruleSet(["rules": .array([
+            .string("not-a-rule"),
+            Self.rule(workflowId: "wf-valid")
+        ])])
+
+        expect(ruleSet.rules.map(\.workflowId)) == ["wf-valid"]
+    }
+
+    func testKeepsCheckpointWithNoRulesWhenRulesArentAnArray() {
+        expect(Self.ruleSet(["rules": .string("nope")]).rules).to(beEmpty())
+    }
+
+    /// A payload carrying only the checkpoint's own id is still a known checkpoint with no rules.
+    func testKeepsCheckpointWithNoRulesKeyAtAll() {
+        let ruleSet = Self.ruleSet(["id": .string("checkpoint-xyz")])
+
+        expect(ruleSet.identifier) == "app_open"
+        expect(ruleSet.id) == "checkpoint-xyz"
+        expect(ruleSet.rules).to(beEmpty())
+    }
+
+    func testIgnoresUnknownFields() {
+        let ruleSet = Self.ruleSet([
+            "something_the_backend_added_later": .bool(true),
+            "rules": .array([
+                .object([
+                    "workflow_id": .string("wf-a"),
+                    "state": .string("active"),
+                    "something_else_new": .bool(true)
+                ])
+            ])
+        ])
+
+        expect(ruleSet.rules.map(\.workflowId)) == ["wf-a"]
+    }
+
+    // MARK: - Optional rule fields
+
+    func testTreatsAnAbsentAudienceAsTargetingEveryone() {
+        let ruleSet = Self.ruleSet(["rules": .array([Self.rule(workflowId: "wf-a")])])
+
+        expect(ruleSet.rules.onlyElement?.audienceId).to(beNil())
+    }
+
+    func testIgnoresAFrequencyCapWithoutAType() {
+        let ruleSet = Self.ruleSet(["rules": .array([
+            .object(["workflow_id": .string("wf-a"), "frequency_cap": .object(["count": .int(3)])])
+        ])])
+
+        expect(ruleSet.rules.onlyElement?.frequencyCap).to(beNil())
+    }
+
+    func testParsesACustomFrequencyCap() {
+        let ruleSet = Self.ruleSet(["rules": .array([
+            .object([
+                "workflow_id": .string("wf-a"),
+                "frequency_cap": .object([
+                    "type": .string("custom"),
+                    "count": .int(3),
+                    "window": .string("P7D")
+                ])
+            ])
+        ])])
+
+        expect(ruleSet.rules.onlyElement?.frequencyCap)
+            == CheckpointFrequencyCap(type: "custom", count: 3, window: "P7D")
+    }
+
+    func testParsesAScheduleWithOnlyOneBound() {
+        let ruleSet = Self.ruleSet(["rules": .array([
+            .object([
+                "workflow_id": .string("wf-a"),
+                "schedule": .object(["start": .string("2026-11-25T00:00:00Z")])
+            ])
+        ])])
+
+        expect(ruleSet.rules.onlyElement?.schedule?.start) == Self.date("2026-11-25T00:00:00Z")
+        expect(ruleSet.rules.onlyElement?.schedule?.end).to(beNil())
+    }
+
+    /// Dropped rather than kept as an open-ended window, which would run a rule outside the dates it was
+    /// scheduled for.
+    func testDropsAScheduleWhoseDatesCantBeParsed() {
+        let ruleSet = Self.ruleSet(["rules": .array([
+            .object([
+                "workflow_id": .string("wf-a"),
+                "schedule": .object(["start": .string("not-a-date"), "end": .string("nope")])
+            ])
+        ])])
+
+        expect(ruleSet.rules.onlyElement?.workflowId) == "wf-a"
+        expect(ruleSet.rules.onlyElement?.schedule).to(beNil())
+    }
+
+    func testParsesFractionalSecondsInASchedule() {
+        let ruleSet = Self.ruleSet(["rules": .array([
+            .object([
+                "workflow_id": .string("wf-a"),
+                "schedule": .object(["start": .string("2026-11-25T00:00:00.251Z")])
+            ])
+        ])])
+
+        expect(ruleSet.rules.onlyElement?.schedule?.start) == Self.date("2026-11-25T00:00:00.251Z")
+    }
+
+    // MARK: - Helpers
+
+    private static func ruleSet(_ fields: [String: AnyDecodable]) -> CheckpointRuleSet {
+        return CheckpointRuleSet.parse(identifier: "app_open", fields: fields)
+    }
+
+    private static func rule(workflowId: String) -> AnyDecodable {
+        return .object(["workflow_id": .string(workflowId)])
+    }
+
+    private static func date(_ string: String) -> Date? {
+        return ISO8601DateFormatter.default.date(from: string)
+    }
+
+}

--- a/Tests/UnitTests/Networking/CheckpointRulesTests.swift
+++ b/Tests/UnitTests/Networking/CheckpointRulesTests.swift
@@ -30,8 +30,7 @@ final class CheckpointRulesTests: TestCase {
             {
               "id": "chkptrule_1a2b3c4d5e6f7a8b",
               "audience": "aud_4412",
-              "workflow_id": "wf-1",
-              "schedule": { "start": "2026-11-25T00:00:00Z", "end": "2026-11-30T00:00:00Z" }
+              "workflow_id": "wf-1"
             },
             {
               "id": "chkptrule_9z8y7x6w5v4u3t2s",
@@ -48,12 +47,8 @@ final class CheckpointRulesTests: TestCase {
         let first = try XCTUnwrap(ruleSet.rules.first)
         expect(first.id) == "chkptrule_1a2b3c4d5e6f7a8b"
         expect(first.audienceId) == "aud_4412"
-        expect(first.schedule?.start) == Self.date("2026-11-25T00:00:00Z")
-        expect(first.schedule?.end) == Self.date("2026-11-30T00:00:00Z")
 
-        let second = try XCTUnwrap(ruleSet.rules.last)
-        expect(second.audienceId) == "aud_4419"
-        expect(second.schedule).to(beNil())
+        expect(ruleSet.rules.last?.audienceId) == "aud_4419"
     }
 
     func testDecodesACheckpointWithNoRules() throws {
@@ -126,42 +121,6 @@ final class CheckpointRulesTests: TestCase {
         expect(ruleSet.rules.map(\.workflowId)) == ["wf-valid"]
     }
 
-    // MARK: - Schedule
-
-    func testDecodesAScheduleWithOnlyOneBound() throws {
-        let ruleSet = try Self.decode("""
-        { "rules": [{ "audience": "aud_4412", "workflow_id": "wf-a",
-                      "schedule": { "start": "2026-11-25T00:00:00Z" } }] }
-        """)
-
-        let schedule = try XCTUnwrap(ruleSet.rules.onlyElement?.schedule)
-        expect(schedule.start) == Self.date("2026-11-25T00:00:00Z")
-        expect(schedule.end).to(beNil())
-    }
-
-    func testDecodesFractionalSecondsInASchedule() throws {
-        let ruleSet = try Self.decode("""
-        { "rules": [{ "audience": "aud_4412", "workflow_id": "wf-a",
-                      "schedule": { "start": "2026-11-25T00:00:00.251Z" } }] }
-        """)
-
-        expect(ruleSet.rules.onlyElement?.schedule?.start) == Self.date("2026-11-25T00:00:00.251Z")
-    }
-
-    /// A bound that's present but unparseable drops the whole rule. Letting it read as `nil` would widen the
-    /// window and run the rule outside the dates it was scheduled for.
-    func testSkipsARuleWhoseScheduleHasAnUnparseableBound() throws {
-        let ruleSet = try Self.decode("""
-        { "rules": [
-            { "audience": "aud_4412", "workflow_id": "wf-broken",
-              "schedule": { "start": "not-a-date", "end": "2026-11-30T00:00:00Z" } },
-            \(Self.rule("wf-valid"))
-        ] }
-        """)
-
-        expect(ruleSet.rules.map(\.workflowId)) == ["wf-valid"]
-    }
-
     // MARK: - Helpers
 
     private static func decode(_ json: String) throws -> CheckpointRuleSet {
@@ -170,10 +129,6 @@ final class CheckpointRulesTests: TestCase {
 
     private static func rule(_ workflowId: String) -> String {
         return #"{ "audience": "aud_4412", "workflow_id": "\#(workflowId)" }"#
-    }
-
-    private static func date(_ string: String) -> Date? {
-        return ISO8601DateFormatter.default.date(from: string)
     }
 
 }

--- a/Tests/UnitTests/Networking/CheckpointsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/CheckpointsConfigProviderTests.swift
@@ -48,13 +48,12 @@ class CheckpointsConfigProviderTests: TestCase {
     }
 
     func testResolvesACheckpointFromItsPayload() async throws {
-        self.commit(rules: ["onboarding": ["wf-a"]], ids: ["onboarding": "checkpoint-abc"])
+        self.commit(rules: ["onboarding": ["wf-a"]])
 
         let ruleSetResult = await self.provider.getCheckpoint("onboarding")
 
         let ruleSet = try XCTUnwrap(ruleSetResult)
 
-        expect(ruleSet.id) == "checkpoint-abc"
         expect(ruleSet.rules.onlyElement?.workflowId) == "wf-a"
     }
 
@@ -138,7 +137,6 @@ class CheckpointsConfigProviderTests: TestCase {
 
         let ruleSet = try XCTUnwrap(ruleSetResult)
 
-        expect(ruleSet.id) == "checkpoint-abc"
         expect(ruleSet.rules).to(beEmpty())
     }
 
@@ -162,14 +160,14 @@ class CheckpointsConfigProviderTests: TestCase {
     // MARK: - Helpers
 
     /// One blob-backed item per checkpoint, each payload carrying one rule per workflow id.
-    private func commit(rules: [String: [String]], ids: [String: String] = [:]) {
+    private func commit(rules: [String: [String]]) {
         var items: [String: RemoteConfiguration.ConfigItem] = [:]
         var blobs: [String: Data] = [:]
 
         for (identifier, workflowIds) in rules {
             let ref = "\(identifier)-\(workflowIds.joined(separator: "-"))-ref"
             items[identifier] = .init(blobRef: ref, prefetch: true)
-            blobs[ref] = Self.payload(id: ids[identifier], workflowIds: workflowIds)
+            blobs[ref] = Self.payload(workflowIds: workflowIds)
         }
 
         self.commit(checkpoints: items, blobs: blobs)
@@ -192,10 +190,10 @@ class CheckpointsConfigProviderTests: TestCase {
         self.blobStore.stubbedData = blobs
     }
 
-    private static func payload(id: String? = nil, workflowIds: [String]) -> Data {
-        let rules = workflowIds.map { #"{ "workflow_id": "\#($0)", "audience": "aud_4412" }"# }.joined(separator: ", ")
-        let idField = id.map { #""id": "\#($0)", "# } ?? ""
-        return Data(#"{ \#(idField)"rules": [\#(rules)] }"#.utf8)
+    private static func payload(workflowIds: [String]) -> Data {
+        let rules = workflowIds.map { #"{ "workflow_id": "\#($0)", "audience_id": "aud_4412" }"# }
+            .joined(separator: ", ")
+        return Data(#"{ "rules": [\#(rules)] }"#.utf8)
     }
 
 }

--- a/Tests/UnitTests/Networking/CheckpointsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/CheckpointsConfigProviderTests.swift
@@ -176,7 +176,7 @@ class CheckpointsConfigProviderTests: TestCase {
     ) {
         var entries: [String: RemoteConfiguration.ConfigTopic] = [:]
         if !checkpoints.isEmpty {
-            entries[RemoteConfigTopic.checkpoints.wireName] = checkpoints
+            entries[RemoteConfigTopic.checkpointRules.wireName] = checkpoints
         }
 
         self.diskCache.stubbedRead = PersistedRemoteConfiguration(
@@ -188,7 +188,7 @@ class CheckpointsConfigProviderTests: TestCase {
     }
 
     private static func payload(id: String? = nil, workflowIds: [String]) -> Data {
-        let rules = workflowIds.map { #"{ "workflow_id": "\#($0)" }"# }.joined(separator: ", ")
+        let rules = workflowIds.map { #"{ "workflow_id": "\#($0)", "audience": 4412 }"# }.joined(separator: ", ")
         let idField = id.map { #""id": "\#($0)", "# } ?? ""
         return Data(#"{ \#(idField)"rules": [\#(rules)] }"#.utf8)
     }

--- a/Tests/UnitTests/Networking/CheckpointsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/CheckpointsConfigProviderTests.swift
@@ -187,7 +187,7 @@ class CheckpointsConfigProviderTests: TestCase {
     }
 
     private static func payload(id: String? = nil, workflowIds: [String]) -> Data {
-        let rules = workflowIds.map { #"{ "workflow_id": "\#($0)", "audience": 4412 }"# }.joined(separator: ", ")
+        let rules = workflowIds.map { #"{ "workflow_id": "\#($0)", "audience": "aud_4412" }"# }.joined(separator: ", ")
         let idField = id.map { #""id": "\#($0)", "# } ?? ""
         return Data(#"{ \#(idField)"rules": [\#(rules)] }"#.utf8)
     }

--- a/Tests/UnitTests/Networking/CheckpointsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/CheckpointsConfigProviderTests.swift
@@ -1,0 +1,335 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CheckpointsConfigProviderTests.swift
+//
+//  Created by Facundo Menzella.
+
+import Foundation
+import Nimble
+import XCTest
+
+@_spi(Internal) @testable import RevenueCat
+
+/// End-to-end: drives a real `RemoteConfigManager` (the single read front door, via `blobData()`) through
+/// `CheckpointsConfigProvider`. Only the backend transport and blob store are faked.
+class CheckpointsConfigProviderTests: TestCase {
+
+    private var diskCache: FakeCheckpointsDiskCache!
+    private var blobStore: FakeCheckpointsBlobStore!
+    private var manager: RemoteConfigManager!
+    private var provider: CheckpointsConfigProvider!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        self.diskCache = FakeCheckpointsDiskCache()
+        self.blobStore = FakeCheckpointsBlobStore()
+        self.manager = RemoteConfigManager(
+            remoteConfigAPI: FakeCheckpointsRemoteConfigAPI(),
+            diskCache: self.diskCache,
+            blobStore: self.blobStore,
+            blobFetcher: FakeCheckpointsBlobFetcher(blobStore: self.blobStore),
+            currentUserProvider: FakeCheckpointsCurrentUserProvider()
+        )
+        self.provider = CheckpointsConfigProvider(manager: self.manager)
+    }
+
+    func testResolvesACheckpointFromItsPayload() async throws {
+        self.commit(rules: ["onboarding": ["wf-a"]], ids: ["onboarding": "checkpoint-abc"])
+
+        let ruleSetResult = await self.provider.getCheckpoint("onboarding")
+
+        let ruleSet = try XCTUnwrap(ruleSetResult)
+
+        expect(ruleSet.identifier) == "onboarding"
+        expect(ruleSet.id) == "checkpoint-abc"
+        expect(ruleSet.rules.onlyElement?.workflowId) == "wf-a"
+    }
+
+    func testKeepsRulesInServedOrder() async throws {
+        self.commit(rules: ["onboarding": ["wf-c", "wf-a", "wf-b"]])
+
+        let ruleSetResult = await self.provider.getCheckpoint("onboarding")
+
+        let ruleSet = try XCTUnwrap(ruleSetResult)
+
+        expect(ruleSet.rules.map(\.workflowId)) == ["wf-c", "wf-a", "wf-b"]
+    }
+
+    func testResolvesEachCheckpointIndependently() async throws {
+        self.commit(rules: ["onboarding": ["wf-a"], "paywall_close": ["wf-exit"]])
+
+        let onboardingResult = await self.provider.getCheckpoint("onboarding")
+        let paywallCloseResult = await self.provider.getCheckpoint("paywall_close")
+
+        let onboarding = try XCTUnwrap(onboardingResult)
+        let paywallClose = try XCTUnwrap(paywallCloseResult)
+
+        expect(onboarding.rules.onlyElement?.workflowId) == "wf-a"
+        expect(paywallClose.rules.onlyElement?.workflowId) == "wf-exit"
+    }
+
+    func testReturnsNilForACheckpointThatHasNoItem() async {
+        self.commit(rules: ["onboarding": ["wf-a"]])
+
+        let ruleSet = await self.provider.getCheckpoint("never_registered")
+
+        expect(ruleSet).to(beNil())
+    }
+
+    func testReturnsNilWhenTheTopicIsAbsent() async {
+        self.commit(rules: [:])
+
+        let ruleSet = await self.provider.getCheckpoint("onboarding")
+
+        expect(ruleSet).to(beNil())
+    }
+
+    func testReturnsNilWhenThePayloadIsMissing() async {
+        self.commit(checkpoints: ["onboarding": .init(blobRef: "missing-ref", prefetch: true)])
+
+        let ruleSet = await self.provider.getCheckpoint("onboarding")
+
+        expect(ruleSet).to(beNil())
+    }
+
+    func testReturnsNilWhenThePayloadIsntJSON() async {
+        self.commit(
+            checkpoints: ["onboarding": .init(blobRef: "onboarding-ref", prefetch: true)],
+            blobs: ["onboarding-ref": Data("not-json".utf8)]
+        )
+
+        let ruleSet = await self.provider.getCheckpoint("onboarding")
+
+        expect(ruleSet).to(beNil())
+    }
+
+    /// Rules live in the item's payload, not its metadata, so an item without a `blob_ref` has nothing to read.
+    func testReturnsNilForAnItemWithoutABlobRef() async {
+        self.commit(checkpoints: [
+            "onboarding": .init(content: ["rules": .array([
+                .object(["workflow_id": .string("wf-metadata")])
+            ])])
+        ])
+
+        let ruleSet = await self.provider.getCheckpoint("onboarding")
+
+        expect(ruleSet).to(beNil())
+    }
+
+    /// A checkpoint whose payload carries no rules is still resolvable, so a caller can tell it apart from
+    /// an unconfigured one.
+    func testResolvesACheckpointWhosePayloadHasNoRules() async throws {
+        self.commit(
+            checkpoints: ["onboarding": .init(blobRef: "onboarding-ref", prefetch: true)],
+            blobs: ["onboarding-ref": Data(#"{ "id": "checkpoint-abc" }"#.utf8)]
+        )
+
+        let ruleSetResult = await self.provider.getCheckpoint("onboarding")
+
+        let ruleSet = try XCTUnwrap(ruleSetResult)
+
+        expect(ruleSet.id) == "checkpoint-abc"
+        expect(ruleSet.rules).to(beEmpty())
+    }
+
+    /// `blobData` re-reads through the manager every time, so a config replacement is picked up without the
+    /// provider holding any state of its own.
+    func testPicksUpANewPayloadAfterTheConfigIsReplaced() async throws {
+        self.commit(rules: ["onboarding": ["wf-a"]])
+        let beforeResult = await self.provider.getCheckpoint("onboarding")
+
+        let before = try XCTUnwrap(beforeResult)
+        expect(before.rules.onlyElement?.workflowId) == "wf-a"
+
+        self.manager.clearCache(forAppUserID: "someone-else")
+        self.commit(rules: ["onboarding": ["wf-b"]])
+
+        let afterResult = await self.provider.getCheckpoint("onboarding")
+
+        let after = try XCTUnwrap(afterResult)
+        expect(after.rules.onlyElement?.workflowId) == "wf-b"
+    }
+
+    // MARK: - Helpers
+
+    /// Commits one blob-backed item per checkpoint, each payload carrying one rule per workflow id. This is
+    /// the shape the topic is expected to arrive in, so most tests can stay a single line.
+    private func commit(rules: [String: [String]], ids: [String: String] = [:]) {
+        var items: [String: RemoteConfiguration.ConfigItem] = [:]
+        var blobs: [String: Data] = [:]
+
+        for (identifier, workflowIds) in rules {
+            // Vary the ref with the payload, the way a content-addressed ref would.
+            let ref = "\(identifier)-\(workflowIds.joined(separator: "-"))-ref"
+            items[identifier] = .init(blobRef: ref, prefetch: true)
+            blobs[ref] = Self.payload(id: ids[identifier], workflowIds: workflowIds)
+        }
+
+        self.commit(checkpoints: items, blobs: blobs)
+    }
+
+    private func commit(
+        checkpoints: [String: RemoteConfiguration.ConfigItem],
+        blobs: [String: Data] = [:]
+    ) {
+        var entries: [String: RemoteConfiguration.ConfigTopic] = [:]
+        if !checkpoints.isEmpty {
+            entries[RemoteConfigTopic.checkpoints.wireName] = checkpoints
+        }
+
+        self.diskCache.stubbedRead = PersistedRemoteConfiguration(
+            manifest: "test-manifest",
+            activeTopics: Array(entries.keys),
+            topics: .init(entries: entries)
+        )
+        self.blobStore.stubbedData = blobs
+    }
+
+    private static func payload(id: String? = nil, workflowIds: [String]) -> Data {
+        let rules = workflowIds.map { #"{ "workflow_id": "\#($0)" }"# }.joined(separator: ", ")
+        let idField = id.map { #""id": "\#($0)", "# } ?? ""
+        return Data(#"{ \#(idField)"rules": [\#(rules)] }"#.utf8)
+    }
+
+}
+
+// MARK: - Fakes
+
+private final class FakeCheckpointsRemoteConfigAPI: RemoteConfigAPIType {
+
+    func getRemoteConfig(
+        request: RemoteConfigRequest,
+        isAppBackgrounded: Bool,
+        completion: @escaping Backend.ResponseHandler<RemoteConfigFetchResult>
+    ) {
+        // `blobData(for:itemKey:)` triggers a refresh-and-wait whenever an item is absent, so this must
+        // always settle rather than hang: report a "204 Not Modified", since state is already pre-committed.
+        // `RemoteConfigManager` calls this from inside a lock and documents that it assumes the completion is
+        // never invoked synchronously, so this must dispatch asynchronously.
+        DispatchQueue.global().async {
+            completion(.success(RemoteConfigFetchResult(response: VerifiedHTTPResponse(
+                httpStatusCode: .noContent,
+                responseHeaders: [:],
+                body: nil,
+                verificationResult: .verified,
+                isLoadShedderResponse: false,
+                isFallbackUrlResponse: false
+            ))))
+        }
+    }
+
+    func getRemoteConfigFallback(
+        domain: String,
+        isAppBackgrounded: Bool,
+        completion: @escaping Backend.ResponseHandler<RemoteConfigFallbackFetchResult>
+    ) {
+        DispatchQueue.global().async {
+            completion(.failure(.networkError(.unexpectedResponse(nil))))
+        }
+    }
+
+}
+
+private final class FakeCheckpointsDiskCache: RemoteConfigDiskCacheType {
+
+    private let lock = Lock()
+    private var _stubbedRead: PersistedRemoteConfiguration?
+    var stubbedRead: PersistedRemoteConfiguration? {
+        get { return self.lock.perform { self._stubbedRead } }
+        set { self.lock.perform { self._stubbedRead = newValue } }
+    }
+
+    func read() -> PersistedRemoteConfiguration? {
+        return self.lock.perform { self._stubbedRead }
+    }
+
+    func topic(_ topic: RemoteConfigTopic) -> RemoteConfiguration.ConfigTopic? {
+        return self.lock.perform { self._stubbedRead?.topics.entries[topic.wireName] }
+    }
+
+    @discardableResult
+    func write(_ configuration: PersistedRemoteConfiguration) -> Bool {
+        self.lock.perform { self._stubbedRead = configuration }
+        return true
+    }
+
+    func clear() {
+        self.lock.perform { self._stubbedRead = nil }
+    }
+
+}
+
+private final class FakeCheckpointsBlobStore: RemoteConfigBlobStoreType {
+
+    private let lock = Lock()
+    private var _stubbedData: [String: Data] = [:]
+    var stubbedData: [String: Data] {
+        get { return self.lock.perform { self._stubbedData } }
+        set { self.lock.perform { self._stubbedData = newValue } }
+    }
+
+    func contains(ref: String) -> Bool {
+        return self.lock.perform { self._stubbedData[ref] != nil }
+    }
+
+    func read(ref: String) -> Data? {
+        return self.lock.perform { self._stubbedData[ref] }
+    }
+
+    @discardableResult
+    func write(ref: String, bytes: UnsafeRawBufferPointer) -> Bool {
+        var data = Data()
+        data.append(contentsOf: bytes.bindMemory(to: UInt8.self))
+        self.lock.perform { self._stubbedData[ref] = data }
+        return true
+    }
+
+    func cachedRefs() -> Set<String> {
+        return self.lock.perform { Set(self._stubbedData.keys) }
+    }
+
+    func retainOnly(_ refs: Set<String>) {
+        self.lock.perform { self._stubbedData = self._stubbedData.filter { refs.contains($0.key) } }
+    }
+
+    func clear() {
+        self.lock.perform { self._stubbedData = [:] }
+    }
+
+}
+
+private final class FakeCheckpointsBlobFetcher: RemoteConfigBlobFetcherType {
+
+    private let blobStore: FakeCheckpointsBlobStore
+
+    init(blobStore: FakeCheckpointsBlobStore) {
+        self.blobStore = blobStore
+    }
+
+    // The store is pre-populated in these tests, so "downloading" is just confirming it's there.
+    func ensureDownloaded(ref: String) async -> Bool {
+        return self.blobStore.contains(ref: ref)
+    }
+
+    func ensureAllDownloaded(refs: [String]) async -> Bool {
+        return refs.allSatisfy { self.blobStore.contains(ref: $0) }
+    }
+
+    func prefetch(refs: [String]) {}
+
+}
+
+private final class FakeCheckpointsCurrentUserProvider: CurrentUserProvider {
+
+    var currentAppUserID: String { return "test-user" }
+    var currentUserIsAnonymous: Bool { return false }
+
+}

--- a/Tests/UnitTests/Networking/CheckpointsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/CheckpointsConfigProviderTests.swift
@@ -41,6 +41,12 @@ class CheckpointsConfigProviderTests: TestCase {
         self.provider = CheckpointsConfigProvider(manager: self.manager)
     }
 
+    /// Pinned as a literal: every other fixture derives the key from the enum, so a wrong wire name would be
+    /// invisible here and would read as an absent topic forever.
+    func testTopicWireNameMatchesTheBackend() {
+        expect(RemoteConfigTopic.checkpointRules.wireName) == "checkpoint_rules"
+    }
+
     func testResolvesACheckpointFromItsPayload() async throws {
         self.commit(rules: ["onboarding": ["wf-a"]], ids: ["onboarding": "checkpoint-abc"])
 

--- a/Tests/UnitTests/Networking/CheckpointsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/CheckpointsConfigProviderTests.swift
@@ -111,7 +111,6 @@ class CheckpointsConfigProviderTests: TestCase {
         expect(ruleSet).to(beNil())
     }
 
-    /// Rules live in the item's payload, not its metadata, so an item without a `blob_ref` has nothing to read.
     func testReturnsNilForAnItemWithoutABlobRef() async {
         self.commit(checkpoints: [
             "onboarding": .init(content: ["rules": .array([
@@ -124,8 +123,6 @@ class CheckpointsConfigProviderTests: TestCase {
         expect(ruleSet).to(beNil())
     }
 
-    /// A checkpoint whose payload carries no rules is still resolvable, so a caller can tell it apart from
-    /// an unconfigured one.
     func testResolvesACheckpointWhosePayloadHasNoRules() async throws {
         self.commit(
             checkpoints: ["onboarding": .init(blobRef: "onboarding-ref", prefetch: true)],
@@ -140,8 +137,7 @@ class CheckpointsConfigProviderTests: TestCase {
         expect(ruleSet.rules).to(beEmpty())
     }
 
-    /// `blobData` re-reads through the manager every time, so a config replacement is picked up without the
-    /// provider holding any state of its own.
+    /// The provider holds no state of its own, so a config replacement is picked up on the next read.
     func testPicksUpANewPayloadAfterTheConfigIsReplaced() async throws {
         self.commit(rules: ["onboarding": ["wf-a"]])
         let beforeResult = await self.provider.getCheckpoint("onboarding")
@@ -160,14 +156,12 @@ class CheckpointsConfigProviderTests: TestCase {
 
     // MARK: - Helpers
 
-    /// Commits one blob-backed item per checkpoint, each payload carrying one rule per workflow id. This is
-    /// the shape the topic is expected to arrive in, so most tests can stay a single line.
+    /// One blob-backed item per checkpoint, each payload carrying one rule per workflow id.
     private func commit(rules: [String: [String]], ids: [String: String] = [:]) {
         var items: [String: RemoteConfiguration.ConfigItem] = [:]
         var blobs: [String: Data] = [:]
 
         for (identifier, workflowIds) in rules {
-            // Vary the ref with the payload, the way a content-addressed ref would.
             let ref = "\(identifier)-\(workflowIds.joined(separator: "-"))-ref"
             items[identifier] = .init(blobRef: ref, prefetch: true)
             blobs[ref] = Self.payload(id: ids[identifier], workflowIds: workflowIds)
@@ -210,10 +204,8 @@ private final class FakeCheckpointsRemoteConfigAPI: RemoteConfigAPIType {
         isAppBackgrounded: Bool,
         completion: @escaping Backend.ResponseHandler<RemoteConfigFetchResult>
     ) {
-        // `blobData(for:itemKey:)` triggers a refresh-and-wait whenever an item is absent, so this must
-        // always settle rather than hang: report a "204 Not Modified", since state is already pre-committed.
-        // `RemoteConfigManager` calls this from inside a lock and documents that it assumes the completion is
-        // never invoked synchronously, so this must dispatch asynchronously.
+        // Must always settle rather than hang, since a missing item triggers a refresh-and-wait. Must also
+        // dispatch asynchronously: `RemoteConfigManager` calls this from inside a lock.
         DispatchQueue.global().async {
             completion(.success(RemoteConfigFetchResult(response: VerifiedHTTPResponse(
                 httpStatusCode: .noContent,

--- a/Tests/UnitTests/Networking/CheckpointsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/CheckpointsConfigProviderTests.swift
@@ -48,7 +48,6 @@ class CheckpointsConfigProviderTests: TestCase {
 
         let ruleSet = try XCTUnwrap(ruleSetResult)
 
-        expect(ruleSet.identifier) == "onboarding"
         expect(ruleSet.id) == "checkpoint-abc"
         expect(ruleSet.rules.onlyElement?.workflowId) == "wf-a"
     }


### PR DESCRIPTION
### Motivation
get the `checkpoints` config topic into the SDK so rules are readable before there's anything evaluating them.
https://linear.app/revenuecat/issue/WFL-429/ios-ingest-the-checkpoints-config-topic

Android counterpart: RevenueCat/purchases-android#3895
<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: this one
- Branch: `facu/checkpoints-config-topic`
- Author / human owner: @facumenzella
- Agent(s): Claude Code (Opus 5, 1M context)
- Session source: current conversation
- Generated: 2026-08-05
- Context document version: 1

## Goal

Ingest the `checkpoints` remote-config topic on iOS: add the `RemoteConfigTopic` case, parsing models for the rules schema, and a `CheckpointsConfigProvider` following the `WorkflowsConfigProvider` pattern. Rules parsed only, kept in memory, no evaluation. No user-visible behavior.

## Initial Prompt

"[iOS] Ingest the checkpoints config topic. Add the new topic to the remote-config machinery: `RemoteConfigTopic.Checkpoints("checkpoints")`, parsing models for the schema, and a `CheckpointsConfigProvider` following the `WorkflowsConfigProvider` pattern. Rules only need to be parsed, no evaluation. Keep the parsed rules in memory." (given alongside a link to the Checkpoints product spec)

## Important Follow-up Prompts

- Pointed at the "Storing and serving checkpoint rules" proposal, which supplied the real served schema and replaced an earlier derived guess.
- Asked to compare against purchases-android#3887 and #3895.
- "about 2, we should support both" (inline content and blob), later reversed by Toni's reply.
- "about 1, looks like its checkpoints" (topic wire name).
- Relayed @tonidero's reply that `blobData` already abstracts inlined vs downloaded blobs and `topic()` is only needed for metadata.
- "can you double-check this by checking the other topic? the one for workflows"

## Agent Contribution

- Implemented `RemoteConfigTopic.checkpoints`, the parsing models, and `CheckpointsConfigProvider`, plus 26 unit tests.
- Established the served schema by locating the proposal doc; confirmed no `checkpoints` topic exists in khepri (`origin/main`, no branch, no open PR), so no backend implementation to conform to yet.
- Empirically verified `JSONDecoder` key conversion with a standalone script rather than assuming: `.convertFromSnakeCase` renames keys read through a keyed container, but not `[String: AnyDecodable]` dictionary keys at any depth. This corrected a wrong field-name assumption that a wire-level test had caught.
- Verified via `RemoteConfigManager.extractInlineBlobs` and khepri's `topics/workflows/publish.py` that an item's payload is always a blob (khepri's `upsert_json_item(content=)` becomes the blob; `item_metadata=` becomes the SDK's `ConfigItem.content`).
- Drafted the review comment posted on purchases-android#3895.

## Human Decisions

- Chose "async parse + sync cached read" for the provider API, and later accepted removing the cache entirely after Toni's reply.
- Chose to support both inline and blob sources, then accepted dropping the inline path once it was shown to be unreachable.
- Confirmed the topic wire name is `checkpoints`, overriding an incorrect reading of the proposal's `checkpoint_rules` heading.
- Directed verification against the workflows topic before acting on Toni's feedback.
- Wrote and approved the exact text of the review comment posted to the Android PR.

## Key Implementation Decisions

- Decision: read the payload via `blobData(for:itemKey:)` only, with no topic-index scan.
  - Rationale: items are keyed by checkpoint name, so the caller's identifier is the item key. `blobData` already resolves inlined vs downloaded blobs and invalidates on identity change.
  - Rejected: pre-parsing the whole topic behind a `GenerationGuardedCache`. Built first, then removed. Its justification was the spec's "evaluation has to be synchronous", but the public checkpoint API is async and a resolved blob read is local, so the constraint did not hold and the cache duplicated manager behavior.
  - Rejected: reading rules from the item's inline `content`. Unreachable, see Agent Contribution.
- Decision: hand-parse from `AnyDecodable` instead of `Decodable` structs.
  - Rationale: a `Decodable` struct throws on the first bad rule and fails the whole payload; per-rule skipping keeps the rest usable while the schema is unstable.
  - Rejected: `Decodable` + `convertFromSnakeCase`, which would be less code. Flagged to the human as a live tradeoff.
- Decision: preserve served rule order, no sorting.
  - Rationale: the proposal states rules arrive in priority order and carry no `order` field.
- Decision: drop a `schedule` whose dates cannot be parsed, keeping the rule.
  - Rationale: an open-ended window would run a rule outside the dates it was scheduled for.
- Decision: do not model `first_seen` / `created_via` / `ordered_rule_ids`.
  - Rationale: dashboard bookkeeping; the SDK reports checkpoint sightings rather than consuming them.

## Files / Symbols Touched

- `Sources/Networking/RemoteConfigTopic.swift`
  - Why: open the read facade for the new topic.
  - Symbols: `RemoteConfigTopic.checkpoints`
  - Review relevance: wire name must match what the backend publishes; a mismatch fails silently.
- `Sources/Networking/CheckpointRules.swift`
  - Why: parsing models.
  - Symbols: `CheckpointRuleSet`, `CheckpointRule`, `CheckpointFrequencyCap`, `CheckpointRuleSchedule`, `CheckpointRuleSet.parse(identifier:blob:)`, `parse(identifier:fields:)`
  - Review relevance: which fields are required vs optional; that rule fields are read at wire spelling (`workflow_id`, `frequency_cap`).
- `Sources/Networking/CheckpointsConfigProvider.swift`
  - Why: topic front door.
  - Symbols: `CheckpointsConfigProviderType`, `CheckpointsConfigProvider.getCheckpoint(_:)`
  - Review relevance: the conflated `nil` cases.
- `Sources/Logging/Strings/RemoteConfigStrings.swift`
  - Why: warn when a rule is skipped.
  - Symbols: `RemoteConfigStrings.checkpointRuleSkipped(checkpoint:reason:)`
- `Tests/UnitTests/Networking/CheckpointRulesTests.swift`, `Tests/UnitTests/Networking/CheckpointsConfigProviderTests.swift`
  - Why: parsing and end-to-end read coverage.
  - Review relevance: `testKeepsPayloadKeysVerbatimWhileItemMetadataIsCamelCased` pins the key-casing contract.

## Dependencies / Config / Migrations

- None. All types are internal, so no public API surface change and no `api/*.swiftinterface` update.

## Validation

- Commands run:
  - `swift build --target RevenueCat`: clean.
  - `xcodebuild test -workspace RevenueCat-Tuist.xcworkspace -scheme UnitTests … -only-testing:UnitTests/CheckpointRulesTests -only-testing:UnitTests/CheckpointsConfigProviderTests`: 26 tests, 0 failures.
  - Same command for `RemoteConfigManagerTests`, `WorkflowsConfigProviderTests`, `RemoteConfigSourceProviderTests`, `UiConfigProviderTests`, `RemoteConfigurationDecodingTests`, `RemoteConfigIntegrationTests`: 258 tests, 0 failures.
  - `swiftlint lint` on all changed files: no violations.
- Manual verification:
  - No device or simulator app run: nothing is wired into `Purchases`, so there is no runtime path to exercise.
  - No real backend response inspected: the topic is not served yet.
- CI:
  - Not captured at time of writing.

## Validation Gaps

- Never exercised against a real `/v1/config` response, since the backend does not serve this topic yet. Tests encode the proposal's example payload, not observed traffic.
- No test asserts behavior when remote config is disabled, beyond the `nil` return that path shares with other cases.
- Only iOS unit tests run; other platform test lanes not run locally.

## Review Focus

- Is the topic wire name `checkpoints` correct? A wrong name returns `nil` forever with no error.
- Should the payload decode into `Decodable` structs instead of hand-parsed `AnyDecodable`, accepting all-or-nothing failure for less code?
- Is `workflow_id` the right sole required field, or should a rule without an `audience` also be rejected?
- Is dropping an unparseable `schedule` while keeping the rule the behavior we want, or should the rule be dropped too?
- Should `frequency_cap.type` stay a raw `String` rather than a typed value while the vocabulary is unsettled?

## Risks / Reviewer Notes

- Risk: the schema shifts before V1 and parsing silently reads `nil` for renamed fields.
  - Evidence: the proposal's own callout says the schema may shift; it is only used internally for testing.
  - Mitigation: unknown fields ignored, malformed rules skipped and logged; `CheckpointRulesTests` encodes the documented example so a rename shows as a test failure.
- Risk: key-casing confusion, since metadata keys are camelCased and payload keys are not.
  - Evidence: verified empirically; an earlier revision read the wrong field names and a wire-level test caught it.
  - Mitigation: documented on `parse(identifier:fields:)` and pinned by a test asserting both sides.
- Risk: `nil` conflates "unconfigured", "unresolvable" and "disabled".
  - Evidence: `blobData` returns `nil` for all three.
  - Mitigation: none yet; noted as a follow-up for when `noMatch` vs `configurationUnavailable` is surfaced.
- Risk: divergence from Android if only one platform's read path changes.
  - Evidence: both now use `getCheckpoint(identifier)` over `blobData`; the Android model is still an empty placeholder.
  - Mitigation: comment posted on purchases-android#3895; naming to be agreed when that model is filled in.

## Non-goals / Out of Scope

- Rule evaluation, audience matching, frequency capping, schedule-window checks.
- Wiring into `Purchases` or any consumer.
- The public `checkpoint()` API (#7345) and `RulesEngine` integration.
- Checkpoint sighting/analytics reporting.

## Omitted Context

- Raw transcript, unrelated exploration, sensitive details, repetitive attempts, and chain-of-thought-style content were omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal networking-only ingestion with no Purchases wiring or public API changes; failures degrade to nil and skipped rules rather than crashing callers.
> 
> **Overview**
> Adds ingestion of the **`checkpoint_rules`** remote-config topic so checkpoint rule payloads can be read and decoded before any evaluation exists. **`RemoteConfigTopic.checkpointRules`** (`wireName: `checkpoint_rules``) is registered alongside existing topics.
> 
> **`CheckpointRuleSet`** and **`CheckpointRule`** decode blob JSON with **`Decodable`**, preserving served rule order and requiring **`audience_id`** and **`workflow_id`**. Malformed or incomplete rules are skipped (with **`checkpointRuleSkipped`** logging) so one bad entry does not fail the whole checkpoint.
> 
> **`CheckpointsConfigProvider`** mirrors **`WorkflowsConfigProvider`**: **`getCheckpoint(_:)`** loads data via **`RemoteConfigManager.blobData(for: .checkpointRules, itemKey:)`** and returns **`nil`** when the topic is absent, the item is missing, or decoding fails. Unit tests cover decoding edge cases and end-to-end reads through a real **`RemoteConfigManager`** with faked transport/storage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7892f185d16ceae2b9614e806a48d40025e2ab27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->