### PR TITLE
fix(paywalls): Resolve bundled fonts by name before downloading

### DIFF
--- a/Sources/Paywalls/PaywallFontManagerType.swift
+++ b/Sources/Paywalls/PaywallFontManagerType.swift
@@ -123,8 +123,7 @@ actor DefaultPaywallFontsManager: PaywallFontManagerType {
             return true
         }
 
-        return Self.installedFontNames(inFamily: fontFamily)
-            .contains { $0.caseInsensitiveCompare(fontName) == .orderedSame }
+        return Self.installedFontNames(inFamily: fontFamily).contains(fontName)
     }
 
     func installFont(_ font: DownloadableFont) async throws {

--- a/Sources/Paywalls/PaywallFontManagerType.swift
+++ b/Sources/Paywalls/PaywallFontManagerType.swift
@@ -117,20 +117,14 @@ actor DefaultPaywallFontsManager: PaywallFontManagerType {
     }
 
     nonisolated func fontIsAlreadyInstalled(fontName: String, fontFamily: String?) -> Bool {
-        var availableFontNames: [String] = []
-        #if canImport(UIKit)
-        if let fontFamily = fontFamily {
-            availableFontNames = UIFont.fontNames(forFamilyName: fontFamily)
-        } else {
-            availableFontNames = UIFont.familyNames.flatMap {
-                UIFont.fontNames(forFamilyName: $0)
-            }
-        }
-        #elseif canImport(AppKit)
-        availableFontNames = NSFontManager.shared.availableFonts
-        #endif
+        guard !fontName.isEmpty else { return false }
 
-        return availableFontNames.contains(fontName)
+        if Self.fontFaceExists(named: fontName) {
+            return true
+        }
+
+        return Self.installedFontNames(inFamily: fontFamily)
+            .contains { $0.caseInsensitiveCompare(fontName) == .orderedSame }
     }
 
     func installFont(_ font: DownloadableFont) async throws {
@@ -166,6 +160,39 @@ actor DefaultPaywallFontsManager: PaywallFontManagerType {
     }
 
     // MARK: - Private
+
+    /// Whether a font face with this name is already available to the process.
+    private static func fontFaceExists(named fontName: String) -> Bool {
+        #if canImport(UIKit)
+        guard let font = UIFont(name: fontName, size: 1) else { return false }
+        // `UIFont(name:)` also resolves family names, so confirm we matched the requested face.
+        return fontName.caseInsensitiveCompare(font.fontName) == .orderedSame
+            || fontName.caseInsensitiveCompare(font.familyName) == .orderedSame
+        #elseif canImport(AppKit)
+        guard let font = NSFont(name: fontName, size: 1) else { return false }
+        if fontName.caseInsensitiveCompare(font.fontName) == .orderedSame { return true }
+        guard let familyName = font.familyName else { return false }
+        return fontName.caseInsensitiveCompare(familyName) == .orderedSame
+        #else
+        return false
+        #endif
+    }
+
+    /// Names of the installed faces in `fontFamily`, or of every installed face when the
+    /// family is unknown to the system.
+    private static func installedFontNames(inFamily fontFamily: String?) -> [String] {
+        #if canImport(UIKit)
+        if let fontFamily = fontFamily {
+            let namesInFamily = UIFont.fontNames(forFamilyName: fontFamily)
+            if !namesInFamily.isEmpty { return namesInFamily }
+        }
+        return UIFont.familyNames.flatMap { UIFont.fontNames(forFamilyName: $0) }
+        #elseif canImport(AppKit)
+        return NSFontManager.shared.availableFonts
+        #else
+        return []
+        #endif
+    }
 
     private static func fontsDirectory(fileManager: FontsFileManaging) throws -> URL {
         let fontsDirectory = try fileManager

--- a/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
@@ -15,6 +15,14 @@ import Nimble
 @_spi(Internal) @testable import RevenueCat
 import XCTest
 
+#if canImport(UIKit)
+import UIKit
+#endif
+
+#if canImport(AppKit)
+import AppKit
+#endif
+
 @available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *)
 final class PaywallCacheWarmingTests: TestCase {
 
@@ -645,6 +653,205 @@ final class PaywallCacheWarmingTests: TestCase {
 
         expect(session.dataFromURLCallCount).to(equal(1))
         expect(registrar.registerFontCallCount).to(equal(2))
+    }
+
+    // MARK: - fontIsAlreadyInstalled
+
+    func testFontIsAlreadyInstalled_WhenServerFamilyDoesNotMatchSystemFamily() throws {
+        let font = try Self.fontWithMultiWordFamily()
+
+        // The backend derives the family from the PostScript name prefix, dropping the
+        // spaces the system family name has (e.g. "Avenir Next" -> "AvenirNext").
+        let derivedFamily = font.family.replacingOccurrences(of: " ", with: "")
+
+        expect(Self.fontsManager.fontIsAlreadyInstalled(fontName: font.name,
+                                                        fontFamily: derivedFamily)).to(beTrue())
+    }
+
+    func testFontIsAlreadyInstalled_WhenFamilyMatchesSystemFamily() throws {
+        let font = try Self.anyInstalledFont()
+
+        expect(Self.fontsManager.fontIsAlreadyInstalled(fontName: font.name,
+                                                        fontFamily: font.family)).to(beTrue())
+    }
+
+    func testFontIsAlreadyInstalled_WhenFamilyIsNil() throws {
+        let font = try Self.anyInstalledFont()
+
+        expect(Self.fontsManager.fontIsAlreadyInstalled(fontName: font.name,
+                                                        fontFamily: nil)).to(beTrue())
+    }
+
+    func testFontIsAlreadyInstalled_WhenFamilyIsEmpty() throws {
+        let font = try Self.anyInstalledFont()
+
+        expect(Self.fontsManager.fontIsAlreadyInstalled(fontName: font.name,
+                                                        fontFamily: "")).to(beTrue())
+    }
+
+    func testFontIsAlreadyInstalled_WhenFamilyBelongsToADifferentInstalledFont() throws {
+        let font = try Self.anyInstalledFont()
+        let otherFamily = try Self.installedFamilyName(otherThan: font.family)
+
+        // A wrong-but-real family must not stop us from resolving the face by name.
+        expect(Self.fontsManager.fontIsAlreadyInstalled(fontName: font.name,
+                                                        fontFamily: otherFamily)).to(beTrue())
+    }
+
+    func testFontIsAlreadyInstalled_IsCaseInsensitiveForFontName() throws {
+        let font = try Self.anyInstalledFont()
+
+        expect(Self.fontsManager.fontIsAlreadyInstalled(fontName: font.name.uppercased(),
+                                                        fontFamily: font.family)).to(beTrue())
+        expect(Self.fontsManager.fontIsAlreadyInstalled(fontName: font.name.lowercased(),
+                                                        fontFamily: font.family)).to(beTrue())
+    }
+
+    func testFontIsAlreadyInstalled_ReturnsFalseForUnknownFontName() {
+        expect(Self.fontsManager.fontIsAlreadyInstalled(fontName: Self.unknownFontName,
+                                                        fontFamily: Self.unknownFamilyName)).to(beFalse())
+        expect(Self.fontsManager.fontIsAlreadyInstalled(fontName: Self.unknownFontName,
+                                                        fontFamily: nil)).to(beFalse())
+    }
+
+    func testFontIsAlreadyInstalled_ReturnsFalseWhenOnlyTheFamilyIsInstalled() throws {
+        let font = try Self.anyInstalledFont()
+
+        // The family exists, but no face in it is named `unknownFontName`.
+        expect(Self.fontsManager.fontIsAlreadyInstalled(fontName: Self.unknownFontName,
+                                                        fontFamily: font.family)).to(beFalse())
+    }
+
+    func testFontIsAlreadyInstalled_ReturnsFalseForEmptyFontName() throws {
+        let font = try Self.anyInstalledFont()
+
+        expect(Self.fontsManager.fontIsAlreadyInstalled(fontName: "", fontFamily: nil)).to(beFalse())
+        expect(Self.fontsManager.fontIsAlreadyInstalled(fontName: "", fontFamily: font.family)).to(beFalse())
+    }
+
+#if !os(tvOS)
+
+    func testTriggerFontDownload_SkipsDownloadWhenInstalledUnderADifferentFamily() async throws {
+        let font = try Self.fontWithMultiWordFamily()
+        let derivedFamily = font.family.replacingOccurrences(of: " ", with: "")
+
+        let session = MockSession()
+        let cache = PaywallCacheWarming(
+            introEligibiltyChecker: self.eligibilityChecker,
+            fontsManager: Self.makeFontsManager(session: session)
+        )
+        let fontsConfig = try Self.fontsConfig(fontName: font.name, family: derivedFamily)
+
+        await cache.triggerFontDownloadIfNeeded(fontsConfig: fontsConfig)
+
+        expect(session.dataFromURLCallCount).to(equal(0))
+    }
+
+    func testTriggerFontDownload_DownloadsWhenFontIsNotInstalled() async throws {
+        let data = Data("valid font".utf8)
+        let session = MockSession()
+        session.dataFromURL = data
+        session.urlResponse = HTTPURLResponse(
+            url: Self.fontURL,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )
+
+        let cache = PaywallCacheWarming(
+            introEligibiltyChecker: self.eligibilityChecker,
+            fontsManager: Self.makeFontsManager(session: session)
+        )
+
+        let fontsConfig = try Self.fontsConfig(fontName: Self.unknownFontName,
+                                               family: Self.unknownFamilyName,
+                                               hash: data.md5String)
+
+        await cache.triggerFontDownloadIfNeeded(fontsConfig: fontsConfig)
+
+        expect(session.dataFromURLCallCount).to(equal(1))
+    }
+
+#endif
+
+    // MARK: - Font test helpers
+
+    private static let unknownFontName = "RevenueCatNotAnInstalledFont-Regular"
+    private static let unknownFamilyName = "RevenueCatNotAnInstalledFont"
+    private static let fontURL = URL(string: "https://example.com/font.ttf")!
+
+    private static let fontsManager = PaywallCacheWarmingTests.makeFontsManager()
+
+    private static func makeFontsManager(session: MockSession = MockSession()) -> DefaultPaywallFontsManager {
+        return DefaultPaywallFontsManager(
+            fileManager: MockFileManager(),
+            session: session,
+            registrar: MockRegistrar()
+        )
+    }
+
+    private static func fontsConfig(
+        fontName: String,
+        family: String,
+        hash: String = "abc123"
+    ) throws -> UIConfig.FontsConfig {
+        let json = """
+        {"family": "\(family)", "url": "\(Self.fontURL.absoluteString)", "hash": "\(hash)"}
+        """
+        let webFontInfo = try JSONDecoder().decode(UIConfig.WebFontInfo.self, from: Data(json.utf8))
+
+        return UIConfig.FontsConfig(ios: UIConfig.FontInfo(name: fontName, webFontInfo: webFontInfo))
+    }
+
+    /// Every installed family and its face names on the current platform.
+    private static func installedFontFamilies() -> [(family: String, names: [String])] {
+        #if canImport(UIKit)
+        return UIFont.familyNames.map { ($0, UIFont.fontNames(forFamilyName: $0)) }
+        #elseif canImport(AppKit)
+        return NSFontManager.shared.availableFontFamilies.map { family in
+            let names = (NSFontManager.shared.availableMembers(ofFontFamily: family) ?? [])
+                .compactMap { $0.first as? String }
+            return (family, names)
+        }
+        #else
+        return []
+        #endif
+    }
+
+    private static func anyInstalledFont() throws -> (family: String, name: String) {
+        for entry in Self.installedFontFamilies() {
+            if let name = entry.names.first {
+                return (entry.family, name)
+            }
+        }
+
+        throw XCTSkip("No installed fonts on this platform")
+    }
+
+    private static func installedFamilyName(otherThan family: String) throws -> String {
+        let other = Self.installedFontFamilies()
+            .first { $0.family.caseInsensitiveCompare(family) != .orderedSame && !$0.names.isEmpty }
+
+        guard let other = other else {
+            throw XCTSkip("Only one installed font family on this platform")
+        }
+        return other.family
+    }
+
+    /// An installed font whose family name contains spaces, so that removing them produces a
+    /// family the system does not know about.
+    private static func fontWithMultiWordFamily() throws -> (family: String, name: String) {
+        let families = Self.installedFontFamilies()
+        let knownFamilies = Set(families.map { $0.family.lowercased() })
+
+        for entry in families where entry.family.contains(" ") {
+            let derived = entry.family.replacingOccurrences(of: " ", with: "").lowercased()
+            // Skip families where dropping spaces happens to produce another known family.
+            guard !knownFamilies.contains(derived), let name = entry.names.first else { continue }
+            return (entry.family, name)
+        }
+
+        throw XCTSkip("No installed font with a multi-word family name on this platform")
     }
 }
 

--- a/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
@@ -698,13 +698,25 @@ final class PaywallCacheWarmingTests: TestCase {
                                                         fontFamily: otherFamily)).to(beTrue())
     }
 
