### PR TITLE
fix(paywalls): dismiss the UIKit exit offer instead of deferring to the host

### DIFF
--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -529,6 +529,19 @@ public class PaywallViewController: UIViewController {
         }
     }
 
+    /// Dismissal handling for the exit-offer controller. The SDK presents that controller itself, so it
+    /// also dismisses it: the host's handler was written for the paywall the host presented, and one that
+    /// dismisses its own captured controller instead of the one it is handed would strand the exit offer
+    /// on screen. The handler is still called afterwards so existing close callbacks keep firing.
+    static func exitOfferDismissRequestedHandler(
+        originalHandler: ((PaywallViewController) -> Void)?
+    ) -> (PaywallViewController) -> Void {
+        return { controller in
+            controller.dismiss(animated: true)
+            originalHandler?(controller)
+        }
+    }
+
     /// Presents the exit offer paywall as a sheet.
     private func presentExitOffer(for offering: Offering) {
         Logger.debug(Strings.presentingExitOffer(offering.identifier))
@@ -574,14 +587,9 @@ public class PaywallViewController: UIViewController {
                 shouldBlockTouchEvents: shouldBlock,
                 performPurchase: performPurchase,
                 performRestore: performRestore,
-                dismissRequestedHandler: { controller in
-                    // When exit offer is dismissed, call the original handler
-                    if let handler = originalDismissHandler {
-                        handler(controller)
-                    } else {
-                        controller.dismiss(animated: true)
-                    }
-                },
+                dismissRequestedHandler: Self.exitOfferDismissRequestedHandler(
+                    originalHandler: originalDismissHandler
+                ),
                 promoOfferCache: self.promoOfferCache
             )
 

--- a/Tests/RevenueCatUITests/UIKit/PaywallViewControllerExitOfferTests.swift
+++ b/Tests/RevenueCatUITests/UIKit/PaywallViewControllerExitOfferTests.swift
@@ -99,6 +99,71 @@ final class PaywallViewControllerExitOfferTests: TestCase {
         )
     }
 
