### PR TITLE
Chore: Signal purchases-ui on purchases configuration

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -780,6 +780,14 @@ jobs:
                 name: SPM RevenueCatUI Release Build (Xcode 16)
                 command: swift build -c release --target RevenueCatUI
                 no_output_timeout: 5m
+            - run:
+                name: PurchasesUIService stripped-symbol integration tests
+                command: bundle exec fastlane test_purchases_ui_service_stripped
+                no_output_timeout: 15m
+                environment:
+                  DEVICE: iPhone 16,OS=18.5
+            - store_test_results:
+                path: fastlane/test_output/purchases_ui_service_stripped/tests.xml
 
       # === RevenueCatUI iOS 18 tests ===
       - run:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -44,6 +44,7 @@ custom_rules:
       - Tests/UnitTests/RulesEngine
       - Tests/v3LoadShedderIntegration
       - Tests/v4LoadShedderIntegration
+      - Tests/PurchasesUIServiceIntegrationTests
     regex: "\\: XCTestCase \\{"
     name: "XCTestCase Superclass"
     message: "Test classes must inherit `TestCase` instead."

--- a/.swiftpm/xcode/xcshareddata/xcschemes/RevenueCatUI-Stripped.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/RevenueCatUI-Stripped.xcscheme
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "RevenueCatUI"
+               BuildableName = "RevenueCatUI"
+               BlueprintName = "RevenueCatUI"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "PurchasesUIServiceIntegrationTests"
+               BuildableName = "PurchasesUIServiceIntegrationTests"
+               BlueprintName = "PurchasesUIServiceIntegrationTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "PurchasesUIServiceIntegrationTests"
+               BuildableName = "PurchasesUIServiceIntegrationTests"
+               BlueprintName = "PurchasesUIServiceIntegrationTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "RevenueCatUI"
+            BuildableName = "RevenueCatUI"
+            BlueprintName = "RevenueCatUI"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Release">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Contributing/DEVELOPMENT.md
+++ b/Contributing/DEVELOPMENT.md
@@ -35,6 +35,7 @@ tuist generate PurchaseTester
 
 tuist generate UnitTests
 tuist generate RevenueCatUITests
+tuist generate PurchasesUIServiceIntegrationTests
 tuist generate StoreKitUnitTests
 tuist generate BackendIntegrationTests
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -8,7 +8,9 @@ EXCLUDED_SWIFT_PATH_PREFIXES = [
   # Tuist-only: these targets exist solely in Projects/PaywallFixtures/Project.swift and are
   # deliberately absent from RevenueCat.xcodeproj.
   'Tests/TestingApps/PaywallFixtures/',
-  'Tests/TestingApps/PaywallFixturesUITests/'
+  'Tests/TestingApps/PaywallFixturesUITests/',
+  # SPM / Tuist-only: Release-stripped integration tests are not in RevenueCat.xcodeproj.
+  'Tests/PurchasesUIServiceIntegrationTests/'
 ].freeze
 
 COMMENT_MARKER = "<!-- purchases-ios-danger -->"

--- a/Package.resolved
+++ b/Package.resolved
@@ -37,24 +37,6 @@
       }
     },
     {
-      "identity" : "swift-package-manager-google-mobile-ads",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/googleads/swift-package-manager-google-mobile-ads.git",
-      "state" : {
-        "revision" : "868149fc50d1452078e83540e636cf519bac3e6a",
-        "version" : "13.7.0"
-      }
-    },
-    {
-      "identity" : "swift-package-manager-google-user-messaging-platform",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/googleads/swift-package-manager-google-user-messaging-platform.git",
-      "state" : {
-        "revision" : "13b248eaa73b7826f0efb1bcf455e251d65ecb1b",
-        "version" : "3.1.0"
-      }
-    },
-    {
       "identity" : "swift-snapshot-testing",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",

--- a/Package.resolved
+++ b/Package.resolved
@@ -37,6 +37,24 @@
       }
     },
     {
+      "identity" : "swift-package-manager-google-mobile-ads",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/swift-package-manager-google-mobile-ads.git",
+      "state" : {
+        "revision" : "868149fc50d1452078e83540e636cf519bac3e6a",
+        "version" : "13.7.0"
+      }
+    },
+    {
+      "identity" : "swift-package-manager-google-user-messaging-platform",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/swift-package-manager-google-user-messaging-platform.git",
+      "state" : {
+        "revision" : "13b248eaa73b7826f0efb1bcf455e251d65ecb1b",
+        "version" : "3.1.0"
+      }
+    },
+    {
       "identity" : "swift-snapshot-testing",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",

--- a/Package.swift
+++ b/Package.swift
@@ -143,6 +143,18 @@ let package = Package(
                         .copy("Resources/header.heic"),
                         .copy("Resources/background.heic"),
                         .copy("PaywallsV2/__PreviewResources__")
-                    ])
+                    ]),
+        // Isolated from RevenueCatUITests so a Swift reference to PurchasesUIService
+        // cannot keep the ObjC class alive. Run via the RevenueCatUI-Stripped scheme.
+        .testTarget(
+            name: "PurchasesUIServiceIntegrationTests",
+            dependencies: [
+                "RevenueCat",
+                "RevenueCatUI"
+            ],
+            linkerSettings: [
+                .unsafeFlags(["-dead_strip"], .when(configuration: .release))
+            ]
+        )
     ]
 )

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -127,6 +127,8 @@
 		16DA8F1E2E4FB6E200283940 /* ImageComponent.json in Resources */ = {isa = PBXBuildFile; fileRef = 16DA8F1B2E4FB6E200283940 /* ImageComponent.json */; };
 		16DA8F1F2E4FB6E200283940 /* VideoComponent.json in Resources */ = {isa = PBXBuildFile; fileRef = 16DA8F1C2E4FB6E200283940 /* VideoComponent.json */; };
 		16E146AD2E99F3480089B609 /* TransactionNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E146AB2E99F1E20089B609 /* TransactionNotifications.swift */; };
