### PR TITLE
refactor(checkpoints): Reuse CustomVariableValue for checkpoint parameters

### DIFF
--- a/Examples/CheckpointTester/CheckpointTester/Sources/CustomVariables.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/CustomVariables.swift
@@ -23,7 +23,7 @@ final class CustomVariables: ObservableObject {
     ]
 
     var checkpointParams: CheckpointParams {
-        var customVariables: [String: CheckpointValue] = [:]
+        var customVariables: [String: CustomVariableValue] = [:]
 
         for variable in self.variables {
             let name = variable.name.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/HardPaywallUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/HardPaywallUseCaseView.swift
@@ -124,7 +124,7 @@ struct HardPaywallUseCaseView: View {
         self.attempts += 1
         var customVariables = self.customVariables.checkpointParams.customVariables
         customVariables["gate"] = .string("hard")
-        customVariables["attempt"] = .integer(Int64(self.attempts))
+        customVariables["attempt"] = .number(Double(self.attempts))
         return CheckpointParams(customVariables: customVariables)
     }
 

--- a/RevenueCatUI/Checkpoints/CheckpointCallStore.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointCallStore.swift
@@ -17,6 +17,7 @@ import Foundation
 
 /// Owns checkpoint presentation state until the UI has fully dismissed.
 @MainActor
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 final class CheckpointCallStore {
 
     final class Call {

--- a/RevenueCatUI/Checkpoints/CheckpointPaywallResult.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointPaywallResult.swift
@@ -17,6 +17,7 @@ import Foundation
 
 /// A checkpoint-triggered paywall was presented and finished.
 @_spi(CheckpointsInternal)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public final class CheckpointPaywallPresentedResult: CheckpointResult {
 
     /// The terminal outcome of the presented paywall.
@@ -45,6 +46,7 @@ public final class CheckpointPaywallPresentedResult: CheckpointResult {
 
 /// Base class for the terminal result of a checkpoint-presented paywall.
 @_spi(CheckpointsInternal)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public class CheckpointPaywallOutcome: Equatable, Hashable, CustomStringConvertible {
 
     fileprivate init() {}
@@ -70,6 +72,7 @@ public class CheckpointPaywallOutcome: Equatable, Hashable, CustomStringConverti
 
 /// The customer dismissed the paywall.
 @_spi(CheckpointsInternal)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public final class CheckpointPaywallDismissedOutcome: CheckpointPaywallOutcome {
 
     static let shared = CheckpointPaywallDismissedOutcome()
@@ -82,6 +85,7 @@ public final class CheckpointPaywallDismissedOutcome: CheckpointPaywallOutcome {
 
 /// The customer completed a purchase.
 @_spi(CheckpointsInternal)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public final class CheckpointPaywallPurchasedOutcome: CheckpointPaywallOutcome {
 
     /// Customer information after the completed purchase.
@@ -104,6 +108,7 @@ public final class CheckpointPaywallPurchasedOutcome: CheckpointPaywallOutcome {
 
 /// The customer restored purchases.
 @_spi(CheckpointsInternal)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public final class CheckpointPaywallRestoredOutcome: CheckpointPaywallOutcome {
 
     /// Customer information after restoring purchases.
@@ -126,6 +131,7 @@ public final class CheckpointPaywallRestoredOutcome: CheckpointPaywallOutcome {
 
 /// The paywall ended with an error.
 @_spi(CheckpointsInternal)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public final class CheckpointPaywallErrorOutcome: CheckpointPaywallOutcome {
 
     /// The error that ended the checkpoint experience.

--- a/RevenueCatUI/Checkpoints/CheckpointWorkflowExecutor.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointWorkflowExecutor.swift
@@ -17,6 +17,7 @@ import Foundation
 
 /// Bridges resolved checkpoint workflows into asynchronous UI outcomes.
 @MainActor
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 protocol CheckpointExecutor: AnyObject {
 
     func execute(_ workflow: ResolvedCheckpointWorkflow) async throws -> CheckpointPaywallOutcome
@@ -25,6 +26,7 @@ protocol CheckpointExecutor: AnyObject {
 
 /// Presents a resolved workflow and reports its terminal outcome through a delegate.
 @MainActor
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 protocol CheckpointPresenter: AnyObject {
 
     func present(
@@ -38,6 +40,7 @@ protocol CheckpointPresenter: AnyObject {
 
 /// Receives the final staged outcome after checkpoint UI has fully dismissed.
 @MainActor
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 protocol CheckpointPresentationDelegate: AnyObject {
 
     func checkpointPresentationFinished(outcome: CheckpointPaywallOutcome)
@@ -46,6 +49,7 @@ protocol CheckpointPresentationDelegate: AnyObject {
 
 /// Executes a resolved workflow using RevenueCatUI's checkpoint presenter.
 @MainActor
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 final class CheckpointWorkflowExecutor: CheckpointExecutor, CheckpointPresentationDelegate {
 
     typealias PresenterProvider = @MainActor () -> CheckpointPresenter?
@@ -58,9 +62,6 @@ final class CheckpointWorkflowExecutor: CheckpointExecutor, CheckpointPresentati
 
     init(presenterProvider: @escaping PresenterProvider = {
         #if canImport(UIKit) && !os(tvOS) && !os(watchOS)
-        guard #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) else {
-            return nil
-        }
         return CheckpointWorkflowPresenter()
         #else
         return nil

--- a/RevenueCatUI/Checkpoints/Checkpoints.swift
+++ b/RevenueCatUI/Checkpoints/Checkpoints.swift
@@ -15,80 +15,29 @@
 import Foundation
 @_spi(Internal) import RevenueCat
 
-/// A custom value supplied when a checkpoint is hit.
-@_spi(CheckpointsInternal)
-public struct CheckpointValue: Equatable, Hashable, Sendable {
+extension CustomVariableValue {
 
-    fileprivate let coreValue: RevenueCat.CheckpointValue
+    init?(foundationValue: Any) {
+        guard let value = RevenueCat.CheckpointValue(foundationValue: foundationValue) else { return nil }
 
-    private init(coreValue: RevenueCat.CheckpointValue) {
-        self.coreValue = coreValue
+        switch value {
+        case let .string(value): self = .string(value)
+        case let .integer(value): self = .number(Double(value))
+        case let .double(value): self = .number(value)
+        case let .boolean(value): self = .bool(value)
+        }
     }
 
-    /// Creates a string checkpoint value.
-    public static func string(_ value: String) -> Self { return .init(coreValue: .string(value)) }
-    /// Creates an integer checkpoint value.
-    public static func integer(_ value: Int64) -> Self { return .init(coreValue: .integer(value)) }
-    /// Creates a floating-point checkpoint value.
-    public static func double(_ value: Double) -> Self { return .init(coreValue: .double(value)) }
-    /// Creates a Boolean checkpoint value.
-    public static func boolean(_ value: Bool) -> Self { return .init(coreValue: .boolean(value)) }
-
-}
-
-extension CheckpointValue: ExpressibleByStringLiteral {
-
-    /// Creates a string checkpoint value from a string literal.
-    public init(stringLiteral value: String) { self = .string(value) }
-
-}
-
-extension CheckpointValue: ExpressibleByIntegerLiteral {
-
-    /// Creates an integer checkpoint value from an integer literal.
-    public init(integerLiteral value: Int64) { self = .integer(value) }
-
-}
-
-extension CheckpointValue: ExpressibleByFloatLiteral {
-
-    /// Creates a floating-point checkpoint value from a floating-point literal.
-    public init(floatLiteral value: Double) { self = .double(value) }
-
-}
-
-extension CheckpointValue: ExpressibleByBooleanLiteral {
-
-    /// Creates a Boolean checkpoint value from a Boolean literal.
-    public init(booleanLiteral value: Bool) { self = .boolean(value) }
-
-}
-
-extension CheckpointValue: Codable {
-
-    /// Creates a checkpoint value by decoding a primitive JSON value.
-    public init(from decoder: Decoder) throws {
-        self.init(coreValue: try RevenueCat.CheckpointValue(from: decoder))
+    var foundationValue: Any {
+        if self.isString { return self.stringValue }
+        if self.isNumber { return NSNumber(value: self.doubleValue) }
+        return NSNumber(value: self.boolValue)
     }
 
-    /// Encodes the checkpoint value as a primitive JSON value.
-    public func encode(to encoder: Encoder) throws {
-        try self.coreValue.encode(to: encoder)
-    }
-
-}
-
-extension CheckpointValue {
-
-    /// Creates a checkpoint value from a supported Foundation primitive.
-    public init?(foundationValue: Any) {
-        guard let coreValue = RevenueCat.CheckpointValue(foundationValue: foundationValue) else { return nil }
-        self.init(coreValue: coreValue)
-    }
-
-    /// The equivalent Foundation primitive value.
-    public var foundationValue: Any {
-        return self.coreValue.foundationValue
+    var coreCheckpointValue: RevenueCat.CheckpointValue {
+        if self.isString { return .string(self.stringValue) }
+        if self.isNumber { return .double(self.doubleValue) }
+        return .boolean(self.boolValue)
     }
 
 }
@@ -98,10 +47,10 @@ extension CheckpointValue {
 public final class CheckpointParams: Equatable, Hashable, CustomStringConvertible, @unchecked Sendable {
 
     /// Custom variables usable in checkpoint targeting rules and feature events.
-    public let customVariables: [String: CheckpointValue]
+    public let customVariables: [String: CustomVariableValue]
 
     /// Creates checkpoint parameters with the supplied custom variables.
-    public init(customVariables: [String: CheckpointValue] = [:]) {
+    public init(customVariables: [String: CustomVariableValue] = [:]) {
         self.customVariables = customVariables
     }
 
@@ -121,7 +70,7 @@ public final class CheckpointParams: Equatable, Hashable, CustomStringConvertibl
     }
 
     var coreParams: RevenueCat.CheckpointParams {
-        return .init(customVariables: self.customVariables.mapValues(\.coreValue))
+        return .init(customVariables: self.customVariables.mapValues(\.coreCheckpointValue))
     }
 
 }

--- a/RevenueCatUI/Checkpoints/Checkpoints.swift
+++ b/RevenueCatUI/Checkpoints/Checkpoints.swift
@@ -18,9 +18,11 @@
 extension CustomVariableValue {
 
     var coreCheckpointValue: RevenueCat.CheckpointValue {
-        if self.isString { return .string(self.stringValue) }
-        if self.isNumber { return .double(self.doubleValue) }
-        return .boolean(self.boolValue)
+        return self.map(
+            string: { .string($0) },
+            number: { .double($0) },
+            boolean: { .boolean($0) }
+        )
     }
 
 }

--- a/RevenueCatUI/Checkpoints/Checkpoints.swift
+++ b/RevenueCatUI/Checkpoints/Checkpoints.swift
@@ -12,27 +12,9 @@
 //  Created by Rick van der Linden.
 //
 
-import Foundation
 @_spi(Internal) import RevenueCat
 
 extension CustomVariableValue {
-
-    init?(foundationValue: Any) {
-        guard let value = RevenueCat.CheckpointValue(foundationValue: foundationValue) else { return nil }
-
-        switch value {
-        case let .string(value): self = .string(value)
-        case let .integer(value): self = .number(Double(value))
-        case let .double(value): self = .number(value)
-        case let .boolean(value): self = .bool(value)
-        }
-    }
-
-    var foundationValue: Any {
-        if self.isString { return self.stringValue }
-        if self.isNumber { return NSNumber(value: self.doubleValue) }
-        return NSNumber(value: self.boolValue)
-    }
 
     var coreCheckpointValue: RevenueCat.CheckpointValue {
         if self.isString { return .string(self.stringValue) }

--- a/RevenueCatUI/Checkpoints/Checkpoints.swift
+++ b/RevenueCatUI/Checkpoints/Checkpoints.swift
@@ -14,6 +14,7 @@
 
 @_spi(Internal) import RevenueCat
 
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension CustomVariableValue {
 
     var coreCheckpointValue: RevenueCat.CheckpointValue {
@@ -26,6 +27,7 @@ extension CustomVariableValue {
 
 /// Per-call parameters for a checkpoint.
 @_spi(CheckpointsInternal)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public final class CheckpointParams: Equatable, Hashable, CustomStringConvertible, @unchecked Sendable {
 
     /// Custom variables usable in checkpoint targeting rules and feature events.
@@ -59,6 +61,7 @@ public final class CheckpointParams: Equatable, Hashable, CustomStringConvertibl
 
 /// Information about a checkpoint that was hit.
 @_spi(CheckpointsInternal)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public final class CheckpointInfo: Equatable, Hashable, CustomStringConvertible, @unchecked Sendable {
 
     /// The identifier of the checkpoint that was hit.
@@ -93,6 +96,7 @@ public final class CheckpointInfo: Equatable, Hashable, CustomStringConvertible,
 
 /// The reason no experience was served for a checkpoint.
 @_spi(CheckpointsInternal)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public final class CheckpointNoActionReason: Equatable, Hashable, CustomStringConvertible, @unchecked Sendable {
 
     /// The value identifying the reason.
@@ -130,6 +134,7 @@ public final class CheckpointNoActionReason: Equatable, Hashable, CustomStringCo
 
 /// Base class for the result of hitting a checkpoint.
 @_spi(CheckpointsInternal)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public class CheckpointResult: Equatable, Hashable, CustomStringConvertible {
 
     /// Information about the checkpoint that produced this result.
@@ -163,6 +168,7 @@ public class CheckpointResult: Equatable, Hashable, CustomStringConvertible {
 
 /// Nothing was served for a checkpoint.
 @_spi(CheckpointsInternal)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public final class CheckpointNoActionResult: CheckpointResult {
 
     /// The reason no experience was served.
@@ -191,6 +197,7 @@ public final class CheckpointNoActionResult: CheckpointResult {
 
 /// Global listener for checkpoint activity. All methods are called on the main thread.
 @_spi(CheckpointsInternal)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public protocol CheckpointListener: AnyObject {
 
     /// A checkpoint was hit, before evaluation.
@@ -201,6 +208,7 @@ public protocol CheckpointListener: AnyObject {
 }
 
 @_spi(CheckpointsInternal)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public extension CheckpointListener {
 
     /// Default no-op implementation.

--- a/RevenueCatUI/Checkpoints/CheckpointsManager.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointsManager.swift
@@ -16,6 +16,7 @@ import Foundation
 @_spi(Internal) import RevenueCat
 
 /// Orchestrates checkpoint resolution, workflow execution, and listener delivery.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 final class CheckpointsManager {
 
     var listener: CheckpointListener? {
@@ -99,6 +100,7 @@ final class CheckpointsManager {
 
 }
 
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private extension CheckpointResolutionReason {
 
     var noActionReason: CheckpointNoActionReason {

--- a/RevenueCatUI/Checkpoints/ObjCCheckpointTypes.swift
+++ b/RevenueCatUI/Checkpoints/ObjCCheckpointTypes.swift
@@ -34,6 +34,7 @@ private enum CheckpointStrings: LogMessage {
 
 /// Objective-C-compatible checkpoint parameters.
 @_spi(CheckpointsInternal)
+@available(iOS 15.0, *)
 @objc(RCCheckpointParams)
 public final class ObjCCheckpointParams: NSObject {
 
@@ -70,6 +71,7 @@ public final class ObjCCheckpointParams: NSObject {
 
 /// Objective-C-compatible checkpoint information.
 @_spi(CheckpointsInternal)
+@available(iOS 15.0, *)
 @objc(RCCheckpointInfo)
 public final class ObjCCheckpointInfo: NSObject {
 
@@ -89,6 +91,7 @@ public final class ObjCCheckpointInfo: NSObject {
 
 /// Objective-C-compatible reason that no experience was served.
 @_spi(CheckpointsInternal)
+@available(iOS 15.0, *)
 @objc(RCCheckpointNoActionReason)
 public final class ObjCCheckpointNoActionReason: NSObject {
 
@@ -104,6 +107,7 @@ public final class ObjCCheckpointNoActionReason: NSObject {
 
 /// Objective-C-compatible base checkpoint result.
 @_spi(CheckpointsInternal)
+@available(iOS 15.0, *)
 @objc(RCCheckpointResult)
 public class ObjCCheckpointResult: NSObject {
 
@@ -130,6 +134,7 @@ public class ObjCCheckpointResult: NSObject {
 
 /// Objective-C-compatible no-action checkpoint result.
 @_spi(CheckpointsInternal)
+@available(iOS 15.0, *)
 @objc(RCCheckpointNoActionResult)
 public final class ObjCCheckpointNoActionResult: ObjCCheckpointResult {
 
@@ -145,6 +150,7 @@ public final class ObjCCheckpointNoActionResult: ObjCCheckpointResult {
 
 /// Objective-C-compatible checkpoint-triggered paywall result.
 @_spi(CheckpointsInternal)
+@available(iOS 15.0, *)
 @objc(RCCheckpointPaywallPresentedResult)
 public final class ObjCCheckpointPaywallPresentedResult: ObjCCheckpointResult {
 
@@ -160,6 +166,7 @@ public final class ObjCCheckpointPaywallPresentedResult: ObjCCheckpointResult {
 
 /// Objective-C-compatible base paywall outcome.
 @_spi(CheckpointsInternal)
+@available(iOS 15.0, *)
 @objc(RCCheckpointPaywallOutcome)
 public class ObjCCheckpointPaywallOutcome: NSObject {
 
@@ -182,11 +189,13 @@ public class ObjCCheckpointPaywallOutcome: NSObject {
 
 /// Objective-C-compatible dismissed paywall outcome.
 @_spi(CheckpointsInternal)
+@available(iOS 15.0, *)
 @objc(RCCheckpointPaywallDismissedOutcome)
 public final class ObjCCheckpointPaywallDismissedOutcome: ObjCCheckpointPaywallOutcome {}
 
 /// Objective-C-compatible purchased paywall outcome.
 @_spi(CheckpointsInternal)
+@available(iOS 15.0, *)
 @objc(RCCheckpointPaywallPurchasedOutcome)
 public final class ObjCCheckpointPaywallPurchasedOutcome: ObjCCheckpointPaywallOutcome {
 
@@ -202,6 +211,7 @@ public final class ObjCCheckpointPaywallPurchasedOutcome: ObjCCheckpointPaywallO
 
 /// Objective-C-compatible restored paywall outcome.
 @_spi(CheckpointsInternal)
+@available(iOS 15.0, *)
 @objc(RCCheckpointPaywallRestoredOutcome)
 public final class ObjCCheckpointPaywallRestoredOutcome: ObjCCheckpointPaywallOutcome {
 
@@ -217,6 +227,7 @@ public final class ObjCCheckpointPaywallRestoredOutcome: ObjCCheckpointPaywallOu
 
 /// Objective-C-compatible error paywall outcome.
 @_spi(CheckpointsInternal)
+@available(iOS 15.0, *)
 @objc(RCCheckpointPaywallErrorOutcome)
 public final class ObjCCheckpointPaywallErrorOutcome: ObjCCheckpointPaywallOutcome {
 

--- a/RevenueCatUI/Checkpoints/ObjCCheckpointTypes.swift
+++ b/RevenueCatUI/Checkpoints/ObjCCheckpointTypes.swift
@@ -42,10 +42,10 @@ public final class ObjCCheckpointParams: NSObject {
     /// Creates checkpoint parameters from Objective-C Foundation primitive values. Unsupported values are dropped.
     @objc(initWithCustomVariables:)
     public init(customVariables: NSDictionary) {
-        var values: [String: CheckpointValue] = [:]
+        var values: [String: CustomVariableValue] = [:]
         for (rawKey, rawValue) in customVariables {
             guard let key = rawKey as? String,
-                  let value = CheckpointValue(foundationValue: rawValue) else {
+                  let value = CustomVariableValue(foundationValue: rawValue) else {
                 Logger.warning(CheckpointStrings.invalidObjectiveCCustomVariable(type(of: rawValue)))
                 continue
             }

--- a/RevenueCatUI/Checkpoints/Purchases+Checkpoints.swift
+++ b/RevenueCatUI/Checkpoints/Purchases+Checkpoints.swift
@@ -18,6 +18,7 @@ import Foundation
 #if os(iOS) && !targetEnvironment(macCatalyst)
 
 @_spi(CheckpointsInternal)
+@available(iOS 15.0, *)
 public extension Purchases {
 
     /// Global listener for checkpoint activity.
@@ -70,6 +71,7 @@ public extension Purchases {
 #if ENABLE_CHECKPOINTS_OBJC
 
 @_spi(CheckpointsInternal)
+@available(iOS 15.0, *)
 public extension Purchases {
 
     /// Objective-C-compatible checkpoint API.
@@ -94,6 +96,7 @@ public extension Purchases {
 
 #endif
 
+@available(iOS 15.0, *)
 private extension Purchases {
 
     var checkpointsManager: CheckpointsManager {

--- a/RevenueCatUI/Data/CustomPaywallVariables.swift
+++ b/RevenueCatUI/Data/CustomPaywallVariables.swift
@@ -186,7 +186,6 @@ extension CustomVariableValue {
 
         switch value {
         case let .string(value): self = .string(value)
-        case let .integer(value): self = .number(Double(value))
         case let .double(value): self = .number(value)
         case let .boolean(value): self = .bool(value)
         }

--- a/RevenueCatUI/Data/CustomPaywallVariables.swift
+++ b/RevenueCatUI/Data/CustomPaywallVariables.swift
@@ -14,10 +14,10 @@
 @_spi(Internal) import RevenueCat
 import SwiftUI
 
-/// A value type for custom paywall variables that can be passed to paywalls at runtime.
+/// A value type for custom variables that can be passed to RevenueCat UI at runtime.
 ///
-/// Custom variables allow developers to personalize paywall text with dynamic values.
-/// Variables are defined in the RevenueCat dashboard and can be overridden at runtime.
+/// Custom variables allow developers to personalize RevenueCat UI and supply values for checkpoint targeting.
+/// Variables are defined in the RevenueCat dashboard and can be supplied at runtime.
 ///
 /// ### Usage
 /// ```swift
@@ -33,7 +33,6 @@ import SwiftUI
 /// ```
 /// Hello {{ custom.player_name }}!
 /// ```
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public struct CustomVariableValue: Sendable, Equatable, Hashable {
 
     private enum Storage: Sendable, Equatable, Hashable {
@@ -131,12 +130,38 @@ public struct CustomVariableValue: Sendable, Equatable, Hashable {
 
 // MARK: - ExpressibleByStringLiteral
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension CustomVariableValue: ExpressibleByStringLiteral {
 
     /// Creates a custom variable value from a string literal.
     public init(stringLiteral value: String) {
         self = .string(value)
+    }
+
+}
+
+extension CustomVariableValue: ExpressibleByIntegerLiteral {
+
+    /// Creates a numeric custom variable value from an integer literal.
+    public init(integerLiteral value: Int64) {
+        self = .number(Double(value))
+    }
+
+}
+
+extension CustomVariableValue: ExpressibleByFloatLiteral {
+
+    /// Creates a numeric custom variable value from a floating-point literal.
+    public init(floatLiteral value: Double) {
+        self = .number(value)
+    }
+
+}
+
+extension CustomVariableValue: ExpressibleByBooleanLiteral {
+
+    /// Creates a Boolean custom variable value from a Boolean literal.
+    public init(booleanLiteral value: Bool) {
+        self = .bool(value)
     }
 
 }

--- a/RevenueCatUI/Data/CustomPaywallVariables.swift
+++ b/RevenueCatUI/Data/CustomPaywallVariables.swift
@@ -166,6 +166,41 @@ extension CustomVariableValue: ExpressibleByBooleanLiteral {
 
 }
 
+// MARK: - Foundation Bridge
+
+extension CustomVariableValue {
+
+    /// Creates a custom variable value from a supported Foundation primitive.
+    ///
+    /// This is intended only for Objective-C and hybrid SDK bridges. Native Swift integrations should use
+    /// ``string(_:)``, ``number(_:)``, or ``bool(_:)`` instead.
+    @_spi(Internal)
+    public init?(foundationValue: Any) {
+        guard let value = RevenueCat.CheckpointValue(foundationValue: foundationValue) else { return nil }
+
+        switch value {
+        case let .string(value): self = .string(value)
+        case let .integer(value): self = .number(Double(value))
+        case let .double(value): self = .number(value)
+        case let .boolean(value): self = .bool(value)
+        }
+    }
+
+    /// The equivalent Foundation primitive value.
+    ///
+    /// This is intended only for Objective-C and hybrid SDK bridges. Native Swift integrations should pass
+    /// ``CustomVariableValue`` directly.
+    @_spi(Internal)
+    public var foundationValue: Any {
+        switch self.storage {
+        case let .string(value): return value
+        case let .number(value): return NSNumber(value: value)
+        case let .bool(value): return NSNumber(value: value)
+        }
+    }
+
+}
+
 // MARK: - Environment Key
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/RevenueCatUI/Data/CustomPaywallVariables.swift
+++ b/RevenueCatUI/Data/CustomPaywallVariables.swift
@@ -127,6 +127,22 @@ public struct CustomVariableValue: Sendable, Equatable, Hashable {
         return false
     }
 
+    /// Maps the underlying value while keeping storage handling exhaustive.
+    ///
+    /// This intentionally switches over every storage case so adding a new custom-variable type produces a
+    /// compiler error instead of silently coercing that type to one of the existing representations.
+    internal func map<Value>(
+        string: (String) -> Value,
+        number: (Double) -> Value,
+        boolean: (Bool) -> Value
+    ) -> Value {
+        switch self.storage {
+        case let .string(value): return string(value)
+        case let .number(value): return number(value)
+        case let .bool(value): return boolean(value)
+        }
+    }
+
 }
 
 // MARK: - ExpressibleByStringLiteral

--- a/RevenueCatUI/Data/CustomPaywallVariables.swift
+++ b/RevenueCatUI/Data/CustomPaywallVariables.swift
@@ -33,6 +33,7 @@ import SwiftUI
 /// ```
 /// Hello {{ custom.player_name }}!
 /// ```
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public struct CustomVariableValue: Sendable, Equatable, Hashable {
 
     private enum Storage: Sendable, Equatable, Hashable {
@@ -130,6 +131,7 @@ public struct CustomVariableValue: Sendable, Equatable, Hashable {
 
 // MARK: - ExpressibleByStringLiteral
 
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension CustomVariableValue: ExpressibleByStringLiteral {
 
     /// Creates a custom variable value from a string literal.
@@ -139,6 +141,7 @@ extension CustomVariableValue: ExpressibleByStringLiteral {
 
 }
 
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension CustomVariableValue: ExpressibleByIntegerLiteral {
 
     /// Creates a numeric custom variable value from an integer literal.
@@ -148,6 +151,7 @@ extension CustomVariableValue: ExpressibleByIntegerLiteral {
 
 }
 
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension CustomVariableValue: ExpressibleByFloatLiteral {
 
     /// Creates a numeric custom variable value from a floating-point literal.
@@ -157,6 +161,7 @@ extension CustomVariableValue: ExpressibleByFloatLiteral {
 
 }
 
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension CustomVariableValue: ExpressibleByBooleanLiteral {
 
     /// Creates a Boolean custom variable value from a Boolean literal.
@@ -168,6 +173,7 @@ extension CustomVariableValue: ExpressibleByBooleanLiteral {
 
 // MARK: - Foundation Bridge
 
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension CustomVariableValue {
 
     /// Creates a custom variable value from a supported Foundation primitive.

--- a/Sources/Checkpoints/Checkpoints.swift
+++ b/Sources/Checkpoints/Checkpoints.swift
@@ -23,7 +23,6 @@ public enum CheckpointValue: Equatable, Hashable, Sendable {
 
     // swiftlint:disable missing_docs
     case string(String)
-    case integer(Int64)
     case double(Double)
     case boolean(Bool)
     // swiftlint:enable missing_docs
@@ -39,8 +38,8 @@ extension CheckpointValue: ExpressibleByStringLiteral {
 
 extension CheckpointValue: ExpressibleByIntegerLiteral {
 
-    /// Creates an integer checkpoint value from an integer literal.
-    public init(integerLiteral value: Int64) { self = .integer(value) }
+    /// Creates a numeric checkpoint value from an integer literal.
+    public init(integerLiteral value: Int64) { self = .double(Double(value)) }
 
 }
 
@@ -68,8 +67,6 @@ extension CheckpointValue: Codable {
             self = .string(value)
         } else if let value = try? container.decode(Bool.self) {
             self = .boolean(value)
-        } else if let value = try? container.decode(Int64.self) {
-            self = .integer(value)
         } else if let value = try? container.decode(Double.self) {
             self = .double(value)
         } else {
@@ -77,7 +74,7 @@ extension CheckpointValue: Codable {
                 Self.self,
                 .init(
                     codingPath: decoder.codingPath,
-                    debugDescription: "Expected a string, integer, double, or boolean."
+                    debugDescription: "Expected a string, number, or boolean."
                 )
             )
         }
@@ -89,7 +86,6 @@ extension CheckpointValue: Codable {
 
         switch self {
         case let .string(value): try container.encode(value)
-        case let .integer(value): try container.encode(value)
         case let .double(value): try container.encode(value)
         case let .boolean(value): try container.encode(value)
         }
@@ -110,10 +106,7 @@ extension CheckpointValue {
         switch number.jsonNumberKind {
         case .boolean:
             self = .boolean(number.boolValue)
-        case .integer:
-            guard let value = Int64(number.stringValue) else { return nil }
-            self = .integer(value)
-        case .floatingPoint:
+        case .integer, .floatingPoint:
             self = .double(number.doubleValue)
         }
     }
@@ -122,7 +115,6 @@ extension CheckpointValue {
     public var foundationValue: Any {
         switch self {
         case let .string(value): return value
-        case let .integer(value): return NSNumber(value: value)
         case let .double(value): return NSNumber(value: value)
         case let .boolean(value): return NSNumber(value: value)
         }
@@ -135,7 +127,6 @@ extension CheckpointValue {
     var dimensionValue: DimensionValue {
         switch self {
         case let .string(value): return .string(value)
-        case let .integer(value): return .int(value)
         case let .double(value): return .double(value)
         case let .boolean(value): return .bool(value)
         }

--- a/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
+++ b/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
@@ -49,11 +49,10 @@ private final class CheckpointListenerAPITester: CheckpointListener {
 private final class CheckpointListenerDefaultsAPITester: CheckpointListener {}
 
 func checkCheckpointAPI(_ purchases: Purchases) {
-    let string: CheckpointValue = .string("value")
-    let integer: CheckpointValue = .integer(2)
-    let double: CheckpointValue = .double(4.5)
-    let boolean: CheckpointValue = .boolean(true)
-    let _: Any = string.foundationValue
+    let string: CustomVariableValue = .string("value")
+    let integer: CustomVariableValue = 2
+    let double: CustomVariableValue = 4.5
+    let boolean: CustomVariableValue = true
 
     purchases.checkpointListener = CheckpointListenerAPITester()
     let _: CheckpointListener? = purchases.checkpointListener
@@ -64,7 +63,7 @@ func checkCheckpointAPI(_ purchases: Purchases) {
         "score": double,
         "subscriber": boolean
     ])
-    let _: [String: CheckpointValue] = params.customVariables
+    let _: [String: CustomVariableValue] = params.customVariables
 
     purchases.checkpoint(
         "test_checkpoint",

--- a/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
+++ b/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
@@ -49,25 +49,27 @@ private final class CheckpointListenerAPITester: CheckpointListener {
 private final class CheckpointListenerDefaultsAPITester: CheckpointListener {}
 
 func checkCheckpointAPI(_ purchases: Purchases) {
-    let string: CustomVariableValue = .string("value")
-    let integer: CustomVariableValue = 2
-    let double: CustomVariableValue = 4.5
-    let boolean: CustomVariableValue = true
-
     purchases.checkpointListener = CheckpointListenerAPITester()
     let _: CheckpointListener? = purchases.checkpointListener
 
-    let params = CheckpointParams(customVariables: [
-        "name": string,
-        "attempts": integer,
-        "score": double,
-        "subscriber": boolean
+    let literalParams = CheckpointParams(customVariables: [
+        "name": "Rick",
+        "points": 120,
+        "score": 4.5,
+        "subscriber": true
     ])
-    let _: [String: CustomVariableValue] = params.customVariables
+    let explicitParams = CheckpointParams(customVariables: [
+        "name": .string("Rick"),
+        "points": .number(120),
+        "score": .number(4.5),
+        "subscriber": .bool(true)
+    ])
+    let _: [String: CustomVariableValue] = literalParams.customVariables
+    let _: [String: CustomVariableValue] = explicitParams.customVariables
 
     purchases.checkpoint(
         "test_checkpoint",
-        params: params
+        params: literalParams
     ) { (_: Result<CheckpointResult, PublicError>) in }
 
     purchases.checkpoint("test_checkpoint") { (_: Result<CheckpointResult, PublicError>) in }

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointWorkflowPresenterTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointWorkflowPresenterTests.swift
@@ -194,6 +194,7 @@ private final class DismissRecordingPaywallController: PaywallViewController {
 
 #endif
 
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private final class MockCheckpointPresenterDelegate: CheckpointPresentationDelegate {
 
     private(set) var outcome: CheckpointPaywallOutcome?

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
@@ -17,6 +17,7 @@
 import XCTest
 
 @MainActor
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 final class CheckpointsManagerTests: TestCase {
 
     #if ENABLE_CHECKPOINTS_OBJC
@@ -208,6 +209,7 @@ final class CheckpointsManagerTests: TestCase {
 }
 
 @MainActor
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 final class CheckpointWorkflowExecutorTests: TestCase {
 
     func testPresentationFailureResumesExecutionAndAllowsRetry() async throws {
@@ -393,6 +395,7 @@ final class CheckpointWorkflowExecutorTests: TestCase {
 }
 
 @MainActor
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private final class MockCheckpointWorkflowExecutor: CheckpointExecutor {
 
     var outcome: CheckpointPaywallOutcome = CheckpointPaywallDismissedOutcome.shared
@@ -410,6 +413,7 @@ private final class MockCheckpointWorkflowExecutor: CheckpointExecutor {
 }
 
 @MainActor
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private final class MockCheckpointPresenter: CheckpointPresenter {
 
     struct Presentation {
@@ -453,6 +457,7 @@ private final class MockCheckpointPresenter: CheckpointPresenter {
 
 }
 
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private final class ListenerRecorder: CheckpointListener {
 
     enum Event: Equatable {

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
@@ -19,6 +19,43 @@ import XCTest
 @MainActor
 final class CheckpointsManagerTests: TestCase {
 
+    #if ENABLE_CHECKPOINTS_OBJC
+
+    func testObjectiveCParamsConvertAndRoundTripSupportedFoundationValues() throws {
+        let params = ObjCCheckpointParams(customVariables: [
+            "string": "value",
+            "integer": NSNumber(value: Int64(42)),
+            "double": NSNumber(value: 4.5),
+            "true": NSNumber(value: true),
+            "false": NSNumber(value: false)
+        ])
+
+        XCTAssertEqual(params.value.customVariables, [
+            "string": .string("value"),
+            "integer": .number(42),
+            "double": .number(4.5),
+            "true": .bool(true),
+            "false": .bool(false)
+        ])
+
+        let roundTrip = ObjCCheckpointParams(customVariables: params.customVariables)
+        XCTAssertEqual(roundTrip.value, params.value)
+    }
+
+    func testObjectiveCParamsDropUnsupportedValuesAndNonStringKeys() {
+        let params = ObjCCheckpointParams(customVariables: [
+            "valid": "value",
+            "null": NSNull(),
+            "date": Date(),
+            "array": ["nested"],
+            NSNumber(value: 1): "invalid key"
+        ])
+
+        XCTAssertEqual(params.value.customVariables, ["valid": .string("value")])
+    }
+
+    #endif
+
     func testCheckpointParamsConvertCustomVariableValuesForCoreResolution() {
         let params = RevenueCatUI.CheckpointParams(customVariables: [
             "string": "value",

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
@@ -19,6 +19,24 @@ import XCTest
 @MainActor
 final class CheckpointsManagerTests: TestCase {
 
+    func testCheckpointParamsConvertCustomVariableValuesForCoreResolution() {
+        let params = RevenueCatUI.CheckpointParams(customVariables: [
+            "string": "value",
+            "integer": 42,
+            "double": 4.5,
+            "boolean": true
+        ])
+
+        let expected: [String: RevenueCat.CheckpointValue] = [
+            "string": .string("value"),
+            "integer": .double(42),
+            "double": .double(4.5),
+            "boolean": .boolean(true)
+        ]
+
+        XCTAssertEqual(params.coreParams.customVariables, expected)
+    }
+
     func testNoActionResultAndListenerEventsAreBuiltInRevenueCatUI() async throws {
         let manager = CheckpointsManager { _, _ in .noAction(.unknownCheckpoint) }
         let listener = ListenerRecorder()

--- a/Tests/RevenueCatUITests/PaywallsV2/VariableHandlerV2Tests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/VariableHandlerV2Tests.swift
@@ -1963,6 +1963,61 @@ class CustomVariableValueTests: TestCase {
         expect(value).to(equal(.string("test")))
     }
 
+    func testExpressibleByNumericAndBooleanLiterals() {
+        let integer: CustomVariableValue = 42
+        let double: CustomVariableValue = 4.5
+        let boolean: CustomVariableValue = true
+
+        expect(integer).to(equal(.number(42)))
+        expect(double).to(equal(.number(4.5)))
+        expect(boolean).to(equal(.bool(true)))
+    }
+
+    // MARK: - Foundation Bridge Tests
+
+    func testFoundationValuesPreserveSupportedPrimitiveTypes() {
+        expect(CustomVariableValue(foundationValue: "value")).to(equal(.string("value")))
+        expect(CustomVariableValue(foundationValue: NSNumber(value: true))).to(equal(.bool(true)))
+        expect(CustomVariableValue(foundationValue: NSNumber(value: false))).to(equal(.bool(false)))
+        expect(CustomVariableValue(foundationValue: NSNumber(value: Int64(42)))).to(equal(.number(42)))
+        expect(CustomVariableValue(foundationValue: NSNumber(value: Double(4.5)))).to(equal(.number(4.5)))
+    }
+
+    func testFoundationValuesSupportAllNSNumberIntegerAndFloatingPointStorageTypes() {
+        let integers: [NSNumber] = [
+            NSNumber(value: Int8(1)), NSNumber(value: Int16(2)), NSNumber(value: Int32(3)),
+            NSNumber(value: Int64(4)), NSNumber(value: UInt8(5)), NSNumber(value: UInt16(6)),
+            NSNumber(value: UInt32(7)), NSNumber(value: UInt64(8))
+        ]
+
+        for number in integers {
+            expect(CustomVariableValue(foundationValue: number)).to(equal(.number(number.doubleValue)))
+        }
+
+        expect(CustomVariableValue(foundationValue: NSNumber(value: Float(1.5)))).to(equal(.number(1.5)))
+        expect(CustomVariableValue(foundationValue: NSNumber(value: Double(2.5)))).to(equal(.number(2.5)))
+    }
+
+    func testFoundationValueRejectsUnsupportedTypes() {
+        expect(CustomVariableValue(foundationValue: Date())).to(beNil())
+        expect(CustomVariableValue(foundationValue: NSNull())).to(beNil())
+        expect(CustomVariableValue(foundationValue: ["nested": "value"])).to(beNil())
+    }
+
+    func testFoundationValueRoundTripsEverySupportedType() {
+        let values: [CustomVariableValue] = [
+            .string("value"),
+            .number(42),
+            .number(4.5),
+            .bool(true),
+            .bool(false)
+        ]
+
+        for value in values {
+            expect(CustomVariableValue(foundationValue: value.foundationValue)).to(equal(value))
+        }
+    }
+
     // MARK: - Dictionary Conversion Tests
 
     func testAsStringDictionary() {

--- a/Tests/UnitTests/Checkpoints/CheckpointValueTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointValueTests.swift
@@ -18,7 +18,7 @@ import XCTest
 
 final class CheckpointValueTests: TestCase {
 
-    func testLiteralValuesPreserveTheirTypes() {
+    func testLiteralValuesConvertToSupportedTypes() {
         let params = CheckpointParams(customVariables: [
             "string": "value",
             "integer": 42,
@@ -27,7 +27,7 @@ final class CheckpointValueTests: TestCase {
         ])
 
         XCTAssertEqual(params.customVariables["string"], .string("value"))
-        XCTAssertEqual(params.customVariables["integer"], .integer(42))
+        XCTAssertEqual(params.customVariables["integer"], .double(42))
         XCTAssertEqual(params.customVariables["double"], .double(4.5))
         XCTAssertEqual(params.customVariables["boolean"], .boolean(true))
     }
@@ -35,7 +35,7 @@ final class CheckpointValueTests: TestCase {
     func testCodableUsesPrimitiveJSONValues() throws {
         let values: [String: CheckpointValue] = [
             "string": .string("value"),
-            "integer": .integer(42),
+            "integer": 42,
             "double": .double(4.5),
             "boolean": .boolean(true)
         ]
@@ -48,27 +48,25 @@ final class CheckpointValueTests: TestCase {
 
     func testFoundationValuesDistinguishBooleansAndNumbers() {
         XCTAssertEqual(CheckpointValue(foundationValue: NSNumber(value: true)), .boolean(true))
-        XCTAssertEqual(CheckpointValue(foundationValue: NSNumber(value: 1)), .integer(1))
+        XCTAssertEqual(CheckpointValue(foundationValue: NSNumber(value: 1)), .double(1))
         XCTAssertEqual(CheckpointValue(foundationValue: NSNumber(value: 1.5)), .double(1.5))
         XCTAssertEqual(CheckpointValue(foundationValue: "value"), .string("value"))
         XCTAssertNil(CheckpointValue(foundationValue: Date()))
     }
 
-    func testFoundationNumberStorageTypesMatchJSONParsingBehavior() {
-        let integers: [NSNumber] = [
+    func testFoundationNumberStorageTypesAllBecomeDoubleValues() {
+        let numbers: [NSNumber] = [
             NSNumber(value: Int8(1)), NSNumber(value: Int16(2)), NSNumber(value: Int32(3)),
             NSNumber(value: Int64(4)), NSNumber(value: UInt8(5)), NSNumber(value: UInt16(6)),
-            NSNumber(value: UInt32(7)), NSNumber(value: UInt64(8))
+            NSNumber(value: UInt32(7)), NSNumber(value: UInt64(8)),
+            NSNumber(value: Float(1.5)), NSNumber(value: Double(2.5))
         ]
 
-        for number in integers {
-            guard case .integer = CheckpointValue(foundationValue: number) else {
-                return XCTFail("Expected NSNumber with objCType \(String(cString: number.objCType)) to be an integer")
+        for number in numbers {
+            guard case .double = CheckpointValue(foundationValue: number) else {
+                return XCTFail("Expected NSNumber with objCType \(String(cString: number.objCType)) to be a double")
             }
         }
-
-        XCTAssertEqual(CheckpointValue(foundationValue: NSNumber(value: Float(1.5))), .double(1.5))
-        XCTAssertEqual(CheckpointValue(foundationValue: NSNumber(value: Double(2.5))), .double(2.5))
     }
 
     func testParamsPreserveValueEqualityAndHashing() {
@@ -79,9 +77,9 @@ final class CheckpointValueTests: TestCase {
         XCTAssertEqual(Set([firstParams, secondParams]).count, 1)
     }
 
-    func testValuesConvertToDimensionsWithoutLosingTheirTypes() {
+    func testValuesConvertToSupportedDimensionTypes() {
         XCTAssertEqual(CheckpointValue.string("value").dimensionValue, .string("value"))
-        XCTAssertEqual(CheckpointValue.integer(42).dimensionValue, .int(42))
+        XCTAssertEqual(CheckpointValue(integerLiteral: 42).dimensionValue, .double(42))
         XCTAssertEqual(CheckpointValue.double(4.5).dimensionValue, .double(4.5))
         XCTAssertEqual(CheckpointValue.boolean(true).dimensionValue, .bool(true))
     }

--- a/api/revenuecatui-api-ios-simulator.swiftinterface
+++ b/api/revenuecatui-api-ios-simulator.swiftinterface
@@ -240,6 +240,24 @@ extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByStringLiteral {
   public typealias UnicodeScalarLiteralType = Swift.String
 }
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByIntegerLiteral {
+  public init(integerLiteral value: Swift.Int64)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias IntegerLiteralType = Swift.Int64
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByFloatLiteral {
+  public init(floatLiteral value: Swift.Double)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias FloatLiteralType = Swift.Double
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByBooleanLiteral {
+  public init(booleanLiteral value: Swift.Bool)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias BooleanLiteralType = Swift.Bool
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension SwiftUICore.EnvironmentValues {
   public var customPaywallVariables: [Swift.String : RevenueCatUI.CustomVariableValue] {
     get

--- a/api/revenuecatui-api-ios.swiftinterface
+++ b/api/revenuecatui-api-ios.swiftinterface
@@ -240,6 +240,24 @@ extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByStringLiteral {
   public typealias UnicodeScalarLiteralType = Swift.String
 }
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByIntegerLiteral {
+  public init(integerLiteral value: Swift.Int64)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias IntegerLiteralType = Swift.Int64
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByFloatLiteral {
+  public init(floatLiteral value: Swift.Double)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias FloatLiteralType = Swift.Double
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByBooleanLiteral {
+  public init(booleanLiteral value: Swift.Bool)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias BooleanLiteralType = Swift.Bool
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension SwiftUICore.EnvironmentValues {
   public var customPaywallVariables: [Swift.String : RevenueCatUI.CustomVariableValue] {
     get

--- a/api/revenuecatui-api-macos.swiftinterface
+++ b/api/revenuecatui-api-macos.swiftinterface
@@ -108,6 +108,24 @@ extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByStringLiteral {
   public typealias UnicodeScalarLiteralType = Swift.String
 }
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByIntegerLiteral {
+  public init(integerLiteral value: Swift.Int64)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias IntegerLiteralType = Swift.Int64
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByFloatLiteral {
+  public init(floatLiteral value: Swift.Double)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias FloatLiteralType = Swift.Double
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByBooleanLiteral {
+  public init(booleanLiteral value: Swift.Bool)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias BooleanLiteralType = Swift.Bool
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension SwiftUICore.EnvironmentValues {
   public var customPaywallVariables: [Swift.String : RevenueCatUI.CustomVariableValue] {
     get

--- a/api/revenuecatui-api-tvos-simulator.swiftinterface
+++ b/api/revenuecatui-api-tvos-simulator.swiftinterface
@@ -106,6 +106,24 @@ extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByStringLiteral {
   public typealias UnicodeScalarLiteralType = Swift.String
 }
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByIntegerLiteral {
+  public init(integerLiteral value: Swift.Int64)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias IntegerLiteralType = Swift.Int64
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByFloatLiteral {
+  public init(floatLiteral value: Swift.Double)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias FloatLiteralType = Swift.Double
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByBooleanLiteral {
+  public init(booleanLiteral value: Swift.Bool)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias BooleanLiteralType = Swift.Bool
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension SwiftUICore.EnvironmentValues {
   public var customPaywallVariables: [Swift.String : RevenueCatUI.CustomVariableValue] {
     get

--- a/api/revenuecatui-api-tvos.swiftinterface
+++ b/api/revenuecatui-api-tvos.swiftinterface
@@ -106,6 +106,24 @@ extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByStringLiteral {
   public typealias UnicodeScalarLiteralType = Swift.String
 }
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByIntegerLiteral {
+  public init(integerLiteral value: Swift.Int64)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias IntegerLiteralType = Swift.Int64
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByFloatLiteral {
+  public init(floatLiteral value: Swift.Double)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias FloatLiteralType = Swift.Double
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByBooleanLiteral {
+  public init(booleanLiteral value: Swift.Bool)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias BooleanLiteralType = Swift.Bool
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension SwiftUICore.EnvironmentValues {
   public var customPaywallVariables: [Swift.String : RevenueCatUI.CustomVariableValue] {
     get

--- a/api/revenuecatui-api-visionos-simulator.swiftinterface
+++ b/api/revenuecatui-api-visionos-simulator.swiftinterface
@@ -109,6 +109,24 @@ extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByStringLiteral {
   public typealias UnicodeScalarLiteralType = Swift.String
 }
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByIntegerLiteral {
+  public init(integerLiteral value: Swift.Int64)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias IntegerLiteralType = Swift.Int64
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByFloatLiteral {
+  public init(floatLiteral value: Swift.Double)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias FloatLiteralType = Swift.Double
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByBooleanLiteral {
+  public init(booleanLiteral value: Swift.Bool)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias BooleanLiteralType = Swift.Bool
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension SwiftUICore.EnvironmentValues {
   public var customPaywallVariables: [Swift.String : RevenueCatUI.CustomVariableValue] {
     get

--- a/api/revenuecatui-api-visionos.swiftinterface
+++ b/api/revenuecatui-api-visionos.swiftinterface
@@ -109,6 +109,24 @@ extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByStringLiteral {
   public typealias UnicodeScalarLiteralType = Swift.String
 }
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByIntegerLiteral {
+  public init(integerLiteral value: Swift.Int64)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias IntegerLiteralType = Swift.Int64
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByFloatLiteral {
+  public init(floatLiteral value: Swift.Double)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias FloatLiteralType = Swift.Double
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByBooleanLiteral {
+  public init(booleanLiteral value: Swift.Bool)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias BooleanLiteralType = Swift.Bool
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension SwiftUICore.EnvironmentValues {
   public var customPaywallVariables: [Swift.String : RevenueCatUI.CustomVariableValue] {
     get

--- a/api/revenuecatui-api-watchos-simulator.swiftinterface
+++ b/api/revenuecatui-api-watchos-simulator.swiftinterface
@@ -106,6 +106,24 @@ extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByStringLiteral {
   public typealias UnicodeScalarLiteralType = Swift.String
 }
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByIntegerLiteral {
+  public init(integerLiteral value: Swift.Int64)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias IntegerLiteralType = Swift.Int64
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByFloatLiteral {
+  public init(floatLiteral value: Swift.Double)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias FloatLiteralType = Swift.Double
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByBooleanLiteral {
+  public init(booleanLiteral value: Swift.Bool)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias BooleanLiteralType = Swift.Bool
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension SwiftUICore.EnvironmentValues {
   public var customPaywallVariables: [Swift.String : RevenueCatUI.CustomVariableValue] {
     get

--- a/api/revenuecatui-api-watchos.swiftinterface
+++ b/api/revenuecatui-api-watchos.swiftinterface
@@ -106,6 +106,24 @@ extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByStringLiteral {
   public typealias UnicodeScalarLiteralType = Swift.String
 }
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByIntegerLiteral {
+  public init(integerLiteral value: Swift.Int64)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias IntegerLiteralType = Swift.Int64
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByFloatLiteral {
+  public init(floatLiteral value: Swift.Double)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias FloatLiteralType = Swift.Double
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension RevenueCatUI.CustomVariableValue : Swift.ExpressibleByBooleanLiteral {
+  public init(booleanLiteral value: Swift.Bool)
+  @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+  public typealias BooleanLiteralType = Swift.Bool
+}
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension SwiftUICore.EnvironmentValues {
   public var customPaywallVariables: [Swift.String : RevenueCatUI.CustomVariableValue] {
     get


### PR DESCRIPTION
## Description
Reuses the `CustomVariableValue` type we are using for custom paywall variables for the Checkpoints API as well. Since our new `CheckpointValue` type was essentially the same thing.

This will keep the API consistent and benefit from the learnings and tests of the existing type.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> SPI checkpoint API surface changes (removed UI CheckpointValue; integers become doubles in core resolution), which can break early adopters and slightly alter how numeric custom variables are represented for targeting.
> 
> **Overview**
> **Checkpoint custom variables** now use **`CustomVariableValue`** (the same type as paywall custom variables) instead of a separate RevenueCatUI **`CheckpointValue`** wrapper. **`CheckpointParams.customVariables`** is **`[String: CustomVariableValue]`**, with conversion to core **`RevenueCat.CheckpointValue`** via **`coreCheckpointValue`**.
> 
> In the core SDK, **`CheckpointValue`** no longer has an **`.integer`** case: integer literals and **`NSNumber`** integers map to **`.double`**, aligning JSON/primitive handling with a single numeric representation.
> 
> **`CustomVariableValue`** gains integer/float/boolean literal conformances, an exhaustive **`map`** helper, and **`@_spi(Internal)`** **`foundationValue`** / **`init(foundationValue:)`** for Objective-C checkpoint params. Checkpoint-related public SPI types pick up **`@available(iOS 15.0, …)`** annotations, and the workflow executor drops a redundant runtime OS-version guard now that types are annotated.
> 
> Tests, API testers, examples, and swiftinterfaces are updated for the unified type and numeric semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8868a39ff2e1d8f145691f80e967cf12dce48dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->