### PR TITLE
Remove duplicate Slack failure notifications

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1,6 +1,5 @@
 orbs:
   macos: circleci/macos@2.5.1
-  slack: circleci/slack@5.0.0
   revenuecat: revenuecat/sdks-common-config@4.5.1
   # Disabled until compatible with M1: codecov: codecov/codecov@3.3.0
   # codecov: codecov/codecov@3.3.0
@@ -135,24 +134,6 @@ commands:
           name: Delete GitHub PR failure comment on success
           when: on_success
           command: bundle exec fastlane clear_pr_ci_failure
-
-  slack-notify-on-fail:
-    steps:
-      # Map custom variable names to the Slack orb variables, since the default variable names are already used by the Fastlane Slack integration
-      # we will probably remove these at some point when we move all jobs to use the Fastlane Slack integration
-      # Note: It's safe to modify SLACK_ACCESS_TOKEN and SLACK_DEFAULT_CHANNEL here because this command is always
-      # called as the last step in jobs, so it won't interfere with Fastlane commands that run before it
-      - run:
-          name: Set Slack environment variables
-          when: always
-          command: |
-            echo 'export SLACK_ACCESS_TOKEN="${SLACK_ACCESS_TOKEN_CIRCLE_CI_NOTIFY_ORB_IOS}"' >> $BASH_ENV
-            echo 'export SLACK_DEFAULT_CHANNEL="${SLACK_DEFAULT_CHANNEL_CIRCLE_CI_NOTIFY_ORB_IOS}"' >> $BASH_ENV
-      - slack/notify:
-          branch_pattern: main
-          channel: "feed-circleci-ios-failures"
-          event: fail
-          template: basic_fail_1
 
   install-bundle-dependencies:
     description: "Runs bundle install. Assumes ruby is already on PATH (see install-mise-tools: tools: ruby in callers)."
@@ -630,7 +611,6 @@ jobs:
       - run:
           name: Check pods and deployment targets
           command: bundle exec fastlane check_pods
-      - slack-notify-on-fail
 
   api-tests:
     executor:
@@ -646,7 +626,6 @@ jobs:
       - run:
           name: API Tests
           command: bundle exec fastlane run_api_tests
-      - slack-notify-on-fail
 
   revenuecat-admob-tests:
     executor:
@@ -675,7 +654,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
-      - slack-notify-on-fail
 
   spm-receipt-parser:
     executor:
@@ -686,7 +664,6 @@ jobs:
           name: SPM Receipt Parser
           command: swift build -c release --target ReceiptParser
           no_output_timeout: 30m
-      - slack-notify-on-fail
 
   spm-revenuecat-ui-ios-15:
     executor:
@@ -718,7 +695,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
-      - slack-notify-on-fail
 
   spm-revenuecat-ui-ios-16:
     executor:
@@ -759,7 +735,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
-      - slack-notify-on-fail
 
   run-revenuecat-ui-ios-18-and-17:
     executor:
@@ -839,7 +814,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output-revenuecatui-17
-      - slack-notify-on-fail
 
   record-and-upload-paywalls-v1-snapshots:
     executor:
@@ -862,7 +836,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: v1-snapshots
-      - slack-notify-on-fail
 
   run-revenuecat-ui-ios-26:
     executor:
@@ -901,7 +874,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
-      - slack-notify-on-fail
 
   spm-revenuecat-ui-watchos:
     executor:
@@ -933,7 +905,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: scan-test-output
-      - slack-notify-on-fail
 
   run-test-tvos-and-macos:
     executor:
@@ -979,7 +950,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output-macos
-      - slack-notify-on-fail
 
   run-test-ios-26:
     executor:
@@ -1022,7 +992,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output-ios-26
-      - slack-notify-on-fail
       - github-notify-pr-on-fail
 
   # As of May 12, 2026, there is a StoreKit bug that is preventing us from running unit tests
@@ -1053,7 +1022,6 @@ jobs:
           name: Build RevenueCatUI with Xcode 26.5
           command: xcodebuild -workspace RevenueCat.xcworkspace -scheme RevenueCatUI -destination "generic/platform=iOS" -sdk iphoneos -configuration Release CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=YES build
           no_output_timeout: 30m
