### PR TITLE
Unify custom variable validation across paywall entry points

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -3118,6 +3118,7 @@
 		FACD000B2F61A1230073D2DE /* PackageVisibilityPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageVisibilityPreview.swift; sourceTree = "<group>"; };
 		FACE0000000000000000A002 /* BackendRemoteConfigLaneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendRemoteConfigLaneTests.swift; sourceTree = "<group>"; };
 		FACE0000000000000000F001 /* PaywallViewControllerExitOfferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallViewControllerExitOfferTests.swift; sourceTree = "<group>"; };
+		FACE0000000000000000F002 /* PaywallViewControllerCustomVariablesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallViewControllerCustomVariablesTests.swift; sourceTree = "<group>"; };
 		FB5A72012F65F5B9005C64A1 /* ViewModelFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelFactoryTests.swift; sourceTree = "<group>"; };
 		FCF81FAC33B948F0947AE312 /* RemoteConfigCallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigCallback.swift; sourceTree = "<group>"; };
 		FD05A7192EE2430E00FE671F /* StoreKit2PromotionalOfferPurchaseOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2PromotionalOfferPurchaseOptions.swift; sourceTree = "<group>"; };
@@ -6672,6 +6673,7 @@
 		FACE0000000000000000F003 /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
+				FACE0000000000000000F002 /* PaywallViewControllerCustomVariablesTests.swift */,
 				FACE0000000000000000F001 /* PaywallViewControllerExitOfferTests.swift */,
 			);
 			path = UIKit;

--- a/RevenueCatUI/Checkpoints/ObjCCheckpointTypes.swift
+++ b/RevenueCatUI/Checkpoints/ObjCCheckpointTypes.swift
@@ -17,6 +17,7 @@
 import Foundation
 @_spi(Internal) import RevenueCat
 
