### PR TITLE
feat(checkpoints): Integrate Checkpoint audience rules

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		16E4A3C89791426AAD027A49 /* PlatformInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043FB8686FEB4A31B9CF48C8 /* PlatformInfoTests.swift */; };
 		16F376262E93F1E300ADF649 /* LargeItemCacheTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16F376252E93F1E300ADF649 /* LargeItemCacheTypeTests.swift */; };
 		1701E7CE20E0879817B3F61B /* RulesEngineLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 232493C1C6A935B7FE1C6873 /* RulesEngineLogger.swift */; };
+		A91C0A012FEA000000000001 /* RulesEngineLoggerBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91C0A022FEA000000000001 /* RulesEngineLoggerBridge.swift */; };
 		1D20E1D62EBCF80E00ABE4CD /* HTTPRequestTimeoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D20E1D52EBCF80E00ABE4CD /* HTTPRequestTimeoutManager.swift */; };
 		1D20E1D82EBCF82900ABE4CD /* HTTPRequestTimeoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D20E1D72EBCF82900ABE4CD /* HTTPRequestTimeoutManager.swift */; };
 		1D291F722F154834008E4FDA /* CacheStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D291F712F154834008E4FDA /* CacheStrings.swift */; };
@@ -1775,6 +1776,7 @@
 		1EFA95142CDBAB7500CA5951 /* MockWebPurchaseRedemptionHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWebPurchaseRedemptionHelper.swift; sourceTree = "<group>"; };
 		1F73FB16F7644A5CBD7FB08A /* PackageSelectionHapticFeedbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageSelectionHapticFeedbackTests.swift; sourceTree = "<group>"; };
 		232493C1C6A935B7FE1C6873 /* RulesEngineLogger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RulesEngineLogger.swift; sourceTree = "<group>"; };
+		A91C0A022FEA000000000001 /* RulesEngineLoggerBridge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RulesEngineLoggerBridge.swift; sourceTree = "<group>"; };
 		26AAFBADBA3F4E339D041135 /* WorkflowStepEventCoordinatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowStepEventCoordinatorTests.swift; sourceTree = "<group>"; };
 		28661C6CE3F64078A0138080 /* WebViewOriginPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewOriginPolicy.swift; sourceTree = "<group>"; };
 		297C50EBB2B69A3F77D13E69 /* Operators.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Operators.swift; sourceTree = "<group>"; };
@@ -3263,6 +3265,7 @@
 			isa = PBXGroup;
 			children = (
 				A0D200000000000000000001 /* LocalRulesEvaluator.swift */,
+				A91C0A022FEA000000000001 /* RulesEngineLoggerBridge.swift */,
 				A0D200000000000000000006 /* DeviceDimensionProvider.swift */,
 				D17A00000000000000000002 /* StoreDimensionProvider.swift */,
 				A0D200000000000000000002 /* DimensionProvider.swift */,
@@ -7824,6 +7827,7 @@
 				2DF8D9550354ECBAE400C547 /* EvaluationError.swift in Sources */,
 				6A24585F01C6C2310AECC0B0 /* Evaluator.swift in Sources */,
 				1701E7CE20E0879817B3F61B /* RulesEngineLogger.swift in Sources */,
+				A91C0A012FEA000000000001 /* RulesEngineLoggerBridge.swift in Sources */,
 				A447209D359C42F9EC541F35 /* RulesEngine.swift in Sources */,
 				923A22C9437BD0A6223B866D /* RulesEngineEvaluate.swift in Sources */,
 				E74208221912EB2DB9191A99 /* Value+JSON.swift in Sources */,