-    func testFontIsAlreadyInstalled_IsCaseInsensitiveForFontName() throws {
+    func testPlatformFontLookupIsCaseSensitive() throws {
         let font = try Self.anyInstalledFont()
+        let miscased = font.name.uppercased()
+        try XCTSkipIf(miscased == font.name)
 
-        expect(Self.fontsManager.fontIsAlreadyInstalled(fontName: font.name.uppercased(),
-                                                        fontFamily: font.family)).to(beTrue())
-        expect(Self.fontsManager.fontIsAlreadyInstalled(fontName: font.name.lowercased(),
-                                                        fontFamily: font.family)).to(beTrue())
+        expect(Self.platformResolvesFont(named: font.name)).to(beTrue())
+        expect(Self.platformResolvesFont(named: miscased)).to(beFalse())
+    }
+
+    func testFontIsAlreadyInstalled_AgreesWithPlatformFontLookupOnCasing() throws {
+        let font = try Self.anyInstalledFont()
+        let miscased = font.name.uppercased()
+        try XCTSkipIf(miscased == font.name)
+
+        // The paywall resolves fonts through this same lookup, so disagreeing means either
+        // re-downloading an available font or skipping one that can never be resolved.
+        expect(Self.fontsManager.fontIsAlreadyInstalled(fontName: miscased,
+                                                        fontFamily: font.family))
+            == Self.platformResolvesFont(named: miscased)
     }
 
     func testFontIsAlreadyInstalled_ReturnsFalseForUnknownFontName() {
@@ -815,6 +827,17 @@ final class PaywallCacheWarmingTests: TestCase {
         }
         #else
         return []
+        #endif
+    }
+
+    /// The same lookup the paywall uses to resolve a custom font.
+    private static func platformResolvesFont(named name: String) -> Bool {
+        #if canImport(UIKit)
+        return UIFont(name: name, size: 1) != nil
+        #elseif canImport(AppKit)
+        return NSFont(name: name, size: 1) != nil
+        #else
+        return false
         #endif
     }
 

--- a/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
@@ -698,13 +698,13 @@ final class PaywallCacheWarmingTests: TestCase {
                                                         fontFamily: otherFamily)).to(beTrue())
     }
 
