### PR TITLE
feat(checkpoints): CheckpointTester app

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1055,6 +1055,25 @@ jobs:
           no_output_timeout: 30m
       - slack-notify-on-fail
 
+  build-checkpoint-tester:
+    executor:
+      name: macos-executor
+    steps:
+      - checkout
+      - tuist-generate-workspace:
+          query: "CheckpointTester"
+      - run:
+          name: Build CheckpointTester
+          command: >-
+            xcodebuild
+            -workspace RevenueCat-Tuist.xcworkspace
+            -scheme CheckpointTester
+            -destination "generic/platform=iOS Simulator"
+            CODE_SIGNING_ALLOWED=NO
+            build
+          no_output_timeout: 30m
+      - slack-notify-on-fail
+
   check-app-extension-safe-api-usage:
     executor:
       name: macos-executor
@@ -2374,6 +2393,9 @@ workflows:
       - build-xcode-265:
           context:
             - slack-secrets
+      - build-checkpoint-tester:
+          context:
+            - slack-secrets
       - pod-lib-lint:
           context:
             - slack-secrets
@@ -2554,6 +2576,7 @@ workflows:
             - check-api-changes-revenuecatui
             - run-test-ios-26
             - build-xcode-265
+            - build-checkpoint-tester
             - pod-lib-lint
             - run-revenuecat-ui-ios-26
             - emerge_purchases_ui_snapshot_tests

