### PR TITLE
IAM Login part 2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -19,12 +19,48 @@
       }
     },
     {
+      "identity" : "flyingfox",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swhitty/FlyingFox.git",
+      "state" : {
+        "revision" : "f7829d4aca8cbfecb410a1cce872b1b045224aa1",
+        "version" : "0.16.0"
+      }
+    },
+    {
       "identity" : "nimble",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/quick/nimble",
       "state" : {
         "revision" : "7795df4fff1a9cd231fe4867ae54f4dc5f5734f9",
         "version" : "13.7.1"
+      }
+    },
+    {
+      "identity" : "ohhttpstubs",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/AliSoftware/OHHTTPStubs.git",
+      "state" : {
+        "revision" : "12f19662426d0434d6c330c6974d53e2eb10ecd9",
+        "version" : "9.1.0"
+      }
+    },
+    {
+      "identity" : "simpledebugger",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/EmergeTools/SimpleDebugger.git",
+      "state" : {
+        "revision" : "f065263eb5db95874b690408d136b573c939db9e",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "snapshotpreviews",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/EmergeTools/SnapshotPreviews.git",
+      "state" : {
+        "revision" : "d42446f0439217941a4e3a2ca58a643c1ac328c4",
+        "version" : "0.14.1"
       }
     },
     {

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -571,6 +571,7 @@
 		551800772FF46C8A0055FD1B /* KeychainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551800762FF46C8A0055FD1B /* KeychainTests.swift */; };
 		552CE0E12FD323EF006E41B4 /* Purchases+PreviewPaywall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 552CE0E02FD323EF006E41B4 /* Purchases+PreviewPaywall.swift */; };
 		552CE1022FEF22AC006E41B4 /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 552CE1012FEF22AC006E41B4 /* Keychain.swift */; };
+		55DACDEC302BC2D1005EE017 /* TokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDEA302BC2D1005EE017 /* TokenManager.swift */; };
 		55DACDED302BC2D1005EE017 /* URLMessage+Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDEB302BC2D1005EE017 /* URLMessage+Description.swift */; };
 		55DACDF7302BC331005EE017 /* JWT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDF6302BC331005EE017 /* JWT.swift */; };
 		55DACDFA302BC356005EE017 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDF8302BC356005EE017 /* Authentication.swift */; };
@@ -2244,6 +2245,7 @@
 		552CE0E02FD323EF006E41B4 /* Purchases+PreviewPaywall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Purchases+PreviewPaywall.swift"; sourceTree = "<group>"; };
 		552CE0E72FD32413006E41B4 /* Purchases+PreviewPaywallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Purchases+PreviewPaywallTests.swift"; sourceTree = "<group>"; };
 		552CE1012FEF22AC006E41B4 /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
+		55DACDEA302BC2D1005EE017 /* TokenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenManager.swift; sourceTree = "<group>"; };
 		55DACDEB302BC2D1005EE017 /* URLMessage+Description.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLMessage+Description.swift"; sourceTree = "<group>"; };
 		55DACDF6302BC331005EE017 /* JWT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWT.swift; sourceTree = "<group>"; };
 		55DACDF8302BC356005EE017 /* Authentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authentication.swift; sourceTree = "<group>"; };
@@ -6535,6 +6537,7 @@
 				B3F3E8D9277158FE0047A5B9 /* DNSChecker.swift */,
 				4F3C98692A44FA60009AECA3 /* ErrorResponse.swift */,
 				35D832CC262A5B7500E60AC5 /* ETagManager.swift */,
+				55DACDEA302BC2D1005EE017 /* TokenManager.swift */,
 				55DACDEB302BC2D1005EE017 /* URLMessage+Description.swift */,
 				35F82BB326A9A74D0051DF03 /* HTTPClient.swift */,
 				57DC9F4527CC2E4900DA6AF9 /* HTTPRequest.swift */,
@@ -7504,6 +7507,7 @@
 				B3C4AAD526B8911300E1B3C8 /* Backend.swift in Sources */,
 				35AAEB452BBB14D000A12548 /* DiagnosticsFileHandler.swift in Sources */,
 				537B4B302DA9742500CEFF4C /* HealthReportOperation.swift in Sources */,
+				55DACDEC302BC2D1005EE017 /* TokenManager.swift in Sources */,
 				55DACDED302BC2D1005EE017 /* URLMessage+Description.swift in Sources */,
 				B34D2AA626976FC700D88C3A /* ErrorCode.swift in Sources */,
 				02F84B23216242A7B8CDAB4A /* ErrorCode+Conformances.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -573,6 +573,7 @@
 		552CE1022FEF22AC006E41B4 /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 552CE1012FEF22AC006E41B4 /* Keychain.swift */; };
 		55DACDEC302BC2D1005EE017 /* TokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDEA302BC2D1005EE017 /* TokenManager.swift */; };
 		55DACDED302BC2D1005EE017 /* URLMessage+Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDEB302BC2D1005EE017 /* URLMessage+Description.swift */; };
+		55DACDEF302BC2DF005EE017 /* Identity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDEE302BC2DF005EE017 /* Identity.swift */; };
 		55DACDF7302BC331005EE017 /* JWT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDF6302BC331005EE017 /* JWT.swift */; };
 		55DACDFA302BC356005EE017 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDF8302BC356005EE017 /* Authentication.swift */; };
 		55DACDFC302BC381005EE017 /* AnyCodingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDFB302BC381005EE017 /* AnyCodingKey.swift */; };
@@ -2257,6 +2258,7 @@
 		552CE1012FEF22AC006E41B4 /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
 		55DACDEA302BC2D1005EE017 /* TokenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenManager.swift; sourceTree = "<group>"; };
 		55DACDEB302BC2D1005EE017 /* URLMessage+Description.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLMessage+Description.swift"; sourceTree = "<group>"; };
+		55DACDEE302BC2DF005EE017 /* Identity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identity.swift; sourceTree = "<group>"; };
 		55DACDF6302BC331005EE017 /* JWT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWT.swift; sourceTree = "<group>"; };
 		55DACDF8302BC356005EE017 /* Authentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authentication.swift; sourceTree = "<group>"; };
 		55DACDFB302BC381005EE017 /* AnyCodingKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCodingKey.swift; sourceTree = "<group>"; };
@@ -6614,6 +6616,7 @@
 				4F15B4A02A6774C9005BEFE8 /* CustomerInfo+NonSubscriptions.swift */,
 				B3A36AAD26BC76340059EDEA /* CustomerInfoManager.swift */,
 				B3852F9F26C1ED1F005384F8 /* IdentityManager.swift */,
+				55DACDEE302BC2DF005EE017 /* Identity.swift */,
 			);
 			path = Identity;
 			sourceTree = "<group>";
@@ -7729,6 +7732,7 @@
 				2DDF41A424F6F331005BC22D /* InstallmentsInfoFactory.swift in Sources */,
 				57CCC6EC2984496D001CE9B6 /* Box.swift in Sources */,
 				80442DA42FDF0B2E0085069A /* StateDeclaration.swift in Sources */,
+				55DACDEF302BC2DF005EE017 /* Identity.swift in Sources */,
 				4F6ABC7E2A81700900250E63 /* PaywallsStrings.swift in Sources */,
 				75B6DFFD2E30ECB8009F0A99 /* WebOfferingProductsResponse.swift in Sources */,
 				575137CF27F50D2F0064AB2C /* HTTPResponseBody.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -576,6 +576,15 @@
 		55DACDF7302BC331005EE017 /* JWT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDF6302BC331005EE017 /* JWT.swift */; };
 		55DACDFA302BC356005EE017 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDF8302BC356005EE017 /* Authentication.swift */; };
 		55DACDFC302BC381005EE017 /* AnyCodingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDFB302BC381005EE017 /* AnyCodingKey.swift */; };
+		55DACE87302E2B95005EE017 /* AuthenticationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE85302E2B95005EE017 /* AuthenticationTests.swift */; };
+		55DACE90302E2BBB005EE017 /* MockInternalAuthenticatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE8E302E2BBB005EE017 /* MockInternalAuthenticatorDelegate.swift */; };
+		55DACE91302E2BBB005EE017 /* MockAuthenticationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE8D302E2BBB005EE017 /* MockAuthenticationDelegate.swift */; };
+		55DACE92302E2BBB005EE017 /* MockSecureItemStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE8F302E2BBB005EE017 /* MockSecureItemStorage.swift */; };
+		55DACE93302E2BBB005EE017 /* MockInternalAuthenticatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE8E302E2BBB005EE017 /* MockInternalAuthenticatorDelegate.swift */; };
+		55DACE94302E2BBB005EE017 /* MockAuthenticationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE8D302E2BBB005EE017 /* MockAuthenticationDelegate.swift */; };
+		55DACE95302E2BBB005EE017 /* MockSecureItemStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE8F302E2BBB005EE017 /* MockSecureItemStorage.swift */; };
+		55DACE97302E320C005EE017 /* MockTokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE96302E320C005EE017 /* MockTokenManager.swift */; };
+		55DACE98302E320C005EE017 /* MockTokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE96302E320C005EE017 /* MockTokenManager.swift */; };
 		57045B3829C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */; };
 		57045B3A29C51751001A5417 /* GetProductEntitlementMappingOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3929C51751001A5417 /* GetProductEntitlementMappingOperation.swift */; };
 		57045B3C29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3B29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift */; };
@@ -2250,6 +2259,11 @@
 		55DACDF6302BC331005EE017 /* JWT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWT.swift; sourceTree = "<group>"; };
 		55DACDF8302BC356005EE017 /* Authentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authentication.swift; sourceTree = "<group>"; };
 		55DACDFB302BC381005EE017 /* AnyCodingKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCodingKey.swift; sourceTree = "<group>"; };
+		55DACE85302E2B95005EE017 /* AuthenticationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationTests.swift; sourceTree = "<group>"; };
+		55DACE8D302E2BBB005EE017 /* MockAuthenticationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAuthenticationDelegate.swift; sourceTree = "<group>"; };
+		55DACE8E302E2BBB005EE017 /* MockInternalAuthenticatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInternalAuthenticatorDelegate.swift; sourceTree = "<group>"; };
+		55DACE8F302E2BBB005EE017 /* MockSecureItemStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSecureItemStorage.swift; sourceTree = "<group>"; };
+		55DACE96302E320C005EE017 /* MockTokenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTokenManager.swift; sourceTree = "<group>"; };
 		55FCA85B959807F2D3DD175A /* TransactionReason.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TransactionReason.swift; sourceTree = "<group>"; };
 		57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEntitlementMappingDecodingTests.swift; sourceTree = "<group>"; };
 		57045B3929C51751001A5417 /* GetProductEntitlementMappingOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetProductEntitlementMappingOperation.swift; sourceTree = "<group>"; };
@@ -3997,6 +4011,7 @@
 			children = (
 				73A620000000000000000020 /* Checkpoints */,
 				9094B43F2E96AA140094AD5F /* Ads */,
+				55DACE86302E2B95005EE017 /* Authentication */,
 				356E2DE62CD3CF890055AABB /* Events */,
 				1EFA950E2CDB7F8800CA5951 /* DeepLink */,
 				357348FE2C3BEAF8000EEB86 /* CustomerCenter */,
@@ -4408,6 +4423,10 @@
 		2DDF41DD24F6F4F9005BC22D /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				55DACE8D302E2BBB005EE017 /* MockAuthenticationDelegate.swift */,
+				55DACE8E302E2BBB005EE017 /* MockInternalAuthenticatorDelegate.swift */,
+				55DACE8F302E2BBB005EE017 /* MockSecureItemStorage.swift */,
+				55DACE96302E320C005EE017 /* MockTokenManager.swift */,
 				1E3084A330178A6E00236A34 /* MockSourceHealthChecker.swift */,
 				900D27022F96929800D32EDF /* MockAdsAPI.swift */,
 				1699BC6C2EEC6EAF002001FB /* MockUnderlyingSynchronizedFileCache.swift */,
@@ -5185,6 +5204,14 @@
 			isa = PBXGroup;
 			children = (
 				55DACDF8302BC356005EE017 /* Authentication.swift */,
+			);
+			path = Authentication;
+			sourceTree = "<group>";
+		};
+		55DACE86302E2B95005EE017 /* Authentication */ = {
+			isa = PBXGroup;
+			children = (
+				55DACE85302E2B95005EE017 /* AuthenticationTests.swift */,
 			);
 			path = Authentication;
 			sourceTree = "<group>";
@@ -7259,6 +7286,7 @@
 				57DD426D2926B9620026DF09 /* StoreKitConfigTestCase+Extensions.swift in Sources */,
 				57ACB12528174B9F000DCC9F /* CustomerInfo+TestExtensions.swift in Sources */,
 				2D90F8C326FD214F009B9142 /* MockAttributionTypeFactory.swift in Sources */,
+				55DACE97302E320C005EE017 /* MockTokenManager.swift in Sources */,
 				FDAADFD72BE2C67700BD1659 /* StoreKit2ObserverModePurchaseDetectorTests.swift in Sources */,
 				A55D083427235DED00D919E0 /* BeginRefundRequestHelperTests.swift in Sources */,
 				57DE80892807540D008D6C6F /* StorefrontTests.swift in Sources */,
@@ -7270,6 +7298,9 @@
 				FDAC7B5C2CF100000DFC0D9 /* WinBackOfferEligibilityCalculatorTests.swift in Sources */,
 				FD2046812CB8333A00166727 /* StoreKit2PurchaseIntentListenerTests.swift in Sources */,
 				57DE80812807529F008D6C6F /* MockStorefront.swift in Sources */,
+				55DACE93302E2BBB005EE017 /* MockInternalAuthenticatorDelegate.swift in Sources */,
+				55DACE94302E2BBB005EE017 /* MockAuthenticationDelegate.swift in Sources */,
+				55DACE95302E2BBB005EE017 /* MockSecureItemStorage.swift in Sources */,
 				FD6D87582FAE4CD400CAF0F2 /* MockProductsRequestFactory.swift in Sources */,
 				57544C29285FA95E004E54D5 /* MockAttributeSyncing.swift in Sources */,
 				57057FF928B0048900995F21 /* TestLogHandler.swift in Sources */,
@@ -7911,6 +7942,7 @@
 				57554C88282AC293009A7E58 /* PurchaseOwnershipTypeTests.swift in Sources */,
 				35109DAB2BC6E436001030C8 /* BackendPostDiagnosticsTests.swift in Sources */,
 				57554C84282AC273009A7E58 /* PeriodTypeTests.swift in Sources */,
+				55DACE87302E2B95005EE017 /* AuthenticationTests.swift in Sources */,
 				903A05962EB3AE3C009B9CE4 /* AdEventStoreTests.swift in Sources */,
 				16F376262E93F1E300ADF649 /* LargeItemCacheTypeTests.swift in Sources */,
 				5757EDE72DEE08C100AC4BE1 /* StoreKitVersionTests.swift in Sources */,
@@ -8074,6 +8106,7 @@
 				858195FCF0E04E3CAA99F9BB /* RemoteConfigurationDecodingTests.swift in Sources */,
 				FEDA000000000000000000B1 /* WeightedSourceSelectorTests.swift in Sources */,
 				FEDA000000000000000000D1 /* RemoteConfigSourceProviderTests.swift in Sources */,
+				55DACE98302E320C005EE017 /* MockTokenManager.swift in Sources */,
 				A1B2C3D42FE1000000000004 /* RCContainerTests.swift in Sources */,
 				A1B2C3D42FE100000000000D /* RCContainerBackwardsCompatibilityTests.swift in Sources */,
 				A1B2C3D42FE4000000000002 /* RCContainerCompressionFixtureTests.swift in Sources */,
@@ -8265,6 +8298,9 @@
 				57FDAA9A2846C2BD009A48F1 /* PurchasesDelegateTests.swift in Sources */,
 				351B516026D44BB600BD2BD7 /* MockAttributionDataMigrator.swift in Sources */,
 				1DEF759E2ECF13C000614CB2 /* BackendPostCreateTicketTests.swift in Sources */,
+				55DACE90302E2BBB005EE017 /* MockInternalAuthenticatorDelegate.swift in Sources */,
+				55DACE91302E2BBB005EE017 /* MockAuthenticationDelegate.swift in Sources */,
+				55DACE92302E2BBB005EE017 /* MockSecureItemStorage.swift in Sources */,
 				2DDF41E024F6F527005BC22D /* MockInAppPurchaseBuilder.swift in Sources */,
 				37E352973B0901E3CAA717E1 /* DateFormatter+ExtensionsTests.swift in Sources */,
 				03F446262D2FE1510046129A /* MaskShapePropertyTests.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -573,6 +573,7 @@
 		552CE1022FEF22AC006E41B4 /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 552CE1012FEF22AC006E41B4 /* Keychain.swift */; };
 		55DACDED302BC2D1005EE017 /* URLMessage+Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDEB302BC2D1005EE017 /* URLMessage+Description.swift */; };
 		55DACDF7302BC331005EE017 /* JWT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDF6302BC331005EE017 /* JWT.swift */; };
+		55DACDFA302BC356005EE017 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDF8302BC356005EE017 /* Authentication.swift */; };
 		55DACDFC302BC381005EE017 /* AnyCodingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDFB302BC381005EE017 /* AnyCodingKey.swift */; };
 		57045B3829C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */; };
 		57045B3A29C51751001A5417 /* GetProductEntitlementMappingOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3929C51751001A5417 /* GetProductEntitlementMappingOperation.swift */; };
@@ -2245,6 +2246,7 @@
 		552CE1012FEF22AC006E41B4 /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
 		55DACDEB302BC2D1005EE017 /* URLMessage+Description.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLMessage+Description.swift"; sourceTree = "<group>"; };
 		55DACDF6302BC331005EE017 /* JWT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWT.swift; sourceTree = "<group>"; };
+		55DACDF8302BC356005EE017 /* Authentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authentication.swift; sourceTree = "<group>"; };
 		55DACDFB302BC381005EE017 /* AnyCodingKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCodingKey.swift; sourceTree = "<group>"; };
 		55FCA85B959807F2D3DD175A /* TransactionReason.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TransactionReason.swift; sourceTree = "<group>"; };
 		57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEntitlementMappingDecodingTests.swift; sourceTree = "<group>"; };
@@ -3953,6 +3955,7 @@
 			isa = PBXGroup;
 			children = (
 				9094B4192E96A9A70094AD5F /* Ads */,
+				55DACDF9302BC356005EE017 /* Authentication */,
 				353DE0042CCA4EA600A8F632 /* Events */,
 				1E8A60402CDBD73E0034ACF3 /* WebPurchaseRedemption */,
 				1ED4CA4F2CC1517D0021AB8F /* DeepLink */,
@@ -5174,6 +5177,14 @@
 				AA110003AABB0001CCDD0001 /* EventsRequest+CustomPaywallImpression.swift */,
 			);
 			path = Networking;
+			sourceTree = "<group>";
+		};
+		55DACDF9302BC356005EE017 /* Authentication */ = {
+			isa = PBXGroup;
+			children = (
+				55DACDF8302BC356005EE017 /* Authentication.swift */,
+			);
+			path = Authentication;
 			sourceTree = "<group>";
 		};
 		571E7AD0279F2CE9003B3606 /* TestHelpers */ = {
@@ -7630,6 +7641,7 @@
 				2DDF41BB24F6F392005BC22D /* UInt8+Extensions.swift in Sources */,
 				1D291F722F154834008E4FDA /* CacheStrings.swift in Sources */,
 				1E98EC092CDE567100A751C0 /* URL+WebPurchaseRedemption.swift in Sources */,
+				55DACDFA302BC356005EE017 /* Authentication.swift in Sources */,
 				903A058D2EB3AE29009B9CE4 /* StoredAdEvent.swift in Sources */,
 				903A058E2EB3AE29009B9CE4 /* StoredAdEventSerializer.swift in Sources */,
 				903A058F2EB3AE29009B9CE4 /* AdEventStore.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -600,6 +600,7 @@
 		551800772FF46C8A0055FD1B /* KeychainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551800762FF46C8A0055FD1B /* KeychainTests.swift */; };
 		552CE0E12FD323EF006E41B4 /* Purchases+PreviewPaywall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 552CE0E02FD323EF006E41B4 /* Purchases+PreviewPaywall.swift */; };
 		552CE1022FEF22AC006E41B4 /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 552CE1012FEF22AC006E41B4 /* Keychain.swift */; };
+		55DACDEC302BC2D1005EE017 /* TokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDEA302BC2D1005EE017 /* TokenManager.swift */; };
 		55DACDED302BC2D1005EE017 /* URLMessage+Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDEB302BC2D1005EE017 /* URLMessage+Description.swift */; };
 		55DACDF7302BC331005EE017 /* JWT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDF6302BC331005EE017 /* JWT.swift */; };
 		55DACDFA302BC356005EE017 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDF8302BC356005EE017 /* Authentication.swift */; };
@@ -2322,6 +2323,7 @@
 		552CE0E02FD323EF006E41B4 /* Purchases+PreviewPaywall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Purchases+PreviewPaywall.swift"; sourceTree = "<group>"; };
 		552CE0E72FD32413006E41B4 /* Purchases+PreviewPaywallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Purchases+PreviewPaywallTests.swift"; sourceTree = "<group>"; };
 		552CE1012FEF22AC006E41B4 /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
+		55DACDEA302BC2D1005EE017 /* TokenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenManager.swift; sourceTree = "<group>"; };
 		55DACDEB302BC2D1005EE017 /* URLMessage+Description.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLMessage+Description.swift"; sourceTree = "<group>"; };
 		55DACDF6302BC331005EE017 /* JWT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWT.swift; sourceTree = "<group>"; };
 		55DACDF8302BC356005EE017 /* Authentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authentication.swift; sourceTree = "<group>"; };
@@ -6705,6 +6707,7 @@
 				B3F3E8D9277158FE0047A5B9 /* DNSChecker.swift */,
 				4F3C98692A44FA60009AECA3 /* ErrorResponse.swift */,
 				35D832CC262A5B7500E60AC5 /* ETagManager.swift */,
+				55DACDEA302BC2D1005EE017 /* TokenManager.swift */,
 				55DACDEB302BC2D1005EE017 /* URLMessage+Description.swift */,
 				35F82BB326A9A74D0051DF03 /* HTTPClient.swift */,
 				57DC9F4527CC2E4900DA6AF9 /* HTTPRequest.swift */,
@@ -7685,6 +7688,7 @@
 				B3C4AAD526B8911300E1B3C8 /* Backend.swift in Sources */,
 				35AAEB452BBB14D000A12548 /* DiagnosticsFileHandler.swift in Sources */,
 				537B4B302DA9742500CEFF4C /* HealthReportOperation.swift in Sources */,
+				55DACDEC302BC2D1005EE017 /* TokenManager.swift in Sources */,
 				55DACDED302BC2D1005EE017 /* URLMessage+Description.swift in Sources */,
 				B34D2AA626976FC700D88C3A /* ErrorCode.swift in Sources */,
 				02F84B23216242A7B8CDAB4A /* ErrorCode+Conformances.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -585,6 +585,7 @@
 		55DACE95302E2BBB005EE017 /* MockSecureItemStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE8F302E2BBB005EE017 /* MockSecureItemStorage.swift */; };
 		55DACE97302E320C005EE017 /* MockTokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE96302E320C005EE017 /* MockTokenManager.swift */; };
 		55DACE98302E320C005EE017 /* MockTokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE96302E320C005EE017 /* MockTokenManager.swift */; };
+		55DACEAC302E837B005EE017 /* TokenManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACEAB302E837B005EE017 /* TokenManagerTests.swift */; };
 		57045B3829C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */; };
 		57045B3A29C51751001A5417 /* GetProductEntitlementMappingOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3929C51751001A5417 /* GetProductEntitlementMappingOperation.swift */; };
 		57045B3C29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3B29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift */; };
@@ -2264,6 +2265,7 @@
 		55DACE8E302E2BBB005EE017 /* MockInternalAuthenticatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInternalAuthenticatorDelegate.swift; sourceTree = "<group>"; };
 		55DACE8F302E2BBB005EE017 /* MockSecureItemStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSecureItemStorage.swift; sourceTree = "<group>"; };
 		55DACE96302E320C005EE017 /* MockTokenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTokenManager.swift; sourceTree = "<group>"; };
+		55DACEAB302E837B005EE017 /* TokenManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenManagerTests.swift; sourceTree = "<group>"; };
 		55FCA85B959807F2D3DD175A /* TransactionReason.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TransactionReason.swift; sourceTree = "<group>"; };
 		57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEntitlementMappingDecodingTests.swift; sourceTree = "<group>"; };
 		57045B3929C51751001A5417 /* GetProductEntitlementMappingOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetProductEntitlementMappingOperation.swift; sourceTree = "<group>"; };
@@ -4888,6 +4890,7 @@
 				576C8AD827D2BCB90058FA6E /* HTTPRequestTests.swift */,
 				57DC9F4927CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift */,
 				57D04BB727D947C6006DAC06 /* HTTPResponseTests.swift */,
+				55DACEAB302E837B005EE017 /* TokenManagerTests.swift */,
 				D9EC4160B6D09441B17D6DA8 /* URLMessageDescriptionTests.swift */,
 				A1B2C3D42FE1000000000009 /* RCContainer */,
 				A1B2C3D42FE2000000000007 /* RemoteConfig */,
