### PR TITLE
fix(remote-config): Fix misleading ui_config warnings for projects without paywalls

### DIFF
--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -28,6 +28,11 @@ protocol RemoteConfigManagerType: AnyObject {
     /// reading again. Returns `nil` when the endpoint is disabled or the topic is still unavailable after refresh.
     func topic(_ topic: RemoteConfigTopic) async -> RemoteConfiguration.ConfigTopic?
 
+    /// Waits for the refresh currently in flight, if any, then returns the latest committed topic.
+    /// Unlike `topic(_:)`, this never starts a refresh.
+    func committedTopicAfterInFlightRefresh(_ topic: RemoteConfigTopic) async
+    -> RemoteConfiguration.ConfigTopic?
+
     /// Returns the blob payload bytes for an item referenced by `blob_ref`.
     ///
     /// Inline item metadata is exposed through `topic(_:)`; items without `blob_ref` return `nil`. Missing items
@@ -90,6 +95,12 @@ extension RemoteConfigManagerType {
     func topicCacheSnapshot(_ topic: RemoteConfigTopic) async
     -> GenerationGuardedCacheSnapshot<RemoteConfiguration.ConfigTopic>? {
         guard let configTopic = await self.topic(topic) else { return nil }
+        return .init(generation: self.configGeneration, key: configTopic)
+    }
+
+    func committedTopicCacheSnapshotAfterInFlightRefresh(_ topic: RemoteConfigTopic) async
+    -> GenerationGuardedCacheSnapshot<RemoteConfiguration.ConfigTopic>? {
+        guard let configTopic = await self.committedTopicAfterInFlightRefresh(topic) else { return nil }
         return .init(generation: self.configGeneration, key: configTopic)
     }
 
@@ -209,6 +220,11 @@ final class NoOpRemoteConfigManager: RemoteConfigManagerType {
     func refreshRemoteConfigIfStale(fetchContext: RemoteConfigFetchContext, isAppBackgrounded: Bool) {}
 
     func topic(_ topic: RemoteConfigTopic) async -> RemoteConfiguration.ConfigTopic? {
+        return nil
+    }
+
+    func committedTopicAfterInFlightRefresh(_ topic: RemoteConfigTopic) async
+    -> RemoteConfiguration.ConfigTopic? {
         return nil
     }
 
@@ -384,6 +400,14 @@ final class RemoteConfigManager: RemoteConfigManagerType {
 
     func topic(_ topic: RemoteConfigTopic) async -> RemoteConfiguration.ConfigTopic? {
         return await self.readCommittedState(refreshIfMissing: true) {
+            await self.committedTopic(topic)
+        }
+    }
+
+    func committedTopicAfterInFlightRefresh(_ topic: RemoteConfigTopic) async
+    -> RemoteConfiguration.ConfigTopic? {
+        _ = await self.awaitInFlightRefresh()
+        return await self.readCommittedState {
             await self.committedTopic(topic)
         }
     }

--- a/Sources/Networking/UiConfigProvider.swift
+++ b/Sources/Networking/UiConfigProvider.swift
@@ -23,7 +23,7 @@ final class UiConfigProvider {
     /// Assembles a ``UIConfig`` from the `ui_config` topic's parts. Returns `nil` when any part is unavailable
     /// or fails to decode, so callers never render with a partially assembled configuration.
     func getUiConfig() async -> UIConfig? {
-        guard let snapshot = await self.manager.topicCacheSnapshot(.uiConfig) else {
+        guard let snapshot = await self.topicSnapshotWithUiConfigParts() else {
             return nil
         }
 
@@ -79,7 +79,7 @@ final class UiConfigProvider {
 #else
     // Paywalls V2 (and therefore workflows) aren't supported on tvOS, where `UIConfig` carries no fields.
     func getUiConfig() async -> UIConfig? {
-        guard let snapshot = await self.manager.topicCacheSnapshot(.uiConfig) else {
+        guard let snapshot = await self.topicSnapshotWithUiConfigParts() else {
             return nil
         }
 
@@ -113,6 +113,17 @@ final class UiConfigProvider {
         return self.cache.value(currentGeneration: currentGeneration)
     }
 #endif
+
+    private func topicSnapshotWithUiConfigParts() async
+    -> GenerationGuardedCacheSnapshot<RemoteConfiguration.ConfigTopic>? {
+        guard var snapshot = await self.manager.topicCacheSnapshot(.uiConfig) else { return nil }
+        guard !Self.itemKeys.contains(where: snapshot.key.keys.contains) else { return snapshot }
+
+        guard let refreshedSnapshot = await self.manager
+            .committedTopicCacheSnapshotAfterInFlightRefresh(.uiConfig) else { return nil }
+        snapshot = refreshedSnapshot
+        return Self.itemKeys.contains(where: snapshot.key.keys.contains) ? snapshot : nil
+    }
 
     private static let appKey = "app"
     private static let localizationsKey = "localizations"

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
@@ -616,6 +616,51 @@ final class RemoteConfigIntegrationTests: TestCase {
         expect(requestedURLs).to(beEmpty())
     }
 
+    func testUiConfigProviderUsesPartsCommittedByRefreshWhenCachedTopicIsEmpty() async throws {
+        let app = #"{"colors": {}, "fonts": {}}"#.asData
+        let localizations = #"{"en_US": {"day": "Day"}}"#.asData
+        let variableConfig = #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#.asData
+        let customVariables = #"{}"#.asData
+        let blobs = [app, localizations, variableConfig, customVariables]
+        let container = try Self.containerData(
+            topics: .init(entries: [
+                RemoteConfigTopic.uiConfig.wireName: [
+                    "app": .init(blobRef: RCContainerTestData.blobRef(for: app)),
+                    "localizations": .init(blobRef: RCContainerTestData.blobRef(for: localizations)),
+                    "variable_config": .init(blobRef: RCContainerTestData.blobRef(for: variableConfig)),
+                    "custom_variables": .init(blobRef: RCContainerTestData.blobRef(for: customVariables))
+                ]
+            ]),
+            contentElements: blobs.map { ($0, .none) }
+        )
+        self.diskCache.write(PersistedRemoteConfiguration(
+            manifest: "v1.1710000000.ui_config:etag0",
+            activeTopics: [RemoteConfigTopic.uiConfig.wireName],
+            topics: .init(entries: [RemoteConfigTopic.uiConfig.wireName: [:]])
+        ))
+        self.mockRemoteConfigResponse(body: container, delay: .milliseconds(200))
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
+        await self.waitForRemoteConfigRequestCount(1)
+
+        let uiConfig = await UiConfigProvider(manager: self.manager).getUiConfig()
+
+        expect(uiConfig).toNot(beNil())
+        expect(self.remoteConfigRequestCount) == 1
+        self.logger.verifyMessageWasNotLogged(
+            Strings.remoteConfig.mergeItemsBlobDataUnavailableItems(
+                topic: .uiConfig,
+                itemKeys: ["app", "localizations", "variable_config", "custom_variables"]
+            ),
+            level: .warn,
+            allowNoMessages: true
+        )
+        self.logger.verifyMessageWasNotLogged(
+            Strings.remoteConfig.uiConfigMissingRequiredPart,
+            level: .warn,
+            allowNoMessages: true
+        )
+    }
+
     func testMalformedRawContainerResponseDoesNotPersistConfigOrBlobs() async throws {
         self.mockRemoteConfigResponse(body: #"{"not":"an rc container"}"#.asData)
 
@@ -697,7 +742,8 @@ private extension RemoteConfigIntegrationTests {
         statusCode: HTTPStatusCode = .success,
         body: Data,
         verificationResult: VerificationResult = .verified,
-        requestDate: Date? = nil
+        requestDate: Date? = nil,
+        delay: DispatchTimeInterval = .never
     ) {
         let responseHeaders: HTTPResponse.Headers = [
             HTTPClient.ResponseHeader.requestDate.rawValue:
@@ -709,7 +755,8 @@ private extension RemoteConfigIntegrationTests {
                 statusCode: statusCode,
                 body: body,
                 responseHeaders: responseHeaders,
-                verificationResult: verificationResult
+                verificationResult: verificationResult,
+                delay: delay
             )
         )
     }

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -585,6 +585,60 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 0
     }
 
+    func testCommittedTopicAfterInFlightRefreshReturnsLatestTopic() async throws {
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.sources:etag1",
+            topics: .init(entries: ["sources": [:]])
+        )
+        self.diskCache.writeHandler = { configuration in
+            self.diskCache.stubbedRead = configuration
+            return true
+        }
+        let response = """
+        {
+          "domain": "app",
+          "manifest": "v1.1710000100.sources:etag2",
+          "active_topics": ["sources"],
+          "topics": {
+            "sources": {
+              "api": { "url": "https://api.revenuecat.com" }
+            }
+          }
+        }
+        """
+        self.manager.refreshRemoteConfig(fetchContext: .appStart, isAppBackgrounded: false)
+        let completed: Atomic<Bool> = false
+
+        let topic = Task {
+            let result = await self.manager.committedTopicAfterInFlightRefresh(.sources)
+            completed.value = true
+            return result
+        }
+        await self.waitForRemoteConfigRequestCount(1)
+        await self.yield()
+        expect(completed.value) == false
+        self.remoteConfigAPI.complete(
+            with: .success(.test(container: try Self.container(config: response)))
+        )
+
+        let refreshedTopic = await topic.value
+        expect(completed.value) == true
+        expect(refreshedTopic?["api"]?.content["url"]) == "https://api.revenuecat.com"
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 1
+    }
+
+    func testCommittedTopicAfterInFlightRefreshDoesNotStartRefresh() async {
+        self.diskCache.stubbedRead = Self.persisted(
+            manifest: "v1.1710000100.sources:etag1",
+            topics: .init(entries: ["sources": [:]])
+        )
+
+        let topic = await self.manager.committedTopicAfterInFlightRefresh(.sources)
+
+        expect(topic).to(beEmpty())
+        expect(self.remoteConfigAPI.invokedGetRemoteConfigCount) == 0
+    }
+
     func testTopicReturnsNilWhenRemoteConfigIsDisabledDuringCommittedRead() async {
         let item = RemoteConfiguration.ConfigItem(content: ["url": "https://api.revenuecat.com"])
         let persisted = Self.persisted(

--- a/Tests/UnitTests/Networking/UiConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/UiConfigProviderTests.swift
@@ -82,6 +82,43 @@ class UiConfigProviderTests: TestCase {
         expect(uiConfig).to(beNil())
     }
 
+    func testEmptyTopicReturnsNilWithoutAttemptingBlobMergeOrLoggingWarning() async {
+        self.mockManager.stubbedTopics[.uiConfig] = [:]
+
+        let uiConfig = await self.provider.getUiConfig()
+
+        expect(uiConfig).to(beNil())
+        expect(self.mockManager.invokedMergeItemsBlobDataParameters).to(beEmpty())
+        expect(self.mockManager.invokedCommittedTopicAfterInFlightRefreshCount) == 1
+        self.logger.verifyMessageWasNotLogged(
+            Strings.remoteConfig.uiConfigMissingRequiredPart,
+            level: .warn,
+            allowNoMessages: true
+        )
+    }
+
+    func testEmptyTopicUsesPartsCommittedByInFlightRefresh() async throws {
+        self.stub(
+            app: #"{"colors": {}, "fonts": {}}"#,
+            localizations: #"{"en_US": {"day": "Day"}}"#,
+            variableConfig: #"{"variable_compatibility_map": {}, "function_compatibility_map": {}}"#,
+            customVariables: #"{}"#
+        )
+        let refreshedTopic = try XCTUnwrap(self.mockManager.stubbedTopics[.uiConfig])
+        self.mockManager.stubbedTopics[.uiConfig] = [:]
+        self.mockManager.committedTopicAfterInFlightRefreshHandler = { [mockManager] topic in
+            mockManager?.configGeneration += 1
+            mockManager?.stubbedTopics[topic] = refreshedTopic
+            return refreshedTopic
+        }
+
+        let uiConfig = await self.provider.getUiConfig()
+
+        expect(uiConfig?.localizations["en_US"]?["day"]) == "Day"
+        expect(self.mockManager.invokedCommittedTopicAfterInFlightRefreshCount) == 1
+        expect(self.mockManager.invokedMergeItemsBlobDataParameters.count) == 1
+    }
+
     func testMalformedVariableConfigReturnsNil() async throws {
         self.stub(app: #"{"colors": {}, "fonts": {}}"#, localizations: #"{"en_US": {"day": "Day"}}"#,
                   variableConfig: #"{"variable_compatibility_map": "not-a-dictionary"}"#,

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -696,6 +696,7 @@ final class MockRemoteConfigManager: RemoteConfigManagerType {
 
     private(set) var invokedRefreshRemoteConfigCount = 0
     private(set) var invokedRefreshRemoteConfigIfStaleCount = 0
+    private(set) var invokedCommittedTopicAfterInFlightRefreshCount = 0
     private(set) var invokedClearCacheCount = 0
     private(set) var invokedCloseCount = 0
     private(set) var invokedRefreshRemoteConfigParametersList: [RefreshParameters] = []
@@ -753,6 +754,15 @@ final class MockRemoteConfigManager: RemoteConfigManagerType {
             self._storedTopicContinuations.modify { $0.append(continuation) }
             self._invokedTopicCount.modify { $0 += 1 }
         }
+    }
+
+    var committedTopicAfterInFlightRefreshHandler:
+    ((RemoteConfigTopic) -> RemoteConfiguration.ConfigTopic?)?
+
+    func committedTopicAfterInFlightRefresh(_ topic: RemoteConfigTopic) async
+    -> RemoteConfiguration.ConfigTopic? {
+        self.invokedCommittedTopicAfterInFlightRefreshCount += 1
+        return self.committedTopicAfterInFlightRefreshHandler?(topic) ?? self.stubbedTopics[topic]
     }
 
     /// Resumes every waiter held while `shouldStoreTopicCompletion` was `true`, and stops


### PR DESCRIPTION
## Description
Prevents logging of misleading `ui_config` warnings for projects without paywalls. 

Previously we were logging the following in case all `ui_config` parts were missing:
```
Unable to merge remote config blob data for topic 'ui_config': unavailable item keys: app, custom_variables, localizations, variable_config.
```

and
```
Could not load UI configuration because one or more required parts are missing.
```

This makes sense, however for apps that do not use paywalls it is expected that all of the parts are missing. Thus the log messages are a bit misleading.

## Changes
In `topicSnapshotWithUiConfigParts` we'll now await once for all `ui_config` parts if there is an existing refresh (instead of once per part (so 4 at the moment)). If no `ui_config` parts are available we'll just return nil for the `ui_config`. If any parts are available we'll try to construct the object, and if that fails we'll continue logging the existing message.

Related Android PR: https://github.com/RevenueCat/purchases-android/pull/3926

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to remote-config read timing and logging for `ui_config`; no auth, purchase, or persistence contract changes beyond awaiting in-flight refresh before deciding the topic is empty.
> 
> **Overview**
> Stops **warn-level** logs about missing `ui_config` blob parts when an app legitimately has no paywalls and the topic stays empty after remote config settles.
> 
> **Remote config:** Adds `committedTopicAfterInFlightRefresh` (and a generation-guarded snapshot helper) that **only waits** on an in-flight refresh—unlike `topic(_:)`, it never triggers a new fetch.
> 
> **UI config:** `UiConfigProvider` now resolves the topic via `topicSnapshotWithUiConfigParts`: if the cached `ui_config` topic has none of the four required item keys, it **once** re-reads after any in-flight refresh; if still no parts, `getUiConfig()` returns `nil` **without** calling `mergeItemsBlobData` (so no “unavailable item keys” / “missing required part” warnings). Assembly and existing warnings still apply when some parts exist but merge/decode fails.
> 
> Tests cover the new manager API, empty-topic behavior, and integration when disk has an empty topic while refresh commits full parts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff24dcf5fa9fa50a65e87bb4d8291666db241664. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->