### PR TITLE
Chore: Create Web Store Manager

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1385,6 +1385,7 @@
 		FA1CDF68EA3C6B2B9F77D5A6 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297C50EBB2B69A3F77D13E69 /* Operators.swift */; };
 		FA360650C0B87331F2EFF527 /* Checkpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346145E8EF291B0E8BB68D12 /* Checkpoints.swift */; };
 		73A610000000000000000002 /* Checkpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A610000000000000000012 /* Checkpoints.swift */; };
+		C4C100000000000000000001 /* WebViewDataStoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4C100000000000000000011 /* WebViewDataStoreManager.swift */; };
 		73A610000000000000000003 /* Purchases+Checkpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A610000000000000000013 /* Purchases+Checkpoints.swift */; };
 		73A610000000000000000004 /* CheckpointPaywallResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A610000000000000000014 /* CheckpointPaywallResult.swift */; };
 		73A690000000000000000001 /* ObjCCheckpointTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A690000000000000000011 /* ObjCCheckpointTypes.swift */; };
@@ -1984,6 +1985,8 @@
 		73A640000000000000000015 /* CheckpointsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckpointsManager.swift; sourceTree = "<group>"; };
 		73A650000000000000000011 /* CheckpointWorkflowPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckpointWorkflowPresenterTests.swift; sourceTree = "<group>"; };
 		73A650000000000000000012 /* CheckpointsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckpointsManagerTests.swift; sourceTree = "<group>"; };
+		C4C100000000000000000011 /* WebViewDataStoreManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewDataStoreManager.swift; sourceTree = "<group>"; };
+		C4C200000000000000000011 /* WebViewDataStoreManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewDataStoreManagerTests.swift; sourceTree = "<group>"; };
 		73A620000000000000000011 /* CheckpointValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckpointValueTests.swift; sourceTree = "<group>"; };
 		73A630000000000000000011 /* NSNumber+JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSNumber+JSON.swift"; sourceTree = "<group>"; };
 		350A1B84226E3E8700CCA10F /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
@@ -3524,6 +3527,22 @@
 				73A650000000000000000012 /* CheckpointsManagerTests.swift */,
 			);
 			path = Checkpoints;