-    func testPlatformFontLookupIsCaseSensitive() throws {
+    func testPlatformFontLookupIsNotCaseSensitive() throws {
         let font = try Self.anyInstalledFont()
-        let miscased = font.name.uppercased()
-        try XCTSkipIf(miscased == font.name)
+        let uppercased = font.name.uppercased()
+        try XCTSkipIf(uppercased == font.name)
 
         expect(Self.platformResolvesFont(named: font.name)).to(beTrue())
-        expect(Self.platformResolvesFont(named: miscased)).to(beFalse())
+        expect(Self.platformResolvesFont(named: uppercased)).to(beTrue())
     }
 
     func testFontIsAlreadyInstalled_AgreesWithPlatformFontLookupOnCasing() throws {


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->
<!-- AI agents: fill in this template, and also follow the "Pull Requests" section in AGENTS.md. -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Paywalls V2 downloaded custom fonts on every cold launch even when the identical files were already bundled and registered via `UIAppFonts`, costing a ~1s stall before the first paywall render. 

Resolves PW-1319

### Description
The skip-check resolved fonts only through `UIFont.fontNames(forFamilyName:)`, using the family the backend derives from the PostScript name prefix. 
That derived family frequently differs from the UIKit family name (spacing and weight naming), and the lookup does no fuzzy matching, one wrong character returns an empty array, so the face was treated as missing. Not typeface-specific; any custom font with this mismatch hits it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to paywall font presence detection and cache-warming skip logic; broader test coverage reduces regression risk with no auth or data handling impact.
> 
> **Overview**
> **Fixes paywall font cache warming treating bundled fonts as missing** when the backend’s derived font family doesn’t match the system family (e.g. `"Avenir Next"` vs `"AvenirNext"`).
> 
> `DefaultPaywallFontsManager.fontIsAlreadyInstalled` now **resolves the face by name first** (`UIFont`/`NSFont(name:size:)` with case-insensitive face/family matching), then falls back to listing names in the given family (with a full installed-font scan when the family is nil, empty, or unknown). Empty font names are rejected up front.
> 
> Unit tests cover family mismatch, nil/empty/wrong family, casing alignment with platform lookup, and integration tests that **`triggerFontDownloadIfNeeded` skips network** when an installed font is detected under a mismatched family.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a85cd0cdc0eec8dbe47d425eed6486419e2b4ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->