--- a/.circleci/generate-requested-jobs-config.js
+++ b/.circleci/generate-requested-jobs-config.js
@@ -18,6 +18,7 @@ const JOBS = {
   "backend-integration-tests-offline": ["slack-secrets"],
   "backend-integration-tests-other": ["slack-secrets"],
   "check-app-extension-safe-api-usage": ["slack-secrets"],
+  "build-checkpoint-tester": ["slack-secrets"],
   "build-xcode-265": ["slack-secrets"],
   "build-tv-watch-mac-and-visionos": ["slack-secrets"],
   "check-api-changes-revenuecat": ["slack-secrets-ios"],

--- a/Examples/CheckpointTester/CheckpointTester/Sources/CheckpointDemoModel.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/CheckpointDemoModel.swift
@@ -1,0 +1,112 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CheckpointDemoModel.swift
+//
+//  Created by Rick van der Linden.
+//
+
+import Combine
+import Foundation
+@_spi(Internal) import RevenueCat
+@_spi(Internal) import RevenueCatUI
+
+final class CheckpointDemoModel: ObservableObject {
+
+    struct OutcomeAlert: Identifiable {
+        let id = UUID()
+        let title: String
+        let message: String
+    }
+
+    @Published private(set) var outcomeAlert: OutcomeAlert?
+
+    private var pendingOutcomeAlerts: [OutcomeAlert] = []
+
+    // MARK: - New checkpoint public API implementation
+
+    // This call is the core integration an app makes when it reaches a checkpoint.
+    func runCheckpoint(identifier: String) {
+        Task { @MainActor in
+            do {
+                let result = try await Purchases.shared.checkpoint(
+                    identifier,
+                    params: CheckpointParams(customProperties: ["name": "Rick"])
+                )
+                self.showOutcomeAlert(
+                    title: "Checkpoint result",
+                    message: Self.describe(result)
+                )
+            } catch {
+                self.showOutcomeAlert(
+                    title: "Checkpoint failed",
+                    message: error.localizedDescription
+                )
+            }
+        }
+    }
+
+    // MARK: - Demo-only result presentation
+
+    private func showOutcomeAlert(
+        title: String,
+        message: String
+    ) {
+        self.pendingOutcomeAlerts.append(
+            OutcomeAlert(title: title, message: message)
+        )
+        self.presentNextOutcomeAlertIfNeeded()
+    }
+
+    func outcomeAlertDismissed() {
+        guard self.outcomeAlert != nil else {
+            return
+        }
+
+        self.outcomeAlert = nil
+        DispatchQueue.main.async {
+            self.presentNextOutcomeAlertIfNeeded()
+        }
+    }
+
+    private func presentNextOutcomeAlertIfNeeded() {
+        guard self.outcomeAlert == nil, !self.pendingOutcomeAlerts.isEmpty else {
+            return
+        }
+        self.outcomeAlert = self.pendingOutcomeAlerts.removeFirst()
+    }
+
+    private static func describe(_ result: CheckpointResult) -> String {
+        switch result {
+        case let presented as CheckpointPaywallPresentedResult:
+            return "Paywall presented · \(presented.checkpoint.identifier)\n\n" +
+                "Paywall outcome: \(Self.describe(presented.paywallOutcome))"
+        case let noAction as CheckpointNoActionResult:
+            return "No action · \(noAction.checkpoint.identifier) · \(noAction.reason.value)"
+        default:
+            return "Unknown checkpoint result · \(result.checkpoint.identifier)"
+        }
+    }
+
+    private static func describe(_ result: CheckpointPaywallOutcome) -> String {
+        switch result {
+        case is CheckpointPaywallDismissedOutcome:
+            return "Dismissed"
+        case is CheckpointPaywallPurchasedOutcome:
+            return "Purchased"
+        case is CheckpointPaywallRestoredOutcome:
+            return "Restored"
+        case let error as CheckpointPaywallErrorOutcome:
+            return "Error · \(error.error.localizedDescription)"
+        default:
+            return "Unknown paywall outcome"
+        }
+    }
+
+}

--- a/Examples/CheckpointTester/CheckpointTester/Sources/CheckpointDemoModel.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/CheckpointDemoModel.swift
@@ -29,27 +29,18 @@ final class CheckpointDemoModel: ObservableObject {
 
     private var pendingOutcomeAlerts: [OutcomeAlert] = []
 
-    // MARK: - New checkpoint public API implementation
+    func showOutcome(_ result: CheckpointResult) {
+        self.showOutcomeAlert(
+            title: "Checkpoint result",
+            message: Self.describe(result)
+        )
+    }
 
-    // This call is the core integration an app makes when it reaches a checkpoint.
-    func runCheckpoint(identifier: String) {
-        Task { @MainActor in
-            do {
-                let result = try await Purchases.shared.checkpoint(
-                    identifier,
-                    params: CheckpointParams(customProperties: ["name": "Rick"])
-                )
-                self.showOutcomeAlert(
-                    title: "Checkpoint result",
-                    message: Self.describe(result)
-                )
-            } catch {
-                self.showOutcomeAlert(
-                    title: "Checkpoint failed",
-                    message: error.localizedDescription
-                )
-            }
-        }
+    func showError(_ error: Error) {
+        self.showOutcomeAlert(
+            title: "Checkpoint failed",
+            message: error.localizedDescription
+        )
     }
 
     // MARK: - Demo-only result presentation

--- a/Examples/CheckpointTester/CheckpointTester/Sources/CheckpointTesterApp.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/CheckpointTesterApp.swift
@@ -1,0 +1,60 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CheckpointTesterApp.swift
+//
+//  Created by Rick van der Linden.
+//
+
+import Foundation
+@_spi(Internal) import RevenueCat
+@_spi(Internal) import RevenueCatUI
+import SwiftUI
+
+@main
+struct CheckpointTesterApp: App {
+
+    @StateObject private var model: CheckpointDemoModel
+    @StateObject private var analyticsTracker: GlobalCheckpointAnalyticsTracker
+
+    init() {
+        let analyticsTracker = GlobalCheckpointAnalyticsTracker()
+        let model = CheckpointDemoModel()
+        self._model = StateObject(wrappedValue: model)
+        self._analyticsTracker = StateObject(wrappedValue: analyticsTracker)
+
+        Purchases.logLevel = .debug
+        Self.configurePurchases(analyticsTracker: analyticsTracker)
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView(
+                model: self.model,
+                analyticsTracker: self.analyticsTracker
+            )
+        }
+    }
+
+    // MARK: - New checkpoint public API implementation
+
+    private static func configurePurchases(analyticsTracker: GlobalCheckpointAnalyticsTracker) {
+        guard let apiKey = Bundle.main.object(forInfoDictionaryKey: "REVENUECAT_API_KEY") as? String,
+              apiKey.hasPrefix("appl_"),
+              !apiKey.contains("$(") else {
+            fatalError("Generate CheckpointTester with a valid TUIST_RC_API_KEY.")
+        }
+
+        let purchases = Purchases.isConfigured
+            ? Purchases.shared
+            : Purchases.configure(withAPIKey: apiKey)
+        purchases.checkpointListener = analyticsTracker
+    }
+
+}

--- a/Examples/CheckpointTester/CheckpointTester/Sources/CheckpointTesterApp.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/CheckpointTesterApp.swift
@@ -46,7 +46,7 @@ struct CheckpointTesterApp: App {
 
     private static func configurePurchases(analyticsTracker: GlobalCheckpointAnalyticsTracker) {
         guard let apiKey = Bundle.main.object(forInfoDictionaryKey: "REVENUECAT_API_KEY") as? String,
-              apiKey.hasPrefix("appl_"),
+              !apiKey.isEmpty,
               !apiKey.contains("$(") else {
             fatalError("Generate CheckpointTester with a valid TUIST_RC_API_KEY.")
         }

--- a/Examples/CheckpointTester/CheckpointTester/Sources/ContentView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/ContentView.swift
@@ -12,15 +12,36 @@
 //  Created by Rick van der Linden.
 //
 
+import Foundation
+@_spi(Internal) import RevenueCat
+@_spi(Internal) import RevenueCatUI
 import SwiftUI
 
 struct ContentView: View {
 
     @ObservedObject var model: CheckpointDemoModel
     @ObservedObject var analyticsTracker: GlobalCheckpointAnalyticsTracker
+    @State private var checkpointVariables = [
+        CheckpointVariable(name: "source", value: "CheckpointTester"),
+    ]
 
     var body: some View {
-        self.demoList
+        TabView {
+            self.demoList
+                .tabItem {
+                    Label("Use cases", systemImage: "list.bullet.rectangle")
+                }
+
+            self.variableEditor
+                .tabItem {
+                    Label("Variables", systemImage: "slider.horizontal.3")
+                }
+
+            self.listenerLog
+                .tabItem {
+                    Label("Listener", systemImage: "waveform.path.ecg")
+                }
+        }
         .alert(
             isPresented: Binding(
                 get: { self.model.outcomeAlert != nil },
@@ -48,7 +69,17 @@ struct ContentView: View {
                         subtitle: "Choose purchased, restored, dismissed, or error.",
                         systemImage: "rectangle.on.rectangle"
                     ) {
-                        self.model.runCheckpoint(identifier: "result_picker")
+                        Task { @MainActor in
+                            do {
+                                let result = try await Purchases.shared.checkpoint(
+                                    "result_picker",
+                                    params: self.checkpointParams
+                                )
+                                self.model.showOutcome(result)
+                            } catch {
+                                self.model.showError(error)
+                            }
+                        }
                     }
 
                     DemoButton(
@@ -56,7 +87,17 @@ struct ContentView: View {
                         subtitle: "An unknown identifier resolves without presenting UI.",
                         systemImage: "arrow.forward"
                     ) {
-                        self.model.runCheckpoint(identifier: "unknown_checkpoint")
+                        Task { @MainActor in
+                            do {
+                                let result = try await Purchases.shared.checkpoint(
+                                    "unknown_checkpoint",
+                                    params: self.checkpointParams
+                                )
+                                self.model.showOutcome(result)
+                            } catch {
+                                self.model.showError(error)
+                            }
+                        }
                     }
 
                     DemoButton(
@@ -64,7 +105,17 @@ struct ContentView: View {
                         subtitle: "The checkpoint call throws a configuration error.",
                         systemImage: "exclamationmark.triangle"
                     ) {
-                        self.model.runCheckpoint(identifier: "error_checkpoint")
+                        Task { @MainActor in
+                            do {
+                                let result = try await Purchases.shared.checkpoint(
+                                    "error_checkpoint",
+                                    params: self.checkpointParams
+                                )
+                                self.model.showOutcome(result)
+                            } catch {
+                                self.model.showError(error)
+                            }
+                        }
                     }
                 }
 
@@ -74,7 +125,17 @@ struct ContentView: View {
                         subtitle: "Can be dismissed without purchasing.",
                         systemImage: "rectangle.portrait.and.arrow.right"
                     ) {
-                        self.model.runCheckpoint(identifier: "soft_paywall")
+                        Task { @MainActor in
+                            do {
+                                let result = try await Purchases.shared.checkpoint(
+                                    "soft_paywall",
+                                    params: self.checkpointParams
+                                )
+                                self.model.showOutcome(result)
+                            } catch {
+                                self.model.showError(error)
+                            }
+                        }
                     }
 
                     DemoButton(
@@ -82,7 +143,17 @@ struct ContentView: View {
                         subtitle: "Interactive dismissal is disabled.",
                         systemImage: "lock.fill"
                     ) {
-                        self.model.runCheckpoint(identifier: "hard_paywall")
+                        Task { @MainActor in
+                            do {
+                                let result = try await Purchases.shared.checkpoint(
+                                    "hard_paywall",
+                                    params: self.checkpointParams
+                                )
+                                self.model.showOutcome(result)
+                            } catch {
+                                self.model.showError(error)
+                            }
+                        }
                     }
                 }
 
@@ -92,10 +163,56 @@ struct ContentView: View {
                         subtitle: "Completes a multi-step flow and displays the checkpoint result.",
                         systemImage: "sparkles"
                     ) {
-                        self.model.runCheckpoint(identifier: "onboarding")
+                        Task { @MainActor in
+                            do {
+                                let result = try await Purchases.shared.checkpoint(
+                                    "onboarding",
+                                    params: self.checkpointParams
+                                )
+                                self.model.showOutcome(result)
+                            } catch {
+                                self.model.showError(error)
+                            }
+                        }
                     }
                 }
+            }
+            .navigationTitle("Checkpoint Tester")
+        }
+    }
 
+    private var variableEditor: some View {
+        NavigationStack {
+            List {
+                Section {
+                    ForEach(self.$checkpointVariables) { $variable in
+                        HStack {
+                            TextField("Name", text: $variable.name)
+                            TextField("Value", text: $variable.value)
+                        }
+                    }
+                    .onDelete { offsets in
+                        self.checkpointVariables.remove(atOffsets: offsets)
+                    }
+
+                    Button {
+                        self.checkpointVariables.append(.init())
+                    } label: {
+                        Label("Add variable", systemImage: "plus")
+                    }
+                } header: {
+                    Text("Checkpoint variables")
+                } footer: {
+                    Text("These custom properties are passed to every checkpoint call.")
+                }
+            }
+            .navigationTitle("Variables")
+        }
+    }
+
+    private var listenerLog: some View {
+        NavigationStack {
+            List {
                 Section {
                     if self.analyticsTracker.events.isEmpty {
                         Text("Global listener events will appear here as checkpoints run.")
@@ -121,9 +238,30 @@ struct ContentView: View {
                     Text("A global analytics tracker can observe checkpoint hits and completed results here.")
                 }
             }
-            .navigationTitle("Checkpoint Tester")
+            .navigationTitle("Global Listener")
         }
     }
+
+    private var checkpointParams: CheckpointParams {
+        var customProperties: [String: RevenueCat.CheckpointValue] = [:]
+
+        for variable in self.checkpointVariables {
+            let name = variable.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !name.isEmpty {
+                customProperties[name] = .string(variable.value)
+            }
+        }
+
+        return CheckpointParams(customProperties: customProperties)
+    }
+
+}
+
+private struct CheckpointVariable: Identifiable {
+
+    let id = UUID()
+    var name = ""
+    var value = ""
 
 }
 

--- a/Examples/CheckpointTester/CheckpointTester/Sources/ContentView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/ContentView.swift
@@ -1,0 +1,156 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ContentView.swift
+//
+//  Created by Rick van der Linden.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+
+    @ObservedObject var model: CheckpointDemoModel
+    @ObservedObject var analyticsTracker: GlobalCheckpointAnalyticsTracker
+
+    var body: some View {
+        self.demoList
+        .alert(
+            isPresented: Binding(
+                get: { self.model.outcomeAlert != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        self.model.outcomeAlertDismissed()
+                    }
+                }
+            )
+        ) {
+            Alert(
+                title: Text(self.model.outcomeAlert?.title ?? "Checkpoint result"),
+                message: Text(self.model.outcomeAlert?.message ?? ""),
+                dismissButton: .default(Text("OK"))
+            )
+        }
+    }
+
+    private var demoList: some View {
+        NavigationStack {
+            List {
+                Section("Checkpoint outcomes") {
+                    DemoButton(
+                        title: "Mock checkpoint UI",
+                        subtitle: "Choose purchased, restored, dismissed, or error.",
+                        systemImage: "rectangle.on.rectangle"
+                    ) {
+                        self.model.runCheckpoint(identifier: "result_picker")
+                    }
+
+                    DemoButton(
+                        title: "No match",
+                        subtitle: "An unknown identifier resolves without presenting UI.",
+                        systemImage: "arrow.forward"
+                    ) {
+                        self.model.runCheckpoint(identifier: "unknown_checkpoint")
+                    }
+
+                    DemoButton(
+                        title: "Simulated error",
+                        subtitle: "The checkpoint call throws a configuration error.",
+                        systemImage: "exclamationmark.triangle"
+                    ) {
+                        self.model.runCheckpoint(identifier: "error_checkpoint")
+                    }
+                }
+
+                Section("Paywalls") {
+                    DemoButton(
+                        title: "Soft paywall",
+                        subtitle: "Can be dismissed without purchasing.",
+                        systemImage: "rectangle.portrait.and.arrow.right"
+                    ) {
+                        self.model.runCheckpoint(identifier: "soft_paywall")
+                    }
+
+                    DemoButton(
+                        title: "Hard paywall",
+                        subtitle: "Interactive dismissal is disabled.",
+                        systemImage: "lock.fill"
+                    ) {
+                        self.model.runCheckpoint(identifier: "hard_paywall")
+                    }
+                }
+
+                Section("Onboarding") {
+                    DemoButton(
+                        title: "Onboarding workflow",
+                        subtitle: "Completes a multi-step flow and displays the checkpoint result.",
+                        systemImage: "sparkles"
+                    ) {
+                        self.model.runCheckpoint(identifier: "onboarding")
+                    }
+                }
+
+                Section {
+                    if self.analyticsTracker.events.isEmpty {
+                        Text("Global listener events will appear here as checkpoints run.")
+                            .foregroundStyle(.secondary)
+                    }
+
+                    ForEach(
+                        Array(self.analyticsTracker.events.enumerated()),
+                        id: \.offset
+                    ) { _, event in
+                        Text(event)
+                            .font(.caption.monospaced())
+                    }
+
+                    if !self.analyticsTracker.events.isEmpty {
+                        Button("Clear event log", role: .destructive) {
+                            self.analyticsTracker.clearEvents()
+                        }
+                    }
+                } header: {
+                    Text("Global checkpoint listener")
+                } footer: {
+                    Text("A global analytics tracker can observe checkpoint hits and completed results here.")
+                }
+            }
+            .navigationTitle("Checkpoint Tester")
+        }
+    }
+
+}
+
+private struct DemoButton: View {
+
+    let title: String
+    let subtitle: String
+    let systemImage: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: self.action) {
+            Label {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(self.title)
+                        .font(.headline)
+                    Text(self.subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } icon: {
+                Image(systemName: self.systemImage)
+                    .frame(width: 28)
+            }
+        }
+        .buttonStyle(.plain)
+        .padding(.vertical, 4)
+    }
+
+}

--- a/Examples/CheckpointTester/CheckpointTester/Sources/GlobalCheckpointAnalyticsTracker.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/GlobalCheckpointAnalyticsTracker.swift
@@ -1,0 +1,81 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  GlobalCheckpointAnalyticsTracker.swift
+//
+//  Created by Rick van der Linden.
+//
+
+import Combine
+import Foundation
+import OSLog
+@_spi(Internal) import RevenueCat
+@_spi(Internal) import RevenueCatUI
+
+/// Example app-wide analytics consumer for the SDK's global checkpoint listener API.
+final class GlobalCheckpointAnalyticsTracker: ObservableObject, CheckpointListener {
+
+    @Published private(set) var events: [String] = []
+
+    private static let logger = Logger(
+        subsystem: "com.revenuecat.PaywallsTester",
+        category: "GlobalCheckpointListener"
+    )
+
+    // MARK: - New checkpoint public API implementation
+
+    // These callbacks demonstrate an app-wide analytics integration using CheckpointListener.
+    func onCheckpointHit(_ checkpoint: CheckpointInfo) {
+        self.track("Hit · \(checkpoint.identifier)")
+    }
+
+    func onCheckpointCompleted(_ checkpoint: CheckpointInfo, result: CheckpointResult) {
+        self.track("Completed · \(Self.describe(result))")
+    }
+
+    // MARK: - Demo-only event display
+
+    func clearEvents() {
+        self.events.removeAll()
+    }
+
+    private func track(_ event: String) {
+        let timestamp = Date.now.formatted(date: .omitted, time: .standard)
+        self.events.append("\(timestamp) · \(event)")
+        Self.logger.info("\(event, privacy: .public)")
+    }
+
+    private static func describe(_ result: CheckpointResult) -> String {
+        switch result {
+        case let presented as CheckpointPaywallPresentedResult:
+            return "Paywall presented · \(presented.checkpoint.identifier) · " +
+                Self.describe(presented.paywallOutcome)
+        case let noAction as CheckpointNoActionResult:
+            return "No action · \(noAction.checkpoint.identifier) · \(noAction.reason.value)"
+        default:
+            return "Unknown result · \(result.checkpoint.identifier)"
+        }
+    }
+
+    private static func describe(_ result: CheckpointPaywallOutcome) -> String {
+        switch result {
+        case is CheckpointPaywallDismissedOutcome:
+            return "Dismissed"
+        case is CheckpointPaywallPurchasedOutcome:
+            return "Purchased"
+        case is CheckpointPaywallRestoredOutcome:
+            return "Restored"
+        case let error as CheckpointPaywallErrorOutcome:
+            return "Error · \(error.error.localizedDescription)"
+        default:
+            return "Unknown paywall outcome"
+        }
+    }
+
+}

--- a/Examples/CheckpointTester/CheckpointTester/Sources/GlobalCheckpointAnalyticsTracker.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/GlobalCheckpointAnalyticsTracker.swift
@@ -24,7 +24,7 @@ final class GlobalCheckpointAnalyticsTracker: ObservableObject, CheckpointListen
     @Published private(set) var events: [String] = []
 
     private static let logger = Logger(
-        subsystem: "com.revenuecat.PaywallsTester",
+        subsystem: "com.revenuecat.CheckpointTester",
         category: "GlobalCheckpointListener"
     )
 

--- a/Examples/CheckpointTester/Project.swift
+++ b/Examples/CheckpointTester/Project.swift
@@ -1,0 +1,65 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Project.swift
+//
+//  Created by Rick van der Linden.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project(
+    name: "CheckpointTester",
+    organizationName: .revenueCatOrgName,
+    packages: .projectPackages,
+    settings: .appProject,
+    targets: [
+        .target(
+            name: "CheckpointTester",
+            destinations: [.iPhone, .iPad],
+            product: .app,
+            bundleId: "com.revenuecat.PaywallsTester",
+            deploymentTargets: .iOS("16.0"),
+            infoPlist: .extendingDefault(
+                with: [
+                    "UILaunchScreen": [
+                        "UIColorName": "",
+                        "UIImageName": "",
+                    ],
+                    "REVENUECAT_API_KEY": .string(
+                        Environment.rcApiKey ?? "$(REVENUECAT_API_KEY)"
+                    ),
+                ]
+            ),
+            sources: ["CheckpointTester/Sources/**/*.swift"],
+            dependencies: [
+                .revenueCat,
+                .revenueCatUI,
+            ],
+            settings: .appTarget(including: [
+                "DEVELOPMENT_TEAM": "",
+            ])
+        ),
+    ],
+    schemes: [
+        .scheme(
+            name: "CheckpointTester",
+            shared: true,
+            buildAction: .buildAction(
+                targets: ["CheckpointTester"],
+                findImplicitDependencies: true
+            ),
+            runAction: .runAction(
+                configuration: "Debug",
+                executable: "CheckpointTester"
+            )
+        ),
+    ]
+)

--- a/Examples/CheckpointTester/Project.swift
+++ b/Examples/CheckpointTester/Project.swift
@@ -15,6 +15,9 @@
 import ProjectDescription
 import ProjectDescriptionHelpers
 
+let storeKitConfigurationPath: Path =
+    "../../Tests/TestingApps/PaywallsTester/PaywallsTester/Products.storekit"
+
 let project = Project(
     name: "CheckpointTester",
     organizationName: .revenueCatOrgName,
@@ -25,7 +28,7 @@ let project = Project(
             name: "CheckpointTester",
             destinations: [.iPhone, .iPad],
             product: .app,
-            bundleId: "com.revenuecat.PaywallsTester",
+            bundleId: Environment.paywallsTesterBundleId,
             deploymentTargets: .iOS("16.0"),
             infoPlist: .extendingDefault(
                 with: [
@@ -58,7 +61,10 @@ let project = Project(
             ),
             runAction: .runAction(
                 configuration: "Debug",
-                executable: "CheckpointTester"
+                executable: "CheckpointTester",
+                options: .options(
+                    storeKitConfigurationPath: storeKitConfigurationPath
+                )
             )
         ),
     ]

--- a/Examples/CheckpointTester/Project.swift
+++ b/Examples/CheckpointTester/Project.swift
@@ -28,6 +28,7 @@ let project = Project(
             name: "CheckpointTester",
             destinations: [.iPhone, .iPad],
             product: .app,
+            // Reuse PaywallsTester's existing products, workflows, and StoreKit configuration for this test app.
             bundleId: Environment.paywallsTesterBundleId,
             deploymentTargets: .iOS("16.0"),
             infoPlist: .extendingDefault(

--- a/Examples/CheckpointTester/README.md
+++ b/Examples/CheckpointTester/README.md
@@ -1,0 +1,19 @@
+# CheckpointTester
+
+`CheckpointTester` is a Tuist-generated example for the experimental checkpoint APIs.
+
+This base app demonstrates the application-facing integration:
+
+- configuring `Purchases` and installing a global `CheckpointListener`;
+- calling a checkpoint with custom properties;
+- handling checkpoint result subclasses and paywall outcomes;
+- displaying call results and a live analytics event log.
+
+Generate the project from the repository root:
+
+```sh
+TUIST_RC_API_KEY=appl_your_key tuist generate CheckpointTester --no-open
+```
+
+The app configures RevenueCat before showing its root screen, so generation requires a valid public
+iOS API key.

--- a/Examples/CheckpointTester/README.md
+++ b/Examples/CheckpointTester/README.md
@@ -9,6 +9,9 @@ This base app demonstrates the application-facing integration:
 - handling checkpoint result subclasses and paywall outcomes;
 - displaying call results and a live analytics event log.
 
+The generated app shares PaywallsTester's bundle identifier and `Products.storekit` configuration so it can use
+the same local in-app purchase products and RevenueCat project.
+
 Generate the project from the repository root:
 
 ```sh

--- a/Workspace.swift
+++ b/Workspace.swift
@@ -3,6 +3,7 @@ import ProjectDescription
 import ProjectDescriptionHelpers
 
 var projects: [Path] = [
+    "./Examples/CheckpointTester/",
     "./Examples/rc-maestro/",
     "./Examples/MagicWeather/",
     "./Examples/MagicWeatherSwiftUI/",


### PR DESCRIPTION
## Description
Adds the initial CheckpointTester test app for testing multiple checkpoint use-cases. This PR is stacked only on the public API surface, therefore the implementation itself is not implemented yet and will be done in a follow-up PR.

| Use cases | Variables | Listener |
|:---:|:---:|:---:|
| <img width="260" alt="Listener" src="https://github.com/user-attachments/assets/98ee6fb2-00dc-415a-975e-40e2da94d8d9" /> | <img width="260" alt="Variables" src="https://github.com/user-attachments/assets/00a1c738-fd05-460e-9c7f-ca3351a7dc5d" /> | <img width="260" alt="Use cases" src="https://github.com/user-attachments/assets/0331ce74-d3ce-436f-ad63-481d9ecd75bd" /> |



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to a new example app, workspace/CI wiring, and no production SDK behavior changes in this diff.
> 
> **Overview**
> Adds a new **CheckpointTester** Tuist example that exercises the experimental checkpoint APIs against **RevenueCat** / **RevenueCatUI** via `@_spi(Internal)`.
> 
> The app configures **Purchases** with a global **CheckpointListener**, drives several checkpoint identifiers (mock outcomes, no-match, errors, soft/hard paywalls, onboarding), lets you edit **CheckpointParams** custom properties, and surfaces results plus listener events in the UI. It reuses PaywallsTester’s bundle ID and **Products.storekit** so local IAP setup stays aligned.
> 
> **CI** gains a **`build-checkpoint-tester`** job (Tuist generate + simulator build without signing), wired into the reduced PR **`all-tasks-passed`** gate and on-demand job allowlist. **Workspace.swift** registers the new example project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c3c32890f33f150d95545c1aa4ada28362f29e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->