### PR TITLE
fix(paywalls): don't leave a hidden package selected by default

### DIFF
--- a/Examples/rc-maestro/maestro/workflows/default_package_hidden_by_visibility_rule.yaml
+++ b/Examples/rc-maestro/maestro/workflows/default_package_hidden_by_visibility_rule.yaml
@@ -1,0 +1,60 @@
+# Regression test for a default-selected package hidden by a conditional-visibility rule.
+#
+# The paywall's default tab holds two groups of package cards, swapped on the `can_trial` custom
+# variable. The card marked "selected by default" is the trial annual one, which the rule hides when
+# `can_trial=false`. The SDK used to keep that hidden card selected, so no radio button appeared
+# filled and the purchase button targeted a package that wasn't on screen.
+#
+# Rendered radio state isn't assertable, so the flow taps the purchase button and reads back which
+# package the SDK was about to buy. `onPurchaseInitiated` declines, so no StoreKit sheet opens.
+#
+# Expected: the first package that actually renders in document order, `$rc_monthly`.
+# Before the fix this reported `$rc_annual` (the hidden trial card).
+#
+# FIXTURE REQUIREMENT: the group shown when `can_trial=false` must not contain the same package
+# identifier as the default-selected card. Selection is compared by package identifier, so a visible
+# card reusing `$rc_annual` would satisfy the selection and render filled, hiding the bug entirely.
+# On workflow `wff08801936be34317` that means the non-trial group holds only `$rc_monthly`; the
+# duplicate `$rc_annual` card has to go. Covered by
+# `PackageValidatorTests.testDuplicatePackageIdentifierAcrossGroupsMasksAHiddenDefault`.
+#
+# Run locally against the test store:
+#   maestro test -e MAESTRO_STORE=test_store \
+#     Examples/rc-maestro/maestro/workflows/default_package_hidden_by_visibility_rule.yaml
+
+appId: com.revenuecat.maestro.ios
+name: Default-selected package hidden by a visibility rule falls back to a visible package
+env:
+  MAESTRO_STORE: ${MAESTRO_STORE || 'test_store'}
+
+---
+- clearState
+# Dismiss any leftover system alerts from previous test runs.
+- pressKey: home
+- launchApp:
+    arguments:
+        e2e_test_flow: open_default_package_visibility
+        can_trial: "false"
+- assertVisible: "entitlement (pro): nil"
+- extendedWaitUntil:
+    visible: "Present Paywall"
+    timeout: 15000
+- tapOn:
+    text: "Present Paywall"
+
+# The non-trial group is on screen and the trial group is hidden.
+- extendedWaitUntil:
+    visible: "Get subscription benefits for the whole family"
+    timeout: 15000
+- assertNotVisible: "(New members only) Start 2-week free trial"
+- takeScreenshot: "default_package_hidden_by_visibility_rule - paywall"
+
+- tapOn:
+    text: "Get subscription benefits for the whole family"
+
+# The fallback picked a package that renders, not the hidden default-selected one.
+- extendedWaitUntil:
+    visible: "selected package: \\$rc_monthly"
+    timeout: 15000
+- assertNotVisible: "selected package: \\$rc_annual"
+- takeScreenshot: "default_package_hidden_by_visibility_rule - selected package"

--- a/Examples/rc-maestro/maestro/workflows/default_package_visible_stays_selected.yaml
+++ b/Examples/rc-maestro/maestro/workflows/default_package_visible_stays_selected.yaml
@@ -1,0 +1,44 @@
+# Companion to default_package_hidden_by_visibility_rule.yaml: the same paywall with the rule not
+# matching. `can_trial=true` leaves the trial group visible, so the card marked "selected by default"
+# is on screen and must stay selected. This is the case that already worked, and it guards against the
+# fallback firing when there is nothing to fall back from.
+#
+# Expected: `$rc_annual`, the authored default.
+#
+# Run locally against the test store:
+#   maestro test -e MAESTRO_STORE=test_store \
+#     Examples/rc-maestro/maestro/workflows/default_package_visible_stays_selected.yaml
+
+appId: com.revenuecat.maestro.ios
+name: Visible default-selected package stays selected
+env:
+  MAESTRO_STORE: ${MAESTRO_STORE || 'test_store'}
+
+---
+- clearState
+# Dismiss any leftover system alerts from previous test runs.
+- pressKey: home
+- launchApp:
+    arguments:
+        e2e_test_flow: open_default_package_visibility
+        can_trial: "true"
+- assertVisible: "entitlement (pro): nil"
+- extendedWaitUntil:
+    visible: "Present Paywall"
+    timeout: 15000
+- tapOn:
+    text: "Present Paywall"
+
+# The trial group is on screen this time.
+- extendedWaitUntil:
+    visible: "(New members only) Start 2-week free trial"
+    timeout: 15000
+- takeScreenshot: "default_package_visible_stays_selected - paywall"
+
+- tapOn:
+    text: "(New members only) Start 2-week free trial"
+
+- extendedWaitUntil:
+    visible: "selected package: \\$rc_annual"
+    timeout: 15000
+- takeScreenshot: "default_package_visible_stays_selected - selected package"

--- a/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/RcMaestroApp.swift
+++ b/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/RcMaestroApp.swift
@@ -84,6 +84,7 @@ enum E2ETestFlow: String {
     case openNoPaywall = "open_no_paywall"
     case openWorkflowPresented = "open_workflow_presented"
     case openWorkflowUIKit = "open_workflow_uikit"
+    case openDefaultPackageVisibility = "open_default_package_visibility"
 
     @ViewBuilder
     var view: some View {
@@ -100,6 +101,8 @@ enum E2ETestFlow: String {
             E2ETestFlowView.OpenWorkflowPresented()
         case .openWorkflowUIKit:
             E2ETestFlowView.OpenWorkflowUIKit()
+        case .openDefaultPackageVisibility:
+            E2ETestFlowView.OpenDefaultPackageVisibility()
         }
     }
 }

--- a/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/e2e-test-flows/open-default-package-visibility.swift
+++ b/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/e2e-test-flows/open-default-package-visibility.swift
@@ -62,8 +62,11 @@ extension E2ETestFlowView {
                                 let identifier = package.identifier
                                 Task { @MainActor in
                                     self.purchaseStartedPackage = identifier
-                                    // Declining keeps the StoreKit sheet from covering the label below.
+                                    // Declining keeps StoreKit out of the flow entirely.
                                     resume(shouldProceed: false)
+                                    // Declining does not dismiss the paywall, and while it is up it
+                                    // covers the label the flow asserts on.
+                                    self.presentPaywall = false
                                 }
                             }
                     }

--- a/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/e2e-test-flows/open-default-package-visibility.swift
+++ b/Examples/rc-maestro/rc-maestro/Sources/rc-maestro/e2e-test-flows/open-default-package-visibility.swift
@@ -1,0 +1,107 @@
+//
+//  open-default-package-visibility.swift
+//  Maestro
+//
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+//
+
+import SwiftUI
+@_spi(Internal) import RevenueCat
+import RevenueCatUI
+
+extension E2ETestFlowView {
+    /// Covers a paywall whose default-selected package is hidden by a conditional-visibility rule.
+    ///
+    /// The paywall swaps trial and non-trial package cards on a `can_trial` custom variable. The card
+    /// marked "selected by default" is the trial one, so with `can_trial=false` it is hidden and the SDK
+    /// has to fall back to a package that actually renders.
+    ///
+    /// Selection isn't assertable from the rendered radio buttons, so the flow taps the purchase button
+    /// and reports which package the SDK was about to buy. `onPurchaseInitiated` declines to proceed, so
+    /// no StoreKit sheet appears and nothing covers the label the flow asserts on.
+    struct OpenDefaultPackageVisibility: View {
+
+        static let offeringIdentifier = "[default pkg + visibility]"
+
+        /// Absent unless the `can_trial` launch argument is passed, so the paywall renders whatever the
+        /// dashboard default for the variable is.
+        static var customVariableOverrides: [String: CustomVariableValue] {
+            guard let raw = UserDefaults.standard.string(forKey: "can_trial") else {
+                return [:]
+            }
+            return ["can_trial": .bool(raw == "true")]
+        }
+
+        enum GetOfferingsState {
+            case loading
+            case loaded(Offering)
+            case failed(Error)
+        }
+
+        @State private var offeringsState: GetOfferingsState = .loading
+        @State private var presentPaywall = false
+        @State private var purchaseStartedPackage: String?
+
+        var body: some View {
+            VStack {
+                Text("Default package visibility")
+                    .font(.largeTitle)
+
+                switch offeringsState {
+                case .loading:
+                    Text("Loading offerings...")
+                case .loaded(let offering):
+                    Button("Present Paywall") {
+                        presentPaywall = true
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .sheet(isPresented: $presentPaywall) {
+                        PaywallView(offering: offering)
+                            .customPaywallVariables(Self.customVariableOverrides)
+                            .onPurchaseInitiated { package, resume in
+                                let identifier = package.identifier
+                                Task { @MainActor in
+                                    self.purchaseStartedPackage = identifier
+                                    // Declining keeps the StoreKit sheet from covering the label below.
+                                    resume(shouldProceed: false)
+                                }
+                            }
+                    }
+                case .failed(let error):
+                    Text("Error: \(error.localizedDescription)")
+                        .foregroundColor(.red)
+                }
+
+                if let purchaseStartedPackage {
+                    Text("selected package: \(purchaseStartedPackage)")
+                }
+
+                EntitlementView(identifier: "pro")
+            }
+            .task {
+                do {
+                    let offerings = try await Purchases.shared.offerings()
+                    if let offering = offerings.offering(identifier: Self.offeringIdentifier) {
+                        offeringsState = .loaded(offering)
+                    } else {
+                        offeringsState = .failed(OfferingError.notFound)
+                    }
+                } catch {
+                    offeringsState = .failed(error)
+                }
+            }
+            .multilineTextAlignment(.center)
+        }
+
+        enum OfferingError: LocalizedError {
+            case notFound
+
+            var errorDescription: String? {
+                switch self {
+                case .notFound:
+                    return "Offering '\(OpenDefaultPackageVisibility.offeringIdentifier)' not found"
+                }
+            }
+        }
+    }
+}

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -211,6 +211,7 @@
 		2CC791562CC0452100FBE120 /* PackageComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC7914B2CC0452100FBE120 /* PackageComponentView.swift */; };
 		2CC791592CC0452100FBE120 /* PurchaseButtonComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC791512CC0452100FBE120 /* PurchaseButtonComponentView.swift */; };
 		2CC7915A2CC0452100FBE120 /* PackageComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC7914C2CC0452100FBE120 /* PackageComponentViewModel.swift */; };