-      - slack-notify-on-fail
 
   build-checkpoint-tester:
     executor:
@@ -1072,7 +1040,6 @@ jobs:
             CODE_SIGNING_ALLOWED=NO
             build
           no_output_timeout: 30m
-      - slack-notify-on-fail
 
   check-app-extension-safe-api-usage:
     executor:
@@ -1097,7 +1064,6 @@ jobs:
           name: Build RevenueCatUI with app extension safe APIs
           command: bundle exec fastlane build_with_app_extension_safe_apis scheme:RevenueCatUI
           no_output_timeout: 30m
-      - slack-notify-on-fail
 
   run-test-ios-18-and-17:
     executor:
@@ -1178,7 +1144,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output-ios-17
-      - slack-notify-on-fail
 
   run-test-ios-16:
     executor:
@@ -1224,7 +1189,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output-ios-16
-      - slack-notify-on-fail
 
   run-test-ios-15-and-14:
     executor:
@@ -1338,7 +1302,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output-ios-14
-      - slack-notify-on-fail
 
   run-test-watchos:
     executor:
@@ -1366,7 +1329,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
-      - slack-notify-on-fail
 
   build-tv-watch-mac-and-visionos:
     executor:
@@ -1378,7 +1340,6 @@ jobs:
           name: Build tvOS, watchOS, macOS and visionOS
           command: bundle exec fastlane build_tv_watch_mac_visionos
           no_output_timeout: 30m
-      - slack-notify-on-fail
 
   remote-config-production-tests:
     executor:
@@ -1405,7 +1366,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
-      - slack-notify-on-fail
 
   backend-integration-tests-SK1:
     executor:
@@ -1413,7 +1373,6 @@ jobs:
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-SK1"
-      - slack-notify-on-fail
 
   backend-integration-tests-SK2:
     executor:
@@ -1421,7 +1380,6 @@ jobs:
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-SK2"
-      - slack-notify-on-fail
 
   backend-integration-tests-other:
     executor:
@@ -1429,7 +1387,6 @@ jobs:
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-Other"
-      - slack-notify-on-fail
 
   backend-integration-tests-offline:
     executor:
@@ -1437,7 +1394,6 @@ jobs:
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-Offline"
-      - slack-notify-on-fail
 
   backend-integration-tests-custom-entitlements:
     executor:
@@ -1445,7 +1401,6 @@ jobs:
     steps:
       - run-backend-tests:
           test_plan: "BackendIntegrationTests-CustomEntitlements"
-      - slack-notify-on-fail
 
   run-all-maestro-e2e-tests:
     executor:
@@ -1634,7 +1589,6 @@ jobs:
       - store_artifacts:
           path: RevenueCatUI.xcframework.zip
           destination: RevenueCatUI.xcframework.zip
-      - slack-notify-on-fail
 
   docs-build:
     executor:
@@ -1653,7 +1607,6 @@ jobs:
           command: bundle exec fastlane build_docs
           environment:
             DOCS_IOS_VERSION: "17.4"
-      - slack-notify-on-fail
 
   docs-deploy:
     executor:
@@ -1839,46 +1792,6 @@ jobs:
           test-name: xcode-direct-integration
           display-name: Xcode Direct Integration
 
