### PR TITLE
Fix tvOS paywall cache warming test compilation

### DIFF
--- a/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
@@ -698,15 +698,6 @@ final class PaywallCacheWarmingTests: TestCase {
                                                         fontFamily: otherFamily)).to(beTrue())
     }
 
-    func testPlatformFontLookupIsNotCaseSensitive() throws {
-        let font = try Self.anyInstalledFont()
-        let uppercased = font.name.uppercased()
-        try XCTSkipIf(uppercased == font.name)
-
-        expect(Self.platformResolvesFont(named: font.name)).to(beTrue())
-        expect(Self.platformResolvesFont(named: uppercased)).to(beTrue())
-    }
-
     func testFontIsAlreadyInstalled_AgreesWithPlatformFontLookupOnCasing() throws {
         let font = try Self.anyInstalledFont()
         let miscased = font.name.uppercased()

--- a/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
@@ -698,6 +698,19 @@ final class PaywallCacheWarmingTests: TestCase {
                                                         fontFamily: otherFamily)).to(beTrue())
     }
 
+#if !os(tvOS)
+
+    func testPlatformFontLookupIsNotCaseSensitive() throws {
+        let font = try Self.anyInstalledFont()
+        let uppercased = font.name.uppercased()
+        try XCTSkipIf(uppercased == font.name)
+
+        expect(Self.platformResolvesFont(named: font.name)).to(beTrue())
+        expect(Self.platformResolvesFont(named: uppercased)).to(beTrue())
+    }
+
+#endif
+
     func testFontIsAlreadyInstalled_AgreesWithPlatformFontLookupOnCasing() throws {
         let font = try Self.anyInstalledFont()
         let miscased = font.name.uppercased()

--- a/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
@@ -802,6 +802,8 @@ final class PaywallCacheWarmingTests: TestCase {
         )
     }
 
+#if !os(tvOS)
+
     private static func fontsConfig(
         fontName: String,
         family: String,
@@ -814,6 +816,8 @@ final class PaywallCacheWarmingTests: TestCase {
 
         return UIConfig.FontsConfig(ios: UIConfig.FontInfo(name: fontName, webFontInfo: webFontInfo))
     }
+
+#endif
 
     /// Every installed family and its face names on the current platform.
     private static func installedFontFamilies() -> [(family: String, names: [String])] {

--- a/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
@@ -698,7 +698,7 @@ final class PaywallCacheWarmingTests: TestCase {
                                                         fontFamily: otherFamily)).to(beTrue())
     }
 
-#if !os(tvOS)
+#if canImport(UIKit)
 
     func testPlatformFontLookupIsNotCaseSensitive() throws {
         let font = try Self.anyInstalledFont()

--- a/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallCacheWarmingTests.swift
@@ -698,19 +698,6 @@ final class PaywallCacheWarmingTests: TestCase {
                                                         fontFamily: otherFamily)).to(beTrue())
     }
 
-#if canImport(UIKit)
-
-    func testPlatformFontLookupIsNotCaseSensitive() throws {
-        let font = try Self.anyInstalledFont()
-        let uppercased = font.name.uppercased()
-        try XCTSkipIf(uppercased == font.name)
-
-        expect(Self.platformResolvesFont(named: font.name)).to(beTrue())
-        expect(Self.platformResolvesFont(named: uppercased)).to(beTrue())
-    }
-
-#endif
-
     func testFontIsAlreadyInstalled_AgreesWithPlatformFontLookupOnCasing() throws {
         let font = try Self.anyInstalledFont()
         let miscased = font.name.uppercased()


### PR DESCRIPTION
## Description
Fixes one test compilation issue on tvOS and fixing a failing test on macOS.

The `fontsConfig` static func used a `UIConfig` initializer that isn't available on tvOS, thus failing compilation, this code is now excluded on tvOS.

The `testPlatformFontLookupIsNotCaseSensitive()` test asserted that the platform's Font initializer is not case sensitive, however this is not guaranteed / documented it seems. With `UIFont` this seems to be the case, but with `NSFont` it doesn't. Since we already have our own behavior tested using `testFontIsAlreadyInstalled_AgreesWithPlatformFontLookupOnCasing()` I don't think we should be testing the platform behavior here, since we already test that we handle it correctly regardless.

Regression introduced in [#7394](https://github.com/RevenueCat/purchases-ios/pull/7394).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production paywall or font manager logic modified.
> 
> **Overview**
> Fixes **PaywallCacheWarmingTests** so tvOS builds and macOS CI stops failing on an invalid platform assumption.
> 
> The `fontsConfig` test helper is wrapped in `#if !os(tvOS)` because it builds `UIConfig.FontsConfig` via an `ios:` initializer that is not available on tvOS, which broke compilation for that target.
> 
> **`testPlatformFontLookupIsNotCaseSensitive()`** is removed. It required both `UIFont` and `NSFont` name lookups to be case-insensitive; that holds on iOS but not reliably on macOS. Casing is still covered by **`testFontIsAlreadyInstalled_AgreesWithPlatformFontLookupOnCasing()`**, which checks that `fontIsAlreadyInstalled` matches whatever the platform actually does rather than documenting Apple API behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60bec55843878529909be98acdb5633f5d0b2152. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->