@@ -8066,6 +8069,7 @@
 				FD299C7E2FC5EB9500A58C89 /* CompoundProductIdentifierTests.swift in Sources */,
 				FD299C802FC5F08800A58C89 /* CompoundProductIdentifierResolverTests.swift in Sources */,
 				356523AC2CF890F400B6E3EA /* CustomerCenterEventsRequestTests.swift in Sources */,
+				55DACEAC302E837B005EE017 /* TokenManagerTests.swift in Sources */,
 				1EFA95102CDB7FAA00CA5951 /* WebPurchaseRedemptionHelperTests.swift in Sources */,
 				35AAEB4C2BBC39D100A12548 /* DiagnosticsFileHandlerTests.swift in Sources */,
 				57DE80802807529F008D6C6F /* MockStorefront.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -602,6 +602,7 @@
 		552CE1022FEF22AC006E41B4 /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 552CE1012FEF22AC006E41B4 /* Keychain.swift */; };
 		55DACDED302BC2D1005EE017 /* URLMessage+Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDEB302BC2D1005EE017 /* URLMessage+Description.swift */; };
 		55DACDF7302BC331005EE017 /* JWT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDF6302BC331005EE017 /* JWT.swift */; };
+		55DACDFA302BC356005EE017 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDF8302BC356005EE017 /* Authentication.swift */; };
 		55DACDFC302BC381005EE017 /* AnyCodingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDFB302BC381005EE017 /* AnyCodingKey.swift */; };
 		57045B3829C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */; };
 		57045B3A29C51751001A5417 /* GetProductEntitlementMappingOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3929C51751001A5417 /* GetProductEntitlementMappingOperation.swift */; };
@@ -2323,6 +2324,7 @@
 		552CE1012FEF22AC006E41B4 /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
 		55DACDEB302BC2D1005EE017 /* URLMessage+Description.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLMessage+Description.swift"; sourceTree = "<group>"; };
 		55DACDF6302BC331005EE017 /* JWT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWT.swift; sourceTree = "<group>"; };
+		55DACDF8302BC356005EE017 /* Authentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authentication.swift; sourceTree = "<group>"; };
 		55DACDFB302BC381005EE017 /* AnyCodingKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCodingKey.swift; sourceTree = "<group>"; };
 		55FCA85B959807F2D3DD175A /* TransactionReason.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TransactionReason.swift; sourceTree = "<group>"; };
 		57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEntitlementMappingDecodingTests.swift; sourceTree = "<group>"; };
@@ -4087,6 +4089,7 @@
 			isa = PBXGroup;
 			children = (
 				9094B4192E96A9A70094AD5F /* Ads */,
+				55DACDF9302BC356005EE017 /* Authentication */,
 				353DE0042CCA4EA600A8F632 /* Events */,
 				1E8A60402CDBD73E0034ACF3 /* WebPurchaseRedemption */,
 				1ED4CA4F2CC1517D0021AB8F /* DeepLink */,
@@ -5322,6 +5325,14 @@
 				AA110003AABB0001CCDD0001 /* EventsRequest+CustomPaywallImpression.swift */,
 			);
 			path = Networking;
+			sourceTree = "<group>";
+		};
+		55DACDF9302BC356005EE017 /* Authentication */ = {
+			isa = PBXGroup;
+			children = (
+				55DACDF8302BC356005EE017 /* Authentication.swift */,
+			);
+			path = Authentication;
 			sourceTree = "<group>";
 		};
 		571E7AD0279F2CE9003B3606 /* TestHelpers */ = {
@@ -7814,6 +7825,7 @@
 				2DDF41BB24F6F392005BC22D /* UInt8+Extensions.swift in Sources */,
 				1D291F722F154834008E4FDA /* CacheStrings.swift in Sources */,
 				1E98EC092CDE567100A751C0 /* URL+WebPurchaseRedemption.swift in Sources */,
+				55DACDFA302BC356005EE017 /* Authentication.swift in Sources */,
 				903A058D2EB3AE29009B9CE4 /* StoredAdEvent.swift in Sources */,
 				903A058E2EB3AE29009B9CE4 /* StoredAdEventSerializer.swift in Sources */,
 				903A058F2EB3AE29009B9CE4 /* AdEventStore.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -605,6 +605,15 @@
 		55DACDF7302BC331005EE017 /* JWT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDF6302BC331005EE017 /* JWT.swift */; };
 		55DACDFA302BC356005EE017 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDF8302BC356005EE017 /* Authentication.swift */; };
 		55DACDFC302BC381005EE017 /* AnyCodingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDFB302BC381005EE017 /* AnyCodingKey.swift */; };
+		55DACE87302E2B95005EE017 /* AuthenticationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE85302E2B95005EE017 /* AuthenticationTests.swift */; };
+		55DACE90302E2BBB005EE017 /* MockInternalAuthenticatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE8E302E2BBB005EE017 /* MockInternalAuthenticatorDelegate.swift */; };
+		55DACE91302E2BBB005EE017 /* MockAuthenticationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE8D302E2BBB005EE017 /* MockAuthenticationDelegate.swift */; };
+		55DACE92302E2BBB005EE017 /* MockSecureItemStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE8F302E2BBB005EE017 /* MockSecureItemStorage.swift */; };
+		55DACE93302E2BBB005EE017 /* MockInternalAuthenticatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE8E302E2BBB005EE017 /* MockInternalAuthenticatorDelegate.swift */; };
+		55DACE94302E2BBB005EE017 /* MockAuthenticationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE8D302E2BBB005EE017 /* MockAuthenticationDelegate.swift */; };
+		55DACE95302E2BBB005EE017 /* MockSecureItemStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE8F302E2BBB005EE017 /* MockSecureItemStorage.swift */; };
+		55DACE97302E320C005EE017 /* MockTokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE96302E320C005EE017 /* MockTokenManager.swift */; };
+		55DACE98302E320C005EE017 /* MockTokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE96302E320C005EE017 /* MockTokenManager.swift */; };
 		57045B3829C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */; };
 		57045B3A29C51751001A5417 /* GetProductEntitlementMappingOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3929C51751001A5417 /* GetProductEntitlementMappingOperation.swift */; };
 		57045B3C29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3B29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift */; };
@@ -2328,6 +2337,11 @@
 		55DACDF6302BC331005EE017 /* JWT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWT.swift; sourceTree = "<group>"; };
 		55DACDF8302BC356005EE017 /* Authentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authentication.swift; sourceTree = "<group>"; };
 		55DACDFB302BC381005EE017 /* AnyCodingKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCodingKey.swift; sourceTree = "<group>"; };
+		55DACE85302E2B95005EE017 /* AuthenticationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationTests.swift; sourceTree = "<group>"; };
+		55DACE8D302E2BBB005EE017 /* MockAuthenticationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAuthenticationDelegate.swift; sourceTree = "<group>"; };
+		55DACE8E302E2BBB005EE017 /* MockInternalAuthenticatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInternalAuthenticatorDelegate.swift; sourceTree = "<group>"; };
+		55DACE8F302E2BBB005EE017 /* MockSecureItemStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSecureItemStorage.swift; sourceTree = "<group>"; };
+		55DACE96302E320C005EE017 /* MockTokenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTokenManager.swift; sourceTree = "<group>"; };
 		55FCA85B959807F2D3DD175A /* TransactionReason.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TransactionReason.swift; sourceTree = "<group>"; };
 		57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEntitlementMappingDecodingTests.swift; sourceTree = "<group>"; };
 		57045B3929C51751001A5417 /* GetProductEntitlementMappingOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetProductEntitlementMappingOperation.swift; sourceTree = "<group>"; };
@@ -4131,6 +4145,7 @@
 			children = (
 				73A620000000000000000020 /* Checkpoints */,
 				9094B43F2E96AA140094AD5F /* Ads */,
+				55DACE86302E2B95005EE017 /* Authentication */,
 				356E2DE62CD3CF890055AABB /* Events */,
 				1EFA950E2CDB7F8800CA5951 /* DeepLink */,
 				357348FE2C3BEAF8000EEB86 /* CustomerCenter */,
@@ -4542,6 +4557,10 @@
 		2DDF41DD24F6F4F9005BC22D /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				55DACE8D302E2BBB005EE017 /* MockAuthenticationDelegate.swift */,
+				55DACE8E302E2BBB005EE017 /* MockInternalAuthenticatorDelegate.swift */,
+				55DACE8F302E2BBB005EE017 /* MockSecureItemStorage.swift */,
+				55DACE96302E320C005EE017 /* MockTokenManager.swift */,
 				1E3084A330178A6E00236A34 /* MockSourceHealthChecker.swift */,
 				900D27022F96929800D32EDF /* MockAdsAPI.swift */,
 				1699BC6C2EEC6EAF002001FB /* MockUnderlyingSynchronizedFileCache.swift */,
@@ -5333,6 +5352,14 @@
 			isa = PBXGroup;
 			children = (
 				55DACDF8302BC356005EE017 /* Authentication.swift */,
+			);
+			path = Authentication;
+			sourceTree = "<group>";
+		};
+		55DACE86302E2B95005EE017 /* Authentication */ = {
+			isa = PBXGroup;
+			children = (
+				55DACE85302E2B95005EE017 /* AuthenticationTests.swift */,
 			);
 			path = Authentication;
 			sourceTree = "<group>";
@@ -7433,6 +7460,7 @@
 				57DD426D2926B9620026DF09 /* StoreKitConfigTestCase+Extensions.swift in Sources */,
 				57ACB12528174B9F000DCC9F /* CustomerInfo+TestExtensions.swift in Sources */,
 				2D90F8C326FD214F009B9142 /* MockAttributionTypeFactory.swift in Sources */,
+				55DACE97302E320C005EE017 /* MockTokenManager.swift in Sources */,
 				FDAADFD72BE2C67700BD1659 /* StoreKit2ObserverModePurchaseDetectorTests.swift in Sources */,
 				A55D083427235DED00D919E0 /* BeginRefundRequestHelperTests.swift in Sources */,
 				57DE80892807540D008D6C6F /* StorefrontTests.swift in Sources */,
@@ -7444,6 +7472,9 @@
 				FDAC7B5C2CF100000DFC0D9 /* WinBackOfferEligibilityCalculatorTests.swift in Sources */,
 				FD2046812CB8333A00166727 /* StoreKit2PurchaseIntentListenerTests.swift in Sources */,
 				57DE80812807529F008D6C6F /* MockStorefront.swift in Sources */,
+				55DACE93302E2BBB005EE017 /* MockInternalAuthenticatorDelegate.swift in Sources */,
+				55DACE94302E2BBB005EE017 /* MockAuthenticationDelegate.swift in Sources */,
+				55DACE95302E2BBB005EE017 /* MockSecureItemStorage.swift in Sources */,
 				FD6D87582FAE4CD400CAF0F2 /* MockProductsRequestFactory.swift in Sources */,
 				57544C29285FA95E004E54D5 /* MockAttributeSyncing.swift in Sources */,
 				57057FF928B0048900995F21 /* TestLogHandler.swift in Sources */,
@@ -8108,6 +8139,7 @@
 				57554C88282AC293009A7E58 /* PurchaseOwnershipTypeTests.swift in Sources */,
 				35109DAB2BC6E436001030C8 /* BackendPostDiagnosticsTests.swift in Sources */,
 				57554C84282AC273009A7E58 /* PeriodTypeTests.swift in Sources */,
+				55DACE87302E2B95005EE017 /* AuthenticationTests.swift in Sources */,
 				903A05962EB3AE3C009B9CE4 /* AdEventStoreTests.swift in Sources */,
 				16F376262E93F1E300ADF649 /* LargeItemCacheTypeTests.swift in Sources */,
 				5757EDE72DEE08C100AC4BE1 /* StoreKitVersionTests.swift in Sources */,
@@ -8277,6 +8309,7 @@
 				858195FCF0E04E3CAA99F9BB /* RemoteConfigurationDecodingTests.swift in Sources */,
 				FEDA000000000000000000B1 /* WeightedSourceSelectorTests.swift in Sources */,
 				FEDA000000000000000000D1 /* RemoteConfigSourceProviderTests.swift in Sources */,
+				55DACE98302E320C005EE017 /* MockTokenManager.swift in Sources */,
 				A1B2C3D42FE1000000000004 /* RCContainerTests.swift in Sources */,
 				A1B2C3D42FE100000000000D /* RCContainerBackwardsCompatibilityTests.swift in Sources */,
 				A1B2C3D42FE4000000000002 /* RCContainerCompressionFixtureTests.swift in Sources */,
@@ -8477,6 +8510,9 @@
 				57FDAA9A2846C2BD009A48F1 /* PurchasesDelegateTests.swift in Sources */,
 				351B516026D44BB600BD2BD7 /* MockAttributionDataMigrator.swift in Sources */,
 				1DEF759E2ECF13C000614CB2 /* BackendPostCreateTicketTests.swift in Sources */,
+				55DACE90302E2BBB005EE017 /* MockInternalAuthenticatorDelegate.swift in Sources */,
+				55DACE91302E2BBB005EE017 /* MockAuthenticationDelegate.swift in Sources */,
+				55DACE92302E2BBB005EE017 /* MockSecureItemStorage.swift in Sources */,
 				2DDF41E024F6F527005BC22D /* MockInAppPurchaseBuilder.swift in Sources */,
 				37E352973B0901E3CAA717E1 /* DateFormatter+ExtensionsTests.swift in Sources */,
 				03F446262D2FE1510046129A /* MaskShapePropertyTests.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -602,6 +602,7 @@
 		552CE1022FEF22AC006E41B4 /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 552CE1012FEF22AC006E41B4 /* Keychain.swift */; };
 		55DACDEC302BC2D1005EE017 /* TokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDEA302BC2D1005EE017 /* TokenManager.swift */; };
 		55DACDED302BC2D1005EE017 /* URLMessage+Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDEB302BC2D1005EE017 /* URLMessage+Description.swift */; };
+		55DACDEF302BC2DF005EE017 /* Identity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDEE302BC2DF005EE017 /* Identity.swift */; };
 		55DACDF7302BC331005EE017 /* JWT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDF6302BC331005EE017 /* JWT.swift */; };
 		55DACDFA302BC356005EE017 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDF8302BC356005EE017 /* Authentication.swift */; };
 		55DACDFC302BC381005EE017 /* AnyCodingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDFB302BC381005EE017 /* AnyCodingKey.swift */; };
@@ -2335,6 +2336,7 @@
 		552CE1012FEF22AC006E41B4 /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
 		55DACDEA302BC2D1005EE017 /* TokenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenManager.swift; sourceTree = "<group>"; };
 		55DACDEB302BC2D1005EE017 /* URLMessage+Description.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLMessage+Description.swift"; sourceTree = "<group>"; };
+		55DACDEE302BC2DF005EE017 /* Identity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identity.swift; sourceTree = "<group>"; };
 		55DACDF6302BC331005EE017 /* JWT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWT.swift; sourceTree = "<group>"; };
 		55DACDF8302BC356005EE017 /* Authentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authentication.swift; sourceTree = "<group>"; };
 		55DACDFB302BC381005EE017 /* AnyCodingKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCodingKey.swift; sourceTree = "<group>"; };
@@ -6785,6 +6787,7 @@
 				4F15B4A02A6774C9005BEFE8 /* CustomerInfo+NonSubscriptions.swift */,
 				B3A36AAD26BC76340059EDEA /* CustomerInfoManager.swift */,
 				B3852F9F26C1ED1F005384F8 /* IdentityManager.swift */,
+				55DACDEE302BC2DF005EE017 /* Identity.swift */,
 			);
 			path = Identity;
 			sourceTree = "<group>";
@@ -7914,6 +7917,7 @@
 				2DDF41A424F6F331005BC22D /* InstallmentsInfoFactory.swift in Sources */,
 				57CCC6EC2984496D001CE9B6 /* Box.swift in Sources */,
 				80442DA42FDF0B2E0085069A /* StateDeclaration.swift in Sources */,
+				55DACDEF302BC2DF005EE017 /* Identity.swift in Sources */,
 				4F6ABC7E2A81700900250E63 /* PaywallsStrings.swift in Sources */,
 				75B6DFFD2E30ECB8009F0A99 /* WebOfferingProductsResponse.swift in Sources */,
 				575137CF27F50D2F0064AB2C /* HTTPResponseBody.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -616,6 +616,7 @@
 		55DACE97302E320C005EE017 /* MockTokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE96302E320C005EE017 /* MockTokenManager.swift */; };
 		55DACE98302E320C005EE017 /* MockTokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE96302E320C005EE017 /* MockTokenManager.swift */; };
 		55DACEAC302E837B005EE017 /* TokenManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACEAB302E837B005EE017 /* TokenManagerTests.swift */; };
+		55DACFD230366629005EE017 /* AuthenticationStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACFCC30366625005EE017 /* AuthenticationStrings.swift */; };
 		57045B3829C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */; };
 		57045B3A29C51751001A5417 /* GetProductEntitlementMappingOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3929C51751001A5417 /* GetProductEntitlementMappingOperation.swift */; };
 		57045B3C29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3B29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift */; };
@@ -2346,6 +2347,7 @@
 		55DACE8F302E2BBB005EE017 /* MockSecureItemStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSecureItemStorage.swift; sourceTree = "<group>"; };
 		55DACE96302E320C005EE017 /* MockTokenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTokenManager.swift; sourceTree = "<group>"; };
 		55DACEAB302E837B005EE017 /* TokenManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenManagerTests.swift; sourceTree = "<group>"; };
+		55DACFCC30366625005EE017 /* AuthenticationStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationStrings.swift; sourceTree = "<group>"; };
 		55FCA85B959807F2D3DD175A /* TransactionReason.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TransactionReason.swift; sourceTree = "<group>"; };
 		57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEntitlementMappingDecodingTests.swift; sourceTree = "<group>"; };
 		57045B3929C51751001A5417 /* GetProductEntitlementMappingOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetProductEntitlementMappingOperation.swift; sourceTree = "<group>"; };
@@ -4011,6 +4013,7 @@
 				AD5000000000000000ADAD01 /* AdsStrings.swift */,
 				5704CDC82D706E5500C7F01A /* AnalyticsStrings.swift */,
 				2D11F5E0250FF886005A70E8 /* AttributionStrings.swift */,
+				55DACFCC30366625005EE017 /* AuthenticationStrings.swift */,
 				B302206D2728B798008F1A0D /* BackendErrorStrings.swift */,
 				F5714EE426DC2F1D00635477 /* CodableStrings.swift */,
 				9A65E03525918B0500DE00B0 /* ConfigureStrings.swift */,
@@ -7802,6 +7805,7 @@
 				B34605BC279A6E380031CA74 /* CallbackCache.swift in Sources */,
 				3592E8862C2ED51700D7F91D /* CustomerCenterConfigCallback.swift in Sources */,
 				75ADC0722E437F8600210ECA /* SimulatedStoreProduct.swift in Sources */,
+				55DACFD230366629005EE017 /* AuthenticationStrings.swift in Sources */,
 				75ADC0732E437F8600210ECA /* WebBillingProduct+SimulatedStoreProduct.swift in Sources */,
 				B3E26A4A26BE0A8E003ACCF3 /* Error+Extensions.swift in Sources */,
 				2C2AEB3B2CA7209F00A50F38 /* PaywallPackageComponent.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -614,6 +614,7 @@
 		55DACE95302E2BBB005EE017 /* MockSecureItemStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE8F302E2BBB005EE017 /* MockSecureItemStorage.swift */; };
 		55DACE97302E320C005EE017 /* MockTokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE96302E320C005EE017 /* MockTokenManager.swift */; };
 		55DACE98302E320C005EE017 /* MockTokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE96302E320C005EE017 /* MockTokenManager.swift */; };
+		55DACEAC302E837B005EE017 /* TokenManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACEAB302E837B005EE017 /* TokenManagerTests.swift */; };
 		57045B3829C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */; };
 		57045B3A29C51751001A5417 /* GetProductEntitlementMappingOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3929C51751001A5417 /* GetProductEntitlementMappingOperation.swift */; };
 		57045B3C29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3B29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift */; };
@@ -2342,6 +2343,7 @@
 		55DACE8E302E2BBB005EE017 /* MockInternalAuthenticatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInternalAuthenticatorDelegate.swift; sourceTree = "<group>"; };
 		55DACE8F302E2BBB005EE017 /* MockSecureItemStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSecureItemStorage.swift; sourceTree = "<group>"; };
 		55DACE96302E320C005EE017 /* MockTokenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTokenManager.swift; sourceTree = "<group>"; };
+		55DACEAB302E837B005EE017 /* TokenManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenManagerTests.swift; sourceTree = "<group>"; };
 		55FCA85B959807F2D3DD175A /* TransactionReason.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TransactionReason.swift; sourceTree = "<group>"; };
 		57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEntitlementMappingDecodingTests.swift; sourceTree = "<group>"; };
 		57045B3929C51751001A5417 /* GetProductEntitlementMappingOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetProductEntitlementMappingOperation.swift; sourceTree = "<group>"; };
@@ -5030,6 +5032,7 @@
 				576C8AD827D2BCB90058FA6E /* HTTPRequestTests.swift */,
 				57DC9F4927CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift */,
 				57D04BB727D947C6006DAC06 /* HTTPResponseTests.swift */,
+				55DACEAB302E837B005EE017 /* TokenManagerTests.swift */,
 				D9EC4160B6D09441B17D6DA8 /* URLMessageDescriptionTests.swift */,
 				A1B2C3D42FE1000000000009 /* RCContainer */,
 				A1B2C3D42FE2000000000007 /* RemoteConfig */,
@@ -8267,6 +8270,7 @@
 				FD299C7E2FC5EB9500A58C89 /* CompoundProductIdentifierTests.swift in Sources */,
 				FD299C802FC5F08800A58C89 /* CompoundProductIdentifierResolverTests.swift in Sources */,
 				356523AC2CF890F400B6E3EA /* CustomerCenterEventsRequestTests.swift in Sources */,
+				55DACEAC302E837B005EE017 /* TokenManagerTests.swift in Sources */,
 				1EFA95102CDB7FAA00CA5951 /* WebPurchaseRedemptionHelperTests.swift in Sources */,
 				FD1197302D6E6423002718E3 /* MockUIScene.swift in Sources */,
 				35AAEB4C2BBC39D100A12548 /* DiagnosticsFileHandlerTests.swift in Sources */,

