### PR TITLE
feat(checkpoints): expose CheckpointParams custom variables as paywall custom variables

### DIFF
--- a/Examples/CheckpointTester/CheckpointTester/Sources/ContentView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/ContentView.swift
@@ -166,6 +166,8 @@ struct ContentView: View {
                     ForEach(self.$customVariables.variables) { $variable in
                         HStack {
                             TextField("Name", text: $variable.name)
+                                .textInputAutocapitalization(.never)
+                                .autocorrectionDisabled()
                             TextField("Value", text: $variable.value)
                         }
                     }

--- a/RevenueCatUI/Checkpoints/CheckpointCallStore.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointCallStore.swift
@@ -21,16 +21,16 @@ import Foundation
 final class CheckpointCallStore {
 
     final class Call {
-        let workflow: ResolvedCheckpointWorkflow
+        let presentation: CheckpointPresentation
         let delegate: CheckpointPresentationDelegate
         fileprivate(set) var stagedOutcome: CheckpointPaywallOutcome
 
         init(
-            workflow: ResolvedCheckpointWorkflow,
+            presentation: CheckpointPresentation,
             delegate: CheckpointPresentationDelegate,
             stagedOutcome: CheckpointPaywallOutcome = CheckpointPaywallDismissedOutcome.shared
         ) {
-            self.workflow = workflow
+            self.presentation = presentation
             self.delegate = delegate
             self.stagedOutcome = stagedOutcome
         }
@@ -39,10 +39,10 @@ final class CheckpointCallStore {
     private(set) var call: Call?
 
     func store(
-        workflow: ResolvedCheckpointWorkflow,
+        presentation: CheckpointPresentation,
         delegate: CheckpointPresentationDelegate
     ) {
-        self.call = Call(workflow: workflow, delegate: delegate)
+        self.call = Call(presentation: presentation, delegate: delegate)
     }
 
     func stage(outcome: CheckpointPaywallOutcome) {

--- a/RevenueCatUI/Checkpoints/CheckpointWorkflowExecutor.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointWorkflowExecutor.swift
@@ -15,12 +15,21 @@
 import Foundation
 @_spi(Internal) import RevenueCat
 
+/// Everything needed to present a checkpoint workflow.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct CheckpointPresentation {
+
+    let workflow: ResolvedCheckpointWorkflow
+    let customVariables: [String: CustomVariableValue]
+
+}
+
 /// Bridges resolved checkpoint workflows into asynchronous UI outcomes.
 @MainActor
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 protocol CheckpointExecutor: AnyObject {
 
-    func execute(_ workflow: ResolvedCheckpointWorkflow) async throws -> CheckpointPaywallOutcome
+    func execute(_ presentation: CheckpointPresentation) async throws -> CheckpointPaywallOutcome
 
 }
 
@@ -30,7 +39,7 @@ protocol CheckpointExecutor: AnyObject {
 protocol CheckpointPresenter: AnyObject {
 
     func present(
-        workflow: ResolvedCheckpointWorkflow,
+        presentation: CheckpointPresentation,
         delegate: CheckpointPresentationDelegate
     ) throws
 
@@ -70,7 +79,7 @@ final class CheckpointWorkflowExecutor: CheckpointExecutor, CheckpointPresentati
         self.presenterProvider = presenterProvider
     }
 
-    func execute(_ workflow: ResolvedCheckpointWorkflow) async throws -> CheckpointPaywallOutcome {
+    func execute(_ presentation: CheckpointPresentation) async throws -> CheckpointPaywallOutcome {
         guard self.pendingContinuation == nil else {
             throw CheckpointError.operationAlreadyInProgress
         }
@@ -88,7 +97,7 @@ final class CheckpointWorkflowExecutor: CheckpointExecutor, CheckpointPresentati
                 }
                 self.store(continuation: continuation)
                 do {
-                    try presenter.present(workflow: workflow, delegate: self)
+                    try presenter.present(presentation: presentation, delegate: self)
                 } catch {
                     self.fail(error: error)
                 }

--- a/RevenueCatUI/Checkpoints/CheckpointWorkflowPresenter.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointWorkflowPresenter.swift
@@ -26,7 +26,7 @@ import UIKit
 @MainActor
 final class CheckpointWorkflowPresenter: NSObject, CheckpointPresenter {
 
-    typealias PresentationHandler = (ResolvedCheckpointWorkflow) throws -> Bool
+    typealias PresentationHandler = (CheckpointPresentation) throws -> Bool
 
     private let callStore: CheckpointCallStore
     private let presentationHandler: PresentationHandler?
@@ -45,18 +45,18 @@ final class CheckpointWorkflowPresenter: NSObject, CheckpointPresenter {
     }
 
     func present(
-        workflow: ResolvedCheckpointWorkflow,
+        presentation: CheckpointPresentation,
         delegate: CheckpointPresentationDelegate
     ) throws {
-        self.callStore.store(workflow: workflow, delegate: delegate)
+        self.callStore.store(presentation: presentation, delegate: delegate)
 
         do {
             if let presentationHandler = self.presentationHandler {
-                guard try presentationHandler(workflow) else {
+                guard try presentationHandler(presentation) else {
                     throw CheckpointError.presentationFailed
                 }
             } else {
-                try self.presentAutomatically(workflow)
+                try self.presentAutomatically(presentation)
             }
         } catch {
             _ = self.callStore.remove()
@@ -104,20 +104,12 @@ final class CheckpointWorkflowPresenter: NSObject, CheckpointPresenter {
         call.delegate.checkpointPresentationFinished(outcome: call.stagedOutcome)
     }
 
-    private func presentAutomatically(_ workflow: ResolvedCheckpointWorkflow) throws {
+    private func presentAutomatically(_ presentation: CheckpointPresentation) throws {
         #if canImport(UIKit) && !os(tvOS) && !os(watchOS)
         guard let presentationContext = UIApplication.extensionSafeApplication?.currentPresentationViewController else {
             throw CheckpointError.noPresentationContext
         }
-        let workflowContext = try WorkflowPreview.makeContext(
-            workflow: workflow.workflow,
-            offerings: workflow.offerings,
-            uiConfig: workflow.uiConfig
-        )
-        let viewController = PaywallViewController(
-            workflowContext: workflowContext,
-            displayCloseButton: true
-        )
+        let viewController = try self.makePaywallViewController(for: presentation)
         viewController.delegate = self
         self.presentedViewController = viewController
         presentationContext.present(viewController, animated: true)
@@ -127,6 +119,22 @@ final class CheckpointWorkflowPresenter: NSObject, CheckpointPresenter {
         #else
         throw CheckpointError.noPresentationContext
         #endif
+    }
+
+    func makePaywallViewController(
+        for presentation: CheckpointPresentation
+    ) throws -> PaywallViewController {
+        let workflowContext = try WorkflowPreview.makeContext(
+            workflow: presentation.workflow.workflow,
+            offerings: presentation.workflow.offerings,
+            uiConfig: presentation.workflow.uiConfig
+        )
+        let viewController = PaywallViewController(
+            workflowContext: workflowContext,
+            displayCloseButton: true
+        )
+        viewController.customVariables = presentation.customVariables
+        return viewController
     }
 
 }

--- a/RevenueCatUI/Checkpoints/Checkpoints.swift
+++ b/RevenueCatUI/Checkpoints/Checkpoints.swift
@@ -37,7 +37,7 @@ public final class CheckpointParams: Equatable, Hashable, CustomStringConvertibl
 
     /// Creates checkpoint parameters with the supplied custom variables.
     public init(customVariables: [String: CustomVariableValue] = [:]) {
-        self.customVariables = customVariables
+        self.customVariables = RevenueCat.CustomVariableKeyValidator.validateAndFilter(customVariables)
     }
 
     /// Returns whether two parameter collections contain the same custom variables.

--- a/RevenueCatUI/Checkpoints/CheckpointsManager.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointsManager.swift
@@ -82,7 +82,11 @@ final class CheckpointsManager {
         let result: CheckpointResult
         switch try await self.resolveCheckpoint(identifier, params) {
         case let .workflow(workflow):
-            let outcome = try await self.executor.execute(workflow)
+            let presentation = CheckpointPresentation(
+                workflow: workflow,
+                customVariables: params.customVariables
+            )
+            let outcome = try await self.executor.execute(presentation)
             result = CheckpointPaywallPresentedResult(
                 checkpoint: checkpoint,
                 paywallOutcome: outcome

--- a/RevenueCatUI/Checkpoints/CheckpointsManager.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointsManager.swift
@@ -82,7 +82,11 @@ final class CheckpointsManager {
         let result: CheckpointResult
         switch try await self.resolveCheckpoint(identifier, params) {
         case let .matchedWorkflow(workflow):
-            let outcome = try await self.executor.execute(workflow)
+            let presentation = CheckpointPresentation(
+                workflow: workflow,
+                customVariables: params.customVariables
+            )
+            let outcome = try await self.executor.execute(presentation)
             result = CheckpointPaywallPresentedResult(
                 checkpoint: checkpoint,
                 paywallOutcome: outcome

--- a/Sources/Misc/CustomVariableKeyValidator.swift
+++ b/Sources/Misc/CustomVariableKeyValidator.swift
@@ -42,11 +42,13 @@ public struct CustomVariableKeyValidator {
         return key.allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" }
     }
 
-    /// Drops invalid keys and logs a warning for each removed entry.
+    /// Drops invalid keys and, in debug builds, logs a warning for each removed entry.
     public static func validateAndFilter<Value>(_ variables: [String: Value]) -> [String: Value] {
         return variables.filter { key, _ in
             guard Self.isValidKey(key) else {
+                #if DEBUG
                 Logger.warn(CustomVariableKeyValidatorStrings.invalidKey(key))
+                #endif
                 return false
             }
 

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointWorkflowPresenterTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointWorkflowPresenterTests.swift
@@ -29,7 +29,7 @@ final class CheckpointWorkflowPresenterTests: TestCase {
         let presenter = CheckpointWorkflowPresenter(callStore: store) { _ in true }
         let error = NSError(domain: "test", code: 1)
 
-        try presenter.present(workflow: Self.workflow(), delegate: delegate)
+        try presenter.present(presentation: Self.presentation(), delegate: delegate)
         presenter.stage(outcome: CheckpointPaywallErrorOutcome(error: error))
 
         XCTAssertEqual(delegate.finishCount, 0)
@@ -49,7 +49,7 @@ final class CheckpointWorkflowPresenterTests: TestCase {
     func testCallStoreDefaultsToDismissedAndRemovesCall() {
         let store = CheckpointCallStore()
         let delegate = MockCheckpointPresenterDelegate()
-        store.store(workflow: Self.workflow(), delegate: delegate)
+        store.store(presentation: Self.presentation(), delegate: delegate)
 
         let call = store.remove()
 
@@ -65,7 +65,7 @@ final class CheckpointWorkflowPresenterTests: TestCase {
         let delegate = MockCheckpointPresenterDelegate()
         let presenter = CheckpointWorkflowPresenter(callStore: store) { _ in true }
         var didFinishDismissing = false
-        try presenter.present(workflow: Self.workflow(), delegate: delegate)
+        try presenter.present(presentation: Self.presentation(), delegate: delegate)
 
         presenter.dismiss {
             didFinishDismissing = true
@@ -80,12 +80,12 @@ final class CheckpointWorkflowPresenterTests: TestCase {
     #if canImport(UIKit) && !os(tvOS) && !os(watchOS)
 
     func testDismissTargetsPresentedExitOfferController() throws {
-        let workflow = Self.workflow()
+        let presentation = Self.presentation()
         let presenter = CheckpointWorkflowPresenter { _ in true }
-        try presenter.present(workflow: workflow, delegate: MockCheckpointPresenterDelegate())
-        let originalController = PaywallViewController(offering: workflow.offering)
+        try presenter.present(presentation: presentation, delegate: MockCheckpointPresenterDelegate())
+        let originalController = PaywallViewController(offering: presentation.workflow.offering)
         let exitOfferController = DismissRecordingPaywallController(
-            offering: workflow.offering
+            offering: presentation.workflow.offering
         )
 
         presenter.paywallViewController(
@@ -103,7 +103,7 @@ final class CheckpointWorkflowPresenterTests: TestCase {
         let presenter = CheckpointWorkflowPresenter(callStore: store) { _ in false }
 
         XCTAssertThrowsError(
-            try presenter.present(workflow: Self.workflow(), delegate: delegate)
+            try presenter.present(presentation: Self.presentation(), delegate: delegate)
         ) { error in
             guard case CheckpointError.presentationFailed = error else {
                 return XCTFail("Expected presentationFailed, got \(error)")
@@ -122,7 +122,7 @@ final class CheckpointWorkflowPresenterTests: TestCase {
         }
 
         XCTAssertThrowsError(
-            try presenter.present(workflow: Self.workflow(), delegate: delegate)
+            try presenter.present(presentation: Self.presentation(), delegate: delegate)
         ) { error in
             XCTAssertEqual(error as NSError, expectedError)
         }
@@ -131,6 +131,107 @@ final class CheckpointWorkflowPresenterTests: TestCase {
     }
 
     #endif
+
+    func testCustomVariablesAreKeptWithThePresentedWorkflow() throws {
+        let store = CheckpointCallStore()
+        let expected: [String: CustomVariableValue] = [
+            "name": "Rick",
+            "attempt": 2,
+            "enabled": true
+        ]
+        var receivedPresentation: CheckpointPresentation?
+        let presenter = CheckpointWorkflowPresenter(callStore: store) { presentation in
+            receivedPresentation = presentation
+            return true
+        }
+
+        try presenter.present(
+            presentation: Self.presentation(customVariables: expected),
+            delegate: MockCheckpointPresenterDelegate()
+        )
+
+        XCTAssertEqual(receivedPresentation?.customVariables, expected)
+        XCTAssertEqual(store.call?.presentation.customVariables, expected)
+    }
+
+    func testCustomVariablesAreAppliedToThePaywallViewController() throws {
+        let expected: [String: CustomVariableValue] = [
+            "name": "Rick",
+            "attempt": 2,
+            "enabled": true
+        ]
+        let presenter = CheckpointWorkflowPresenter { _ in true }
+
+        let viewController = try presenter.makePaywallViewController(
+            for: Self.renderablePresentation(customVariables: expected)
+        )
+
+        XCTAssertEqual(viewController.customVariables, expected)
+    }
+
+    private static func presentation(
+        customVariables: [String: CustomVariableValue] = [:]
+    ) -> CheckpointPresentation {
+        return CheckpointPresentation(
+            workflow: self.workflow(),
+            customVariables: customVariables
+        )
+    }
+
+    private static func renderablePresentation(
+        customVariables: [String: CustomVariableValue]
+    ) throws -> CheckpointPresentation {
+        let resolvedWorkflow = self.workflow()
+        let screen = WorkflowScreen(
+            name: nil,
+            templateName: "test",
+            assetBaseURL: try XCTUnwrap(URL(string: "https://assets.revenuecat.com")),
+            componentsConfig: try self.componentsConfig(),
+            componentsLocalizations: [:],
+            defaultLocale: "en_US",
+            offeringIdentifier: resolvedWorkflow.offering.identifier
+        )
+        let workflow = PublishedWorkflow(
+            id: "workflow-id",
+            displayName: "Test",
+            initialStepId: "step-id",
+            singleStepFallbackId: nil,
+            steps: ["step-id": WorkflowStep(id: "step-id", type: "screen", screenId: "screen-id")],
+            screens: ["screen-id": screen]
+        )
+        return CheckpointPresentation(
+            workflow: ResolvedCheckpointWorkflow(
+                workflow: workflow,
+                uiConfig: resolvedWorkflow.uiConfig,
+                offering: resolvedWorkflow.offering,
+                offerings: resolvedWorkflow.offerings
+            ),
+            customVariables: customVariables
+        )
+    }
+
+    private static func componentsConfig() throws -> PaywallComponentsData.ComponentsConfig {
+        let json = """
+        {
+          "base": {
+            "stack": {
+              "type": "stack",
+              "components": [],
+              "dimension": { "type": "vertical", "alignment": "center", "distribution": "center" },
+              "size": { "width": { "type": "fill" }, "height": { "type": "fill" } },
+              "padding": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 },
+              "margin": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 }
+            },
+            "background": {
+              "type": "color",
+              "value": { "light": { "type": "hex", "value": "#FFFFFF" } }
+            }
+          }
+        }
+        """
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        return try JSONDecoder.default.decode(PaywallComponentsData.ComponentsConfig.self, from: data)
+    }
 
     private static func workflow() -> ResolvedCheckpointWorkflow {
         let workflow = PublishedWorkflow(

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
@@ -46,6 +46,7 @@ final class CheckpointsManagerTests: TestCase {
     func testObjectiveCParamsDropUnsupportedValuesAndNonStringKeys() {
         let params = ObjCCheckpointParams(customVariables: [
             "valid": "value",
+            "invalid-key": "value",
             "null": NSNull(),
             "date": Date(),
             "array": ["nested"],
@@ -75,6 +76,18 @@ final class CheckpointsManagerTests: TestCase {
         XCTAssertEqual(params.coreParams.customVariables, expected)
     }
 
+    func testCheckpointParamsDropInvalidCustomVariableKeys() {
+        let params = RevenueCatUI.CheckpointParams(customVariables: [
+            "valid_key": "value",
+            "invalid-key": "value",
+            "1invalid": "value",
+            "": "value"
+        ])
+
+        XCTAssertEqual(params.customVariables, ["valid_key": "value"])
+        XCTAssertEqual(params.coreParams.customVariables, ["valid_key": .string("value")])
+    }
+
     func testNoActionResultAndListenerEventsAreBuiltInRevenueCatUI() async throws {
         let manager = CheckpointsManager { _, _ in .noAction(.unknownCheckpoint) }
         let listener = ListenerRecorder()
@@ -97,6 +110,24 @@ final class CheckpointsManagerTests: TestCase {
         )
     }
 
+    func testInvalidCustomVariableKeysDoNotReachResolution() async throws {
+        var resolvedParams: RevenueCatUI.CheckpointParams?
+        let manager = CheckpointsManager { _, params in
+            resolvedParams = params
+            return .noAction(.noMatch)
+        }
+
+        _ = try await manager.checkpoint(
+            identifier: "test",
+            params: CheckpointParams(customVariables: [
+                "valid_key": "value",
+                "invalid-key": "value"
+            ])
+        )
+
+        XCTAssertEqual(resolvedParams?.customVariables, ["valid_key": "value"])
+    }
+
     func testResolvedWorkflowProducesPaywallResult() async throws {
         let executor = MockCheckpointWorkflowExecutor()
         executor.outcome = CheckpointPaywallDismissedOutcome.shared
@@ -105,13 +136,27 @@ final class CheckpointsManagerTests: TestCase {
             executor: executor
         )
 
-        let result = try await manager.checkpoint(identifier: "soft_paywall", params: .init())
+        let customVariables: [String: CustomVariableValue] = [
+            "name": "Rick",
+            "attempt": 2,
+            "enabled": true,
+            "invalid-key": "not forwarded"
+        ]
+        let result = try await manager.checkpoint(
+            identifier: "soft_paywall",
+            params: .init(customVariables: customVariables)
+        )
 
         guard let presented = result as? CheckpointPaywallPresentedResult else {
             return XCTFail("Expected a presented-paywall result")
         }
         XCTAssertTrue(presented.paywallOutcome is CheckpointPaywallDismissedOutcome)
-        XCTAssertEqual(executor.executedWorkflows.map(\.workflow.id), ["workflow-id"])
+        XCTAssertEqual(executor.presentations.map(\.workflow.workflow.id), ["workflow-id"])
+        XCTAssertEqual(executor.presentations.first?.customVariables, [
+            "name": "Rick",
+            "attempt": 2,
+            "enabled": true
+        ])
     }
 
     func testResolutionErrorIsForwardedWithoutCompletedListenerEvent() async {
@@ -212,6 +257,28 @@ final class CheckpointsManagerTests: TestCase {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 final class CheckpointWorkflowExecutorTests: TestCase {
 
+    func testCustomVariablesAreForwardedToThePresenter() async throws {
+        let expected: [String: CustomVariableValue] = [
+            "name": "Rick",
+            "attempt": 2,
+            "enabled": true
+        ]
+        let presenter = MockCheckpointPresenter()
+        presenter.onPresent = { presentation in
+            presentation.delegate.checkpointPresentationFinished(
+                outcome: CheckpointPaywallDismissedOutcome.shared
+            )
+        }
+        let executor = CheckpointWorkflowExecutor { presenter }
+
+        _ = try await executor.execute(Self.presentation(customVariables: expected))
+
+        XCTAssertEqual(
+            presenter.presentations.first?.checkpointPresentation.customVariables,
+            expected
+        )
+    }
+
     func testPresentationFailureResumesExecutionAndAllowsRetry() async throws {
         let presenter = MockCheckpointPresenter()
         let expectedError = NSError(domain: "test", code: 42)
@@ -219,7 +286,7 @@ final class CheckpointWorkflowExecutorTests: TestCase {
         let executor = CheckpointWorkflowExecutor { presenter }
 
         do {
-            _ = try await executor.execute(Self.workflow())
+            _ = try await executor.execute(Self.presentation())
             XCTFail("Expected presentation failure")
         } catch {
             XCTAssertEqual(error as NSError, expectedError)
@@ -231,7 +298,7 @@ final class CheckpointWorkflowExecutorTests: TestCase {
                 outcome: CheckpointPaywallDismissedOutcome.shared
             )
         }
-        _ = try await executor.execute(Self.workflow())
+        _ = try await executor.execute(Self.presentation())
 
         XCTAssertEqual(presenter.presentations.count, 1)
     }
@@ -241,11 +308,11 @@ final class CheckpointWorkflowExecutorTests: TestCase {
         let presentationStarted = self.expectation(description: "Presentation starts")
         presenter.onPresent = { _ in presentationStarted.fulfill() }
         let executor = CheckpointWorkflowExecutor { presenter }
-        let firstExecution = Task { try await executor.execute(Self.workflow()) }
+        let firstExecution = Task { try await executor.execute(Self.presentation()) }
         await self.fulfillment(of: [presentationStarted], timeout: 1)
 
         do {
-            _ = try await executor.execute(Self.workflow())
+            _ = try await executor.execute(Self.presentation())
             XCTFail("Expected concurrent execution to throw")
         } catch {
             XCTAssertEqual(
@@ -270,8 +337,8 @@ final class CheckpointWorkflowExecutorTests: TestCase {
         }
         let executor = CheckpointWorkflowExecutor { presenter }
 
-        _ = try await executor.execute(Self.workflow())
-        _ = try await executor.execute(Self.workflow())
+        _ = try await executor.execute(Self.presentation())
+        _ = try await executor.execute(Self.presentation())
 
         XCTAssertEqual(presenter.presentations.count, 2)
     }
@@ -281,7 +348,7 @@ final class CheckpointWorkflowExecutorTests: TestCase {
         let presentationStarted = self.expectation(description: "Presentation starts")
         presenter.onPresent = { _ in presentationStarted.fulfill() }
         let executor = CheckpointWorkflowExecutor { presenter }
-        let firstExecution = Task { try await executor.execute(Self.workflow()) }
+        let firstExecution = Task { try await executor.execute(Self.presentation()) }
         await self.fulfillment(of: [presentationStarted], timeout: 1)
 
         firstExecution.cancel()
@@ -297,7 +364,7 @@ final class CheckpointWorkflowExecutorTests: TestCase {
                 outcome: CheckpointPaywallDismissedOutcome.shared
             )
         }
-        _ = try await executor.execute(Self.workflow())
+        _ = try await executor.execute(Self.presentation())
 
         XCTAssertEqual(presenter.presentations.count, 2)
         XCTAssertEqual(presenter.dismissCallCount, 1)
@@ -311,14 +378,14 @@ final class CheckpointWorkflowExecutorTests: TestCase {
         presenter.onPresent = { _ in presentationStarted.fulfill() }
         presenter.onDismiss = { dismissalStarted.fulfill() }
         let executor = CheckpointWorkflowExecutor { presenter }
-        let firstExecution = Task { try await executor.execute(Self.workflow()) }
+        let firstExecution = Task { try await executor.execute(Self.presentation()) }
         await self.fulfillment(of: [presentationStarted], timeout: 1)
 
         firstExecution.cancel()
         await self.fulfillment(of: [dismissalStarted], timeout: 1)
 
         do {
-            _ = try await executor.execute(Self.workflow())
+            _ = try await executor.execute(Self.presentation())
             XCTFail("Expected execution to remain active while dismissing")
         } catch {
             XCTAssertEqual(
@@ -349,7 +416,7 @@ final class CheckpointWorkflowExecutorTests: TestCase {
         }
         let executor = CheckpointWorkflowExecutor { presenter }
 
-        execution = Task { try await executor.execute(Self.workflow()) }
+        execution = Task { try await executor.execute(Self.presentation()) }
         let outcome = try await XCTUnwrap(execution).value
 
         guard let errorOutcome = outcome as? CheckpointPaywallErrorOutcome else {
@@ -368,6 +435,15 @@ final class CheckpointWorkflowExecutorTests: TestCase {
         )
 
         XCTAssertTrue(presenter.presentations.isEmpty)
+    }
+
+    private static func presentation(
+        customVariables: [String: CustomVariableValue] = [:]
+    ) -> CheckpointPresentation {
+        return CheckpointPresentation(
+            workflow: self.workflow(),
+            customVariables: customVariables
+        )
     }
 
     private static func workflow() -> ResolvedCheckpointWorkflow {
@@ -400,10 +476,10 @@ private final class MockCheckpointWorkflowExecutor: CheckpointExecutor {
 
     var outcome: CheckpointPaywallOutcome = CheckpointPaywallDismissedOutcome.shared
     var error: Error?
-    private(set) var executedWorkflows: [ResolvedCheckpointWorkflow] = []
+    private(set) var presentations: [CheckpointPresentation] = []
 
-    func execute(_ workflow: ResolvedCheckpointWorkflow) async throws -> CheckpointPaywallOutcome {
-        self.executedWorkflows.append(workflow)
+    func execute(_ presentation: CheckpointPresentation) async throws -> CheckpointPaywallOutcome {
+        self.presentations.append(presentation)
         if let error {
             throw error
         }
@@ -417,7 +493,7 @@ private final class MockCheckpointWorkflowExecutor: CheckpointExecutor {
 private final class MockCheckpointPresenter: CheckpointPresenter {
 
     struct Presentation {
-        let workflow: ResolvedCheckpointWorkflow
+        let checkpointPresentation: CheckpointPresentation
         let delegate: CheckpointPresentationDelegate
     }
 
@@ -430,15 +506,15 @@ private final class MockCheckpointPresenter: CheckpointPresenter {
     private var dismissalCompletions: [() -> Void] = []
 
     func present(
-        workflow: ResolvedCheckpointWorkflow,
+        presentation: CheckpointPresentation,
         delegate: CheckpointPresentationDelegate
     ) throws {
         if let presentationError {
             throw presentationError
         }
-        let presentation = Presentation(workflow: workflow, delegate: delegate)
-        self.presentations.append(presentation)
-        self.onPresent?(presentation)
+        let record = Presentation(checkpointPresentation: presentation, delegate: delegate)
+        self.presentations.append(record)
+        self.onPresent?(record)
     }
 
     func dismiss(completion: @escaping () -> Void) {

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
@@ -46,6 +46,7 @@ final class CheckpointsManagerTests: TestCase {
     func testObjectiveCParamsDropUnsupportedValuesAndNonStringKeys() {
         let params = ObjCCheckpointParams(customVariables: [
             "valid": "value",
+            "invalid-key": "value",
             "null": NSNull(),
             "date": Date(),
             "array": ["nested"],
@@ -75,6 +76,18 @@ final class CheckpointsManagerTests: TestCase {
         XCTAssertEqual(params.coreParams.customVariables, expected)
     }
 
+    func testCheckpointParamsDropInvalidCustomVariableKeys() {
+        let params = RevenueCatUI.CheckpointParams(customVariables: [
+            "valid_key": "value",
+            "invalid-key": "value",
+            "1invalid": "value",
+            "": "value"
+        ])
+
+        XCTAssertEqual(params.customVariables, ["valid_key": "value"])
+        XCTAssertEqual(params.coreParams.customVariables, ["valid_key": .string("value")])
+    }
+
     func testNoActionResultAndListenerEventsAreBuiltInRevenueCatUI() async throws {
         let manager = CheckpointsManager { _, _ in .noAction(.unknownCheckpoint) }
         let listener = ListenerRecorder()
@@ -97,6 +110,24 @@ final class CheckpointsManagerTests: TestCase {
         )
     }
 
+    func testInvalidCustomVariableKeysDoNotReachResolution() async throws {
+        var resolvedParams: RevenueCatUI.CheckpointParams?
+        let manager = CheckpointsManager { _, params in
+            resolvedParams = params
+            return .noAction(.noMatch)
+        }
+
+        _ = try await manager.checkpoint(
+            identifier: "test",
+            params: CheckpointParams(customVariables: [
+                "valid_key": "value",
+                "invalid-key": "value"
+            ])
+        )
+
+        XCTAssertEqual(resolvedParams?.customVariables, ["valid_key": "value"])
+    }
+
     func testResolvedWorkflowProducesPaywallResult() async throws {
         let executor = MockCheckpointWorkflowExecutor()
         executor.outcome = CheckpointPaywallDismissedOutcome.shared
@@ -105,13 +136,27 @@ final class CheckpointsManagerTests: TestCase {
             executor: executor
         )
 
-        let result = try await manager.checkpoint(identifier: "soft_paywall", params: .init())
+        let customVariables: [String: CustomVariableValue] = [
+            "name": "Rick",
+            "attempt": 2,
+            "enabled": true,
+            "invalid-key": "not forwarded"
+        ]
+        let result = try await manager.checkpoint(
+            identifier: "soft_paywall",
+            params: .init(customVariables: customVariables)
+        )
 
         guard let presented = result as? CheckpointPaywallPresentedResult else {
             return XCTFail("Expected a presented-paywall result")
         }
         XCTAssertTrue(presented.paywallOutcome is CheckpointPaywallDismissedOutcome)
-        XCTAssertEqual(executor.executedWorkflows.map(\.workflow.id), ["workflow-id"])
+        XCTAssertEqual(executor.presentations.map(\.workflow.workflow.id), ["workflow-id"])
+        XCTAssertEqual(executor.presentations.first?.customVariables, [
+            "name": "Rick",
+            "attempt": 2,
+            "enabled": true
+        ])
     }
 
     func testResolvedOfferingProducesReceivedOfferingResultWithoutPresenting() async throws {
@@ -131,7 +176,7 @@ final class CheckpointsManagerTests: TestCase {
         XCTAssertEqual(received.offering.identifier, "offering-id")
         XCTAssertEqual(received.checkpoint.identifier, "onboarding")
         // Data-only, so it never claims the executor's one-presentation-at-a-time slot.
-        XCTAssertTrue(executor.executedWorkflows.isEmpty)
+        XCTAssertTrue(executor.presentations.isEmpty)
         XCTAssertEqual(listener.events, [.hit("onboarding"), .completed("onboarding")])
     }
 
@@ -237,6 +282,28 @@ final class CheckpointsManagerTests: TestCase {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 final class CheckpointWorkflowExecutorTests: TestCase {
 
+    func testCustomVariablesAreForwardedToThePresenter() async throws {
+        let expected: [String: CustomVariableValue] = [
+            "name": "Rick",
+            "attempt": 2,
+            "enabled": true
+        ]
+        let presenter = MockCheckpointPresenter()
+        presenter.onPresent = { presentation in
+            presentation.delegate.checkpointPresentationFinished(
+                outcome: CheckpointPaywallDismissedOutcome.shared
+            )
+        }
+        let executor = CheckpointWorkflowExecutor { presenter }
+
+        _ = try await executor.execute(Self.presentation(customVariables: expected))
+
+        XCTAssertEqual(
+            presenter.presentations.first?.checkpointPresentation.customVariables,
+            expected
+        )
+    }
+
     func testPresentationFailureResumesExecutionAndAllowsRetry() async throws {
         let presenter = MockCheckpointPresenter()
         let expectedError = NSError(domain: "test", code: 42)
@@ -244,7 +311,7 @@ final class CheckpointWorkflowExecutorTests: TestCase {
         let executor = CheckpointWorkflowExecutor { presenter }
 
         do {
-            _ = try await executor.execute(Self.workflow())
+            _ = try await executor.execute(Self.presentation())
             XCTFail("Expected presentation failure")
         } catch {
             XCTAssertEqual(error as NSError, expectedError)
@@ -256,7 +323,7 @@ final class CheckpointWorkflowExecutorTests: TestCase {
                 outcome: CheckpointPaywallDismissedOutcome.shared
             )
         }
-        _ = try await executor.execute(Self.workflow())
+        _ = try await executor.execute(Self.presentation())
 
         XCTAssertEqual(presenter.presentations.count, 1)
     }
@@ -266,11 +333,11 @@ final class CheckpointWorkflowExecutorTests: TestCase {
         let presentationStarted = self.expectation(description: "Presentation starts")
         presenter.onPresent = { _ in presentationStarted.fulfill() }
         let executor = CheckpointWorkflowExecutor { presenter }
-        let firstExecution = Task { try await executor.execute(Self.workflow()) }
+        let firstExecution = Task { try await executor.execute(Self.presentation()) }
         await self.fulfillment(of: [presentationStarted], timeout: 1)
 
         do {
-            _ = try await executor.execute(Self.workflow())
+            _ = try await executor.execute(Self.presentation())
             XCTFail("Expected concurrent execution to throw")
         } catch {
             XCTAssertEqual(
@@ -295,8 +362,8 @@ final class CheckpointWorkflowExecutorTests: TestCase {
         }
         let executor = CheckpointWorkflowExecutor { presenter }
 
-        _ = try await executor.execute(Self.workflow())
-        _ = try await executor.execute(Self.workflow())
+        _ = try await executor.execute(Self.presentation())
+        _ = try await executor.execute(Self.presentation())
 
         XCTAssertEqual(presenter.presentations.count, 2)
     }
@@ -306,7 +373,7 @@ final class CheckpointWorkflowExecutorTests: TestCase {
         let presentationStarted = self.expectation(description: "Presentation starts")
         presenter.onPresent = { _ in presentationStarted.fulfill() }
         let executor = CheckpointWorkflowExecutor { presenter }
-        let firstExecution = Task { try await executor.execute(Self.workflow()) }
+        let firstExecution = Task { try await executor.execute(Self.presentation()) }
         await self.fulfillment(of: [presentationStarted], timeout: 1)
 
         firstExecution.cancel()
@@ -322,7 +389,7 @@ final class CheckpointWorkflowExecutorTests: TestCase {
                 outcome: CheckpointPaywallDismissedOutcome.shared
             )
         }
-        _ = try await executor.execute(Self.workflow())
+        _ = try await executor.execute(Self.presentation())
 
         XCTAssertEqual(presenter.presentations.count, 2)
         XCTAssertEqual(presenter.dismissCallCount, 1)
@@ -336,14 +403,14 @@ final class CheckpointWorkflowExecutorTests: TestCase {
         presenter.onPresent = { _ in presentationStarted.fulfill() }
         presenter.onDismiss = { dismissalStarted.fulfill() }
         let executor = CheckpointWorkflowExecutor { presenter }
-        let firstExecution = Task { try await executor.execute(Self.workflow()) }
+        let firstExecution = Task { try await executor.execute(Self.presentation()) }
         await self.fulfillment(of: [presentationStarted], timeout: 1)
 
         firstExecution.cancel()
         await self.fulfillment(of: [dismissalStarted], timeout: 1)
 
         do {
-            _ = try await executor.execute(Self.workflow())
+            _ = try await executor.execute(Self.presentation())
             XCTFail("Expected execution to remain active while dismissing")
         } catch {
             XCTAssertEqual(
@@ -374,7 +441,7 @@ final class CheckpointWorkflowExecutorTests: TestCase {
         }
         let executor = CheckpointWorkflowExecutor { presenter }
 
-        execution = Task { try await executor.execute(Self.workflow()) }
+        execution = Task { try await executor.execute(Self.presentation()) }
         let outcome = try await XCTUnwrap(execution).value
 
         guard let errorOutcome = outcome as? CheckpointPaywallErrorOutcome else {
@@ -393,6 +460,15 @@ final class CheckpointWorkflowExecutorTests: TestCase {
         )
 
         XCTAssertTrue(presenter.presentations.isEmpty)
+    }
+
+    private static func presentation(
+        customVariables: [String: CustomVariableValue] = [:]
+    ) -> CheckpointPresentation {
+        return CheckpointPresentation(
+            workflow: self.workflow(),
+            customVariables: customVariables
+        )
     }
 
     private static func workflow() -> ResolvedCheckpointWorkflow {
@@ -425,10 +501,10 @@ private final class MockCheckpointWorkflowExecutor: CheckpointExecutor {
 
     var outcome: CheckpointPaywallOutcome = CheckpointPaywallDismissedOutcome.shared
     var error: Error?
-    private(set) var executedWorkflows: [ResolvedCheckpointWorkflow] = []
+    private(set) var presentations: [CheckpointPresentation] = []
 
-    func execute(_ workflow: ResolvedCheckpointWorkflow) async throws -> CheckpointPaywallOutcome {
-        self.executedWorkflows.append(workflow)
+    func execute(_ presentation: CheckpointPresentation) async throws -> CheckpointPaywallOutcome {
+        self.presentations.append(presentation)
         if let error {
             throw error
         }
@@ -442,7 +518,7 @@ private final class MockCheckpointWorkflowExecutor: CheckpointExecutor {
 private final class MockCheckpointPresenter: CheckpointPresenter {
 
     struct Presentation {
-        let workflow: ResolvedCheckpointWorkflow
+        let checkpointPresentation: CheckpointPresentation
         let delegate: CheckpointPresentationDelegate
     }
 
@@ -455,15 +531,15 @@ private final class MockCheckpointPresenter: CheckpointPresenter {
     private var dismissalCompletions: [() -> Void] = []
 
     func present(
-        workflow: ResolvedCheckpointWorkflow,
+        presentation: CheckpointPresentation,
         delegate: CheckpointPresentationDelegate
     ) throws {
         if let presentationError {
             throw presentationError
         }
-        let presentation = Presentation(workflow: workflow, delegate: delegate)
-        self.presentations.append(presentation)
-        self.onPresent?(presentation)
+        let record = Presentation(checkpointPresentation: presentation, delegate: delegate)
+        self.presentations.append(record)
+        self.onPresent?(record)
     }
 
     func dismiss(completion: @escaping () -> Void) {


### PR DESCRIPTION
## Description
Updates the `CheckpointsManager` to pass the `customVariables` passed to the checkpoint through to the presenting workflow as custom paywall variables.

Will unify the custom variable validation and filtering in a follow up PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkpoint-to-paywall data plumbing and silently drops invalid custom variable keys at params construction, which could affect targeting if callers used non-conforming names.
> 
> **Overview**
> Checkpoint **`customVariables`** now flow from **`CheckpointParams`** into the **`PaywallViewController`** shown for a matched workflow, so paywall templates can use the same keys passed at the checkpoint call.
> 
> The presentation pipeline is refactored around a new **`CheckpointPresentation`** type (workflow + custom variables) instead of passing only **`ResolvedCheckpointWorkflow`**. **`CheckpointParams`** now filters keys through **`CustomVariableKeyValidator`** at init, so invalid names never reach resolution or the paywall; invalid-key warnings log only in **DEBUG**.
> 
> The Checkpoint Tester demo disables autocapitalization/autocorrection on custom variable name fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 075c4fc0f7e3b074359c489d5021adcc0320acc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->