### PR TITLE
fix(checkpoints): Refine unknown checkpoint and workflow resolution

### DIFF
--- a/Examples/CheckpointTester/CheckpointTester/Sources/ContentView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/ContentView.swift
@@ -83,7 +83,7 @@ struct ContentView: View {
                     }
 
                     DemoButton(
-                        title: "No match",
+                        title: "Unknown checkpoint",
                         subtitle: "An unknown identifier resolves without presenting UI.",
                         systemImage: "arrow.forward"
                     ) {

--- a/RevenueCatUI/Checkpoints/Checkpoints.swift
+++ b/RevenueCatUI/Checkpoints/Checkpoints.swift
@@ -88,6 +88,8 @@ import Foundation
     public static let configurationUnavailable = CheckpointNoActionReason(value: "CONFIGURATION_UNAVAILABLE")
     /// Checkpoints are disabled.
     public static let disabled = CheckpointNoActionReason(value: "DISABLED")
+    /// The checkpoint identifier is not configured.
+    public static let unknownCheckpoint = CheckpointNoActionReason(value: "UNKNOWN_CHECKPOINT")
 
     init(value: String) {
         self.value = value

--- a/RevenueCatUI/Checkpoints/CheckpointsManager.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointsManager.swift
@@ -109,6 +109,8 @@ private extension CheckpointResolutionReason {
             return .configurationUnavailable
         case .disabled:
             return .disabled
+        case .unknownCheckpoint:
+            return .unknownCheckpoint
         }
     }
 

--- a/Sources/Checkpoints/CheckpointWorkflowResolver.swift
+++ b/Sources/Checkpoints/CheckpointWorkflowResolver.swift
@@ -33,6 +33,8 @@ import Foundation
     case configurationUnavailable
     /// Checkpoints are disabled.
     case disabled
+    /// The checkpoint identifier is not configured.
+    case unknownCheckpoint
 
 }
 

--- a/Sources/Checkpoints/RandomWorkflowCheckpointResolver.swift
+++ b/Sources/Checkpoints/RandomWorkflowCheckpointResolver.swift
@@ -16,10 +16,10 @@ import Foundation
 
 /// Temporary production resolver used until checkpoint targeting configuration is available.
 /// Every checkpoint currently resolves to a randomly selected configured workflow, except two identifiers that