--- a/Sources/Authentication/Authentication.swift
+++ b/Sources/Authentication/Authentication.swift
@@ -30,6 +30,7 @@ public final class Authentication: NSObject {
 
     private let backend: Backend
     private let identityManager: IdentityManager
+    private let tokenManager: TokenManager
     private let operationDispatcher: OperationDispatcher
     private let systemInfo: SystemInfo
     internal weak var internalDelegate: InternalAuthenticatorDelegate?
@@ -45,11 +46,13 @@ public final class Authentication: NSObject {
     public weak var delegate: AuthenticationDelegate?
     internal init(backend: Backend,
                   identityManager: IdentityManager,
+                  tokenManager: TokenManager,
                   operationDispatcher: OperationDispatcher,
                   systemInfo: SystemInfo,
                   internalDelegate: InternalAuthenticatorDelegate? = nil) {
         self.backend = backend
         self.identityManager = identityManager
+        self.tokenManager = tokenManager
         self.operationDispatcher = operationDispatcher
         self.systemInfo = systemInfo
         self.internalDelegate = internalDelegate
@@ -75,6 +78,16 @@ public final class Authentication: NSObject {
     @objc(identifyCurrentUserAsID:completion:)
     public func identifyCurrentUser(as appUserID: String,
                                     completion: @escaping (CustomerInfo?, Bool, PublicError?) -> Void) {
+        guard tokenManager.enabled == false else {
+            self.operationDispatcher.dispatchOnMainThread {
+                let error = NewErrorUtils.unsupportedError(message:
+                    "Providing an alias for the current user is unsupported when using IAM identities"
+                )
+                completion(nil, false, error.asPublicError)
+            }
+            return
+        }
+
         let normalizedAppUserID = appUserID.trimmingWhitespacesAndNewLines
 
         self.identityManager.logIn(appUserID: normalizedAppUserID) { result in

--- a/Sources/Authentication/Authentication.swift
+++ b/Sources/Authentication/Authentication.swift
@@ -1,5 +1,5 @@
 //
-//  Authenticator.swift
+//  Authentication.swift
 //  RevenueCat
 //
 //  Created by Dave DeLong on 7/30/26.
@@ -7,12 +7,12 @@
 
 import Foundation
 
-/// The delegate for ``Authentication``, responsible for responding to authentication errors that occuring
+/// The delegate for ``Authentication``, responsible for responding to authentication errors that occur
 /// during passive SDK use.
 ///
 /// Typically, getting an authentication error means that the SDK needs a new ``Identity`` token provided
 /// to the ``Authentication.logIn(using:)`` method
-@_spi(Experimental)
+@_spi(Internal)
 @objc(RCPurchasesAuthenticationDelegate)
 public protocol AuthenticationDelegate: NSObjectProtocol {
 
@@ -28,7 +28,7 @@ internal protocol InternalAuthenticatorDelegate: AnyObject {
 }
 
 /// A namespace for providing authentication-related functionality to the ``Purchases`` instance
-@_spi(Experimental)
+@_spi(Internal)
 @objc(RCPurchasesAuthentication)
 public final class Authentication: NSObject {
 
@@ -47,6 +47,9 @@ public final class Authentication: NSObject {
     ///
     /// However, if an error occurs during an explicit ``logIn(using:)`` call, that will be reported
     /// via the corresponding completion handler (or thrown when called using `await`).
+    ///
+    /// - Warning: The delegate is not retained, so your app must retain a reference
+    /// to the delegate to prevent it from being unintentionally deallocated.
     @objc public weak var delegate: AuthenticationDelegate?
 
     internal init(backend: Backend,
@@ -103,14 +106,11 @@ public final class Authentication: NSObject {
 
         self.identityManager.logIn(appUserID: normalizedAppUserID) { result in
             self.operationDispatcher.dispatchOnMainThread {
+                if case let .success(values) = result {
+                    self.internalDelegate?.authenticatorDidLogIn(info: values.info)
+                }
                 completion(result.value?.info, result.value?.created ?? false, result.error?.asPublicError)
             }
-
-            guard case let .success(values) = result else {
-                return
-            }
-
-            self.internalDelegate?.authenticatorDidLogIn(info: values.info)
         }
 
     }
@@ -187,16 +187,18 @@ public final class Authentication: NSObject {
                     self.reportAuthenticationError(error.asPublicError)
                 }
             } else {
-                guard let delegate = self.internalDelegate else {
-                    // there was no error, but we also don't have a CustomerInfo object to provide
-                    // that *should* be provided by the delegate, but for some unknown reason,
-                    // the delegate is missing.
-                    let error = NewErrorUtils.customerInfoError(withMessage: "Missing internal auth delegate")
-                    completion?(nil, error.asPublicError)
-                    return
-                }
-                delegate.authenticatorDidChangeIdentity { result in
-                    completion?(result.value, result.error)
+                self.operationDispatcher.dispatchOnMainThread {
+                    guard let delegate = self.internalDelegate else {
+                        // there was no error, but we also don't have a CustomerInfo object to provide
+                        // that *should* be provided by the delegate, but for some unknown reason,
+                        // the delegate is missing.
+                        let error = NewErrorUtils.customerInfoError(withMessage: "Missing internal auth delegate")
+                        completion?(nil, error.asPublicError)
+                        return
+                    }
+                    delegate.authenticatorDidChangeIdentity { result in
+                        completion?(result.value, result.error)
+                    }
                 }
             }
         }

--- a/Sources/Authentication/Authentication.swift
+++ b/Sources/Authentication/Authentication.swift
@@ -15,6 +15,10 @@ import Foundation
 @_spi(Experimental)
 @objc(RCPurchasesAuthenticationDelegate)
 public protocol AuthenticationDelegate: NSObjectProtocol {
+
+    /// The SDK encountered an unrecoverable authentication error while performing other operations
+    ///
+    /// - Parameter error: The ``PublicError`` indicating why authentication has failed
     func authenticatorDidEncounterError(_ error: PublicError)
 }
 
@@ -57,7 +61,13 @@ public final class Authentication: NSObject {
         self.systemInfo = systemInfo
         self.internalDelegate = internalDelegate
         super.init()
+    }
 
+    /// Provide an app-specific alias for the current user
+    /// - Parameters:
+    ///   - appUserID: The user's alias
+    ///   - completion: A completion handler that is invoked with the updated ``CustomerInfo`` (if any),
+    ///   a boolean indicating whether the user was created or restored, and an optional ``PublicError``
     @available(*, deprecated, message: """
     The appUserID passed to logIn is a constant string known at compile time.
     This is likely a programmer error. This ID is used to identify the current user.
@@ -115,6 +125,10 @@ public final class Authentication: NSObject {
 
     // MARK: - Async
 
+    /// Provide an app-specific alias for the current user
+    /// - Parameter appUserID: The user's alias
+    /// - Returns: A tuple of the new ``CustomerInfo`` and a boolean indicating whether it was created or restored
+    /// - Throws: an error if the alias could not be applied to the current user
     @available(*, deprecated, message: """
     The appUserID passed to logIn is a constant string known at compile time.
     This is likely a programmer error. This ID is used to identify the current user.
@@ -127,6 +141,10 @@ public final class Authentication: NSObject {
         return try await identifyCurrentUser(as: appUserID.description)
     }
 
+    /// Provide an app-specific alias for the current user
+    /// - Parameter appUserID: The user's alias
+    /// - Returns: A tuple of the new ``CustomerInfo`` and a boolean indicating whether it was created or restored
+    /// - Throws: an error if the alias could not be applied to the current user
     @_disfavoredOverload
     public func identifyCurrentUser(as appUserID: String) async throws -> (customerInfo: CustomerInfo, created: Bool) {
         return try await withUnsafeThrowingContinuation { continuation in
@@ -137,6 +155,8 @@ public final class Authentication: NSObject {
         }
     }
 
+    /// Log out the current user and revert to an anonymous user identifier
+    /// - Returns: The ``CustomerInfo`` of the anonymous user
     public func logOut() async throws -> CustomerInfo {
         return try await withUnsafeThrowingContinuation { continuation in
             self.logOut(completion: { customerInfo, error in

--- a/Sources/Authentication/Authentication.swift
+++ b/Sources/Authentication/Authentication.swift
@@ -23,7 +23,7 @@ public protocol AuthenticationDelegate: NSObjectProtocol {
 }
 
 internal protocol InternalAuthenticatorDelegate: AnyObject {
-    func authenticatorDidLogIn(info: CustomerInfo?, error: PublicError?)
+    func authenticatorDidLogIn(info: CustomerInfo)
     func authenticatorDidChangeIdentity(completion: @escaping (Result<CustomerInfo, PublicError>) -> Void)
 }
 
@@ -106,11 +106,11 @@ public final class Authentication: NSObject {
                 completion(result.value?.info, result.value?.created ?? false, result.error?.asPublicError)
             }
 
-            guard case .success = result else {
+            guard case let .success(values) = result else {
                 return
             }
 
-            self.internalDelegate?.authenticatorDidLogIn(info: result.value?.info, error: result.error?.asPublicError)
+            self.internalDelegate?.authenticatorDidLogIn(info: values.info)
         }
 
     }

--- a/Sources/Authentication/Authentication.swift
+++ b/Sources/Authentication/Authentication.swift
@@ -47,7 +47,8 @@ public final class Authentication: NSObject {
     ///
     /// However, if an error occurs during an explicit ``logIn(using:)`` call, that will be reported
     /// via the corresponding completion handler (or thrown when called using `await`).
-    public weak var delegate: AuthenticationDelegate?
+    @objc public weak var delegate: AuthenticationDelegate?
+
     internal init(backend: Backend,
                   identityManager: IdentityManager,
                   tokenManager: TokenManager,

--- a/Sources/Authentication/Authentication.swift
+++ b/Sources/Authentication/Authentication.swift
@@ -187,7 +187,15 @@ public final class Authentication: NSObject {
                     self.reportAuthenticationError(error.asPublicError)
                 }
             } else {
-                self.internalDelegate?.authenticatorDidChangeIdentity { result in
+                guard let delegate = self.internalDelegate else {
+                    // there was no error, but we also don't have a CustomerInfo object to provide
+                    // that *should* be provided by the delegate, but for some unknown reason,
+                    // the delegate is missing.
+                    let error = NewErrorUtils.customerInfoError(withMessage: "Missing internal auth delegate")
+                    completion?(nil, error.asPublicError)
+                    return
+                }
+                delegate.authenticatorDidChangeIdentity { result in
                     completion?(result.value, result.error)
                 }
             }

--- a/Sources/Authentication/Authentication.swift
+++ b/Sources/Authentication/Authentication.swift
@@ -1,0 +1,171 @@
+//
+//  Authenticator.swift
+//  RevenueCat
+//
+//  Created by Dave DeLong on 7/30/26.
+//
+
+import Foundation
+
+/// The delegate for ``Authentication``, responsible for responding to authentication errors that occuring
+/// during passive SDK use.
+///
+/// Typically, getting an authentication error means that the SDK needs a new ``Identity`` token provided
+/// to the ``Authentication.logIn(using:)`` method
+@_spi(Experimental)
+@objc(RCPurchasesAuthenticationDelegate)
+public protocol AuthenticationDelegate: NSObjectProtocol {
+    func authenticatorDidEncounterError(_ error: PublicError)
+}
+
+internal protocol InternalAuthenticatorDelegate: AnyObject {
+    func authenticatorDidLogIn(info: CustomerInfo?, error: PublicError?)
+    func authenticatorDidChangeIdentity(completion: @escaping (Result<CustomerInfo, PublicError>) -> Void)
+}
+
+/// A namespace for providing authentication-related functionality to the ``Purchases`` instance
+@_spi(Experimental)
+@objc(RCPurchasesAuthentication)
+public final class Authentication: NSObject {
+
+    private let backend: Backend
+    private let identityManager: IdentityManager
+    private let operationDispatcher: OperationDispatcher
+    private let systemInfo: SystemInfo
+    internal weak var internalDelegate: InternalAuthenticatorDelegate?
+
+    /// The delegate responsible for responding to any authentication errors that occur
+    /// during operations that do not explicitly report their own errors.
+    ///
+    /// For example, if an authentication error occurs while updating the ``CustomerInfo``,
+    /// that will be reported to the delegate.
+    ///
+    /// However, if an error occurs during an explicit ``logIn(using:)`` call, that will be reported
+    /// via the corresponding completion handler (or thrown when called using `await`).
+    public weak var delegate: AuthenticationDelegate?
+    internal init(backend: Backend,
+                  identityManager: IdentityManager,
+                  operationDispatcher: OperationDispatcher,
+                  systemInfo: SystemInfo,
+                  internalDelegate: InternalAuthenticatorDelegate? = nil) {
+        self.backend = backend
+        self.identityManager = identityManager
+        self.operationDispatcher = operationDispatcher
+        self.systemInfo = systemInfo
+        self.internalDelegate = internalDelegate
+        super.init()
+
+    @available(*, deprecated, message: """
+    The appUserID passed to logIn is a constant string known at compile time.
+    This is likely a programmer error. This ID is used to identify the current user.
+    See https://docs.revenuecat.com/docs/user-ids for more information.
+    """)
+    public func identifyCurrentUser(as appUserID: StaticString,
+                                    completion: @escaping (CustomerInfo?, Bool, PublicError?) -> Void) {
+        Logger.warn(Strings.identity.logging_in_with_static_string)
+        self.identifyCurrentUser(as: appUserID.description, completion: completion)
+    }
+
+    /// Provide an app-specific alias for the current user
+    /// - Parameters:
+    ///   - appUserID: The user's alias
+    ///   - completion: A completion handler that is invoked with the updated ``CustomerInfo`` (if any),
+    ///   a boolean indicating whether the user was created or restored, and an optional ``PublicError``
+    @_disfavoredOverload
+    @objc(identifyCurrentUserAsID:completion:)
+    public func identifyCurrentUser(as appUserID: String,
+                                    completion: @escaping (CustomerInfo?, Bool, PublicError?) -> Void) {
+        let normalizedAppUserID = appUserID.trimmingWhitespacesAndNewLines
+
+        self.identityManager.logIn(appUserID: normalizedAppUserID) { result in
+            self.operationDispatcher.dispatchOnMainThread {
+                completion(result.value?.info, result.value?.created ?? false, result.error?.asPublicError)
+            }
+
+            guard case .success = result else {
+                return
+            }
+
+            self.internalDelegate?.authenticatorDidLogIn(info: result.value?.info, error: result.error?.asPublicError)
+        }
+
+    }
+
+    /// Log the current identity out
+    ///
+    /// Invoking this reverts the SDK to an anonymous identity
+    /// - Parameter completion: A handler invoked after logging out has finished
+    @objc
+    public func logOut(completion: ((CustomerInfo?, PublicError?) -> Void)?) {
+        self.logOut(userInitiated: true, completion: completion)
+    }
+
+    // MARK: - Async
+
+    @available(*, deprecated, message: """
+    The appUserID passed to logIn is a constant string known at compile time.
+    This is likely a programmer error. This ID is used to identify the current user.
+    See https://docs.revenuecat.com/docs/user-ids for more information.
+    """)
+    public func identifyCurrentUser(as appUserID: StaticString) async throws ->
+        (customerInfo: CustomerInfo, created: Bool) {
+
+        Logger.warn(Strings.identity.logging_in_with_static_string)
+        return try await identifyCurrentUser(as: appUserID.description)
+    }
+
+    @_disfavoredOverload
+    public func identifyCurrentUser(as appUserID: String) async throws -> (customerInfo: CustomerInfo, created: Bool) {
+        return try await withUnsafeThrowingContinuation { continuation in
+            self.identifyCurrentUser(as: appUserID, completion: { customerInfo, created, error in
+                continuation.resume(with: Result(customerInfo, error)
+                    .map { ($0, created) })
+            })
+        }
+    }
+
+    public func logOut() async throws -> CustomerInfo {
+        return try await withUnsafeThrowingContinuation { continuation in
+            self.logOut(completion: { customerInfo, error in
+                continuation.resume(with: Result(customerInfo, error))
+            })
+        }
+    }
+
+    // MARK: - Internals
+
+    internal func logOut(userInitiated: Bool, completion: ((CustomerInfo?, PublicError?) -> Void)?) {
+        guard !self.systemInfo.dangerousSettings.customEntitlementComputation else {
+            let error = NewErrorUtils.featureNotAvailableInCustomEntitlementsComputationModeError().asPublicError
+            completion?(nil, error)
+            if userInitiated == false { self.reportAuthenticationError(error) }
+            return
+        }
+
+        self.identityManager.logOut { error in
+            if let error {
+                if let completion = completion {
+                    self.operationDispatcher.dispatchOnMainThread {
+                        completion(nil, error.asPublicError)
+                    }
+                }
+                if userInitiated == false {
+                    self.reportAuthenticationError(error.asPublicError)
+                }
+            } else {
+                self.internalDelegate?.authenticatorDidChangeIdentity { result in
+                    completion?(result.value, result.error)
+                }
+            }
+        }
+    }
+
+    internal func reportAuthenticationError(_ error: PublicError) {
+        guard let delegate else { return }
+
+        self.operationDispatcher.dispatchOnMainThread {
+            delegate.authenticatorDidEncounterError(error)
+        }
+    }
+
+}

--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -170,7 +170,8 @@ public typealias ProductIdentifier = String
             "verification=\(verificationResult)"
         ]
         if let attributes = self.data.response.subscriber.subscriberAttributes {
-            parts.append("attributes=\(attributes)")
+            let keyNames = attributes.attributes.map(\.key)
+            parts.append("attributes=\(keyNames)")
         }
 
         let contents = parts.map { "  " + $0 }.joined(separator: ",\n")

--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -156,19 +156,28 @@ public typealias ProductIdentifier = String
 
         let subscriptionsDescription = self.subscriptionsByProductIdentifier.mapValues { $0.description }
 
+        var parts = [
+            "originalApplicationVersion=\(self.originalApplicationVersion ?? "")",
+            "latestExpirationDate=\(String(describing: self.latestExpirationDate))",
+            "activeEntitlements=\(activeEntitlementsDescription)",
+            "activeSubscriptions=\(activeSubsDescription)",
+            "nonSubscriptions=\(self.nonSubscriptions)",
+            "subscriptions=\(subscriptionsDescription)",
+            "requestDate=\(String(describing: self.requestDate))",
+            "firstSeen=\(String(describing: self.firstSeen))",
+            "originalAppUserId=\(self.originalAppUserId)",
+            "entitlements=\(allEntitlementsDescription)",
+            "verification=\(verificationResult)"
+        ]
+        if let attributes = self.data.response.subscriber.subscriberAttributes {
+            parts.append("attributes=\(attributes)")
+        }
+
+        let contents = parts.map { "  " + $0 }.joined(separator: ",\n")
+
         return """
             <\(String(describing: CustomerInfo.self)):
-            originalApplicationVersion=\(self.originalApplicationVersion ?? ""),
-            latestExpirationDate=\(String(describing: self.latestExpirationDate)),
-            activeEntitlements=\(activeEntitlementsDescription),
-            activeSubscriptions=\(activeSubsDescription),
-            nonSubscriptions=\(self.nonSubscriptions),
-            subscriptions=\(subscriptionsDescription),
-            requestDate=\(String(describing: self.requestDate)),
-            firstSeen=\(String(describing: self.firstSeen)),
-            originalAppUserId=\(self.originalAppUserId),
-            entitlements=\(allEntitlementsDescription)
-            verification=\(verificationResult)
+            \(contents)
             >
             """
     }

--- a/Sources/Identity/Identity.swift
+++ b/Sources/Identity/Identity.swift
@@ -24,7 +24,7 @@ public final class Identity: NSObject {
 //    @objc public static func google(_ token: Data) -> Identity {
 //        Identity(token: .google(token))
 //    }
-    
+
     /// A Sign In With Apple identity
     /// - Parameter identityToken: The `identityToken` from an `ASAuthorizationAppleIDCredential`
     /// - Returns: An ``Identity`` that can be used to log in to the ``Purchases`` type
@@ -46,7 +46,7 @@ public final class Identity: NSObject {
 //    }
 
     internal let authToken: IdentityAuthToken
-    
+
     /// Retrieve the source service of this identity
     @objc public var identitySource: IdentitySource { authToken.authenticationMethod }
 
@@ -61,12 +61,12 @@ public final class Identity: NSObject {
 @_spi(Experimental)
 @objc(RCIdentitySource)
 public final class IdentitySource: NSObject, CaseIterable {
-    
+
     /// An array of all supported identity source values
     public static let allCases: [IdentitySource] = [
         .anonymous, .oidc, .google, .signInWithApple, .facebook, .firebase
     ]
-    
+
     /// The identity is considered "anonymous"
     @objc public static let anonymous = IdentitySource("anonymous")
 

--- a/Sources/Identity/Identity.swift
+++ b/Sources/Identity/Identity.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+/// An identity from an external provider
 @_spi(Experimental)
 @objc(RCIdentity)
 public final class Identity: NSObject {
@@ -23,7 +24,10 @@ public final class Identity: NSObject {
 //    @objc public static func google(_ token: Data) -> Identity {
 //        Identity(token: .google(token))
 //    }
-
+    
+    /// A Sign In With Apple identity
+    /// - Parameter identityToken: The `identityToken` from an `ASAuthorizationAppleIDCredential`
+    /// - Returns: An ``Identity`` that can be used to log in to the ``Purchases`` type
     @objc(identityWithSignInWithAppleToken:)
     public static func signInWithApple(_ identityToken: Data) -> Identity {
         Identity(token: .signInWithApple(identityToken))
@@ -42,7 +46,8 @@ public final class Identity: NSObject {
 //    }
 
     internal let authToken: IdentityAuthToken
-
+    
+    /// Retrieve the source service of this identity
     @objc public var identitySource: IdentitySource { authToken.authenticationMethod }
 
     private init(token: IdentityAuthToken) {
@@ -52,24 +57,39 @@ public final class Identity: NSObject {
 
 }
 
+/// The source of an identity
 @_spi(Experimental)
 @objc(RCIdentitySource)
 public final class IdentitySource: NSObject, CaseIterable {
+    
+    /// An array of all supported identity source values
     public static let allCases: [IdentitySource] = [
         .anonymous, .oidc, .google, .signInWithApple, .facebook, .firebase
     ]
-
+    
+    /// The identity is considered "anonymous"
     @objc public static let anonymous = IdentitySource("anonymous")
+
+    /// The identity is from an OpenID Connect provider
     @objc public static let oidc = IdentitySource("oidc")
+
+    /// The identity is from Google
     @objc public static let google = IdentitySource("google")
+
+    /// The identity is a Sign In With Apple identity
     @objc public static let signInWithApple = IdentitySource("signInWithApple")
+
+    /// The identity is from Facebook
     @objc public static let facebook = IdentitySource("facebook")
+
+    /// The identity is from Firebase
     @objc public static let firebase = IdentitySource("firebase")
 
     internal static func source(with rawValue: String) -> IdentitySource? {
         return allCases.first(where: { $0.rawValue == rawValue })
     }
-
+    
+    /// A raw textual representation of this identity, such as `"anonymous"`
     @objc public let rawValue: String
 
     public override var description: String { rawValue }

--- a/Sources/Identity/Identity.swift
+++ b/Sources/Identity/Identity.swift
@@ -17,14 +17,6 @@ public final class Identity: NSObject {
         Identity(token: .anonymous)
     }
 
-//    @objc public static func oidc(_ token: Data) -> Identity {
-//        Identity(token: .oidc(token))
-//    }
-//
-//    @objc public static func google(_ token: Data) -> Identity {
-//        Identity(token: .google(token))
-//    }
-
     /// A Sign In With Apple identity
     /// - Parameter identityToken: The `identityToken` from an `ASAuthorizationAppleIDCredential`
     /// - Returns: An ``Identity`` that can be used to log in to the ``Purchases`` type
@@ -32,18 +24,6 @@ public final class Identity: NSObject {
     public static func signInWithApple(_ identityToken: Data) -> Identity {
         Identity(token: .signInWithApple(identityToken))
     }
-
-//    @objc public static func facebook(_ idToken: Data) -> Identity {
-//        Identity(token: .facebook(idToken, nil))
-//    }
-//
-//    @objc public static func facebook(idToken: Data, email: String) -> Identity {
-//        Identity(token: .facebook(idToken, email))
-//    }
-//
-//    @objc public static func firebase(_ token: Data) -> Identity {
-//        Identity(token: .firebase(token))
-//    }
 
     internal let authToken: IdentityAuthToken
 

--- a/Sources/Identity/Identity.swift
+++ b/Sources/Identity/Identity.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// An identity from an external provider
-@_spi(Experimental)
+@_spi(Internal)
 @objc(RCIdentity)
 public final class Identity: NSObject {
 
@@ -38,7 +38,7 @@ public final class Identity: NSObject {
 }
 
 /// The source of an identity
-@_spi(Experimental)
+@_spi(Internal)
 @objc(RCIdentitySource)
 public final class IdentitySource: NSObject, CaseIterable {
 

--- a/Sources/Identity/Identity.swift
+++ b/Sources/Identity/Identity.swift
@@ -88,7 +88,7 @@ public final class IdentitySource: NSObject, CaseIterable {
     internal static func source(with rawValue: String) -> IdentitySource? {
         return allCases.first(where: { $0.rawValue == rawValue })
     }
-    
+
     /// A raw textual representation of this identity, such as `"anonymous"`
     @objc public let rawValue: String
 

--- a/Sources/Identity/Identity.swift
+++ b/Sources/Identity/Identity.swift
@@ -1,0 +1,122 @@
+//
+//  Identity.swift
+//  RevenueCat
+//
+//  Created by Dave DeLong on 7/8/26.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+//
+
+import Foundation
+
+@_spi(Experimental)
+@objc(RCIdentity)
+public final class Identity: NSObject {
+
+    internal static var anonymous: Identity {
+        Identity(token: .anonymous)
+    }
+
+//    @objc public static func oidc(_ token: Data) -> Identity {
+//        Identity(token: .oidc(token))
+//    }
+//
+//    @objc public static func google(_ token: Data) -> Identity {
+//        Identity(token: .google(token))
+//    }
+
+    @objc(identityWithSignInWithAppleToken:)
+    public static func signInWithApple(_ identityToken: Data) -> Identity {
+        Identity(token: .signInWithApple(identityToken))
+    }
+
+//    @objc public static func facebook(_ idToken: Data) -> Identity {
+//        Identity(token: .facebook(idToken, nil))
+//    }
+//
+//    @objc public static func facebook(idToken: Data, email: String) -> Identity {
+//        Identity(token: .facebook(idToken, email))
+//    }
+//
+//    @objc public static func firebase(_ token: Data) -> Identity {
+//        Identity(token: .firebase(token))
+//    }
+
+    internal let authToken: IdentityAuthToken
+
+    @objc public var identitySource: IdentitySource { authToken.authenticationMethod }
+
+    private init(token: IdentityAuthToken) {
+        self.authToken = token
+        super.init()
+    }
+
+}
+
+@_spi(Experimental)
+@objc(RCIdentitySource)
+public final class IdentitySource: NSObject, CaseIterable {
+    public static let allCases: [IdentitySource] = [
+        .anonymous, .oidc, .google, .signInWithApple, .facebook, .firebase
+    ]
+
+    @objc public static let anonymous = IdentitySource("anonymous")
+    @objc public static let oidc = IdentitySource("oidc")
+    @objc public static let google = IdentitySource("google")
+    @objc public static let signInWithApple = IdentitySource("signInWithApple")
+    @objc public static let facebook = IdentitySource("facebook")
+    @objc public static let firebase = IdentitySource("firebase")
+
+    internal static func source(with rawValue: String) -> IdentitySource? {
+        return allCases.first(where: { $0.rawValue == rawValue })
+    }
+
+    @objc public let rawValue: String
+
+    public override var description: String { rawValue }
+
+    private init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+}
+
+internal enum IdentityAuthToken: Hashable {
+    case anonymous
+    case oidc(Data)
+    case google(Data)
+    case signInWithApple(Data)
+    case facebook(Data, String?)
+    case firebase(Data)
+
+    var authenticationMethod: IdentitySource {
+        switch self {
+        case .anonymous: return .anonymous
+        case .oidc: return .oidc
+        case .google: return .google
+        case .signInWithApple: return .signInWithApple
+        case .facebook: return .facebook
+        case .firebase: return .firebase
+        }
+    }
+
+    internal var cacheIdentifier: String {
+        switch self {
+        case .anonymous: return "anon"
+        case .oidc(let data): return "oidc-\(data.hashString)"
+        case .google(let data): return "google-\(data.hashString)"
+        case .signInWithApple(let data): return "siwa-\(data.hashString)"
+        case .facebook(let data, _): return "fb-\(data.hashString)"
+        case .firebase(let data): return "firebase-\(data.hashString)"
+        }
+    }
+
+    internal func validate() -> Bool {
+        switch self {
+        case .anonymous: return true
+        case .oidc(let data): return data.isEmpty == false
+        case .google(let data): return data.isEmpty == false
+        case .signInWithApple(let data): return data.isEmpty == false
+        case .facebook(let data, _): return data.isEmpty == false
+        case .firebase(let data): return data.isEmpty == false
+        }
+    }
+}

--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -30,6 +30,7 @@ class IdentityManager: CurrentUserProvider {
     private let deviceCache: DeviceCache
     private let backend: Backend
     private let customerInfoManager: CustomerInfoManager
+    private let tokenManager: TokenManager
     private let attributeSyncing: AttributeSyncing
     // Weak because RemoteConfigManager keeps IdentityManager as its CurrentUserProvider.
     weak var remoteConfigManager: RemoteConfigManagerType?
@@ -41,12 +42,14 @@ class IdentityManager: CurrentUserProvider {
         systemInfo: SystemInfo,
         backend: Backend,
         customerInfoManager: CustomerInfoManager,
+        tokenManager: TokenManager,
         attributeSyncing: AttributeSyncing,
         appUserID: String?
     ) {
         self.deviceCache = deviceCache
         self.backend = backend
         self.customerInfoManager = customerInfoManager
+        self.tokenManager = tokenManager
         self.attributeSyncing = attributeSyncing
 
         let finalAppUserID: String

--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -13,7 +13,7 @@
 
 import Foundation
 
-protocol CurrentUserProvider: Sendable {
+protocol CurrentUserProvider: AnyObject, Sendable {
 
     var currentAppUserID: String { get }
     var currentUserIsAnonymous: Bool { get }

--- a/Sources/Logging/Strings/AuthenticationStrings.swift
+++ b/Sources/Logging/Strings/AuthenticationStrings.swift
@@ -1,0 +1,36 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  AuthenticationStrings.swift
+//
+//  Created by Dave DeLong on 8/19/26.
+
+import Foundation
+
+// swiftlint:disable identifier_name
+enum AuthenticationStrings {
+
+    case unknownItem(_ key: String)
+    case failedModification(_ key: String, _ error: any Error)
+}
+
+
+extension AuthenticationStrings: LogMessage {
+
+    var description: String {
+        switch self {
+        case .unknownItem(let key):
+            return "Unknown secure item: \(key)"
+        case .failedModification(let key, let error):
+            return "Failed to modify item \(key): \(error)"
+        }
+    }
+
+    var category: String { "authentication" }
+}

--- a/Sources/Logging/Strings/AuthenticationStrings.swift
+++ b/Sources/Logging/Strings/AuthenticationStrings.swift
@@ -13,13 +13,11 @@
 
 import Foundation
 
-// swiftlint:disable identifier_name
 enum AuthenticationStrings {
 
     case unknownItem(_ key: String)
     case failedModification(_ key: String, _ error: any Error)
 }
-
 
 extension AuthenticationStrings: LogMessage {
 

--- a/Sources/Logging/Strings/Strings.swift
+++ b/Sources/Logging/Strings/Strings.swift
@@ -16,6 +16,7 @@ enum Strings {
 
     static let attribution = AttributionStrings.self
     static let analytics = AnalyticsStrings.self
+    static let authentication = AuthenticationStrings.self
     static let cache = CacheStrings.self
     static let codable = CodableStrings.self
     static let configure = ConfigureStrings.self

--- a/Sources/Misc/Concurrency/Purchases+async.swift
+++ b/Sources/Misc/Concurrency/Purchases+async.swift
@@ -30,23 +30,6 @@ extension Purchases {
         }
     }
 
-    func logInAsync(_ appUserID: String) async throws -> (customerInfo: CustomerInfo, created: Bool) {
-        return try await withUnsafeThrowingContinuation { continuation in
-            logIn(appUserID) { customerInfo, created, error in
-                continuation.resume(with: Result(customerInfo, error)
-                                        .map { ($0, created) })
-            }
-        }
-    }
-
-    func logOutAsync() async throws -> CustomerInfo {
-        return try await withUnsafeThrowingContinuation { continuation in
-            logOut { customerInfo, error in
-                continuation.resume(with: Result(customerInfo, error))
-            }
-        }
-    }
-
     func syncAttributesAndOfferingsIfNeededAsync() async throws -> Offerings? {
         return try await withUnsafeThrowingContinuation { continuation in
             syncAttributesAndOfferingsIfNeeded { offerings, error in

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -33,6 +33,7 @@ class Backend {
         systemInfo: SystemInfo,
         httpClientTimeout: NetworkTimeout = .default,
         eTagManager: ETagManager,
+        tokenManager: TokenManager,
         operationDispatcher: OperationDispatcher,
         attributionFetcher: AttributionFetcher,
         offlineCustomerInfoCreator: OfflineCustomerInfoCreator?,
@@ -70,6 +71,7 @@ class Backend {
         let remoteConfigConfig = BackendConfiguration(
             httpClient: .dedicatedRemoteConfig(systemInfo: systemInfo,
                                                eTagManager: eTagManager,
+                                               tokenManager: tokenManager,
                                                diagnosticsTracker: diagnosticsTracker,
                                                networkTimeout: httpClientTimeout,
                                                apiSourceFailover: apiSourceFailover,
@@ -312,6 +314,7 @@ private extension HTTPClient {
     static func dedicatedRemoteConfig(
         systemInfo: SystemInfo,
         eTagManager: ETagManager,
+        tokenManager: TokenManager,
         diagnosticsTracker: DiagnosticsTrackerType?,
         networkTimeout: NetworkTimeout,
         apiSourceFailover: APISourceFailoverType?,

--- a/Sources/Networking/HTTPClient/TokenManager.swift
+++ b/Sources/Networking/HTTPClient/TokenManager.swift
@@ -1,0 +1,134 @@
+//
+//  TokenManager.swift
+//  RevenueCat
+//
+//  Created by Dave DeLong on 7/13/26.
+//
+
+import Foundation
+
+class TokenManager {
+
+    fileprivate enum Key {
+        case refresh(String)
+        case access(String)
+        case id(String)
+
+        var identifier: String {
+            switch self {
+            case .refresh(let user): return "RC-refresh-\(user)"
+            case .access(let user): return "RC-access-\(user)"
+            case .id(let user): return "RC-id-\(user)"
+            }
+        }
+    }
+
+    let enabled: Bool
+    private let storage: any SecureItemStorage
+
+    weak var currentUserProvider: CurrentUserProvider?
+
+    private var currentUser: String? { currentUserProvider?.currentAppUserID }
+
+    init(enabled: Bool, storage: any SecureItemStorage) {
+        self.enabled = enabled
+        self.storage = storage
+    }
+
+    var reportError: ((PublicError) -> Void)?
+
+    var hasCurrentAccessToken: Bool { currentAccessToken != nil }
+
+    var currentRefreshToken: String? {
+        get {
+            guard enabled == true else { return nil }
+            guard let user = currentUser else { return nil }
+            return storage.string(for: .refresh(user))
+        }
+        set {
+            guard enabled == true else { return }
+            guard let user = currentUser else { return }
+            storage.setString(newValue, for: .refresh(user))
+        }
+    }
+
+    var currentAccessToken: String? {
+        get {
+            guard enabled == true else { return nil }
+            guard let user = currentUser else { return nil }
+            return storage.string(for: .access(user))
+        }
+        set {
+            guard enabled == true else { return }
+            guard let user = currentUser else { return }
+            storage.setString(newValue, for: .access(user))
+        }
+    }
+
+    var currentIDToken: String? {
+        get {
+            guard enabled == true else { return nil }
+            guard let user = currentUser else { return nil }
+            return storage.string(for: .id(user))
+        }
+        set {
+            guard enabled == true else { return }
+            guard let user = currentUser else { return }
+            storage.setString(newValue, for: .id(user))
+        }
+    }
+
+    var currentIdentitySources: [IdentitySource]? {
+        guard let currentIDToken else { return nil }
+        guard let jwt = try? JWT(from: currentIDToken) else { return nil }
+        return jwt.amr?.compactMap { IdentitySource.source(with: $0) }
+    }
+
+    var isCurrentIdentityAnonymous: Bool {
+        // returns true iff all (1+) the amr claim values are "anonymous"
+        guard let sources = currentIdentitySources else { return false }
+        if sources.isEmpty { return false }
+        return sources.allSatisfy { $0 == .anonymous }
+    }
+
+    var currentIdentitySource: IdentitySource? {
+        currentIdentitySources?.last
+    }
+
+    func idToken(for user: String) -> String? {
+        storage.string(for: .id(user))
+    }
+
+    func saveTokens(refreshToken: String?, accessToken: String, idToken: String?, for userID: String) {
+        storage.setString(refreshToken, for: .refresh(userID))
+        storage.setString(accessToken, for: .access(userID))
+        storage.setString(idToken, for: .id(userID))
+    }
+
+    func deleteTokens(for userID: String) {
+        storage.setString(nil, for: .refresh(userID))
+        storage.setString(nil, for: .access(userID))
+        storage.setString(nil, for: .id(userID))
+    }
+
+    func deleteAccessToken(for userID: String) {
+        storage.setString(nil, for: .access(userID))
+    }
+
+}
+
+extension SecureItemStorage {
+
+    fileprivate func string(for key: TokenManager.Key) -> String? {
+        guard let data = try? self.readItem(identifier: key.identifier) else {
+            return nil
+        }
+        return String(bytes: data, encoding: .utf8)
+    }
+
+    fileprivate func setString(_ string: String?, for key: TokenManager.Key) {
+        let data = string.map { Data($0.utf8) }
+        try? self.modifyItem(identifier: key.identifier, contents: data)
+    }
+
+}

--- a/Sources/Networking/HTTPClient/TokenManager.swift
+++ b/Sources/Networking/HTTPClient/TokenManager.swift
@@ -78,23 +78,6 @@ class TokenManager {
         }
     }
 
-    var currentIdentitySources: [IdentitySource]? {
-        guard let currentIDToken else { return nil }
-        guard let jwt = try? JWT(from: currentIDToken) else { return nil }
-        return jwt.amr?.compactMap { IdentitySource.source(with: $0) }
-    }
-
-    var isCurrentIdentityAnonymous: Bool {
-        // returns true iff all (1+) the amr claim values are "anonymous"
-        guard let sources = currentIdentitySources else { return false }
-        if sources.isEmpty { return false }
-        return sources.allSatisfy { $0 == .anonymous }
-    }
-
-    var currentIdentitySource: IdentitySource? {
-        currentIdentitySources?.last
-    }
-
     func idToken(for user: String) -> String? {
         storage.string(for: .id(user))
     }

--- a/Sources/Networking/HTTPClient/TokenManager.swift
+++ b/Sources/Networking/HTTPClient/TokenManager.swift
@@ -104,6 +104,7 @@ extension SecureItemStorage {
 
     fileprivate func string(for key: TokenManager.Key) -> String? {
         guard let data = try? self.readItem(identifier: key.identifier) else {
+            Logger.debug(Strings.authentication.unknownItem(key.identifier))
             return nil
         }
         return String(bytes: data, encoding: .utf8)
@@ -111,7 +112,11 @@ extension SecureItemStorage {
 
     fileprivate func setString(_ string: String?, for key: TokenManager.Key) {
         let data = string.map { Data($0.utf8) }
-        try? self.modifyItem(identifier: key.identifier, contents: data)
+        do {
+            try self.modifyItem(identifier: key.identifier, contents: data)
+        } catch {
+            Logger.warn(Strings.authentication.failedModification(key.identifier, error))
+        }
     }
 
 }

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -372,7 +372,7 @@ import Foundation
         /// Enabling tells the SDK to prefer using token-based user sessions for communicating with the server.
         ///
         /// - SeeAlso: ``with(iamEnabled:keychainAccessGroup:)``
-        @_spi(Experimental)
+        @_spi(Internal)
         @objc(withIAMEnabled:) public func with(iamEnabled: Bool) -> Builder {
             self.iamEnabled = iamEnabled
             self.keychainAccessGroup = nil
@@ -383,7 +383,7 @@ import Foundation
         ///
         /// Enabling tells the SDK to prefer using token-based user sessions for communicating with the server.
         /// Use the `keychainAccessGroup` parameter to share tokens between your app and its extensions.
-        @_spi(Experimental)
+        @_spi(Internal)
         @objc(withIAMEnabled:keychainAccessGroup:) public func with(iamEnabled: Bool,
                                                                     keychainAccessGroup: String) -> Builder {
             self.iamEnabled = iamEnabled

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -61,6 +61,7 @@ import Foundation
         let automaticDeviceIdentifierCollectionEnabled: Bool
         let diagnosticsEnabled: Bool
         let iamEnabled: Bool
+        let keychainAccessGroup: String?
     }
 
     internal let storage: Storage
@@ -84,6 +85,7 @@ import Foundation
     }
     internal var diagnosticsEnabled: Bool { self.storage.diagnosticsEnabled }
     internal var iamEnabled: Bool { self.storage.iamEnabled }
+    internal var keychainAccessGroup: String? { self.storage.keychainAccessGroup }
 
     private init(with builder: Builder) {
         self.storage = Storage(
@@ -101,7 +103,8 @@ import Foundation
             preferredLocale: builder.preferredLocale,
             automaticDeviceIdentifierCollectionEnabled: builder.automaticDeviceIdentifierCollectionEnabled,
             diagnosticsEnabled: builder.diagnosticsEnabled,
-            iamEnabled: builder.iamEnabled
+            iamEnabled: builder.iamEnabled,
+            keychainAccessGroup: builder.keychainAccessGroup
         )
     }
 
@@ -153,6 +156,7 @@ import Foundation
         private(set) var showStoreMessagesAutomatically: Bool = true
         private(set) var diagnosticsEnabled: Bool = false
         private(set) var iamEnabled: Bool = false
+        private(set) var keychainAccessGroup: String? = nil
         private(set) var storeKitVersion: StoreKitVersion = .default
 
         /// The preferred locale for the requests.
@@ -366,9 +370,24 @@ import Foundation
         /// Set `iamEnabled`. This is *disabled* by default.
         ///
         /// Enabling tells the SDK to prefer using token-based user sessions for communicating with the server.
+        ///
+        /// - SeeAlso: ``with(iamEnabled:keychainAccessGroup:)``
         @_spi(Experimental)
         @objc(withIAMEnabled:) public func with(iamEnabled: Bool) -> Builder {
             self.iamEnabled = iamEnabled
+            self.keychainAccessGroup = nil
+            return self
+        }
+
+        /// Set `iamEnabled` with a specific keychain access group. This is *disabled* by default.
+        ///
+        /// Enabling tells the SDK to prefer using token-based user sessions for communicating with the server.
+        /// Use the `keychainAccessGroup` parameter to share tokens between your app and its extensions.
+        @_spi(Experimental)
+        @objc(withIAMEnabled:keychainAccessGroup:) public func with(iamEnabled: Bool,
+                                                                    keychainAccessGroup: String) -> Builder {
+            self.iamEnabled = iamEnabled
+            self.keychainAccessGroup = keychainAccessGroup
             return self
         }
 

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -156,7 +156,7 @@ import Foundation
         private(set) var showStoreMessagesAutomatically: Bool = true
         private(set) var diagnosticsEnabled: Bool = false
         private(set) var iamEnabled: Bool = false
-        private(set) var keychainAccessGroup: String? = nil
+        private(set) var keychainAccessGroup: String?
         private(set) var storeKitVersion: StoreKitVersion = .default
 
         /// The preferred locale for the requests.

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -286,6 +286,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
     private let deviceCache: DeviceCache
     private let paywallCache: PaywallCacheWarmingType?
     private let identityManager: IdentityManager
+    private let tokenManager: TokenManager
     private let userDefaults: UserDefaults
     private let notificationCenter: NotificationCenter
     private let offeringsFactory: OfferingsFactory
@@ -384,6 +385,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
         let receiptFetcher = ReceiptFetcher(requestFetcher: fetcher, systemInfo: systemInfo)
         let eTagManager = ETagManager()
+        let tokenManager = TokenManager(enabled: iamEnabled, storage: Keychain(access: nil))
         let attributionTypeFactory = AttributionTypeFactory()
         let attributionFetcher = AttributionFetcher(attributionFactory: attributionTypeFactory, systemInfo: systemInfo)
         let userDefaults = userDefaults ?? UserDefaults.computeDefault()
@@ -425,6 +427,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             systemInfo: systemInfo,
             httpClientTimeout: networkTimeout,
             eTagManager: eTagManager,
+            tokenManager: tokenManager,
             operationDispatcher: operationDispatcher,
             attributionFetcher: attributionFetcher,
             offlineCustomerInfoCreator: .createIfAvailable(
@@ -515,6 +518,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                                               systemInfo: systemInfo,
                                               backend: backend,
                                               customerInfoManager: customerInfoManager,
+                                              tokenManager: tokenManager,
                                               attributeSyncing: subscriberAttributesManager,
                                               appUserID: appUserID
         )
@@ -540,6 +544,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             )
         }()
         identityManager.remoteConfigManager = remoteConfigManager
+        tokenManager.currentUserProvider = identityManager
 
         let eventsManager: EventsManagerType?
         if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *),
@@ -809,6 +814,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                   deviceCache: deviceCache,
                   paywallCache: paywallCache,
                   identityManager: identityManager,
+                  tokenManager: tokenManager,
                   subscriberAttributes: subscriberAttributes,
                   operationDispatcher: operationDispatcher,
                   customerInfoManager: customerInfoManager,
@@ -845,6 +851,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
          deviceCache: DeviceCache,
          paywallCache: PaywallCacheWarmingType?,
          identityManager: IdentityManager,
+         tokenManager: TokenManager,
          subscriberAttributes: Attribution,
          operationDispatcher: OperationDispatcher,
          customerInfoManager: CustomerInfoManager,
@@ -897,6 +904,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.deviceCache = deviceCache
         self.paywallCache = paywallCache
         self.identityManager = identityManager
+        self.tokenManager = tokenManager
         self.userDefaults = userDefaults
         self.notificationCenter = notificationCenter
         self.systemInfo = systemInfo
@@ -920,6 +928,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.currentConfiguration = currentConfiguration
         self._authentication = Authentication(backend: backend,
                                               identityManager: identityManager,
+                                              tokenManager: tokenManager,
                                               operationDispatcher: operationDispatcher,
                                               systemInfo: systemInfo)
 
@@ -2648,7 +2657,7 @@ extension Purchases: InternalPurchasesType {
 }
 
 /// Necessary because `ErrorUtils` inside of `Purchases` finds the obsoleted type.
-private typealias NewErrorUtils = ErrorUtils
+internal typealias NewErrorUtils = ErrorUtils
 
 // MARK: - Custom Paywall Impressions
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1211,6 +1211,8 @@ public extension Purchases {
 
 }
 
+#endif
+
 extension Purchases: InternalAuthenticatorDelegate {
 
     func authenticatorDidLogIn(info: CustomerInfo?, error: PublicError?) {
@@ -1228,8 +1230,6 @@ extension Purchases: InternalAuthenticatorDelegate {
     }
 
 }
-
-#endif
 
 // - MARK: - Custom entitlement computation API
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1239,7 +1239,7 @@ public extension Purchases {
 
 extension Purchases: InternalAuthenticatorDelegate {
 
-    func authenticatorDidLogIn(info: CustomerInfo?, error: PublicError?) {
+    func authenticatorDidLogIn(info: CustomerInfo) {
         self.systemInfo.isApplicationBackgrounded { isAppBackgrounded in
             self.updateOfferingsCache(isAppBackgrounded: isAppBackgrounded)
             self.remoteConfigManager.refreshRemoteConfig(

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1147,7 +1147,7 @@ public extension Purchases {
 
 public extension Purchases {
 
-    @_spi(Experimental)
+    @_spi(Internal)
     @objc
     var authentication: Authentication { _authentication }
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1235,6 +1235,8 @@ public extension Purchases {
 
 }
 
+#endif
+
 extension Purchases: InternalAuthenticatorDelegate {
 
     func authenticatorDidLogIn(info: CustomerInfo?, error: PublicError?) {
@@ -1252,8 +1254,6 @@ extension Purchases: InternalAuthenticatorDelegate {
     }
 
 }
-
-#endif
 
 // - MARK: - Custom entitlement computation API
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -518,6 +518,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                                               systemInfo: systemInfo,
                                               backend: backend,
                                               customerInfoManager: customerInfoManager,
+                                              tokenManager: tokenManager,
                                               attributeSyncing: subscriberAttributesManager,
                                               appUserID: appUserID
         )
@@ -1121,6 +1122,7 @@ public extension Purchases {
 public extension Purchases {
 
     @_spi(Experimental)
+    @objc
     var authentication: Authentication { _authentication }
 
     @available(*, deprecated, message: """

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -518,7 +518,6 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                                               systemInfo: systemInfo,
                                               backend: backend,
                                               customerInfoManager: customerInfoManager,
-                                              tokenManager: tokenManager,
                                               attributeSyncing: subscriberAttributesManager,
                                               appUserID: appUserID
         )

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -356,6 +356,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                      preferredLocale: String?,
                      automaticDeviceIdentifierCollectionEnabled: Bool = true,
                      iamEnabled: Bool = false,
+                     keychainAccessGroup: String? = nil,
                      currentConfiguration: Configuration?
     ) {
         if userDefaults != nil {
@@ -385,7 +386,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
         let receiptFetcher = ReceiptFetcher(requestFetcher: fetcher, systemInfo: systemInfo)
         let eTagManager = ETagManager()
-        let tokenManager = TokenManager(enabled: iamEnabled, storage: Keychain(access: nil))
+        let accessGroup = keychainAccessGroup.map { Keychain.AccessGroup(accessGroup: $0, appIdentifier: apiKey) }
+        let tokenManager = TokenManager(enabled: iamEnabled, storage: Keychain(access: accessGroup))
         let attributionTypeFactory = AttributionTypeFactory()
         let attributionFetcher = AttributionFetcher(attributionFactory: attributionTypeFactory, systemInfo: systemInfo)
         let userDefaults = userDefaults ?? UserDefaults.computeDefault()
@@ -2107,6 +2109,7 @@ public extension Purchases {
                 preferredLocale: configuration.preferredLocale,
                 automaticDeviceIdentifierCollectionEnabled: configuration.automaticDeviceIdentifierCollectionEnabled,
                 iamEnabled: configuration.iamEnabled,
+                keychainAccessGroup: configuration.keychainAccessGroup,
                 currentConfiguration: configuration
             ),
             dedupingAgainst: configuration
@@ -2378,7 +2381,8 @@ public extension Purchases {
         diagnosticsEnabled: Bool,
         preferredLocale: String?,
         automaticDeviceIdentifierCollectionEnabled: Bool = true,
-        iamEnabled: Bool = false
+        iamEnabled: Bool = false,
+        keychainAccessGroup: String? = nil
     ) -> Purchases {
         return self.setDefaultInstance(
             .init(apiKey: apiKey,
@@ -2397,6 +2401,7 @@ public extension Purchases {
                   preferredLocale: preferredLocale,
                   automaticDeviceIdentifierCollectionEnabled: automaticDeviceIdentifierCollectionEnabled,
                   iamEnabled: iamEnabled,
+                  keychainAccessGroup: keychainAccessGroup,
                   currentConfiguration: nil)
         )
     }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -518,6 +518,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                                               systemInfo: systemInfo,
                                               backend: backend,
                                               customerInfoManager: customerInfoManager,
+                                              tokenManager: tokenManager,
                                               attributeSyncing: subscriberAttributesManager,
                                               appUserID: appUserID
         )
@@ -1145,6 +1146,7 @@ public extension Purchases {
 public extension Purchases {
 
     @_spi(Experimental)
+    @objc
     var authentication: Authentication { _authentication }
 
     @available(*, deprecated, message: """

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -286,6 +286,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
     private let deviceCache: DeviceCache
     private let paywallCache: PaywallCacheWarmingType?
     private let identityManager: IdentityManager
+    private let tokenManager: TokenManager
     private let userDefaults: UserDefaults
     private let notificationCenter: NotificationCenter
     private let offeringsFactory: OfferingsFactory
@@ -384,6 +385,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
         let receiptFetcher = ReceiptFetcher(requestFetcher: fetcher, systemInfo: systemInfo)
         let eTagManager = ETagManager()
+        let tokenManager = TokenManager(enabled: iamEnabled, storage: Keychain(access: nil))
         let attributionTypeFactory = AttributionTypeFactory()
         let attributionFetcher = AttributionFetcher(attributionFactory: attributionTypeFactory, systemInfo: systemInfo)
         let userDefaults = userDefaults ?? UserDefaults.computeDefault()
@@ -425,6 +427,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             systemInfo: systemInfo,
             httpClientTimeout: networkTimeout,
             eTagManager: eTagManager,
+            tokenManager: tokenManager,
             operationDispatcher: operationDispatcher,
             attributionFetcher: attributionFetcher,
             offlineCustomerInfoCreator: .createIfAvailable(
@@ -515,6 +518,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                                               systemInfo: systemInfo,
                                               backend: backend,
                                               customerInfoManager: customerInfoManager,
+                                              tokenManager: tokenManager,
                                               attributeSyncing: subscriberAttributesManager,
                                               appUserID: appUserID
         )
@@ -540,6 +544,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             )
         }()
         identityManager.remoteConfigManager = remoteConfigManager
+        tokenManager.currentUserProvider = identityManager
 
         let eventsManager: EventsManagerType?
         if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *),
@@ -792,6 +797,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                   deviceCache: deviceCache,
                   paywallCache: paywallCache,
                   identityManager: identityManager,
+                  tokenManager: tokenManager,
                   subscriberAttributes: subscriberAttributes,
                   operationDispatcher: operationDispatcher,
                   customerInfoManager: customerInfoManager,
@@ -828,6 +834,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
          deviceCache: DeviceCache,
          paywallCache: PaywallCacheWarmingType?,
          identityManager: IdentityManager,
+         tokenManager: TokenManager,
          subscriberAttributes: Attribution,
          operationDispatcher: OperationDispatcher,
          customerInfoManager: CustomerInfoManager,
@@ -880,6 +887,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.deviceCache = deviceCache
         self.paywallCache = paywallCache
         self.identityManager = identityManager
+        self.tokenManager = tokenManager
         self.userDefaults = userDefaults
         self.notificationCenter = notificationCenter
         self.systemInfo = systemInfo
@@ -903,6 +911,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.currentConfiguration = currentConfiguration
         self._authentication = Authentication(backend: backend,
                                               identityManager: identityManager,
+                                              tokenManager: tokenManager,
                                               operationDispatcher: operationDispatcher,
                                               systemInfo: systemInfo)
 
@@ -2524,7 +2533,7 @@ extension Purchases: InternalPurchasesType {
 }
 
 /// Necessary because `ErrorUtils` inside of `Purchases` finds the obsoleted type.
-private typealias NewErrorUtils = ErrorUtils
+internal typealias NewErrorUtils = ErrorUtils
 
 // MARK: - Custom Paywall Impressions
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -281,6 +281,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
     private let attributionFetcher: AttributionFetcher
     private let attributionPoster: AttributionPoster
+    private let _authentication: Authentication
     private let backend: Backend
     private let deviceCache: DeviceCache
     private let paywallCache: PaywallCacheWarmingType?
@@ -900,8 +901,13 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.healthManager = healthManager
         self.transactionMetadataSyncHelper = transactionMetadataSyncHelper
         self.currentConfiguration = currentConfiguration
+        self._authentication = Authentication(backend: backend,
+                                              identityManager: identityManager,
+                                              operationDispatcher: operationDispatcher,
+                                              systemInfo: systemInfo)
 
         super.init()
+        self._authentication.internalDelegate = self
 
         self.identityManager.remoteConfigManager = self.remoteConfigManager
         self.remoteConfigManager.onRemoteConfigDisabled = { [weak self] in
@@ -1106,15 +1112,16 @@ public extension Purchases {
 
 public extension Purchases {
 
+    @_spi(Experimental)
+    var authentication: Authentication { _authentication }
+
     @available(*, deprecated, message: """
     The appUserID passed to logIn is a constant string known at compile time.
     This is likely a programmer error. This ID is used to identify the current user.
     See https://docs.revenuecat.com/docs/user-ids for more information.
     """)
     func logIn(_ appUserID: StaticString, completion: @escaping (CustomerInfo?, Bool, PublicError?) -> Void) {
-        Logger.warn(Strings.identity.logging_in_with_static_string)
-
-        self.logIn("\(appUserID)", completion: completion)
+        _authentication.identifyCurrentUser(as: appUserID, completion: completion)
     }
 
     // Favor `StaticString` overload (`String` is not convertible to `StaticString`).
@@ -1123,31 +1130,16 @@ public extension Purchases {
     @_disfavoredOverload
     @objc(logIn:completion:)
     func logIn(_ appUserID: String, completion: @escaping (CustomerInfo?, Bool, PublicError?) -> Void) {
-        let normalizedAppUserID = appUserID.trimmingWhitespacesAndNewLines
-
-        self.identityManager.logIn(appUserID: normalizedAppUserID) { result in
-            self.operationDispatcher.dispatchOnMainThread {
-                completion(result.value?.info, result.value?.created ?? false, result.error?.asPublicError)
-            }
-
-            guard case .success = result else {
-                return
-            }
-
-            self.systemInfo.isApplicationBackgrounded { isAppBackgrounded in
-                self.updateOfferingsCache(isAppBackgrounded: isAppBackgrounded)
-                self.remoteConfigManager.refreshRemoteConfig(
-                    fetchContext: .identityChange,
-                    isAppBackgrounded: isAppBackgrounded
-                )
-            }
-        }
+        _authentication.identifyCurrentUser(as: appUserID, completion: completion)
     }
 
+    @available(*, deprecated, message: """
+    The appUserID passed to logIn is a constant string known at compile time.
+    This is likely a programmer error. This ID is used to identify the current user.
+    See https://docs.revenuecat.com/docs/user-ids for more information.
+    """)
     func logIn(_ appUserID: StaticString) async throws -> (customerInfo: CustomerInfo, created: Bool) {
-        Logger.warn(Strings.identity.logging_in_with_static_string)
-
-        return try await self.logIn("\(appUserID)")
+        try await _authentication.identifyCurrentUser(as: appUserID)
     }
 
     // Favor `StaticString` overload (`String` is not convertible to `StaticString`).
@@ -1155,33 +1147,15 @@ public extension Purchases {
     // call logIn with hardcoded user ids in their app
     @_disfavoredOverload
     func logIn(_ appUserID: String) async throws -> (customerInfo: CustomerInfo, created: Bool) {
-        return try await self.logInAsync(appUserID)
+        try await _authentication.identifyCurrentUser(as: appUserID)
     }
 
     @objc func logOut(completion: ((CustomerInfo?, PublicError?) -> Void)?) {
-        guard !self.systemInfo.dangerousSettings.customEntitlementComputation else {
-            completion?(nil, NewErrorUtils.featureNotAvailableInCustomEntitlementsComputationModeError().asPublicError)
-            return
-       }
-
-        self.identityManager.logOut { error in
-            guard error == nil else {
-                if let completion = completion {
-                    self.operationDispatcher.dispatchOnMainThread {
-                        completion(nil, error?.asPublicError)
-                    }
-                }
-                return
-            }
-
-            self.updateAllCaches(fetchContext: .identityChange) {
-                completion?($0.value, $0.error)
-            }
-        }
+        _authentication.logOut(completion: completion)
     }
 
     func logOut() async throws -> CustomerInfo {
-        return try await logOutAsync()
+        return try await _authentication.logOut()
     }
 
     @objc func syncAttributesAndOfferingsIfNeeded(completion: @escaping (Offerings?, PublicError?) -> Void) {
@@ -1223,6 +1197,24 @@ public extension Purchases {
 
     func getStorefront() async -> Storefront? {
         return await getStorefrontAsync()
+    }
+
+}
+
+extension Purchases: InternalAuthenticatorDelegate {
+
+    func authenticatorDidLogIn(info: CustomerInfo?, error: PublicError?) {
+        self.systemInfo.isApplicationBackgrounded { isAppBackgrounded in
+            self.updateOfferingsCache(isAppBackgrounded: isAppBackgrounded)
+            self.remoteConfigManager.refreshRemoteConfig(
+                fetchContext: .identityChange,
+                isAppBackgrounded: isAppBackgrounded
+            )
+        }
+    }
+
+    func authenticatorDidChangeIdentity(completion: @escaping (Result<CustomerInfo, PublicError>) -> Void) {
+        self.updateAllCaches(fetchContext: .identityChange, completion: completion)
     }
 
 }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -281,6 +281,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
     private let attributionFetcher: AttributionFetcher
     private let attributionPoster: AttributionPoster
+    private let _authentication: Authentication
     private let backend: Backend
     private let deviceCache: DeviceCache
     private let paywallCache: PaywallCacheWarmingType?
@@ -917,8 +918,13 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.healthManager = healthManager
         self.transactionMetadataSyncHelper = transactionMetadataSyncHelper
         self.currentConfiguration = currentConfiguration
+        self._authentication = Authentication(backend: backend,
+                                              identityManager: identityManager,
+                                              operationDispatcher: operationDispatcher,
+                                              systemInfo: systemInfo)
 
         super.init()
+        self._authentication.internalDelegate = self
 
         self.identityManager.remoteConfigManager = self.remoteConfigManager
         self.remoteConfigManager.onRemoteConfigDisabled = { [weak self] in
@@ -1130,15 +1136,16 @@ public extension Purchases {
 
 public extension Purchases {
 
+    @_spi(Experimental)
+    var authentication: Authentication { _authentication }
+
     @available(*, deprecated, message: """
     The appUserID passed to logIn is a constant string known at compile time.
     This is likely a programmer error. This ID is used to identify the current user.
     See https://docs.revenuecat.com/docs/user-ids for more information.
     """)
     func logIn(_ appUserID: StaticString, completion: @escaping (CustomerInfo?, Bool, PublicError?) -> Void) {
-        Logger.warn(Strings.identity.logging_in_with_static_string)
-
-        self.logIn("\(appUserID)", completion: completion)
+        _authentication.identifyCurrentUser(as: appUserID, completion: completion)
     }
 
     // Favor `StaticString` overload (`String` is not convertible to `StaticString`).
@@ -1147,31 +1154,16 @@ public extension Purchases {
     @_disfavoredOverload
     @objc(logIn:completion:)
     func logIn(_ appUserID: String, completion: @escaping (CustomerInfo?, Bool, PublicError?) -> Void) {
-        let normalizedAppUserID = appUserID.trimmingWhitespacesAndNewLines
-
-        self.identityManager.logIn(appUserID: normalizedAppUserID) { result in
-            self.operationDispatcher.dispatchOnMainThread {
-                completion(result.value?.info, result.value?.created ?? false, result.error?.asPublicError)
-            }
-
-            guard case .success = result else {
-                return
-            }
-
-            self.systemInfo.isApplicationBackgrounded { isAppBackgrounded in
-                self.updateOfferingsCache(isAppBackgrounded: isAppBackgrounded)
-                self.remoteConfigManager.refreshRemoteConfig(
-                    fetchContext: .identityChange,
-                    isAppBackgrounded: isAppBackgrounded
-                )
-            }
-        }
+        _authentication.identifyCurrentUser(as: appUserID, completion: completion)
     }
 
+    @available(*, deprecated, message: """
+    The appUserID passed to logIn is a constant string known at compile time.
+    This is likely a programmer error. This ID is used to identify the current user.
+    See https://docs.revenuecat.com/docs/user-ids for more information.
+    """)
     func logIn(_ appUserID: StaticString) async throws -> (customerInfo: CustomerInfo, created: Bool) {
-        Logger.warn(Strings.identity.logging_in_with_static_string)
-
-        return try await self.logIn("\(appUserID)")
+        try await _authentication.identifyCurrentUser(as: appUserID)
     }
 
     // Favor `StaticString` overload (`String` is not convertible to `StaticString`).
@@ -1179,33 +1171,15 @@ public extension Purchases {
     // call logIn with hardcoded user ids in their app
     @_disfavoredOverload
     func logIn(_ appUserID: String) async throws -> (customerInfo: CustomerInfo, created: Bool) {
-        return try await self.logInAsync(appUserID)
+        try await _authentication.identifyCurrentUser(as: appUserID)
     }
 
     @objc func logOut(completion: ((CustomerInfo?, PublicError?) -> Void)?) {
-        guard !self.systemInfo.dangerousSettings.customEntitlementComputation else {
-            completion?(nil, NewErrorUtils.featureNotAvailableInCustomEntitlementsComputationModeError().asPublicError)
-            return
-       }
-
-        self.identityManager.logOut { error in
-            guard error == nil else {
-                if let completion = completion {
-                    self.operationDispatcher.dispatchOnMainThread {
-                        completion(nil, error?.asPublicError)
-                    }
-                }
-                return
-            }
-
-            self.updateAllCaches(fetchContext: .identityChange) {
-                completion?($0.value, $0.error)
-            }
-        }
+        _authentication.logOut(completion: completion)
     }
 
     func logOut() async throws -> CustomerInfo {
-        return try await logOutAsync()
+        return try await _authentication.logOut()
     }
 
     @objc func syncAttributesAndOfferingsIfNeeded(completion: @escaping (Offerings?, PublicError?) -> Void) {
@@ -1247,6 +1221,24 @@ public extension Purchases {
 
     func getStorefront() async -> Storefront? {
         return await getStorefrontAsync()
+    }
+
+}
+
+extension Purchases: InternalAuthenticatorDelegate {
+
+    func authenticatorDidLogIn(info: CustomerInfo?, error: PublicError?) {
+        self.systemInfo.isApplicationBackgrounded { isAppBackgrounded in
+            self.updateOfferingsCache(isAppBackgrounded: isAppBackgrounded)
+            self.remoteConfigManager.refreshRemoteConfig(
+                fetchContext: .identityChange,
+                isAppBackgrounded: isAppBackgrounded
+            )
+        }
+    }
+
+    func authenticatorDidChangeIdentity(completion: @escaping (Result<CustomerInfo, PublicError>) -> Void) {
+        self.updateAllCaches(fetchContext: .identityChange, completion: completion)
     }
 
 }

--- a/Sources/Security/Keychain.swift
+++ b/Sources/Security/Keychain.swift
@@ -132,7 +132,6 @@ struct Keychain: SecureItemStorage {
 
         // the identifier of this particular app (and its extensions)
         // this is used to disambiguate values saved by other apps
-        // to prevent values from
         let appIdentifier: String
     }
 

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCAuthenticationAPI.h
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCAuthenticationAPI.h
@@ -1,0 +1,19 @@
+//
+//  RCAuthenticationAPI.h
+//  ObjcAPITester
+//
+//  Created by Dave DeLong on 8/13/26.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RCAuthenticationAPI : NSObject
+
++ (void)checkAPI;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCAuthenticationAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCAuthenticationAPI.m
@@ -1,0 +1,38 @@
+//
+//  RCAuthenticationAPI.m
+//  ObjcAPITester
+//
+//  Created by Dave DeLong on 8/13/26.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+//
+
+#import "RCAuthenticationAPI.h"
+
+@import RevenueCat;
+
+@interface RCAuthenticationAPI () <RCPurchasesAuthenticationDelegate>
+@end
+
+@implementation RCAuthenticationAPI
+
++ (void)checkAPI {
+    RCPurchases *p = [RCPurchases configureWithAPIKey:@""];
+
+    RCPurchasesAuthentication *auth = p.authentication;
+    [auth identifyCurrentUserAsID:@"" completion:^(RCCustomerInfo *i, BOOL created, NSError *error) { }];
+    [auth logOutWithCompletion:^(RCCustomerInfo *i, NSError *error) { }];
+
+    RCIdentity *siwa = [RCIdentity identityWithSignInWithAppleToken:[NSData data]];
+    RCIdentitySource *source = siwa.identitySource;
+
+    RCIdentitySource *anonymousSource = [RCIdentitySource anonymous];
+    RCIdentitySource *appleSource = [RCIdentitySource signInWithApple];
+    RCIdentitySource *googleSource = [RCIdentitySource google];
+    RCIdentitySource *firebase = [RCIdentitySource firebase];
+    RCIdentitySource *facebook = [RCIdentitySource facebook];
+    RCIdentitySource *oidc = [RCIdentitySource oidc];
+}
+
+- (void)authenticatorDidEncounterError:(NSError *)error { }
+
+@end

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCAuthenticationAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCAuthenticationAPI.m
@@ -25,14 +25,14 @@
     [auth logOutWithCompletion:^(RCCustomerInfo *i, NSError *error) { }];
 
     RCIdentity *siwa = [RCIdentity identityWithSignInWithAppleToken:[NSData data]];
-    RCIdentitySource *source = siwa.identitySource;
+    RCIdentitySource *__unused source = siwa.identitySource;
 
-    RCIdentitySource *anonymousSource = [RCIdentitySource anonymous];
-    RCIdentitySource *appleSource = [RCIdentitySource signInWithApple];
-    RCIdentitySource *googleSource = [RCIdentitySource google];
-    RCIdentitySource *firebase = [RCIdentitySource firebase];
-    RCIdentitySource *facebook = [RCIdentitySource facebook];
-    RCIdentitySource *oidc = [RCIdentitySource oidc];
+    RCIdentitySource *__unused anonymousSource = [RCIdentitySource anonymous];
+    RCIdentitySource *__unused appleSource = [RCIdentitySource signInWithApple];
+    RCIdentitySource *__unused googleSource = [RCIdentitySource google];
+    RCIdentitySource *__unused firebase = [RCIdentitySource firebase];
+    RCIdentitySource *__unused facebook = [RCIdentitySource facebook];
+    RCIdentitySource *__unused oidc = [RCIdentitySource oidc];
 }
 
 - (void)authenticatorDidEncounterError:(NSError *)error { }

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCAuthenticationAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCAuthenticationAPI.m
@@ -19,6 +19,8 @@
     RCPurchases *p = [RCPurchases configureWithAPIKey:@""];
 
     RCPurchasesAuthentication *auth = p.authentication;
+    auth.delegate = nil;
+
     [auth identifyCurrentUserAsID:@"" completion:^(RCCustomerInfo *i, BOOL created, NSError *error) { }];
     [auth logOutWithCompletion:^(RCCustomerInfo *i, NSError *error) { }];
 

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCConfigurationAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCConfigurationAPI.m
@@ -13,21 +13,22 @@
 
 + (void)checkAPI {
     RCConfigurationBuilder *builder = [RCConfiguration builderWithAPIKey:@""];
-    RCConfiguration *config __unused = [[[[[[[[[[[[[[[[builder withApiKey:@""]
-                                                      withPreferredUILocaleOverride:@"de_DE"]
-                                                     withPurchasesAreCompletedBy:RCPurchasesAreCompletedByRevenueCat storeKitVersion:RCStoreKitVersion2]
-                                                    withUserDefaults:NSUserDefaults.standardUserDefaults]
-                                                   withAppUserID:@""]
-                                                  withAppUserID:nil]
-                                                 withDangerousSettings:[[RCDangerousSettings alloc] initWithAutoSyncPurchases:true]]
-                                                withNetworkTimeout:1]
-                                               withStoreKit1Timeout: 1]
-                                              withPlatformInfo:[[RCPlatformInfo alloc] initWithFlavor:@"" version:@""]]
-                                             withUsesStoreKit2IfAvailable:false]
-                                            withStoreKitVersion:RCStoreKitVersion2]
-                                           withEntitlementVerificationMode:RCEntitlementVerificationModeInformational]
+    RCConfiguration *config __unused = [[[[[[[[[[[[[[[[[builder withApiKey:@""]
+                                                       withPreferredUILocaleOverride:@"de_DE"]
+                                                      withPurchasesAreCompletedBy:RCPurchasesAreCompletedByRevenueCat storeKitVersion:RCStoreKitVersion2]
+                                                     withUserDefaults:NSUserDefaults.standardUserDefaults]
+                                                    withAppUserID:@""]
+                                                   withAppUserID:nil]
+                                                  withDangerousSettings:[[RCDangerousSettings alloc] initWithAutoSyncPurchases:true]]
+                                                 withNetworkTimeout:1]
+                                                withStoreKit1Timeout: 1]
+                                               withPlatformInfo:[[RCPlatformInfo alloc] initWithFlavor:@"" version:@""]]
+                                              withUsesStoreKit2IfAvailable:false]
+                                             withStoreKitVersion:RCStoreKitVersion2]
+                                            withEntitlementVerificationMode:RCEntitlementVerificationModeInformational]
                                            withAutomaticDeviceIdentifierCollectionEnabled:true]
-                                          withIAMEnabled: true]
+                                          withIAMEnabled: false]
+                                         withIAMEnabled: false keychainAccessGroup:@"access_group"]
                                         build];
 
     if (@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)) {

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/main.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/main.m
@@ -9,6 +9,7 @@
 #import "RCAdTrackerAPI.h"
 #import "RCAttributionAPI.h"
 #import "RCAttributionNetworkAPI.h"
+#import "RCAuthenticationAPI.h"
 #import "RCBillingPlanTypeAPI.h"
 #if ENABLE_CHECKPOINTS_OBJC
 #import "RCCheckpointAPI.h"
@@ -76,6 +77,8 @@ int main(int argc, const char * argv[]) {
         [RCPurchasesAPI checkAPI];
         [RCPurchasesAPI checkConstants];
         [RCPurchasesAPI checkEnums];
+
+        [RCAuthenticationAPI checkAPI];
 
         [RCConfigurationAPI checkAPI];
 

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/AuthenticationAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/AuthenticationAPI.swift
@@ -25,18 +25,20 @@ func checkAuthenticationAPI() {
     }
 
     let siwa: Identity = Identity.signInWithApple(Data())
-    let source: IdentitySource = siwa.identitySource
+    let _: IdentitySource = siwa.identitySource
 
-    let anonymousSource: IdentitySource = IdentitySource.anonymous
-    let appleSource: IdentitySource = IdentitySource.signInWithApple
-    let googleSource: IdentitySource = IdentitySource.google
-    let firebase: IdentitySource = IdentitySource.firebase
-    let facebook: IdentitySource = IdentitySource.facebook
-    let oidc: IdentitySource = IdentitySource.oidc
+    let _: IdentitySource = IdentitySource.anonymous
+    let _: IdentitySource = IdentitySource.signInWithApple
+    let _: IdentitySource = IdentitySource.google
+    let _: IdentitySource = IdentitySource.firebase
+    let _: IdentitySource = IdentitySource.facebook
+    let _: IdentitySource = IdentitySource.oidc
 
     Task {
-        let (customerInfo: CustomerInfo, created: Bool) = try await auth.identifyCurrentUser(as: "")
-        let info: CustomerInfo = try await auth.logOut()
+        let result = try await auth.identifyCurrentUser(as: "")
+        let _: CustomerInfo = result.customerInfo
+        let _: Bool = result.created
+        let _: CustomerInfo = try await auth.logOut()
     }
 }
 

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/AuthenticationAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/AuthenticationAPI.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-@_spi(Experimental) import RevenueCat
+@_spi(Internal) import RevenueCat
 
 func checkAuthenticationAPI() {
 

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/AuthenticationAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/AuthenticationAPI.swift
@@ -1,0 +1,40 @@
+//
+//  AuthenticationAPI.swift
+//  ObjcAPITester
+//
+//  Created by Dave DeLong on 8/13/26.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+//
+
+import Foundation
+@_spi(Experimental) import RevenueCat
+
+func checkAuthenticationAPI() {
+
+    let p = Purchases.configure(withAPIKey: "")
+
+    let auth = p.authentication
+    auth.delegate = nil
+
+    auth.identifyCurrentUser(as: "") { (info: CustomerInfo?, created: Bool, error: PublicError?) in
+
+    }
+
+    auth.logOut { (info: CustomerInfo?, error: PublicError?) in
+
+    }
+
+    let siwa = Identity.signInWithApple(Data())
+    let source = siwa.identitySource
+
+    let anonymousSource = IdentitySource.anonymous
+    let appleSource = IdentitySource.signInWithApple
+    let googleSource = IdentitySource.google
+    let firebase = IdentitySource.firebase
+    let facebook = IdentitySource.facebook
+    let oidc = IdentitySource.oidc
+}
+
+class AuthDelegate: NSObject, AuthenticationDelegate {
+    func authenticatorDidEncounterError(_ error: PublicError) { }
+}

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/AuthenticationAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/AuthenticationAPI.swift
@@ -24,15 +24,20 @@ func checkAuthenticationAPI() {
 
     }
 
-    let siwa = Identity.signInWithApple(Data())
-    let source = siwa.identitySource
+    let siwa: Identity = Identity.signInWithApple(Data())
+    let source: IdentitySource = siwa.identitySource
 
-    let anonymousSource = IdentitySource.anonymous
-    let appleSource = IdentitySource.signInWithApple
-    let googleSource = IdentitySource.google
-    let firebase = IdentitySource.firebase
-    let facebook = IdentitySource.facebook
-    let oidc = IdentitySource.oidc
+    let anonymousSource: IdentitySource = IdentitySource.anonymous
+    let appleSource: IdentitySource = IdentitySource.signInWithApple
+    let googleSource: IdentitySource = IdentitySource.google
+    let firebase: IdentitySource = IdentitySource.firebase
+    let facebook: IdentitySource = IdentitySource.facebook
+    let oidc: IdentitySource = IdentitySource.oidc
+
+    Task {
+        let (customerInfo: CustomerInfo, created: Bool) = try await auth.identifyCurrentUser(as: "")
+        let info: CustomerInfo = try await auth.logOut()
+    }
 }
 
 class AuthDelegate: NSObject, AuthenticationDelegate {

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/ConfigurationAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/ConfigurationAPI.swift
@@ -24,6 +24,7 @@ func checkConfigurationAPI() {
         .with(entitlementVerificationMode: .informational)
         .with(automaticDeviceIdentifierCollectionEnabled: true)
         .with(iamEnabled: false)
+        .with(iamEnabled: false, keychainAccessGroup: "access_group")
         .with(preferredUILocaleOverride: "de_DE")
         .with(preferredUILocaleOverride: nil)
 

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/ConfigurationAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/ConfigurationAPI.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@_spi(Experimental) import RevenueCat
+@_spi(Internal) import RevenueCat
 
 func checkConfigurationAPI() {
     let builder = Configuration

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/main.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/main.swift
@@ -18,6 +18,8 @@ func main() -> Int {
 
     checkAttributionNetworkEnums()
 
+    checkAuthenticationAPI()
+
     checkEntitlementInfoAPI()
     checkEntitlementInfoEnums()
     checkEntitlementInfosAPI()

--- a/Tests/BackendIntegrationTests/ProductionRemoteConfigIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/ProductionRemoteConfigIntegrationTests.swift
@@ -133,6 +133,7 @@ private extension BaseProductionRemoteConfigIntegrationTests {
         let backend = Backend(
             systemInfo: systemInfo,
             eTagManager: ETagManager(),
+            tokenManager: TokenManager(enabled: false, storage: Keychain(access: nil)),
             operationDispatcher: .default,
             attributionFetcher: AttributionFetcher(
                 attributionFactory: AttributionTypeFactory(),

--- a/Tests/RemoteConfigProductionTests/RemoteConfigBlobHealthTests.swift
+++ b/Tests/RemoteConfigProductionTests/RemoteConfigBlobHealthTests.swift
@@ -134,13 +134,16 @@ final class RemoteConfigBlobHealthTests: TestCase {
         let backend = Backend(
             systemInfo: systemInfo,
             eTagManager: ETagManager(),
+            tokenManager: TokenManager(enabled: false, storage: Keychain(access: nil)),
             operationDispatcher: .default,
             attributionFetcher: AttributionFetcher(
                 attributionFactory: AttributionTypeFactory(),
                 systemInfo: systemInfo
             ),
             offlineCustomerInfoCreator: nil,
-            diagnosticsTracker: nil
+            diagnosticsTracker: nil,
+            apiSourceProvider: nil,
+            timeoutManager: HTTPRequestTimeoutManager(networkTimeout: .default)
         )
         return RemoteConfigManager(
             remoteConfigAPI: backend.remoteConfigAPI,

--- a/Tests/StoreKitUnitTests/KeychainTests.swift
+++ b/Tests/StoreKitUnitTests/KeychainTests.swift
@@ -628,7 +628,8 @@ class KeychainAccessGroupTests: TestCase {
     func testTokenManagerBackedByAccessGroupKeychainRoundTripsCurrentUserTokens() throws {
         let tokenManager = try makeAccessGroupTokenManager()
         let userID = trackTokenManagerUser(uniqueID(), in: tokenManager)
-        tokenManager.currentUserProvider = MockCurrentUserProvider(mockAppUserID: userID)
+        let mockUserProvider = MockCurrentUserProvider(mockAppUserID: userID)
+        tokenManager.currentUserProvider = mockUserProvider
 
         tokenManager.currentRefreshToken = "refresh-token"
         tokenManager.currentAccessToken = "access-token"

--- a/Tests/StoreKitUnitTests/KeychainTests.swift
+++ b/Tests/StoreKitUnitTests/KeychainTests.swift
@@ -389,10 +389,14 @@ class KeychainAccessGroupTests: TestCase {
     private static let keychainAccessGroupsEntitlement = "keychain-access-groups"
 
     private var createdIdentifiers: [(keychain: Keychain, id: String)] = []
+    private var createdTokenManagerUsers: [(tokenManager: TokenManager, userID: String)] = []
 
     override func tearDown() {
         for (keychain, id) in createdIdentifiers {
             try? keychain.deleteItem(identifier: id)
+        }
+        for (tokenManager, userID) in createdTokenManagerUsers {
+            tokenManager.deleteTokens(for: userID)
         }
         super.tearDown()
     }
@@ -423,6 +427,29 @@ class KeychainAccessGroupTests: TestCase {
     private func track(_ id: String, in keychain: Keychain) -> String {
         createdIdentifiers.append((keychain, id))
         return id
+    }
+
+    /// Builds a `TokenManager` backed by the shared test access-group `Keychain`, mirroring exactly
+    /// how `Purchases` builds its `TokenManager` from a configured `keychainAccessGroup`:
+    /// `Keychain.AccessGroup(accessGroup: $0, appIdentifier: apiKey)`, passed to
+    /// `TokenManager(enabled:storage:)`.
+    ///
+    /// - Parameters:
+    ///   - appIdentifier: Stands in for the API key `Purchases` uses as the access group's `appIdentifier`.
+    ///   - enabled: Whether IAM/token-based sessions are enabled on the returned `TokenManager`.
+    private func makeAccessGroupTokenManager(
+        appIdentifier: String = "com.revenuecat.test",
+        enabled: Bool = true
+    ) throws -> TokenManager {
+        let keychain = try makeAccessGroupKeychain(appIdentifier: appIdentifier)
+        return TokenManager(enabled: enabled, storage: keychain)
+    }
+
+    /// Registers `userID` for cleanup against `tokenManager` at tearDown.
+    @discardableResult
+    private func trackTokenManagerUser(_ userID: String, in tokenManager: TokenManager) -> String {
+        createdTokenManagerUsers.append((tokenManager, userID))
+        return userID
     }
 
     // MARK: - Service-name scoping
@@ -574,6 +601,104 @@ class KeychainAccessGroupTests: TestCase {
         try keychain.saveItem(identifier: id, contents: data(byte: 0x01))
         try keychain.modifyItem(identifier: id, contents: nil)
         expect(try keychain.containsItem(identifier: id)) == false
+    }
+
+    // MARK: - TokenManager wiring (mirrors how `Purchases` builds its `TokenManager`)
+    //
+    // `Purchases` never talks to `Keychain` directly outside of building the `TokenManager`:
+    //
+    //   let accessGroup = keychainAccessGroup.map {
+    //       Keychain.AccessGroup(accessGroup: $0, appIdentifier: apiKey)
+    //   }
+    //   let tokenManager = TokenManager(enabled: iamEnabled, storage: Keychain(access: accessGroup))
+    //
+    // These tests exercise that exact construction through `TokenManager`'s own API, confirming
+    // the configured access group actually reaches -- and is honored by -- the `TokenManager`,
+    // not just the underlying `Keychain`.
+
+    func testTokenManagerBackedByAccessGroupKeychainSavesAndReadsTokensForAnExplicitUser() throws {
+        let tokenManager = try makeAccessGroupTokenManager()
+        let userID = trackTokenManagerUser(uniqueID(), in: tokenManager)
+
+        tokenManager.saveTokens(refreshToken: "refresh", accessToken: "access", idToken: "id", for: userID)
+
+        expect(tokenManager.idToken(for: userID)) == "id"
+    }
+
+    func testTokenManagerBackedByAccessGroupKeychainRoundTripsCurrentUserTokens() throws {
+        let tokenManager = try makeAccessGroupTokenManager()
+        let userID = trackTokenManagerUser(uniqueID(), in: tokenManager)
+        tokenManager.currentUserProvider = MockCurrentUserProvider(mockAppUserID: userID)
+
+        tokenManager.currentRefreshToken = "refresh-token"
+        tokenManager.currentAccessToken = "access-token"
+        tokenManager.currentIDToken = "id-token"
+
+        expect(tokenManager.currentRefreshToken) == "refresh-token"
+        expect(tokenManager.currentAccessToken) == "access-token"
+        expect(tokenManager.currentIDToken) == "id-token"
+        expect(tokenManager.hasCurrentAccessToken) == true
+    }
+
+    func testTokenManagerTokensAreIsolatedByAppIdentifierWithinTheSameAccessGroup() throws {
+        // Mirrors two apps (different API keys) both enabling IAM with the *same* keychain
+        // access group -- `Purchases` namespaces by `appIdentifier: apiKey`, so they must not
+        // see each other's tokens even though they share the raw access group.
+        let tokenManagerApp1 = try makeAccessGroupTokenManager(appIdentifier: "com.revenuecat.app1")
+        let tokenManagerApp2 = try makeAccessGroupTokenManager(appIdentifier: "com.revenuecat.app2")
+
+        let userID = uniqueID()
+        trackTokenManagerUser(userID, in: tokenManagerApp1)
+        trackTokenManagerUser(userID, in: tokenManagerApp2)
+
+        tokenManagerApp1.saveTokens(refreshToken: "refresh", accessToken: "access", idToken: "app1-id",
+                                    for: userID)
+
+        expect(tokenManagerApp2.idToken(for: userID)).to(beNil())
+    }
+
+    func testTokenManagersWithIdenticalConfigurationShareTokens() throws {
+        // Mirrors an app and its extension: both configure IAM with the same API key and access
+        // group, so a fresh `TokenManager` instance (as the extension would create) must see
+        // tokens saved by the main app's `TokenManager`.
+        let appTokenManager = try makeAccessGroupTokenManager(appIdentifier: "com.revenuecat.sharedapp")
+        let extensionTokenManager = try makeAccessGroupTokenManager(appIdentifier: "com.revenuecat.sharedapp")
+
+        let userID = uniqueID()
+        trackTokenManagerUser(userID, in: appTokenManager)
+
+        appTokenManager.saveTokens(refreshToken: "refresh", accessToken: "access", idToken: "shared-id",
+                                   for: userID)
+
+        expect(extensionTokenManager.idToken(for: userID)) == "shared-id"
+    }
+
+    func testDeleteTokensRemovesThemFromTheAccessGroupScopedKeychain() throws {
+        let tokenManager = try makeAccessGroupTokenManager()
+        let userID = trackTokenManagerUser(uniqueID(), in: tokenManager)
+        tokenManager.saveTokens(refreshToken: "refresh", accessToken: "access", idToken: "id", for: userID)
+
+        tokenManager.deleteTokens(for: userID)
+
+        expect(tokenManager.idToken(for: userID)).to(beNil())
+    }
+
+    func testTokenManagerWithNilAccessGroupIsIsolatedFromAccessGroupScopedTokenManager() throws {
+        // Mirrors the default (`keychainAccessGroup == nil`) configuration path in `Purchases`,
+        // which builds a plain `Keychain(access: nil)`.
+        let plainTokenManager = TokenManager(enabled: true, storage: Keychain(access: nil))
+        let accessGroupTokenManager = try makeAccessGroupTokenManager()
+
+        let userID = uniqueID()
+        // The plain keychain isn't tracked by `createdTokenManagerUsers` (that array assumes an
+        // access-group keychain), so clean it up directly.
+        defer { plainTokenManager.deleteTokens(for: userID) }
+        trackTokenManagerUser(userID, in: accessGroupTokenManager)
+
+        plainTokenManager.saveTokens(refreshToken: "refresh", accessToken: "access", idToken: "plain-id",
+                                     for: userID)
+
+        expect(accessGroupTokenManager.idToken(for: userID)).to(beNil())
     }
 
 }

--- a/Tests/UnitTests/Authentication/AuthenticationTests.swift
+++ b/Tests/UnitTests/Authentication/AuthenticationTests.swift
@@ -14,7 +14,7 @@
 import Nimble
 import XCTest
 
-@testable @_spi(Experimental) import RevenueCat
+@testable @_spi(Internal) import RevenueCat
 
 class AuthenticationTests: TestCase {
 

--- a/Tests/UnitTests/Authentication/AuthenticationTests.swift
+++ b/Tests/UnitTests/Authentication/AuthenticationTests.swift
@@ -1,0 +1,344 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  AuthenticationTests.swift
+//
+//  Created by RevenueCat on 8/13/26.
+
+import Nimble
+import XCTest
+
+@testable @_spi(Experimental) import RevenueCat
+
+class AuthenticationTests: TestCase {
+
+    private static let appUserID = "test-app-user-id"
+
+    private var backend: MockBackend!
+    private var identityManager: MockIdentityManager!
+    private var operationDispatcher: MockOperationDispatcher!
+    private var internalDelegate: MockInternalAuthenticatorDelegate!
+    private var authenticationDelegate: MockAuthenticationDelegate!
+    private var secureItemStorage: MockSecureItemStorage!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        self.backend = MockBackend()
+        self.identityManager = MockIdentityManager(mockAppUserID: Self.appUserID,
+                                                   mockDeviceCache: MockDeviceCache())
+        self.operationDispatcher = MockOperationDispatcher()
+        self.internalDelegate = MockInternalAuthenticatorDelegate()
+        self.authenticationDelegate = MockAuthenticationDelegate()
+        self.secureItemStorage = MockSecureItemStorage()
+    }
+
+    /// - Parameters:
+    ///   - tokenManagerEnabled: mirrors whether IAM identities are enabled; when `true`,
+    ///   `identifyCurrentUser` should refuse to provide an alias for the current user.
+    private func makeAuthentication(
+        tokenManagerEnabled: Bool = false,
+        customEntitlementComputation: Bool = false
+    ) -> Authentication {
+        let tokenManager = TokenManager(enabled: tokenManagerEnabled, storage: self.secureItemStorage)
+        let systemInfo = MockSystemInfo(finishTransactions: false,
+                                        customEntitlementsComputation: customEntitlementComputation)
+
+        let authentication = Authentication(backend: self.backend,
+                                            identityManager: self.identityManager,
+                                            tokenManager: tokenManager,
+                                            operationDispatcher: self.operationDispatcher,
+                                            systemInfo: systemInfo,
+                                            internalDelegate: self.internalDelegate)
+        authentication.delegate = self.authenticationDelegate
+        return authentication
+    }
+
+    // MARK: - identifyCurrentUser(as: String, completion:)
+
+    func testIdentifyCurrentUserWithStringSucceedsAndNotifiesInternalDelegate() throws {
+        let authentication = self.makeAuthentication()
+        let expectedInfo = try CustomerInfo(data: Self.customerInfoData(originalAppUserId: "logged-in-user"))
+        self.identityManager.mockLogInResult = .success((expectedInfo, true))
+
+        var receivedInfo: CustomerInfo?
+        var receivedCreated: Bool?
+        var receivedError: PublicError?
+
+        authentication.identifyCurrentUser(as: Self.appUserID) { info, created, error in
+            receivedInfo = info
+            receivedCreated = created
+            receivedError = error
+        }
+
+        expect(receivedInfo) == expectedInfo
+        expect(receivedCreated) == true
+        expect(receivedError).to(beNil())
+        expect(self.identityManager.invokedLogInParametersList) == [Self.appUserID]
+        expect(self.internalDelegate.invokedAuthenticatorDidLogIn) == true
+        expect(self.internalDelegate.invokedAuthenticatorDidLogInParametersList.last?.info) == expectedInfo
+    }
+
+    func testIdentifyCurrentUserWithStringFailureDoesNotNotifyInternalDelegate() {
+        let authentication = self.makeAuthentication()
+        let backendError = BackendError.networkError(.offlineConnection())
+        self.identityManager.mockLogInResult = .failure(backendError)
+
+        var receivedInfo: CustomerInfo?
+        var receivedCreated: Bool?
+        var receivedError: PublicError?
+
+        authentication.identifyCurrentUser(as: Self.appUserID) { info, created, error in
+            receivedInfo = info
+            receivedCreated = created
+            receivedError = error
+        }
+
+        expect(receivedInfo).to(beNil())
+        expect(receivedCreated) == false
+        expect(receivedError).to(matchError(backendError.asPurchasesError))
+        expect(self.internalDelegate.invokedAuthenticatorDidLogIn) == false
+    }
+
+    func testIdentifyCurrentUserWithStringTrimsWhitespaceBeforeLoggingIn() throws {
+        let authentication = self.makeAuthentication()
+        let info = try XCTUnwrap(CustomerInfo(data: Self.customerInfoData(originalAppUserId: "logged-in-user")))
+        self.identityManager.mockLogInResult = .success((info, true))
+        let untrimmedAppUserID = "  \(Self.appUserID)  "
+
+        authentication.identifyCurrentUser(as: untrimmedAppUserID) { _, _, _ in }
+
+        expect(self.identityManager.invokedLogInParametersList) == [Self.appUserID]
+    }
+
+    func testIdentifyCurrentUserWithStringReturnsUnsupportedErrorWhenTokenManagerIsEnabled() {
+        let authentication = self.makeAuthentication(tokenManagerEnabled: true)
+
+        var receivedError: PublicError?
+        authentication.identifyCurrentUser(as: Self.appUserID) { _, _, error in
+            receivedError = error
+        }
+
+        expect(receivedError).to(matchError(ErrorCode.unsupportedError))
+        expect(self.identityManager.invokedLogIn) == false
+        expect(self.internalDelegate.invokedAuthenticatorDidLogIn) == false
+    }
+
+    // MARK: - identifyCurrentUser(as: StaticString, completion:) [deprecated]
+
+    @available(*, deprecated)
+    func testIdentifyCurrentUserWithStaticStringLogsDeprecationWarningAndDelegatesToStringOverload() throws {
+        let authentication = self.makeAuthentication()
+        let info = try XCTUnwrap(CustomerInfo(data: Self.customerInfoData(originalAppUserId: "logged-in-user")))
+        self.identityManager.mockLogInResult = .success((info, true))
+
+        authentication.identifyCurrentUser(as: "static-user-id") { _, _, _ in }
+
+        self.logger.verifyMessageWasLogged(Strings.identity.logging_in_with_static_string, level: .warn)
+        expect(self.identityManager.invokedLogInParametersList) == ["static-user-id"]
+    }
+
+    // MARK: - identifyCurrentUser(as: String) async
+
+    func testIdentifyCurrentUserAsyncReturnsCustomerInfoAndCreated() async throws {
+        let authentication = self.makeAuthentication()
+        let expectedInfo = try CustomerInfo(data: Self.customerInfoData(originalAppUserId: "logged-in-user"))
+        self.identityManager.mockLogInResult = .success((expectedInfo, true))
+        let appUserID = Self.appUserID
+
+        let result = try await authentication.identifyCurrentUser(as: appUserID)
+
+        expect(result.customerInfo) == expectedInfo
+        expect(result.created) == true
+    }
+
+    func testIdentifyCurrentUserAsyncPropagatesFailure() async {
+        let authentication = self.makeAuthentication()
+        let backendError = BackendError.networkError(.offlineConnection())
+        self.identityManager.mockLogInResult = .failure(backendError)
+        let appUserID = Self.appUserID
+
+        do {
+            _ = try await authentication.identifyCurrentUser(as: appUserID)
+            fail("Expected identifyCurrentUser to throw")
+        } catch {
+            expect(error).to(matchError(backendError.asPurchasesError))
+        }
+    }
+
+    @available(*, deprecated)
+    func testIdentifyCurrentUserAsyncWithStaticStringLogsDeprecationWarning() async throws {
+        let authentication = self.makeAuthentication()
+        self.identityManager.mockLogInResult = .success(
+            (try CustomerInfo(data: Self.customerInfoData(originalAppUserId: "logged-in-user")), true)
+        )
+
+        _ = try await authentication.identifyCurrentUser(as: "static-user-id")
+
+        self.logger.verifyMessageWasLogged(Strings.identity.logging_in_with_static_string, level: .warn)
+    }
+
+    // MARK: - logOut(completion:)
+
+    func testLogOutCallsLogOutWithUserInitiatedTrueAndForwardsResult() throws {
+        let authentication = self.makeAuthentication()
+        self.identityManager.mockLogOutError = nil
+        let expectedInfo = try CustomerInfo(data: Self.customerInfoData(originalAppUserId: "logged-out-user"))
+        self.internalDelegate.stubbedAuthenticatorDidChangeIdentityResult = .success(expectedInfo)
+
+        var receivedInfo: CustomerInfo?
+        var receivedError: PublicError?
+
+        authentication.logOut { info, error in
+            receivedInfo = info
+            receivedError = error
+        }
+
+        expect(receivedInfo) == expectedInfo
+        expect(receivedError).to(beNil())
+        expect(self.identityManager.invokedLogOutCount) == 1
+        expect(self.internalDelegate.invokedAuthenticatorDidChangeIdentity) == true
+    }
+
+    func testLogOutForwardsIdentityManagerErrorToCompletionAndDoesNotChangeIdentity() {
+        let authentication = self.makeAuthentication()
+        let logOutError = BackendError.networkError(.offlineConnection()).asPurchasesError
+        self.identityManager.mockLogOutError = logOutError
+
+        var receivedError: PublicError?
+        authentication.logOut { _, error in
+            receivedError = error
+        }
+
+        expect(receivedError).to(matchError(logOutError))
+        expect(self.internalDelegate.invokedAuthenticatorDidChangeIdentity) == false
+    }
+
+    // MARK: - logOut(userInitiated:completion:) - custom entitlement computation
+
+    func testLogOutReturnsFeatureNotAvailableErrorWhenCustomEntitlementComputationIsEnabled() {
+        let authentication = self.makeAuthentication(customEntitlementComputation: true)
+
+        var receivedInfo: CustomerInfo?
+        var receivedError: PublicError?
+        authentication.logOut { info, error in
+            receivedInfo = info
+            receivedError = error
+        }
+
+        expect(receivedInfo).to(beNil())
+        expect(receivedError).to(matchError(ErrorCode.featureNotAvailableInCustomEntitlementsComputationMode))
+        expect(self.identityManager.invokedLogOut) == false
+    }
+
+    func testLogOutReportsErrorToDelegateWhenCustomEntitlementComputationIsEnabledAndNotUserInitiated() {
+        let authentication = self.makeAuthentication(customEntitlementComputation: true)
+
+        authentication.logOut(userInitiated: false, completion: nil)
+
+        expect(self.authenticationDelegate.invokedAuthenticatorDidEncounterError) == true
+        expect(self.authenticationDelegate.invokedAuthenticatorDidEncounterErrorParametersList.last).to(
+            matchError(ErrorCode.featureNotAvailableInCustomEntitlementsComputationMode)
+        )
+    }
+
+    func testLogOutDoesNotReportErrorToDelegateWhenCustomEntitlementComputationIsEnabledAndUserInitiated() {
+        let authentication = self.makeAuthentication(customEntitlementComputation: true)
+
+        authentication.logOut(userInitiated: true, completion: nil)
+
+        expect(self.authenticationDelegate.invokedAuthenticatorDidEncounterError) == false
+    }
+
+    // MARK: - logOut(userInitiated:completion:) - identityManager failure
+
+    func testLogOutReportsErrorToDelegateWhenIdentityManagerFailsAndNotUserInitiated() {
+        let authentication = self.makeAuthentication()
+        self.identityManager.mockLogOutError = BackendError.networkError(.offlineConnection()).asPurchasesError
+
+        authentication.logOut(userInitiated: false, completion: nil)
+
+        expect(self.authenticationDelegate.invokedAuthenticatorDidEncounterError) == true
+    }
+
+    func testLogOutDoesNotReportErrorToDelegateWhenIdentityManagerFailsAndUserInitiated() {
+        let authentication = self.makeAuthentication()
+        self.identityManager.mockLogOutError = BackendError.networkError(.offlineConnection()).asPurchasesError
+
+        authentication.logOut(userInitiated: true, completion: nil)
+
+        expect(self.authenticationDelegate.invokedAuthenticatorDidEncounterError) == false
+    }
+
+    // MARK: - logOut() async
+
+    func testLogOutAsyncReturnsCustomerInfo() async throws {
+        let authentication = self.makeAuthentication()
+        self.identityManager.mockLogOutError = nil
+        let expectedInfo = try CustomerInfo(data: Self.customerInfoData(originalAppUserId: "logged-out-user"))
+        self.internalDelegate.stubbedAuthenticatorDidChangeIdentityResult = .success(expectedInfo)
+
+        let result = try await authentication.logOut()
+
+        expect(result) == expectedInfo
+    }
+
+    func testLogOutAsyncPropagatesFailure() async {
+        let authentication = self.makeAuthentication()
+        let logOutError = BackendError.networkError(.offlineConnection()).asPurchasesError
+        self.identityManager.mockLogOutError = logOutError
+
+        do {
+            _ = try await authentication.logOut()
+            fail("Expected logOut to throw")
+        } catch {
+            expect(error).to(matchError(logOutError))
+        }
+    }
+
+    // MARK: - reportAuthenticationError(_:)
+
+    func testReportAuthenticationErrorDoesNothingWhenNoDelegateIsSet() {
+        let authentication = self.makeAuthentication()
+        authentication.delegate = nil
+
+        authentication.reportAuthenticationError(NSError(domain: "AuthenticationTests", code: 1))
+
+        expect(self.operationDispatcher.invokedDispatchOnMainThread) == false
+        expect(self.authenticationDelegate.invokedAuthenticatorDidEncounterError) == false
+    }
+
+    func testReportAuthenticationErrorNotifiesTheDelegateOnTheMainThread() {
+        let authentication = self.makeAuthentication()
+        let error = NSError(domain: "AuthenticationTests", code: 1)
+
+        authentication.reportAuthenticationError(error)
+
+        expect(self.operationDispatcher.invokedDispatchOnMainThread) == true
+        expect(self.authenticationDelegate.invokedAuthenticatorDidEncounterErrorParametersList) == [error]
+    }
+
+}
+
+private extension AuthenticationTests {
+
+    static func customerInfoData(originalAppUserId: String) -> [String: Any] {
+        return [
+            "request_date": "2019-08-16T10:30:42Z",
+            "subscriber": [
+                "first_seen": "2019-07-17T00:05:54Z",
+                "original_app_user_id": originalAppUserId,
+                "subscriptions": [:] as [String: Any],
+                "other_purchases": [:] as [String: Any],
+                "original_application_version": NSNull()
+            ] as [String: Any]
+        ]
+    }
+
+}

--- a/Tests/UnitTests/Authentication/AuthenticationTests.swift
+++ b/Tests/UnitTests/Authentication/AuthenticationTests.swift
@@ -82,7 +82,7 @@ class AuthenticationTests: TestCase {
         expect(receivedError).to(beNil())
         expect(self.identityManager.invokedLogInParametersList) == [Self.appUserID]
         expect(self.internalDelegate.invokedAuthenticatorDidLogIn) == true
-        expect(self.internalDelegate.invokedAuthenticatorDidLogInParametersList.last?.info) == expectedInfo
+        expect(self.internalDelegate.invokedAuthenticatorDidLogInParametersList.last) == expectedInfo
     }
 
     func testIdentifyCurrentUserWithStringFailureDoesNotNotifyInternalDelegate() {

--- a/Tests/UnitTests/Identity/IdentityManagerTests.swift
+++ b/Tests/UnitTests/Identity/IdentityManagerTests.swift
@@ -12,6 +12,7 @@ class IdentityManagerTests: TestCase {
 
     private var mockDeviceCache: MockDeviceCache!
     private let mockBackend = MockBackend()
+    private var mockTokenManager = MockTokenManager()
     private var mockCustomerInfoManager: MockCustomerInfoManager!
     private var mockAttributeSyncing: MockAttributeSyncing!
 
@@ -25,6 +26,7 @@ class IdentityManagerTests: TestCase {
                                systemInfo: self.mockSystemInfo,
                                backend: self.mockBackend,
                                customerInfoManager: self.mockCustomerInfoManager,
+                               tokenManager: self.mockTokenManager,
                                attributeSyncing: self.mockAttributeSyncing,
                                appUserID: appUserID)
     }

--- a/Tests/UnitTests/Mocks/MockAuthenticationDelegate.swift
+++ b/Tests/UnitTests/Mocks/MockAuthenticationDelegate.swift
@@ -13,7 +13,7 @@
 
 import Foundation
 
-@_spi(Experimental) @testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 
 final class MockAuthenticationDelegate: NSObject, AuthenticationDelegate {
 

--- a/Tests/UnitTests/Mocks/MockAuthenticationDelegate.swift
+++ b/Tests/UnitTests/Mocks/MockAuthenticationDelegate.swift
@@ -1,0 +1,30 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MockAuthenticationDelegate.swift
+//
+//  Created by RevenueCat on 8/13/26.
+
+import Foundation
+
+@_spi(Experimental) @testable import RevenueCat
+
+final class MockAuthenticationDelegate: NSObject, AuthenticationDelegate {
+
+    private(set) var invokedAuthenticatorDidEncounterError = false
+    private(set) var invokedAuthenticatorDidEncounterErrorCount = 0
+    private(set) var invokedAuthenticatorDidEncounterErrorParametersList: [PublicError] = []
+
+    func authenticatorDidEncounterError(_ error: PublicError) {
+        self.invokedAuthenticatorDidEncounterError = true
+        self.invokedAuthenticatorDidEncounterErrorCount += 1
+        self.invokedAuthenticatorDidEncounterErrorParametersList.append(error)
+    }
+
+}

--- a/Tests/UnitTests/Mocks/MockIdentityManager.swift
+++ b/Tests/UnitTests/Mocks/MockIdentityManager.swift
@@ -35,6 +35,7 @@ class MockIdentityManager: IdentityManager {
                     transactionPoster: MockTransactionPoster(),
                     systemInfo: mockSystemInfo
                    ),
+                   tokenManager: MockTokenManager(),
                    attributeSyncing: self.mockAttributeSyncing,
                    appUserID: mockAppUserID)
     }

--- a/Tests/UnitTests/Mocks/MockInternalAuthenticatorDelegate.swift
+++ b/Tests/UnitTests/Mocks/MockInternalAuthenticatorDelegate.swift
@@ -17,12 +17,12 @@ final class MockInternalAuthenticatorDelegate: InternalAuthenticatorDelegate {
 
     private(set) var invokedAuthenticatorDidLogIn = false
     private(set) var invokedAuthenticatorDidLogInCount = 0
-    private(set) var invokedAuthenticatorDidLogInParametersList: [(info: CustomerInfo?, error: PublicError?)] = []
+    private(set) var invokedAuthenticatorDidLogInParametersList: [CustomerInfo] = []
 
-    func authenticatorDidLogIn(info: CustomerInfo?, error: PublicError?) {
+    func authenticatorDidLogIn(info: CustomerInfo) {
         self.invokedAuthenticatorDidLogIn = true
         self.invokedAuthenticatorDidLogInCount += 1
-        self.invokedAuthenticatorDidLogInParametersList.append((info, error))
+        self.invokedAuthenticatorDidLogInParametersList.append(info)
     }
 
     private(set) var invokedAuthenticatorDidChangeIdentity = false

--- a/Tests/UnitTests/Mocks/MockInternalAuthenticatorDelegate.swift
+++ b/Tests/UnitTests/Mocks/MockInternalAuthenticatorDelegate.swift
@@ -1,0 +1,45 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MockInternalAuthenticatorDelegate.swift
+//
+//  Created by RevenueCat on 8/13/26.
+
+@testable import RevenueCat
+
+final class MockInternalAuthenticatorDelegate: InternalAuthenticatorDelegate {
+
+    private(set) var invokedAuthenticatorDidLogIn = false
+    private(set) var invokedAuthenticatorDidLogInCount = 0
+    private(set) var invokedAuthenticatorDidLogInParametersList: [(info: CustomerInfo?, error: PublicError?)] = []
+
+    func authenticatorDidLogIn(info: CustomerInfo?, error: PublicError?) {
+        self.invokedAuthenticatorDidLogIn = true
+        self.invokedAuthenticatorDidLogInCount += 1
+        self.invokedAuthenticatorDidLogInParametersList.append((info, error))
+    }
+
+    private(set) var invokedAuthenticatorDidChangeIdentity = false
+    private(set) var invokedAuthenticatorDidChangeIdentityCount = 0
+
+    /// The result that will be handed to the completion passed to ``authenticatorDidChangeIdentity(completion:)``.
+    /// If left `nil`, the completion is never invoked, to make it easy to test that a caller correctly
+    /// waits for this delegate callback.
+    var stubbedAuthenticatorDidChangeIdentityResult: Result<CustomerInfo, PublicError>?
+
+    func authenticatorDidChangeIdentity(completion: @escaping (Result<CustomerInfo, PublicError>) -> Void) {
+        self.invokedAuthenticatorDidChangeIdentity = true
+        self.invokedAuthenticatorDidChangeIdentityCount += 1
+
+        if let result = self.stubbedAuthenticatorDidChangeIdentityResult {
+            completion(result)
+        }
+    }
+
+}

--- a/Tests/UnitTests/Mocks/MockSecureItemStorage.swift
+++ b/Tests/UnitTests/Mocks/MockSecureItemStorage.swift
@@ -1,0 +1,70 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MockSecureItemStorage.swift
+//
+//  Created by RevenueCat on 8/13/26.
+
+import Foundation
+
+@testable import RevenueCat
+
+/// An in-memory fake of ``SecureItemStorage``, used so that tests exercising code that reads/writes
+/// secure items (e.g. ``TokenManager``) don't need to touch the real system Keychain.
+///
+/// `storedItems` is exposed directly so tests can seed or inspect state without going through
+/// `saveItem`/`deleteItem`, and `errorToThrow`, when set, makes every operation throw instead of
+/// performing its normal behavior.
+final class MockSecureItemStorage: SecureItemStorage {
+
+    var storedItems: [String: Data] = [:]
+    var errorToThrow: SecureStorageError?
+
+    private(set) var invokedReadItemIdentifiers: [String] = []
+
+    private(set) var saveCallCount = 0
+    private(set) var invokedSaveItemIdentifiers: [String] = []
+    private(set) var lastSaveIdentifier: String?
+    private(set) var lastSaveContents: Data?
+    private(set) var lastSaveAttributes: SecureItemAttributes?
+
+    private(set) var deleteCallCount = 0
+    private(set) var invokedDeleteItemIdentifiers: [String] = []
+    private(set) var lastDeleteIdentifier: String?
+
+    func allItemIdentifiers() throws -> [String] {
+        if let errorToThrow { throw errorToThrow }
+        return Array(self.storedItems.keys)
+    }
+
+    func readItem(identifier: String) throws -> Data? {
+        if let errorToThrow { throw errorToThrow }
+        self.invokedReadItemIdentifiers.append(identifier)
+        return self.storedItems[identifier]
+    }
+
+    func saveItem(identifier: String, contents: Data, attributes: SecureItemAttributes) throws {
+        if let errorToThrow { throw errorToThrow }
+        self.saveCallCount += 1
+        self.invokedSaveItemIdentifiers.append(identifier)
+        self.lastSaveIdentifier = identifier
+        self.lastSaveContents = contents
+        self.lastSaveAttributes = attributes
+        self.storedItems[identifier] = contents
+    }
+
+    func deleteItem(identifier: String) throws {
+        if let errorToThrow { throw errorToThrow }
+        self.deleteCallCount += 1
+        self.invokedDeleteItemIdentifiers.append(identifier)
+        self.lastDeleteIdentifier = identifier
+        self.storedItems.removeValue(forKey: identifier)
+    }
+
+}

--- a/Tests/UnitTests/Mocks/MockTokenManager.swift
+++ b/Tests/UnitTests/Mocks/MockTokenManager.swift
@@ -1,0 +1,149 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MockTokenManager.swift
+//
+//  Created by RevenueCat on 8/13/26.
+
+@testable import RevenueCat
+
+class MockTokenManager: TokenManager {
+
+    convenience init(enabled: Bool = false) {
+        self.init(enabled: enabled, storage: MockSecureItemStorage())
+    }
+
+    // MARK: - currentRefreshToken
+
+    var stubbedCurrentRefreshToken: String?
+    private(set) var invokedCurrentRefreshTokenGetter = false
+    private(set) var invokedCurrentRefreshTokenGetterCount = 0
+    private(set) var invokedCurrentRefreshTokenSetter = false
+    private(set) var invokedCurrentRefreshTokenSetterCount = 0
+    private(set) var invokedCurrentRefreshTokenSetterParametersList: [String?] = []
+
+    override var currentRefreshToken: String? {
+        get {
+            self.invokedCurrentRefreshTokenGetter = true
+            self.invokedCurrentRefreshTokenGetterCount += 1
+            return self.stubbedCurrentRefreshToken
+        }
+        set {
+            self.invokedCurrentRefreshTokenSetter = true
+            self.invokedCurrentRefreshTokenSetterCount += 1
+            self.invokedCurrentRefreshTokenSetterParametersList.append(newValue)
+            self.stubbedCurrentRefreshToken = newValue
+        }
+    }
+
+    // MARK: - currentAccessToken
+
+    var stubbedCurrentAccessToken: String?
+    private(set) var invokedCurrentAccessTokenGetter = false
+    private(set) var invokedCurrentAccessTokenGetterCount = 0
+    private(set) var invokedCurrentAccessTokenSetter = false
+    private(set) var invokedCurrentAccessTokenSetterCount = 0
+    private(set) var invokedCurrentAccessTokenSetterParametersList: [String?] = []
+
+    override var currentAccessToken: String? {
+        get {
+            self.invokedCurrentAccessTokenGetter = true
+            self.invokedCurrentAccessTokenGetterCount += 1
+            return self.stubbedCurrentAccessToken
+        }
+        set {
+            self.invokedCurrentAccessTokenSetter = true
+            self.invokedCurrentAccessTokenSetterCount += 1
+            self.invokedCurrentAccessTokenSetterParametersList.append(newValue)
+            self.stubbedCurrentAccessToken = newValue
+        }
+    }
+
+    // Note: `hasCurrentAccessToken` is intentionally not overridden; the base implementation
+    // (`currentAccessToken != nil`) dispatches to the override above, so it reflects
+    // `stubbedCurrentAccessToken` automatically.
+
+    // MARK: - currentIDToken
+
+    var stubbedCurrentIDToken: String?
+    private(set) var invokedCurrentIDTokenGetter = false
+    private(set) var invokedCurrentIDTokenGetterCount = 0
+    private(set) var invokedCurrentIDTokenSetter = false
+    private(set) var invokedCurrentIDTokenSetterCount = 0
+    private(set) var invokedCurrentIDTokenSetterParametersList: [String?] = []
+
+    override var currentIDToken: String? {
+        get {
+            self.invokedCurrentIDTokenGetter = true
+            self.invokedCurrentIDTokenGetterCount += 1
+            return self.stubbedCurrentIDToken
+        }
+        set {
+            self.invokedCurrentIDTokenSetter = true
+            self.invokedCurrentIDTokenSetterCount += 1
+            self.invokedCurrentIDTokenSetterParametersList.append(newValue)
+            self.stubbedCurrentIDToken = newValue
+        }
+    }
+
+    // MARK: - idToken(for:)
+
+    var stubbedIDToken: String?
+    private(set) var invokedIDTokenFor = false
+    private(set) var invokedIDTokenForCount = 0
+    private(set) var invokedIDTokenForParametersList: [String] = []
+
+    override func idToken(for user: String) -> String? {
+        self.invokedIDTokenFor = true
+        self.invokedIDTokenForCount += 1
+        self.invokedIDTokenForParametersList.append(user)
+        return self.stubbedIDToken
+    }
+
+    // MARK: - saveTokens(refreshToken:accessToken:idToken:for:)
+
+    typealias SaveTokensParameters = (refreshToken: String?, accessToken: String, idToken: String?, userID: String)
+
+    private(set) var invokedSaveTokens = false
+    private(set) var invokedSaveTokensCount = 0
+    private(set) var invokedSaveTokensParametersList: [SaveTokensParameters] = []
+
+    override func saveTokens(refreshToken: String?, accessToken: String, idToken: String?, for userID: String) {
+        self.invokedSaveTokens = true
+        self.invokedSaveTokensCount += 1
+        self.invokedSaveTokensParametersList.append((refreshToken, accessToken, idToken, userID))
+    }
+
+    // MARK: - deleteTokens(for:)
+
+    private(set) var invokedDeleteTokens = false
+    private(set) var invokedDeleteTokensCount = 0
+    private(set) var invokedDeleteTokensParametersList: [String] = []
+
+    override func deleteTokens(for userID: String) {
+        self.invokedDeleteTokens = true
+        self.invokedDeleteTokensCount += 1
+        self.invokedDeleteTokensParametersList.append(userID)
+    }
+
+    // MARK: - deleteAccessToken(for:)
+
+    private(set) var invokedDeleteAccessToken = false
+    private(set) var invokedDeleteAccessTokenCount = 0
+    private(set) var invokedDeleteAccessTokenParametersList: [String] = []
+
+    override func deleteAccessToken(for userID: String) {
+        self.invokedDeleteAccessToken = true
+        self.invokedDeleteAccessTokenCount += 1
+        self.invokedDeleteAccessTokenParametersList.append(userID)
+    }
+
+}
+
+extension MockTokenManager: @unchecked Sendable {}

--- a/Tests/UnitTests/Networking/Backend/BackendAPISourceFailoverIntegrationTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendAPISourceFailoverIntegrationTests.swift
@@ -244,6 +244,7 @@ final class BackendAPISourceFailoverIntegrationTests: TestCase {
         return Backend(
             systemInfo: systemInfo,
             eTagManager: MockETagManager(),
+            tokenManager: MockTokenManager(),
             operationDispatcher: OperationDispatcher(),
             attributionFetcher: AttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
                                                    systemInfo: systemInfo),

--- a/Tests/UnitTests/Networking/Backend/BackendRemoteConfigLaneTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendRemoteConfigLaneTests.swift
@@ -131,7 +131,6 @@ final class BackendRemoteConfigLaneParallelTests: TestCase {
         func makeClient() -> HTTPClient {
             return HTTPClient(systemInfo: systemInfo,
                               eTagManager: eTagManager,
-                              tokenManager: MockTokenManager(),
                               signing: MockSigning(),
                               diagnosticsTracker: nil,
                               networkTimeout: .custom(30),

--- a/Tests/UnitTests/Networking/Backend/BackendRemoteConfigLaneTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendRemoteConfigLaneTests.swift
@@ -131,6 +131,7 @@ final class BackendRemoteConfigLaneParallelTests: TestCase {
         func makeClient() -> HTTPClient {
             return HTTPClient(systemInfo: systemInfo,
                               eTagManager: eTagManager,
+                              tokenManager: MockTokenManager(),
                               signing: MockSigning(),
                               diagnosticsTracker: nil,
                               networkTimeout: .custom(30),
@@ -202,6 +203,7 @@ final class BackendRemoteConfigLaneParallelTests: TestCase {
             systemInfo: systemInfo,
             httpClientTimeout: .default,
             eTagManager: MockETagManager(),
+            tokenManager: MockTokenManager(),
             operationDispatcher: OperationDispatcher(),
             attributionFetcher: AttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
                                                    systemInfo: systemInfo),

--- a/Tests/UnitTests/Networking/TokenManagerTests.swift
+++ b/Tests/UnitTests/Networking/TokenManagerTests.swift
@@ -1,0 +1,282 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  TokenManagerTests.swift
+//
+//  Created by RevenueCat on 8/13/26.
+
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+class TokenManagerTests: TestCase {
+
+    private var storage: MockSecureItemStorage!
+    private var userProvider: MockCurrentUserProvider!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        self.storage = MockSecureItemStorage()
+        self.userProvider = MockCurrentUserProvider(mockAppUserID: "test-user")
+    }
+
+    // MARK: - enabled
+
+    func testEnabledReflectsTheValuePassedToTheInitializer() {
+        expect(TokenManager(enabled: true, storage: self.storage).enabled) == true
+        expect(TokenManager(enabled: false, storage: self.storage).enabled) == false
+    }
+
+    // MARK: - currentRefreshToken
+
+    func testCurrentRefreshTokenIsNilWhenDisabled() {
+        let manager = TokenManager(enabled: false, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+
+        manager.currentRefreshToken = "refresh-token"
+
+        expect(manager.currentRefreshToken).to(beNil())
+        expect(self.storage.invokedSaveItemIdentifiers).to(beEmpty())
+    }
+
+    func testCurrentRefreshTokenIsNilWhenThereIsNoCurrentUser() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        // `currentUserProvider` is intentionally left unset.
+
+        manager.currentRefreshToken = "refresh-token"
+
+        expect(manager.currentRefreshToken).to(beNil())
+        expect(self.storage.invokedSaveItemIdentifiers).to(beEmpty())
+    }
+
+    func testCurrentRefreshTokenRoundTripsWhenEnabledWithACurrentUser() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+
+        manager.currentRefreshToken = "refresh-token"
+
+        expect(manager.currentRefreshToken) == "refresh-token"
+    }
+
+    func testCurrentRefreshTokenCanBeClearedBySettingItToNil() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.currentRefreshToken = "refresh-token"
+
+        manager.currentRefreshToken = nil
+
+        expect(manager.currentRefreshToken).to(beNil())
+    }
+
+    func testCurrentRefreshTokenIsIsolatedPerUser() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.currentRefreshToken = "user-a-refresh-token"
+
+        self.userProvider.mockAppUserID = "another-user"
+
+        expect(manager.currentRefreshToken).to(beNil())
+
+        manager.currentRefreshToken = "user-b-refresh-token"
+        expect(manager.currentRefreshToken) == "user-b-refresh-token"
+
+        self.userProvider.mockAppUserID = "test-user"
+        expect(manager.currentRefreshToken) == "user-a-refresh-token"
+    }
+
+    // MARK: - currentAccessToken
+
+    func testCurrentAccessTokenIsNilWhenDisabled() {
+        let manager = TokenManager(enabled: false, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+
+        manager.currentAccessToken = "access-token"
+
+        expect(manager.currentAccessToken).to(beNil())
+        expect(self.storage.invokedSaveItemIdentifiers).to(beEmpty())
+    }
+
+    func testCurrentAccessTokenRoundTripsWhenEnabledWithACurrentUser() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+
+        manager.currentAccessToken = "access-token"
+
+        expect(manager.currentAccessToken) == "access-token"
+    }
+
+    // MARK: - hasCurrentAccessToken
+
+    func testHasCurrentAccessTokenIsFalseWhenNoAccessTokenIsStored() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+
+        expect(manager.hasCurrentAccessToken) == false
+    }
+
+    func testHasCurrentAccessTokenIsTrueAfterSettingAnAccessToken() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.currentAccessToken = "access-token"
+
+        expect(manager.hasCurrentAccessToken) == true
+    }
+
+    func testHasCurrentAccessTokenIsFalseWhenDisabledEvenIfATokenWasPreviouslySavedForThatUser() {
+        let enabledManager = TokenManager(enabled: true, storage: self.storage)
+        enabledManager.currentUserProvider = self.userProvider
+        enabledManager.currentAccessToken = "access-token"
+
+        let disabledManager = TokenManager(enabled: false, storage: self.storage)
+        disabledManager.currentUserProvider = self.userProvider
+
+        expect(disabledManager.hasCurrentAccessToken) == false
+    }
+
+    // MARK: - currentIDToken
+
+    func testCurrentIDTokenIsNilWhenDisabled() {
+        let manager = TokenManager(enabled: false, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+
+        manager.currentIDToken = "id-token"
+
+        expect(manager.currentIDToken).to(beNil())
+    }
+
+    func testCurrentIDTokenRoundTripsWhenEnabledWithACurrentUser() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+
+        manager.currentIDToken = "id-token"
+
+        expect(manager.currentIDToken) == "id-token"
+    }
+
+    // MARK: - idToken(for:)
+
+    func testIDTokenForUserReadsDirectlyFromStorageEvenWhenDisabled() {
+        // Unlike `currentIDToken`, `idToken(for:)` bypasses the `enabled` and `currentUser` checks
+        // and always reads whatever is in storage for the given user.
+        let manager = TokenManager(enabled: false, storage: self.storage)
+
+        manager.saveTokens(refreshToken: nil,
+                           accessToken: "access",
+                           idToken: "id-token-for-explicit-user",
+                           for: "explicit-user")
+
+        expect(manager.idToken(for: "explicit-user")) == "id-token-for-explicit-user"
+    }
+
+    func testIDTokenForUserReturnsNilWhenNoTokenHasBeenSaved() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+
+        expect(manager.idToken(for: "unknown-user")).to(beNil())
+    }
+
+    // MARK: - saveTokens(refreshToken:accessToken:idToken:for:)
+
+    func testSaveTokensSavesAllThreeTokensForTheGivenUser() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+
+        manager.saveTokens(refreshToken: "refresh", accessToken: "access", idToken: "id", for: "test-user")
+
+        expect(manager.currentRefreshToken) == "refresh"
+        expect(manager.currentAccessToken) == "access"
+        expect(manager.currentIDToken) == "id"
+    }
+
+    func testSaveTokensWritesToStorageEvenWhenDisabled() {
+        // `saveTokens` writes directly to storage using the passed-in `userID`, bypassing the
+        // `enabled`/`currentUser` guard used by the computed properties.
+        let manager = TokenManager(enabled: false, storage: self.storage)
+
+        manager.saveTokens(refreshToken: "refresh", accessToken: "access", idToken: "id", for: "test-user")
+
+        expect(manager.idToken(for: "test-user")) == "id"
+    }
+
+    func testSaveTokensAllowsNilRefreshAndIDTokens() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+
+        manager.saveTokens(refreshToken: nil, accessToken: "access", idToken: nil, for: "test-user")
+
+        expect(manager.currentRefreshToken).to(beNil())
+        expect(manager.currentAccessToken) == "access"
+        expect(manager.currentIDToken).to(beNil())
+    }
+
+    // MARK: - deleteTokens(for:)
+
+    func testDeleteTokensRemovesAllThreeTokensForTheGivenUser() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.saveTokens(refreshToken: "refresh", accessToken: "access", idToken: "id", for: "test-user")
+
+        manager.deleteTokens(for: "test-user")
+
+        expect(manager.currentRefreshToken).to(beNil())
+        expect(manager.currentAccessToken).to(beNil())
+        expect(manager.currentIDToken).to(beNil())
+    }
+
+    func testDeleteTokensDoesNotAffectTokensBelongingToOtherUsers() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.saveTokens(refreshToken: "refresh", accessToken: "access", idToken: "id", for: "test-user")
+        manager.saveTokens(refreshToken: "other-refresh",
+                           accessToken: "other-access",
+                           idToken: "other-id",
+                           for: "other-user")
+
+        manager.deleteTokens(for: "test-user")
+
+        expect(manager.idToken(for: "test-user")).to(beNil())
+        expect(manager.idToken(for: "other-user")) == "other-id"
+    }
+
+    // MARK: - deleteAccessToken(for:)
+
+    func testDeleteAccessTokenOnlyRemovesTheAccessToken() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.saveTokens(refreshToken: "refresh", accessToken: "access", idToken: "id", for: "test-user")
+
+        manager.deleteAccessToken(for: "test-user")
+
+        expect(manager.currentAccessToken).to(beNil())
+        expect(manager.currentRefreshToken) == "refresh"
+        expect(manager.currentIDToken) == "id"
+    }
+
+    // MARK: - reportError
+
+    func testReportErrorIsNilByDefault() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+
+        expect(manager.reportError).to(beNil())
+    }
+
+    func testReportErrorCanBeSetAndIsInvokedWhenCalled() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        let expectedError = NSError(domain: "TokenManagerTests", code: 1)
+        var receivedError: PublicError?
+
+        manager.reportError = { error in
+            receivedError = error
+        }
+        manager.reportError?(expectedError)
+
+        expect(receivedError) == expectedError
+    }
+
+}

--- a/Tests/UnitTests/Purchasing/ConfigurationTests.swift
+++ b/Tests/UnitTests/Purchasing/ConfigurationTests.swift
@@ -96,6 +96,65 @@ class ConfigurationTests: TestCase {
         expect(configuration.iamEnabled) == true
     }
 
+    func testKeychainAccessGroupIsNilByDefault() {
+        let configuration = Configuration.Builder(withAPIKey: "test")
+            .build()
+
+        expect(configuration.keychainAccessGroup).to(beNil())
+    }
+
+    func testIAMEnabledWithoutKeychainAccessGroupLeavesItNil() {
+        let configuration = Configuration.Builder(withAPIKey: "test")
+            .with(iamEnabled: true)
+            .build()
+
+        expect(configuration.iamEnabled) == true
+        expect(configuration.keychainAccessGroup).to(beNil())
+    }
+
+    func testIAMEnabledWithKeychainAccessGroupSetsBothValues() {
+        let configuration = Configuration.Builder(withAPIKey: "test")
+            .with(iamEnabled: true, keychainAccessGroup: "group.com.revenuecat.shared")
+            .build()
+
+        expect(configuration.iamEnabled) == true
+        expect(configuration.keychainAccessGroup) == "group.com.revenuecat.shared"
+    }
+
+    func testSingleArgumentIAMEnabledResetsAPreviouslySetKeychainAccessGroup() {
+        // `with(iamEnabled:)` (no access group) represents a complete IAM configuration on its
+        // own, so it must clear out any keychain access group set by an earlier call to the
+        // two-argument overload -- otherwise a stale access group could silently persist.
+        let configuration = Configuration.Builder(withAPIKey: "test")
+            .with(iamEnabled: true, keychainAccessGroup: "group.com.revenuecat.shared")
+            .with(iamEnabled: true)
+            .build()
+
+        expect(configuration.iamEnabled) == true
+        expect(configuration.keychainAccessGroup).to(beNil())
+    }
+
+    func testKeychainAccessGroupCanBeSetAfterAPlainIAMEnabledCall() {
+        let configuration = Configuration.Builder(withAPIKey: "test")
+            .with(iamEnabled: true)
+            .with(iamEnabled: true, keychainAccessGroup: "group.com.revenuecat.shared")
+            .build()
+
+        expect(configuration.iamEnabled) == true
+        expect(configuration.keychainAccessGroup) == "group.com.revenuecat.shared"
+    }
+
+    func testDifferentKeychainAccessGroupIsNotEqual() {
+        let lhs = Configuration.Builder(withAPIKey: "test")
+            .with(iamEnabled: true, keychainAccessGroup: "group_a")
+            .build()
+        let rhs = Configuration.Builder(withAPIKey: "test")
+            .with(iamEnabled: true, keychainAccessGroup: "group_b")
+            .build()
+
+        expect(lhs) != rhs
+    }
+
     func testStoreKitVersionUsesStoreKit1ByDefault() {
         let configuration = Configuration.Builder(withAPIKey: "test")
             .build()

--- a/Tests/UnitTests/Purchasing/ConfigurationTests.swift
+++ b/Tests/UnitTests/Purchasing/ConfigurationTests.swift
@@ -15,7 +15,7 @@ import Foundation
 import Nimble
 import XCTest
 
-@testable @_spi(Experimental) import RevenueCat
+@testable @_spi(Internal) import RevenueCat
 
 class ConfigurationTests: TestCase {
 

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -63,6 +63,7 @@ class BasePurchasesTests: TestCase {
         self.mockOperationDispatcher = MockOperationDispatcher()
         self.mockReceiptParser = MockReceiptParser()
         self.identityManager = MockIdentityManager(mockAppUserID: Self.appUserID, mockDeviceCache: self.deviceCache)
+        self.tokenManager = MockTokenManager()
         self.mockIntroEligibilityCalculator = MockIntroEligibilityCalculator(productsManager: self.mockProductsManager,
                                                                              receiptParser: self.mockReceiptParser)
         let platformInfo = Purchases.PlatformInfo(flavor: "iOS", version: "4.4.0")
@@ -178,6 +179,7 @@ class BasePurchasesTests: TestCase {
     var subscriberAttributesManager: MockSubscriberAttributesManager!
     var attribution: Attribution!
     var identityManager: MockIdentityManager!
+    var tokenManager: MockTokenManager!
     var clock: TestClock!
     var systemInfo: MockSystemInfo!
     var mockOperationDispatcher: MockOperationDispatcher!
@@ -345,6 +347,7 @@ class BasePurchasesTests: TestCase {
                                    deviceCache: self.deviceCache,
                                    paywallCache: self.paywallCache,
                                    identityManager: self.identityManager,
+                                   tokenManager: self.tokenManager,
                                    subscriberAttributes: self.attribution,
                                    operationDispatcher: self.mockOperationDispatcher,
                                    customerInfoManager: self.customerInfoManager,
@@ -896,6 +899,7 @@ private extension BasePurchasesTests {
         self.attribution = nil
         self.customerInfoManager = nil
         self.identityManager = nil
+        self.tokenManager = nil
         self.mockOfferingsManager = nil
         self.mockOfflineEntitlementsManager = nil
         self.mockPurchasedProductsFetcher = nil

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -14,7 +14,7 @@
 import Nimble
 import XCTest
 
-@_spi(Internal) @testable import RevenueCat
+@_spi(Internal) @_spi(Experimental) @testable import RevenueCat
 
 class PurchasesConfiguringTests: BasePurchasesTests {
 
@@ -67,6 +67,22 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         expect(Purchases.isConfigured) == false
         self.setupPurchases()
         expect(Purchases.isConfigured) == true
+    }
+
+    func testKeychainAccessGroupPassedThroughConfiguration() {
+        let configurationBuilder = Configuration.Builder(withAPIKey: "")
+            .with(iamEnabled: true, keychainAccessGroup: "group.com.revenuecat.shared")
+        let purchases = Purchases.configure(with: configurationBuilder.build())
+
+        expect(purchases.currentConfiguration?.keychainAccessGroup) == "group.com.revenuecat.shared"
+    }
+
+    func testKeychainAccessGroupIsNilWhenNotConfigured() {
+        let configurationBuilder = Configuration.Builder(withAPIKey: "")
+            .with(iamEnabled: true)
+        let purchases = Purchases.configure(with: configurationBuilder.build())
+
+        expect(purchases.currentConfiguration?.keychainAccessGroup).to(beNil())
     }
 
     func testConfigurationPassedThroughTimeouts() {

--- a/Tests/UnitTests/Security/SecureItemStorageTests.swift
+++ b/Tests/UnitTests/Security/SecureItemStorageTests.swift
@@ -101,52 +101,9 @@ class SecureItemAttributesTests: TestCase {
 }
 
 // MARK: - SecureItemStorage default implementation tests
-
-/// In-memory mock that records calls and supports configurable error injection.
-private class MockSecureItemStorage: SecureItemStorage {
-
-    var storedItems: [String: Data] = [:]
-    var errorToThrow: SecureStorageError?
-
-    // Call-tracking
-    private(set) var saveCallCount = 0
-    private(set) var deleteCallCount = 0
-    private(set) var lastSaveIdentifier: String?
-    private(set) var lastSaveContents: Data?
-    private(set) var lastSaveAttributes: SecureItemAttributes?
-    private(set) var lastDeleteIdentifier: String?
-
-    func allItemIdentifiers() throws -> [String] {
-        if let error = errorToThrow { throw error }
-        return Array(storedItems.keys)
-    }
-
-    func readItem(identifier: String) throws -> Data? {
-        if let error = errorToThrow { throw error }
-        return storedItems[identifier]
-    }
-
-    func saveItem(
-        identifier: String,
-        contents: Data,
-        attributes: SecureItemAttributes
-    ) throws {
-        if let error = errorToThrow { throw error }
-        saveCallCount += 1
-        lastSaveIdentifier = identifier
-        lastSaveContents = contents
-        lastSaveAttributes = attributes
-        storedItems[identifier] = contents
-    }
-
-    func deleteItem(identifier: String) throws {
-        if let error = errorToThrow { throw error }
-        deleteCallCount += 1
-        lastDeleteIdentifier = identifier
-        storedItems.removeValue(forKey: identifier)
-    }
-
-}
+//
+// `MockSecureItemStorage` (used below) lives in Tests/UnitTests/Mocks/MockSecureItemStorage.swift
+// so it can be shared with other tests (e.g. TokenManagerTests).
 
 class MockSecureItemStorageTests: TestCase {
 

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -246,6 +246,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
                               deviceCache: mockDeviceCache,
                               paywallCache: MockPaywallCacheWarming(),
                               identityManager: mockIdentityManager,
+                              tokenManager: MockTokenManager(),
                               subscriberAttributes: attribution,
                               operationDispatcher: mockOperationDispatcher,
                               customerInfoManager: customerInfoManager,

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -249,6 +249,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
                               deviceCache: mockDeviceCache,
                               paywallCache: MockPaywallCacheWarming(),
                               identityManager: mockIdentityManager,
+                              tokenManager: MockTokenManager(),
                               subscriberAttributes: attribution,
                               operationDispatcher: mockOperationDispatcher,
                               customerInfoManager: customerInfoManager,

--- a/api/revenuecat-api-ios-simulator.swiftinterface
+++ b/api/revenuecat-api-ios-simulator.swiftinterface
@@ -2155,6 +2155,7 @@ extension RevenueCat.Purchases {
   @available(*, deprecated, message: "The appUserID passed to logIn is a constant string known at compile time.\nThis is likely a programmer error. This ID is used to identify the current user.\nSee https://docs.revenuecat.com/docs/user-ids for more information.")
   final public func logIn(_ appUserID: Swift.StaticString, completion: @escaping (RevenueCat.CustomerInfo?, Swift.Bool, RevenueCat.PublicError?) -> Swift.Void)
   @_disfavoredOverload @objc(logIn:completion:) final public func logIn(_ appUserID: Swift.String, completion: @escaping (RevenueCat.CustomerInfo?, Swift.Bool, RevenueCat.PublicError?) -> Swift.Void)
+  @available(*, deprecated, message: "The appUserID passed to logIn is a constant string known at compile time.\nThis is likely a programmer error. This ID is used to identify the current user.\nSee https://docs.revenuecat.com/docs/user-ids for more information.")
   final public func logIn(_ appUserID: Swift.StaticString) async throws -> (customerInfo: RevenueCat.CustomerInfo, created: Swift.Bool)
   @_disfavoredOverload @objc final public func logIn(_ appUserID: Swift.String) async throws -> (customerInfo: RevenueCat.CustomerInfo, created: Swift.Bool)
   @objc final public func logOut(completion: ((RevenueCat.CustomerInfo?, RevenueCat.PublicError?) -> Swift.Void)?)

--- a/api/revenuecat-api-ios.swiftinterface
+++ b/api/revenuecat-api-ios.swiftinterface
@@ -2155,6 +2155,7 @@ extension RevenueCat.Purchases {
   @available(*, deprecated, message: "The appUserID passed to logIn is a constant string known at compile time.\nThis is likely a programmer error. This ID is used to identify the current user.\nSee https://docs.revenuecat.com/docs/user-ids for more information.")
   final public func logIn(_ appUserID: Swift.StaticString, completion: @escaping (RevenueCat.CustomerInfo?, Swift.Bool, RevenueCat.PublicError?) -> Swift.Void)
   @_disfavoredOverload @objc(logIn:completion:) final public func logIn(_ appUserID: Swift.String, completion: @escaping (RevenueCat.CustomerInfo?, Swift.Bool, RevenueCat.PublicError?) -> Swift.Void)
+  @available(*, deprecated, message: "The appUserID passed to logIn is a constant string known at compile time.\nThis is likely a programmer error. This ID is used to identify the current user.\nSee https://docs.revenuecat.com/docs/user-ids for more information.")
   final public func logIn(_ appUserID: Swift.StaticString) async throws -> (customerInfo: RevenueCat.CustomerInfo, created: Swift.Bool)
   @_disfavoredOverload @objc final public func logIn(_ appUserID: Swift.String) async throws -> (customerInfo: RevenueCat.CustomerInfo, created: Swift.Bool)
   @objc final public func logOut(completion: ((RevenueCat.CustomerInfo?, RevenueCat.PublicError?) -> Swift.Void)?)

--- a/api/revenuecat-api-macos.swiftinterface
+++ b/api/revenuecat-api-macos.swiftinterface
@@ -2122,6 +2122,7 @@ extension RevenueCat.Purchases {
   @available(*, deprecated, message: "The appUserID passed to logIn is a constant string known at compile time.\nThis is likely a programmer error. This ID is used to identify the current user.\nSee https://docs.revenuecat.com/docs/user-ids for more information.")
   final public func logIn(_ appUserID: Swift.StaticString, completion: @escaping (RevenueCat.CustomerInfo?, Swift.Bool, RevenueCat.PublicError?) -> Swift.Void)
   @_disfavoredOverload @objc(logIn:completion:) final public func logIn(_ appUserID: Swift.String, completion: @escaping (RevenueCat.CustomerInfo?, Swift.Bool, RevenueCat.PublicError?) -> Swift.Void)
+  @available(*, deprecated, message: "The appUserID passed to logIn is a constant string known at compile time.\nThis is likely a programmer error. This ID is used to identify the current user.\nSee https://docs.revenuecat.com/docs/user-ids for more information.")
   final public func logIn(_ appUserID: Swift.StaticString) async throws -> (customerInfo: RevenueCat.CustomerInfo, created: Swift.Bool)
   @_disfavoredOverload @objc final public func logIn(_ appUserID: Swift.String) async throws -> (customerInfo: RevenueCat.CustomerInfo, created: Swift.Bool)
   @objc final public func logOut(completion: ((RevenueCat.CustomerInfo?, RevenueCat.PublicError?) -> Swift.Void)?)

--- a/api/revenuecat-api-tvos-simulator.swiftinterface
+++ b/api/revenuecat-api-tvos-simulator.swiftinterface
@@ -2122,6 +2122,7 @@ extension RevenueCat.Purchases {
   @available(*, deprecated, message: "The appUserID passed to logIn is a constant string known at compile time.\nThis is likely a programmer error. This ID is used to identify the current user.\nSee https://docs.revenuecat.com/docs/user-ids for more information.")
   final public func logIn(_ appUserID: Swift.StaticString, completion: @escaping (RevenueCat.CustomerInfo?, Swift.Bool, RevenueCat.PublicError?) -> Swift.Void)
   @_disfavoredOverload @objc(logIn:completion:) final public func logIn(_ appUserID: Swift.String, completion: @escaping (RevenueCat.CustomerInfo?, Swift.Bool, RevenueCat.PublicError?) -> Swift.Void)
+  @available(*, deprecated, message: "The appUserID passed to logIn is a constant string known at compile time.\nThis is likely a programmer error. This ID is used to identify the current user.\nSee https://docs.revenuecat.com/docs/user-ids for more information.")
   final public func logIn(_ appUserID: Swift.StaticString) async throws -> (customerInfo: RevenueCat.CustomerInfo, created: Swift.Bool)
   @_disfavoredOverload @objc final public func logIn(_ appUserID: Swift.String) async throws -> (customerInfo: RevenueCat.CustomerInfo, created: Swift.Bool)
   @objc final public func logOut(completion: ((RevenueCat.CustomerInfo?, RevenueCat.PublicError?) -> Swift.Void)?)

--- a/api/revenuecat-api-tvos.swiftinterface
+++ b/api/revenuecat-api-tvos.swiftinterface
@@ -2122,6 +2122,7 @@ extension RevenueCat.Purchases {
   @available(*, deprecated, message: "The appUserID passed to logIn is a constant string known at compile time.\nThis is likely a programmer error. This ID is used to identify the current user.\nSee https://docs.revenuecat.com/docs/user-ids for more information.")
   final public func logIn(_ appUserID: Swift.StaticString, completion: @escaping (RevenueCat.CustomerInfo?, Swift.Bool, RevenueCat.PublicError?) -> Swift.Void)
   @_disfavoredOverload @objc(logIn:completion:) final public func logIn(_ appUserID: Swift.String, completion: @escaping (RevenueCat.CustomerInfo?, Swift.Bool, RevenueCat.PublicError?) -> Swift.Void)
+  @available(*, deprecated, message: "The appUserID passed to logIn is a constant string known at compile time.\nThis is likely a programmer error. This ID is used to identify the current user.\nSee https://docs.revenuecat.com/docs/user-ids for more information.")
   final public func logIn(_ appUserID: Swift.StaticString) async throws -> (customerInfo: RevenueCat.CustomerInfo, created: Swift.Bool)
   @_disfavoredOverload @objc final public func logIn(_ appUserID: Swift.String) async throws -> (customerInfo: RevenueCat.CustomerInfo, created: Swift.Bool)
   @objc final public func logOut(completion: ((RevenueCat.CustomerInfo?, RevenueCat.PublicError?) -> Swift.Void)?)

--- a/api/revenuecat-api-visionos-simulator.swiftinterface
+++ b/api/revenuecat-api-visionos-simulator.swiftinterface
@@ -2155,6 +2155,7 @@ extension RevenueCat.Purchases {
   @available(*, deprecated, message: "The appUserID passed to logIn is a constant string known at compile time.\nThis is likely a programmer error. This ID is used to identify the current user.\nSee https://docs.revenuecat.com/docs/user-ids for more information.")
   final public func logIn(_ appUserID: Swift.StaticString, completion: @escaping (RevenueCat.CustomerInfo?, Swift.Bool, RevenueCat.PublicError?) -> Swift.Void)
   @_disfavoredOverload @objc(logIn:completion:) final public func logIn(_ appUserID: Swift.String, completion: @escaping (RevenueCat.CustomerInfo?, Swift.Bool, RevenueCat.PublicError?) -> Swift.Void)
+  @available(*, deprecated, message: "The appUserID passed to logIn is a constant string known at compile time.\nThis is likely a programmer error. This ID is used to identify the current user.\nSee https://docs.revenuecat.com/docs/user-ids for more information.")
   final public func logIn(_ appUserID: Swift.StaticString) async throws -> (customerInfo: RevenueCat.CustomerInfo, created: Swift.Bool)
   @_disfavoredOverload @objc final public func logIn(_ appUserID: Swift.String) async throws -> (customerInfo: RevenueCat.CustomerInfo, created: Swift.Bool)
   @objc final public func logOut(completion: ((RevenueCat.CustomerInfo?, RevenueCat.PublicError?) -> Swift.Void)?)

--- a/api/revenuecat-api-visionos.swiftinterface
+++ b/api/revenuecat-api-visionos.swiftinterface
@@ -2155,6 +2155,7 @@ extension RevenueCat.Purchases {
   @available(*, deprecated, message: "The appUserID passed to logIn is a constant string known at compile time.\nThis is likely a programmer error. This ID is used to identify the current user.\nSee https://docs.revenuecat.com/docs/user-ids for more information.")
   final public func logIn(_ appUserID: Swift.StaticString, completion: @escaping (RevenueCat.CustomerInfo?, Swift.Bool, RevenueCat.PublicError?) -> Swift.Void)
   @_disfavoredOverload @objc(logIn:completion:) final public func logIn(_ appUserID: Swift.String, completion: @escaping (RevenueCat.CustomerInfo?, Swift.Bool, RevenueCat.PublicError?) -> Swift.Void)
+  @available(*, deprecated, message: "The appUserID passed to logIn is a constant string known at compile time.\nThis is likely a programmer error. This ID is used to identify the current user.\nSee https://docs.revenuecat.com/docs/user-ids for more information.")
   final public func logIn(_ appUserID: Swift.StaticString) async throws -> (customerInfo: RevenueCat.CustomerInfo, created: Swift.Bool)
   @_disfavoredOverload @objc final public func logIn(_ appUserID: Swift.String) async throws -> (customerInfo: RevenueCat.CustomerInfo, created: Swift.Bool)
   @objc final public func logOut(completion: ((RevenueCat.CustomerInfo?, RevenueCat.PublicError?) -> Swift.Void)?)

--- a/api/revenuecat-api-watchos-simulator.swiftinterface
+++ b/api/revenuecat-api-watchos-simulator.swiftinterface
@@ -2121,6 +2121,7 @@ extension RevenueCat.Purchases {
   @available(*, deprecated, message: "The appUserID passed to logIn is a constant string known at compile time.\nThis is likely a programmer error. This ID is used to identify the current user.\nSee https://docs.revenuecat.com/docs/user-ids for more information.")
   final public func logIn(_ appUserID: Swift.StaticString, completion: @escaping (RevenueCat.CustomerInfo?, Swift.Bool, RevenueCat.PublicError?) -> Swift.Void)
   @_disfavoredOverload @objc(logIn:completion:) final public func logIn(_ appUserID: Swift.String, completion: @escaping (RevenueCat.CustomerInfo?, Swift.Bool, RevenueCat.PublicError?) -> Swift.Void)
+  @available(*, deprecated, message: "The appUserID passed to logIn is a constant string known at compile time.\nThis is likely a programmer error. This ID is used to identify the current user.\nSee https://docs.revenuecat.com/docs/user-ids for more information.")
   final public func logIn(_ appUserID: Swift.StaticString) async throws -> (customerInfo: RevenueCat.CustomerInfo, created: Swift.Bool)
   @_disfavoredOverload @objc final public func logIn(_ appUserID: Swift.String) async throws -> (customerInfo: RevenueCat.CustomerInfo, created: Swift.Bool)
   @objc final public func logOut(completion: ((RevenueCat.CustomerInfo?, RevenueCat.PublicError?) -> Swift.Void)?)

--- a/api/revenuecat-api-watchos.swiftinterface
+++ b/api/revenuecat-api-watchos.swiftinterface
@@ -2121,6 +2121,7 @@ extension RevenueCat.Purchases {
   @available(*, deprecated, message: "The appUserID passed to logIn is a constant string known at compile time.\nThis is likely a programmer error. This ID is used to identify the current user.\nSee https://docs.revenuecat.com/docs/user-ids for more information.")
   final public func logIn(_ appUserID: Swift.StaticString, completion: @escaping (RevenueCat.CustomerInfo?, Swift.Bool, RevenueCat.PublicError?) -> Swift.Void)
   @_disfavoredOverload @objc(logIn:completion:) final public func logIn(_ appUserID: Swift.String, completion: @escaping (RevenueCat.CustomerInfo?, Swift.Bool, RevenueCat.PublicError?) -> Swift.Void)
+  @available(*, deprecated, message: "The appUserID passed to logIn is a constant string known at compile time.\nThis is likely a programmer error. This ID is used to identify the current user.\nSee https://docs.revenuecat.com/docs/user-ids for more information.")
   final public func logIn(_ appUserID: Swift.StaticString) async throws -> (customerInfo: RevenueCat.CustomerInfo, created: Swift.Bool)
   @_disfavoredOverload @objc final public func logIn(_ appUserID: Swift.String) async throws -> (customerInfo: RevenueCat.CustomerInfo, created: Swift.Bool)
   @objc final public func logOut(completion: ((RevenueCat.CustomerInfo?, RevenueCat.PublicError?) -> Swift.Void)?)


### PR DESCRIPTION
This adds some of the APIs (still marked as "Experimental") need for IAM login. As discussed in slack, the existing "logIn" and "logOut" methods having their implementations moved from the `Purchases` type to the new `Authentication` type for namespacing. There is no change to the public API at this point.

The `TokenManager` uses the `SecureItemStorage` for reading and writing tokens from the keychain. In an upcoming PR, it will also handle applying those tokens to HTTP requests and handling token refresh responses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches identity/login/logout and stores auth tokens in the Keychain (including optional shared access groups). Wiring is incomplete (tokens not yet applied to HTTP), so mistakes here affect future session security.
> 
> **Overview**
> Adds an internal `Authentication` namespace on `Purchases` and moves `logIn`/`logOut` implementations there (public `Purchases` APIs still forward). Introduces `Identity` / `IdentitySource` types and a `TokenManager` that stores refresh/access/ID tokens in the keychain.
> 
> IAM configuration can now take a `keychainAccessGroup` so tokens can be shared with extensions (namespaced by API key). Alias login is rejected when IAM is enabled. Token application on HTTP requests is not in this PR.
> 
> Also includes unit tests, mocks, and ObjC/Swift API testers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2df41b88a9a3ae806dc9e84a93a7422c7cd4f18c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->