+		16E147A22F3B4C010089B609 /* PurchasesConfiguredNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E147A12F3B4C010089B609 /* PurchasesConfiguredNotifier.swift */; };
+		16E147A42F3B4C010089B609 /* PurchasesUIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E147A32F3B4C010089B609 /* PurchasesUIService.swift */; };
 		16E146B22E99FC7E0089B609 /* PurchaseResultComparator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E146B12E99FC7E0089B609 /* PurchaseResultComparator.swift */; };
 		16E2B7F12EA01DFA00F04A7A /* SynchronizedLargeItemCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E2B7F02EA01DFA00F04A7A /* SynchronizedLargeItemCacheTests.swift */; };
 		16E4A3C89791426AAD027A49 /* PlatformInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043FB8686FEB4A31B9CF48C8 /* PlatformInfoTests.swift */; };
@@ -1708,6 +1710,9 @@
 		16DA8F1B2E4FB6E200283940 /* ImageComponent.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ImageComponent.json; sourceTree = "<group>"; };
 		16DA8F1C2E4FB6E200283940 /* VideoComponent.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = VideoComponent.json; sourceTree = "<group>"; };
 		16E146AB2E99F1E20089B609 /* TransactionNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionNotifications.swift; sourceTree = "<group>"; };
+		16E147A12F3B4C010089B609 /* PurchasesConfiguredNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesConfiguredNotifier.swift; sourceTree = "<group>"; };
+		16E147A32F3B4C010089B609 /* PurchasesUIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesUIService.swift; sourceTree = "<group>"; };
+		16E147A52F3B4C010089B609 /* PurchasesUIServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesUIServiceTests.swift; sourceTree = "<group>"; };
 		16E146B12E99FC7E0089B609 /* PurchaseResultComparator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseResultComparator.swift; sourceTree = "<group>"; };
 		16E146B42E99FF640089B609 /* MockStoreTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreTransaction.swift; sourceTree = "<group>"; };
 		16E2B7F02EA01DFA00F04A7A /* SynchronizedLargeItemCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedLargeItemCacheTests.swift; sourceTree = "<group>"; };
@@ -5847,6 +5852,7 @@
 				887A5FED2C1D037000E1A461 /* MockPurchases.swift */,
 				887A5FEE2C1D037000E1A461 /* PaywallPurchasesType.swift */,
 				887A5FEF2C1D037000E1A461 /* PurchaseHandler.swift */,
+				16E147A32F3B4C010089B609 /* PurchasesUIService.swift */,
 				887A5FF02C1D037000E1A461 /* PurchaseHandler+TestData.swift */,
 				F598F832810DB534092FBED3 /* WorkflowContext.swift */,
 				9FA3AA2BC4C1B8CE7E9A3B59 /* WorkflowPreview.swift */,
@@ -6043,6 +6049,7 @@
 				57F4B2C12F8E10A600BB46C9 /* ExitOfferHelperTests.swift */,
 				16E146B42E99FF640089B609 /* MockStoreTransaction.swift */,
 				887A61372C1D168B00E1A461 /* PurchaseHandlerTests.swift */,
+				16E147A52F3B4C010089B609 /* PurchasesUIServiceTests.swift */,
 				45010544C32C2A21A2F323D7 /* OnWebCheckoutOpenedModifierTests.swift */,
 				4B7C1E3A5D2F41908A6C0D11 /* OnURLOpenedModifierTests.swift */,
 				B10A136C03A9FF34FB805EFA /* ExitOfferPresenterTests.swift */,
@@ -6533,6 +6540,7 @@
 				4F8038322A1EA7C300D21039 /* TransactionPoster.swift */,
 				757E73FF2F1700000066DCDC /* TransactionMetadataSyncHelper.swift */,
 				16E146AB2E99F1E20089B609 /* TransactionNotifications.swift */,
+				16E147A12F3B4C010089B609 /* PurchasesConfiguredNotifier.swift */,
 				757E73CC2F0FE2410066DCDC /* LocalTransactionMetadata.swift */,
 				757E73E32F101EAF0066DCDC /* LocalTransactionMetadataStore.swift */,
 			);