+			sourceTree = "<group>";
+		};
+		C4C100000000000000000020 /* WebViewCaching */ = {
+			isa = PBXGroup;
+			children = (
+				C4C100000000000000000011 /* WebViewDataStoreManager.swift */,
+			);
+			path = WebViewCaching;
+			sourceTree = "<group>";
+		};
+		C4C200000000000000000020 /* WebViewCaching */ = {
+			isa = PBXGroup;
+			children = (
+				C4C200000000000000000011 /* WebViewDataStoreManagerTests.swift */,
+			);
+			path = WebViewCaching;
 			sourceTree = "<group>";
 		};
 		73A620000000000000000020 /* Checkpoints */ = {
@@ -6000,6 +6019,7 @@
 				887A604F2C1D037000E1A461 /* Templates */,
 				887A60522C1D037000E1A461 /* UIKit */,
 				887A605F2C1D037000E1A461 /* Views */,
+				C4C100000000000000000020 /* WebViewCaching */,
 				2D2AFE902C6A9EF500D1B0B4 /* Binding+Extensions.swift */,
 				887A60602C1D037000E1A461 /* PaywallFontProvider.swift */,
 				887A60612C1D037000E1A461 /* PaywallView.swift */,
@@ -6124,6 +6144,7 @@
 				887A613B2C1D168B00E1A461 /* Resources */,
 				887A62172C1D168B00E1A461 /* Templates */,
 				FACE0000000000000000F003 /* UIKit */,
+				C4C200000000000000000020 /* WebViewCaching */,
 				887A621C2C1D168B00E1A461 /* TestPlans */,
 				887A621D2C1D168B00E1A461 /* BaseSnapshotTest.swift */,
 				887A621E2C1D168B00E1A461 /* ImageLoaderTests.swift */,
@@ -8325,6 +8346,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				73A610000000000000000002 /* Checkpoints.swift in Sources */,
+				C4C100000000000000000001 /* WebViewDataStoreManager.swift in Sources */,
 				73A610000000000000000004 /* CheckpointPaywallResult.swift in Sources */,
 				73A690000000000000000001 /* ObjCCheckpointTypes.swift in Sources */,
 				73A640000000000000000001 /* CheckpointCallStore.swift in Sources */,

--- a/RevenueCatUI/WebViewCaching/WebViewDataStoreManager.swift
+++ b/RevenueCatUI/WebViewCaching/WebViewDataStoreManager.swift
@@ -1,0 +1,201 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WebViewDataStoreManager.swift
+//
+//  Created by Jacob Zivan Rakidzich on 8/12/26.
+//
+
+@preconcurrency import Combine
+import Foundation
+@_spi(Internal) import RevenueCat
+
+#if !os(tvOS) && !os(watchOS) && canImport(WebKit)
+
+import WebKit
+
+#endif
+
+/// Isolates web-view storage on message receipt, then deletes retired stores later.
+@_spi(Internal) public final class WebViewDataStoreManager {
+
+    /// Shared manager backed by the SDK's UserDefaults suite.
+    public static let shared = WebViewDataStoreManager(userDefaults: .revenueCatSuite)
+
+    /// Fires when the current store is retired. Late subscribers receive nothing.
+    public let storeRetired: AnyPublisher<Void, Never>
+
+    private let userDefaults: UserDefaults
+    private let lock = NSLock()
+    private let storeRetiredSubject = PassthroughSubject<Void, Never>()
+    private var _isSweeping: Bool = false
+    private var isSweeping: Bool {
+        get {
+            lock.withLock {
+                return _isSweeping
+            }
+        }
+        set {
+            lock.withLock {
+                self._isSweeping = newValue
+            }
+        }
+    }
+
+    private static let currentKey = "com.revenuecat.webViewDataStoreIdentifier"
+    private static let pendingKey = "com.revenuecat.webViewDataStorePendingRemovalIdentifiers"
+
+    /// Creates a manager that persists identifiers in `userDefaults`.
+    public init(userDefaults: UserDefaults) {
+        self.userDefaults = userDefaults
+        self.storeRetired = self.storeRetiredSubject.eraseToAnyPublisher()
+    }
+
+    /// Stable identifier for the current store; creates and persists one on first use.
+    public func currentIdentifier() -> UUID {
+        return self.lock.withLock {
+            if let value = self.userDefaults.string(forKey: Self.currentKey),
+               let identifier = UUID(uuidString: value) {
+                return identifier
+            }
+
+            let identifier = UUID()
+            self.userDefaults.set(identifier.uuidString, forKey: Self.currentKey)
+            return identifier
+        }
+    }
+
+    /// Moves the current identifier (if any) into the pending-removal set and fires `storeRetired`.
+    /// Does not create an identifier.
+    public func retireCurrentStore() {
+        let retired = self.lock.withLock { () -> UUID? in
+            let current = self.userDefaults.string(forKey: Self.currentKey)
+                .flatMap(UUID.init(uuidString:))
+            self.userDefaults.removeObject(forKey: Self.currentKey)
+
+            if let current {
+                var pending = self.pendingIdentifiersLocked()
+                pending.insert(current)
+                self.setPendingIdentifiersLocked(pending)
+            }
+
+            return current
+        }
+
+        guard retired != nil else { return }
+        self.storeRetiredSubject.send(())
+    }
+
+    /// Schedules async deletion of pending stores on the main actor.
+    /// Failed removals stay pending for a later pass.
+    public func sweepPendingStores() {
+        if isSweeping { return }
+        isSweeping = true
+
+        Task { @MainActor [weak self] in
+            defer { self?.isSweeping = false }
+            await self?.performSweep()
+        }
+    }
+
+    func pendingRemovalIdentifiers() -> Set<UUID> {
+        return self.lock.withLock {
+            return self.pendingIdentifiersLocked()
+        }
+    }
+
+    /// Subtracts `identifiers` from the pending-removal set.
+    /// IDs added after a sweep snapshot (for example by a concurrent logout) are preserved.
+    func removeFromPending(_ identifiers: Set<UUID>) {
+        guard !identifiers.isEmpty else { return }
+
+        self.lock.withLock {
+            var pending = self.pendingIdentifiersLocked()
+            pending.subtract(identifiers)
+            self.setPendingIdentifiersLocked(pending)
+        }
+    }
+
+    /// Drops pending IDs whose stores are already gone. Only calls `remove` for IDs that still exist.
+    /// Failed removals stay pending so they can be retried later.
+    static func sweep(
+        pending: Set<UUID>,
+        existing: Set<UUID>,
+        remove: (UUID) async -> Bool
+    ) async -> Set<UUID> {
+        var remaining = pending
+
+        for identifier in pending {
+            if !existing.contains(identifier) {
+                remaining.remove(identifier)
+                continue
+            }
+
+            if await remove(identifier) {
+                remaining.remove(identifier)
+            }
+        }
+
+        return remaining
+    }
+
+    @MainActor
+    private func performSweep() async {
+        let pending = self.pendingRemovalIdentifiers()
+        guard !pending.isEmpty else { return }
+
+        #if !os(tvOS) && !os(watchOS) && canImport(WebKit)
+        if #available(iOS 17.0, macOS 14.0, *) {
+            let existing = Set(await WKWebsiteDataStore.allDataStoreIdentifiers)
+            let remaining = await Self.sweep(
+                pending: pending,
+                existing: existing,
+                remove: { identifier in
+                    await self.removeStore(for: identifier)
+                }
+            )
+            // Subtract only IDs this pass cleared. Replacing the set would drop IDs
+            // retired during the WebKit awaits (logout / overlapping sweeps).
+            self.removeFromPending(pending.subtracting(remaining))
+            return
+        }
+        #endif
+
+        self.removeFromPending(pending)
+    }
+
+#if !os(tvOS) && !os(watchOS) && canImport(WebKit)
+
+    @available(iOS 17.0, macOS 14.0, *)
+    @MainActor
+    private func removeStore(for identifier: UUID) async -> Bool {
+        do {
+            try await WKWebsiteDataStore.remove(forIdentifier: identifier)
+            return true
+        } catch {
+//            Logger.debug(Strings.paywalls.web_view_data_store_removal_failed(identifier, error))
+            return false
+        }
+    }
+
+#endif
+
+    private func pendingIdentifiersLocked() -> Set<UUID> {
+        let strings = self.userDefaults.stringArray(forKey: Self.pendingKey) ?? []
+        return Set(strings.compactMap(UUID.init(uuidString:)))
+    }
+
+    private func setPendingIdentifiersLocked(_ identifiers: Set<UUID>) {
+        if identifiers.isEmpty {
+            self.userDefaults.removeObject(forKey: Self.pendingKey)
+        } else {
+            self.userDefaults.set(identifiers.map(\.uuidString), forKey: Self.pendingKey)
+        }
+    }
+
+}