-/// simulate the no-match and error resolutions the future checkpoints configuration will produce.
+/// simulate the unknown-checkpoint and error resolutions the future checkpoints configuration will produce.
 final class RandomWorkflowCheckpointResolver: CheckpointWorkflowResolver {
 
-    typealias WorkflowSelector = ([String: String?]) -> (workflowID: String, offeringID: String?)?
+    typealias WorkflowSelector = ([String: String]) -> (workflowID: String, offeringID: String)?
 
     private let workflowManager: WorkflowManager
     private let offeringsProvider: () async throws -> Offerings
@@ -41,8 +41,8 @@ final class RandomWorkflowCheckpointResolver: CheckpointWorkflowResolver {
             throw ErrorUtils.configurationError(
                 message: "Simulated error: checkpoint workflow not presentable."
             )
-        case Self.simulatedNoMatchCheckpointIdentifier:
-            return .noAction(.noMatch)
+        case Self.simulatedUnknownCheckpointIdentifier:
+            return .noAction(.unknownCheckpoint)
         default:
             break
         }
@@ -60,15 +60,11 @@ final class RandomWorkflowCheckpointResolver: CheckpointWorkflowResolver {
             return .noAction(.configurationUnavailable)
         }
 
-        guard let offeringID = selectedWorkflow.offeringID else {
-            return .noAction(.configurationUnavailable)
-        }
-
         let offering: Offering
         let offerings: Offerings
         do {
             let resolvedOfferings = try await self.offeringsProvider()
-            guard let resolvedOffering = resolvedOfferings.offering(identifier: offeringID) else {
+            guard let resolvedOffering = resolvedOfferings.offering(identifier: selectedWorkflow.offeringID) else {
                 return .noAction(.configurationUnavailable)
             }
             offering = resolvedOffering
@@ -88,15 +84,13 @@ final class RandomWorkflowCheckpointResolver: CheckpointWorkflowResolver {
         )
     }
 
-    private static let simulatedNoMatchCheckpointIdentifier = "unknown_checkpoint"
+    private static let simulatedUnknownCheckpointIdentifier = "unknown_checkpoint"
     private static let simulatedErrorCheckpointIdentifier = "error_checkpoint"
 
     static func chooseRandomWorkflow(
-        from workflows: [String: String?]
-    ) -> (workflowID: String, offeringID: String?)? {
-        return workflows.compactMap { workflowID, offeringID in
-            return offeringID.map { (workflowID, $0) }
-        }.randomElement()
+        from workflows: [String: String]
+    ) -> (workflowID: String, offeringID: String)? {
+        return workflows.randomElement().map { ($0.key, $0.value) }
     }
 
 }

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -11,7 +11,7 @@ import Foundation
 
 protocol WorkflowsConfigProviderType {
 
-    func offeringIdByWorkflowId() async -> [String: String?]
+    func offeringIdByWorkflowId() async -> [String: String]
     func workflowId(forOfferingId offeringId: String) async -> String?
     func getWorkflow(workflowId: String) async -> Result<WorkflowDataResult, WorkflowResolutionError>
     func decodeCachedWorkflowForAssetPrewarming(
@@ -74,16 +74,13 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         self.workflowDecoder = workflowDecoder
     }
 
-    /// Returns every workflow and the offering identifier from its topic metadata, when present.
-    func offeringIdByWorkflowId() async -> [String: String?] {
+    /// Returns workflows that contain an offering identifier in their topic metadata.
+    func offeringIdByWorkflowId() async -> [String: String] {
         guard let topic = await self.manager.topic(.workflows) else { return [:] }
 
-        return Dictionary(uniqueKeysWithValues: topic.map { workflowID, item in
-            let offeringID: String?
-            if case let .string(value)? = item.content[Self.offeringIdentifierKey] {
-                offeringID = value
-            } else {
-                offeringID = nil
+        return Dictionary(uniqueKeysWithValues: topic.compactMap { workflowID, item in
+            guard case let .string(offeringID)? = item.content[Self.offeringIdentifierKey] else {
+                return nil
             }
             return (workflowID, offeringID)
         })

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -74,7 +74,7 @@ class WorkflowManager: WorkflowAssetPrewarmingType {
         }
     }
 
-    func offeringIdByWorkflowId() async -> [String: String?] {
+    func offeringIdByWorkflowId() async -> [String: String] {
         return await self.workflowsConfigProvider.offeringIdByWorkflowId()
     }
 

--- a/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
+++ b/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
@@ -76,4 +76,5 @@ func checkCheckpointAPI(_ purchases: Purchases) {
     let _: CheckpointNoActionReason = .frequencyCapped
     let _: CheckpointNoActionReason = .configurationUnavailable
     let _: CheckpointNoActionReason = .disabled
+    let _: CheckpointNoActionReason = .unknownCheckpoint
 }

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/CheckpointAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/CheckpointAPI.swift
@@ -36,9 +36,10 @@ func checkCheckpointResolutionReasonAPI(_ reason: CheckpointResolutionReason) {
     let _: CheckpointResolutionReason = .noMatch
     let _: CheckpointResolutionReason = .configurationUnavailable
     let _: CheckpointResolutionReason = .disabled
+    let _: CheckpointResolutionReason = .unknownCheckpoint
 
     switch reason {
-    case .noMatch, .configurationUnavailable, .disabled:
+    case .noMatch, .configurationUnavailable, .disabled, .unknownCheckpoint:
         break
     @unknown default:
         break

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
@@ -20,7 +20,7 @@ import XCTest
 final class CheckpointsManagerTests: TestCase {
 
     func testNoActionResultAndListenerEventsAreBuiltInRevenueCatUI() async throws {
-        let manager = CheckpointsManager { _, _ in .noAction(.noMatch) }
+        let manager = CheckpointsManager { _, _ in .noAction(.unknownCheckpoint) }
         let listener = ListenerRecorder()
         manager.listener = listener
 
@@ -32,7 +32,7 @@ final class CheckpointsManagerTests: TestCase {
         guard let noAction = result as? CheckpointNoActionResult else {
             return XCTFail("Expected a no-action result")
         }
-        XCTAssertEqual(noAction.reason, .noMatch)
+        XCTAssertEqual(noAction.reason, .unknownCheckpoint)
         XCTAssertEqual(noAction.checkpoint.identifier, "unknown_checkpoint")
         XCTAssertEqual(noAction.checkpoint.params.customProperties["name"], "Rick")
         XCTAssertEqual(

--- a/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
@@ -64,10 +64,10 @@ final class RandomWorkflowCheckpointResolverTests: TestCase {
         }
     }
 
-    func testSimulatedUnknownCheckpointResolvesNoMatch() async throws {
+    func testSimulatedUnknownCheckpointResolvesUnknownCheckpoint() async throws {
         let resolution = try await self.resolve(identifier: "unknown_checkpoint")
 
-        XCTAssertEqual(Self.noActionReason(resolution), .noMatch)
+        XCTAssertEqual(Self.noActionReason(resolution), .unknownCheckpoint)
     }
 
     func testDisabledResolverResolvesDisabled() async throws {
@@ -84,11 +84,8 @@ final class RandomWorkflowCheckpointResolverTests: TestCase {
         XCTAssertEqual(Self.noActionReason(resolution), .configurationUnavailable)
     }
 
-    func testDefaultChooserOnlySelectsWorkflowsWithOfferingMetadata() {
-        let workflows = [
-            "eligible": Optional("offering"),
-            "missing-offering": nil
-        ]
+    func testDefaultChooserSelectsAWorkflowAndItsOfferingMetadata() {
+        let workflows = ["eligible": "offering"]
 
         for _ in 0..<10 {
             let selected = RandomWorkflowCheckpointResolver.chooseRandomWorkflow(from: workflows)
@@ -143,7 +140,7 @@ final class RandomWorkflowCheckpointResolverTests: TestCase {
     }
 
     func testCheckpointResolvesConfigurationUnavailableWithoutFetchingOfferingsWhenMetadataHasNone() async throws {
-        self.provider.stubbedOfferingIdByWorkflowId = [self.workflowID: nil]
+        self.provider.stubbedOfferingIdByWorkflowId = [:]
         let offeringsFetchCount = Atomic<Int>(0)
         let resolver = self.makeResolver(offeringsProvider: {
             offeringsFetchCount.modify { $0 += 1 }
@@ -169,8 +166,8 @@ final class RandomWorkflowCheckpointResolverTests: TestCase {
             workflowManager: self.workflowManager,
             offeringsProvider: offeringsProvider ?? { self.offerings },
             workflowSelector: { workflows in
-                guard workflows.keys.contains(self.workflowID) else { return nil }
-                return (self.workflowID, workflows[self.workflowID] ?? nil)
+                guard let offeringID = workflows[self.workflowID] else { return nil }
+                return (self.workflowID, offeringID)
             }
         )
     }

--- a/Tests/UnitTests/Mocks/MockWorkflowsConfigProvider.swift
+++ b/Tests/UnitTests/Mocks/MockWorkflowsConfigProvider.swift
@@ -16,10 +16,10 @@ import Foundation
 
 final class MockWorkflowsConfigProvider: WorkflowsConfigProviderType, @unchecked Sendable {
 
-    var stubbedOfferingIdByWorkflowId: [String: String?] = [:]
+    var stubbedOfferingIdByWorkflowId: [String: String] = [:]
     private(set) var invokedOfferingIdByWorkflowIdCount = 0
 
-    func offeringIdByWorkflowId() async -> [String: String?] {
+    func offeringIdByWorkflowId() async -> [String: String] {
         self.invokedOfferingIdByWorkflowIdCount += 1
         return self.stubbedOfferingIdByWorkflowId
     }

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -60,10 +60,7 @@ class WorkflowsConfigProviderTests: TestCase {
 
         let workflows = await self.provider.offeringIdByWorkflowId()
 
-        expect(Set(workflows.keys)) == Set(["workflow-with-offering", "workflow-without-offering"])
-        expect(workflows["workflow-with-offering"] ?? nil) == "premium_annual"
-        expect(workflows.keys.contains("workflow-without-offering")) == true
-        expect(workflows["workflow-without-offering"] ?? nil).to(beNil())
+        expect(workflows) == ["workflow-with-offering": "premium_annual"]
     }
 
     func testResolvesAWorkflowAlreadyCommittedToTheWorkflowsTopic() async throws {

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -41,7 +41,7 @@ class WorkflowManagerTests: TestCase {
     // MARK: - getWorkflow
 
     func testOfferingIdByWorkflowIdDelegatesToProvider() async {
-        self.mockProvider.stubbedOfferingIdByWorkflowId = ["wf_1": "offering_1", "wf_2": nil]
+        self.mockProvider.stubbedOfferingIdByWorkflowId = ["wf_1": "offering_1"]
 
         let result = await self.manager.offeringIdByWorkflowId()
 


### PR DESCRIPTION
## Description
- Adds a distinct `.unknownCheckpoint` no action reason, making it clear that there is no checkpoint configured for this identifier, rather than just not matching a checkpoint
- Changes the workflow-to-offering metadata from `[String: String?]` to `[String: String]`, since we now just omit workflows without an offering from the dictionary, which is more clear

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> SPI checkpoint enums and workflow metadata types change behavior for unknown ids and workflows missing offering metadata; callers depending on `.noMatch` or optional offering entries need to adapt.
> 
> **Overview**
> Checkpoint resolution now exposes a dedicated **unknown checkpoint** no-action reason (`UNKNOWN_CHECKPOINT`) instead of treating unconfigured identifiers like a targeting **no match**. The temporary `RandomWorkflowCheckpointResolver` maps the demo `unknown_checkpoint` id to that reason, and RevenueCatUI maps it through `CheckpointsManager` to `CheckpointNoActionResult`.
> 
> Workflow-to-offering metadata is narrowed from `[String: String?]` to `[String: String]`: `WorkflowsConfigProvider.offeringIdByWorkflowId()` only includes workflows whose topic content has an `offeringIdentifier`, so entries without offering metadata are omitted rather than stored with a nil offering. Downstream checkpoint resolution and random workflow selection assume a non-optional offering id when a workflow is chosen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 865164a7976f98d74a236dc905912e0c32a1eeb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->