--- a/Sources/Checkpoints/CheckpointWorkflowResolver.swift
+++ b/Sources/Checkpoints/CheckpointWorkflowResolver.swift
@@ -76,25 +76,28 @@ final class DisabledCheckpointWorkflowResolver: CheckpointWorkflowResolver {
 
 /// Resolves checkpoints through the ordered rules served by the `checkpoint_rules` remote-config topic.
 ///
-/// Audience evaluation is not available yet. Until it is, the first rule supplied by the backend is treated as
-/// the match.
+/// Audience predicates are not served yet, so each rule temporarily uses a predicate that always matches and the
+/// published order remains the effective signal.
 final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
 
     private let checkpointsConfigProvider: CheckpointsConfigProviderType
     private let workflowManager: WorkflowManager
+    private let localRulesEvaluator: LocalRulesEvaluator
     private let offeringsProvider: () async throws -> Offerings
 
     init(
         checkpointsConfigProvider: CheckpointsConfigProviderType,
         workflowManager: WorkflowManager,
+        localRulesEvaluator: LocalRulesEvaluator,
         offeringsProvider: @escaping () async throws -> Offerings
     ) {
         self.checkpointsConfigProvider = checkpointsConfigProvider
         self.workflowManager = workflowManager
+        self.localRulesEvaluator = localRulesEvaluator
         self.offeringsProvider = offeringsProvider
     }
 
-    func resolve(identifier: String, params _: CheckpointParams) async throws -> CheckpointResolution {
+    func resolve(identifier: String, params: CheckpointParams) async throws -> CheckpointResolution {
         #if DEBUG
         // Temporary CheckpointTester escape hatch. Config-backed resolution has no natural throwing case yet.
         if identifier == Self.simulatedErrorCheckpointIdentifier {
@@ -104,10 +107,13 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
         }
         #endif
 
-        return try await self.resolveConfiguredWorkflow(identifier: identifier)
+        return try await self.resolveConfiguredWorkflow(identifier: identifier, params: params)
     }
 
-    private func resolveConfiguredWorkflow(identifier: String) async throws -> CheckpointResolution {
+    private func resolveConfiguredWorkflow(
+        identifier: String,
+        params: CheckpointParams
+    ) async throws -> CheckpointResolution {
         let rulesSnapshot: CheckpointRulesSnapshot
         do {
             guard let snapshot = try await self.checkpointsConfigProvider.rules(for: identifier) else {
@@ -122,7 +128,17 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
             return .noAction(.configurationUnavailable)
         }
 
-        guard let rule = self.matchingRule(in: rulesSnapshot.ruleSet.rules) else { return .noAction(.noMatch) }
+        let rule: CheckpointRule?
+        do {
+            rule = try await self.matchingRule(in: rulesSnapshot.ruleSet.rules, params: params)
+        } catch let error as CancellationError {
+            throw error
+        } catch {
+            Logger.error("The audiences for checkpoint '\(identifier)' could not be evaluated: \(error)")
+            return .noAction(.configurationUnavailable)
+        }
+
+        guard let rule else { return .noAction(.noMatch) }
         guard let offeringID = await self.offeringID(for: rule) else {
             return .noAction(.configurationUnavailable)
         }
@@ -139,9 +155,19 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
         return resolution
     }
 
-    private func matchingRule(in rules: [CheckpointRule]) -> CheckpointRule? {
-        // Audience rules will be evaluated here later. Until then, the first backend-ordered rule always matches.
-        return rules.first
+    private func matchingRule(
+        in rules: [CheckpointRule],
+        params: CheckpointParams
+    ) async throws -> CheckpointRule? {
+        let audienceRules = rules.map {
+            CheckpointAudienceRule(checkpointRule: $0)
+        }
+        let customVariables = params.customVariables.mapValues(\.dimensionValue)
+
+        return try await self.localRulesEvaluator.match(
+            in: audienceRules,
+            customVariables: customVariables
+        )?.checkpointRule
     }
 
     private func offeringID(for rule: CheckpointRule) async -> String? {
@@ -200,5 +226,13 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
     #if DEBUG
     private static let simulatedErrorCheckpointIdentifier = "error_checkpoint"
     #endif
+
+    private struct CheckpointAudienceRule: LocalRule {
+
+        let checkpointRule: CheckpointRule
+        /// Audience predicates are not served yet, so backend order remains the effective selection signal.
+        let predicate = "true"
+
+    }
 
 }

--- a/Sources/LocalRules/RulesEngineLoggerBridge.swift
+++ b/Sources/LocalRules/RulesEngineLoggerBridge.swift
@@ -1,0 +1,35 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  RulesEngineLoggerBridge.swift
+//
+//  Created by Rick van der Linden on 8/13/26.
+//
+
+import Foundation
+
+/// Routes rules-engine diagnostics through the SDK logger while keeping the engine independently extractable.
+struct RulesEngineLoggerBridge: RulesEngineLogger {
+
+    func warn(_ message: String) {
+        Logger.debug(RulesEngineLogMessage(description: "Rules engine: \(message)"))
+    }
+
+    func log(_ message: String) {
+        Logger.verbose(RulesEngineLogMessage(description: "Rules engine: \(message)"))
+    }
+
+}
+
+private struct RulesEngineLogMessage: LogMessage {
+
+    let description: String
+    let category = "rules_engine"
+
+}

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -652,9 +652,17 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         let notificationCenter: NotificationCenter = .default
         let checkpointResolver: CheckpointWorkflowResolver
         if systemInfo.remoteConfigEnabled {
+            RulesEngine.setLogger(RulesEngineLoggerBridge())
+            let localRulesEvaluator = LocalRulesEvaluator(
+                dimensionProviders: [
+                    DeviceDimensionProvider(),
+                    StoreDimensionProvider()
+                ]
+            )
             checkpointResolver = DefaultCheckpointWorkflowResolver(
                 checkpointsConfigProvider: checkpointsConfigProvider,
                 workflowManager: workflowManager,
+                localRulesEvaluator: localRulesEvaluator,
                 offeringsProvider: {
                     try await withCheckedThrowingContinuation { continuation in
                         offeringsManager.offerings(

--- a/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
@@ -14,6 +14,8 @@
 
 import XCTest
 
+// swiftlint:disable type_body_length
+
 #if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 @_spi(Internal) @testable import RevenueCat_CustomEntitlementComputation
 #else
@@ -139,6 +141,38 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
         XCTAssertEqual(self.workflowsProvider.invokedGetWorkflowParameters, [self.workflowID])
     }
 
+    func testDimensionProviderFailureResolvesConfigurationUnavailableWithoutFetchingOfferings() async throws {
+        let fetchCount = Atomic<Int>(0)
+        let evaluator = LocalRulesEvaluator(dimensionProviders: [FailingDimensionProvider()])
+        let resolver = self.makeResolver(
+            offeringsProvider: {
+                fetchCount.modify { $0 += 1 }
+                return self.offerings
+            },
+            localRulesEvaluator: evaluator
+        )
+
+        let resolution = try await resolver.resolve(identifier: self.checkpointIdentifier, params: self.params)
+
+        XCTAssertEqual(Self.noActionReason(resolution), .configurationUnavailable)
+        XCTAssertEqual(fetchCount.value, 0)
+        XCTAssertTrue(self.workflowsProvider.invokedGetWorkflowParameters.isEmpty)
+    }
+
+    func testCancellationWhileCollectingDimensionsPropagates() async {
+        let evaluator = LocalRulesEvaluator(dimensionProviders: [CancellingDimensionProvider()])
+        let resolver = self.makeResolver(localRulesEvaluator: evaluator)
+
+        do {
+            _ = try await resolver.resolve(identifier: self.checkpointIdentifier, params: self.params)
+            XCTFail("Expected resolution to throw")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
+    }
+
     func testFirstRuleWithoutOfferingMetadataDoesNotFallThrough() async throws {
         let unservableWorkflowID = "wf_without_offering"
         self.checkpointsProvider.result = .success(CheckpointRuleSet(rules: [
@@ -250,11 +284,13 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
     }
 
     private func makeResolver(
-        offeringsProvider: (() async throws -> Offerings)? = nil
+        offeringsProvider: (() async throws -> Offerings)? = nil,
+        localRulesEvaluator: LocalRulesEvaluator = LocalRulesEvaluator(dimensionProviders: [])
     ) -> DefaultCheckpointWorkflowResolver {
         return DefaultCheckpointWorkflowResolver(
             checkpointsConfigProvider: self.checkpointsProvider,
             workflowManager: self.workflowManager,
+            localRulesEvaluator: localRulesEvaluator,
             offeringsProvider: offeringsProvider ?? { self.offerings }
         )
     }
@@ -313,6 +349,28 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
             contents: Offerings.Contents(response: response, httpResponseOriginalSource: .mainServer),
             loadedFromDiskCache: false
         )
+    }
+
+}
+
+private struct FailingDimensionProvider: DimensionProvider {
+
+    let namespace = DimensionNamespace.device
+
+    func dimensions(at _: Date) async throws -> [String: DimensionValue] {
+        throw FailingDimensionProviderError()
+    }
+
+}
+
+private struct FailingDimensionProviderError: Error {}
+
+private struct CancellingDimensionProvider: DimensionProvider {
+
+    let namespace = DimensionNamespace.device
+
+    func dimensions(at _: Date) async throws -> [String: DimensionValue] {
+        throw CancellationError()
     }
 
 }


### PR DESCRIPTION
## Description
Starts integrating the `LocalRuleEvaluator` in the `CheckpointWorkflowResolver`, passing the `CheckpointRule` and `customVariables` to the rule evaluator. 

Note: for now the `predicate` isn't available from the audiences topic just yet, so the `predicate` is hardcoded to `true` for now. This will be done in a follow up PR

Related Android PR https://github.com/RevenueCat/purchases-android/pull/3942

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the checkpoint resolution path and adds async dimension collection; behavior should match today while predicates are hardcoded to true, but failures now short-circuit before offerings/workflow loads.
> 
> **Overview**
> **Checkpoint rule selection** now goes through `LocalRulesEvaluator` instead of always taking the first configured rule. `CheckpointParams.customVariables` are passed into matching, and each `CheckpointRule` is wrapped as a `LocalRule` with a temporary `"true"` predicate until audience predicates are served from remote config—so **backend order still picks the first rule** for now.
> 
> When dimension collection or predicate evaluation fails, resolution returns `.configurationUnavailable` (with logging); `CancellationError` still propagates. **Purchases** wires this up when remote config is enabled: `RulesEngine.setLogger(RulesEngineLoggerBridge())`, a `LocalRulesEvaluator` with device/store dimension providers, and injection into `DefaultCheckpointWorkflowResolver`.
> 
> New unit tests cover dimension-provider failures (no offerings fetch) and cancellation during dimension collection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66431d6db708763dfe2b499d281b00e7fc34404b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->