### PR TITLE
feat(checkpoints): add store dimensions for local rule evaluation

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D17A00000000000000000001 /* StoreDimensionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17A00000000000000000002 /* StoreDimensionProvider.swift */; };
+		D17A00000000000000000003 /* StoreDimensionProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17A00000000000000000004 /* StoreDimensionProviderTests.swift */; };
 		C05A00000000000000000001 /* CustomVariableKeyValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05A00000000000000000002 /* CustomVariableKeyValidator.swift */; };
 		C05A00000000000000000003 /* CustomVariableKeyValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05A00000000000000000004 /* CustomVariableKeyValidatorTests.swift */; };
 		A0D100000000000000000001 /* LocalRulesEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D200000000000000000001 /* LocalRulesEvaluator.swift */; };
@@ -1574,6 +1576,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		D17A00000000000000000002 /* StoreDimensionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreDimensionProvider.swift; sourceTree = "<group>"; };
+		D17A00000000000000000004 /* StoreDimensionProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreDimensionProviderTests.swift; sourceTree = "<group>"; };
 		C05A00000000000000000002 /* CustomVariableKeyValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomVariableKeyValidator.swift; sourceTree = "<group>"; };
 		C05A00000000000000000004 /* CustomVariableKeyValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomVariableKeyValidatorTests.swift; sourceTree = "<group>"; };
 		A0D200000000000000000001 /* LocalRulesEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalRulesEvaluator.swift; sourceTree = "<group>"; };
@@ -3246,6 +3250,7 @@
 			children = (
 				A0D200000000000000000001 /* LocalRulesEvaluator.swift */,
 				A0D200000000000000000006 /* DeviceDimensionProvider.swift */,
+				D17A00000000000000000002 /* StoreDimensionProvider.swift */,
 				A0D200000000000000000002 /* DimensionProvider.swift */,
 				A0D200000000000000000003 /* DimensionResolver.swift */,
 			);
@@ -3258,6 +3263,7 @@
 				C05A00000000000000000004 /* CustomVariableKeyValidatorTests.swift */,
 				A0D200000000000000000005 /* LocalRulesEvaluatorTests.swift */,
 				A0D200000000000000000007 /* DeviceDimensionProviderTests.swift */,
+				D17A00000000000000000004 /* StoreDimensionProviderTests.swift */,
 			);
 			path = LocalRules;
 			sourceTree = "<group>";
@@ -7810,6 +7816,7 @@
 				B2D1A168EB359D71CAD9D64D /* StringArrayOperators.swift in Sources */,
 				A0D100000000000000000001 /* LocalRulesEvaluator.swift in Sources */,
 				A0D100000000000000000006 /* DeviceDimensionProvider.swift in Sources */,
+				D17A00000000000000000001 /* StoreDimensionProvider.swift in Sources */,
 				A0D100000000000000000002 /* DimensionProvider.swift in Sources */,
 				A0D100000000000000000003 /* DimensionResolver.swift in Sources */,
 				FA360650C0B87331F2EFF527 /* Checkpoints.swift in Sources */,
@@ -8236,6 +8243,7 @@
 				6ACB35318F329FCE9195865D /* Value+Decodable.swift in Sources */,
 				A0D100000000000000000005 /* LocalRulesEvaluatorTests.swift in Sources */,
 				A0D100000000000000000007 /* DeviceDimensionProviderTests.swift in Sources */,