-      # Slack notification with failed test details
-      - run:
-          name: Collect failed test names for Slack
-          when: always
-          command: |
-            echo 'export SLACK_ACCESS_TOKEN="${SLACK_ACCESS_TOKEN_CIRCLE_CI_NOTIFY_ORB_IOS}"' >> $BASH_ENV
-            echo 'export SLACK_DEFAULT_CHANNEL="${SLACK_DEFAULT_CHANNEL_CIRCLE_CI_NOTIFY_ORB_IOS}"' >> $BASH_ENV
-            FAILED_TESTS=""
-            for test in cocoapods spm spm-custom-entitlement-computation receipt-parser xcode-direct-integration; do
-              STATUS_FILE="/tmp/test_status/$test"
-              if [ ! -f "$STATUS_FILE" ]; then
-                FAILED_TESTS="${FAILED_TESTS:+$FAILED_TESTS, }$test (did not run)"
-              else
-                STATUS=$(cat "$STATUS_FILE")
-                if [ "$STATUS" = "FAILED" ] || [ "$STATUS" = "STARTED" ]; then
-                  FAILED_TESTS="${FAILED_TESTS:+$FAILED_TESTS, }$test"
-                fi
-              fi
-            done
-            if [ -z "$FAILED_TESTS" ]; then
-              FAILED_TESTS="(none detected)"
-            fi
-            echo "export FAILED_INSTALLATION_TESTS=\"$FAILED_TESTS\"" >> $BASH_ENV
-      - slack/notify:
-          branch_pattern: main
-          channel: "feed-circleci-ios-failures"
-          event: fail
-          custom: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":red_circle: *${CIRCLE_JOB}* failed on branch `${CIRCLE_BRANCH}`\n\nFailed installation tests: ${FAILED_INSTALLATION_TESTS}\n\n<${CIRCLE_BUILD_URL}|View Job>"
-                  }
-                }
-              ]
-            }
-
   installation-tests-carthage:
     parameters:
       xcode_version:
@@ -1904,7 +1817,6 @@ jobs:
       - set-signing-repo-deploy-key-for-git
       - install-dependencies-scan-and-archive:
           directory: Tests/InstallationTests/CarthageInstallation/
-      - slack-notify-on-fail
 
   lint:
     executor:
@@ -2000,7 +1912,6 @@ jobs:
       - run:
           name: Submit Purchase Tester
           command: bundle exec fastlane deploy_purchase_tester dry_run:<< parameters.dry_run >>
-      - slack-notify-on-fail
 
   deploy-rct-tester:
     executor:
@@ -2020,7 +1931,6 @@ jobs:
       - run:
           name: Submit RCT Tester
           command: bundle exec fastlane deploy_rct_tester dry_run:<< parameters.dry_run >>
-      - slack-notify-on-fail
 
   emerge_purchases_ui_snapshot_tests:
     executor:
@@ -2034,7 +1944,6 @@ jobs:
       - run:
           name: Build Paywalls Tester
           command: bundle exec fastlane build_paywalls_tester_for_emerge
-      - slack-notify-on-fail
 
   emerge_binary_size_analysis:
     executor:
@@ -2124,7 +2033,6 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output
           destination: paywall-template-screenshots
-      - slack-notify-on-fail
 
   update-paywall-preview-resources-commit:
     docker:
@@ -2188,7 +2096,6 @@ jobs:
       - store_artifacts:
           path: /tmp/pr-swiftinterface/RevenueCat-visionos.swiftinterface
           destination: revenuecat-api-visionos.swiftinterface
-      - slack-notify-on-fail
 
   check-api-changes-revenuecatui:
     executor:
@@ -2240,7 +2147,6 @@ jobs:
       - store_artifacts:
           path: /tmp/pr-swiftinterface/RevenueCatUI-visionos.swiftinterface
           destination: revenuecatui-api-visionos.swiftinterface
-      - slack-notify-on-fail
 
   generate-swiftinterface:
     executor:
@@ -2258,7 +2164,6 @@ jobs:
           name: Update baseline swiftinterface files
           command: |
             bundle exec fastlane ios create_swiftinterface_pr
-      - slack-notify-on-fail
 
   deploy-to-spm:
     docker:


### PR DESCRIPTION

The official CircleCI Slack app now reports failures on `main`, so the legacy orb sends duplicate messages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI failure visibility on `main` now depends on the official CircleCI Slack app only; if that integration misses a job class, failures may go unannounced until someone checks CircleCI.
> 
> **Overview**
> Stops duplicate Slack alerts on `main` by deleting the legacy **CircleCI Slack orb** (`circleci/slack@5.0.0`), the shared **`slack-notify-on-fail`** command (token/channel setup plus `slack/notify` to `feed-circleci-ios-failures`), and that step from every job that used it.
> 
> The **`installation-tests-all-but-carthage`** job no longer runs the custom failure collector or bespoke Slack block that listed which installation tests failed. **GitHub PR CI comments** (`github-notify-pr-on-fail`) and **Fastlane-driven Slack** (e.g. Maestro consolidated notifications, API-change lanes) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7396b1056a711f239122d210683bf29a9da0c16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->