### PR TITLE
feat(checkpoints): support custom variables in local rules

### DIFF
--- a/Examples/CheckpointTester/CheckpointTester/Sources/ContentView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/ContentView.swift
@@ -21,7 +21,7 @@ struct ContentView: View {
 
     @ObservedObject var model: CheckpointDemoModel
     @ObservedObject var analyticsTracker: GlobalCheckpointAnalyticsTracker
-    @StateObject private var checkpointVariables = CheckpointVariables()
+    @StateObject private var customVariables = CustomVariables()
 
     var body: some View {
         TabView {
@@ -32,7 +32,7 @@ struct ContentView: View {
 
             self.variableEditor
                 .tabItem {
-                    Label("Variables", systemImage: "slider.horizontal.3")
+                    Label("Custom variables", systemImage: "slider.horizontal.3")
                 }
 
             self.listenerLog
@@ -63,7 +63,7 @@ struct ContentView: View {
             List {
                 Section("App-driven use cases") {
                     NavigationLink {
-                        HardPaywallUseCaseView(checkpointVariables: self.checkpointVariables)
+                        HardPaywallUseCaseView(customVariables: self.customVariables)
                     } label: {
                         DemoLabel(
                             title: "Hard paywall",
@@ -73,7 +73,7 @@ struct ContentView: View {
                     }
 
                     NavigationLink {
-                        SoftPaywallUseCaseView(checkpointVariables: self.checkpointVariables)
+                        SoftPaywallUseCaseView(customVariables: self.customVariables)
                     } label: {
                         DemoLabel(
                             title: "Soft paywall",
@@ -83,7 +83,7 @@ struct ContentView: View {
                     }
 
                     NavigationLink {
-                        OnboardingUseCaseView(checkpointVariables: self.checkpointVariables)
+                        OnboardingUseCaseView(customVariables: self.customVariables)
                     } label: {
                         DemoLabel(
                             title: "Onboarding",
@@ -93,7 +93,7 @@ struct ContentView: View {
                     }
 
                     NavigationLink {
-                        EntitlementGateUseCaseView(checkpointVariables: self.checkpointVariables)
+                        EntitlementGateUseCaseView(customVariables: self.customVariables)
                     } label: {
                         DemoLabel(
                             title: "Entitlement gate",
@@ -105,7 +105,7 @@ struct ContentView: View {
                     NavigationLink {
                         CustomCheckpointUseCaseView(
                             model: self.model,
-                            checkpointVariables: self.checkpointVariables
+                            customVariables: self.customVariables
                         )
                     } label: {
                         DemoLabel(
@@ -126,7 +126,7 @@ struct ContentView: View {
                             do {
                                 let result = try await Purchases.shared.checkpoint(
                                     "this-checkpoint-does-not-exist",
-                                    params: self.checkpointVariables.checkpointParams
+                                    params: self.customVariables.checkpointParams
                                 )
                                 self.model.showOutcome(result)
                             } catch {
@@ -144,7 +144,7 @@ struct ContentView: View {
                             do {
                                 let result = try await Purchases.shared.checkpoint(
                                     "error_checkpoint",
-                                    params: self.checkpointVariables.checkpointParams
+                                    params: self.customVariables.checkpointParams
                                 )
                                 self.model.showOutcome(result)
                             } catch {
@@ -163,28 +163,28 @@ struct ContentView: View {
         NavigationStack {
             List {
                 Section {
-                    ForEach(self.$checkpointVariables.variables) { $variable in
+                    ForEach(self.$customVariables.variables) { $variable in
                         HStack {
                             TextField("Name", text: $variable.name)
                             TextField("Value", text: $variable.value)
                         }
                     }
                     .onDelete { offsets in
-                        self.checkpointVariables.variables.remove(atOffsets: offsets)
+                        self.customVariables.variables.remove(atOffsets: offsets)
                     }
 
                     Button {
-                        self.checkpointVariables.variables.append(.init())
+                        self.customVariables.variables.append(.init())
                     } label: {
                         Label("Add variable", systemImage: "plus")
                     }
                 } header: {
-                    Text("Checkpoint variables")
+                    Text("Custom variables")
                 } footer: {
-                    Text("These custom properties are passed to every checkpoint call.")
+                    Text("These custom variables are passed to every checkpoint call.")
                 }
             }
-            .navigationTitle("Variables")
+            .navigationTitle("Custom variables")
         }
     }
 

--- a/Examples/CheckpointTester/CheckpointTester/Sources/CustomVariables.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/CustomVariables.swift
@@ -7,7 +7,7 @@
 //
 //      https://opensource.org/licenses/MIT
 //
-//  CheckpointVariables.swift
+//  CustomVariables.swift
 //
 //  Created by Rick van der Linden.
 //
@@ -16,28 +16,28 @@ import Combine
 import Foundation
 @_spi(CheckpointsInternal) import RevenueCatUI
 
-final class CheckpointVariables: ObservableObject {
+final class CustomVariables: ObservableObject {
 
     @Published var variables = [
-        CheckpointVariable(name: "source", value: "CheckpointTester"),
+        CustomVariable(name: "source", value: "CheckpointTester"),
     ]
 
     var checkpointParams: CheckpointParams {
-        var customProperties: [String: CheckpointValue] = [:]
+        var customVariables: [String: CheckpointValue] = [:]
 
         for variable in self.variables {
             let name = variable.name.trimmingCharacters(in: .whitespacesAndNewlines)
             if !name.isEmpty {
-                customProperties[name] = .string(variable.value)
+                customVariables[name] = .string(variable.value)
             }
         }
 
-        return CheckpointParams(customProperties: customProperties)
+        return CheckpointParams(customVariables: customVariables)
     }
 
 }
 
-struct CheckpointVariable: Identifiable {
+struct CustomVariable: Identifiable {
 
     let id = UUID()
     var name = ""

--- a/Examples/CheckpointTester/CheckpointTester/Sources/GlobalCheckpointAnalyticsTracker.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/GlobalCheckpointAnalyticsTracker.swift
@@ -33,13 +33,13 @@ final class GlobalCheckpointAnalyticsTracker: ObservableObject, CheckpointListen
     // These callbacks demonstrate an app-wide analytics integration using CheckpointListener.
     func onCheckpointHit(_ checkpoint: CheckpointInfo) {
         self.track(
-            "Hit · \(checkpoint.identifier) · params=\(checkpoint.params.customProperties)"
+            "Hit · \(checkpoint.identifier) · customVariables=\(checkpoint.params.customVariables)"
         )
     }
 
     func onCheckpointCompleted(_ checkpoint: CheckpointInfo, result: CheckpointResult) {
         self.track(
-            "Completed · \(Self.describe(result)) · params=\(checkpoint.params.customProperties)"
+            "Completed · \(Self.describe(result)) · customVariables=\(checkpoint.params.customVariables)"
         )
     }
 

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/CustomCheckpointUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/CustomCheckpointUseCaseView.swift
@@ -19,7 +19,7 @@ import SwiftUI
 struct CustomCheckpointUseCaseView: View {
 
     @ObservedObject var model: CheckpointDemoModel
-    @ObservedObject var checkpointVariables: CheckpointVariables
+    @ObservedObject var customVariables: CustomVariables
 
     @State private var identifier = ""
     @State private var isRunning = false
@@ -42,7 +42,7 @@ struct CustomCheckpointUseCaseView: View {
                 }
                 .disabled(self.trimmedIdentifier.isEmpty || self.isRunning)
             } footer: {
-                Text("The current variables are passed as checkpoint parameters.")
+                Text("The current custom variables are passed as checkpoint parameters.")
             }
         }
         .navigationTitle("Custom checkpoint")
@@ -58,7 +58,7 @@ struct CustomCheckpointUseCaseView: View {
         do {
             let result = try await Purchases.shared.checkpoint(
                 self.trimmedIdentifier,
-                params: self.checkpointVariables.checkpointParams
+                params: self.customVariables.checkpointParams
             )
             self.model.showOutcome(result)
         } catch {

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/EntitlementGateUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/EntitlementGateUseCaseView.swift
@@ -19,7 +19,7 @@ import SwiftUI
 
 struct EntitlementGateUseCaseView: View {
 
-    @ObservedObject var checkpointVariables: CheckpointVariables
+    @ObservedObject var customVariables: CustomVariables
 
     @State private var isRunning = false
     @State private var didLoad = false
@@ -135,9 +135,9 @@ struct EntitlementGateUseCaseView: View {
     }
 
     private var entitlementCheckpointParams: CheckpointParams {
-        var customProperties = self.checkpointVariables.checkpointParams.customProperties
-        customProperties["gate"] = .string("entitlement")
-        return CheckpointParams(customProperties: customProperties)
+        var customVariables = self.customVariables.checkpointParams.customVariables
+        customVariables["gate"] = .string("entitlement")
+        return CheckpointParams(customVariables: customVariables)
     }
 
     private static func activeEntitlementIdentifiers(from customerInfo: CustomerInfo) -> [String] {

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/HardPaywallUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/HardPaywallUseCaseView.swift
@@ -19,7 +19,7 @@ import SwiftUI
 
 struct HardPaywallUseCaseView: View {
 
-    @ObservedObject var checkpointVariables: CheckpointVariables
+    @ObservedObject var customVariables: CustomVariables
 
     @State private var isRunning = false
     @State private var didLoad = false
@@ -122,10 +122,10 @@ struct HardPaywallUseCaseView: View {
     @MainActor
     private func paramsForNextAttempt() -> CheckpointParams {
         self.attempts += 1
-        var customProperties = self.checkpointVariables.checkpointParams.customProperties
-        customProperties["gate"] = .string("hard")
-        customProperties["attempt"] = .integer(Int64(self.attempts))
-        return CheckpointParams(customProperties: customProperties)
+        var customVariables = self.customVariables.checkpointParams.customVariables
+        customVariables["gate"] = .string("hard")
+        customVariables["attempt"] = .integer(Int64(self.attempts))
+        return CheckpointParams(customVariables: customVariables)
     }
 
 }

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/OnboardingUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/OnboardingUseCaseView.swift
@@ -44,7 +44,7 @@ struct OnboardingUseCaseView: View {
         }
     }
 
-    @ObservedObject var checkpointVariables: CheckpointVariables
+    @ObservedObject var customVariables: CustomVariables
 
     @State private var step: Step = .welcome
     @State private var isRunning = false
@@ -151,9 +151,9 @@ struct OnboardingUseCaseView: View {
     }
 
     private var personalizationCheckpointParams: CheckpointParams {
-        var customProperties = self.checkpointVariables.checkpointParams.customProperties
-        customProperties["step"] = .string("personalize")
-        return CheckpointParams(customProperties: customProperties)
+        var customVariables = self.customVariables.checkpointParams.customVariables
+        customVariables["step"] = .string("personalize")
+        return CheckpointParams(customVariables: customVariables)
     }
 
 }

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/SoftPaywallUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/SoftPaywallUseCaseView.swift
@@ -19,7 +19,7 @@ import SwiftUI
 
 struct SoftPaywallUseCaseView: View {
 
-    @ObservedObject var checkpointVariables: CheckpointVariables
+    @ObservedObject var customVariables: CustomVariables
 
     @State private var isRunning = false
     @State private var didLoad = false
@@ -72,7 +72,7 @@ struct SoftPaywallUseCaseView: View {
         do {
             let result = try await Purchases.shared.checkpoint(
                 "soft_paywall",
-                params: self.checkpointVariables.checkpointParams
+                params: self.customVariables.checkpointParams
             )
             self.handle(result)
         } catch {

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C05A00000000000000000001 /* CustomVariableKeyValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05A00000000000000000002 /* CustomVariableKeyValidator.swift */; };
+		C05A00000000000000000003 /* CustomVariableKeyValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05A00000000000000000004 /* CustomVariableKeyValidatorTests.swift */; };
 		A0D100000000000000000001 /* LocalRulesEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D200000000000000000001 /* LocalRulesEvaluator.swift */; };
 		A0D100000000000000000002 /* DimensionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D200000000000000000002 /* DimensionProvider.swift */; };
 		A0D100000000000000000006 /* DeviceDimensionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D200000000000000000006 /* DeviceDimensionProvider.swift */; };
@@ -1572,6 +1574,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		C05A00000000000000000002 /* CustomVariableKeyValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomVariableKeyValidator.swift; sourceTree = "<group>"; };
+		C05A00000000000000000004 /* CustomVariableKeyValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomVariableKeyValidatorTests.swift; sourceTree = "<group>"; };
 		A0D200000000000000000001 /* LocalRulesEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalRulesEvaluator.swift; sourceTree = "<group>"; };
 		A0D200000000000000000002 /* DimensionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DimensionProvider.swift; sourceTree = "<group>"; };
 		A0D200000000000000000006 /* DeviceDimensionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceDimensionProvider.swift; sourceTree = "<group>"; };
@@ -3251,6 +3255,7 @@
 		A0D300000000000000000002 /* LocalRules */ = {
 			isa = PBXGroup;
 			children = (
+				C05A00000000000000000004 /* CustomVariableKeyValidatorTests.swift */,
 				A0D200000000000000000005 /* LocalRulesEvaluatorTests.swift */,
 				A0D200000000000000000007 /* DeviceDimensionProviderTests.swift */,
 			);
@@ -4289,6 +4294,7 @@
 		2DDA3E4524DB0B4500EDFE5B /* Misc */ = {
 			isa = PBXGroup;
 			children = (
+				C05A00000000000000000002 /* CustomVariableKeyValidator.swift */,
 				35F38B492C32BC2800CD29FD /* Locale */,
 				57F3C0CA29B7A08F0004FD7E /* Codable */,
 				57F3C0CB29B7A0B10004FD7E /* Concurrency */,
@@ -7309,6 +7315,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C05A00000000000000000001 /* CustomVariableKeyValidator.swift in Sources */,
 				73A630000000000000000001 /* NSNumber+JSON.swift in Sources */,
 				1E30849C30178A2100236A34 /* SourceHealthChecker.swift in Sources */,
 				1E30849D30178A2100236A34 /* APISourceFailover.swift in Sources */,
@@ -7814,6 +7821,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C05A00000000000000000003 /* CustomVariableKeyValidatorTests.swift in Sources */,
 				73A620000000000000000001 /* CheckpointValueTests.swift in Sources */,
 				1E3084A830178A9100236A34 /* APISourceFailoverTests.swift in Sources */,
 				1E3084A930178A9100236A34 /* SourceHealthCheckerTests.swift in Sources */,

--- a/RevenueCatUI/Checkpoints/Checkpoints.swift
+++ b/RevenueCatUI/Checkpoints/Checkpoints.swift
@@ -97,31 +97,31 @@ extension CheckpointValue {
 @_spi(CheckpointsInternal)
 public final class CheckpointParams: Equatable, Hashable, CustomStringConvertible, @unchecked Sendable {
 
-    /// Custom properties usable in checkpoint targeting rules and feature events.
-    public let customProperties: [String: CheckpointValue]
+    /// Custom variables usable in checkpoint targeting rules and feature events.
+    public let customVariables: [String: CheckpointValue]
 
-    /// Creates checkpoint parameters with the supplied custom properties.
-    public init(customProperties: [String: CheckpointValue] = [:]) {
-        self.customProperties = customProperties
+    /// Creates checkpoint parameters with the supplied custom variables.
+    public init(customVariables: [String: CheckpointValue] = [:]) {
+        self.customVariables = customVariables
     }
 
-    /// Returns whether two parameter collections contain the same custom properties.
+    /// Returns whether two parameter collections contain the same custom variables.
     public static func == (lhs: CheckpointParams, rhs: CheckpointParams) -> Bool {
-        return lhs.customProperties == rhs.customProperties
+        return lhs.customVariables == rhs.customVariables
     }
 
     /// Hashes the checkpoint parameters.
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(self.customProperties)
+        hasher.combine(self.customVariables)
     }
 
     /// A debug description of the checkpoint parameters.
     public var description: String {
-        return "CheckpointParams(customProperties=\(self.customProperties))"
+        return "CheckpointParams(customVariables=\(self.customVariables))"
     }
 
     var coreParams: RevenueCat.CheckpointParams {
-        return .init(customProperties: self.customProperties.mapValues(\.coreValue))
+        return .init(customVariables: self.customVariables.mapValues(\.coreValue))
     }
 
 }

--- a/RevenueCatUI/Checkpoints/ObjCCheckpointTypes.swift
+++ b/RevenueCatUI/Checkpoints/ObjCCheckpointTypes.swift
@@ -19,12 +19,12 @@ import Foundation
 
 private enum CheckpointStrings: LogMessage {
 
-    case invalidObjectiveCCustomProperty(Any.Type)
+    case invalidObjectiveCCustomVariable(Any.Type)
 
     var description: String {
         switch self {
-        case let .invalidObjectiveCCustomProperty(type):
-            return "Dropping invalid Objective-C checkpoint custom property: \(String(reflecting: type))"
+        case let .invalidObjectiveCCustomVariable(type):
+            return "Dropping invalid Objective-C checkpoint custom variable: \(String(reflecting: type))"
         }
     }
 
@@ -40,18 +40,18 @@ public final class ObjCCheckpointParams: NSObject {
     let value: CheckpointParams
 
     /// Creates checkpoint parameters from Objective-C Foundation primitive values. Unsupported values are dropped.
-    @objc(initWithCustomProperties:)
-    public init(customProperties: NSDictionary) {
+    @objc(initWithCustomVariables:)
+    public init(customVariables: NSDictionary) {
         var values: [String: CheckpointValue] = [:]
-        for (rawKey, rawValue) in customProperties {
+        for (rawKey, rawValue) in customVariables {
             guard let key = rawKey as? String,
                   let value = CheckpointValue(foundationValue: rawValue) else {
-                Logger.warning(CheckpointStrings.invalidObjectiveCCustomProperty(type(of: rawValue)))
+                Logger.warning(CheckpointStrings.invalidObjectiveCCustomVariable(type(of: rawValue)))
                 continue
             }
             values[key] = value
         }
-        self.value = CheckpointParams(customProperties: values)
+        self.value = CheckpointParams(customVariables: values)
         super.init()
     }
 
@@ -60,10 +60,10 @@ public final class ObjCCheckpointParams: NSObject {
         super.init()
     }
 
-    /// The custom properties as Objective-C Foundation primitive values.
-    @objc(customProperties)
-    public var customProperties: NSDictionary {
-        return self.value.customProperties.mapValues { $0.foundationValue } as NSDictionary
+    /// The custom variables as Objective-C Foundation primitive values.
+    @objc(customVariables)
+    public var customVariables: NSDictionary {
+        return self.value.customVariables.mapValues { $0.foundationValue } as NSDictionary
     }
 
 }

--- a/RevenueCatUI/Data/CustomPaywallVariables.swift
+++ b/RevenueCatUI/Data/CustomPaywallVariables.swift
@@ -11,6 +11,7 @@
 //
 //  Created by Facundo Menzella on 1/22/26.
 
+@_spi(Internal) import RevenueCat
 import SwiftUI
 
 /// A value type for custom paywall variables that can be passed to paywalls at runtime.
@@ -211,7 +212,7 @@ enum CustomVariableKeyValidator {
     /// Only performs validation in DEBUG builds.
     static func validate(_ key: String) {
         #if DEBUG
-        if !isValidKey(key) {
+        if !RevenueCat.CustomVariableKeyValidator.isValidKey(key) {
             Logger.warning(Strings.paywall_custom_variable_invalid_key(key: key))
         }
         #endif
@@ -221,19 +222,11 @@ enum CustomVariableKeyValidator {
     /// Only performs validation in DEBUG builds.
     static func validate(_ variables: [String: CustomVariableValue]) {
         #if DEBUG
-        for key in variables.keys where !isValidKey(key) {
+        for key in variables.keys where !RevenueCat.CustomVariableKeyValidator.isValidKey(key) {
             Logger.warning(Strings.paywall_custom_variable_invalid_key(key: key))
         }
         #endif
     }
-
-    #if DEBUG
-    private static func isValidKey(_ key: String) -> Bool {
-        guard !key.isEmpty else { return false }
-        guard let first = key.first, first.isLetter else { return false }
-        return key.allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" }
-    }
-    #endif
 
 }
 

--- a/Sources/Checkpoints/Checkpoints.swift
+++ b/Sources/Checkpoints/Checkpoints.swift
@@ -130,31 +130,44 @@ extension CheckpointValue {
 
 }
 
+extension CheckpointValue {
+
+    var dimensionValue: DimensionValue {
+        switch self {
+        case let .string(value): return .string(value)
+        case let .integer(value): return .int(value)
+        case let .double(value): return .double(value)
+        case let .boolean(value): return .bool(value)
+        }
+    }
+
+}
+
 /// Per-call parameters for a checkpoint.
 @_spi(Internal)
 public final class CheckpointParams: Equatable, Hashable, CustomStringConvertible, @unchecked Sendable {
 
-    /// Custom properties usable in checkpoint targeting rules and feature events.
-    public let customProperties: [String: CheckpointValue]
+    /// Custom variables usable in checkpoint targeting rules and feature events.
+    public let customVariables: [String: CheckpointValue]
 
-    /// Creates checkpoint parameters with the supplied custom properties.
-    public init(customProperties: [String: CheckpointValue] = [:]) {
-        self.customProperties = customProperties
+    /// Creates checkpoint parameters with the supplied custom variables.
+    public init(customVariables: [String: CheckpointValue] = [:]) {
+        self.customVariables = customVariables
     }
 
-    /// Returns whether two parameter collections contain the same custom properties.
+    /// Returns whether two parameter collections contain the same custom variables.
     public static func == (lhs: CheckpointParams, rhs: CheckpointParams) -> Bool {
-        return lhs.customProperties == rhs.customProperties
+        return lhs.customVariables == rhs.customVariables
     }
 
     /// Hashes the checkpoint parameters.
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(self.customProperties)
+        hasher.combine(self.customVariables)
     }
 
     /// A debug description of the checkpoint parameters.
     public var description: String {
-        return "CheckpointParams(customProperties=\(self.customProperties))"
+        return "CheckpointParams(customVariables=\(self.customVariables))"
     }
 
 }

--- a/Sources/LocalRules/DimensionProvider.swift
+++ b/Sources/LocalRules/DimensionProvider.swift
@@ -17,6 +17,7 @@ import Foundation
 /// Roots containing dimensions that may be evaluated locally by the rules engine.
 enum DimensionNamespace: String, CaseIterable, Sendable {
 
+    case custom
     case device
     case session
     case client

--- a/Sources/LocalRules/DimensionResolver.swift
+++ b/Sources/LocalRules/DimensionResolver.swift
@@ -45,7 +45,7 @@ struct DimensionResolver: Sendable {
     ///
     /// For example, device `appVersion: "1.2.3"` becomes
     /// `device.appVersion: "1.2.3"` in the RulesEngine input.
-    func snapshot() async throws -> DimensionSnapshot {
+    func snapshot(customVariables: [String: DimensionValue] = [:]) async throws -> DimensionSnapshot {
         let date = self.dateProvider.now()
         var values: [String: RulesEngine.Value] = [:]
 
@@ -81,6 +81,12 @@ struct DimensionResolver: Sendable {
             }
 
             values[namespace] = .object(namespaceValues)
+        }
+
+        if !customVariables.isEmpty {
+            values[DimensionNamespace.custom.rawValue] = .object(
+                customVariables.mapValues(\.rulesEngineValue)
+            )
         }
 
         try Task.checkCancellation()

--- a/Sources/LocalRules/DimensionResolver.swift
+++ b/Sources/LocalRules/DimensionResolver.swift
@@ -83,9 +83,10 @@ struct DimensionResolver: Sendable {
             values[namespace] = .object(namespaceValues)
         }
 
-        if !customVariables.isEmpty {
+        let validCustomVariables = CustomVariableKeyValidator.validateAndFilter(customVariables)
+        if !validCustomVariables.isEmpty {
             values[DimensionNamespace.custom.rawValue] = .object(
-                customVariables.mapValues(\.rulesEngineValue)
+                validCustomVariables.mapValues(\.rulesEngineValue)
             )
         }
 

--- a/Sources/LocalRules/LocalRulesEvaluator.swift
+++ b/Sources/LocalRules/LocalRulesEvaluator.swift
@@ -44,12 +44,16 @@ final class LocalRulesEvaluator: Sendable {
     /// Returns the first matching rule, using one snapshot for the full call.
     ///
     /// For example, rules `[("a", false), ("b", true)]` return the second rule.
-    func match<Rule: LocalRule>(in rules: [Rule]) async throws -> Rule? {
+    /// Developer-supplied values are available to predicates under `custom.*`.
+    func match<Rule: LocalRule>(
+        in rules: [Rule],
+        customVariables: [String: DimensionValue] = [:]
+    ) async throws -> Rule? {
         guard !rules.isEmpty else {
             return nil
         }
 
-        let snapshot = try await self.dimensionResolver.snapshot()
+        let snapshot = try await self.dimensionResolver.snapshot(customVariables: customVariables)
 
         var firstEvaluationError: LocalRulesEvaluationError?
 

--- a/Sources/Misc/CustomVariableKeyValidator.swift
+++ b/Sources/Misc/CustomVariableKeyValidator.swift
@@ -1,0 +1,57 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CustomVariableKeyValidator.swift
+//
+//  Created by Rick van der Linden on 8/12/26.
+//
+
+import Foundation
+
+private enum CustomVariableKeyValidatorStrings: LogMessage {
+
+    case invalidKey(String)
+
+    var description: String {
+        switch self {
+        case .invalidKey(let key):
+            return "Custom variable key '\(key)' is invalid and will be ignored. " +
+                "Keys must start with a letter and contain only letters, numbers, and underscores."
+        }
+    }
+
+    var category: String { return "custom_variables" }
+
+}
+
+/// The naming policy for developer-supplied custom variable keys.
+@_spi(Internal)
+public struct CustomVariableKeyValidator {
+
+    private init() {}
+
+    /// Returns whether a key can be addressed using a `custom.<key>` path.
+    public static func isValidKey(_ key: String) -> Bool {
+        guard let first = key.first, first.isLetter else { return false }
+        return key.allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" }
+    }
+
+    /// Drops invalid keys and logs a warning for each removed entry.
+    public static func validateAndFilter<Value>(_ variables: [String: Value]) -> [String: Value] {
+        return variables.filter { key, _ in
+            guard Self.isValidKey(key) else {
+                Logger.warn(CustomVariableKeyValidatorStrings.invalidKey(key))
+                return false
+            }
+
+            return true
+        }
+    }
+
+}

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCCheckpointAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCCheckpointAPI.m
@@ -23,11 +23,11 @@
 
 + (void)checkAPI {
     RCPurchases *purchases = RCPurchases.sharedPurchases;
-    RCCheckpointParams *params = [[RCCheckpointParams alloc] initWithCustomProperties:@{
+    RCCheckpointParams *params = [[RCCheckpointParams alloc] initWithCustomVariables:@{
         @"name": @"Rick",
         @"subscriber": @YES,
     }];
-    NSDictionary * __unused customProperties = params.customProperties;
+    NSDictionary * __unused customVariables = params.customVariables;
 
     [purchases checkpointWithIdentifier:@"test_checkpoint"
                                   params:params

--- a/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
+++ b/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
@@ -58,13 +58,13 @@ func checkCheckpointAPI(_ purchases: Purchases) {
     purchases.checkpointListener = CheckpointListenerAPITester()
     let _: CheckpointListener? = purchases.checkpointListener
 
-    let params = CheckpointParams(customProperties: [
+    let params = CheckpointParams(customVariables: [
         "name": string,
         "attempts": integer,
         "score": double,
         "subscriber": boolean
     ])
-    let _: [String: CheckpointValue] = params.customProperties
+    let _: [String: CheckpointValue] = params.customVariables
 
     purchases.checkpoint(
         "test_checkpoint",

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
@@ -26,7 +26,7 @@ final class CheckpointsManagerTests: TestCase {
 
         let result = try await manager.checkpoint(
             identifier: "unknown_checkpoint",
-            params: CheckpointParams(customProperties: ["name": "Rick"])
+            params: CheckpointParams(customVariables: ["name": "Rick"])
         )
 
         guard let noAction = result as? CheckpointNoActionResult else {
@@ -34,7 +34,7 @@ final class CheckpointsManagerTests: TestCase {
         }
         XCTAssertEqual(noAction.reason, .unknownCheckpoint)
         XCTAssertEqual(noAction.checkpoint.identifier, "unknown_checkpoint")
-        XCTAssertEqual(noAction.checkpoint.params.customProperties["name"], "Rick")
+        XCTAssertEqual(noAction.checkpoint.params.customVariables["name"], "Rick")
         XCTAssertEqual(
             listener.events,
             [.hit("unknown_checkpoint"), .completed("unknown_checkpoint")]
@@ -113,11 +113,11 @@ final class CheckpointsManagerTests: TestCase {
     func testUIOwnedReferenceModelsPreserveValueEqualityAndHashing() {
         let firstInfo = CheckpointInfo(
             identifier: "test",
-            params: CheckpointParams(customProperties: ["name": "Rick"])
+            params: CheckpointParams(customVariables: ["name": "Rick"])
         )
         let secondInfo = CheckpointInfo(
             identifier: "test",
-            params: CheckpointParams(customProperties: ["name": "Rick"])
+            params: CheckpointParams(customVariables: ["name": "Rick"])
         )
         let firstResult = CheckpointNoActionResult(checkpoint: firstInfo, reason: .noMatch)
         let secondResult = CheckpointNoActionResult(checkpoint: secondInfo, reason: .noMatch)

--- a/Tests/UnitTests/Checkpoints/CheckpointValueTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointValueTests.swift
@@ -19,17 +19,17 @@ import XCTest
 final class CheckpointValueTests: TestCase {
 
     func testLiteralValuesPreserveTheirTypes() {
-        let params = CheckpointParams(customProperties: [
+        let params = CheckpointParams(customVariables: [
             "string": "value",
             "integer": 42,
             "double": 4.5,
             "boolean": true
         ])
 
-        XCTAssertEqual(params.customProperties["string"], .string("value"))
-        XCTAssertEqual(params.customProperties["integer"], .integer(42))
-        XCTAssertEqual(params.customProperties["double"], .double(4.5))
-        XCTAssertEqual(params.customProperties["boolean"], .boolean(true))
+        XCTAssertEqual(params.customVariables["string"], .string("value"))
+        XCTAssertEqual(params.customVariables["integer"], .integer(42))
+        XCTAssertEqual(params.customVariables["double"], .double(4.5))
+        XCTAssertEqual(params.customVariables["boolean"], .boolean(true))
     }
 
     func testCodableUsesPrimitiveJSONValues() throws {
@@ -72,11 +72,18 @@ final class CheckpointValueTests: TestCase {
     }
 
     func testParamsPreserveValueEqualityAndHashing() {
-        let firstParams = CheckpointParams(customProperties: ["name": "Rick"])
-        let secondParams = CheckpointParams(customProperties: ["name": "Rick"])
+        let firstParams = CheckpointParams(customVariables: ["name": "Rick"])
+        let secondParams = CheckpointParams(customVariables: ["name": "Rick"])
 
         XCTAssertEqual(firstParams, secondParams)
         XCTAssertEqual(Set([firstParams, secondParams]).count, 1)
+    }
+
+    func testValuesConvertToDimensionsWithoutLosingTheirTypes() {
+        XCTAssertEqual(CheckpointValue.string("value").dimensionValue, .string("value"))
+        XCTAssertEqual(CheckpointValue.integer(42).dimensionValue, .int(42))
+        XCTAssertEqual(CheckpointValue.double(4.5).dimensionValue, .double(4.5))
+        XCTAssertEqual(CheckpointValue.boolean(true).dimensionValue, .bool(true))
     }
 
 }

--- a/Tests/UnitTests/LocalRules/CustomVariableKeyValidatorTests.swift
+++ b/Tests/UnitTests/LocalRules/CustomVariableKeyValidatorTests.swift
@@ -1,0 +1,64 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CustomVariableKeyValidatorTests.swift
+//
+//  Created by Rick van der Linden on 8/12/26.
+//
+
+// Swift Testing is only available with the Xcode 16+ toolchain
+#if compiler(>=5.9)
+#if canImport(Testing)
+
+import Testing
+
+@_spi(Internal) @testable import RevenueCat
+
+@Suite("Custom variable key validation")
+struct CustomVariableKeyValidatorTests {
+
+    @Test
+    func acceptsAddressableKeys() {
+        let validKeys = ["validKey", "valid_key_name", "key123", "player_score_2024", "a", "kéy"]
+
+        #expect(validKeys.allSatisfy { CustomVariableKeyValidator.isValidKey($0) })
+    }
+
+    @Test
+    func rejectsUnaddressableKeys() {
+        let invalidKeys = ["", "123key", "_key", "key-name", "key name", "key.name", "key!"]
+
+        #expect(invalidKeys.allSatisfy { !CustomVariableKeyValidator.isValidKey($0) })
+    }
+
+    @Test
+    func invalidKeysAreOmittedFromCustomNamespace() async throws {
+        let snapshot = try await DimensionResolver(dimensionProviders: []).snapshot(customVariables: [
+            "valid_key": .string("kept"),
+            "my.property": .string("dropped"),
+            "2fast": .string("dropped"),
+            "has space": .string("dropped")
+        ])
+
+        #expect(snapshot.values["custom"] == .object(["valid_key": .string("kept")]))
+    }
+
+    @Test
+    func onlyInvalidVariablesLeaveCustomNamespaceAbsent() async throws {
+        let snapshot = try await DimensionResolver(dimensionProviders: []).snapshot(customVariables: [
+            "invalid.key": .string("dropped")
+        ])
+
+        #expect(snapshot.values["custom"] == nil)
+    }
+
+}
+
+#endif
+#endif

--- a/Tests/UnitTests/LocalRules/DeviceDimensionProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/DeviceDimensionProviderTests.swift
@@ -25,7 +25,7 @@ import Testing
 struct DeviceDimensionProviderTests {
 
     @Test
-    func providesDeviceVariablesInDeviceNamespace() async throws {
+    func providesDeviceDimensionsInDeviceNamespace() async throws {
         let provider = DeviceDimensionProvider(
             appVersion: "1.2.3",
             localeProvider: { "NL-nl" },

--- a/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
+++ b/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
@@ -138,6 +138,60 @@ struct LocalRulesEvaluatorTests {
     }
 
     @Test
+    func customVariablesAreAvailableInCustomNamespace() async throws {
+        let evaluator = Self.evaluator(dimensionProviders: [])
+
+        let rule = try await evaluator.match(
+            in: [
+                TestLocalRule(
+                    id: "matching-rule",
+                    predicate: """
+                        {
+                          "and": [
+                            { "==": [{ "var": "custom.name" }, "Rick"] },
+                            { "==": [{ "var": "custom.attempts" }, 3] },
+                            { "==": [{ "var": "custom.score" }, 4.5] },
+                            { "==": [{ "var": "custom.subscriber" }, true] }
+                          ]
+                        }
+                        """
+                )
+            ],
+            customVariables: [
+                "name": .string("Rick"),
+                "attempts": .int(3),
+                "score": .double(4.5),
+                "subscriber": .bool(true)
+            ]
+        )
+
+        #expect(rule?.id == "matching-rule")
+    }
+
+    @Test
+    func customVariablesAreScopedToOneEvaluation() async throws {
+        let evaluator = Self.evaluator(dimensionProviders: [])
+        let rules = [
+            TestLocalRule(
+                id: "matching-rule",
+                predicate: #"{"==":[{"var":"custom.source"},"onboarding"]}"#
+            )
+        ]
+
+        let first = try await evaluator.match(
+            in: rules,
+            customVariables: ["source": .string("onboarding")]
+        )
+        let second = try await evaluator.match(
+            in: rules,
+            customVariables: ["source": .string("paywall")]
+        )
+
+        #expect(first?.id == "matching-rule")
+        #expect(second?.id == nil)
+    }
+
+    @Test
     func duplicateLeafIsAConfigurationError() async {
         let first = TestDimensionProvider(
             namespace: .device,


### PR DESCRIPTION
## Description
Implements support for passing `customVariables` to checkpoints, which will be injected when evaluating the rules through the rules engine.

Custom variables can be passed when invoking the checkpoint through the `customVariables` property on `CheckpointParams`:

```swift
Purchases.shared.checkpoint("onboarding_completed", params: CheckpointParams(customVariables: ["level": 3]))
```

They will be available through `custom.level` in the rule itself. Keys must start with a letter and contain only letters, numbers, and underscores. Invalid keys are logged and omitted from rule evaluation.

Note: rule evaluation itself isn't wired up yet for checkpoints, that will come in a follow-up PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking SPI rename of `CheckpointParams` and changes to local-rules dimension snapshots. Risk is moderated because checkpoint→rules wiring is not complete yet.
> 
> **Overview**
> **Renames checkpoint `customProperties` to `customVariables`** and wires those values into local rule evaluation under the new `custom.*` namespace.
> 
> `LocalRulesEvaluator.match` and `DimensionResolver.snapshot` now accept per-call custom variables, filter invalid keys via a shared `CustomVariableKeyValidator`, and expose them as `custom.<key>` for predicates. `CheckpointValue` gains a `dimensionValue` conversion for that path.
> 
> Paywall custom-variable validation now reuses the core validator. The CheckpointTester demo and API testers are updated for the rename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 196397c65ef1936c11337acb7cac6ce71e5c2b10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
