### PR TITLE
fix(paywalls-v2): select each tab's own default package on workflows

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -2938,6 +2938,7 @@
 		B3F8418E26F3A93400E560FB /* ErrorCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorCodeTests.swift; sourceTree = "<group>"; };
 		B413E59F2F97B3B900B5F0CA /* CarouselTabSwitchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselTabSwitchTests.swift; sourceTree = "<group>"; };
 		B413E5A02F97B3B900B5F0CA /* PaywallsV2ViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallsV2ViewTests.swift; sourceTree = "<group>"; };
+		B413E5A12F97B3B900B5F0CA /* TabsWorkflowDefaultPackageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsWorkflowDefaultPackageTests.swift; sourceTree = "<group>"; };
 		BDE6FC116D66BBEFEE662547 /* Value.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Value.swift; sourceTree = "<group>"; };
 		C07759C930F712D2D53B9333 /* WorkflowStepEventTrackerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowStepEventTrackerTests.swift; sourceTree = "<group>"; };
 		C1B939C7DAAFEA1DE2DE2674 /* WebViewEnvelopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewEnvelopeTests.swift; sourceTree = "<group>"; };
@@ -3245,6 +3246,7 @@
 				E78770053AB84EF380CC0C1D /* TextComponentViewLoadingTests.swift */,
 				B413E59F2F97B3B900B5F0CA /* CarouselTabSwitchTests.swift */,
 				B413E5A02F97B3B900B5F0CA /* PaywallsV2ViewTests.swift */,
+				B413E5A12F97B3B900B5F0CA /* TabsWorkflowDefaultPackageTests.swift */,
 				DBB32F183007CACD00A86DC7 /* BottomSheetSwitchTests.swift */,
 				DB1FC9592F9A1B74009A95EA /* WorkflowScreenMapperTests.swift */,
 				F468C7BCEB786BEC80277ECA /* WorkflowNavigatorTests.swift */,