+#if DEBUG
 private enum CheckpointStrings: LogMessage {
 
     case invalidObjectiveCCustomVariable(Any.Type)
@@ -31,6 +32,7 @@ private enum CheckpointStrings: LogMessage {
     var category: String { return "checkpoints" }
 
 }
+#endif
 
 /// Objective-C-compatible checkpoint parameters.
 @_spi(CheckpointsInternal)
@@ -47,7 +49,9 @@ public final class ObjCCheckpointParams: NSObject {
         for (rawKey, rawValue) in customVariables {
             guard let key = rawKey as? String,
                   let value = CustomVariableValue(foundationValue: rawValue) else {
+                #if DEBUG
                 Logger.warning(CheckpointStrings.invalidObjectiveCCustomVariable(type(of: rawValue)))
+                #endif
                 continue
             }
             values[key] = value

--- a/RevenueCatUI/Data/CustomPaywallVariables.swift
+++ b/RevenueCatUI/Data/CustomPaywallVariables.swift
@@ -239,7 +239,9 @@ extension EnvironmentValues {
     /// Use the `.customPaywallVariables(_:)` view modifier to set this value.
     public var customPaywallVariables: [String: CustomVariableValue] {
         get { self[CustomPaywallVariablesKey.self] }
-        set { self[CustomPaywallVariablesKey.self] = newValue }
+        set {
+            self[CustomPaywallVariablesKey.self] = RevenueCat.CustomVariableKeyValidator.validateAndFilter(newValue)
+        }
     }
 
 }
@@ -272,41 +274,12 @@ extension View {
     ///
     /// - Parameter variables: A dictionary mapping variable names to their values.
     ///   The keys should match the variable names defined in the dashboard (without the `custom.` prefix).
+    ///   Invalid keys are ignored.
     /// - Returns: A view with the custom variables set in the environment.
     public func customPaywallVariables(
         _ variables: [String: CustomVariableValue]
     ) -> some View {
-        #if DEBUG
-        CustomVariableKeyValidator.validate(variables)
-        #endif
         return environment(\.customPaywallVariables, variables)
-    }
-
-}
-
-// MARK: - Key Validator
-
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-enum CustomVariableKeyValidator {
-
-    /// Validates a single custom variable key and logs a warning if invalid.
-    /// Only performs validation in DEBUG builds.
-    static func validate(_ key: String) {
-        #if DEBUG
-        if !RevenueCat.CustomVariableKeyValidator.isValidKey(key) {
-            Logger.warning(Strings.paywall_custom_variable_invalid_key(key: key))
-        }
-        #endif
-    }
-
-    /// Validates all keys in a custom variables dictionary and logs warnings for invalid keys.
-    /// Only performs validation in DEBUG builds.
-    static func validate(_ variables: [String: CustomVariableValue]) {
-        #if DEBUG
-        for key in variables.keys where !RevenueCat.CustomVariableKeyValidator.isValidKey(key) {
-            Logger.warning(Strings.paywall_custom_variable_invalid_key(key: key))
-        }
-        #endif
     }
 
 }

--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -104,7 +104,6 @@ enum Strings {
     case paywall_custom_variable_invalid_number(value: String)
     case paywall_custom_variable_unknown_type(type: String)
     case paywall_variable_looks_like_custom(variableName: String)
-    case paywall_custom_variable_invalid_key(key: String)
 
     // Video
     case video_failed_to_set_audio_session_category(Error)
@@ -371,10 +370,6 @@ extension Strings: CustomStringConvertible {
         case .paywall_variable_looks_like_custom(let variableName):
             return "Variable '\(variableName)' looks like a custom variable but uses incorrect syntax. " +
             "Custom variables must use the 'custom.' prefix with a dot, e.g., '{{ custom.variable_name }}'."
-
-        case .paywall_custom_variable_invalid_key(let key):
-            return "Custom variable key '\(key)' is invalid. " +
-            "Keys must start with a letter and contain only letters, numbers, and underscores."
 
         case .video_failed_to_set_audio_session_category(let error):
             return "Failed to set audio session category: \(error)"

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -53,6 +53,7 @@ public class PaywallViewController: UIViewController {
     ///
     /// - Important: Set this property before presenting the view controller.
     ///   Changes made after presentation will not be reflected in the paywall.
+    ///   Invalid keys are ignored.
     ///
     /// ### Example
     /// ```swift
@@ -62,38 +63,39 @@ public class PaywallViewController: UIViewController {
     /// ]
     /// present(vc, animated: true)
     /// ```
-    public var customVariables: [String: CustomVariableValue] = [:] {
-        didSet {
+    public var customVariables: [String: CustomVariableValue] {
+        get { return self.storedCustomVariables }
+        set {
             assert(hostingController == nil, "Custom variables can only be set before presenting the paywall")
+            self.storedCustomVariables = RevenueCat.CustomVariableKeyValidator.validateAndFilter(newValue)
         }
     }
+
+    private var storedCustomVariables: [String: CustomVariableValue] = [:]
 
     // MARK: - Objective-C Custom Variable Methods
 
     /// Sets a string custom variable value for the given key.
     /// - Parameters:
     ///   - value: The string value to set.
-    ///   - key: The variable key (without the `custom.` prefix).
+    ///   - key: The variable key (without the `custom.` prefix). Invalid keys are ignored.
     @objc public func setCustomVariable(_ value: String, forKey key: String) {
-        CustomVariableKeyValidator.validate(key)
         self.customVariables[key] = .string(value)
     }
 
     /// Sets a numeric custom variable value for the given key.
     /// - Parameters:
     ///   - value: The numeric value to set.
-    ///   - key: The variable key (without the `custom.` prefix).
+    ///   - key: The variable key (without the `custom.` prefix). Invalid keys are ignored.
     @objc public func setCustomVariableNumber(_ value: Double, forKey key: String) {
-        CustomVariableKeyValidator.validate(key)
         self.customVariables[key] = .number(value)
     }
 
     /// Sets a boolean custom variable value for the given key.
     /// - Parameters:
     ///   - value: The boolean value to set.
-    ///   - key: The variable key (without the `custom.` prefix).
+    ///   - key: The variable key (without the `custom.` prefix). Invalid keys are ignored.
     @objc public func setCustomVariableBool(_ value: Bool, forKey key: String) {
-        CustomVariableKeyValidator.validate(key)
         self.customVariables[key] = .bool(value)
     }
 

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -63,15 +63,12 @@ public class PaywallViewController: UIViewController {
     /// ]
     /// present(vc, animated: true)
     /// ```
-    public var customVariables: [String: CustomVariableValue] {
-        get { return self.storedCustomVariables }
-        set {
+    public var customVariables: [String: CustomVariableValue] = [:] {
+        didSet {
             assert(hostingController == nil, "Custom variables can only be set before presenting the paywall")
-            self.storedCustomVariables = RevenueCat.CustomVariableKeyValidator.validateAndFilter(newValue)
+            self.customVariables = RevenueCat.CustomVariableKeyValidator.validateAndFilter(self.customVariables)
         }
     }
-
-    private var storedCustomVariables: [String: CustomVariableValue] = [:]
 
     // MARK: - Objective-C Custom Variable Methods
 

--- a/Sources/Misc/CustomVariableKeyValidator.swift
+++ b/Sources/Misc/CustomVariableKeyValidator.swift
@@ -22,7 +22,7 @@ private enum CustomVariableKeyValidatorStrings: LogMessage {
         switch self {
         case .invalidKey(let key):
             return "Custom variable key '\(key)' is invalid and will be ignored. " +
-                "Keys must start with a letter and contain only letters, numbers, and underscores."
+                "Keys must be 1–256 characters and contain only ASCII letters, numbers, and underscores."
         }
     }
 
@@ -38,8 +38,19 @@ public struct CustomVariableKeyValidator {
 
     /// Returns whether a key can be addressed using a `custom.<key>` path.
     public static func isValidKey(_ key: String) -> Bool {
-        guard let first = key.first, first.isLetter else { return false }
-        return key.allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" }
+        guard (1...256).contains(key.utf8.count) else { return false }
+
+        return key.utf8.allSatisfy { character in
+            switch character {
+            case UInt8(ascii: "a")...UInt8(ascii: "z"),
+                 UInt8(ascii: "A")...UInt8(ascii: "Z"),
+                 UInt8(ascii: "0")...UInt8(ascii: "9"),
+                 UInt8(ascii: "_"):
+                return true
+            default:
+                return false
+            }
+        }
     }
 
     /// Drops invalid keys and, in debug builds, logs a warning for each removed entry.

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
@@ -80,12 +80,21 @@ final class CheckpointsManagerTests: TestCase {
         let params = RevenueCatUI.CheckpointParams(customVariables: [
             "valid_key": "value",
             "invalid-key": "value",
-            "1invalid": "value",
+            "1valid": "value",
+            "_valid": "value",
             "": "value"
         ])
 
-        XCTAssertEqual(params.customVariables, ["valid_key": "value"])
-        XCTAssertEqual(params.coreParams.customVariables, ["valid_key": .string("value")])
+        XCTAssertEqual(params.customVariables, [
+            "valid_key": "value",
+            "1valid": "value",
+            "_valid": "value"
+        ])
+        XCTAssertEqual(params.coreParams.customVariables, [
+            "valid_key": .string("value"),
+            "1valid": .string("value"),
+            "_valid": .string("value")
+        ])
     }
 
     func testNoActionResultAndListenerEventsAreBuiltInRevenueCatUI() async throws {

--- a/Tests/RevenueCatUITests/PaywallsV2/VariableHandlerV2Tests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/VariableHandlerV2Tests.swift
@@ -15,6 +15,7 @@
 import Nimble
 @testable import RevenueCat
 @_spi(Internal) @testable import RevenueCatUI
+import SwiftUI
 import XCTest
 
 #if !os(tvOS) // For Paywalls V2
@@ -1875,6 +1876,23 @@ class CustomVariablesV2Tests: TestCase {
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 class CustomVariableValueTests: TestCase {
+
+    func testEnvironmentFiltersInvalidCustomVariableKeys() {
+        var environment = EnvironmentValues()
+
+        environment.customPaywallVariables = [
+            "valid_key": "kept",
+            "invalid-key": "dropped",
+            "2fast": "also kept",
+            "_private": "also kept"
+        ]
+
+        expect(environment.customPaywallVariables).to(equal([
+            "valid_key": "kept",
+            "2fast": "also kept",
+            "_private": "also kept"
+        ]))
+    }
 
     // MARK: - stringValue Tests
 

--- a/Tests/RevenueCatUITests/UIKit/PaywallViewControllerCustomVariablesTests.swift
+++ b/Tests/RevenueCatUITests/UIKit/PaywallViewControllerCustomVariablesTests.swift
@@ -1,0 +1,64 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PaywallViewControllerCustomVariablesTests.swift
+//
+//  Created by Rick van der Linden.
+//
+
+import Nimble
+@_spi(Internal) @testable import RevenueCat
+@testable import RevenueCatUI
+import XCTest
+
+#if canImport(UIKit) && !os(tvOS) && !os(watchOS)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+final class PaywallCustomVariablesTests: TestCase {
+
+    func testCustomVariablesPropertyFiltersInvalidKeys() {
+        let controller = PaywallViewController(offering: Self.offering)
+
+        controller.customVariables = [
+            "valid_key": "kept",
+            "invalid-key": "dropped",
+            "2fast": "also kept"
+        ]
+
+        expect(controller.customVariables).to(equal([
+            "valid_key": "kept",
+            "2fast": "also kept"
+        ]))
+    }
+
+    func testObjectiveCCustomVariableSettersFilterInvalidKeys() {
+        let controller = PaywallViewController(offering: Self.offering)
+
+        controller.setCustomVariable("kept", forKey: "string_value")
+        controller.setCustomVariableNumber(2, forKey: "number-value")
+        controller.setCustomVariableBool(true, forKey: "1boolean")
+
+        expect(controller.customVariables).to(equal([
+            "string_value": "kept",
+            "1boolean": true
+        ]))
+    }
+
+    private static let offering = Offering(
+        identifier: "main",
+        serverDescription: "Main offering",
+        metadata: [:],
+        paywall: nil,
+        availablePackages: [],
+        webCheckoutUrl: nil
+    )
+
+}
+
+#endif

--- a/Tests/RevenueCatUITests/UIKit/PaywallViewControllerExitOfferTests.swift
+++ b/Tests/RevenueCatUITests/UIKit/PaywallViewControllerExitOfferTests.swift
@@ -20,34 +20,6 @@ import XCTest
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
 final class PaywallViewControllerExitOfferTests: TestCase {
 
-    func testCustomVariablesPropertyFiltersInvalidKeys() {
-        let controller = PaywallViewController(offering: Self.makeOffering(identifier: "main"))
-
-        controller.customVariables = [
-            "valid_key": "kept",
-            "invalid-key": "dropped",
-            "2fast": "also kept"
-        ]
-
-        expect(controller.customVariables).to(equal([
-            "valid_key": "kept",
-            "2fast": "also kept"
-        ]))
-    }
-
-    func testObjectiveCCustomVariableSettersFilterInvalidKeys() {
-        let controller = PaywallViewController(offering: Self.makeOffering(identifier: "main"))
-
-        controller.setCustomVariable("kept", forKey: "string_value")
-        controller.setCustomVariableNumber(2, forKey: "number-value")
-        controller.setCustomVariableBool(true, forKey: "1boolean")
-
-        expect(controller.customVariables).to(equal([
-            "string_value": "kept",
-            "1boolean": true
-        ]))
-    }
-
     func testUpdateDisplayCloseButtonDoesNotClearWorkflowExitOffer() {
         let controller = PaywallViewController(offering: Self.makeOffering(identifier: "main"))
         controller.remoteConfigEnabledForTesting = true

--- a/Tests/RevenueCatUITests/UIKit/PaywallViewControllerExitOfferTests.swift
+++ b/Tests/RevenueCatUITests/UIKit/PaywallViewControllerExitOfferTests.swift
@@ -20,6 +20,34 @@ import XCTest
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
 final class PaywallViewControllerExitOfferTests: TestCase {
 
+    func testCustomVariablesPropertyFiltersInvalidKeys() {
+        let controller = PaywallViewController(offering: Self.makeOffering(identifier: "main"))
+
+        controller.customVariables = [
+            "valid_key": "kept",
+            "invalid-key": "dropped",
+            "2fast": "also kept"
+        ]
+
+        expect(controller.customVariables).to(equal([
+            "valid_key": "kept",
+            "2fast": "also kept"
+        ]))
+    }
+
+    func testObjectiveCCustomVariableSettersFilterInvalidKeys() {
+        let controller = PaywallViewController(offering: Self.makeOffering(identifier: "main"))
+
+        controller.setCustomVariable("kept", forKey: "string_value")
+        controller.setCustomVariableNumber(2, forKey: "number-value")
+        controller.setCustomVariableBool(true, forKey: "1boolean")
+
+        expect(controller.customVariables).to(equal([
+            "string_value": "kept",
+            "1boolean": true
+        ]))
+    }
+
     func testUpdateDisplayCloseButtonDoesNotClearWorkflowExitOffer() {
         let controller = PaywallViewController(offering: Self.makeOffering(identifier: "main"))
         controller.remoteConfigEnabledForTesting = true

--- a/Tests/UnitTests/LocalRules/CustomVariableKeyValidatorTests.swift
+++ b/Tests/UnitTests/LocalRules/CustomVariableKeyValidatorTests.swift
@@ -25,14 +25,31 @@ struct CustomVariableKeyValidatorTests {
 
     @Test
     func acceptsAddressableKeys() {
-        let validKeys = ["validKey", "valid_key_name", "key123", "player_score_2024", "a", "kéy"]
+        let validKeys = [
+            "validKey",
+            "valid_key_name",
+            "key123",
+            "player_score_2024",
+            "a",
+            "123key",
+            "_key",
+            String(repeating: "a", count: 256)
+        ]
 
         #expect(validKeys.allSatisfy { CustomVariableKeyValidator.isValidKey($0) })
     }
 
     @Test
     func rejectsUnaddressableKeys() {
-        let invalidKeys = ["", "123key", "_key", "key-name", "key name", "key.name", "key!"]
+        let invalidKeys = [
+            "",
+            "key-name",
+            "key name",
+            "key.name",
+            "key!",
+            "kéy",
+            String(repeating: "a", count: 257)
+        ]
 
         #expect(invalidKeys.allSatisfy { !CustomVariableKeyValidator.isValidKey($0) })
     }
@@ -42,11 +59,14 @@ struct CustomVariableKeyValidatorTests {
         let snapshot = try await DimensionResolver(dimensionProviders: []).snapshot(customVariables: [
             "valid_key": .string("kept"),
             "my.property": .string("dropped"),
-            "2fast": .string("dropped"),
+            "2fast": .string("also kept"),
             "has space": .string("dropped")
         ])
 
-        #expect(snapshot.values["custom"] == .object(["valid_key": .string("kept")]))
+        #expect(snapshot.values["custom"] == .object([
+            "valid_key": .string("kept"),
+            "2fast": .string("also kept")
+        ]))
     }
 
     @Test


### PR DESCRIPTION
## Description
Centralizes the custom variable validation across all entry points:

Paywalls:
- SwiftUI `.customPaywallVariables()`
- UIKit `PaywallViewController.customVariables`
- UIKit `setCustomVariable(forKey)`, `setCustomVariableNumber(forKey)`, `setCustomVariableBool(forKey)`

Checkpoints:
- `CheckpointParams(customVariables)`

## Implementation
- All entry points will now feed the custom variables through `CustomVariableKeyValidator`
- Validation is now actually enforced and invalid keys are dropped
- The validation rules were updated to match the dashboard
- Invalid custom variable keys are still only logged in DEBUG

## Validation rules
As mentioned the validation rules were updated to match the [dashboard's validation rules](https://github.com/RevenueCat/revenuecat-app/blob/d26f5109ce4709c889b318f2d15ceb4872097229/src/concepts/projects/paywalls/builder/side-nav/variants/variables/components/add-custom-variable-modal.tsx#L30-L37). Since existing SDKs would not use invalid custom variable names anyways (since the dashboard wouldn't have registered them) this should not be a behavioral change.

The newly implemented validation is:
- Contains between 1 and 256 characters.
- Uses only ASCII letters (A–Z, a–z), digits (0–9), and underscores (_).
- May start with a letter, digit, or underscore.
- Is case-sensitive.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes for keys outside the new ASCII rules (e.g. unicode or hyphenated keys) that may have been accepted or only warned before; impact is limited because dashboard-defined variables should already comply.
> 
> **Overview**
> **Custom variable keys are now validated in one place** (`CustomVariableKeyValidator`) and **invalid keys are removed** instead of only logging in DEBUG at some call sites.
> 
> Paywall and checkpoint entry points all route assignments through `validateAndFilter`: SwiftUI `customPaywallVariables` environment, `PaywallViewController.customVariables` and ObjC setters, `CheckpointParams`, and rules-engine snapshots via `DimensionResolver`. Docs note that invalid keys are ignored.
> 
> **Validation rules are aligned with the dashboard:** length 1–256 UTF-8 bytes, ASCII letters, digits, and underscores only (case-sensitive). Keys may start with a letter, digit, or underscore—so names like `1valid` and `_key` are accepted; empty, punctuation, spaces, non-ASCII, and overlong keys are rejected.
> 
> RevenueCatUI’s duplicate DEBUG-only key validator and related paywall log string are removed; ObjC checkpoint invalid-value warnings are confined to DEBUG builds. Tests cover the new rules and filtering on UIKit/SwiftUI/checkpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20f9a2b73cfbd9e940504c060e20f0f612793335. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->