+		FA11D0C22E4A000100AB0002 /* PackageVisibilityResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA11D0C12E4A000100AB0001 /* PackageVisibilityResolver.swift */; };
 		2CC791622CC0493600FBE120 /* PaywallComponentPropertyTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC7915F2CC0493600FBE120 /* PaywallComponentPropertyTypes.swift */; };
 		2CC791632CC0493600FBE120 /* PaywallComponentLocalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC7915E2CC0493600FBE120 /* PaywallComponentLocalization.swift */; };
 		2CC791642CC0493600FBE120 /* Border.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC7915B2CC0493600FBE120 /* Border.swift */; };
@@ -1766,6 +1767,7 @@
 		2CB8CF9227BF538F00C34DE3 /* PlatformInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformInfo.swift; sourceTree = "<group>"; };
 		2CC7914B2CC0452100FBE120 /* PackageComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageComponentView.swift; sourceTree = "<group>"; };
 		2CC7914C2CC0452100FBE120 /* PackageComponentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageComponentViewModel.swift; sourceTree = "<group>"; };
+		FA11D0C12E4A000100AB0001 /* PackageVisibilityResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageVisibilityResolver.swift; sourceTree = "<group>"; };
 		2CC791512CC0452100FBE120 /* PurchaseButtonComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseButtonComponentView.swift; sourceTree = "<group>"; };
 		2CC791522CC0452100FBE120 /* PurchaseButtonComponentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseButtonComponentViewModel.swift; sourceTree = "<group>"; };
 		2CC7915B2CC0493600FBE120 /* Border.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Border.swift; sourceTree = "<group>"; };
@@ -3577,6 +3579,7 @@
 				2C8EC71A2CCDD43500D6CCF8 /* ComponentViewState.swift */,
 				2CC7914B2CC0452100FBE120 /* PackageComponentView.swift */,
 				2CC7914C2CC0452100FBE120 /* PackageComponentViewModel.swift */,
+				FA11D0C12E4A000100AB0001 /* PackageVisibilityResolver.swift */,
 			);
 			path = Package;
 			sourceTree = "<group>";
@@ -8403,6 +8406,7 @@
 				2CC791562CC0452100FBE120 /* PackageComponentView.swift in Sources */,
 				2CC791592CC0452100FBE120 /* PurchaseButtonComponentView.swift in Sources */,
 				2CC7915A2CC0452100FBE120 /* PackageComponentViewModel.swift in Sources */,
+				FA11D0C22E4A000100AB0002 /* PackageVisibilityResolver.swift in Sources */,
 				887A60772C1D037000E1A461 /* TemplateViewConfiguration+Images.swift in Sources */,
 				0387D4AE2EC58AA5008E4A6B /* CountdownComponentViewModel.swift in Sources */,
 				0387D4AF2EC58AA5008E4A6B /* CountdownComponentView.swift in Sources */,