+				D17A00000000000000000003 /* StoreDimensionProviderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/LocalRules/DimensionProvider.swift
+++ b/Sources/LocalRules/DimensionProvider.swift
@@ -19,6 +19,7 @@ enum DimensionNamespace: String, CaseIterable, Sendable {
 
     case custom
     case device
+    case store
     case session
     case client
 }

--- a/Sources/LocalRules/StoreDimensionProvider.swift
+++ b/Sources/LocalRules/StoreDimensionProvider.swift
@@ -1,0 +1,41 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  StoreDimensionProvider.swift
+//
+//  Created by Rick van der Linden on 8/12/26.
+//
+
+import Foundation
+
+/// Supplies current App Store information to the local rules engine.
+struct StoreDimensionProvider: DimensionProvider {
+
+    let namespace = DimensionNamespace.store
+
+    private let storefrontCountryCodeProvider: @Sendable () async -> String?
+
+    init(
+        storefrontCountryCodeProvider: @escaping @Sendable () async -> String? = {
+            await Storefront.currentStorefront?.countryCode
+        }
+    ) {
+        self.storefrontCountryCodeProvider = storefrontCountryCodeProvider
+    }
+
+    func dimensions(at _: Date) async throws -> [String: DimensionValue] {
+        guard let storefrontCountryCode = await self.storefrontCountryCodeProvider(),
+              !storefrontCountryCode.isEmpty else {
+            return [:]
+        }
+
+        return ["country": .string(storefrontCountryCode)]
+    }
+
+}

--- a/Sources/LocalRules/StoreDimensionProvider.swift
+++ b/Sources/LocalRules/StoreDimensionProvider.swift
@@ -35,6 +35,7 @@ struct StoreDimensionProvider: DimensionProvider {
             return [:]
         }
 
+        // Storefront country codes use ISO 3166-1 alpha-3 format, such as "USA".
         return ["country": .string(storefrontCountryCode)]
     }
 

--- a/Tests/UnitTests/LocalRules/StoreDimensionProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/StoreDimensionProviderTests.swift
@@ -1,0 +1,87 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  StoreDimensionProviderTests.swift
+//
+//  Created by Rick van der Linden on 8/12/26.
+//
+
+// Swift Testing is only available with the Xcode 16+ toolchain
+#if compiler(>=5.9)
+#if canImport(Testing)
+
+import Foundation
+import Testing
+
+@testable import RevenueCat
+
+@Suite("Store dimension provider")
+struct StoreDimensionProviderTests {
+
+    @Test
+    func providesStoreCountryInStoreNamespace() async throws {
+        let provider = StoreDimensionProvider(storefrontCountryCodeProvider: { "USA" })
+
+        #expect(provider.namespace == .store)
+        #expect(try await provider.dimensions(at: Date()) == [
+            "country": .string("USA")
+        ])
+    }
+
+    @Test
+    func omitsUnavailableOrEmptyStoreCountry() async throws {
+        let unavailableProvider = StoreDimensionProvider(storefrontCountryCodeProvider: { nil })
+        let emptyProvider = StoreDimensionProvider(storefrontCountryCodeProvider: { "" })
+
+        #expect(try await unavailableProvider.dimensions(at: Date()).isEmpty)
+        #expect(try await emptyProvider.dimensions(at: Date()).isEmpty)
+    }
+
+    @Test
+    func collectsStoreCountryForEverySnapshot() async throws {
+        let storefrontCountryCode = Atomic<String?>("USA")
+        let provider = StoreDimensionProvider(
+            storefrontCountryCodeProvider: { storefrontCountryCode.value }
+        )
+
+        let first = try await provider.dimensions(at: Date())
+        storefrontCountryCode.value = "NLD"
+        let second = try await provider.dimensions(at: Date())
+
+        #expect(first["country"] == .string("USA"))
+        #expect(second["country"] == .string("NLD"))
+    }
+
+    @Test
+    func countryCanBeEvaluatedUsingSDKDimensionPath() async throws {
+        let evaluator = LocalRulesEvaluator(
+            dimensionProviders: [
+                StoreDimensionProvider(storefrontCountryCodeProvider: { "NLD" })
+            ]
+        )
+
+        let match = try await evaluator.match(in: [
+            TestStoreRule(
+                predicate: #"{"==":[{"var":"store.country"},"NLD"]}"#
+            )
+        ])
+
+        #expect(match != nil)
+    }
+
+}
+
+private struct TestStoreRule: LocalRule {
+
+    let predicate: String
+
+}
+
+#endif
+#endif


### PR DESCRIPTION
## Description
Adds the `StoreDimensionProvider`, currently only providing `store.country` as a 3 letter country code like `USA`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive dimension provider with no changes to purchase or auth flows; behavior is gated on including the provider in the evaluator’s provider list.
> 
> **Overview**
> Adds a **`store`** dimension namespace and **`StoreDimensionProvider`** so local rules can read the App Store storefront country as **`store.country`** (ISO 3166-1 alpha-3, e.g. `USA`).
> 
> The provider reads `Storefront.currentStorefront?.countryCode` by default, returns no dimensions when the code is missing or empty, and is injectable for tests. Unit tests cover snapshots, omission behavior, and predicate evaluation via `LocalRulesEvaluator`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32f2e75f64fa75989335f837b2338c555a9df179. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->