--- a/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentView.swift
@@ -244,7 +244,29 @@ struct LoadedTabsComponentView: View {
            tabPackages.contains(where: { $0.identifier == cached.identifier }) {
             return cached
         }
-        return workflowDefaultPackage ?? tabDefaultPackage
+        return Self.effectiveTabDefaultPackage(
+            workflowDefaultPackage: workflowDefaultPackage,
+            tabPackages: tabPackages,
+            tabDefaultPackage: tabDefaultPackage
+        )
+    }
+
+    /// Picks the default selection for a tab, preferring the workflow-global default only when this
+    /// tab actually offers it.
+    ///
+    /// `WorkflowContext` derives its default by flattening every tab, so on a paywall whose tabs hold
+    /// disjoint packages that default belongs to whichever tab declares one first. Letting it win
+    /// everywhere leaves the other tabs with a package they don't list, so nothing renders as selected.
+    static func effectiveTabDefaultPackage(
+        workflowDefaultPackage: Package?,
+        tabPackages: [Package],
+        tabDefaultPackage: Package?
+    ) -> Package? {
+        if let workflowDefaultPackage,
+           tabPackages.contains(where: { $0.identifier == workflowDefaultPackage.identifier }) {
+            return workflowDefaultPackage
+        }
+        return tabDefaultPackage
     }
 
     var body: some View {
@@ -281,7 +303,11 @@ struct LoadedTabsComponentView: View {
             .environmentObject(tierPackageContext)
             .environment(
                 \.planSelectionDefaultPackage,
-                self.workflowDefaultPackage ?? activeTabViewModel.defaultSelectedPackage
+                Self.effectiveTabDefaultPackage(
+                    workflowDefaultPackage: self.workflowDefaultPackage,
+                    tabPackages: activeTabViewModel.packages,
+                    tabDefaultPackage: activeTabViewModel.defaultSelectedPackage
+                )
             )
             .onAppear {
                 if !self.viewModel.didSeedInitialState {
@@ -326,7 +352,11 @@ struct LoadedTabsComponentView: View {
                     parentOwnedVariableContext: self.parentOwnedVariableContext,
                     parentCurrentVariableContext: self.packageContext.variableContext,
                     tabPackages: newTabViewModel.packages,
-                    tabDefaultPackage: self.workflowDefaultPackage ?? newTabViewModel.defaultSelectedPackage
+                    tabDefaultPackage: Self.effectiveTabDefaultPackage(
+                        workflowDefaultPackage: self.workflowDefaultPackage,
+                        tabPackages: newTabViewModel.packages,
+                        tabDefaultPackage: newTabViewModel.defaultSelectedPackage
+                    )
                 )
                 if let tabUpdate = updatePlan.tabUpdate {
                     newTierPackageContext.update(

--- a/RevenueCatUI/Templates/V2/Components/Tabs/TabsPackageSelectionResolver.swift
+++ b/RevenueCatUI/Templates/V2/Components/Tabs/TabsPackageSelectionResolver.swift
@@ -61,7 +61,9 @@ enum TabsPackageSelectionResolver {
             return .init(parentUpdate: update, tabUpdate: update)
         }
 
-        guard let defaultPackage = tabDefaultPackage else {
+        // Never select a package the tab doesn't offer: it would leave every row unselected.
+        guard let defaultPackage = tabDefaultPackage,
+              tabPackageIdentifiers.contains(defaultPackage.identifier) else {
             return .init(parentUpdate: nil, tabUpdate: nil)
         }
 

--- a/Tests/RevenueCatUITests/PaywallsV2/TabsPackageInheritanceTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/TabsPackageInheritanceTests.swift
@@ -1167,6 +1167,110 @@ extension TabsPackageInheritanceTests {
 
 }
 
+// MARK: - Cross-Tab Workflow Default Tests
+//
+// Regression seen in 5.83.0 (remote config + workflows enabled by default, #7327): a tabs paywall
+// served as a single-step workflow stopped selecting the second tab's own default package.
+//
+// `WorkflowContext.collectPackages` flattens every tab into one list, so the workflow-global
+// default is whichever package is marked `isSelectedByDefault` first across all tabs (tab 1's).
+// `LoadedTabsComponentView` then preferred that workflow default over each tab's own default,
+// so tab 2 received a package that isn't even in its list and nothing rendered as selected.
+// Before 5.83.0 `workflowPackageContext` was nil for these paywalls, so the tab defaults were used.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension TabsPackageInheritanceTests {
+
+    /// Tab 2's packages, disjoint from tab 1's (mirrors the customer paywall: subscriptions in
+    /// tab 1, one-time purchases in tab 2).
+    private var tab2PackageOne: Package {
+        Package(
+            identifier: "onetime1",
+            packageType: .custom,
+            storeProduct: TestData.lifetimeProduct.toStoreProduct(),
+            offeringIdentifier: "test_offering",
+            webCheckoutUrl: nil
+        )
+    }
+
+    private var tab2PackageTwo: Package {
+        Package(
+            identifier: "onetime2",
+            packageType: .custom,
+            storeProduct: TestData.consumableProduct.toStoreProduct(),
+            offeringIdentifier: "test_offering",
+            webCheckoutUrl: nil
+        )
+    }
+
+    func testInitialPackageUsesTabDefaultWhenWorkflowDefaultBelongsToAnotherTab() {
+        // Scenario: tab 1 declares annual (parentPackageB) as its default, so the flattened
+        // workflow default is annual. Tab 2 only has one-time packages and declares its own
+        // default. Tab 2 must show its own default, not the other tab's package.
+        let result = LoadedTabsComponentView.initialPackage(
+            parentPackage: nil,
+            tabPackages: [self.tab2PackageOne, self.tab2PackageTwo],
+            workflowDefaultPackage: self.parentPackageB,
+            tabDefaultPackage: self.tab2PackageOne
+        )
+
+        expect(result?.identifier) == self.tab2PackageOne.identifier
+    }
+
+    func testTabSwitchSelectsTabDefaultWhenWorkflowDefaultBelongsToAnotherTab() {
+        // Scenario: user switches to tab 2 without having picked a package. Tab 2's own default
+        // must be selected in both the tab and the parent (purchase button) context.
+        let tab2Packages = [self.tab2PackageOne, self.tab2PackageTwo]
+        let variableContext = PackageContext.VariableContext(packages: tab2Packages)
+
+        let updatePlan = TabsPackageSelectionResolver.resolveTabSwitch(
+            // No explicit user selection yet, so the tabs view passes nil here.
+            parentOwnedPackage: nil,
+            parentOwnedVariableContext: variableContext,
+            parentCurrentVariableContext: variableContext,
+            tabPackages: tab2Packages,
+            tabDefaultPackage: LoadedTabsComponentView.effectiveTabDefaultPackage(
+                workflowDefaultPackage: self.parentPackageB,
+                tabPackages: tab2Packages,
+                tabDefaultPackage: self.tab2PackageOne
+            )
+        )
+
+        expect(updatePlan.tabUpdate?.package?.identifier) == self.tab2PackageOne.identifier
+        expect(updatePlan.parentUpdate?.package?.identifier) == self.tab2PackageOne.identifier
+    }
+
+    func testEffectiveTabDefaultKeepsWorkflowDefaultWhenTabOffersIt() {
+        // The workflow default still wins when the tab actually offers it, so a selection carried
+        // across workflow steps sharing a package set is preserved.
+        let result = LoadedTabsComponentView.effectiveTabDefaultPackage(
+            workflowDefaultPackage: self.parentPackageB,
+            tabPackages: [self.parentPackageA, self.parentPackageB],
+            tabDefaultPackage: self.parentPackageA
+        )
+
+        expect(result?.identifier) == self.parentPackageB.identifier
+    }
+
+    func testResolverIgnoresTabDefaultOutsideTabPackages() {
+        // Defense in depth: whatever the call site passes, the resolver must never hand a tab a
+        // package it doesn't list, because no row would render as selected.
+        let tab2Packages = [self.tab2PackageOne, self.tab2PackageTwo]
+        let variableContext = PackageContext.VariableContext(packages: tab2Packages)
+
+        let updatePlan = TabsPackageSelectionResolver.resolveTabSwitch(
+            parentOwnedPackage: nil,
+            parentOwnedVariableContext: variableContext,
+            parentCurrentVariableContext: variableContext,
+            tabPackages: tab2Packages,
+            tabDefaultPackage: self.parentPackageB
+        )
+
+        expect(updatePlan.tabUpdate).to(beNil())
+        expect(updatePlan.parentUpdate).to(beNil())
+    }
+
+}
+
 // MARK: - Test Helpers
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/Tests/RevenueCatUITests/PaywallsV2/TabsWorkflowDefaultPackageTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/TabsWorkflowDefaultPackageTests.swift
@@ -1,0 +1,233 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  TabsWorkflowDefaultPackageTests.swift
+//
+//  Created by RevenueCat on 8/5/26.
+
+@_spi(Internal) import RevenueCat
+@testable import RevenueCatUI
+import SwiftUI
+import XCTest
+
+#if os(iOS)
+
+/// Drives a real tab switch through `LoadedTabsComponentView` (hosted in a window) to cover the
+/// wiring, not just the helper: a workflow-backed tabs paywall whose tabs hold disjoint packages
+/// must select each tab's own default.
+///
+/// `WorkflowContext` derives its default by flattening every tab, so `workflowDefaultPackage` here
+/// is tab 1's annual package, exactly what the SDK computes for this paywall shape. Before the fix
+/// that package won everywhere, so tab 2 was handed a package it doesn't offer and nothing rendered
+/// as selected.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@MainActor
+final class TabsWorkflowDefaultPackageTests: TestCase {
+
+    private static let tab1Id = "subscriptions"
+    private static let tab2Id = "onetime"
+
+    func testSwitchingToSecondTabSelectsItsOwnDefaultPackage() throws {
+        let (viewModel, tabControlContext, offering) = try Self.makeTabsViewModel()
+        let annual = try XCTUnwrap(offering.package(identifier: "annual"))
+        let onetimeFirst = try XCTUnwrap(offering.package(identifier: "onetime1"))
+
+        let packageContext = PackageContext(package: nil, variableContext: .init(packages: []))
+        let (window, _) = Self.host(
+            Self.tabsView(
+                viewModel: viewModel,
+                packageContext: packageContext,
+                // What WorkflowContext computes: the first default across all flattened tabs.
+                workflowDefaultPackage: annual,
+                tabControlContext: tabControlContext
+            )
+        )
+        defer {
+            window.isHidden = true
+            window.rootViewController = nil
+        }
+
+        // Tab 1 seeds its own default, which happens to match the workflow default.
+        XCTAssertEqual(packageContext.package?.identifier, annual.identifier)
+
+        tabControlContext.selectedTabId = Self.tab2Id
+        Self.settle(window)
+
+        // Tab 2 offers neither monthly nor annual, so it must fall back to its own default.
+        // Before the fix this stayed on `annual`, leaving every row in tab 2 unselected.
+        XCTAssertEqual(
+            packageContext.package?.identifier,
+            onetimeFirst.identifier,
+            "Second tab must select its own default package, not the flattened workflow default"
+        )
+    }
+
+    func testReturningToFirstTabKeepsItsOwnDefaultPackage() throws {
+        let (viewModel, tabControlContext, offering) = try Self.makeTabsViewModel()
+        let annual = try XCTUnwrap(offering.package(identifier: "annual"))
+
+        let packageContext = PackageContext(package: nil, variableContext: .init(packages: []))
+        let (window, _) = Self.host(
+            Self.tabsView(
+                viewModel: viewModel,
+                packageContext: packageContext,
+                workflowDefaultPackage: annual,
+                tabControlContext: tabControlContext
+            )
+        )
+        defer {
+            window.isHidden = true
+            window.rootViewController = nil
+        }
+
+        tabControlContext.selectedTabId = Self.tab2Id
+        Self.settle(window)
+        tabControlContext.selectedTabId = Self.tab1Id
+        Self.settle(window)
+
+        // The round trip must not leave tab 1 holding tab 2's package.
+        XCTAssertEqual(packageContext.package?.identifier, annual.identifier)
+    }
+
+}
+
+// MARK: - Helpers
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension TabsWorkflowDefaultPackageTests {
+
+    /// Tab 1: monthly + annual (annual is the default). Tab 2: onetime1 (default) + onetime2.
+    static func makeTabsViewModel() throws -> (TabsComponentViewModel, TabControlContext, Offering) {
+        let offering = Offering(
+            identifier: "test_offering",
+            serverDescription: "",
+            availablePackages: [
+                Self.package(identifier: "monthly", product: TestData.monthlyProduct),
+                Self.package(identifier: "annual", product: TestData.annualProduct),
+                Self.package(identifier: "onetime1", product: TestData.lifetimeProduct),
+                Self.package(identifier: "onetime2", product: TestData.consumableProduct)
+            ],
+            webCheckoutUrl: nil
+        )
+
+        let tabsComponent = PaywallComponent.TabsComponent(
+            control: .init(
+                type: .buttons,
+                stack: PaywallComponent.StackComponent(components: [
+                    .tabControlButton(.init(tabId: Self.tab1Id, stack: Self.textStack("Subscribe"))),
+                    .tabControlButton(.init(tabId: Self.tab2Id, stack: Self.textStack("One-off")))
+                ])
+            ),
+            tabs: [
+                .init(id: Self.tab1Id, stack: PaywallComponent.StackComponent(components: [
+                    Self.packageComponent(packageID: "monthly", isSelectedByDefault: false),
+                    Self.packageComponent(packageID: "annual", isSelectedByDefault: true)
+                ])),
+                .init(id: Self.tab2Id, stack: PaywallComponent.StackComponent(components: [
+                    Self.packageComponent(packageID: "onetime1", isSelectedByDefault: true),
+                    Self.packageComponent(packageID: "onetime2", isSelectedByDefault: false)
+                ]))
+            ],
+            defaultTabId: Self.tab1Id
+        )
+
+        let factory = ViewModelFactory()
+        guard case .tabs(let tabsViewModel) = try factory.toViewModel(
+            component: .tabs(tabsComponent),
+            packageValidator: factory.packageValidator,
+            offering: offering,
+            localizationProvider: .init(locale: Locale(identifier: "en_US"), localizedStrings: [:]),
+            uiConfigProvider: UIConfigProvider(uiConfig: PreviewUIConfig.make()),
+            colorScheme: .light
+        ) else {
+            throw XCTSkip("Expected a .tabs PaywallComponentViewModel")
+        }
+
+        let tabControlContext = TabControlContext(
+            controlStackViewModel: tabsViewModel.controlStackViewModel,
+            tabIds: tabsViewModel.tabIds,
+            defaultTabId: tabsViewModel.defaultTabId,
+            name: nil
+        )
+
+        return (tabsViewModel, tabControlContext, offering)
+    }
+
+    static func tabsView(
+        viewModel: TabsComponentViewModel,
+        packageContext: PackageContext,
+        workflowDefaultPackage: Package,
+        tabControlContext: TabControlContext
+    ) -> some View {
+        LoadedTabsComponentView(
+            viewModel: viewModel,
+            parentPackageContext: packageContext,
+            workflowDefaultPackage: workflowDefaultPackage,
+            onDismiss: {},
+            tabControlContext: tabControlContext
+        )
+        .environmentObject(packageContext)
+        .environmentObject(IntroOfferEligibilityContext(
+            introEligibilityChecker: BaseSnapshotTest.eligibleChecker
+        ))
+        .environmentObject(PaywallPromoOfferCache(
+            subscriptionHistoryTracker: SubscriptionHistoryTracker()
+        ))
+        .environment(\.screenCondition, .compact)
+        .environment(\.componentViewState, .default)
+        .environment(\.safeAreaInsets, EdgeInsets())
+        .environment(\.selectedPackageId, nil)
+        .frame(width: 400, height: 600)
+    }
+
+    static func package(identifier: String, product: TestStoreProduct) -> Package {
+        Package(
+            identifier: identifier,
+            packageType: .custom,
+            storeProduct: product.toStoreProduct(),
+            offeringIdentifier: "test_offering",
+            webCheckoutUrl: nil
+        )
+    }
+
+    static func packageComponent(packageID: String, isSelectedByDefault: Bool) -> PaywallComponent {
+        .package(.init(
+            packageID: packageID,
+            isSelectedByDefault: isSelectedByDefault,
+            applePromoOfferProductCode: nil,
+            stack: Self.textStack(packageID)
+        ))
+    }
+
+    static func textStack(_ text: String) -> PaywallComponent.StackComponent {
+        PaywallComponent.StackComponent(components: [
+            .text(.init(text: text, color: .init(light: .hex("#000000"))))
+        ])
+    }
+
+    static func host<Content: View>(_ view: Content) -> (UIWindow, UIView) {
+        let controller = UIHostingController(rootView: view)
+        let window = UIWindow(frame: CGRect(origin: .zero, size: CGSize(width: 400, height: 600)))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        controller.view.layoutIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.2))
+        return (window, controller.view)
+    }
+
+    static func settle(_ window: UIWindow) {
+        RunLoop.main.run(until: Date().addingTimeInterval(0.3))
+        window.rootViewController?.view.setNeedsLayout()
+        window.rootViewController?.view.layoutIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+    }
+
+}
+
+#endif

--- a/Tests/RevenueCatUITests/PaywallsV2/TabsWorkflowDefaultPackageTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/TabsWorkflowDefaultPackageTests.swift
@@ -95,6 +95,39 @@ final class TabsWorkflowDefaultPackageTests: TestCase {
         XCTAssertEqual(packageContext.package?.identifier, annual.identifier)
     }
 
+    /// A switch is a tabs component with a `.toggle` control, so it runs through the same view and
+    /// is affected by the same bug and the same fix.
+    func testTogglingASwitchSelectsTheOtherSideOwnDefaultPackage() throws {
+        let (viewModel, tabControlContext, offering) = try Self.makeTabsViewModel(controlType: .toggle)
+        let annual = try XCTUnwrap(offering.package(identifier: "annual"))
+        let onetimeFirst = try XCTUnwrap(offering.package(identifier: "onetime1"))
+
+        let packageContext = PackageContext(package: nil, variableContext: .init(packages: []))
+        let (window, _) = Self.host(
+            Self.tabsView(
+                viewModel: viewModel,
+                packageContext: packageContext,
+                workflowDefaultPackage: annual,
+                tabControlContext: tabControlContext
+            )
+        )
+        defer {
+            window.isHidden = true
+            window.rootViewController = nil
+        }
+
+        XCTAssertEqual(packageContext.package?.identifier, annual.identifier)
+
+        tabControlContext.selectedTabId = Self.tab2Id
+        Self.settle(window)
+
+        XCTAssertEqual(
+            packageContext.package?.identifier,
+            onetimeFirst.identifier,
+            "Flipping the switch must select the other side's own default package"
+        )
+    }
+
 }
 
 // MARK: - Helpers
@@ -103,7 +136,9 @@ final class TabsWorkflowDefaultPackageTests: TestCase {
 private extension TabsWorkflowDefaultPackageTests {
 
     /// Tab 1: monthly + annual (annual is the default). Tab 2: onetime1 (default) + onetime2.
-    static func makeTabsViewModel() throws -> (TabsComponentViewModel, TabControlContext, Offering) {
+    static func makeTabsViewModel(
+        controlType: PaywallComponent.TabsComponent.TabControl.TabControlType = .buttons
+    ) throws -> (TabsComponentViewModel, TabControlContext, Offering) {
         let offering = Offering(
             identifier: "test_offering",
             serverDescription: "",
@@ -116,13 +151,31 @@ private extension TabsWorkflowDefaultPackageTests {
             webCheckoutUrl: nil
         )
 
-        let tabsComponent = PaywallComponent.TabsComponent(
-            control: .init(
-                type: .buttons,
-                stack: PaywallComponent.StackComponent(components: [
+        let controlStack: PaywallComponent.StackComponent = {
+            switch controlType {
+            case .toggle:
+                // A switch flips between the first two tabs.
+                return PaywallComponent.StackComponent(components: [
+                    .tabControlToggle(.init(
+                        defaultValue: false,
+                        thumbColorOn: .init(light: .hex("#000000")),
+                        thumbColorOff: .init(light: .hex("#ffffff")),
+                        trackColorOn: .init(light: .hex("#000000")),
+                        trackColorOff: .init(light: .hex("#ffffff"))
+                    ))
+                ])
+            case .buttons:
+                return PaywallComponent.StackComponent(components: [
                     .tabControlButton(.init(tabId: Self.tab1Id, stack: Self.textStack("Subscribe"))),
                     .tabControlButton(.init(tabId: Self.tab2Id, stack: Self.textStack("One-off")))
                 ])
+            }
+        }()
+
+        let tabsComponent = PaywallComponent.TabsComponent(
+            control: .init(
+                type: controlType,
+                stack: controlStack
             ),
             tabs: [
                 .init(id: Self.tab1Id, stack: PaywallComponent.StackComponent(components: [


### PR DESCRIPTION
### Motivation

Customer report: on a tabs paywall where each tab has its own "Selected by Default" package, switching to the second tab leaves nothing selected. 
Worked on 5.82.0, broken from 5.83.0

> Havent'checked android yet

Before vs after
https://github.com/user-attachments/assets/9b866ab0-fb0f-4001-8c27-f8cdeb97b0bc



<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: this PR
- Branch: `facu/fix-tabs-workflow-default-per-tab`
- Author / human owner: facumenzella
- Agent(s): Claude Code (Claude Opus 5, 1M context)
- Session source: current conversation
- Generated: 2026-08-05
- Context document version: 1

## Goal

Find and fix the root cause of the "Selected by Default" regression introduced in iOS 5.83.0: on a Paywalls V2 tabs paywall where each tab declares its own default package, the second tab's default is no longer selected. Correct on 5.82.0 and earlier.

## Initial Prompt

Investigate a customer report ("check the Selected by Default bug introduced in iOS v5.83.0, causing the default selected tab to no longer be selected in the second tab"), with the affected project (`74dafd93`), offering (`ofrngfd3dd1e17f`) and paywall (`wf5ec4930912124a92`) linked, plus repro steps: launch the paywall on 5.83.0+, switch to the second tab, observe the tab's default package is not selected.

## Important Follow-up Prompts

- Chose the wider fix scope when asked: membership guard at the call sites **plus** the resolver guard (defense in depth). Android scoped out.
- "to make sure you've fixed it, please test it out with and without the changes and record a video of the fix" — drove the before/after PaywallsTester runs and the recorded comparison.

## Agent Contribution

- Bisected the release window: `git log 5.82.0..5.83.0` showed no tab-related changes in `RevenueCatUI`, pointing at `6e80ef5ba` (#7327) enabling remote config/workflows by default as the activating change.
- Traced the chain: `WorkflowContext.collectPackages` flattens `.tabs` → workflow-global default is tab 1's `$rc_annual` → `TabsComponentView` prefers it over each tab's own default → `TabsPackageSelectionResolver` assigns a package the tab doesn't list → nothing renders as selected.
- Confirmed the payload with `mafdet workflow content`: single-step workflow (`single_step_fallback_id: LtJpNg9`), tab 1 = `$rc_monthly` / `$rc_annual` (default), tab 2 = `onetime3` (default) / `onetime2` / `onetime1`. `is_selected_by_default` is present on both tabs, which ruled out the competing theory that remote-config-served components drop the flag.
- Wrote the failing tests, implemented the guard, ran the tab suites and the full `RevenueCatUITests` target, ran SwiftLint.
- Reproduced before/after in PaywallsTester on a simulator (StoreKit config placed into the simulator's `group.com.apple.storekit` container so products resolve outside Xcode), drove the flow with Maestro, recorded both runs and built a side-by-side comparison.

## Human Decisions

- Approved the fix scope (call sites + resolver guard) and kept the work iOS-only for now.
- Required before/after video proof rather than accepting unit tests alone.

## Key Implementation Decisions

- Decision: gate the workflow-global default on tab membership, in one helper (`effectiveTabDefaultPackage`) used at all three `TabsComponentView` sites.
  - Rationale: mirrors `WorkflowContext.effectivePackageContext(for:preferring:)`; fixing only the tab-switch site would leave first render and selected-state styling wrong.
  - Rejected: dropping `.tabs` from `WorkflowContext.collectPackages` — that package set also feeds packageless-step inheritance and `promoOfferCodesByPackageId`.
- Decision: also guard `TabsPackageSelectionResolver.resolveTabSwitch` so it never selects a package outside `tabPackages`.
  - Rationale: whatever a call site passes, handing a tab a foreign package always renders as "nothing selected".

## Files / Symbols Touched

- `RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentView.swift`
  - Why: the three places that preferred the workflow default over the tab's own default.
  - Symbols: `LoadedTabsComponentView.effectiveTabDefaultPackage` (new), `LoadedTabsComponentView.initialPackage`, `planSelectionDefaultPackage` environment value, the `selectedTabId` `onChangeOf` handler.
  - Review relevance: confirm all three sites go through the helper, and that carry-forward of a user selection across workflow steps is unaffected.
- `RevenueCatUI/Templates/V2/Components/Tabs/TabsPackageSelectionResolver.swift`
  - Why: it accepted a `tabDefaultPackage` outside `tabPackages`.
  - Symbols: `resolveTabSwitch`.
  - Review relevance: the new `tabPackageIdentifiers.contains` guard now returns "no updates" in that case.
- `Tests/RevenueCatUITests/PaywallsV2/TabsPackageInheritanceTests.swift`
  - Why: regression coverage for disjoint per-tab package sets.
  - Symbols: `testInitialPackageUsesTabDefaultWhenWorkflowDefaultBelongsToAnotherTab`, `testTabSwitchSelectsTabDefaultWhenWorkflowDefaultBelongsToAnotherTab`, `testEffectiveTabDefaultKeepsWorkflowDefaultWhenTabOffersIt`, `testResolverIgnoresTabDefaultOutsideTabPackages`.
  - Review relevance: `testInitialPackageFallsBackToWorkflowDefaultWhenParentPackageAbsentFromTab` still passes, which is the signal the guard is not too broad.
- `Tests/RevenueCatUITests/PaywallsV2/TabsWorkflowDefaultPackageTests.swift` (new)
  - Why: the helper/resolver tests pin pure functions, so nothing failed if the guard stopped being called from the view. These host `LoadedTabsComponentView` and flip the tab through `TabControlContext`, covering the `onChangeOf` wiring.
  - Symbols: `testSwitchingToSecondTabSelectsItsOwnDefaultPackage`, `testReturningToFirstTabKeepsItsOwnDefaultPackage`.
  - Review relevance: same shape as the reported paywall (two tabs, disjoint packages, `workflowDefaultPackage` = tab 1's annual). Follows the existing `CarouselTabSwitchTests` hosting pattern.

## Dependencies / Config / Migrations

- None. No public API change, no new flags.

## Validation

- Commands run:
  - `swift test --filter 'TabsPackageInheritanceTests|TabsPackageSelectionResolverTests'`: 41 tests, 0 failures.
  - `swift test --filter 'RevenueCatUITests'`: 1135 tests, 34 failures, all in `PaywallDataValidationTests` / `LocalizedAlertErrorCodeTests` / `TakeScreenshotTests`; the same suites fail identically at base `72bd78ed1`, so they are pre-existing and unrelated.
  - `swiftlint lint --quiet` on the changed files: clean.
  - `xcodebuild -workspace RevenueCat-Tuist.xcworkspace -scheme PaywallsTester ... build` (both with and without the fix): BUILD SUCCEEDED.
  - `xcodebuild test -workspace RevenueCat-Tuist.xcworkspace -scheme RevenueCatUITests -destination 'platform=iOS Simulator,...iOS 18.4' -only-testing:RevenueCatUITests/TabsWorkflowDefaultPackageTests -only-testing:RevenueCatUITests/TabsPackageInheritanceTests -only-testing:RevenueCatUITests/TabsPackageSelectionResolverTests -only-testing:RevenueCatUITests/CarouselTabSwitchTests -only-testing:RevenueCatUITests/TabsComponentDuplicateInstanceTests`: 45 tests, 0 failures.
- RED → GREEN:
  - `testSwitchingToSecondTabSelectsItsOwnDefaultPackage` (view-level, the strongest one): RED on the base sources — `XCTAssertEqual failed: ("Optional("annual")") is not equal to ("Optional("onetime1")")` — green with the fix. This is the wiring, driven through a hosted `LoadedTabsComponentView`.
  - `testInitialPackageUsesTabDefaultWhenWorkflowDefaultBelongsToAnotherTab`: RED before the fix (`expected to equal <onetime1>, got <parent_package_b>`), green after.
  - `testResolverIgnoresTabDefaultOutsideTabPackages`: re-checked against the base resolver, RED (returns an update holding the foreign package), green with the guard.
  - `testTabSwitchSelectsTabDefaultWhenWorkflowDefaultBelongsToAnotherTab` and `testEffectiveTabDefaultKeepsWorkflowDefaultWhenTabOffersIt` were written after the fix (they call the new helper, so they cannot exist pre-fix). `testReturningToFirstTabKeepsItsOwnDefaultPackage` passes on base too — it is a guard-rail, not a regression witness.
- Manual verification:
  - PaywallsTester on iPhone 16 Pro / iOS 18.4, same paywall and same Maestro flow on both builds. Without the fix, the One-off tab shows `$0.99` with an empty circle. With the fix it shows `Only $0.99`, checked and outlined. Frames from the fixed run's Subscribe → One-off → Subscribe round trip show Yearly still checked on the revisit.
- CI:
  - Not captured (draft opened from this session).

## Validation Gaps

- iOS 16 not exercised. This file previously had a pre-iOS 17 `onChange` stale-capture bug (#7168) and the PR CI light suite does not run the iOS 16 UI job. The new code does fresh id lookups (`tabViewModels[newTabId]`, `tierPackageContexts[newTabId]`) and reads an immutable `let`, so it is stale-safe by construction, but this was not run on a 16.4 simulator.
- Only the reported paywall shape was exercised on device (two tabs, disjoint package sets). Overlapping package sets are covered by existing unit tests only.
- No snapshot test added; the selected-state difference is visual and the existing tab snapshots do not cover a workflow-backed tabs paywall.

## Review Focus

- `PaywallsV2View.effectiveDefaultPackage` is still `workflowDefaultPackage ?? pageDefaultPackage`, unguarded, and feeds root-level `planSelectionDefaultPackage` plus `RootView.restoredPackageAfterSheetDismissal`. For the reported paywall it resolves to the correct root default, so it is not part of this symptom — worth deciding whether it deserves the same membership guard.
- Does any real workflow rely on the previous behavior of a workflow-global default overriding a tab's own default even when the tab does not offer that package? The intent here is that it should not.
- The resolver returning "no updates" for a foreign default means the tab keeps whatever it had. Confirm that is the desired outcome versus falling back to the tab's first package.

## Risks / Reviewer Notes

- Risk: breaking package carry-forward across workflow steps that share a package set.
  - Evidence: the guard keeps the workflow default whenever the tab offers it, and `testInitialPackageFallsBackToWorkflowDefaultWhenParentPackageAbsentFromTab` (pre-existing) still passes.
  - Mitigation: `testEffectiveTabDefaultKeepsWorkflowDefaultWhenTabOffersIt` locks that path in.
- Risk: tab 1 losing its default after a round trip through tab 2.
  - Evidence: video frames from the fixed build show Yearly still checked after returning to Subscribe.
  - Mitigation: covered by the existing tab-switch tests plus manual verification.

## Non-goals / Out of Scope

- `purchases-android` (and the hybrids) were not checked for the same cross-tab flattening.
- `WorkflowContext.collectPackages` behavior is unchanged.
- No change to root-level (non-tabs) default package resolution.

## Omitted Context

- Raw transcript, unrelated exploration, sensitive details, repetitive attempts, and chain-of-thought-style content were omitted.

</details>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default package selection for workflow-backed tabs paywalls (purchase button and highlighted row), but behavior is constrained by tab membership checks and is heavily regression-tested; overlapping-package and cached-selection paths are intended to stay the same.
> 
> **Overview**
> Fixes a **5.83.0 regression** where workflow-backed tabs paywalls with **disjoint packages per tab** showed **no selected package** after switching to a second tab. Workflows flatten all tab packages to derive a global default (often tab 1’s), and the tabs UI previously preferred that value even when the active tab did not list that package.
> 
> **`LoadedTabsComponentView`** adds **`effectiveTabDefaultPackage`**, which uses the workflow default only if the tab’s package list contains it; otherwise it uses the tab’s authored default. That helper replaces the old `workflowDefaultPackage ?? tabDefaultPackage` at initial package seeding, `planSelectionDefaultPackage`, and tab-switch handling.
> 
> **`TabsPackageSelectionResolver.resolveTabSwitch`** additionally refuses to apply a `tabDefaultPackage` whose identifier is not in the tab’s packages, so no row can be left unselected.
> 
> Tests cover the helper/resolver paths in **`TabsPackageInheritanceTests`** and hosted **`LoadedTabsComponentView`** tab switches (including toggle controls) in **`TabsWorkflowDefaultPackageTests`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60067f6ad73904c31782bf257c3d4678149d7c9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


