### PR TITLE
fix(paywalls): tolerate duplicate font names when registering

### DIFF
--- a/Sources/Paywalls/PaywallFontManagerType.swift
+++ b/Sources/Paywalls/PaywallFontManagerType.swift
@@ -32,8 +32,8 @@ struct SystemFontRegistry: FontRegistrar {
 
         if !CTFontManagerRegisterFontsForURL(url as CFURL, .process, &errorRef) {
             let error = errorRef?.takeUnretainedValue()
-            if Self.isAlreadyRegisteredError(error) {
-                // Font is already registered for the process; treat as success.
+            if Self.isRecoverableRegistrationError(error) {
+                // Font is already available to the process; treat as success.
                 return
             }
 
@@ -41,11 +41,24 @@ struct SystemFontRegistry: FontRegistrar {
         }
     }
 
-    static func isAlreadyRegisteredError(_ error: Error?) -> Bool {
+    /// Whether registration failed only because the face is already available to the process.
+    static func isRecoverableRegistrationError(_ error: Error?) -> Bool {
         guard let error = error else { return false }
+
         let nsError = error as NSError
-        return nsError.domain == (kCTFontManagerErrorDomain as String)
-            && nsError.code == CTFontManagerError.alreadyRegistered.rawValue
+        guard nsError.domain == (kCTFontManagerErrorDomain as String) else { return false }
+
+        switch nsError.code {
+        case CTFontManagerError.alreadyRegistered.rawValue:
+            // This exact file is already registered.
+            return true
+        case CTFontManagerError.duplicatedName.rawValue:
+            // Another file already provides a face with this name, e.g. one bundled
+            // through `UIAppFonts` or downloaded from a different URL.
+            return true
+        default:
+            return false
+        }
     }
 }
 

--- a/Tests/UnitTests/Paywalls/SystemFontRegistryTests.swift
+++ b/Tests/UnitTests/Paywalls/SystemFontRegistryTests.swift
@@ -14,19 +14,59 @@ import XCTest
 
 final class SystemFontRegistryTests: TestCase {
 
-    func testIsAlreadyRegisteredErrorReturnsTrueForCoreTextAlreadyRegistered() {
+    func testAlreadyRegisteredErrorIsRecoverable() {
         let error = NSError(domain: kCTFontManagerErrorDomain as String,
                             code: CTFontManagerError.alreadyRegistered.rawValue)
 
-        XCTAssertTrue(SystemFontRegistry.isAlreadyRegisteredError(error))
+        XCTAssertTrue(SystemFontRegistry.isRecoverableRegistrationError(error))
     }
 
-    func testIsAlreadyRegisteredErrorReturnsFalseForOtherErrors() {
-        let wrongDomain = NSError(domain: "com.revenuecat.test", code: 0)
+    func testDuplicatedNameErrorIsRecoverable() {
+        // Raised when a face with this name is already loaded from a different file,
+        // e.g. one bundled through `UIAppFonts`.
+        let error = NSError(domain: kCTFontManagerErrorDomain as String,
+                            code: CTFontManagerError.duplicatedName.rawValue)
+
+        XCTAssertTrue(SystemFontRegistry.isRecoverableRegistrationError(error))
+    }
+
+    func testRecoverableErrorCodesMatchCoreText() {
+        // Guards against the tolerated codes silently changing meaning.
+        XCTAssertEqual(CTFontManagerError.alreadyRegistered.rawValue, 105)
+        XCTAssertEqual(CTFontManagerError.duplicatedName.rawValue, 305)
+    }
+
+    func testGenuineRegistrationFailuresAreNotRecoverable() {
+        let failures: [CTFontManagerError] = [
+            .fileNotFound,
+            .insufficientPermissions,
+            .unrecognizedFormat,
+            .invalidFontData,
+            .exceededResourceLimit,
+            .notRegistered,
+            .registrationFailed,
+            .missingEntitlement,
+            .insufficientInfo,
+            .invalidFilePath,
+            .unsupportedScope
+        ]
+
+        for failure in failures {
+            let error = NSError(domain: kCTFontManagerErrorDomain as String, code: failure.rawValue)
+
+            XCTAssertFalse(SystemFontRegistry.isRecoverableRegistrationError(error),
+                           "Expected CTFontManagerError code \(failure.rawValue) to be surfaced")
+        }
+    }
+
+    func testIsRecoverableRegistrationErrorReturnsFalseForOtherErrors() {
+        // Same code, but not a CoreText error.
+        let wrongDomain = NSError(domain: "com.revenuecat.test",
+                                  code: CTFontManagerError.duplicatedName.rawValue)
         let wrongCode = NSError(domain: kCTFontManagerErrorDomain as String, code: -1)
 
-        XCTAssertFalse(SystemFontRegistry.isAlreadyRegisteredError(wrongDomain))
-        XCTAssertFalse(SystemFontRegistry.isAlreadyRegisteredError(wrongCode))
-        XCTAssertFalse(SystemFontRegistry.isAlreadyRegisteredError(nil))
+        XCTAssertFalse(SystemFontRegistry.isRecoverableRegistrationError(wrongDomain))
+        XCTAssertFalse(SystemFontRegistry.isRecoverableRegistrationError(wrongCode))
+        XCTAssertFalse(SystemFontRegistry.isRecoverableRegistrationError(nil))
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->
<!-- AI agents: fill in this template, and also follow the "Pull Requests" section in AGENTS.md. -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Registering a paywall font whose face name is already loaded from another file failed and logged `Error installing font … GSFont "…" already exists`, despite the paywall rendering correctly. 
Resolves PW-1320

### Description
Only `CTFontManagerError.alreadyRegistered` (105) was tolerated, which CoreText returns for re-registering the *same file URL*. Two different files claiming the same PostScript name produce `duplicatedName` (305) instead, reachable whenever the font is also bundled via `UIAppFonts`, or when two offerings reference the same face at different URLs, since the cache filename is keyed on the remote URL.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow error-handling change in paywall font registration with expanded unit coverage; no auth, data, or payment impact.
> 
> **Overview**
> Treats CoreText `duplicatedName` as a successful paywall font registration, not only `alreadyRegistered`.
> 
> `SystemFontRegistry` now uses `isRecoverableRegistrationError`, so registration no longer fails when the same face is already available from another file (for example via `UIAppFonts` or a different download URL). Unit tests cover both recoverable codes and genuine registration failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 972c71a0d895d2f818b78c4eca75301c9014997d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->