--- a/Sources/FoundationExtensions/UserDefaults+Extensions.swift
+++ b/Sources/FoundationExtensions/UserDefaults+Extensions.swift
@@ -10,6 +10,7 @@
 //  UserDefaults+Extensions.swift
 //
 //  Created by Nacho Soto on 11/9/22.
+// swiftlint:disable missing_docs
 
 import Foundation
 
@@ -23,7 +24,7 @@ extension UserDefaults {
     // - The globalDomain is also an invalid suite name, because it isn't writeable by apps.
     //
     // Because we know at compile time that it's neither of those, this is a safe force-unwrap.
-    static let revenueCatSuite: UserDefaults = .init(suiteName: UserDefaults.revenueCatSuiteName)!
+    @_spi(Internal) public static let revenueCatSuite = UserDefaults(suiteName: UserDefaults.revenueCatSuiteName)!
 
     // swiftlint:enable force_unwrapping
 

--- a/Tests/RevenueCatUITests/WebViewCaching/WebViewDataStoreManagerTests.swift
+++ b/Tests/RevenueCatUITests/WebViewCaching/WebViewDataStoreManagerTests.swift
@@ -1,0 +1,210 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WebViewDataStoreManagerTests.swift
+//
+//  Created by Jacob Zivan Rakidzich on 8/12/26.
+//
+
+import Combine
+@_spi(Internal) @testable import RevenueCat
+@_spi(Internal) @testable import RevenueCatUI
+import XCTest
+
+final class WebViewDataStoreManagerTests: TestCase {
+
+    private var cancellables: Set<AnyCancellable> = []
+
+    override func tearDown() {
+        self.cancellables = []
+        super.tearDown()
+    }
+
+    func testIdentifierIsGeneratedOnceAndPersisted() throws {
+        let manager = try self.makeManager()
+
+        let firstIdentifier = manager.currentIdentifier()
+        let secondIdentifier = manager.currentIdentifier()
+
+        XCTAssertEqual(firstIdentifier, secondIdentifier)
+    }
+
+    func testRetiringIdentifierEnqueuesItAndRotatesOnNextUse() throws {
+        let manager = try self.makeManager()
+        let firstIdentifier = manager.currentIdentifier()
+
+        manager.retireCurrentStore()
+
+        XCTAssertEqual(manager.pendingRemovalIdentifiers(), [firstIdentifier])
+        XCTAssertNotEqual(manager.currentIdentifier(), firstIdentifier)
+    }
+
+    func testRetireDoesNotCreateAnIdentifierWhenNoneExists() throws {
+        let manager = try self.makeManager()
+
+        var received = 0
+        manager.storeRetired
+            .sink { received += 1 }
+            .store(in: &self.cancellables)
+
+        manager.retireCurrentStore()
+
+        XCTAssertTrue(manager.pendingRemovalIdentifiers().isEmpty)
+        XCTAssertEqual(received, 0)
+    }
+
+    func testMultipleRetiresAccumulatePendingIdentifiers() throws {
+        let manager = try self.makeManager()
+
+        let first = manager.currentIdentifier()
+        manager.retireCurrentStore()
+        let second = manager.currentIdentifier()
+        manager.retireCurrentStore()
+
+        XCTAssertEqual(manager.pendingRemovalIdentifiers(), [first, second])
+    }
+
+    func testRemoveFromPendingSubtractsWithoutReplacingTheSet() throws {
+        let manager = try self.makeManager()
+
+        let first = manager.currentIdentifier()
+        manager.retireCurrentStore()
+        let second = manager.currentIdentifier()
+        manager.retireCurrentStore()
+
+        manager.removeFromPending([first])
+
+        XCTAssertEqual(manager.pendingRemovalIdentifiers(), [second])
+    }
+
+    func testRemoveFromPendingPreservesIdentifiersAddedAfterSnapshot() throws {
+        let manager = try self.makeManager()
+
+        let first = manager.currentIdentifier()
+        manager.retireCurrentStore()
+        let second = manager.currentIdentifier()
+        manager.retireCurrentStore()
+
+        let snapshot = manager.pendingRemovalIdentifiers()
+
+        let third = manager.currentIdentifier()
+        manager.retireCurrentStore()
+
+        let remainingAfterSweep: Set<UUID> = [second]
+        manager.removeFromPending(snapshot.subtracting(remainingAfterSweep))
+
+        XCTAssertEqual(manager.pendingRemovalIdentifiers(), [second, third])
+        XCTAssertFalse(manager.pendingRemovalIdentifiers().contains(first))
+    }
+
+    func testStoreRetiredFiresOnRetire() throws {
+        let manager = try self.makeManager()
+        _ = manager.currentIdentifier()
+
+        var received = 0
+        manager.storeRetired
+            .sink { received += 1 }
+            .store(in: &self.cancellables)
+
+        manager.retireCurrentStore()
+
+        XCTAssertEqual(received, 1)
+    }
+
+    func testLateSubscriberDoesNotReceivePriorRetire() throws {
+        let manager = try self.makeManager()
+        _ = manager.currentIdentifier()
+        manager.retireCurrentStore()
+
+        var received = 0
+        manager.storeRetired
+            .sink { received += 1 }
+            .store(in: &self.cancellables)
+
+        XCTAssertEqual(received, 0)
+    }
+
+    func testMultipleSubscribersReceiveTheSameRetirePulse() throws {
+        let manager = try self.makeManager()
+        _ = manager.currentIdentifier()
+
+        var firstReceived = 0
+        var secondReceived = 0
+        manager.storeRetired
+            .sink { firstReceived += 1 }
+            .store(in: &self.cancellables)
+        manager.storeRetired
+            .sink { secondReceived += 1 }
+            .store(in: &self.cancellables)
+
+        manager.retireCurrentStore()
+
+        XCTAssertEqual(firstReceived, 1)
+        XCTAssertEqual(secondReceived, 1)
+    }
+
+    func testSweepRemovesIdentifiersThatExistAndWereDeleted() async {
+        let first = UUID()
+        let second = UUID()
+        var removed: [UUID] = []
+
+        let remaining = await WebViewDataStoreManager.sweep(
+            pending: [first, second],
+            existing: [first, second],
+            remove: { identifier in
+                removed.append(identifier)
+                return true
+            }
+        )
+
+        XCTAssertEqual(Set(removed), [first, second])
+        XCTAssertTrue(remaining.isEmpty)
+    }
+
+    func testSweepKeepsIdentifiersWhenRemoveFails() async {
+        let identifier = UUID()
+
+        let remaining = await WebViewDataStoreManager.sweep(
+            pending: [identifier],
+            existing: [identifier],
+            remove: { _ in false }
+        )
+
+        XCTAssertEqual(remaining, [identifier])
+    }
+
+    func testSweepDropsMissingIdentifiersWithoutCallingRemove() async {
+        let identifier = UUID()
+        var removeCalled = false
+
+        let remaining = await WebViewDataStoreManager.sweep(
+            pending: [identifier],
+            existing: [],
+            remove: { _ in
+                removeCalled = true
+                return true
+            }
+        )
+
+        XCTAssertFalse(removeCalled)
+        XCTAssertTrue(remaining.isEmpty)
+    }
+
+    private func makeManager() throws -> WebViewDataStoreManager {
+        let suiteName = "com.revenuecat.WebViewDataStoreManagerTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+
+        addTeardownBlock { [weak defaults] in
+            defaults?.removePersistentDomain(forName: suiteName)
+        }
+
+        return WebViewDataStoreManager(userDefaults: defaults)
+    }
+
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->
<!-- AI agents: fill in this template, and also follow the "Pull Requests" section in AGENTS.md. -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->
We are starting the process of persisting the web data for the custom component. This class will be responsible for the details. 
### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->


This store manager will retain the current store identifier, and when needing to clear the cache, it will cycle the ids and schedule that store for destruction. Clean up will attempt to happen on webview destruction if it's needed (in a future pr, and on foreground event if the app was dismissed and relaunched)