@@ -7788,6 +7796,7 @@
 				03E37BEA2D30B32200CD9678 /* PaywallTabsComponent.swift in Sources */,
 				FD20467F2CB82F2000166727 /* StoreKit2PurchaseIntentListener.swift in Sources */,
 				16E146AD2E99F3480089B609 /* TransactionNotifications.swift in Sources */,
+				16E147A22F3B4C010089B609 /* PurchasesConfiguredNotifier.swift in Sources */,
 				B34605BD279A6E380031CA74 /* CallbackCacheStatus.swift in Sources */,
 				42F1DF385E3C1F9903A07FBF /* ProductsFetcherSK1.swift in Sources */,
 				805B60C97993B311CEC93EAF /* ProductsFetcherSK2.swift in Sources */,
@@ -8346,6 +8355,7 @@
 				887A60BE2C1D037000E1A461 /* PaywallFooterViewController.swift in Sources */,
 				DBD2A168300E81E20019DB7F /* VideoAudioSessionHandler.swift in Sources */,
 				887A608A2C1D037000E1A461 /* PurchaseHandler.swift in Sources */,
+				16E147A42F3B4C010089B609 /* PurchasesUIService.swift in Sources */,
 				2D2AFE8D2C6A834D00D1B0B4 /* TestData.swift in Sources */,
 				03A98D382D2AC63B009BCA61 /* UIConfigProvider.swift in Sources */,
 				887A60C92C1D037000E1A461 /* PurchaseButton.swift in Sources */,

--- a/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/CustomerCenterView.swift
@@ -93,6 +93,7 @@ public struct CustomerCenterView: View {
             self._viewModel = .init(wrappedValue: CustomerCenterViewModel(actionWrapper: actionWrapper))
             self.mode = mode
             self.navigationOptions = navigationOptions
+            PurchasesUIService.activateIfNeeded()
     }
 
     // swiftlint:disable:next missing_docs

--- a/RevenueCatUI/Data/PaywallViewConfiguration.swift
+++ b/RevenueCatUI/Data/PaywallViewConfiguration.swift
@@ -50,6 +50,8 @@ struct PaywallViewConfiguration {
         self.introEligibility = introEligibility
         self.purchaseHandler = purchaseHandler
         self.promoOfferCache = promoOfferCache
+
+        PurchasesUIService.activateIfNeeded()
     }
 
 }

--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -136,6 +136,7 @@ enum Strings {
     case workflow_package_context_unresolvable(stepId: String)
     case workflow_fetch_failed_falling_back_to_offerings_paywall(offeringIdentifier: String, error: Error)
     case restored_paywall_components_for_disabled_remote_config(offeringIdentifier: String)
+    case purchases_did_configure
 
 }
 
@@ -442,6 +443,8 @@ extension Strings: CustomStringConvertible {
         case let .restored_paywall_components_for_disabled_remote_config(offeringIdentifier):
             return "Remote config is disabled, so offering '\(offeringIdentifier)' was re-resolved to restore " +
             "its offerings-provided paywall."
+        case .purchases_did_configure:
+            return "Purchases notified purchases-ui of configuration"
         }
     }
 

--- a/RevenueCatUI/Purchasing/PurchasesUIService.swift
+++ b/RevenueCatUI/Purchasing/PurchasesUIService.swift
@@ -22,6 +22,9 @@ import Foundation
 /// execution, so that call can run after ``Purchases/configure`` and still keep
 /// the class in the binary. The same path replays if RevenueCatUI loads after
 /// configuration.
