### PR TITLE
feat(checkpoints): add device dimensions for local rule evaluation

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		A0D100000000000000000001 /* LocalRulesEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D200000000000000000001 /* LocalRulesEvaluator.swift */; };
 		A0D100000000000000000002 /* DimensionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D200000000000000000002 /* DimensionProvider.swift */; };
+		A0D100000000000000000006 /* DeviceDimensionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D200000000000000000006 /* DeviceDimensionProvider.swift */; };
+		A0D100000000000000000007 /* DeviceDimensionProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D200000000000000000007 /* DeviceDimensionProviderTests.swift */; };
 		A0D100000000000000000003 /* DimensionResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D200000000000000000003 /* DimensionResolver.swift */; };
 		A0D100000000000000000005 /* LocalRulesEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D200000000000000000005 /* LocalRulesEvaluatorTests.swift */; };
 		02F84B23216242A7B8CDAB4A /* ErrorCode+Conformances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F92C8B490F4B78AC8B1AAF /* ErrorCode+Conformances.swift */; };
@@ -1572,6 +1574,8 @@
 /* Begin PBXFileReference section */
 		A0D200000000000000000001 /* LocalRulesEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalRulesEvaluator.swift; sourceTree = "<group>"; };
 		A0D200000000000000000002 /* DimensionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DimensionProvider.swift; sourceTree = "<group>"; };
+		A0D200000000000000000006 /* DeviceDimensionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceDimensionProvider.swift; sourceTree = "<group>"; };
+		A0D200000000000000000007 /* DeviceDimensionProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceDimensionProviderTests.swift; sourceTree = "<group>"; };
 		A0D200000000000000000003 /* DimensionResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DimensionResolver.swift; sourceTree = "<group>"; };
 		A0D200000000000000000005 /* LocalRulesEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalRulesEvaluatorTests.swift; sourceTree = "<group>"; };
 		019BA4A7731BC93FEC1A74FA /* PaywallScrollEnvironment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaywallScrollEnvironment.swift; path = RevenueCatUI/Templates/V2/Layout/PaywallScrollEnvironment.swift; sourceTree = SOURCE_ROOT; };
@@ -3237,6 +3241,7 @@
 			isa = PBXGroup;
 			children = (
 				A0D200000000000000000001 /* LocalRulesEvaluator.swift */,
+				A0D200000000000000000006 /* DeviceDimensionProvider.swift */,
 				A0D200000000000000000002 /* DimensionProvider.swift */,
 				A0D200000000000000000003 /* DimensionResolver.swift */,
 			);
@@ -3247,6 +3252,7 @@
 			isa = PBXGroup;
 			children = (
 				A0D200000000000000000005 /* LocalRulesEvaluatorTests.swift */,
+				A0D200000000000000000007 /* DeviceDimensionProviderTests.swift */,
 			);
 			path = LocalRules;
 			sourceTree = "<group>";
@@ -7796,6 +7802,7 @@
 				FA1CDF68EA3C6B2B9F77D5A6 /* Operators.swift in Sources */,
 				B2D1A168EB359D71CAD9D64D /* StringArrayOperators.swift in Sources */,
 				A0D100000000000000000001 /* LocalRulesEvaluator.swift in Sources */,
+				A0D100000000000000000006 /* DeviceDimensionProvider.swift in Sources */,
 				A0D100000000000000000002 /* DimensionProvider.swift in Sources */,
 				A0D100000000000000000003 /* DimensionResolver.swift in Sources */,
 				FA360650C0B87331F2EFF527 /* Checkpoints.swift in Sources */,
@@ -8220,6 +8227,7 @@
 				EF36FED83964489EE46DABE9 /* PredicateConformanceRunner.swift in Sources */,
 				6ACB35318F329FCE9195865D /* Value+Decodable.swift in Sources */,
 				A0D100000000000000000005 /* LocalRulesEvaluatorTests.swift in Sources */,