+    // MARK: - Exit offer dismissal
+
+    // The exit-offer controller is created and presented by the SDK, so the SDK has to dismiss it.
+    // Forwarding to the host's handler alone strands the exit offer whenever that handler dismisses
+    // its own captured controller instead of the one it is handed — a common shape, since the host
+    // wrote it for the paywall it presented itself.
+    func testExitOfferIsDismissedEvenWhenHostHandlerIgnoresTheGivenController() {
+        var hostHandlerCallCount = 0
+        let handler = PaywallViewController.exitOfferDismissRequestedHandler(
+            originalHandler: { _ in
+                // Host dismisses whatever it captured for the first paywall; the argument is ignored.
+                hostHandlerCallCount += 1
+            }
+        )
+
+        let exitOffer = DismissRecordingPaywallViewController(offering: Self.makeOffering(identifier: "exit"))
+        handler(exitOffer)
+
+        expect(exitOffer.dismissCallCount).to(
+            equal(1),
+            description: "the SDK must dismiss the exit offer controller it presented"
+        )
+        expect(hostHandlerCallCount).to(
+            equal(1),
+            description: "the host handler must still be called, so existing close callbacks keep firing"
+        )
+    }
+
+    func testExitOfferIsDismissedWhenHostHasNoHandler() {
+        let handler = PaywallViewController.exitOfferDismissRequestedHandler(originalHandler: nil)
+
+        let exitOffer = DismissRecordingPaywallViewController(offering: Self.makeOffering(identifier: "exit"))
+        handler(exitOffer)
+
+        expect(exitOffer.dismissCallCount).to(equal(1))
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+private final class DismissRecordingPaywallViewController: PaywallViewController {
+
+    private(set) var dismissCallCount = 0
+
+    init(offering: Offering) {
+        super.init(
+            content: .offering(offering),
+            fonts: DefaultPaywallFontProvider(),
+            displayCloseButton: false,
+            shouldBlockTouchEvents: false,
+            performPurchase: nil,
+            performRestore: nil,
+            dismissRequestedHandler: nil
+        )
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func dismiss(animated flag: Bool, completion: (() -> Void)?) {
+        self.dismissCallCount += 1
+        completion?()
+    }
+
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)


### PR DESCRIPTION
### Motivation

A customer reported that the exit offer paywall would not close. It reproduces on the UIKit path whenever the host passes a `dismissRequestedHandler`.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: (this PR)
- Branch: `facu/fix-uikit-exit-offer-dismissal`
- Author / human owner: facumenzella
- Agent(s): Claude Code (Opus 5, 1M context)
- Session source: current conversation
- Generated: 2026-08-05
- Context document version: 1

## Goal

Determine whether a customer report ("the exit offer paywall does not close, regardless of the button's action") was real, and fix it if so.

## Initial Prompt

Investigate a customer report against paywall `wf63738396ee374036` (project 2403eb57): when using the exit offer feature, the second paywall (the exit offer) does not close when tapping the close button, whether the action is "navigate back" or "close paywall". The human flagged up front that it might be a false positive.

## Important Follow-up Prompts

- "it might be a false positive eh, but just to make sure" — framed the task as verification, not fixing.
- "maybe they are using a custom close for the first paywall, and maybe that breaks the second one?" — theory tested and ruled out.
- "maybe the header works, but its broken without header?" — theory tested and ruled out.
- "why are you looking for it in offerings? it should try to resolve it as a workflow" — corrected an inaccurate claim the agent had made about exit-offer resolution.
- "looks like they are testing with <customer paywall URL>, let's test it out ourselves" — moved testing onto the customer's real config (project 7069a935).
- "to be fair, in the video they sent it looks as if the button is tappable (it animates)" — the decisive clue; moved the search past hit testing.
- "i think we should call it, we shouldn't introduce a breaking change" — decided the fix shape.

## Agent Contribution

- Pulled the dashboard config for both the reconstruction and the customer's real workflow via `mafdet` (`workflow summary`, `workflow steps`, `workflow screen`, `workflow content`).
- Drove PaywallsTester with Maestro across sheet, `.fullScreen`, `presentPaywallIfNeeded`, and UIKit presentation, on iOS 26 (iPhone 17 Pro) and iOS 17.4 (iPhone SE), all initially passing.
- Frame-by-frame analysis of the customer's screen recording with `ffmpeg`: cropped the close-button region per frame and tiled it, showing the button dim and recover 4+ times.
- Located the root cause in `PaywallViewController.presentExitOffer(for:)` and reproduced it by supplying a host `dismissRequestedHandler` in the naive shape.
- Extracted the dismissal seam, wrote the failing test, applied the fix, confirmed RED then GREEN at both unit and end-to-end level.

## Human Decisions

- Decision: call the host handler after dismissing rather than dropping it, to avoid a breaking change.
- Decision: scope this PR to the fix plus unit test; Maestro UIKit flow as a follow-up; PaywallsTester host-handler change not taken for now.
- Correction: pushed back on the agent's claim that exit offers are resolved via offerings rather than as a workflow, which led to a corrected explanation (identifier -> Offering -> workflow).

## Key Implementation Decisions

- Decision: the SDK dismisses the exit-offer controller itself, then calls the host handler.
  - Rationale: the SDK presents that controller (`presenter.present(exitOfferVC, animated: true)`), so it should own dismissing it. Keeping the host call preserves existing close callbacks.
  - Rejected: never forwarding to the host handler (would silently stop analytics/state callbacks, a behaviour change). Also rejected: documentation only, which would leave every host to get it right.
- Decision: extract `exitOfferDismissRequestedHandler(originalHandler:)` as a static factory.
  - Rationale: the handler was built inline inside `presentExitOffer`, with no way to assert on it. The factory makes the behaviour unit-testable without presenting view controllers.

## Files / Symbols Touched

- `RevenueCatUI/UIKit/PaywallViewController.swift`
  - Why: the defect and the fix.
  - Symbols: `exitOfferDismissRequestedHandler(originalHandler:)` (new), `presentExitOffer(for:)`
  - Review relevance: ordering (dismiss before notifying) and that the host handler still receives the exit-offer controller.
- `Tests/RevenueCatUITests/UIKit/PaywallViewControllerExitOfferTests.swift`
  - Why: regression coverage.
  - Symbols: `testExitOfferIsDismissedEvenWhenHostHandlerIgnoresTheGivenController`, `testExitOfferIsDismissedWhenHostHasNoHandler`, `DismissRecordingPaywallViewController`
  - Review relevance: the spy overrides `dismiss(animated:completion:)`; the assertion is that the exit-offer controller is dismissed even when the host handler ignores its argument.

## Dependencies / Config / Migrations

- None. No public API change: `exitOfferDismissRequestedHandler` is internal.

## Validation

- Commands run:
  - `xcodebuild test -workspace RevenueCat-Tuist.xcworkspace -scheme "RevenueCatUITests (RevenueCatTests project)" -only-testing:RevenueCatUITests/PaywallViewControllerExitOfferTests`: RED before the fix (1 failure of 7, on the new test), GREEN after (7/7 passing).
  - `swiftlint lint RevenueCatUI/UIKit/PaywallViewController.swift Tests/RevenueCatUITests/UIKit/PaywallViewControllerExitOfferTests.swift`: no violations.
- Manual verification:
  - PaywallsTester against the customer project (7069a935, workflow `wf5fbe599a5fb64a0f`, exit offer `wf311010e024db496e`), UIKit presentation with a host `dismissRequestedHandler` that dismisses its own captured controller. Before the fix the exit offer survived 5 close taps; after the fix a single tap dismisses it and returns to the offering list. Confirmed against a binary verified to contain the change (`strings` on the installed `PaywallsTester.debug.dylib`).
- CI:
  - Not captured at time of writing.

## Validation Gaps

- No automated end-to-end coverage of this path yet; rc-maestro has no UIKit host. Follow-up flow planned.
- The double-dismiss interaction (SDK dismisses, then a correctly written host handler also calls `controller.dismiss`) was reasoned about (UIKit no-ops once `presentingViewController` is nil) but not separately unit tested.
- Only exercised on iOS 26 for the UIKit path; the earlier iOS 17.4 runs predate the fix.

## Review Focus

- Should the host handler be called before or after dismissal? Current order dismisses first so the exit offer always goes away regardless of what the host does.
- Is calling the host handler with a controller the host did not create still the right contract, or should this move to `PaywallViewControllerDelegate`?
- Hosts that previously relied on their handler being the *only* dismissal path for the exit offer will now see the SDK dismiss it too; is a no-op second dismiss acceptable in every embedding (pushed in a nav stack, for example)?

## Risks / Reviewer Notes

- Risk: a host handler that dismisses the passed controller now runs after the SDK already dismissed it.
  - Evidence: `UIViewController.dismiss(animated:)` is a no-op once the controller is no longer presented; observed no double-dismiss artifact in the end-to-end run.
  - Mitigation: covered indirectly by `testExitOfferIsDismissedWhenHostHasNoHandler` plus the manual run; a dedicated test is listed under Validation Gaps.
- Risk: the exit offer is only reachable through a specific host shape, so regressions are easy to miss.
  - Evidence: this bug survived five different presentation configurations in this session before the host shape was varied.
  - Mitigation: the follow-up Maestro flow pins the host shape.

## Non-goals / Out of Scope

- The SwiftUI presentation paths, which were verified unaffected.
- Two adjacent findings surfaced during investigation and deliberately left alone: `ExitOfferHelper.validExitOffer` returns nil with no log when the target offering is absent from the offerings payload, and the dashboard emits an `on_close_workflow_press` step trigger type the SDK does not implement (decoded as `.unknown`).

## Omitted Context

- Raw transcript, unrelated exploration, sensitive details, repetitive attempts, and chain-of-thought-style content were omitted. A stale-simulator-build detour (a `tuist generate` reset the PaywallsTester bundle id, so one verification run drove an old app) is omitted except for its effect: the end-to-end result was re-verified against a binary confirmed to contain the fix.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UIKit dismissal behavior for SDK-presented exit offers; no public API change and host handlers are still invoked after dismiss.
> 
> **Overview**
> Fixes a bug where the **UIKit exit-offer paywall stayed on screen** when the host supplied a `dismissRequestedHandler` for the main paywall. Closing the exit offer reused that handler; hosts often dismiss the controller they presented and ignore the argument, so the SDK-presented exit offer never went away (close button could still animate on tap).
> 
> The SDK now **dismisses the exit-offer `PaywallViewController` itself**, then still invokes the host’s original handler so existing close callbacks keep firing. Wiring is centralized in **`exitOfferDismissRequestedHandler(originalHandler:)`**, used when building the exit-offer controller in `presentExitOffer(for:)`.
> 
> Unit tests cover dismissal when the host handler ignores the passed controller and when there is no host handler (`DismissRecordingPaywallViewController` spy).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a57b86d0723fd5bdef82c83abf1fb15aa85b443. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->