--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -63,6 +63,7 @@ enum Strings {
     case paywall_could_not_find_localization(String)
     case paywall_could_not_find_package(String)
     case paywall_could_not_find_default_package
+    case paywall_default_package_not_visible(defaultPackage: String, selectedPackage: String)
     case paywall_could_not_find_any_packages
     case paywall_invalid_url(String)
     case no_in_app_browser_tvos
@@ -254,6 +255,11 @@ extension Strings: CustomStringConvertible {
             return "Could not find default package for paywall. Using first package instead. " +
             "This package will not show in the paywall. This could be caused by a package that doesn't have a " +
             "product on this platform or the product might not be available for this region."
+
+        case let .paywall_default_package_not_visible(defaultPackage, selectedPackage):
+            return "Package '\(defaultPackage)' is selected by default but is hidden by a visibility " +
+            "rule, so '\(selectedPackage)' was selected instead. Check the visibility rules on the " +
+            "default package if this isn't what you expected."
 
         case .paywall_could_not_find_any_packages:
             return "Could not find any packages for the paywall"

--- a/RevenueCatUI/Templates/V2/Components/Packages/Package/PackageComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/Package/PackageComponentViewModel.swift
@@ -29,9 +29,7 @@ class PackageComponentViewModel {
     let hasPurchaseButton: Bool
     let hapticFeedbackEnabled: Bool
 
-    private let componentVisible: Bool?
-    private let uiConfigProvider: UIConfigProvider
-    private let presentedOverrides: PresentedOverrides<PresentedPackagePartial>?
+    let visibilityResolver: PackageVisibilityResolver
 
     init(
         component: PaywallComponent.PackageComponent,
@@ -41,8 +39,11 @@ class PackageComponentViewModel {
         uiConfigProvider: UIConfigProvider,
         discardRules: Bool = false
     ) {
-        self.componentVisible = component.visible
-        self.uiConfigProvider = uiConfigProvider
+        self.visibilityResolver = PackageVisibilityResolver(
+            component: component,
+            uiConfigProvider: uiConfigProvider,
+            discardRules: discardRules
+        )
         self.isSelectedByDefault = component.isSelectedByDefault
         self.promotionalOfferProductCode = component.applePromoOfferProductCode
         self.componentName = component.name
@@ -55,7 +56,6 @@ class PackageComponentViewModel {
 
         self.stackViewModel = stackViewModel
         self.hasPurchaseButton = hasPurchaseButton
-        self.presentedOverrides = component.overrides?.toPresentedOverrides(discardRules: discardRules)
     }
 
     // swiftlint:disable:next function_parameter_count
@@ -67,21 +67,14 @@ class PackageComponentViewModel {
         selectedPackageId: String?,
         customVariables: [String: CustomVariableValue]
     ) -> Bool {
-        let conditionContext = self.uiConfigProvider.conditionContext(
-            selectedPackageId: selectedPackageId,
-            customVariables: customVariables
-        )
-
-        let partial = PresentedPackagePartial.buildPartial(
+        return self.visibilityResolver.visible(
             state: state,
             condition: condition,
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
-            conditionContext: conditionContext,
-            with: self.presentedOverrides
+            selectedPackageId: selectedPackageId,
+            customVariables: customVariables
         )
-
-        return partial?.visible ?? self.componentVisible ?? true
     }
 
 }

--- a/RevenueCatUI/Templates/V2/Components/Packages/Package/PackageVisibilityResolver.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/Package/PackageVisibilityResolver.swift
@@ -1,0 +1,70 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PackageVisibilityResolver.swift
+//
+//  Created by Facundo Menzella on 8/6/26.
+
+import Foundation
+@_spi(Internal) import RevenueCat
+
+#if !os(tvOS) // For Paywalls V2
+
+/// Resolves whether a package component is visible, running the same override pipeline for both the
+/// renderer (`PackageComponentView`) and default-package selection (`PackageValidator`).
+///
+/// It is built straight from the component, so it carries no dependency on the package's stack. That
+/// lets the package be recorded for selection before its subtree is walked, keeping iOS's ordering
+/// pre-order like Android's `StyleFactory.recordPackage`.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct PackageVisibilityResolver {
+
+    private let componentVisible: Bool?
+    private let uiConfigProvider: UIConfigProvider
+    private let presentedOverrides: PresentedOverrides<PresentedPackagePartial>?
+
+    init(
+        component: PaywallComponent.PackageComponent,
+        uiConfigProvider: UIConfigProvider,
+        discardRules: Bool
+    ) {
+        self.componentVisible = component.visible
+        self.uiConfigProvider = uiConfigProvider
+        self.presentedOverrides = component.overrides?.toPresentedOverrides(discardRules: discardRules)
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    func visible(
+        state: ComponentViewState,
+        condition: ScreenCondition,
+        isEligibleForIntroOffer: Bool,
+        isEligibleForPromoOffer: Bool,
+        selectedPackageId: String?,
+        customVariables: [String: CustomVariableValue]
+    ) -> Bool {
+        let conditionContext = self.uiConfigProvider.conditionContext(
+            selectedPackageId: selectedPackageId,
+            customVariables: customVariables
+        )
+
+        let partial = PresentedPackagePartial.buildPartial(
+            state: state,
+            condition: condition,
+            isEligibleForIntroOffer: isEligibleForIntroOffer,
+            isEligibleForPromoOffer: isEligibleForPromoOffer,
+            conditionContext: conditionContext,
+            with: self.presentedOverrides
+        )
+
+        return partial?.visible ?? self.componentVisible ?? true
+    }
+
+}
+
+#endif

--- a/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentView.swift
@@ -117,6 +117,9 @@ struct LoadedTabsComponentView: View {
     @Environment(\.paywallStateStore)
     private var stateStore
 
+    @Environment(\.isPaywallLoading)
+    private var isPaywallLoading
+
     private let viewModel: TabsComponentViewModel
     private let workflowDefaultPackage: Package?
     private let onDismiss: () -> Void
@@ -211,7 +214,10 @@ struct LoadedTabsComponentView: View {
                             parentPackage: parentPackageContext.package,
                             tabPackages: tabViewModel.packages,
                             workflowDefaultPackage: workflowDefaultPackage,
-                            tabDefaultPackage: tabViewModel.defaultSelectedPackage
+                            // Provisional: view `init` has no environment, so variable/eligibility rules
+                            // can't be evaluated yet. `reconcileSelection` corrects this once the body
+                            // resolves the real context.
+                            tabDefaultPackage: tabViewModel.defaultSelectedPackage(in: .provisional)
                         ),
                         variableContext: .init(
                             packages: tabViewModel.packages,
@@ -226,6 +232,35 @@ struct LoadedTabsComponentView: View {
                 }
             }
         ))
+    }
+
+    private var packageSelectionContext: PackageSelectionContext {
+        return PackageSelectionContext(
+            condition: self.screenCondition,
+            customVariables: self.customVariables,
+            isEligibleForIntroOffer: { [introOfferEligibilityContext] in
+                introOfferEligibilityContext.isEligible(package: $0)
+            },
+            isEligibleForPromoOffer: { [paywallPromoOfferCache] in
+                paywallPromoOfferCache.isMostLikelyEligible(for: $0)
+            }
+        )
+    }
+
+    /// Moves the selection off a package that isn't rendering.
+    ///
+    /// The selection seeded in `init` can't evaluate rules that depend on custom variables or offer
+    /// eligibility, and eligibility lands after first render, so the seeded package may turn out to be
+    /// hidden.
+    private func reconcileSelection(_ context: PackageContext, tabViewModel: TabViewModel) {
+        guard let resolved = tabViewModel.reconciledSelection(
+            current: context.package,
+            in: self.packageSelectionContext
+        ) else {
+            return
+        }
+
+        context.update(package: resolved, variableContext: context.variableContext)
     }
 
     /// Determines the initial package selection for a tab that has its own packages.
@@ -281,9 +316,17 @@ struct LoadedTabsComponentView: View {
             .environmentObject(tierPackageContext)
             .environment(
                 \.planSelectionDefaultPackage,
-                self.workflowDefaultPackage ?? activeTabViewModel.defaultSelectedPackage
+                self.workflowDefaultPackage
+                    ?? activeTabViewModel.defaultSelectedPackage(in: self.packageSelectionContext)
             )
+            // Intro and promo eligibility both land after first render and can flip a package's
+            // visibility. `isPaywallLoading` goes false once both have resolved.
+            .onChangeOf(self.isPaywallLoading) { _ in
+                self.reconcileSelection(tierPackageContext, tabViewModel: activeTabViewModel)
+            }
             .onAppear {
+                // The provisional selection made in `init` couldn't evaluate variable/eligibility rules.
+                self.reconcileSelection(tierPackageContext, tabViewModel: activeTabViewModel)
                 if !self.viewModel.didSeedInitialState {
                     self.viewModel.didSeedInitialState = true
                     // Seed the store with the initial selection so components that react to the tab
@@ -326,7 +369,8 @@ struct LoadedTabsComponentView: View {
                     parentOwnedVariableContext: self.parentOwnedVariableContext,
                     parentCurrentVariableContext: self.packageContext.variableContext,
                     tabPackages: newTabViewModel.packages,
-                    tabDefaultPackage: self.workflowDefaultPackage ?? newTabViewModel.defaultSelectedPackage
+                    tabDefaultPackage: self.workflowDefaultPackage
+                        ?? newTabViewModel.defaultSelectedPackage(in: self.packageSelectionContext)
                 )
                 if let tabUpdate = updatePlan.tabUpdate {
                     newTierPackageContext.update(

--- a/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentViewModel.swift
@@ -126,8 +126,11 @@ class TabViewModel {
     let tab: PaywallComponent.TabsComponent.Tab
     let uiConfigProvider: UIConfigProvider
     let stackViewModel: StackComponentViewModel
-    let defaultSelectedPackage: Package?
     let packages: [Package]
+
+    /// Held rather than pre-resolved because a package's visibility can depend on custom variables and
+    /// offer eligibility, which are only known at render time.
+    private let packageValidator: PackageValidator
 
     var name: String? {
         return self.tab.name
@@ -136,15 +139,22 @@ class TabViewModel {
     init(
         tab: PaywallComponent.TabsComponent.Tab,
         stackViewModel: StackComponentViewModel,
-        defaultSelectedPackage: Package?,
-        packages: [Package],
+        packageValidator: PackageValidator,
         uiConfigProvider: UIConfigProvider
     ) {
         self.tab = tab
         self.stackViewModel = stackViewModel
-        self.defaultSelectedPackage = defaultSelectedPackage
-        self.packages = packages
+        self.packageValidator = packageValidator
+        self.packages = packageValidator.packages
         self.uiConfigProvider = uiConfigProvider
+    }
+
+    func defaultSelectedPackage(in context: PackageSelectionContext) -> Package? {
+        return self.packageValidator.defaultSelectedPackage(in: context)
+    }
+
+    func reconciledSelection(current: Package?, in context: PackageSelectionContext) -> Package? {
+        return self.packageValidator.reconciledSelection(current: current, in: context)
     }
 
 }

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -210,7 +210,10 @@ struct PaywallsV2View: View {
             selectedPackageContext = Self.makeSelectedPackageContext(
                 from: paywallState,
                 defaultPackage: Self.effectiveDefaultPackage(
-                    pageDefaultPackage: paywallState.viewModelFactory.packageValidator.defaultSelectedPackage,
+                    // Provisional: `init` has no environment, so variable/eligibility rules can't be
+                    // evaluated. `LoadedPaywallsV2View` reconciles once the body resolves the real context.
+                    pageDefaultPackage: paywallState.viewModelFactory.packageValidator
+                        .defaultSelectedPackage(in: .provisional),
                     workflowDefaultPackage: workflowDefaultPackage
                 ),
                 workflowPackages: workflowPackages,
@@ -263,16 +266,14 @@ struct PaywallsV2View: View {
 
     private func loadedPaywallView(paywallState: PaywallState) -> some View {
         let contentLocale = paywallState.rootViewModel.localizationProvider.locale
-        let defaultPackage = Self.effectiveDefaultPackage(
-            pageDefaultPackage: paywallState.viewModelFactory.packageValidator.defaultSelectedPackage,
-            workflowDefaultPackage: self.workflowPackageContext?.selectedPackage ?? self.workflowDefaultPackage
-        )
         return LoadedPaywallsV2View(
             introOfferEligibilityContext: introOfferEligibilityContext,
             paywallState: paywallState,
             uiConfigProvider: self.uiConfigProvider,
             selectedPackageContext: self.selectedPackageContext,
-            defaultPackage: defaultPackage,
+            // Resolved inside the loaded view, where the render environment (custom variables, screen
+            // condition) and the eligibility contexts are available.
+            workflowDefaultPackage: self.workflowPackageContext?.selectedPackage ?? self.workflowDefaultPackage,
             onDismiss: self.onDismiss,
             closeWorkflowAction: self.closeWorkflowAction
         )
@@ -584,7 +585,19 @@ private struct LoadedPaywallsV2View: View {
     private let uiConfigProvider: UIConfigProvider
     private let onDismiss: () -> Void
     private let closeWorkflowAction: (() -> Void)?
-    private let defaultPackage: Package?
+    private let workflowDefaultPackage: Package?
+
+    @EnvironmentObject
+    private var paywallPromoOfferCache: PaywallPromoOfferCache
+
+    @Environment(\.screenCondition)
+    private var screenCondition
+
+    @Environment(\.customPaywallVariables)
+    private var customVariables
+
+    @Environment(\.isPaywallLoading)
+    private var isPaywallLoading
 
     @ObservedObject
     private var selectedPackageContext: PackageContext
@@ -594,7 +607,7 @@ private struct LoadedPaywallsV2View: View {
         paywallState: PaywallState,
         uiConfigProvider: UIConfigProvider,
         selectedPackageContext: PackageContext,
-        defaultPackage: Package?,
+        workflowDefaultPackage: Package?,
         onDismiss: @escaping () -> Void,
         closeWorkflowAction: (() -> Void)? = nil
     ) {
@@ -602,9 +615,54 @@ private struct LoadedPaywallsV2View: View {
         self.paywallState = paywallState
         self.uiConfigProvider = uiConfigProvider
         self.selectedPackageContext = selectedPackageContext
-        self.defaultPackage = defaultPackage
+        self.workflowDefaultPackage = workflowDefaultPackage
         self.onDismiss = onDismiss
         self.closeWorkflowAction = closeWorkflowAction
+    }
+
+    private var packageSelectionContext: PackageSelectionContext {
+        return PackageSelectionContext(
+            condition: self.screenCondition,
+            customVariables: self.customVariables,
+            isEligibleForIntroOffer: { [introOfferEligibilityContext] in
+                introOfferEligibilityContext.isEligible(package: $0)
+            },
+            isEligibleForPromoOffer: { [paywallPromoOfferCache] in
+                paywallPromoOfferCache.isMostLikelyEligible(for: $0)
+            }
+        )
+    }
+
+    private var defaultPackage: Package? {
+        return PaywallsV2View.effectiveDefaultPackage(
+            pageDefaultPackage: self.paywallState.viewModelFactory.packageValidator
+                .defaultSelectedPackage(in: self.packageSelectionContext),
+            workflowDefaultPackage: self.workflowDefaultPackage
+        )
+    }
+
+    /// Moves the selection off a package that isn't rendering.
+    private func reconcileSelection() {
+        let packageValidator = self.paywallState.viewModelFactory.packageValidator
+
+        // Selection is tab-local, so a tabbed paywall reconciles inside `LoadedTabsComponentView`.
+        // Resolving here would walk document order across every tab and could select a package from a
+        // tab the user isn't on.
+        guard !packageValidator.containsTabScopedPackages else {
+            return
+        }
+
+        guard let resolved = packageValidator.reconciledSelection(
+            current: self.selectedPackageContext.package,
+            in: self.packageSelectionContext
+        ) else {
+            return
+        }
+
+        self.selectedPackageContext.update(
+            package: resolved,
+            variableContext: self.selectedPackageContext.variableContext
+        )
     }
 
     var body: some View {
@@ -642,6 +700,14 @@ private struct LoadedPaywallsV2View: View {
             .environment(\.planSelectionDefaultPackage, self.defaultPackage)
             .environmentObject(self.selectedPackageContext)
             .edgesIgnoringSafeArea(.bottom)
+            .onAppear {
+                self.reconcileSelection()
+            }
+            // Intro and promo eligibility both land after first render and can flip a package's
+            // visibility. `isPaywallLoading` goes false once both have resolved.
+            .onChangeOf(self.isPaywallLoading) { _ in
+                self.reconcileSelection()
+            }
         }
     }
 

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PackageValidator.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PackageValidator.swift
@@ -16,19 +16,64 @@ import Foundation
 
 #if !os(tvOS) // For Paywalls V2
 
+/// The inputs default-package selection needs to resolve package visibility the same way the renderer
+/// does. Eligibility is passed as lookups because it is resolved per package and lands asynchronously.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct PackageSelectionContext {
+
+    let condition: ScreenCondition
+    let customVariables: [String: CustomVariableValue]
+    let isEligibleForIntroOffer: (Package) -> Bool
+    let isEligibleForPromoOffer: (Package) -> Bool
+
+    init(
+        condition: ScreenCondition,
+        customVariables: [String: CustomVariableValue],
+        isEligibleForIntroOffer: @escaping (Package) -> Bool,
+        isEligibleForPromoOffer: @escaping (Package) -> Bool
+    ) {
+        self.condition = condition
+        self.customVariables = customVariables
+        self.isEligibleForIntroOffer = isEligibleForIntroOffer
+        self.isEligibleForPromoOffer = isEligibleForPromoOffer
+    }
+
+    /// For the few places that must seed a selection before the render environment exists (view `init`).
+    /// Rules keyed on custom variables or offer eligibility cannot be evaluated yet, so a selection made
+    /// with this is provisional and has to be reconciled once the body resolves the real context.
+    static var provisional: PackageSelectionContext {
+        return .init(
+            condition: .compact,
+            customVariables: [:],
+            isEligibleForIntroOffer: { _ in false },
+            isEligibleForPromoOffer: { _ in false }
+        )
+    }
+
+}
+
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 class PackageValidator {
 
     typealias PackageInfo = (
         package: Package,
         isSelectedByDefault: Bool,
-        isStaticallyVisible: Bool,
+        visibilityResolver: PackageVisibilityResolver,
         promotionalOfferProductCode: String?
     )
 
     private(set) var packageInfos: [PackageInfo] = []
 
+    /// True when this validator has packages merged in from tabs. Selection is tab-local, so the
+    /// page-level validator must not reconcile a selection across tab boundaries.
+    private(set) var containsTabScopedPackages: Bool = false
+
     func add(_ packageInfo: PackageInfo) {
+        self.packageInfos.append(packageInfo)
+    }
+
+    func addTabScoped(_ packageInfo: PackageInfo) {
+        self.containsTabScopedPackages = true
         self.packageInfos.append(packageInfo)
     }
 
@@ -40,25 +85,73 @@ class PackageValidator {
         packageInfos.map(\.package)
     }
 
-    var defaultSelectedPackage: Package? {
-        let visiblePackageInfos = self.packageInfos.filter { $0.isStaticallyVisible }
+    private func visiblePackageInfos(in context: PackageSelectionContext) -> [PackageInfo] {
+        return self.packageInfos.filter { info in
+            info.visibilityResolver.visible(
+                // Selection is what's being resolved, so nothing is selected yet. Pinning these two
+                // inputs keeps resolution independent of its own output — otherwise a paywall with
+                // `selected` or `selected_package` visibility rules could oscillate.
+                state: .default,
+                condition: context.condition,
+                isEligibleForIntroOffer: context.isEligibleForIntroOffer(info.package),
+                isEligibleForPromoOffer: context.isEligibleForPromoOffer(info.package),
+                selectedPackageId: nil,
+                customVariables: context.customVariables
+            )
+        }
+    }
 
-        let defaultSelectedPackage = visiblePackageInfos.first(where: { pkg in
-            return pkg.isSelectedByDefault
-        })
+    /// The packages that actually render for the given context, in document order.
+    func visiblePackages(in context: PackageSelectionContext) -> [Package] {
+        return self.visiblePackageInfos(in: context).map(\.package)
+    }
 
-        // Set selected package
-        if let defaultSelectedPackage {
+    /// Resolves which package should start selected.
+    ///
+    /// 1. the authored default (first `isSelectedByDefault` in document order), if it resolves visible
+    /// 2. otherwise the first visible package in document order
+    /// 3. otherwise `nil`
+    func defaultSelectedPackage(in context: PackageSelectionContext) -> Package? {
+        let visiblePackageInfos = self.visiblePackageInfos(in: context)
+
+        if let defaultSelectedPackage = visiblePackageInfos.first(where: { $0.isSelectedByDefault }) {
             return defaultSelectedPackage.package
         }
 
-        guard !visiblePackageInfos.isEmpty else {
+        guard let fallback = visiblePackageInfos.first else {
             Logger.warning(Strings.paywall_could_not_find_any_packages)
             return nil
         }
 
-        Logger.warning(Strings.paywall_could_not_find_default_package)
-        return visiblePackageInfos.first?.package
+        if let hiddenDefault = self.packageInfos.first(where: { $0.isSelectedByDefault }) {
+            // The authored default resolved hidden, so nothing would appear selected. Falling back keeps
+            // a package selected, but the paywall almost certainly isn't behaving as authored.
+            Logger.warning(
+                Strings.paywall_default_package_not_visible(
+                    defaultPackage: hiddenDefault.package.identifier,
+                    selectedPackage: fallback.package.identifier
+                )
+            )
+        } else {
+            Logger.warning(Strings.paywall_could_not_find_default_package)
+        }
+
+        return fallback.package
+    }
+
+    /// The selection that should be in effect for `context`, given whatever is currently selected.
+    ///
+    /// Returns `nil` when `current` is still visible, meaning nothing needs to change. Selection is only
+    /// moved when the current package isn't rendering, which is why this can't discard a deliberate
+    /// choice: the user can't have tapped a card that isn't on screen.
+    func reconciledSelection(current: Package?, in context: PackageSelectionContext) -> Package? {
+        let visiblePackageInfos = self.visiblePackageInfos(in: context)
+
+        if let current, visiblePackageInfos.contains(where: { $0.package.identifier == current.identifier }) {
+            return nil
+        }
+
+        return self.defaultSelectedPackage(in: context)
     }
 
 }

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
@@ -194,6 +194,24 @@ struct ViewModelFactory {
                 )
             )
         case .package(let component):
+            // Recorded before walking the stack so ordering is pre-order, matching Android's
+            // `StyleFactory.recordPackage`. Both platforms resolve the default package by document
+            // order, so the two walks have to agree. Nothing here depends on the stack.
+            if let package = offering.package(identifier: component.packageID) {
+                packageValidator.add(
+                    PackageValidator.PackageInfo(
+                        package: package,
+                        isSelectedByDefault: component.isSelectedByDefault,
+                        visibilityResolver: PackageVisibilityResolver(
+                            component: component,
+                            uiConfigProvider: uiConfigProvider,
+                            discardRules: discardRules
+                        ),
+                        promotionalOfferProductCode: component.applePromoOfferProductCode
+                    )
+                )
+            }
+
             // Specifically override the parent PurchaseButtonCollector so that
             // we can see if the package has a purchase button inside of it
             let packagePurchaseButtonCollector = PurchaseButtonCollector()
@@ -218,20 +236,6 @@ struct ViewModelFactory {
                 uiConfigProvider: uiConfigProvider,
                 discardRules: discardRules
             )
-
-            if let package = viewModel.package {
-                let packageInfo = PackageValidator.PackageInfo(
-                    package: package,
-                    isSelectedByDefault: viewModel.isSelectedByDefault,
-                    // Only the static `visible` flag is considered here; override-based visibility
-                    // is evaluated at render time and is not used for default package selection.
-                    // The paywall builder enforces that the default-selected package cannot be
-                    // statically hidden (`visible: false`), so this is safe.
-                    isStaticallyVisible: component.visible ?? true,
-                    promotionalOfferProductCode: viewModel.promotionalOfferProductCode
-                )
-                packageValidator.add(packageInfo)
-            }
 
             return .package(viewModel)
         case .purchaseButton(let component):
@@ -385,14 +389,13 @@ struct ViewModelFactory {
 
                 // Merging into entire paywall package validator
                 for packageInfo in tabPackageValidator.packageInfos {
-                    packageValidator.add(packageInfo)
+                    packageValidator.addTabScoped(packageInfo)
                 }
 
                 return .init(
                     tab: tab,
                     stackViewModel: tabsStackViewModel.copy(withViewModels: [.stack(stackViewModel)]),
-                    defaultSelectedPackage: tabPackageValidator.defaultSelectedPackage,
-                    packages: tabPackageValidator.packages,
+                    packageValidator: tabPackageValidator,
                     uiConfigProvider: uiConfigProvider
                 )
             }

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -931,6 +931,9 @@ private struct WorkflowHeaderOverlayPageView: View {
 
     @StateObject private var stateManager: WorkflowHeaderOverlayStateManager
 
+    @Environment(\.customPaywallVariables)
+    private var customVariables
+
     private let page: RenderedPage
     private let purchaseHandler: PurchaseHandler
     private let introOfferEligibilityContext: IntroOfferEligibilityContext
@@ -1005,7 +1008,18 @@ private struct WorkflowHeaderOverlayPageView: View {
         if let headerViewModel = paywallState.rootViewModel.headerViewModel {
             let contentLocale = paywallState.rootViewModel.localizationProvider.locale
             let defaultPackage = PaywallsV2View.effectiveDefaultPackage(
-                pageDefaultPackage: paywallState.viewModelFactory.packageValidator.defaultSelectedPackage,
+                pageDefaultPackage: paywallState.viewModelFactory.packageValidator.defaultSelectedPackage(
+                    in: PackageSelectionContext(
+                        condition: ScreenCondition.from(self.horizontalSizeClass),
+                        customVariables: self.customVariables,
+                        isEligibleForIntroOffer: { [introOfferEligibilityContext] in
+                            introOfferEligibilityContext.isEligible(package: $0)
+                        },
+                        isEligibleForPromoOffer: { [paywallPromoOfferCache] in
+                            paywallPromoOfferCache.isMostLikelyEligible(for: $0)
+                        }
+                    )
+                ),
                 workflowDefaultPackage: self.page.effectiveWorkflowPackageContext?.selectedPackage
             )
 

--- a/Tests/RevenueCatUITests/PaywallsV2/PackageValidatorTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PackageValidatorTests.swift
@@ -24,21 +24,19 @@ final class PackageValidatorTests: TestCase {
     func testDefaultSelectedPackageSkipsStaticallyHiddenSelectedPackage() {
         let validator = PackageValidator()
 
-        validator.add((
+        validator.add(Self.makePackageInfo(
             package: TestData.monthlyPackage,
             isSelectedByDefault: true,
-            isStaticallyVisible: false,
-            promotionalOfferProductCode: nil
+            visible: false
         ))
-        validator.add((
+        validator.add(Self.makePackageInfo(
             package: TestData.annualPackage,
             isSelectedByDefault: false,
-            isStaticallyVisible: true,
-            promotionalOfferProductCode: nil
+            visible: true
         ))
 
         XCTAssertEqual(
-            validator.defaultSelectedPackage?.identifier,
+            validator.defaultSelectedPackage(in: Self.context())?.identifier,
             TestData.annualPackage.identifier
         )
     }
@@ -46,27 +44,24 @@ final class PackageValidatorTests: TestCase {
     func testDefaultSelectedPackageFallsBackToFirstStaticallyVisiblePackage() {
         let validator = PackageValidator()
 
-        validator.add((
+        validator.add(Self.makePackageInfo(
             package: TestData.monthlyPackage,
             isSelectedByDefault: false,
-            isStaticallyVisible: false,
-            promotionalOfferProductCode: nil
+            visible: false
         ))
-        validator.add((
+        validator.add(Self.makePackageInfo(
             package: TestData.annualPackage,
             isSelectedByDefault: false,
-            isStaticallyVisible: true,
-            promotionalOfferProductCode: nil
+            visible: true
         ))
-        validator.add((
+        validator.add(Self.makePackageInfo(
             package: TestData.weeklyPackage,
             isSelectedByDefault: false,
-            isStaticallyVisible: true,
-            promotionalOfferProductCode: nil
+            visible: true
         ))
 
         XCTAssertEqual(
-            validator.defaultSelectedPackage?.identifier,
+            validator.defaultSelectedPackage(in: Self.context())?.identifier,
             TestData.annualPackage.identifier
         )
     }
@@ -74,23 +69,341 @@ final class PackageValidatorTests: TestCase {
     func testDefaultSelectedPackageReturnsNilWhenAllPackagesAreStaticallyHidden() {
         let validator = PackageValidator()
 
-        validator.add((
+        validator.add(Self.makePackageInfo(
             package: TestData.monthlyPackage,
             isSelectedByDefault: true,
-            isStaticallyVisible: false,
-            promotionalOfferProductCode: nil
+            visible: false
         ))
-        validator.add((
+        validator.add(Self.makePackageInfo(
             package: TestData.annualPackage,
             isSelectedByDefault: false,
-            isStaticallyVisible: false,
-            promotionalOfferProductCode: nil
+            visible: false
         ))
 
-        XCTAssertNil(validator.defaultSelectedPackage)
+        XCTAssertNil(validator.defaultSelectedPackage(in: Self.context()))
     }
 
-    func testViewModelFactoryTracksStaticVisibilityForDefaultSelection() throws {
+    // MARK: - Override-driven visibility
+
+    /// The customer-reported bug: the default package is hidden by a `variable` rule, so nothing ends up
+    /// selected even though another package is on screen.
+    func testDefaultSelectedPackageSkipsPackageHiddenByVariableRule() {
+        let validator = PackageValidator()
+
+        validator.add(Self.makePackageInfo(
+            package: TestData.annualPackage,
+            isSelectedByDefault: true,
+            visible: true,
+            overrides: [Self.visibilityOverride(whenCanTrial: false, visible: false)]
+        ))
+        validator.add(Self.makePackageInfo(
+            package: TestData.monthlyPackage,
+            isSelectedByDefault: false,
+            visible: true,
+            overrides: [
+                Self.visibilityOverride(whenCanTrial: true, visible: false),
+                Self.visibilityOverride(whenCanTrial: false, visible: true)
+            ]
+        ))
+
+        XCTAssertEqual(
+            validator.defaultSelectedPackage(
+                in: Self.context(customVariables: ["can_trial": .bool(false)])
+            )?.identifier,
+            TestData.monthlyPackage.identifier
+        )
+    }
+
+    /// The same paywall with the rule not matching: the authored default is visible and stays selected.
+    func testDefaultSelectedPackageKeepsAuthoredDefaultWhenVariableRuleDoesNotMatch() {
+        let validator = PackageValidator()
+
+        validator.add(Self.makePackageInfo(
+            package: TestData.annualPackage,
+            isSelectedByDefault: true,
+            visible: true,
+            overrides: [Self.visibilityOverride(whenCanTrial: false, visible: false)]
+        ))
+        validator.add(Self.makePackageInfo(
+            package: TestData.monthlyPackage,
+            isSelectedByDefault: false,
+            visible: true,
+            overrides: [
+                Self.visibilityOverride(whenCanTrial: true, visible: false),
+                Self.visibilityOverride(whenCanTrial: false, visible: true)
+            ]
+        ))
+
+        XCTAssertEqual(
+            validator.defaultSelectedPackage(
+                in: Self.context(customVariables: ["can_trial": .bool(true)])
+            )?.identifier,
+            TestData.annualPackage.identifier
+        )
+    }
+
+    /// The fallback picks by document order, not by "first statically visible", so a package that is only
+    /// visible because a rule turned it on is still eligible.
+    func testFallbackPicksFirstOverrideVisiblePackageInDocumentOrder() {
+        let validator = PackageValidator()
+
+        validator.add(Self.makePackageInfo(
+            package: TestData.annualPackage,
+            isSelectedByDefault: true,
+            visible: true,
+            overrides: [Self.visibilityOverride(whenCanTrial: false, visible: false)]
+        ))
+        validator.add(Self.makePackageInfo(
+            package: TestData.weeklyPackage,
+            isSelectedByDefault: false,
+            visible: false,
+            overrides: [Self.visibilityOverride(whenCanTrial: false, visible: true)]
+        ))
+        validator.add(Self.makePackageInfo(
+            package: TestData.monthlyPackage,
+            isSelectedByDefault: false,
+            visible: true
+        ))
+
+        XCTAssertEqual(
+            validator.defaultSelectedPackage(
+                in: Self.context(customVariables: ["can_trial": .bool(false)])
+            )?.identifier,
+            TestData.weeklyPackage.identifier
+        )
+    }
+
+    func testDefaultSelectedPackageReturnsNilWhenEveryPackageIsHiddenByRule() {
+        let validator = PackageValidator()
+
+        validator.add(Self.makePackageInfo(
+            package: TestData.annualPackage,
+            isSelectedByDefault: true,
+            visible: true,
+            overrides: [Self.visibilityOverride(whenCanTrial: false, visible: false)]
+        ))
+        validator.add(Self.makePackageInfo(
+            package: TestData.monthlyPackage,
+            isSelectedByDefault: false,
+            visible: true,
+            overrides: [Self.visibilityOverride(whenCanTrial: false, visible: false)]
+        ))
+
+        XCTAssertNil(
+            validator.defaultSelectedPackage(
+                in: Self.context(customVariables: ["can_trial": .bool(false)])
+            )
+        )
+    }
+
+    /// Intro-offer eligibility lands asynchronously, so selection has to resolve correctly both before and
+    /// after it arrives.
+    func testDefaultSelectedPackageSkipsPackageHiddenByIntroOfferRule() {
+        let validator = PackageValidator()
+
+        validator.add(Self.makePackageInfo(
+            package: TestData.annualPackage,
+            isSelectedByDefault: true,
+            visible: true,
+            overrides: [
+                .init(
+                    extendedConditions: [.introOfferCondition(operator: .equals, value: true)],
+                    properties: .init(visible: false)
+                )
+            ]
+        ))
+        validator.add(Self.makePackageInfo(
+            package: TestData.monthlyPackage,
+            isSelectedByDefault: false,
+            visible: true
+        ))
+
+        XCTAssertEqual(
+            validator.defaultSelectedPackage(
+                in: Self.context(isEligibleForIntroOffer: { _ in true })
+            )?.identifier,
+            TestData.monthlyPackage.identifier
+        )
+
+        XCTAssertEqual(
+            validator.defaultSelectedPackage(
+                in: Self.context(isEligibleForIntroOffer: { _ in false })
+            )?.identifier,
+            TestData.annualPackage.identifier
+        )
+    }
+
+    // MARK: - Reconciling a provisional selection
+
+    /// End-to-end shape of the fix: the seed happens before the render environment exists, so it picks
+    /// the trial card (an absent `can_trial` makes `can_trial = false` not match). Once the real context
+    /// is known, reconciling moves the selection to the card that's actually on screen.
+    func testReconcileMovesSelectionOffProvisionallySeededHiddenPackage() {
+        let validator = Self.canTrialValidator()
+
+        let seeded = validator.defaultSelectedPackage(in: .provisional)
+        XCTAssertEqual(seeded?.identifier, TestData.annualPackage.identifier)
+
+        let reconciled = validator.reconciledSelection(
+            current: seeded,
+            in: Self.context(customVariables: ["can_trial": .bool(false)])
+        )
+        XCTAssertEqual(reconciled?.identifier, TestData.monthlyPackage.identifier)
+    }
+
+    /// Nothing to do when the seeded package is visible: reconciling returns `nil` so the caller leaves
+    /// the selection alone.
+    func testReconcileIsANoOpWhenSelectionIsVisible() {
+        let validator = Self.canTrialValidator()
+
+        XCTAssertNil(
+            validator.reconciledSelection(
+                current: TestData.annualPackage,
+                in: Self.context(customVariables: ["can_trial": .bool(true)])
+            )
+        )
+    }
+
+    /// A deliberate tap can't be discarded, because reconciling only fires for a package that isn't
+    /// rendering, and the user can't tap a card that isn't on screen.
+    func testReconcileKeepsAUserSelectionThatIsStillVisible() {
+        let validator = Self.canTrialValidator()
+
+        XCTAssertNil(
+            validator.reconciledSelection(
+                current: TestData.monthlyPackage,
+                in: Self.context(customVariables: ["can_trial": .bool(false)])
+            )
+        )
+    }
+
+    func testReconcileReturnsNilWhenNothingIsVisible() {
+        let validator = PackageValidator()
+        validator.add(Self.makePackageInfo(
+            package: TestData.annualPackage,
+            isSelectedByDefault: true,
+            visible: true,
+            overrides: [Self.visibilityOverride(whenCanTrial: false, visible: false)]
+        ))
+
+        XCTAssertNil(
+            validator.reconciledSelection(
+                current: TestData.annualPackage,
+                in: Self.context(customVariables: ["can_trial": .bool(false)])
+            )
+        )
+    }
+
+    /// A paywall that swaps groups but reuses the same package identifier on both sides does NOT hit this
+    /// bug, and this test pins down why: selection is compared by identifier
+    /// (`PackageComponentView.packageViewState`), so a visible card carrying the authored default's
+    /// identifier satisfies the selection and renders filled even though the authored card is hidden.
+    ///
+    /// This is why the customer's `family_plus_paywall2` was unaffected while `family_plus_paywall` broke,
+    /// and it's the trap to avoid when authoring a fixture for this bug: the two groups need *distinct*
+    /// package identifiers (the customer's were `family_annual` vs `family_annual_non-trial`).
+    ///
+    /// `weeklyPackage` stands in for `$rc_lifetime`, which `TestData` doesn't have. It's hidden in the
+    /// `can_trial=false` case either way.
+    func testDuplicatePackageIdentifierAcrossGroupsMasksAHiddenDefault() {
+        let validator = PackageValidator()
+
+        // Trial group: both hidden when can_trial=false.
+        validator.add(Self.makePackageInfo(
+            package: TestData.annualPackage,
+            isSelectedByDefault: true,
+            visible: true,
+            overrides: [Self.visibilityOverride(whenCanTrial: false, visible: false)]
+        ))
+        validator.add(Self.makePackageInfo(
+            package: TestData.weeklyPackage,
+            isSelectedByDefault: false,
+            visible: true,
+            overrides: [Self.visibilityOverride(whenCanTrial: false, visible: false)]
+        ))
+        // Non-trial group: shown when can_trial=false. Note the second card reuses annualPackage.
+        for package in [TestData.monthlyPackage, TestData.annualPackage] {
+            validator.add(Self.makePackageInfo(
+                package: package,
+                isSelectedByDefault: false,
+                visible: true,
+                overrides: [
+                    .init(
+                        extendedConditions: [.introOfferCondition(operator: .equals, value: true)],
+                        properties: .init(visible: false)
+                    ),
+                    Self.visibilityOverride(whenCanTrial: true, visible: false),
+                    Self.visibilityOverride(whenCanTrial: false, visible: true)
+                ]
+            ))
+        }
+
+        // Intro-eligible as a fresh test-store user is: the later can_trial override still wins.
+        let context = Self.context(
+            customVariables: ["can_trial": .bool(false)],
+            isEligibleForIntroOffer: { _ in true }
+        )
+
+        // Resolved from scratch the fallback would take the first visible card in document order...
+        XCTAssertEqual(
+            validator.defaultSelectedPackage(in: context)?.identifier,
+            TestData.monthlyPackage.identifier
+        )
+
+        // ...but the seeded selection is `$rc_annual`, and a visible card still carries that identifier,
+        // so there is nothing to reconcile and the selection stays put. No bug to observe here.
+        let seeded = validator.defaultSelectedPackage(in: .provisional)
+        XCTAssertEqual(seeded?.identifier, TestData.annualPackage.identifier)
+        XCTAssertNil(validator.reconciledSelection(current: seeded, in: context))
+    }
+
+    /// The fixture shape that does reproduce the bug: the group shown when `can_trial=false` shares no
+    /// package identifier with the authored default, so the seeded selection has nothing visible backing
+    /// it and must be moved. This is what `default_package_hidden_by_visibility_rule.yaml` exercises.
+    func testDistinctPackageIdentifiersAcrossGroupsReproduceTheBug() {
+        let validator = PackageValidator()
+
+        validator.add(Self.makePackageInfo(
+            package: TestData.annualPackage,
+            isSelectedByDefault: true,
+            visible: true,
+            overrides: [Self.visibilityOverride(whenCanTrial: false, visible: false)]
+        ))
+        validator.add(Self.makePackageInfo(
+            package: TestData.weeklyPackage,
+            isSelectedByDefault: false,
+            visible: true,
+            overrides: [Self.visibilityOverride(whenCanTrial: false, visible: false)]
+        ))
+        validator.add(Self.makePackageInfo(
+            package: TestData.monthlyPackage,
+            isSelectedByDefault: false,
+            visible: true,
+            overrides: [
+                .init(
+                    extendedConditions: [.introOfferCondition(operator: .equals, value: true)],
+                    properties: .init(visible: false)
+                ),
+                Self.visibilityOverride(whenCanTrial: true, visible: false),
+                Self.visibilityOverride(whenCanTrial: false, visible: true)
+            ]
+        ))
+
+        let context = Self.context(
+            customVariables: ["can_trial": .bool(false)],
+            isEligibleForIntroOffer: { _ in true }
+        )
+
+        let seeded = validator.defaultSelectedPackage(in: .provisional)
+        XCTAssertEqual(seeded?.identifier, TestData.annualPackage.identifier)
+
+        XCTAssertEqual(
+            validator.reconciledSelection(current: seeded, in: context)?.identifier,
+            TestData.monthlyPackage.identifier
+        )
+    }
+
+    func testViewModelFactoryResolvesOverrideVisibilityForDefaultSelection() throws {
         let offering = Offering(
             identifier: "default",
             serverDescription: "",
@@ -108,9 +421,10 @@ final class PackageValidatorTests: TestCase {
         _ = try factory.toViewModel(
             component: .package(
                 Self.makePackageComponent(
-                    packageID: TestData.monthlyPackage.identifier,
+                    packageID: TestData.annualPackage.identifier,
                     isSelectedByDefault: true,
-                    visible: false
+                    visible: true,
+                    overrides: [Self.visibilityOverride(whenCanTrial: false, visible: false)]
                 )
             ),
             packageValidator: packageValidator,
@@ -124,7 +438,7 @@ final class PackageValidatorTests: TestCase {
         _ = try factory.toViewModel(
             component: .package(
                 Self.makePackageComponent(
-                    packageID: TestData.annualPackage.identifier,
+                    packageID: TestData.monthlyPackage.identifier,
                     isSelectedByDefault: false,
                     visible: nil
                 )
@@ -138,8 +452,10 @@ final class PackageValidatorTests: TestCase {
         )
 
         XCTAssertEqual(
-            packageValidator.defaultSelectedPackage?.identifier,
-            TestData.annualPackage.identifier
+            packageValidator.defaultSelectedPackage(
+                in: Self.context(customVariables: ["can_trial": .bool(false)])
+            )?.identifier,
+            TestData.monthlyPackage.identifier
         )
     }
 
@@ -148,10 +464,85 @@ final class PackageValidatorTests: TestCase {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private extension PackageValidatorTests {
 
+    /// The customer's shape, reduced to two packages: an annual card selected by default and hidden when
+    /// `can_trial = false`, and a monthly card that only shows in that case.
+    static func canTrialValidator() -> PackageValidator {
+        let validator = PackageValidator()
+
+        validator.add(Self.makePackageInfo(
+            package: TestData.annualPackage,
+            isSelectedByDefault: true,
+            visible: true,
+            overrides: [Self.visibilityOverride(whenCanTrial: false, visible: false)]
+        ))
+        validator.add(Self.makePackageInfo(
+            package: TestData.monthlyPackage,
+            isSelectedByDefault: false,
+            visible: true,
+            overrides: [
+                Self.visibilityOverride(whenCanTrial: true, visible: false),
+                Self.visibilityOverride(whenCanTrial: false, visible: true)
+            ]
+        ))
+
+        return validator
+    }
+
+    static func context(
+        customVariables: [String: CustomVariableValue] = [:],
+        isEligibleForIntroOffer: @escaping (Package) -> Bool = { _ in false },
+        isEligibleForPromoOffer: @escaping (Package) -> Bool = { _ in false }
+    ) -> PackageSelectionContext {
+        return PackageSelectionContext(
+            condition: .compact,
+            customVariables: customVariables,
+            isEligibleForIntroOffer: isEligibleForIntroOffer,
+            isEligibleForPromoOffer: isEligibleForPromoOffer
+        )
+    }
+
+    static func visibilityOverride(
+        whenCanTrial canTrial: Bool,
+        visible: Bool
+    ) -> PaywallComponent.ComponentOverride<PaywallComponent.PartialPackageComponent> {
+        return .init(
+            extendedConditions: [
+                .variable(operator: .equals, variable: "can_trial", value: .bool(canTrial))
+            ],
+            properties: .init(visible: visible)
+        )
+    }
+
+    static func makePackageInfo(
+        package: Package,
+        isSelectedByDefault: Bool,
+        visible: Bool?,
+        overrides: [PaywallComponent.ComponentOverride<PaywallComponent.PartialPackageComponent>]? = nil
+    ) -> PackageValidator.PackageInfo {
+        let component = Self.makePackageComponent(
+            packageID: package.identifier,
+            isSelectedByDefault: isSelectedByDefault,
+            visible: visible,
+            overrides: overrides
+        )
+
+        return PackageValidator.PackageInfo(
+            package: package,
+            isSelectedByDefault: isSelectedByDefault,
+            visibilityResolver: PackageVisibilityResolver(
+                component: component,
+                uiConfigProvider: UIConfigProvider(uiConfig: PreviewUIConfig.make()),
+                discardRules: false
+            ),
+            promotionalOfferProductCode: nil
+        )
+    }
+
     static func makePackageComponent(
         packageID: String,
         isSelectedByDefault: Bool,
-        visible: Bool?
+        visible: Bool?,
+        overrides: [PaywallComponent.ComponentOverride<PaywallComponent.PartialPackageComponent>]? = nil
     ) -> PaywallComponent.PackageComponent {
         return PaywallComponent.PackageComponent(
             packageID: packageID,
@@ -167,7 +558,8 @@ private extension PackageValidatorTests {
                         )
                     )
                 ]
-            )
+            ),
+            overrides: overrides
         )
     }
 


### PR DESCRIPTION
### Motivation

A customer did some tricks hiding the default package. This leads to a screen with no package selected. 
The default package is annual. As you can see in the video, the left side selects nothing and the right side (with the fix) defaults to monthly

See:
https://github.com/user-attachments/assets/03d2a611-259e-448e-841b-e357aba4e50d

Android port: RevenueCat/purchases-android#3915

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: this PR
- Branch: `facu/paywall-default-selection-visibility-rule`
- Author / human owner: facumenzella
- Agent(s): Claude Code (Opus 5, 1M context)
- Session source: current conversation
- Generated: 2026-08-06
- Context document version: 1

## Goal

Diagnose and fix a customer-reported bug where hiding and showing package cards via conditional visibility leaves no package selected on iOS, then add a Maestro regression test.

## Initial Prompt

Investigate a pasted DSE bug report for project 305fdff6 (쑥쑥찰칵 / Jejememe, ~$81,750 trailing 30d MTR): a `can_trial` custom variable swaps trial and non-trial package cards via conditional visibility; both annual cards are marked "Selected by default" but only one is ever visible; with `can_trial=false` the visible card renders with an empty radio button. Reproduced on a range of SDK versions including latest.

## Important Follow-up Prompts

- "explain the clean fix" — asked for the design before any implementation.
- "The thing is, there's only one default package. Their claim is not true. So SDKs need to pick another one deterministically when the default is hidden." — **this reframed the whole design.** Dropped the earlier "honor multiple defaults / re-resolve everything" plan in favor of a deterministic ordered fallback, which is materially smaller.
- "can you guarantee this will be true for iOS and Android? If true, let's work on iOS first." — forced verifying the walk order on both platforms rather than assuming it.
- "I also want a maestro test that validates this is working. Can you copy <builder URL> to <project>" — added the E2E scope and the fixture.
- "just published the workflow, write the maestro test"

## Agent Contribution

- Root-caused the bug to `PackageValidator.defaultSelectedPackage` filtering on `isStaticallyVisible` (`ViewModelFactory.swift`), proving it against the live paywall JSON pulled via `mafdet` (workflow `wfbf3687120a274171`, screen `pw7c6c183cfede42ea`).
- Established the purchase-path consequence by inspection: the tab default propagates to the parent `packageContext` (`TabsComponentView`) and `PurchaseButtonComponentView` buys `packageContext.package` with no visibility guard.
- Verified the iOS/Android ordering divergence (post-order vs pre-order) rather than asserting agreement.
- Implemented `PackageVisibilityResolver`, `PackageSelectionContext`, `defaultSelectedPackage(in:)`, `reconciledSelection(current:in:)`, and the reconcile wiring; moved package recording to pre-order.
- Wrote 15 unit tests including a genuine RED→GREEN, and the two Maestro flows plus the `rc-maestro` app flow.
- Found that the published Maestro fixture does not reproduce the bug (see Risks).

## Human Decisions

- Decision: there is exactly one default package; do not support multiple defaults. Superseded the agent's initial plan.
- Decision: iOS first; Android port deferred.
- Re-authored and published the Maestro fixture in the dashboard (agent is read-only on dashboard config).
- Rejected (implicitly, by the reframing): the agent's original two-part "resolve everything + PackageContext ownership flag" design.

## Key Implementation Decisions

- Decision: share one visibility question between renderer and selection via `PackageVisibilityResolver`.
  - Rationale: duplicating the override pipeline would drift. The resolver is built from the component only, so it has no stack dependency.
  - Rejected: re-deriving visibility inside `PackageValidator` from raw overrides.
- Decision: resolve with `state: .default, selectedPackageId: nil`.
  - Rationale: honest input (nothing is selected yet) and makes resolution independent of its own output, so a paywall with `selected` / `selected_package` visibility rules cannot oscillate.
- Decision: record packages pre-order.
  - Rationale: matches Android `StyleFactory.kt` `recordPackage`, so "first in document order" means the same thing on both platforms. Safe because no `PackageInfo` field depends on the stack.
- Decision: reconcile only when the selected package is not visible.
  - Rationale: cannot discard a deliberate tap, since the user can't tap a card that isn't on screen. This removed the need for a "user owns this selection" flag on `PackageContext`.
- Decision: trigger the reconcile on `\.isPaywallLoading`.
  - Rationale: goes false once *both* intro and promo eligibility resolve. An earlier draft watched only `introOfferEligibilityContext`, which silently left `promo_offer_condition` broken.
- Decision: skip the page-level reconcile when `containsTabScopedPackages`.
  - Rationale: `ViewModelFactory` merges every tab's packages into the page validator, so resolving there could select a package from a tab the user isn't on. Selection is tab-local.
- Decision: fallback picks by document order, no smarter tiebreak.
  - Rejected: "prefer the same package type as the hidden default" — agreed here, but one more thing for iOS and Android to disagree about.

## Files / Symbols Touched

- `RevenueCatUI/Templates/V2/Components/Packages/Package/PackageVisibilityResolver.swift`
  - Why: new shared visibility resolution
  - Symbols: `PackageVisibilityResolver.visible(...)`
  - Review relevance: must stay behaviourally identical to what the renderer asks
- `RevenueCatUI/Templates/V2/ViewModelHelpers/PackageValidator.swift`
  - Why: the fix
  - Symbols: `PackageSelectionContext`, `defaultSelectedPackage(in:)`, `reconciledSelection(current:in:)`, `visiblePackageInfos(in:)`, `addTabScoped`, `containsTabScopedPackages`
  - Review relevance: the three-step rule and the pinned `state`/`selectedPackageId`
- `RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift`
  - Why: pre-order recording; removed `isStaticallyVisible` and its now-wrong comment
  - Review relevance: confirm nothing between the old and new record position depended on the stack
- `RevenueCatUI/Templates/V2/PaywallsV2View.swift`
  - Why: resolution moved into `LoadedPaywallsV2View` where the environment exists; reconcile
  - Symbols: `LoadedPaywallsV2View.packageSelectionContext`, `defaultPackage`, `reconcileSelection()`
  - Review relevance: the tab guard, and that `init` seeding is provisional by design
- `RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentView.swift`, `TabsComponentViewModel.swift`
  - Why: tab-local resolution and reconcile; `TabViewModel` holds the validator instead of a pre-resolved package
  - Review relevance: the customer's packages live in tabs, so this is the path that actually fixes their paywall
- `RevenueCatUI/Templates/V2/WorkflowPaywallView.swift`
  - Why: `WorkflowHeaderOverlayPageView` needed a real context
- `RevenueCatUI/Data/Strings.swift`
  - Symbols: `paywall_default_package_not_visible(defaultPackage:selectedPackage:)`
- `Tests/RevenueCatUITests/PaywallsV2/PackageValidatorTests.swift` — 15 tests
- `Examples/rc-maestro/rc-maestro/Sources/rc-maestro/e2e-test-flows/open-default-package-visibility.swift`, `RcMaestroApp.swift`
- `Examples/rc-maestro/maestro/workflows/default_package_hidden_by_visibility_rule.yaml`, `default_package_visible_stays_selected.yaml`
- `RevenueCat.xcodeproj/project.pbxproj` — 4 entries for the new source file

## Dependencies / Config / Migrations

- No package or dependency changes. No public API change (all touched types are internal or `@_spi(Internal)`).
- New `e2e_test_flow` value `open_default_package_visibility` and a new `can_trial` launch argument.
- Maestro fixture: project `6627e5bc`, workflow `wff08801936be34317`, offering `[default pkg + visibility]`.

## Validation

- Commands run:
  - `swift test --filter PackageValidatorTests` (before the rule landed): `Executed 9 tests, with 5 failures` — RED. `testDefaultSelectedPackageSkipsPackageHiddenByVariableRule` returned `$rc_annual`, the hidden trial card.
  - `swift test --filter PackageValidatorTests` (after): `Executed 15 tests, with 0 failures` — GREEN.
  - `swift test --filter RevenueCatUITests`: `Executed 1142 tests, with 34 failures`. Same 34 before and after the change; all are legacy-V1-on-macOS and missing-macOS-snapshot failures plus one unrelated error-string drift.
  - `swift build --target RevenueCatUI`: no errors, re-run after the rebase onto `origin/main`.
  - `xcodebuild build -workspace Maestro.xcworkspace -scheme Maestro -destination 'generic/platform=iOS Simulator'`: `** BUILD SUCCEEDED **`
  - `swiftlint`: no findings on touched files.
  - `plutil -lint RevenueCat.xcodeproj/project.pbxproj`: OK
- Manual verification:
  - Not run. No simulator or device run of the customer paywall.
- CI:
  - Not captured at time of writing.

## Validation Gaps

- The Maestro flows were **not executed**. They need a simulator, test-store config, and an API key, and they would pass vacuously against the current fixture (see Risks).
- The reconcile wiring itself (SwiftUI `onAppear` / `onChangeOf` ordering, tab propagation) is covered only by unit tests on the pure functions, not by a view-level test.
- Whether the two annual packages on the customer's offering resolve to different store products is unverified; `mafdet` does not expose the package-to-product mapping. This affects how bad the mis-purchase is, not whether it happens.
- Android is untouched.

## Review Focus

- `PackageValidator.visiblePackageInfos(in:)` pins `state: .default, selectedPackageId: nil`. Is that right for a paywall whose package visibility is keyed on `selected_package`?
- The page-level reconcile is skipped whenever any tab contributed packages. Is there a mixed layout (packages both inside and outside tabs) where the non-tab packages then never get reconciled?
- `PackageSelectionContext.provisional` deliberately resolves "wrong" at `init`. Confirm every path that seeds a selection is followed by a reconcile.
- Pre-order recording changes `packageValidator.packages` ordering for a package nested inside another package's stack. Is anything else order-sensitive there?
- `onPurchaseInitiated` in the Maestro app hops to `@MainActor` via `Task` before touching `@State`. Is that the house pattern?

## Risks / Reviewer Notes

- Risk: the published Maestro fixture does not reproduce the bug.
  - Evidence: its non-trial group reuses `$rc_annual`, the same identifier as the authored default. Selection compares by identifier (`PackageComponentView.packageViewState`), so the visible non-trial annual card satisfies the selection and renders filled. Pre-fix and post-fix behave identically. Pinned by `testDuplicatePackageIdentifierAcrossGroupsMasksAHiddenDefault`.
  - Mitigation: delete the duplicate `$rc_annual` card so the non-trial group holds only `$rc_monthly`. `testDistinctPackageIdentifiersAcrossGroupsReproduceTheBug` covers the corrected shape. This is also why the customer's `family_plus_paywall2` is unaffected while `family_plus_paywall` breaks.
- Risk: iOS and Android can still disagree on "document order".
  - Evidence: iOS is now pre-order, matching `StyleFactory.kt` `recordPackage`. But nothing enforces it, and Android (`PaywallState.kt`) has no visibility filter at all yet.
  - Mitigation: write the rule into sdk-specs and port to Android.
- Risk: a brief frame where the provisional selection is wrong before the reconcile runs.
  - Evidence: not measured. The reconcile is in `onAppear`, which runs before the user can interact.
  - Mitigation: none beyond that; worth a look on device.
- Risk: reconcile could fight a user tap.
  - Evidence: it only fires when the selected package isn't visible, and the user cannot tap an invisible card. Covered by `testReconcileKeepsAUserSelectionThatIsStillVisible`.

## Non-goals / Out of Scope

- Android port.
- Dashboard-side guard. The builder cannot enforce this for `variable_condition`, whose value is only known at runtime.
- Any change to how the purchase button picks its package.
- Supporting more than one default-selected package.

## Omitted Context

- Raw transcript, unrelated exploration, sensitive details, repetitive attempts, and chain-of-thought-style content were omitted. Customer identifiers are limited to what the ticket already carries.

</details>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default package selection and purchase targeting across Paywalls V2 (including tabbed layouts); behavior is well-tested but eligibility/async reconciliation and tab-scoped edge cases deserve review.
> 
> **Overview**
> Fixes Paywalls V2 leaving the **authored default package selected** when conditional visibility hides that card—so no option looked selected and purchase could target a package not on screen.
> 
> **Default selection** now uses the same override pipeline as rendering via **`PackageVisibilityResolver`** and **`PackageSelectionContext`** (custom variables, intro/promo eligibility, screen condition). **`PackageValidator`** picks the authored default if visible, otherwise the **first visible package in document order**, and **`reconciledSelection`** only moves selection when the current package is not rendering.
> 
> **Reconciliation** runs on paywall appear and when **`isPaywallLoading`** clears (after eligibility resolves), in **`LoadedPaywallsV2View`** for non-tab paywalls and in **`LoadedTabsComponentView`** per tab. Initial seeding in view `init` stays **provisional** until the real environment exists. Package recording in **`ViewModelFactory`** is moved **before** the stack walk so document order matches Android.
> 
> Adds a **`paywall_default_package_not_visible`** warning, expanded **`PackageValidatorTests`**, Maestro workflows plus **`open_default_package_visibility`** in rc-maestro (purchase initiated reports selected package).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0c2454fe40bf4d21b9e0c71c070b4e87e2645f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->