+///
+/// The `RevenueCatUI-Stripped` scheme runs `PurchasesUIServiceIntegrationTests`
+/// in Release with dead-code stripping to catch regressions.
 @objc(RCPurchasesUIService)
 final class PurchasesUIService: NSObject, PurchasesPostConfigurationStep {
 

--- a/RevenueCatUI/Purchasing/PurchasesUIService.swift
+++ b/RevenueCatUI/Purchasing/PurchasesUIService.swift
@@ -33,10 +33,6 @@ final class PurchasesUIService: NSObject, PurchasesPostConfigurationStep {
     private static let lock = NSLock()
     private static var didConfigure = false
 
-    #if DEBUG
-    static var configureCallCount = 0
-    #endif
-
     /// Retains this class from a public RevenueCatUI entry point and replays
     /// configure-time work if `Purchases` is already configured.
     ///
@@ -52,9 +48,6 @@ final class PurchasesUIService: NSObject, PurchasesPostConfigurationStep {
         lock.withLock {
             guard !didConfigure else { return }
             self.didConfigure = true
-            #if DEBUG
-            Self.configureCallCount += 1
-            #endif
             Logger.debug(Strings.purchases_did_configure)
             // Next PR: subscribe to publishers
         }
@@ -64,7 +57,6 @@ final class PurchasesUIService: NSObject, PurchasesPostConfigurationStep {
     static func resetForTests() {
         lock.withLock {
             Self.didConfigure = false
-            Self.configureCallCount = 0
         }
     }
     #endif

--- a/RevenueCatUI/Purchasing/PurchasesUIService.swift
+++ b/RevenueCatUI/Purchasing/PurchasesUIService.swift
@@ -1,0 +1,72 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PurchasesUIService.swift
+//
+
+import Foundation
+@_spi(Internal) import RevenueCat
+
+/// Receives a message from `Purchases` after `Purchases.shared` is configured.
+///
+/// Looked up by ObjC name so RevenueCat does not need to import this module.
+///
+/// Reachable RevenueCatUI entry points call ``activateIfNeeded()`` so this class is
+/// retained by a real, observable use of runtime state. Linking happens before
+/// execution, so that call can run after ``Purchases/configure`` and still keep
+/// the class in the binary. The same path replays if RevenueCatUI loads after
+/// configuration.
+///
+/// `@_used` is not used here: it can prevent stripping after an object is loaded,
+/// but it does not reliably force extraction from a static archive. If this type
+/// must activate merely by being linked, with no RevenueCatUI API reference, the
+/// host has to pass `-ObjC` or, more reliably, `-force_load`.
+@objc(RCPurchasesUIService)
+final class PurchasesUIService: NSObject, PurchasesUIConfiguring {
+
+    private static let lock = NSLock()
+    private static var didConfigure = false
+
+    #if DEBUG
+    static var configureCallCount = 0
+    #endif
+
+    /// Retains this class from a public RevenueCatUI entry point and replays
+    /// configure-time work if `Purchases` is already configured.
+    ///
+    /// Reads runtime state and may mutate locked state, so it cannot be
+    /// optimized away as a no-op keep-alive.
+    static func activateIfNeeded() {
+        guard Purchases.isConfigured else { return }
+        Self.purchasesDidConfigure()
+    }
+
+    /// Cheap wake-up. Must stay cheap: start publishers here later, do not create WebKit.
+    @objc static func purchasesDidConfigure() {
+        lock.withLock {
+            guard !didConfigure else { return }
+            self.didConfigure = true
+            #if DEBUG
+            Self.configureCallCount += 1
+            #endif
+            Logger.debug(Strings.purchases_did_configure)
+            // Next PR: subscribe to publishers
+        }
+    }
+
+    #if DEBUG
+    static func resetForTests() {
+        lock.withLock {
+            Self.didConfigure = false
+            Self.configureCallCount = 0
+        }
+    }
+    #endif
+
+}

--- a/RevenueCatUI/Purchasing/PurchasesUIService.swift
+++ b/RevenueCatUI/Purchasing/PurchasesUIService.swift
@@ -39,7 +39,7 @@ final class PurchasesUIService: NSObject, PurchasesPostConfigurationStep {
         Self.purchasesDidConfigure()
     }
 
-    /// Cheap wake-up. Must stay cheap: start subsciptions here later, do not perform heavy work synchronously here.
+    /// Cheap wake-up. Must stay cheap: start subscriptions here later, do not perform heavy work synchronously here.
     @objc static func purchasesDidConfigure() {
         lock.withLock {
             guard !didConfigure else { return }

--- a/RevenueCatUI/Purchasing/PurchasesUIService.swift
+++ b/RevenueCatUI/Purchasing/PurchasesUIService.swift
@@ -47,7 +47,7 @@ final class PurchasesUIService: NSObject, PurchasesPostConfigurationStep {
         Self.purchasesDidConfigure()
     }
 
-    /// Cheap wake-up. Must stay cheap: start publishers here later, do not create WebKit.
+    /// Cheap wake-up. Must stay cheap: start subsciptions here later, do not perform heavy work synchronously here.
     @objc static func purchasesDidConfigure() {
         lock.withLock {
             guard !didConfigure else { return }

--- a/RevenueCatUI/Purchasing/PurchasesUIService.swift
+++ b/RevenueCatUI/Purchasing/PurchasesUIService.swift
@@ -22,11 +22,6 @@ import Foundation
 /// execution, so that call can run after ``Purchases/configure`` and still keep
 /// the class in the binary. The same path replays if RevenueCatUI loads after
 /// configuration.
-///
-/// `@_used` is not used here: it can prevent stripping after an object is loaded,
-/// but it does not reliably force extraction from a static archive. If this type
-/// must activate merely by being linked, with no RevenueCatUI API reference, the
-/// host has to pass `-ObjC` or, more reliably, `-force_load`.
 @objc(RCPurchasesUIService)
 final class PurchasesUIService: NSObject, PurchasesPostConfigurationStep {
 

--- a/RevenueCatUI/Purchasing/PurchasesUIService.swift
+++ b/RevenueCatUI/Purchasing/PurchasesUIService.swift
@@ -28,13 +28,11 @@ final class PurchasesUIService: NSObject, PurchasesPostConfigurationStep {
     private static let lock = NSLock()
     private static var didConfigure = false
 
-    /// Retains this class from a public RevenueCatUI entry point and replays
-    /// configure-time work if `Purchases` is already configured.
+    /// Retains this class from a public RevenueCatUI entry point.
     ///
     /// Reads runtime state and may mutate locked state, so it cannot be
     /// optimized away as a no-op keep-alive.
     static func activateIfNeeded() {
-        guard Purchases.isConfigured else { return }
         Self.purchasesDidConfigure()
     }
 

--- a/RevenueCatUI/Purchasing/PurchasesUIService.swift
+++ b/RevenueCatUI/Purchasing/PurchasesUIService.swift
@@ -28,7 +28,7 @@ import Foundation
 /// must activate merely by being linked, with no RevenueCatUI API reference, the
 /// host has to pass `-ObjC` or, more reliably, `-force_load`.
 @objc(RCPurchasesUIService)
-final class PurchasesUIService: NSObject, PurchasesUIConfiguring {
+final class PurchasesUIService: NSObject, PurchasesPostConfigurationStep {
 
     private static let lock = NSLock()
     private static var didConfigure = false

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -990,12 +990,12 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         _ purchases: @autoclosure () -> Purchases,
         dedupingAgainst configuration: Configuration? = nil
     ) -> Purchases {
-        return self.purchases.modify { currentInstance in
+        let (newInstance, didConfigure): (Purchases, Bool) = self.purchases.modify { currentInstance in
             if let configuration,
                let existingInstance = currentInstance,
                existingInstance.currentConfiguration == configuration {
                 Logger.info(Strings.configure.instance_already_exists_with_same_config)
-                return existingInstance
+                return (existingInstance, false)
             }
 
             if currentInstance != nil {
@@ -1012,8 +1012,15 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
             let newInstance = purchases()
             currentInstance = newInstance
-            return newInstance
+            return (newInstance, true)
         }
+
+        // Outside the singleton lock so RevenueCatUI can safely use ``Purchases/shared``.
+        if didConfigure {
+            PurchasesConfiguredNotifier.notify()
+        }
+
+        return newInstance
     }
 
 }

--- a/Sources/Purchasing/Purchases/PurchasesConfiguredNotifier.swift
+++ b/Sources/Purchasing/Purchases/PurchasesConfiguredNotifier.swift
@@ -14,29 +14,27 @@ import Foundation
 
 /// RevenueCatUI implements this so ``Purchases`` can invoke it without importing that module.
 @_spi(Internal)
-@objc public protocol PurchasesUIConfiguring: NSObjectProtocol {
+@objc public protocol PurchasesPostConfigurationStep: NSObjectProtocol {
 
     /// Called after ``Purchases/shared`` has been set by ``Purchases/configure(withAPIKey:)``.
     static func purchasesDidConfigure()
 
 }
 
-/// Sends a one-shot message to RevenueCatUI when ``Purchases`` is configured.
-///
-/// RevenueCat does not import RevenueCatUI. If the UI module is linked, its
-/// `@objc(RCPurchasesUIService)` class is present and ``PurchasesUIConfiguring/purchasesDidConfigure()``
-/// is invoked. Otherwise this is a no-op.
+/// Sends a message to listeners when ``Purchases`` is configured.
 enum PurchasesConfiguredNotifier {
 
-    /// Must match `@objc(RCPurchasesUIService)` in RevenueCatUI.
-    static let uiServiceClassName = "RCPurchasesUIService"
+    // OBJC symbols must be linked for them to receive the notification
+    static let serviceClassNames = ["RCPurchasesUIService"]
 
     static func notify() {
-        guard let service = NSClassFromString(Self.uiServiceClassName) as? PurchasesUIConfiguring.Type else {
-            return
-        }
+        for name in serviceClassNames {
+            guard let service = NSClassFromString(name) as? PurchasesPostConfigurationStep.Type else {
+                return
+            }
 
-        service.purchasesDidConfigure()
+            service.purchasesDidConfigure()
+        }
     }
 
 }

--- a/Sources/Purchasing/Purchases/PurchasesConfiguredNotifier.swift
+++ b/Sources/Purchasing/Purchases/PurchasesConfiguredNotifier.swift
@@ -1,0 +1,42 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PurchasesConfiguredNotifier.swift
+//
+
+import Foundation
+
+/// RevenueCatUI implements this so ``Purchases`` can invoke it without importing that module.
+@_spi(Internal)
+@objc public protocol PurchasesUIConfiguring: NSObjectProtocol {
+
+    /// Called after ``Purchases/shared`` has been set by ``Purchases/configure(withAPIKey:)``.
+    static func purchasesDidConfigure()
+
+}
+
+/// Sends a one-shot message to RevenueCatUI when ``Purchases`` is configured.
+///
+/// RevenueCat does not import RevenueCatUI. If the UI module is linked, its
+/// `@objc(RCPurchasesUIService)` class is present and ``PurchasesUIConfiguring/purchasesDidConfigure()``
+/// is invoked. Otherwise this is a no-op.
+enum PurchasesConfiguredNotifier {
+
+    /// Must match `@objc(RCPurchasesUIService)` in RevenueCatUI.
+    static let uiServiceClassName = "RCPurchasesUIService"
+
+    static func notify() {
+        guard let service = NSClassFromString(Self.uiServiceClassName) as? PurchasesUIConfiguring.Type else {
+            return
+        }
+
+        service.purchasesDidConfigure()
+    }
+
+}

--- a/Sources/Purchasing/Purchases/PurchasesConfiguredNotifier.swift
+++ b/Sources/Purchasing/Purchases/PurchasesConfiguredNotifier.swift
@@ -30,7 +30,7 @@ enum PurchasesConfiguredNotifier {
     static func notify() {
         for name in serviceClassNames {
             guard let service = NSClassFromString(name) as? PurchasesPostConfigurationStep.Type else {
-                return
+                continue
             }
 
             service.purchasesDidConfigure()

--- a/Tests/PurchasesUIServiceIntegrationTests/.swiftlint.yml
+++ b/Tests/PurchasesUIServiceIntegrationTests/.swiftlint.yml
@@ -1,0 +1,3 @@
+disabled_rules:
+  - missing_docs
+  - force_unwrapping

--- a/Tests/PurchasesUIServiceIntegrationTests/PurchasesUIServiceStrippedTests.swift
+++ b/Tests/PurchasesUIServiceIntegrationTests/PurchasesUIServiceStrippedTests.swift
@@ -1,0 +1,83 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PurchasesUIServiceStrippedTests.swift
+//
+
+@_spi(Internal) import RevenueCat
+import RevenueCatUI
+import XCTest
+
+/// Verifies `RCPurchasesUIService` survives Release dead-stripping / symbol stripping.
+///
+/// Run with the `RevenueCatUI-Stripped` scheme (Release). This target must not
+/// mention `PurchasesUIService` by its Swift name: a Swift reference would keep
+/// the class even if the ObjC keep-alive path failed, hiding the production bug.
+///
+/// `Purchases` looks the class up with `NSClassFromString("RCPurchasesUIService")`.
+/// SPM links RevenueCatUI statically, so the class is only in the binary when a
+/// public RevenueCatUI entry point is reachable.
+///
+/// Release modules are built without `-enable-testing`, so this file uses public
+/// / SPI APIs only — no `@testable import`.
+final class PurchasesUIServiceStrippedTests: XCTestCase {
+
+    func testServiceSurvivesSymbolStrippingAndIsDiscoverable() throws {
+        try skipIfNoPublicKeepAlive()
+
+        self.retainPublicRevenueCatUIEntryPoints()
+
+        // Must match `PurchasesConfiguredNotifier.serviceClassNames`.
+        let className = "RCPurchasesUIService"
+        let service = NSClassFromString(className)
+
+        XCTAssertNotNil(
+            service,
+            "\(className) was stripped from the binary. Purchases.configure cannot notify RevenueCatUI."
+        )
+        XCTAssertNotNil(
+            service as? PurchasesPostConfigurationStep.Type,
+            "\(className) is present but does not conform to PurchasesPostConfigurationStep."
+        )
+
+        _ = Purchases.configure(withAPIKey: "test_purchases_ui_service_stripped")
+
+        XCTAssertNotNil(
+            NSClassFromString(className) as? PurchasesPostConfigurationStep.Type,
+            "\(className) must still be discoverable after Purchases.configure."
+        )
+    }
+
+    /// Touches the same public types an app would. That keeps `RCPurchasesUIService`
+    /// through `activateIfNeeded()` without naming the class in this test target.
+    private func retainPublicRevenueCatUIEntryPoints() {
+        #if os(tvOS)
+        return
+        #else
+        if #available(iOS 15.0, macOS 12.0, watchOS 8.0, *) {
+            _ = PaywallView()
+            #if os(iOS)
+            _ = CustomerCenterView()
+            #endif
+        }
+        #endif
+    }
+
+    private func skipIfNoPublicKeepAlive() throws {
+        #if os(tvOS)
+        throw XCTSkip("RevenueCatUI has no public keep-alive for RCPurchasesUIService on tvOS.")
+        #else
+        if #available(iOS 15.0, macOS 12.0, watchOS 8.0, *) {
+            return
+        }
+        throw XCTSkip("PaywallView requires iOS 15 / macOS 12 / watchOS 8.")
+        #endif
+    }
+
+}

--- a/Tests/RevenueCatUITests/Purchasing/PurchasesUIServiceTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/PurchasesUIServiceTests.swift
@@ -48,9 +48,11 @@ class PurchasesUIServiceTests: TestCase {
         self.verifyPurchasesDidConfigureLogged(count: 1)
     }
 
-    func testActivateIfNeededDoesNothingWhenPurchasesIsNotConfigured() {
+    func testActivateIfNeededPingsEvenWhenPurchasesIsNotConfigured() {
+        // Keep-alive must actually run: a no-op would be stripped, and UI may
+        // load before ``Purchases/configure``.
         PurchasesUIService.activateIfNeeded()
-        self.verifyPurchasesDidConfigureLogged(count: 0)
+        self.verifyPurchasesDidConfigureLogged(count: 1)
     }
 
     func testActivateIfNeededReplaysWhenPurchasesAlreadyConfigured() {

--- a/Tests/RevenueCatUITests/Purchasing/PurchasesUIServiceTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/PurchasesUIServiceTests.swift
@@ -41,29 +41,29 @@ class PurchasesUIServiceTests: TestCase {
 
     func testConfigurePingsRevenueCatUIOnce() {
         _ = Purchases.configure(withAPIKey: "test_purchases_ui_service")
-        expect(PurchasesUIService.configureCallCount) == 1
+        self.verifyPurchasesDidConfigureLogged(count: 1)
 
         // same config: dedup must not ping again
         _ = Purchases.configure(withAPIKey: "test_purchases_ui_service")
-        expect(PurchasesUIService.configureCallCount) == 1
+        self.verifyPurchasesDidConfigureLogged(count: 1)
     }
 
     func testActivateIfNeededDoesNothingWhenPurchasesIsNotConfigured() {
         PurchasesUIService.activateIfNeeded()
-        expect(PurchasesUIService.configureCallCount) == 0
+        self.verifyPurchasesDidConfigureLogged(count: 0)
     }
 
     func testActivateIfNeededReplaysWhenPurchasesAlreadyConfigured() {
         _ = Purchases.configure(withAPIKey: "test_purchases_ui_service")
-        expect(PurchasesUIService.configureCallCount) == 1
+        self.verifyPurchasesDidConfigureLogged(count: 1)
 
         // Simulate RevenueCatUI loading after configuration: the class is now
         // present, but its once-only flag has not run yet.
         PurchasesUIService.resetForTests()
-        expect(PurchasesUIService.configureCallCount) == 0
+        self.logger.clearMessages()
 
         PurchasesUIService.activateIfNeeded()
-        expect(PurchasesUIService.configureCallCount) == 1
+        self.verifyPurchasesDidConfigureLogged(count: 1)
     }
 
     func testPaywallViewConfigurationActivateIfNeededWhenConfigured() throws {
@@ -71,12 +71,13 @@ class PurchasesUIServiceTests: TestCase {
 
         _ = Purchases.configure(withAPIKey: "test_purchases_ui_service")
         PurchasesUIService.resetForTests()
+        self.logger.clearMessages()
 
         if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
             _ = PaywallViewConfiguration(purchaseHandler: .default())
         }
 
-        expect(PurchasesUIService.configureCallCount) == 1
+        self.verifyPurchasesDidConfigureLogged(count: 1)
     }
 
     #if os(iOS)
@@ -85,13 +86,33 @@ class PurchasesUIServiceTests: TestCase {
 
         _ = Purchases.configure(withAPIKey: "test_purchases_ui_service")
         PurchasesUIService.resetForTests()
+        self.logger.clearMessages()
 
         if #available(iOS 15.0, *) {
             _ = CustomerCenterView()
         }
 
-        expect(PurchasesUIService.configureCallCount) == 1
+        self.verifyPurchasesDidConfigureLogged(count: 1)
     }
     #endif
+
+}
+
+private extension PurchasesUIServiceTests {
+
+    func verifyPurchasesDidConfigureLogged(count: Int) {
+        if count == 0 {
+            self.logger.verifyMessageWasNotLogged(
+                Strings.purchases_did_configure,
+                allowNoMessages: true
+            )
+        } else {
+            self.logger.verifyMessageWasLogged(
+                Strings.purchases_did_configure,
+                level: .debug,
+                expectedCount: count
+            )
+        }
+    }
 
 }

--- a/Tests/RevenueCatUITests/Purchasing/PurchasesUIServiceTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/PurchasesUIServiceTests.swift
@@ -1,0 +1,96 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PurchasesUIServiceTests.swift
+//
+
+import Nimble
+@_spi(Internal) @testable import RevenueCat
+@testable import RevenueCatUI
+import XCTest
+
+class PurchasesUIServiceTests: TestCase {
+
+    override func setUp() {
+        super.setUp()
+
+        Purchases.clearSingleton()
+        PurchasesUIService.resetForTests()
+    }
+
+    override func tearDown() {
+        Purchases.clearSingleton()
+        PurchasesUIService.resetForTests()
+
+        super.tearDown()
+    }
+
+    func testServiceConformsAndIsDiscoverable() {
+        let service: AnyClass? = NSClassFromString(PurchasesConfiguredNotifier.uiServiceClassName)
+
+        expect(service).toNot(beNil())
+        expect(service as? PurchasesUIConfiguring.Type).toNot(beNil())
+    }
+
+    func testConfigurePingsRevenueCatUIOnce() {
+        _ = Purchases.configure(withAPIKey: "test_purchases_ui_service")
+        expect(PurchasesUIService.configureCallCount) == 1
+
+        // same config: dedup must not ping again
+        _ = Purchases.configure(withAPIKey: "test_purchases_ui_service")
+        expect(PurchasesUIService.configureCallCount) == 1
+    }
+
+    func testActivateIfNeededDoesNothingWhenPurchasesIsNotConfigured() {
+        PurchasesUIService.activateIfNeeded()
+        expect(PurchasesUIService.configureCallCount) == 0
+    }
+
+    func testActivateIfNeededReplaysWhenPurchasesAlreadyConfigured() {
+        _ = Purchases.configure(withAPIKey: "test_purchases_ui_service")
+        expect(PurchasesUIService.configureCallCount) == 1
+
+        // Simulate RevenueCatUI loading after configuration: the class is now
+        // present, but its once-only flag has not run yet.
+        PurchasesUIService.resetForTests()
+        expect(PurchasesUIService.configureCallCount) == 0
+
+        PurchasesUIService.activateIfNeeded()
+        expect(PurchasesUIService.configureCallCount) == 1
+    }
+
+    func testPaywallViewConfigurationActivateIfNeededWhenConfigured() throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        _ = Purchases.configure(withAPIKey: "test_purchases_ui_service")
+        PurchasesUIService.resetForTests()
+
+        if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
+            _ = PaywallViewConfiguration(purchaseHandler: .default())
+        }
+
+        expect(PurchasesUIService.configureCallCount) == 1
+    }
+
+    #if os(iOS)
+    func testCustomerCenterViewActivateIfNeededWhenConfigured() throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        _ = Purchases.configure(withAPIKey: "test_purchases_ui_service")
+        PurchasesUIService.resetForTests()
+
+        if #available(iOS 15.0, *) {
+            _ = CustomerCenterView()
+        }
+
+        expect(PurchasesUIService.configureCallCount) == 1
+    }
+    #endif
+
+}

--- a/Tests/RevenueCatUITests/Purchasing/PurchasesUIServiceTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/PurchasesUIServiceTests.swift
@@ -32,10 +32,11 @@ class PurchasesUIServiceTests: TestCase {
     }
 
     func testServiceConformsAndIsDiscoverable() {
-        let service: AnyClass? = NSClassFromString(PurchasesConfiguredNotifier.uiServiceClassName)
+        // swiftlint:disable:next force_unwrapping
+        let service: AnyClass? = NSClassFromString(PurchasesConfiguredNotifier.serviceClassNames.first!)
 
         expect(service).toNot(beNil())
-        expect(service as? PurchasesUIConfiguring.Type).toNot(beNil())
+        expect(service as? PurchasesPostConfigurationStep.Type).toNot(beNil())
     }
 
     func testConfigurePingsRevenueCatUIOnce() {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -954,6 +954,26 @@ platform :ios do
     end
   end
 
+  desc "Runs PurchasesUIService integration tests against a Release, symbol-stripped RevenueCatUI build"
+  lane :test_purchases_ui_service_stripped do
+    platform = ENV['PLATFORM'] || 'iOS Simulator'
+    destination = ENV['DEVICE'] || "iPhone 16,OS=18.5"
+    sdk = ENV['BUILD_SDK'] || 'iphonesimulator'
+
+    xcodebuild(
+      workspace: '.',
+      scheme: 'RevenueCatUI-Stripped',
+      destination: "platform=" + platform + ",name=" + destination,
+      sdk: sdk,
+      configuration: 'Release',
+      result_bundle_path: 'fastlane/test_output/purchases_ui_service_stripped.xcresult',
+      report_formats: [:junit],
+      report_path: 'fastlane/test_output/purchases_ui_service_stripped/tests.xml',
+      test: true,
+      xcargs: "DEAD_CODE_STRIPPING=YES STRIP_SWIFT_SYMBOLS=YES ONLY_ACTIVE_ARCH=YES"
+    )
+  end
+
   desc "Release checks"
   lane :release_checks do |options|
     version_number = current_version_number


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->
<!-- AI agents: This PR is prep work for up coming PRs. This should be reviewed independently of the feature that will use it. All of the other mechanics will be based on subscriptions to events coming from purchases. We cannot simply notify using the notification center or a combine publisher UNTIL we have a listener initialized and ready to go, and for the work we need to do, waiting for a view to be initialized is too late. Also, we had to get rid of `@_used` or `@used` to support old compiler versions. And the ceremony in the function being invoked by objective C is just for testing purposes until we wire in the listener which will come in a future pr. -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

We are needing to prewarm things in the UI library, but we don't want to muddy the imports of the Purchases library since it's supposed to compile for extensions. We also don't want to make the user call 2 different configuration methods when all the other prewarming (even for the UI library) is done from the one configuration method they call already. 

We need a way to signal purchases-ui and start work before a developer would present a view in their app

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
Set up a message system using objective c hooks that triggers on the purchases shared instance getting set -> Also added a separate scheme to test symbol stripping works as expected in a release build environment



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Purchases singleton configuration path and cross-module signaling; incorrect stripping or notify timing could break future UI prewarm, though current behavior is logging-only.
> 
> **Overview**
> **Purchases** now notifies RevenueCatUI when a new shared instance is set, without importing the UI module. After `setDefaultInstance` actually configures (not on same-config dedup), it calls `PurchasesConfiguredNotifier`, which looks up `RCPurchasesUIService` via `NSClassFromString` and invokes `purchasesDidConfigure()` on conforming types.
> 
> **RevenueCatUI** adds `PurchasesUIService` (`PurchasesPostConfigurationStep`) with a once-only debug log today (subscriptions planned later). `PaywallViewConfiguration` and `CustomerCenterView` call `activateIfNeeded()` so the ObjC class stays linked under Release dead-stripping and can replay if UI loads after configure.
> 
> **CI / tooling:** new SPM target `PurchasesUIServiceIntegrationTests`, `RevenueCatUI-Stripped` scheme, CircleCI + `test_purchases_ui_service_stripped` fastlane lane, unit tests in `RevenueCatUITests`, and Danger/SwiftLint exclusions for the integration test folder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97b16b98b6e9be0a7485ed55e676986094e1c8bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->