+				A0D100000000000000000007 /* DeviceDimensionProviderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/LocalRules/DeviceDimensionProvider.swift
+++ b/Sources/LocalRules/DeviceDimensionProvider.swift
@@ -43,7 +43,7 @@ struct DeviceDimensionProvider: DimensionProvider {
         var variables: [String: DimensionValue] = [:]
 
         if !self.appVersion.isEmpty {
-            variables["app_version"] = .string(self.appVersion)
+            variables["appVersion"] = .string(self.appVersion)
         }
 
         if let locale = self.localeProvider(), !locale.isEmpty {
@@ -54,10 +54,10 @@ struct DeviceDimensionProvider: DimensionProvider {
             variables["platform"] = .string(self.platform.lowercased())
         }
 
-        variables["platform_version"] = .string(Self.semanticVersion(self.platformVersion))
+        variables["platformVersion"] = .string(Self.semanticVersion(self.platformVersion))
 
         if let sdkVersion = Self.semanticVersion(self.sdkVersion) {
-            variables["sdk_version"] = .string(sdkVersion)
+            variables["sdkVersion"] = .string(sdkVersion)
         }
 
         return variables

--- a/Sources/LocalRules/DeviceDimensionProvider.swift
+++ b/Sources/LocalRules/DeviceDimensionProvider.swift
@@ -23,14 +23,14 @@ struct DeviceDimensionProvider: DimensionProvider {
     private let appVersion: String
     private let localeProvider: @Sendable () -> String?
     private let platform: String
-    private let platformVersion: String
+    private let platformVersion: OperatingSystemVersion
     private let sdkVersion: String
 
     init(
         appVersion: String = SystemInfo.appVersion,
         localeProvider: @escaping @Sendable () -> String? = { Locale.preferredLanguages.first },
-        platform: String = SystemInfo.platformHeader,
-        platformVersion: String = SystemInfo.systemVersion,
+        platform: String = SystemInfo.platformHeaderConstant,
+        platformVersion: OperatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion,
         sdkVersion: String = SystemInfo.frameworkVersion
     ) {
         self.appVersion = appVersion
@@ -48,22 +48,39 @@ struct DeviceDimensionProvider: DimensionProvider {
         }
 
         if let locale = self.localeProvider(), !locale.isEmpty {
-            variables["locale"] = .string(locale)
+            variables["locale"] = .string(locale.lowercased().replacingOccurrences(of: "-", with: "_"))
         }
 
         if !self.platform.isEmpty {
-            variables["platform"] = .string(self.platform)
+            variables["platform"] = .string(self.platform.lowercased())
         }
 
-        if !self.platformVersion.isEmpty {
-            variables["platform_version"] = .string(self.platformVersion)
-        }
+        variables["platform_version"] = .string(Self.semanticVersion(self.platformVersion))
 
-        if !self.sdkVersion.isEmpty {
-            variables["sdk_version"] = .string(self.sdkVersion)
+        if let sdkVersion = Self.semanticVersion(self.sdkVersion) {
+            variables["sdk_version"] = .string(sdkVersion)
         }
 
         return variables
+    }
+
+    private static func semanticVersion(_ version: OperatingSystemVersion) -> String {
+        return "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+    }
+
+    private static func semanticVersion(_ version: String) -> String? {
+        let numericComponents = version
+            .split(separator: ".", omittingEmptySubsequences: false)
+            .prefix(3)
+            .map { $0.prefix(while: { $0.isNumber }) }
+
+        guard !numericComponents.isEmpty,
+              numericComponents.allSatisfy({ !$0.isEmpty }) else {
+            return nil
+        }
+
+        return (numericComponents.map(String.init) + Array(repeating: "0", count: 3 - numericComponents.count))
+            .joined(separator: ".")
     }
 
 }

--- a/Sources/LocalRules/DeviceDimensionProvider.swift
+++ b/Sources/LocalRules/DeviceDimensionProvider.swift
@@ -17,7 +17,6 @@ import Foundation
 /// Supplies app and device information to the local rules engine.
 struct DeviceDimensionProvider: DimensionProvider {
 
-    let identifier = "device"
     let namespace = DimensionNamespace.device
 
     private let appVersion: String

--- a/Sources/LocalRules/DeviceDimensionProvider.swift
+++ b/Sources/LocalRules/DeviceDimensionProvider.swift
@@ -1,0 +1,69 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  DeviceDimensionProvider.swift
+//
+//  Created by Rick van der Linden on 8/11/26.
+//
+
+import Foundation
+
+/// Supplies app and device information to the local rules engine.
+struct DeviceDimensionProvider: DimensionProvider {
+
+    let identifier = "device"
+    let namespace = DimensionNamespace.device
+
+    private let appVersion: String
+    private let localeProvider: @Sendable () -> String?
+    private let platform: String
+    private let platformVersion: String
+    private let sdkVersion: String
+
+    init(
+        appVersion: String = SystemInfo.appVersion,
+        localeProvider: @escaping @Sendable () -> String? = { Locale.preferredLanguages.first },
+        platform: String = SystemInfo.platformHeader,
+        platformVersion: String = SystemInfo.systemVersion,
+        sdkVersion: String = SystemInfo.frameworkVersion
+    ) {
+        self.appVersion = appVersion
+        self.localeProvider = localeProvider
+        self.platform = platform
+        self.platformVersion = platformVersion
+        self.sdkVersion = sdkVersion
+    }
+
+    func dimensions(at _: Date) async throws -> [String: DimensionValue] {
+        var variables: [String: DimensionValue] = [:]
+
+        if !self.appVersion.isEmpty {
+            variables["app_version"] = .string(self.appVersion)
+        }
+
+        if let locale = self.localeProvider(), !locale.isEmpty {
+            variables["locale"] = .string(locale)
+        }
+
+        if !self.platform.isEmpty {
+            variables["platform"] = .string(self.platform)
+        }
+
+        if !self.platformVersion.isEmpty {
+            variables["platform_version"] = .string(self.platformVersion)
+        }
+
+        if !self.sdkVersion.isEmpty {
+            variables["sdk_version"] = .string(self.sdkVersion)
+        }
+
+        return variables
+    }
+
+}

--- a/Sources/LocalRules/DimensionProvider.swift
+++ b/Sources/LocalRules/DimensionProvider.swift
@@ -44,7 +44,7 @@ protocol DimensionProvider: Sendable {
 
     /// Returns the complete current set of scalar dimensions relative to ``namespace``.
     ///
-    /// Keys are lowercase snake-case names such as `app_version`. The resolver
+    /// Keys are lower camel-case names such as `appVersion`. The resolver
     /// adds the provider's namespace. Missing individual values must be
     /// omitted. Throwing is reserved for a systemic failure to produce the
     /// provider's dimensions.

--- a/Sources/LocalRules/DimensionProvider.swift
+++ b/Sources/LocalRules/DimensionProvider.swift
@@ -39,9 +39,6 @@ enum DimensionValue: Equatable, Sendable {
 /// pulled only when a rules evaluation requests a new snapshot.
 protocol DimensionProvider: Sendable {
 
-    /// Stable identifier used only for configuration diagnostics.
-    var identifier: String { get }
-
     /// Root namespace containing the returned dimensions.
     var namespace: DimensionNamespace { get }
 

--- a/Sources/LocalRules/DimensionResolver.swift
+++ b/Sources/LocalRules/DimensionResolver.swift
@@ -22,7 +22,7 @@ struct DimensionSnapshot: Equatable, Sendable {
 
 enum DimensionResolutionError: Error, Equatable, Sendable {
 
-    case providerFailed(identifier: String, message: String)
+    case providerFailed(namespace: DimensionNamespace, message: String)
     case conflictingValue(path: String)
 }
 
@@ -59,7 +59,7 @@ struct DimensionResolver: Sendable {
                 throw error
             } catch {
                 throw DimensionResolutionError.providerFailed(
-                    identifier: provider.identifier,
+                    namespace: provider.namespace,
                     message: String(describing: error)
                 )
             }

--- a/Sources/LocalRules/DimensionResolver.swift
+++ b/Sources/LocalRules/DimensionResolver.swift
@@ -43,8 +43,8 @@ struct DimensionResolver: Sendable {
 
     /// Collects each provider once and merges its values under its namespace.
     ///
-    /// For example, device `app_version: "1.2.3"` becomes
-    /// `device.app_version: "1.2.3"` in the RulesEngine input.
+    /// For example, device `appVersion: "1.2.3"` becomes
+    /// `device.appVersion: "1.2.3"` in the RulesEngine input.
     func snapshot() async throws -> DimensionSnapshot {
         let date = self.dateProvider.now()
         var values: [String: RulesEngine.Value] = [:]

--- a/Tests/UnitTests/LocalRules/DeviceDimensionProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/DeviceDimensionProviderTests.swift
@@ -34,7 +34,6 @@ struct DeviceDimensionProviderTests {
             sdkVersion: "5.84.0-SNAPSHOT"
         )
 
-        #expect(provider.identifier == "device")
         #expect(provider.namespace == .device)
         #expect(try await provider.dimensions(at: Date()) == [
             "app_version": .string("1.2.3"),

--- a/Tests/UnitTests/LocalRules/DeviceDimensionProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/DeviceDimensionProviderTests.swift
@@ -28,34 +28,36 @@ struct DeviceDimensionProviderTests {
     func providesDeviceVariablesInDeviceNamespace() async throws {
         let provider = DeviceDimensionProvider(
             appVersion: "1.2.3",
-            localeProvider: { "nl_NL" },
+            localeProvider: { "NL-nl" },
             platform: "iOS",
-            platformVersion: "Version 26.3 (Build 23D127)",
-            sdkVersion: "5.84.0"
+            platformVersion: Self.platformVersion,
+            sdkVersion: "5.84.0-SNAPSHOT"
         )
 
         #expect(provider.identifier == "device")
         #expect(provider.namespace == .device)
         #expect(try await provider.dimensions(at: Date()) == [
             "app_version": .string("1.2.3"),
-            "locale": .string("nl_NL"),
-            "platform": .string("iOS"),
-            "platform_version": .string("Version 26.3 (Build 23D127)"),
+            "locale": .string("nl_nl"),
+            "platform": .string("ios"),
+            "platform_version": .string("26.3.0"),
             "sdk_version": .string("5.84.0")
         ])
     }
 
     @Test
-    func omitsUnavailableValues() async throws {
+    func omitsUnavailableOptionalValues() async throws {
         let provider = DeviceDimensionProvider(
             appVersion: "",
             localeProvider: { "" },
             platform: "",
-            platformVersion: "",
-            sdkVersion: ""
+            platformVersion: Self.platformVersion,
+            sdkVersion: "invalid"
         )
 
-        #expect(try await provider.dimensions(at: Date()).isEmpty)
+        #expect(try await provider.dimensions(at: Date()) == [
+            "platform_version": .string("26.3.0")
+        ])
     }
 
     @Test
@@ -65,15 +67,15 @@ struct DeviceDimensionProviderTests {
             appVersion: "1.2.3",
             localeProvider: { locale.value },
             platform: "iOS",
-            platformVersion: "Version 26.3 (Build 23D127)"
+            platformVersion: Self.platformVersion
         )
 
         let first = try await provider.dimensions(at: Date())
         locale.value = "nl_NL"
         let second = try await provider.dimensions(at: Date())
 
-        #expect(first["locale"] == .string("en_US"))
-        #expect(second["locale"] == .string("nl_NL"))
+        #expect(first["locale"] == .string("en_us"))
+        #expect(second["locale"] == .string("nl_nl"))
     }
 
     @Test
@@ -84,7 +86,7 @@ struct DeviceDimensionProviderTests {
                     appVersion: "1.2.3",
                     localeProvider: { "en_US" },
                     platform: "iOS",
-                    platformVersion: "Version 26.3 (Build 23D127)"
+                    platformVersion: Self.platformVersion
                 )
             ]
         )
@@ -96,7 +98,7 @@ struct DeviceDimensionProviderTests {
             )
         ])
 
-        #expect(match == "matching-rule")
+        #expect(match?.id == "matching-rule")
     }
 
     @Test
@@ -107,7 +109,7 @@ struct DeviceDimensionProviderTests {
                     appVersion: "1.2.3",
                     localeProvider: { "nl-NL" },
                     platform: "iOS",
-                    platformVersion: "Version 26.3 (Build 23D127)"
+                    platformVersion: Self.platformVersion
                 )
             ]
         )
@@ -115,11 +117,11 @@ struct DeviceDimensionProviderTests {
         let match = try await evaluator.match(in: [
             TestRule(
                 id: "matching-rule",
-                predicate: #"{"==":[{"var":"device.locale"},"nl-NL"]}"#
+                predicate: #"{"==":[{"var":"device.locale"},"nl_nl"]}"#
             )
         ])
 
-        #expect(match == "matching-rule")
+        #expect(match?.id == "matching-rule")
     }
 
     @Test
@@ -130,7 +132,7 @@ struct DeviceDimensionProviderTests {
                     appVersion: "1.2.3",
                     localeProvider: { "en-US" },
                     platform: "iOS",
-                    platformVersion: "Version 26.3 (Build 23D127)"
+                    platformVersion: Self.platformVersion
                 )
             ]
         )
@@ -138,11 +140,22 @@ struct DeviceDimensionProviderTests {
         let match = try await evaluator.match(in: [
             TestRule(
                 id: "matching-rule",
-                predicate: #"{"==":[{"var":"device.platform"},"iOS"]}"#
+                predicate: #"{"==":[{"var":"device.platform"},"ios"]}"#
             )
         ])
 
-        #expect(match == "matching-rule")
+        #expect(match?.id == "matching-rule")
+    }
+
+    @Test
+    func platformUsesCompileTargetWhenUniversalAppStoreIsForced() async throws {
+        let previousValue = SystemInfo.forceUniversalAppStore
+        defer { SystemInfo.forceUniversalAppStore = previousValue }
+        SystemInfo.forceUniversalAppStore = true
+
+        let dimensions = try await DeviceDimensionProvider().dimensions(at: Date())
+
+        #expect(dimensions["platform"] == .string(SystemInfo.platformHeaderConstant.lowercased()))
     }
 
     @Test
@@ -153,7 +166,7 @@ struct DeviceDimensionProviderTests {
                     appVersion: "1.2.3",
                     localeProvider: { "en-US" },
                     platform: "iOS",
-                    platformVersion: "Version 26.3 (Build 23D127)"
+                    platformVersion: Self.platformVersion
                 )
             ]
         )
@@ -161,11 +174,11 @@ struct DeviceDimensionProviderTests {
         let match = try await evaluator.match(in: [
             TestRule(
                 id: "matching-rule",
-                predicate: #"{"==":[{"var":"device.platform_version"},"Version 26.3 (Build 23D127)"]}"#
+                predicate: #"{"==":[{"var":"device.platform_version"},"26.3.0"]}"#
             )
         ])
 
-        #expect(match == "matching-rule")
+        #expect(match?.id == "matching-rule")
     }
 
     @Test
@@ -176,8 +189,8 @@ struct DeviceDimensionProviderTests {
                     appVersion: "1.2.3",
                     localeProvider: { "en-US" },
                     platform: "iOS",
-                    platformVersion: "Version 26.3 (Build 23D127)",
-                    sdkVersion: "5.84.0"
+                    platformVersion: Self.platformVersion,
+                    sdkVersion: "5.84.0-SNAPSHOT"
                 )
             ]
         )
@@ -189,8 +202,14 @@ struct DeviceDimensionProviderTests {
             )
         ])
 
-        #expect(match == "matching-rule")
+        #expect(match?.id == "matching-rule")
     }
+
+    private static let platformVersion = OperatingSystemVersion(
+        majorVersion: 26,
+        minorVersion: 3,
+        patchVersion: 0
+    )
 
 }
 

--- a/Tests/UnitTests/LocalRules/DeviceDimensionProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/DeviceDimensionProviderTests.swift
@@ -1,0 +1,205 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  DeviceDimensionProviderTests.swift
+//
+//  Created by Rick van der Linden on 8/11/26.
+//
+
+// Swift Testing is only available with the Xcode 16+ toolchain
+#if compiler(>=5.9)
+#if canImport(Testing)
+
+import Foundation
+import Testing
+
+@testable import RevenueCat
+
+@Suite("Device variable provider")
+struct DeviceDimensionProviderTests {
+
+    @Test
+    func providesDeviceVariablesInDeviceNamespace() async throws {
+        let provider = DeviceDimensionProvider(
+            appVersion: "1.2.3",
+            localeProvider: { "nl_NL" },
+            platform: "iOS",
+            platformVersion: "Version 26.3 (Build 23D127)",
+            sdkVersion: "5.84.0"
+        )
+
+        #expect(provider.identifier == "device")
+        #expect(provider.namespace == .device)
+        #expect(try await provider.dimensions(at: Date()) == [
+            "app_version": .string("1.2.3"),
+            "locale": .string("nl_NL"),
+            "platform": .string("iOS"),
+            "platform_version": .string("Version 26.3 (Build 23D127)"),
+            "sdk_version": .string("5.84.0")
+        ])
+    }
+
+    @Test
+    func omitsUnavailableValues() async throws {
+        let provider = DeviceDimensionProvider(
+            appVersion: "",
+            localeProvider: { "" },
+            platform: "",
+            platformVersion: "",
+            sdkVersion: ""
+        )
+
+        #expect(try await provider.dimensions(at: Date()).isEmpty)
+    }
+
+    @Test
+    func collectsLocaleForEverySnapshot() async throws {
+        let locale = Atomic<String?>("en_US")
+        let provider = DeviceDimensionProvider(
+            appVersion: "1.2.3",
+            localeProvider: { locale.value },
+            platform: "iOS",
+            platformVersion: "Version 26.3 (Build 23D127)"
+        )
+
+        let first = try await provider.dimensions(at: Date())
+        locale.value = "nl_NL"
+        let second = try await provider.dimensions(at: Date())
+
+        #expect(first["locale"] == .string("en_US"))
+        #expect(second["locale"] == .string("nl_NL"))
+    }
+
+    @Test
+    func appVersionCanBeEvaluatedUsingSDKVariablePath() async throws {
+        let evaluator = LocalRulesEvaluator(
+            dimensionProviders: [
+                DeviceDimensionProvider(
+                    appVersion: "1.2.3",
+                    localeProvider: { "en_US" },
+                    platform: "iOS",
+                    platformVersion: "Version 26.3 (Build 23D127)"
+                )
+            ]
+        )
+
+        let match = try await evaluator.match(in: [
+            TestRule(
+                id: "matching-rule",
+                predicate: #"{"==":[{"var":"device.app_version"},"1.2.3"]}"#
+            )
+        ])
+
+        #expect(match == "matching-rule")
+    }
+
+    @Test
+    func localeCanBeEvaluatedUsingSDKVariablePath() async throws {
+        let evaluator = LocalRulesEvaluator(
+            dimensionProviders: [
+                DeviceDimensionProvider(
+                    appVersion: "1.2.3",
+                    localeProvider: { "nl-NL" },
+                    platform: "iOS",
+                    platformVersion: "Version 26.3 (Build 23D127)"
+                )
+            ]
+        )
+
+        let match = try await evaluator.match(in: [
+            TestRule(
+                id: "matching-rule",
+                predicate: #"{"==":[{"var":"device.locale"},"nl-NL"]}"#
+            )
+        ])
+
+        #expect(match == "matching-rule")
+    }
+
+    @Test
+    func platformCanBeEvaluatedUsingSDKVariablePath() async throws {
+        let evaluator = LocalRulesEvaluator(
+            dimensionProviders: [
+                DeviceDimensionProvider(
+                    appVersion: "1.2.3",
+                    localeProvider: { "en-US" },
+                    platform: "iOS",
+                    platformVersion: "Version 26.3 (Build 23D127)"
+                )
+            ]
+        )
+
+        let match = try await evaluator.match(in: [
+            TestRule(
+                id: "matching-rule",
+                predicate: #"{"==":[{"var":"device.platform"},"iOS"]}"#
+            )
+        ])
+
+        #expect(match == "matching-rule")
+    }
+
+    @Test
+    func platformVersionCanBeEvaluatedUsingSDKVariablePath() async throws {
+        let evaluator = LocalRulesEvaluator(
+            dimensionProviders: [
+                DeviceDimensionProvider(
+                    appVersion: "1.2.3",
+                    localeProvider: { "en-US" },
+                    platform: "iOS",
+                    platformVersion: "Version 26.3 (Build 23D127)"
+                )
+            ]
+        )
+
+        let match = try await evaluator.match(in: [
+            TestRule(
+                id: "matching-rule",
+                predicate: #"{"==":[{"var":"device.platform_version"},"Version 26.3 (Build 23D127)"]}"#
+            )
+        ])
+
+        #expect(match == "matching-rule")
+    }
+
+    @Test
+    func sdkVersionCanBeEvaluatedUsingSDKVariablePath() async throws {
+        let evaluator = LocalRulesEvaluator(
+            dimensionProviders: [
+                DeviceDimensionProvider(
+                    appVersion: "1.2.3",
+                    localeProvider: { "en-US" },
+                    platform: "iOS",
+                    platformVersion: "Version 26.3 (Build 23D127)",
+                    sdkVersion: "5.84.0"
+                )
+            ]
+        )
+
+        let match = try await evaluator.match(in: [
+            TestRule(
+                id: "matching-rule",
+                predicate: #"{"==":[{"var":"device.sdk_version"},"5.84.0"]}"#
+            )
+        ])
+
+        #expect(match == "matching-rule")
+    }
+
+}
+
+private struct TestRule: LocalRule {
+
+    let id: String
+    let predicate: String
+
+}
+
+#endif
+#endif

--- a/Tests/UnitTests/LocalRules/DeviceDimensionProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/DeviceDimensionProviderTests.swift
@@ -36,11 +36,11 @@ struct DeviceDimensionProviderTests {
 
         #expect(provider.namespace == .device)
         #expect(try await provider.dimensions(at: Date()) == [
-            "app_version": .string("1.2.3"),
+            "appVersion": .string("1.2.3"),
             "locale": .string("nl_nl"),
             "platform": .string("ios"),
-            "platform_version": .string("26.3.0"),
-            "sdk_version": .string("5.84.0")
+            "platformVersion": .string("26.3.0"),
+            "sdkVersion": .string("5.84.0")
         ])
     }
 
@@ -55,7 +55,7 @@ struct DeviceDimensionProviderTests {
         )
 
         #expect(try await provider.dimensions(at: Date()) == [
-            "platform_version": .string("26.3.0")
+            "platformVersion": .string("26.3.0")
         ])
     }
 
@@ -93,7 +93,7 @@ struct DeviceDimensionProviderTests {
         let match = try await evaluator.match(in: [
             TestRule(
                 id: "matching-rule",
-                predicate: #"{"==":[{"var":"device.app_version"},"1.2.3"]}"#
+                predicate: #"{"==":[{"var":"device.appVersion"},"1.2.3"]}"#
             )
         ])
 
@@ -173,7 +173,7 @@ struct DeviceDimensionProviderTests {
         let match = try await evaluator.match(in: [
             TestRule(
                 id: "matching-rule",
-                predicate: #"{"==":[{"var":"device.platform_version"},"26.3.0"]}"#
+                predicate: #"{"==":[{"var":"device.platformVersion"},"26.3.0"]}"#
             )
         ])
 
@@ -197,7 +197,7 @@ struct DeviceDimensionProviderTests {
         let match = try await evaluator.match(in: [
             TestRule(
                 id: "matching-rule",
-                predicate: #"{"==":[{"var":"device.sdk_version"},"5.84.0"]}"#
+                predicate: #"{"==":[{"var":"device.sdkVersion"},"5.84.0"]}"#
             )
         ])
 

--- a/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
+++ b/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
@@ -28,7 +28,6 @@ struct LocalRulesEvaluatorTests {
     func batchUsesOneFreshSnapshotForEveryRule() async throws {
         let date = Date(timeIntervalSince1970: 1_234)
         let provider = TestDimensionProvider(
-            identifier: "device-info",
             namespace: .device,
             snapshots: [
                 ["launch_count": .int(1)],
@@ -60,7 +59,6 @@ struct LocalRulesEvaluatorTests {
     @Test
     func subsequentEvaluationPullsProviderAgain() async throws {
         let provider = TestDimensionProvider(
-            identifier: "session",
             namespace: .session,
             snapshots: [
                 ["count": .int(1)],
@@ -85,12 +83,10 @@ struct LocalRulesEvaluatorTests {
     func allProvidersReceiveSameDate() async throws {
         let date = Date(timeIntervalSince1970: 9_876)
         let device = TestDimensionProvider(
-            identifier: "device",
             namespace: .device,
             snapshots: [["ready": .bool(true)]]
         )
         let session = TestDimensionProvider(
-            identifier: "session",
             namespace: .session,
             snapshots: [["ready": .bool(true)]]
         )
@@ -108,7 +104,6 @@ struct LocalRulesEvaluatorTests {
     func mergesProviderValuesByNamespace() async throws {
         let date = Date(timeIntervalSince1970: 5_432)
         let identity = TestDimensionProvider(
-            identifier: "identity",
             namespace: .device,
             snapshots: [[
                 "app_version": .string("1.2.3"),
@@ -117,12 +112,10 @@ struct LocalRulesEvaluatorTests {
             ]]
         )
         let environment = TestDimensionProvider(
-            identifier: "environment",
             namespace: .device,
             snapshots: [["tracking_enabled": .bool(false)]]
         )
         let client = TestDimensionProvider(
-            identifier: "client",
             namespace: .client,
             snapshots: [["shoe_size": .int(42)]]
         )
@@ -147,12 +140,10 @@ struct LocalRulesEvaluatorTests {
     @Test
     func duplicateLeafIsAConfigurationError() async {
         let first = TestDimensionProvider(
-            identifier: "first",
             namespace: .device,
             snapshots: [["app_version": .string("1.2.3")]]
         )
         let second = TestDimensionProvider(
-            identifier: "second",
             namespace: .device,
             snapshots: [["app_version": .string("2.0.0")]]
         )
@@ -170,7 +161,7 @@ struct LocalRulesEvaluatorTests {
     @Test
     func providerFailureIsThrown() async {
         let evaluator = Self.evaluator(dimensionProviders: [
-            FailingDimensionProvider(identifier: "broken", namespace: .session)
+            FailingDimensionProvider(namespace: .session)
         ])
 
         do {
@@ -179,11 +170,11 @@ struct LocalRulesEvaluatorTests {
             ])
             Issue.record("Expected provider failure to be thrown")
         } catch let error as DimensionResolutionError {
-            guard case .providerFailed(let identifier, _) = error else {
+            guard case .providerFailed(let namespace, _) = error else {
                 Issue.record("Unexpected resolution error: \(error)")
                 return
             }
-            #expect(identifier == "broken")
+            #expect(namespace == .session)
         } catch {
             Issue.record("Unexpected error: \(error)")
         }
@@ -224,7 +215,6 @@ struct LocalRulesEvaluatorTests {
     func omittedVariableRetainsRulesEngineNullSemantics() async throws {
         let evaluator = Self.evaluator(dimensionProviders: [
             TestDimensionProvider(
-                identifier: "device",
                 namespace: .device,
                 snapshots: [["known": .bool(true)]]
             )
@@ -243,7 +233,6 @@ struct LocalRulesEvaluatorTests {
     @Test
     func emptyBatchDoesNotCollectVariables() async throws {
         let provider = TestDimensionProvider(
-            identifier: "unused",
             namespace: .device,
             snapshots: [["value": .int(1)]]
         )
@@ -268,7 +257,7 @@ struct LocalRulesEvaluatorTests {
     @Test
     func cancellationIsThrownByMatch() async {
         let evaluator = Self.evaluator(dimensionProviders: [
-            CancellingDimensionProvider(identifier: "cancelled", namespace: .session)
+            CancellingDimensionProvider(namespace: .session)
         ])
 
         do {
@@ -312,7 +301,6 @@ private enum TestRuleID: Sendable {
 
 private actor TestDimensionProvider: DimensionProvider {
 
-    nonisolated let identifier: String
     nonisolated let namespace: DimensionNamespace
 
     private let snapshots: [[String: DimensionValue]]
@@ -320,11 +308,9 @@ private actor TestDimensionProvider: DimensionProvider {
     private(set) var receivedDates: [Date] = []
 
     init(
-        identifier: String,
         namespace: DimensionNamespace,
         snapshots: [[String: DimensionValue]]
     ) {
-        self.identifier = identifier
         self.namespace = namespace
         self.snapshots = snapshots
     }
@@ -341,7 +327,6 @@ private struct FailingDimensionProvider: DimensionProvider {
 
     struct ProviderError: Error {}
 
-    let identifier: String
     let namespace: DimensionNamespace
 
     func dimensions(at date: Date) async throws -> [String: DimensionValue] {
@@ -351,7 +336,6 @@ private struct FailingDimensionProvider: DimensionProvider {
 
 private struct CancellingDimensionProvider: DimensionProvider {
 
-    let identifier: String
     let namespace: DimensionNamespace
 
     func dimensions(at date: Date) async throws -> [String: DimensionValue] {

--- a/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
+++ b/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
@@ -30,8 +30,8 @@ struct LocalRulesEvaluatorTests {
         let provider = TestDimensionProvider(
             namespace: .device,
             snapshots: [
-                ["launch_count": .int(1)],
-                ["launch_count": .int(2)]
+                ["launchCount": .int(1)],
+                ["launchCount": .int(2)]
             ]
         )
         let evaluator = Self.evaluator(dimensionProviders: [provider], date: date)
@@ -39,11 +39,11 @@ struct LocalRulesEvaluatorTests {
         let rule = try await evaluator.match(in: [
             TestLocalRule(
                 id: TestRuleID.doesNotMatch,
-                predicate: #"{"==":[{"var":"device.launch_count"},2]}"#
+                predicate: #"{"==":[{"var":"device.launchCount"},2]}"#
             ),
             TestLocalRule(
                 id: TestRuleID.matches,
-                predicate: #"{"==":[{"var":"device.launch_count"},1]}"#
+                predicate: #"{"==":[{"var":"device.launchCount"},1]}"#
             ),
             TestLocalRule(
                 id: TestRuleID.notEvaluated,
@@ -106,18 +106,18 @@ struct LocalRulesEvaluatorTests {
         let identity = TestDimensionProvider(
             namespace: .device,
             snapshots: [[
-                "app_version": .string("1.2.3"),
-                "is_debug_build": .bool(true),
-                "screen_scale": .double(3)
+                "appVersion": .string("1.2.3"),
+                "isDebugBuild": .bool(true),
+                "screenScale": .double(3)
             ]]
         )
         let environment = TestDimensionProvider(
             namespace: .device,
-            snapshots: [["tracking_enabled": .bool(false)]]
+            snapshots: [["trackingEnabled": .bool(false)]]
         )
         let client = TestDimensionProvider(
             namespace: .client,
-            snapshots: [["shoe_size": .int(42)]]
+            snapshots: [["shoeSize": .int(42)]]
         )
 
         let snapshot = try await DimensionResolver(
@@ -128,12 +128,12 @@ struct LocalRulesEvaluatorTests {
         #expect(snapshot.evaluationDate == date)
         #expect(snapshot.values == [
             "device": .object([
-                "app_version": .string("1.2.3"),
-                "is_debug_build": .bool(true),
-                "screen_scale": .float(3),
-                "tracking_enabled": .bool(false)
+                "appVersion": .string("1.2.3"),
+                "isDebugBuild": .bool(true),
+                "screenScale": .float(3),
+                "trackingEnabled": .bool(false)
             ]),
-            "client": .object(["shoe_size": .int(42)])
+            "client": .object(["shoeSize": .int(42)])
         ])
     }
 
@@ -141,18 +141,18 @@ struct LocalRulesEvaluatorTests {
     func duplicateLeafIsAConfigurationError() async {
         let first = TestDimensionProvider(
             namespace: .device,
-            snapshots: [["app_version": .string("1.2.3")]]
+            snapshots: [["appVersion": .string("1.2.3")]]
         )
         let second = TestDimensionProvider(
             namespace: .device,
-            snapshots: [["app_version": .string("2.0.0")]]
+            snapshots: [["appVersion": .string("2.0.0")]]
         )
 
         do {
             _ = try await DimensionResolver(dimensionProviders: [first, second]).snapshot()
             Issue.record("Expected duplicate ownership to fail")
         } catch let error as DimensionResolutionError {
-            #expect(error == .conflictingValue(path: "device.app_version"))
+            #expect(error == .conflictingValue(path: "device.appVersion"))
         } catch {
             Issue.record("Unexpected error: \(error)")
         }


### PR DESCRIPTION
## Description

Adds `DeviceDimensionProvider`, which supplies `device.*` variables to the local rules engine.

| SDK variable | Example value | Derived from | Implementation details | Current backend equivalent |
| --- | --- | --- | --- | --- |
| `device.appVersion` | `1.2.3` | `CFBundleShortVersionString`, through `SystemInfo.appVersion` | Unmodified | `last_seen.app_version`, currently sent in `X-Client-Version` |
| `device.locale` | `nl_nl` | `Locale.preferredLanguages.first` | Lowercased and converted to snake case | `last_seen.locale`, currently populated from the request's `Accept-Language` header on iOS |
| `device.platform` | `ios` | `SystemInfo.platformHeaderConstant` | Lowercased; unaffected by `forceUniversalAppStore` | `last_seen.platform`, currently sent in `X-Platform` |
| `device.platformVersion` | `26.3.0` | `ProcessInfo.operatingSystemVersion` | Only the version, as a three-component semantic version string | `last_seen.platform_version`, currently sent in `X-Platform-Version` |
| `device.sdkVersion` | `5.84.0` | `SystemInfo.frameworkVersion` | Only the version, as a three-component semantic version string | `last_seen.sdk_version`, currently sent in `X-Version` |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches local rule evaluation inputs and renames dimension variable paths, so incorrect key/normalization choices can change which rules match. Not in auth or payment paths.
> 
> **Overview**
> Adds **`DeviceDimensionProvider`**, which exposes `device.*` variables (`appVersion`, `locale`, `platform`, `platformVersion`, `sdkVersion`) to the local rules engine from `SystemInfo` / process locale and OS version.
> 
> Also **renames dimension keys from snake_case to lower camelCase** (e.g. `device.app_version` → `device.appVersion`) and drops the unused `identifier` on `DimensionProvider`, so provider failures are reported by **namespace** instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb7bd42e84242f87eac94dda48c6142e21bc87ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
