### PR TITLE
HTTP Paths can change their absolute path based on IAM enablement

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -607,6 +607,7 @@
 		55DACDFA302BC356005EE017 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDF8302BC356005EE017 /* Authentication.swift */; };
 		55DACDFC302BC381005EE017 /* AnyCodingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDFB302BC381005EE017 /* AnyCodingKey.swift */; };
 		55DACE87302E2B95005EE017 /* AuthenticationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE85302E2B95005EE017 /* AuthenticationTests.swift */; };
+		2485B5EE8B74A157C83795EE /* IdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B9F0E7224E89051D2DC8EC /* IdentityTests.swift */; };
 		55DACE90302E2BBB005EE017 /* MockInternalAuthenticatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE8E302E2BBB005EE017 /* MockInternalAuthenticatorDelegate.swift */; };
 		55DACE91302E2BBB005EE017 /* MockAuthenticationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE8D302E2BBB005EE017 /* MockAuthenticationDelegate.swift */; };
 		55DACE92302E2BBB005EE017 /* MockSecureItemStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE8F302E2BBB005EE017 /* MockSecureItemStorage.swift */; };
@@ -2342,6 +2343,7 @@
 		55DACDF8302BC356005EE017 /* Authentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authentication.swift; sourceTree = "<group>"; };
 		55DACDFB302BC381005EE017 /* AnyCodingKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCodingKey.swift; sourceTree = "<group>"; };
 		55DACE85302E2B95005EE017 /* AuthenticationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationTests.swift; sourceTree = "<group>"; };
+		02B9F0E7224E89051D2DC8EC /* IdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityTests.swift; sourceTree = "<group>"; };
 		55DACE8D302E2BBB005EE017 /* MockAuthenticationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAuthenticationDelegate.swift; sourceTree = "<group>"; };
 		55DACE8E302E2BBB005EE017 /* MockInternalAuthenticatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInternalAuthenticatorDelegate.swift; sourceTree = "<group>"; };
 		55DACE8F302E2BBB005EE017 /* MockSecureItemStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSecureItemStorage.swift; sourceTree = "<group>"; };
@@ -5176,6 +5178,7 @@
 				75ABFDB42D5F579E00D69DF1 /* CustomerInfoManagerUIPreviewModeTests.swift */,
 				FE5151005A0000000000A002 /* CustomerInfoManagerSimulatedStoreTests.swift */,
 				37E35294EBC1E5A879C95540 /* IdentityManagerTests.swift */,
+				02B9F0E7224E89051D2DC8EC /* IdentityTests.swift */,
 			);
 			path = Identity;
 			sourceTree = "<group>";
@@ -8151,6 +8154,7 @@
 				35109DAB2BC6E436001030C8 /* BackendPostDiagnosticsTests.swift in Sources */,
 				57554C84282AC273009A7E58 /* PeriodTypeTests.swift in Sources */,
 				55DACE87302E2B95005EE017 /* AuthenticationTests.swift in Sources */,
+				2485B5EE8B74A157C83795EE /* IdentityTests.swift in Sources */,
 				903A05962EB3AE3C009B9CE4 /* AdEventStoreTests.swift in Sources */,
 				16F376262E93F1E300ADF649 /* LargeItemCacheTypeTests.swift in Sources */,
 				5757EDE72DEE08C100AC4BE1 /* StoreKitVersionTests.swift in Sources */,

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -55,6 +55,7 @@ class Backend {
         // same host, and a success on any of them clears it for all.
         let httpClient = HTTPClient(systemInfo: systemInfo,
                                     eTagManager: eTagManager,
+                                    tokenManager: tokenManager,
                                     signing: Signing(apiKey: systemInfo.apiKey, clock: systemInfo.clock),
                                     diagnosticsTracker: diagnosticsTracker,
                                     networkTimeout: httpClientTimeout,
@@ -322,6 +323,7 @@ private extension HTTPClient {
     ) -> HTTPClient {
         HTTPClient(systemInfo: systemInfo,
                    eTagManager: eTagManager,
+                   tokenManager: tokenManager,
                    signing: Signing(apiKey: systemInfo.apiKey, clock: systemInfo.clock),
                    diagnosticsTracker: diagnosticsTracker,
                    networkTimeout: networkTimeout,

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -24,6 +24,7 @@ class HTTPClient {
     let systemInfo: SystemInfo
     let timeout: TimeInterval
     let authHeaders: RequestHeaders
+    let tokenManager: TokenManager
 
     private let session: URLSession
     private let state: Atomic<State> = .init(.initial)
@@ -49,6 +50,7 @@ class HTTPClient {
 
     init(systemInfo: SystemInfo,
          eTagManager: ETagManager,
+         tokenManager: TokenManager,
          signing: SigningType,
          diagnosticsTracker: DiagnosticsTrackerType?,
          dnsChecker: DNSCheckerType.Type = DNSChecker.self,
@@ -69,6 +71,7 @@ class HTTPClient {
                                   delegateQueue: nil)
         self.systemInfo = systemInfo
         self.eTagManager = eTagManager
+        self.tokenManager = tokenManager
         self.signing = signing
         self.diagnosticsTracker = diagnosticsTracker
         self.dnsChecker = dnsChecker
@@ -91,6 +94,7 @@ class HTTPClient {
                                     authHeaders: self.authHeaders,
                                     defaultHeaders: self.defaultHeaders,
                                     verificationMode: verificationMode ?? self.systemInfo.responseVerificationMode,
+                                    preferIAMPath: self.tokenManager.enabled,
                                     internalSettings: self.systemInfo.dangerousSettings.internalSettings,
                                     completionHandler: completionHandler))
     }
@@ -290,6 +294,7 @@ internal extension HTTPClient {
         var httpRequest: HTTPRequest
         var headers: HTTPClient.RequestHeaders
         var verificationMode: Signing.ResponseVerificationMode
+        var preferIAMPath: Bool
         var completionHandler: HTTPClient.Completion<Data>?
         private(set) var fallbackUrlIndex: Int?
 
@@ -321,6 +326,7 @@ internal extension HTTPClient {
                                       authHeaders: HTTPClient.RequestHeaders,
                                       defaultHeaders: HTTPClient.RequestHeaders,
                                       verificationMode: Signing.ResponseVerificationMode,
+                                      preferIAMPath: Bool,
                                       internalSettings: InternalDangerousSettingsType,
                                       completionHandler: HTTPClient.Completion<Value>?) {
             self.httpRequest = httpRequest.requestAddingNonceIfRequired(with: verificationMode)
@@ -331,6 +337,7 @@ internal extension HTTPClient {
                 internalSettings: internalSettings
             )
             self.verificationMode = verificationMode
+            self.preferIAMPath = preferIAMPath
 
             if let completionHandler = completionHandler {
                 self.completionHandler = { result in
@@ -342,13 +349,20 @@ internal extension HTTPClient {
         }
 
         var method: HTTPRequest.Method { self.httpRequest.method }
-        var path: String { self.httpRequest.path.relativePath }
+        var path: String {
+            if self.preferIAMPath {
+                return self.httpRequest.path.relativeIAMPath
+            } else {
+                return self.httpRequest.path.relativePath
+            }
+        }
 
         func getCurrentRequestURL(proxyURL: URL?, apiSourceURL: URL?) -> URL? {
             return self.httpRequest.path.url(
                 proxyURL: proxyURL,
                 apiSourceURL: apiSourceURL,
-                fallbackUrlIndex: self.fallbackUrlIndex
+                fallbackUrlIndex: self.fallbackUrlIndex,
+                preferIAMPath: self.preferIAMPath
             )
         }
 
@@ -486,10 +500,10 @@ private extension HTTPClient {
             ))
             requestHeaders = [:]
         } else {
-            requestHeaders = request.headers
+            requestHeaders = urlRequest.allHTTPHeaderFields ?? [:]
         }
         #else
-        let requestHeaders = request.headers
+        let requestHeaders = urlRequest.allHTTPHeaderFields ?? [:]
         #endif
 
         let result = Result
@@ -512,7 +526,8 @@ private extension HTTPClient {
                     requestHeaders: requestHeaders,
                     publicKey: request.verificationMode.publicKey,
                     isLoadShedderResponse: isLoadShedderResponse,
-                    isFallbackUrlResponse: isFallbackUrlResponse
+                    isFallbackUrlResponse: isFallbackUrlResponse,
+                    iamEnabled: request.preferIAMPath
                 )
             }
             // Fetch from ETagManager if available

--- a/Sources/Networking/HTTPClient/HTTPRequest.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequest.swift
@@ -142,3 +142,34 @@ extension HTTPRequest.Method {
     }
 
 }
+
+extension HTTPRequest.Headers {
+
+    var bearerAuthorizationValue: String? {
+        get {
+            guard let value = authorizationValue else { return nil }
+            guard let firstSpaceIndex = value.firstIndex(of: " ") else { return nil }
+            guard value[..<firstSpaceIndex] == "Bearer" else { return nil }
+
+            let afterSpace = value.index(after: firstSpaceIndex)
+            return String(value[afterSpace...])
+        }
+        set {
+            if let newValue {
+                self.authorizationValue = "Bearer \(newValue)"
+            } else {
+                self.authorizationValue = nil
+            }
+        }
+    }
+
+    var authorizationValue: String? {
+        get {
+            return self[HTTPClient.RequestHeader.authorization.rawValue]
+        }
+        set {
+            self[HTTPClient.RequestHeader.authorization.rawValue] = newValue
+        }
+    }
+
+}

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -471,7 +471,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
         case .getIntroEligibility:
             return "customer/intro_eligibility"
         case .logIn:
-            precondition(false, "The .login endpoint is not allowed when IAM is enabled")
+            assertionFailure("The .login endpoint is not allowed when IAM is enabled")
             return self.pathComponent
         case .postAttributionData:
             return "customer/attribution"

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -471,7 +471,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
         case .getIntroEligibility:
             return "customer/intro_eligibility"
         case .logIn:
-            // SHOULD NOT BE USED
+            precondition(false, "The .login endpoint is not allowed when IAM is enabled")
             return self.pathComponent
         case .postAttributionData:
             return "customer/attribution"

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -43,6 +43,9 @@ protocol HTTPRequestPath {
     /// The full relative path for this endpoint.
     var relativePath: String { get }
 
+    /// The full relative path for this endpoint when using IAM tokens.
+    var relativeIAMPath: String { get }
+
     /// The fallback relative path for this endpoint, if any.
     var fallbackRelativePath: String? { get }
 
@@ -62,6 +65,9 @@ protocol HTTPRequestPath {
 
     /// Provides endpoint-specific inputs for response signature verification.
     var responseSignatureContextProvider: ResponseSignatureContextProvider { get }
+
+    /// Whether this path corresponds to an IAM request
+    var isIAMPath: Bool { get }
 }
 
 /// Provides endpoint-specific inputs for backend response signature verification.
@@ -106,6 +112,10 @@ extension HTTPRequestPath {
         return nil
     }
 
+    var relativeIAMPath: String {
+        return self.relativePath
+    }
+
     var usesAPISources: Bool {
         return false
     }
@@ -122,9 +132,14 @@ extension HTTPRequestPath {
         return DefaultResponseSignatureContextProvider()
     }
 
-    var url: URL? { return self.url(proxyURL: nil) }
+    var isIAMPath: Bool {
+        return false
+    }
 
-    func url(proxyURL: URL? = nil, apiSourceURL: URL? = nil, fallbackUrlIndex: Int? = nil) -> URL? {
+    func url(proxyURL: URL? = nil,
+             apiSourceURL: URL? = nil,
+             fallbackUrlIndex: Int? = nil,
+             preferIAMPath: Bool) -> URL? {
         let baseURL: URL
         if let proxyURL {
             // When a Proxy URL is set, we don't support API sources or fallback URLs
@@ -141,7 +156,9 @@ extension HTTPRequestPath {
         } else {
             baseURL = Self.serverHostURL
         }
-        return URL(string: self.relativePath, relativeTo: baseURL)
+
+        let path = preferIAMPath ? self.relativeIAMPath : self.relativePath
+        return URL(string: path, relativeTo: baseURL)
     }
 }
 
@@ -368,7 +385,15 @@ extension HTTPRequest.Path: HTTPRequestPath {
     }
 
     var relativePath: String {
-        return "/v1/\(self.pathComponent)"
+        let component = self.pathComponent
+        if component.hasPrefix("/") { return component }
+        return "/v1/\(component)"
+    }
+
+    var relativeIAMPath: String {
+        let component = self.iamPathComponent
+        if component.hasPrefix("/") { return component }
+        return "/v1/\(component)"
     }
 
     var pathComponent: String {
@@ -431,6 +456,55 @@ extension HTTPRequest.Path: HTTPRequestPath {
 
         case let .remoteConfig(domain):
             return "config/\(Self.escape(domain))"
+        }
+    }
+
+    var iamPathComponent: String {
+        // NOTE: cases below that "return self.pathComponent" are indicating
+        // that the corresponding server paths have not yet been migrated to
+        // support access token authorization
+        switch self {
+        case .getCustomerInfo:
+            return "customer"
+        case .getOfferings:
+            return "customer/offerings"
+        case .getIntroEligibility:
+            return "customer/intro_eligibility"
+        case .logIn:
+            // SHOULD NOT BE USED
+            return self.pathComponent
+        case .postAttributionData:
+            return "customer/attribution"
+        case .postOfferForSigning:
+            return "offers"
+        case .postReceiptData:
+            return "receipts"
+        case .postSubscriberAttributes:
+            return "customer/attributes"
+        case .postAdServicesToken:
+            return "customer/adservices_attribution"
+        case .health:
+            return self.pathComponent
+        case .appHealthReport:
+            return "customer/health_report"
+        case .appHealthReportAvailability:
+            return self.pathComponent
+        case .getProductEntitlementMapping:
+            return "product_entitlement_mapping"
+        case .getCustomerCenterConfig:
+            return "customer/customercenter"
+        case .getVirtualCurrencies:
+            return "customer/virtual_currencies"
+        case .postRedeemWebPurchase:
+            return self.pathComponent
+        case .postCreateTicket:
+            return self.pathComponent
+        case .isPurchaseAllowedByRestoreBehavior:
+            return "customer/restore/eligibility"
+        case .rewardVerificationStatus:
+            return self.pathComponent
+        case .remoteConfig:
+            return self.pathComponent
         }
     }
 

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -472,6 +472,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
             return "customer/intro_eligibility"
         case .logIn:
             assertionFailure("The .login endpoint is not allowed when IAM is enabled")
+            Logger.error("The .login endpoint is not allowed when IAM is enabled")
             return self.pathComponent
         case .postAttributionData:
             return "customer/attribution"

--- a/Sources/Security/Signing+ResponseVerification.swift
+++ b/Sources/Security/Signing+ResponseVerification.swift
@@ -22,7 +22,8 @@ extension HTTPResponse where Body == Data? {
         requestHeaders: HTTPRequest.Headers,
         publicKey: Signing.PublicKey?,
         isLoadShedderResponse: Bool,
-        isFallbackUrlResponse: Bool
+        isFallbackUrlResponse: Bool,
+        iamEnabled: Bool
     ) -> VerifiedHTTPResponse<Body> {
         let verificationResult = Self.verificationResult(
             body: self.body,
@@ -33,6 +34,7 @@ extension HTTPResponse where Body == Data? {
             request: request,
             publicKey: publicKey,
             signing: signing,
+            iamEnabled: iamEnabled,
             isFallbackUrlResponse: isFallbackUrlResponse
         )
 
@@ -62,6 +64,7 @@ extension HTTPResponse where Body == Data? {
         request: HTTPRequest,
         publicKey: Signing.PublicKey?,
         signing: SigningType,
+        iamEnabled: Bool,
         isFallbackUrlResponse: Bool
     ) -> VerificationResult {
         guard let publicKey = publicKey, statusCode.isSuccessfulResponse else {
@@ -99,6 +102,7 @@ extension HTTPResponse where Body == Data? {
         if signing.verify(signature: signature,
                           with: .init(
                             path: request.path,
+                            iamEnabled: iamEnabled,
                             message: message,
                             requestHeaders: requestHeaders,
                             requestBody: contextProvider.requestBodyForSignature(for: request),

--- a/Sources/Security/Signing.swift
+++ b/Sources/Security/Signing.swift
@@ -14,6 +14,8 @@
 import CryptoKit
 import Foundation
 
+// swiftlint:disable file_length
+
 /// A type that can verify signatures.
 protocol SigningType {
 

--- a/Sources/Security/Signing.swift
+++ b/Sources/Security/Signing.swift
@@ -98,17 +98,7 @@ final class Signing: SigningType {
             return false
         }
 
-        let authValue: String
-        if let authHeader = parameters.requestHeaders[HTTPClient.RequestHeader.authorization.rawValue] {
-            if let firstSpaceIndex = authHeader.firstIndex(of: " ") {
-                let afterSpace = authHeader.index(after: firstSpaceIndex)
-                authValue = String(authHeader[afterSpace...])
-            } else {
-                authValue = authHeader
-            }
-        } else {
-            authValue = self.apiKey
-        }
+        let authValue = parameters.requestHeaders.bearerAuthorizationValue ?? self.apiKey
 
         let salt = signature.component(.salt)
         let payload = signature.component(.payload)

--- a/Sources/Security/Signing.swift
+++ b/Sources/Security/Signing.swift
@@ -35,6 +35,7 @@ final class Signing: SigningType {
     struct SignatureParameters {
 
         var path: HTTPRequestPath
+        var iamEnabled: Bool
         var message: Data?
         var requestHeaders: HTTPRequest.Headers
         var requestBody: HTTPRequestBody?
@@ -95,9 +96,21 @@ final class Signing: SigningType {
             return false
         }
 
+        let authValue: String
+        if let authHeader = parameters.requestHeaders[HTTPClient.RequestHeader.authorization.rawValue] {
+            if let firstSpaceIndex = authHeader.firstIndex(of: " ") {
+                let afterSpace = authHeader.index(after: firstSpaceIndex)
+                authValue = String(authHeader[afterSpace...])
+            } else {
+                authValue = authHeader
+            }
+        } else {
+            authValue = self.apiKey
+        }
+
         let salt = signature.component(.salt)
         let payload = signature.component(.payload)
-        let messageToVerify = parameters.signature(salt: salt, apiKey: self.apiKey)
+        let messageToVerify = parameters.signature(salt: salt, authValue: authValue)
 
         #if DEBUG
         Logger.verbose(Strings.signing.verifying_signature(
@@ -240,6 +253,7 @@ extension Signing.SignatureParameters {
 
     init(
         path: HTTPRequest.Path,
+        iamEnabled: Bool,
         message: Data? = nil,
         requestHeaders: HTTPRequest.Headers = [:],
         requestBody: HTTPRequestBody? = nil,
@@ -249,6 +263,7 @@ extension Signing.SignatureParameters {
         useFallbackPath: Bool = false
     ) {
         self.path = path
+        self.iamEnabled = iamEnabled
         self.message = message
         self.requestHeaders = requestHeaders
         self.requestBody = requestBody
@@ -258,9 +273,9 @@ extension Signing.SignatureParameters {
         self.useFallbackPath = useFallbackPath
     }
 
-    func signature(salt: Data, apiKey: String) -> Data {
-        let apiKey = self.path.authenticated ? apiKey : ""
-        return salt + apiKey.asData + self.asData
+    func signature(salt: Data, authValue: String) -> Data {
+        let auth = self.path.authenticated ? authValue : ""
+        return salt + auth.asData + self.asData
     }
 
     var asData: Data {
@@ -269,7 +284,7 @@ extension Signing.SignatureParameters {
         if useFallbackPath, let fallbackRelativePath = self.path.fallbackRelativePath {
             relativePath = fallbackRelativePath
         } else {
-            relativePath = self.path.relativePath
+            relativePath = self.iamEnabled ? self.path.relativeIAMPath : self.path.relativePath
         }
         let path: Data = relativePath.asData
         let postParameterHash: Data = self.requestBody?.postParameterHeader?.asData ?? .init()
@@ -292,7 +307,7 @@ extension Signing.SignatureParameters: CustomDebugStringConvertible {
     var debugDescription: String {
         return """
         SignatureParameters(" +
-            path: '\(self.path.relativePath)'
+            path: '\(self.iamEnabled ? self.path.relativeIAMPath : self.path.relativePath)'
             message: '\(self.messageString.trimmingWhitespacesAndNewLines)'
             headerParametersHash: '\(HTTPRequest.headerParametersForSignatureHeader(
                 headers: self.requestHeaders,

--- a/Tests/BackendIntegrationTests/CachedOfferingsUsageIntegrationTest.swift
+++ b/Tests/BackendIntegrationTests/CachedOfferingsUsageIntegrationTest.swift
@@ -49,7 +49,7 @@ class CachedOfferingsUsageIntegrationTest: BaseStoreKitIntegrationTests {
                 return .defaultServerError
             }
             return .fakeResponse(
-                HTTPURLResponse(url: request.httpRequest.path.url!,
+                HTTPURLResponse(url: request.httpRequest.path.url(preferIAMPath: false)!,
                                 statusCode: 401,
                                 httpVersion: nil,
                                 headerFields: nil)!,

--- a/Tests/BackendIntegrationTests/WorkflowComponentsIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/WorkflowComponentsIntegrationTests.swift
@@ -87,7 +87,7 @@ private final class RemoteConfigKillSwitchFake: @unchecked Sendable {
         data: Data,
         request: HTTPClient.Request
     ) -> ForceServerErrorStrategy.Action {
-        guard let url = request.httpRequest.path.url,
+        guard let url = request.httpRequest.path.url(preferIAMPath: false),
               let response = HTTPURLResponse(url: url,
                                              statusCode: statusCode,
                                              httpVersion: nil,

--- a/Tests/RemoteConfigProductionTests/RemoteConfigBlobHealthTests.swift
+++ b/Tests/RemoteConfigProductionTests/RemoteConfigBlobHealthTests.swift
@@ -160,7 +160,7 @@ final class RemoteConfigBlobHealthTests: TestCase {
 
 }
 
-private struct ProductionTestUserProvider: CurrentUserProvider {
+private final class ProductionTestUserProvider: CurrentUserProvider {
     var currentAppUserID: String { "remote-config-production-test-user" }
     var currentUserIsAnonymous: Bool { true }
 }

--- a/Tests/UnitTests/Identity/IdentityTests.swift
+++ b/Tests/UnitTests/Identity/IdentityTests.swift
@@ -14,7 +14,7 @@
 import Nimble
 import XCTest
 
-@testable @_spi(Experimental) import RevenueCat
+@testable @_spi(Internal) import RevenueCat
 
 class IdentityTests: TestCase {
 

--- a/Tests/UnitTests/Identity/IdentityTests.swift
+++ b/Tests/UnitTests/Identity/IdentityTests.swift
@@ -1,0 +1,150 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  IdentityTests.swift
+//
+//  Created by RevenueCat on 8/18/26.
+
+import Nimble
+import XCTest
+
+@testable @_spi(Experimental) import RevenueCat
+
+class IdentityTests: TestCase {
+
+    // MARK: - Identity
+
+    func testAnonymousIdentityHasAnonymousSource() {
+        let identity: Identity = .anonymous
+
+        expect(identity.identitySource) === IdentitySource.anonymous
+    }
+
+    func testSignInWithAppleFactoryCreatesIdentityWithSignInWithAppleSource() {
+        let token = "identity-token".asData
+        let identity = Identity.signInWithApple(token)
+
+        expect(identity.identitySource) === IdentitySource.signInWithApple
+    }
+
+    func testSignInWithAppleFactoryCreatesDistinctIdentitiesForDifferentTokens() {
+        let identity1 = Identity.signInWithApple("token-1".asData)
+        let identity2 = Identity.signInWithApple("token-2".asData)
+
+        expect(identity1.authToken.cacheIdentifier) != identity2.authToken.cacheIdentifier
+    }
+
+    func testSignInWithAppleFactoryCreatesEqualCacheIdentifierForSameToken() {
+        let token = "identity-token".asData
+        let identity1 = Identity.signInWithApple(token)
+        let identity2 = Identity.signInWithApple(token)
+
+        expect(identity1.authToken.cacheIdentifier) == identity2.authToken.cacheIdentifier
+    }
+
+    // MARK: - IdentitySource
+
+    func testIdentitySourceAllCasesContainsEverySource() {
+        let rawValues = Set(IdentitySource.allCases.map { $0.rawValue })
+
+        expect(rawValues) == Set(["anonymous", "oidc", "google", "signInWithApple", "facebook", "firebase"])
+    }
+
+    func testIdentitySourceDescriptionMatchesRawValue() {
+        for source in IdentitySource.allCases {
+            expect(source.description) == source.rawValue
+        }
+    }
+
+    func testIdentitySourceWithRawValueReturnsMatchingCase() {
+        for source in IdentitySource.allCases {
+            expect(IdentitySource.source(with: source.rawValue)) === source
+        }
+    }
+
+    func testIdentitySourceWithUnrecognizedRawValueReturnsNil() {
+        expect(IdentitySource.source(with: "not-a-real-source")).to(beNil())
+    }
+
+    // MARK: - IdentityAuthToken
+
+    func testAuthenticationMethodMapsToExpectedSource() {
+        let data = "token".asData
+
+        expect(IdentityAuthToken.anonymous.authenticationMethod) === IdentitySource.anonymous
+        expect(IdentityAuthToken.oidc(data).authenticationMethod) === IdentitySource.oidc
+        expect(IdentityAuthToken.google(data).authenticationMethod) === IdentitySource.google
+        expect(IdentityAuthToken.signInWithApple(data).authenticationMethod) === IdentitySource.signInWithApple
+        expect(IdentityAuthToken.facebook(data, nil).authenticationMethod) === IdentitySource.facebook
+        expect(IdentityAuthToken.facebook(data, "user@example.com").authenticationMethod) === IdentitySource.facebook
+        expect(IdentityAuthToken.firebase(data).authenticationMethod) === IdentitySource.firebase
+    }
+
+    func testCacheIdentifierForAnonymousIsConstant() {
+        expect(IdentityAuthToken.anonymous.cacheIdentifier) == "anon"
+    }
+
+    func testCacheIdentifierUsesExpectedPrefixPerCase() {
+        let data = "some-token-data".asData
+
+        expect(IdentityAuthToken.oidc(data).cacheIdentifier).to(beginWith("oidc-"))
+        expect(IdentityAuthToken.google(data).cacheIdentifier).to(beginWith("google-"))
+        expect(IdentityAuthToken.signInWithApple(data).cacheIdentifier).to(beginWith("siwa-"))
+        expect(IdentityAuthToken.facebook(data, nil).cacheIdentifier).to(beginWith("fb-"))
+        expect(IdentityAuthToken.firebase(data).cacheIdentifier).to(beginWith("firebase-"))
+    }
+
+    func testCacheIdentifierIsDeterministicForIdenticalData() {
+        let data = "consistent-token".asData
+
+        expect(IdentityAuthToken.oidc(data).cacheIdentifier) == IdentityAuthToken.oidc(data).cacheIdentifier
+        expect(IdentityAuthToken.signInWithApple(data).cacheIdentifier)
+            == IdentityAuthToken.signInWithApple(data).cacheIdentifier
+    }
+
+    func testCacheIdentifierDiffersForDifferentData() {
+        let data1 = "token-1".asData
+        let data2 = "token-2".asData
+
+        expect(IdentityAuthToken.oidc(data1).cacheIdentifier) != IdentityAuthToken.oidc(data2).cacheIdentifier
+    }
+
+    func testCacheIdentifierForFacebookIgnoresEmail() {
+        let data = "fb-token".asData
+
+        // The email is not part of the cache identifier, only the token data is.
+        expect(IdentityAuthToken.facebook(data, nil).cacheIdentifier)
+            == IdentityAuthToken.facebook(data, "user@example.com").cacheIdentifier
+    }
+
+    func testValidateIsAlwaysTrueForAnonymous() {
+        expect(IdentityAuthToken.anonymous.validate()) == true
+    }
+
+    func testValidateIsFalseForEmptyTokenData() {
+        let empty = Data()
+
+        expect(IdentityAuthToken.oidc(empty).validate()) == false
+        expect(IdentityAuthToken.google(empty).validate()) == false
+        expect(IdentityAuthToken.signInWithApple(empty).validate()) == false
+        expect(IdentityAuthToken.facebook(empty, nil).validate()) == false
+        expect(IdentityAuthToken.firebase(empty).validate()) == false
+    }
+
+    func testValidateIsTrueForNonEmptyTokenData() {
+        let data = "non-empty".asData
+
+        expect(IdentityAuthToken.oidc(data).validate()) == true
+        expect(IdentityAuthToken.google(data).validate()) == true
+        expect(IdentityAuthToken.signInWithApple(data).validate()) == true
+        expect(IdentityAuthToken.facebook(data, nil).validate()) == true
+        expect(IdentityAuthToken.firebase(data).validate()) == true
+    }
+
+}

--- a/Tests/UnitTests/Mocks/MockBackendConfiguration.swift
+++ b/Tests/UnitTests/Mocks/MockBackendConfiguration.swift
@@ -23,6 +23,7 @@ class MockBackendConfiguration: BackendConfiguration {
         }
         let httpClient = MockHTTPClient(systemInfo: systemInfo,
                                         eTagManager: MockETagManager(),
+                                        tokenManager: MockTokenManager(),
                                         diagnosticsTracker: diagnosticsTracker,
                                         networkTimeout: .custom(7))
 

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -84,6 +84,7 @@ class MockHTTPClient: HTTPClient {
 
     init(systemInfo: SystemInfo,
          eTagManager: ETagManager,
+         tokenManager: TokenManager,
          diagnosticsTracker: DiagnosticsTrackerType?,
          dnsChecker: DNSCheckerType.Type = DNSChecker.self,
          networkTimeout: NetworkTimeout = .custom(7),
@@ -92,6 +93,7 @@ class MockHTTPClient: HTTPClient {
 
         super.init(systemInfo: systemInfo,
                    eTagManager: eTagManager,
+                   tokenManager: tokenManager,
                    signing: FakeSigning.default,
                    diagnosticsTracker: diagnosticsTracker,
                    dnsChecker: dnsChecker,
@@ -135,7 +137,7 @@ class MockHTTPClient: HTTPClient {
                                testName: CurrentTestCaseTracker.osVersionAndTestName)
             }
 
-            let mock = self.mocks[request.path.url!] ?? .init(statusCode: .success)
+            let mock = self.mocks[request.path.url(preferIAMPath: false)!] ?? .init(statusCode: .success)
 
             if let completionHandler = completionHandler {
                 let response: VerifiedHTTPResponse<Value>.Result = mock.response.parseResponse()
@@ -168,7 +170,7 @@ class MockHTTPClient: HTTPClient {
     }
 
     private func mock(path: HTTPRequestPath, response: Response) {
-        self.mocks[path.url!] = response
+        self.mocks[path.url(preferIAMPath: false)!] = response
     }
 
     /// Override headers that depend on the environment to make them stable.
@@ -207,7 +209,7 @@ extension RevenueCat.HTTPRequest: Swift.Encodable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
-        try container.encode(self.path.url, forKey: .url)
+        try container.encode(self.path.url(preferIAMPath: false), forKey: .url)
         try container.encode(self.method.httpMethod, forKey: .method)
 
         if let body = self.requestBody {

--- a/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetRemoteConfigTests.swift
@@ -136,7 +136,7 @@ final class BackendGetRemoteConfigTests: BaseBackendTests {
         expect(self.httpClient.calls.first?.request.method.httpMethod) == "GET"
         expect(self.httpClient.calls.first?.request.path as? HTTPRequest.FallbackPath)
             == HTTPRequest.FallbackPath.remoteConfig(domain: "app")
-        expect(self.httpClient.calls.first?.request.path.url?.absoluteString)
+        expect(self.httpClient.calls.first?.request.path.url(preferIAMPath: false)?.absoluteString)
             == "https://api-production.8-lives-cat.io/v1/config/app"
         expect(self.httpClient.calls.first?.request.requestBody).to(beNil())
     }

--- a/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
@@ -779,7 +779,7 @@ class BackendPostReceiptDataTests: BaseBackendPostReceiptDataTests {
             originalSubscriberInfo.value = result.value
             callOrder.value.initialGet = true
 
-            self.httpClient.mocks.removeValue(forKey: getCustomerInfoPath.url!)
+            self.httpClient.mocks.removeValue(forKey: getCustomerInfoPath.url(preferIAMPath: false)!)
         }
 
         backend.post(receipt: Self.receipt,

--- a/Tests/UnitTests/Networking/Backend/BackendRemoteConfigLaneTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendRemoteConfigLaneTests.swift
@@ -127,10 +127,12 @@ final class BackendRemoteConfigLaneParallelTests: TestCase {
     func testConfigCompletesWhileOfferingsHangsOnSeparateLane() throws {
         let systemInfo = MockSystemInfo(finishTransactions: true)
         let eTagManager = MockETagManager()
+        let tokenManager = MockTokenManager()
 
         func makeClient() -> HTTPClient {
             return HTTPClient(systemInfo: systemInfo,
                               eTagManager: eTagManager,
+                              tokenManager: tokenManager,
                               signing: MockSigning(),
                               diagnosticsTracker: nil,
                               networkTimeout: .custom(30),

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -140,6 +140,7 @@ extension BaseBackendTests {
 
         return MockHTTPClient(systemInfo: self.systemInfo,
                               eTagManager: eTagManager,
+                              tokenManager: MockTokenManager(),
                               diagnosticsTracker: self.diagnosticsTracker,
                               sourceTestFile: file)
     }

--- a/Tests/UnitTests/Networking/Backend/PostReceiptDataOperationFactoryTests.swift
+++ b/Tests/UnitTests/Networking/Backend/PostReceiptDataOperationFactoryTests.swift
@@ -37,6 +37,7 @@ class PostReceiptDataOperationFactoryTests: TestCase {
         let httpClient = MockHTTPClient(
             systemInfo: systemInfo,
             eTagManager: MockETagManager(),
+            tokenManager: MockTokenManager(),
             diagnosticsTracker: nil
         )
         return NetworkOperation.UserSpecificConfiguration(

--- a/Tests/UnitTests/Networking/ETagManagerTests.swift
+++ b/Tests/UnitTests/Networking/ETagManagerTests.swift
@@ -1195,8 +1195,8 @@ private extension ETagManagerTests {
                      isFallbackUrlResponse: isFallbackUrlResponse)
     }
 
-    private static let testURL = HTTPRequest.Path.getCustomerInfo(appUserID: "appUserID").url!
-    private static let testURL2 = HTTPRequest.Path.getCustomerInfo(appUserID: "appUserID_2").url!
+    private static let testURL = HTTPRequest.Path.getCustomerInfo(appUserID: "appUserID").url(preferIAMPath: false)!
+    private static let testURL2 = HTTPRequest.Path.getCustomerInfo(appUserID: "appUserID_2").url(preferIAMPath: false)!
 
     static let testETag = "etag_1"
 

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -3220,10 +3220,9 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
         expect(response).to(beSuccess())
         expect(response?.value?.body) == responseData
 
-        self.logger.verifyMessageWasLogged("""
-            Performing redirect from '\(pathA.url(preferIAMPath: self.tokenManager.enabled)!.absoluteString)'
-             to '\(pathB.url(preferIAMPath: self.tokenManager.enabled)!.absoluteString)'
-            """,
+        self.logger.verifyMessageWasLogged(
+            "Performing redirect from '\(pathA.url(preferIAMPath: self.tokenManager.enabled)!.absoluteString)' " +
+            "to '\(pathB.url(preferIAMPath: self.tokenManager.enabled)!.absoluteString)'",
             level: .debug
         )
     }

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -3531,6 +3531,18 @@ extension HTTPClientTests {
         expect(secondRetriedRequest.fallbackUrlIndex).to(equal(0))
     }
 
+    func testRequestPathUsesRegularPathWhenIAMPathNotPreferred() {
+        let request = buildEmptyRequest(isRetryable: true, preferIAMPath: false)
+
+        expect(request.path) == "/v1/subscribers/abc123"
+    }
+
+    func testRequestPathUsesIAMPathWhenIAMPathPreferred() {
+        let request = buildEmptyRequest(isRetryable: true, preferIAMPath: true)
+
+        expect(request.path) == "/v1/customer"
+    }
+
     private func buildEmptyRequest(
         isRetryable: Bool,
         hasFallbackUrls: Bool = false,

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1824,7 +1824,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
         let request = HTTPRequest(method: .get, path: .getOfferings(appUserID: "test_user_id"))
 
         // main request
-        let url = try XCTUnwrap(request.path.url(preferIAMPath: false)?.absoluteString)
+        let url = try XCTUnwrap(request.path.url(preferIAMPath: self.tokenManager.enabled)?.absoluteString)
         stub(condition: isAbsoluteURLString(url)) { request in
 
             // Main-source request supporting a fallback should use the base tier for that kind
@@ -1855,7 +1855,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
         let client = self.createClient(self.systemInfoUsingAPISources())
         let request = HTTPRequest(method: .get, path: .getOfferings(appUserID: "test_user_id"))
 
-        let url = try XCTUnwrap(request.path.url(preferIAMPath: false)?.absoluteString)
+        let url = try XCTUnwrap(request.path.url(preferIAMPath: self.tokenManager.enabled)?.absoluteString)
         stub(condition: isAbsoluteURLString(url)) { _ in
             return .timeoutResponse()
         }
@@ -1951,7 +1951,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
         let request = HTTPRequest(method: .get, path: HTTPRequest.FallbackPath.remoteConfig(domain: "app"))
         let host = try XCTUnwrap(HTTPRequest.FallbackPath.serverHostURL.host)
 
-        let url = try XCTUnwrap(request.path.url(preferIAMPath: false)?.absoluteString)
+        let url = try XCTUnwrap(request.path.url(preferIAMPath: self.tokenManager.enabled)?.absoluteString)
         stub(condition: isAbsoluteURLString(url)) { request in
             XCTAssertEqual(request.timeoutInterval, HTTPRequestTimeoutManager.Timeout.flat)
             return .timeoutResponse()
@@ -1982,7 +1982,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
 
         timeoutManager.recordRequestResult(host: host, .mainSourceTimedOut)
 
-        let url = try XCTUnwrap(request.path.url(preferIAMPath: false)?.absoluteString)
+        let url = try XCTUnwrap(request.path.url(preferIAMPath: self.tokenManager.enabled)?.absoluteString)
         stub(condition: isAbsoluteURLString(url)) { _ in
             return .emptySuccessResponse()
         }
@@ -2079,7 +2079,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
         let request = HTTPRequest(method: .get, path: .getProductEntitlementMapping)
 
         // main request fails with server error (triggers fallback)
-        let url = try XCTUnwrap(request.path.url(preferIAMPath: false)?.absoluteString)
+        let url = try XCTUnwrap(request.path.url(preferIAMPath: self.tokenManager.enabled)?.absoluteString)
         stub(condition: isAbsoluteURLString(url)) { request in
             // Main-source request should use the base tier for a request supporting fallback
             XCTAssertEqual(
@@ -3196,11 +3196,12 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
         let responseData = "{\"message\": \"something is great up in the cloud\"}".asData
 
         stub(condition: isPath(pathA)) { _ in
+            let locationValue = pathB.url(preferIAMPath: self.tokenManager.enabled)!.absoluteString
             return HTTPStubsResponse(
                 data: .init(),
                 statusCode: .temporaryRedirect,
                 headers: [
-                    HTTPClient.ResponseHeader.location.rawValue: pathB.url(preferIAMPath: false)!.absoluteString
+                    HTTPClient.ResponseHeader.location.rawValue: locationValue
                 ]
             )
         }
@@ -3220,8 +3221,8 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
         expect(response?.value?.body) == responseData
 
         self.logger.verifyMessageWasLogged("""
-            Performing redirect from '\(pathA.url(preferIAMPath: false)!.absoluteString)'
-             to '\(pathB.url(preferIAMPath: false)!.absoluteString)'
+            Performing redirect from '\(pathA.url(preferIAMPath: self.tokenManager.enabled)!.absoluteString)'
+             to '\(pathB.url(preferIAMPath: self.tokenManager.enabled)!.absoluteString)'
             """,
             level: .debug
         )
@@ -4649,7 +4650,7 @@ final class HTTPClientTimeoutManagerTests: BaseHTTPClientTests<MockETagManager, 
         let request = HTTPRequest(method: .get, path: .getOfferings(appUserID: "test_user_id"))
 
         // main request times out
-        let url = try XCTUnwrap(request.path.url(preferIAMPath: false)?.absoluteString)
+        let url = try XCTUnwrap(request.path.url(preferIAMPath: self.tokenManager.enabled)?.absoluteString)
         stub(condition: isAbsoluteURLString(url)) { _ in
             return .timeoutResponse()
         }
@@ -4776,7 +4777,7 @@ final class HTTPClientTimeoutManagerTests: BaseHTTPClientTests<MockETagManager, 
         let request = HTTPRequest(method: .get, path: .getProductEntitlementMapping)
 
         // main request fails with server error (triggers fallback)
-        let url = try XCTUnwrap(request.path.url(preferIAMPath: false)?.absoluteString)
+        let url = try XCTUnwrap(request.path.url(preferIAMPath: self.tokenManager.enabled)?.absoluteString)
         stub(condition: isAbsoluteURLString(url)) { _ in
             return .serverDownResponse()
         }

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -27,6 +27,7 @@ class BaseHTTPClientTests<ETag: ETagManager, TimeoutManager: HTTPRequestTimeoutM
     var signing: MockSigning!
     var client: HTTPClient!
     var eTagManager: ETag!
+    var tokenManager: TokenManager!
     var diagnosticsTracker: DiagnosticsTrackerType?
     var operationDispatcher: OperationDispatcher!
     var dateProvider: MockCurrentDateProvider!
@@ -85,6 +86,7 @@ class BaseHTTPClientTests<ETag: ETagManager, TimeoutManager: HTTPRequestTimeoutM
         }
         return HTTPClient(systemInfo: systemInfo,
                           eTagManager: self.eTagManager,
+                          tokenManager: self.tokenManager,
                           signing: self.signing,
                           diagnosticsTracker: self.diagnosticsTracker,
                           dnsChecker: MockDNSChecker.self,
@@ -99,6 +101,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
 
     override func setUpWithError() throws {
         self.eTagManager = MockETagManager()
+        self.tokenManager = MockTokenManager()
         self.timeoutManager = HTTPRequestTimeoutManager(
             networkTimeout: .default,
             dateProvider: MockCurrentDateProvider()
@@ -1821,7 +1824,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
         let request = HTTPRequest(method: .get, path: .getOfferings(appUserID: "test_user_id"))
 
         // main request
-        let url = try XCTUnwrap(request.path.url?.absoluteString)
+        let url = try XCTUnwrap(request.path.url(preferIAMPath: false)?.absoluteString)
         stub(condition: isAbsoluteURLString(url)) { request in
 
             // Main-source request supporting a fallback should use the base tier for that kind
@@ -1852,7 +1855,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
         let client = self.createClient(self.systemInfoUsingAPISources())
         let request = HTTPRequest(method: .get, path: .getOfferings(appUserID: "test_user_id"))
 
-        let url = try XCTUnwrap(request.path.url?.absoluteString)
+        let url = try XCTUnwrap(request.path.url(preferIAMPath: false)?.absoluteString)
         stub(condition: isAbsoluteURLString(url)) { _ in
             return .timeoutResponse()
         }
@@ -1948,7 +1951,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
         let request = HTTPRequest(method: .get, path: HTTPRequest.FallbackPath.remoteConfig(domain: "app"))
         let host = try XCTUnwrap(HTTPRequest.FallbackPath.serverHostURL.host)
 
-        let url = try XCTUnwrap(request.path.url?.absoluteString)
+        let url = try XCTUnwrap(request.path.url(preferIAMPath: false)?.absoluteString)
         stub(condition: isAbsoluteURLString(url)) { request in
             XCTAssertEqual(request.timeoutInterval, HTTPRequestTimeoutManager.Timeout.flat)
             return .timeoutResponse()
@@ -1979,7 +1982,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
 
         timeoutManager.recordRequestResult(host: host, .mainSourceTimedOut)
 
-        let url = try XCTUnwrap(request.path.url?.absoluteString)
+        let url = try XCTUnwrap(request.path.url(preferIAMPath: false)?.absoluteString)
         stub(condition: isAbsoluteURLString(url)) { _ in
             return .emptySuccessResponse()
         }
@@ -2076,7 +2079,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
         let request = HTTPRequest(method: .get, path: .getProductEntitlementMapping)
 
         // main request fails with server error (triggers fallback)
-        let url = try XCTUnwrap(request.path.url?.absoluteString)
+        let url = try XCTUnwrap(request.path.url(preferIAMPath: false)?.absoluteString)
         stub(condition: isAbsoluteURLString(url)) { request in
             // Main-source request should use the base tier for a request supporting fallback
             XCTAssertEqual(
@@ -3197,7 +3200,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
                 data: .init(),
                 statusCode: .temporaryRedirect,
                 headers: [
-                    HTTPClient.ResponseHeader.location.rawValue: pathB.url!.absoluteString
+                    HTTPClient.ResponseHeader.location.rawValue: pathB.url(preferIAMPath: false)!.absoluteString
                 ]
             )
         }
@@ -3216,8 +3219,10 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
         expect(response).to(beSuccess())
         expect(response?.value?.body) == responseData
 
-        self.logger.verifyMessageWasLogged(
-            "Performing redirect from '\(pathA.url!.absoluteString)' to '\(pathB.url!.absoluteString)'",
+        self.logger.verifyMessageWasLogged("""
+            Performing redirect from '\(pathA.url(preferIAMPath: false)!.absoluteString)' 
+             to '\(pathB.url(preferIAMPath: false)!.absoluteString)'
+            """,
             level: .debug
         )
     }
@@ -3527,7 +3532,8 @@ extension HTTPClientTests {
 
     private func buildEmptyRequest(
         isRetryable: Bool,
-        hasFallbackUrls: Bool = false
+        hasFallbackUrls: Bool = false,
+        preferIAMPath: Bool = false
     ) -> HTTPClient.Request {
         let completionHandler: HTTPClient.Completion<CustomerInfo> = { _ in return }
 
@@ -3547,6 +3553,7 @@ extension HTTPClientTests {
             authHeaders: .init(),
             defaultHeaders: .init(),
             verificationMode: .default,
+            preferIAMPath: preferIAMPath,
             internalSettings: DangerousSettings.Internal.default,
             completionHandler: completionHandler
         )
@@ -4629,6 +4636,7 @@ final class HTTPClientTimeoutManagerTests: BaseHTTPClientTests<MockETagManager, 
 
     override func setUpWithError() throws {
         self.eTagManager = MockETagManager()
+        self.tokenManager = MockTokenManager()
         let mockTimeoutManager = MockHTTPRequestTimeoutManager(defaultTimeout: defaultRequestTimeout)
         self.timeoutManager = mockTimeoutManager
 
@@ -4641,7 +4649,7 @@ final class HTTPClientTimeoutManagerTests: BaseHTTPClientTests<MockETagManager, 
         let request = HTTPRequest(method: .get, path: .getOfferings(appUserID: "test_user_id"))
 
         // main request times out
-        let url = try XCTUnwrap(request.path.url?.absoluteString)
+        let url = try XCTUnwrap(request.path.url(preferIAMPath: false)?.absoluteString)
         stub(condition: isAbsoluteURLString(url)) { _ in
             return .timeoutResponse()
         }
@@ -4768,7 +4776,7 @@ final class HTTPClientTimeoutManagerTests: BaseHTTPClientTests<MockETagManager, 
         let request = HTTPRequest(method: .get, path: .getProductEntitlementMapping)
 
         // main request fails with server error (triggers fallback)
-        let url = try XCTUnwrap(request.path.url?.absoluteString)
+        let url = try XCTUnwrap(request.path.url(preferIAMPath: false)?.absoluteString)
         stub(condition: isAbsoluteURLString(url)) { _ in
             return .serverDownResponse()
         }

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -3220,7 +3220,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
         expect(response?.value?.body) == responseData
 
         self.logger.verifyMessageWasLogged("""
-            Performing redirect from '\(pathA.url(preferIAMPath: false)!.absoluteString)' 
+            Performing redirect from '\(pathA.url(preferIAMPath: false)!.absoluteString)'
              to '\(pathB.url(preferIAMPath: false)!.absoluteString)'
             """,
             level: .debug

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -80,7 +80,7 @@ class HTTPRequestTests: TestCase {
 
     func testPathsHaveValidURLs() {
         for path in Self.paths {
-            expect(path.url).toNot(beNil())
+            expect(path.url(preferIAMPath: false)).toNot(beNil())
         }
     }
 
@@ -414,5 +414,142 @@ class HTTPRequestTests: TestCase {
         expect(headers[sandboxHeader]) == "false"
         expect(headers[HTTPClient.RequestHeader.headerParametersForSignature.rawValue])
             == HTTPRequest.signatureHashHeader(keys: [sandboxHeader], hash: expectedHash)
+    }
+
+    // MARK: - IAM paths
+
+    /// Maps each `HTTPRequest.Path` case (other than `.logIn`, which is disallowed under IAM) to the
+    /// relative path it should resolve to when IAM access-token authorization is preferred.
+    private static let iamPathComponentsByPath: [HTTPRequest.Path: String] = [
+        .getCustomerInfo(appUserID: userID): "customer",
+        .getOfferings(appUserID: userID): "customer/offerings",
+        .getIntroEligibility(appUserID: userID): "customer/intro_eligibility",
+        .postAttributionData(appUserID: userID): "customer/attribution",
+        .postOfferForSigning: "offers",
+        .postReceiptData: "receipts",
+        .postSubscriberAttributes(appUserID: userID): "customer/attributes",
+        .postAdServicesToken(appUserID: userID): "customer/adservices_attribution",
+        .health: "health",
+        .appHealthReport(appUserID: userID): "customer/health_report",
+        .appHealthReportAvailability(appUserID: userID): "subscribers/\(userID)/health_report_availability",
+        .getProductEntitlementMapping: "product_entitlement_mapping",
+        .getCustomerCenterConfig(appUserID: userID): "customer/customercenter",
+        .getVirtualCurrencies(appUserID: userID): "customer/virtual_currencies",
+        .postRedeemWebPurchase: "subscribers/redeem_purchase",
+        .postCreateTicket: "customercenter/support/create-ticket",
+        .isPurchaseAllowedByRestoreBehavior(appUserID: userID): "customer/restore/eligibility",
+        .rewardVerificationStatus(appUserID: userID, clientTransactionID: clientTransactionID):
+            "subscribers/\(userID)/ads/reward_verifications/\(clientTransactionID)",
+        .remoteConfig(domain: "app"): "config/app"
+    ]
+
+    func testRelativeIAMPathMatchesExpectedComponentPerPath() {
+        for (path, expectedComponent) in Self.iamPathComponentsByPath {
+            expect(path.relativeIAMPath).to(
+                equal("/v1/\(expectedComponent)"),
+                description: "Path '\(path)' has an unexpected IAM relative path"
+            )
+        }
+    }
+
+    func testRelativeIAMPathForLoginEndpointCrashes() {
+        // The `.logIn` endpoint is not allowed once IAM access tokens are enabled: exchanging a
+        // static app-user-id-based endpoint for a token-authenticated one doesn't make sense.
+        expect {
+            _ = HTTPRequest.Path.logIn.relativeIAMPath
+        }.to(throwAssertion())
+    }
+
+    func testUrlPreferringIAMPathUsesIAMRelativePath() {
+        let path: HTTPRequest.Path = .getCustomerInfo(appUserID: Self.userID)
+
+        let regularURL = path.url(preferIAMPath: false)
+        let iamURL = path.url(preferIAMPath: true)
+
+        expect(regularURL?.absoluteString) == "https://api.revenuecat.com/v1/subscribers/\(Self.userID)"
+        expect(iamURL?.absoluteString) == "https://api.revenuecat.com/v1/customer"
+        expect(iamURL) != regularURL
+    }
+
+    func testUrlPreferringIAMPathForPathsWithSharedComponentMatchesRegularURL() {
+        // `.health` resolves to the same relative path regardless of IAM preference.
+        let path: HTTPRequest.Path = .health
+
+        expect(path.url(preferIAMPath: true)?.absoluteString) == path.url(preferIAMPath: false)?.absoluteString
+    }
+
+    func testDefaultHTTPRequestPathIsNotAnIAMPath() {
+        for path in Self.paths {
+            expect(path.isIAMPath).to(
+                beFalse(),
+                description: "Path '\(path)' should not be reported as an IAM path by default"
+            )
+        }
+    }
+
+    func testDefaultRelativeIAMPathFallsBackToRelativePathForOtherPathTypes() {
+        // `HTTPRequest.FallbackPath` doesn't override `relativeIAMPath`, so it should fall back
+        // to the default implementation, which just returns `relativePath`.
+        let path = HTTPRequest.FallbackPath.remoteConfig(domain: "app")
+
+        expect(path.relativeIAMPath) == path.relativePath
+    }
+
+    // MARK: - Bearer authorization header
+
+    func testBearerAuthorizationValueIsNilWhenNoAuthorizationHeaderIsSet() {
+        let headers: HTTPRequest.Headers = [:]
+
+        expect(headers.bearerAuthorizationValue).to(beNil())
+    }
+
+    func testBearerAuthorizationValueParsesBearerToken() {
+        var headers: HTTPRequest.Headers = [:]
+        headers.authorizationValue = "Bearer abc123"
+
+        expect(headers.bearerAuthorizationValue) == "abc123"
+    }
+
+    func testBearerAuthorizationValueIsNilForNonBearerScheme() {
+        var headers: HTTPRequest.Headers = [:]
+        headers.authorizationValue = "Basic abc123"
+
+        expect(headers.bearerAuthorizationValue).to(beNil())
+    }
+
+    func testBearerAuthorizationValueIsNilWhenSchemeHasNoSeparatingSpace() {
+        var headers: HTTPRequest.Headers = [:]
+        headers.authorizationValue = "Bearer"
+
+        expect(headers.bearerAuthorizationValue).to(beNil())
+    }
+
+    func testBearerAuthorizationValueIsNilWhenPrefixIsSimilarButNotExactMatch() {
+        var headers: HTTPRequest.Headers = [:]
+        headers.authorizationValue = "Bearertoken abc123"
+
+        expect(headers.bearerAuthorizationValue).to(beNil())
+    }
+
+    func testSettingBearerAuthorizationValueUpdatesAuthorizationHeader() {
+        var headers: HTTPRequest.Headers = [:]
+        headers.bearerAuthorizationValue = "my-access-token"
+
+        expect(headers.authorizationValue) == "Bearer my-access-token"
+    }
+
+    func testSettingBearerAuthorizationValueToNilClearsAuthorizationHeader() {
+        var headers: HTTPRequest.Headers = [:]
+        headers.authorizationValue = "Bearer abc123"
+        headers.bearerAuthorizationValue = nil
+
+        expect(headers.authorizationValue).to(beNil())
+    }
+
+    func testBearerAuthorizationValueRoundTrips() {
+        var headers: HTTPRequest.Headers = [:]
+        headers.bearerAuthorizationValue = "round-trip-token"
+
+        expect(headers.bearerAuthorizationValue) == "round-trip-token"
     }
 }

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -216,7 +216,7 @@ class HTTPRequestTests: TestCase {
         let path = HTTPRequest.FallbackPath.remoteConfig(domain: "app workflows/project")
 
         expect(path.relativePath) == "/v1/config/app%20workflows%2Fproject"
-        expect(path.url?.absoluteString)
+        expect(path.url(preferIAMPath: false)?.absoluteString)
             == "https://api-production.8-lives-cat.io/v1/config/app%20workflows%2Fproject"
         expect(path.fallbackUrls).to(beEmpty())
         expect(path.authenticated).to(beTrue())
@@ -245,25 +245,26 @@ class HTTPRequestTests: TestCase {
         let encodeableUserID = "userid with spaces"
         let encodedUserID = "userid%20with%20spaces"
         let expectedURL = "https://api.revenuecat.com/v1/subscribers/\(encodedUserID)"
-        let result = HTTPRequest.Path.getCustomerInfo(appUserID: encodeableUserID).url
+        let result = HTTPRequest.Path.getCustomerInfo(appUserID: encodeableUserID).url(preferIAMPath: false)
 
         expect(result?.absoluteString) == expectedURL
     }
 
     func testURLWithNoProxy() {
         let path: HTTPRequest.Path = .health
-        expect(path.url?.absoluteString) == "https://api.revenuecat.com/v1/health"
-        expect(path.url(proxyURL: nil)?.absoluteString) == "https://api.revenuecat.com/v1/health"
+        expect(path.url(preferIAMPath: false)?.absoluteString) == "https://api.revenuecat.com/v1/health"
+        expect(path.url(proxyURL: nil, preferIAMPath: false)?.absoluteString) == "https://api.revenuecat.com/v1/health"
     }
 
     func testURLWithProxy() {
         let path: HTTPRequest.Path = .health
-        expect(path.url(proxyURL: URL(string: "https://test_url"))?.absoluteString) == "https://test_url/v1/health"
+        let url = path.url(proxyURL: URL(string: "https://test_url"), preferIAMPath: false)
+        expect(url?.absoluteString) == "https://test_url/v1/health"
     }
 
     func testURLWithAPISource() {
         let path: HTTPRequest.Path = .health
-        expect(path.url(apiSourceURL: URL(string: "https://api.rc-backup.com/"))?.absoluteString)
+        expect(path.url(apiSourceURL: URL(string: "https://api.rc-backup.com/"), preferIAMPath: false)?.absoluteString)
             == "https://api.rc-backup.com/v1/health"
     }
 
@@ -272,13 +273,14 @@ class HTTPRequestTests: TestCase {
         // and must not silently route around the proxy.
         let path: HTTPRequest.Path = .health
         expect(path.url(proxyURL: URL(string: "https://test_url"),
-                        apiSourceURL: URL(string: "https://api.rc-backup.com/"))).to(beNil())
+                        apiSourceURL: URL(string: "https://api.rc-backup.com/"), preferIAMPath: false)).to(beNil())
     }
 
     func testURLFallbackIndexTakesPrecedenceOverAPISource() {
         let path: HTTPRequest.Path = .getOfferings(appUserID: Self.userID)
         expect(path.url(apiSourceURL: URL(string: "https://api.rc-backup.com/"),
-                        fallbackUrlIndex: 0)?.absoluteString)
+                        fallbackUrlIndex: 0,
+                        preferIAMPath: false)?.absoluteString)
             == path.fallbackUrls.first?.absoluteString
     }
 

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -452,6 +452,7 @@ class HTTPRequestTests: TestCase {
         }
     }
 
+    #if !os(watchOS)
     func testRelativeIAMPathForLoginEndpointCrashes() {
         // The `.logIn` endpoint is not allowed once IAM access tokens are enabled: exchanging a
         // static app-user-id-based endpoint for a token-authenticated one doesn't make sense.
@@ -459,6 +460,7 @@ class HTTPRequestTests: TestCase {
             _ = HTTPRequest.Path.logIn.relativeIAMPath
         }.to(throwAssertion())
     }
+    #endif
 
     func testUrlPreferringIAMPathUsesIAMRelativePath() {
         let path: HTTPRequest.Path = .getCustomerInfo(appUserID: Self.userID)

--- a/Tests/UnitTests/Networking/HTTPResponseTests.swift
+++ b/Tests/UnitTests/Networking/HTTPResponseTests.swift
@@ -34,7 +34,8 @@ class HTTPResponseTests: TestCase {
             requestHeaders: [:],
             publicKey: nil,
             isLoadShedderResponse: false,
-            isFallbackUrlResponse: false
+            isFallbackUrlResponse: false,
+            iamEnabled: false
         )
 
         expect(verifiedResponse.verificationResult) == .notRequested
@@ -55,7 +56,8 @@ class HTTPResponseTests: TestCase {
             requestHeaders: [:],
             publicKey: key,
             isLoadShedderResponse: false,
-            isFallbackUrlResponse: false
+            isFallbackUrlResponse: false,
+            iamEnabled: false
         )
 
         expect(verifiedResponse.verificationResult) == .notRequested
@@ -76,7 +78,8 @@ class HTTPResponseTests: TestCase {
             requestHeaders: [:],
             publicKey: key,
             isLoadShedderResponse: false,
-            isFallbackUrlResponse: false
+            isFallbackUrlResponse: false,
+            iamEnabled: false
         )
 
         expect(verifiedResponse.verificationResult) == .failed

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
@@ -61,6 +61,7 @@ final class RemoteConfigIntegrationTests: TestCase {
         self.httpClient = MockHTTPClient(
             systemInfo: self.systemInfo,
             eTagManager: MockETagManager(),
+            tokenManager: MockTokenManager(),
             diagnosticsTracker: nil,
             sourceTestFile: #file
         )
@@ -908,15 +909,17 @@ private extension RemoteConfigIntegrationTests {
     }
 
     var remoteConfigCalls: [MockHTTPClient.Call] {
+        let url = HTTPRequest.Path.remoteConfig(domain: RemoteConfiguration.defaultDomain).url(preferIAMPath: false)
         return self.httpClient.calls.filter {
-            $0.request.path.url == HTTPRequest.Path.remoteConfig(domain: RemoteConfiguration.defaultDomain).url
+            $0.request.path.url(preferIAMPath: false) == url
         }
     }
 
     var remoteConfigFallbackRequestCount: Int {
+        let fallbackURL = HTTPRequest.FallbackPath.remoteConfig(domain: RemoteConfiguration.defaultDomain)
+                                                  .url(preferIAMPath: false)
         return self.httpClient.calls.filter {
-            $0.request.path.url
-                == HTTPRequest.FallbackPath.remoteConfig(domain: RemoteConfiguration.defaultDomain).url
+            $0.request.path.url(preferIAMPath: false) == fallbackURL
         }.count
     }
 

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -33,6 +33,7 @@ class BaseSignatureVerificationHTTPClientTests: BaseHTTPClientTests<ETagManager,
             basePath: self.suiteName
         )
         self.eTagManager = ETagManager(largeItemCache: largeItemCache)
+        self.tokenManager = TokenManager(enabled: false, storage: Keychain(access: nil))
         self.timeoutManager = HTTPRequestTimeoutManager(networkTimeout: .default)
 
         try super.setUpWithError()

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -77,6 +77,7 @@ class BasePurchasesTests: TestCase {
 
         let httpClient = MockHTTPClient(systemInfo: self.systemInfo,
                                         eTagManager: MockETagManager(),
+                                        tokenManager: MockTokenManager(),
                                         diagnosticsTracker: self.diagnosticsTracker)
         let config = BackendConfiguration(httpClient: httpClient,
                                           operationDispatcher: self.mockOperationDispatcher,

--- a/Tests/UnitTests/Security/SigningTests.swift
+++ b/Tests/UnitTests/Security/SigningTests.swift
@@ -1199,10 +1199,13 @@ class SigningTests: TestCase {
 
     func testVerificationUsesBearerTokenFromHeadersInsteadOfAPIKeyWhenPresent() throws {
         let message = "Hello World"
+        let nonce = "0123456789ab"
         let requestDate = Date().millisecondsSince1970
         let intermediateKey = try self.createIntermediatePublicKeyData(expiration: Self.intermediateKeyFutureExpiration)
         let salt = Self.createSalt()
-        let request = HTTPRequest(method: .get, path: .health, nonce: nil)
+        // `.getCustomerInfo` is an authenticated path: unlike `.health`, the auth value is actually
+        // folded into the signed bytes, so this test can tell bearer-token from API-key signing apart.
+        let request = HTTPRequest(method: .get, path: .getCustomerInfo(appUserID: "user"), nonce: nonce.asData)
         let accessToken = "iam-access-token-123"
         let requestHeaders: HTTPRequest.Headers = [
             HTTPClient.RequestHeader.authorization.rawValue: "Bearer \(accessToken)"
@@ -1213,7 +1216,7 @@ class SigningTests: TestCase {
             iamEnabled: true,
             message: message.asData,
             requestHeaders: requestHeaders,
-            nonce: nil,
+            nonce: nonce.asData,
             etag: nil,
             requestDate: requestDate,
             useFallbackPath: false
@@ -1253,10 +1256,13 @@ class SigningTests: TestCase {
 
     func testVerificationFailsWhenSignedWithAPIKeyButRequestHasBearerToken() throws {
         let message = "Hello World"
+        let nonce = "0123456789ab"
         let requestDate = Date().millisecondsSince1970
         let intermediateKey = try self.createIntermediatePublicKeyData(expiration: Self.intermediateKeyFutureExpiration)
         let salt = Self.createSalt()
-        let request = HTTPRequest(method: .get, path: .health, nonce: nil)
+        // `.getCustomerInfo` is an authenticated path: unlike `.health`, the auth value is actually
+        // folded into the signed bytes, so this test can tell bearer-token from API-key signing apart.
+        let request = HTTPRequest(method: .get, path: .getCustomerInfo(appUserID: "user"), nonce: nonce.asData)
         let requestHeaders: HTTPRequest.Headers = [
             HTTPClient.RequestHeader.authorization.rawValue: "Bearer some-access-token"
         ]
@@ -1266,7 +1272,7 @@ class SigningTests: TestCase {
             iamEnabled: true,
             message: message.asData,
             requestHeaders: requestHeaders,
-            nonce: nil,
+            nonce: nonce.asData,
             etag: nil,
             requestDate: requestDate,
             useFallbackPath: false

--- a/Tests/UnitTests/Security/SigningTests.swift
+++ b/Tests/UnitTests/Security/SigningTests.swift
@@ -49,6 +49,7 @@ class SigningTests: TestCase {
             signature: signature,
             with: .init(
                 path: Self.mockPath,
+                iamEnabled: false,
                 message: message.asData,
                 nonce: nonce.asData,
                 etag: nil,
@@ -69,6 +70,7 @@ class SigningTests: TestCase {
         let salt = Self.createSalt()
         let parameters: Signing.SignatureParameters = .init(
             path: Self.mockPath,
+            iamEnabled: false,
             message: message.asData,
             nonce: nonce.asData,
             etag: etag,
@@ -100,6 +102,7 @@ class SigningTests: TestCase {
         let salt = Self.createSalt()
         let parameters: Signing.SignatureParameters = .init(
             path: Self.mockPath,
+            iamEnabled: false,
             message: message.asData,
             nonce: nonce.asData,
             etag: etag,
@@ -130,6 +133,7 @@ class SigningTests: TestCase {
             signature: "invalid signature".asData.base64EncodedString(),
             with: .init(
                 path: Self.mockPath,
+                iamEnabled: false,
                 message: "Hello World".asData,
                 nonce: "nonce".asData,
                 etag: nil,
@@ -147,6 +151,7 @@ class SigningTests: TestCase {
             signature: signature.base64EncodedString(),
             with: .init(
                 path: Self.mockPath,
+                iamEnabled: false,
                 message: "Hello World".asData,
                 nonce: "nonce".asData,
                 etag: nil,
@@ -177,6 +182,7 @@ class SigningTests: TestCase {
                 signature: fullSignature.base64EncodedString(),
                 with: .init(
                     path: Self.mockPath,
+                    iamEnabled: false,
                     message: message.asData,
                     nonce: nonce.asData,
                     etag: nil,
@@ -197,6 +203,7 @@ class SigningTests: TestCase {
             signature: signature.base64EncodedString(),
             with: .init(
                 path: Self.mockPath,
+                iamEnabled: false,
                 message: "Hello World".asData,
                 nonce: "nonce".asData,
                 etag: nil,
@@ -219,6 +226,7 @@ class SigningTests: TestCase {
         let signature = try self.sign(
             parameters: .init(
                 path: Self.mockPath,
+                iamEnabled: false,
                 message: message.asData,
                 nonce: nonce.asData,
                 etag: nil,
@@ -236,6 +244,7 @@ class SigningTests: TestCase {
             signature: fullSignature.base64EncodedString(),
             with: .init(
                 path: Self.mockPath,
+                iamEnabled: false,
                 message: message.asData,
                 nonce: nonce.asData,
                 etag: nil,
@@ -256,6 +265,7 @@ class SigningTests: TestCase {
         let signature = try self.sign(
             parameters: .init(
                 path: Self.mockPath,
+                iamEnabled: false,
                 message: message.asData,
                 nonce: nonce.asData,
                 etag: etag,
@@ -273,6 +283,7 @@ class SigningTests: TestCase {
             signature: fullSignature.base64EncodedString(),
             with: .init(
                 path: Self.mockPath,
+                iamEnabled: false,
                 message: message.asData,
                 nonce: nonce.asData,
                 etag: etag,
@@ -316,6 +327,7 @@ class SigningTests: TestCase {
                 signature: expectedSignature,
                 with: .init(
                     path: .getCustomerInfo(appUserID: "login"),
+                    iamEnabled: false,
                     message: response.asData,
                     nonce: nonce,
                     etag: etag,
@@ -349,6 +361,7 @@ class SigningTests: TestCase {
                 signature: expectedSignature,
                 with: .init(
                     path: .getOfferings(appUserID: "test"),
+                    iamEnabled: false,
                     message: response.asData,
                     nonce: nil,
                     etag: nil,
@@ -380,6 +393,7 @@ class SigningTests: TestCase {
                 signature: expectedSignature,
                 with: .init(
                     path: .health,
+                    iamEnabled: false,
                     message: response.asData,
                     nonce: nonce,
                     etag: nil,
@@ -413,6 +427,7 @@ class SigningTests: TestCase {
                 signature: expectedSignature,
                 with: .init(
                     path: .getCustomerInfo(appUserID: "login"),
+                    iamEnabled: false,
                     message: nil, // 304 response
                     nonce: nonce,
                     etag: etag,
@@ -448,6 +463,7 @@ class SigningTests: TestCase {
                 signature: expectedSignature,
                 with: .init(
                     path: .getCustomerInfo(appUserID: "$RCAnonymousID:1af512a3b9c848899fe427f39dd69f2b"),
+                    iamEnabled: false,
                     message: response.asData,
                     nonce: nonce,
                     etag: etag,
@@ -485,6 +501,7 @@ class SigningTests: TestCase {
                 signature: expectedSignature,
                 with: .init(
                     path: .logIn,
+                    iamEnabled: false,
                     message: response.asData,
                     requestBody: LogInOperation.Body(
                         appUserID: "$RCAnonymousID:6b2787de2fb848a8b403a45f695ee74f",
@@ -525,6 +542,7 @@ class SigningTests: TestCase {
                 signature: expectedSignature,
                 with: .init(
                     path: .getCustomerInfo(appUserID: "$RCAnonymousID:6ca4535c42714f88abc99c563703f113"),
+                    iamEnabled: false,
                     message: response.asData,
                     requestHeaders: [
                         "X-Is-Sandbox": "true"
@@ -567,6 +585,7 @@ class SigningTests: TestCase {
                 signature: expectedSignature,
                 with: .init(
                     path: .logIn,
+                    iamEnabled: false,
                     message: response.asData,
                     requestHeaders: [
                         "X-Is-Sandbox": "true"
@@ -593,7 +612,8 @@ class SigningTests: TestCase {
             requestHeaders: [:],
             publicKey: nil,
             isLoadShedderResponse: false,
-            isFallbackUrlResponse: false
+            isFallbackUrlResponse: false,
+            iamEnabled: false
         )
 
         expect(verifiedResponse.verificationResult) == .notRequested
@@ -609,7 +629,8 @@ class SigningTests: TestCase {
             requestHeaders: [:],
             publicKey: self.publicKey,
             isLoadShedderResponse: false,
-            isFallbackUrlResponse: false
+            isFallbackUrlResponse: false,
+            iamEnabled: false
         )
 
         expect(verifiedResponse.verificationResult) == .failed
@@ -633,7 +654,8 @@ class SigningTests: TestCase {
             requestHeaders: [:],
             publicKey: self.publicKey,
             isLoadShedderResponse: false,
-            isFallbackUrlResponse: false
+            isFallbackUrlResponse: false,
+            iamEnabled: false
         )
 
         expect(verifiedResponse.verificationResult) == .failed
@@ -651,6 +673,7 @@ class SigningTests: TestCase {
         ]
 
         let signature = try self.sign(parameters: .init(path: request.path,
+                                                        iamEnabled: false,
                                                         message: message.asData,
                                                         requestHeaders: requestHeaders,
                                                         nonce: nonce.asData,
@@ -678,7 +701,8 @@ class SigningTests: TestCase {
             requestHeaders: requestHeaders,
             publicKey: self.publicKey,
             isLoadShedderResponse: false,
-            isFallbackUrlResponse: false
+            isFallbackUrlResponse: false,
+            iamEnabled: false
         )
 
         expect(verifiedResponse.verificationResult) == .verified
@@ -694,6 +718,7 @@ class SigningTests: TestCase {
         let requestHeaders: HTTPRequest.Headers = [:]
 
         let signature = try self.sign(parameters: .init(path: request.path,
+                                                        iamEnabled: false,
                                                         message: nil,
                                                         requestHeaders: requestHeaders,
                                                         nonce: nonce.asData,
@@ -722,7 +747,8 @@ class SigningTests: TestCase {
             requestHeaders: requestHeaders,
             publicKey: self.publicKey,
             isLoadShedderResponse: false,
-            isFallbackUrlResponse: false
+            isFallbackUrlResponse: false,
+            iamEnabled: false
         )
 
         expect(verifiedResponse.verificationResult) == .verified
@@ -739,6 +765,7 @@ class SigningTests: TestCase {
         ]
 
         let signature = try self.sign(parameters: .init(path: request.path,
+                                                        iamEnabled: false,
                                                         message: message.asData,
                                                         requestHeaders: requestHeaders,
                                                         nonce: nil,
@@ -766,7 +793,8 @@ class SigningTests: TestCase {
             requestHeaders: requestHeaders,
             publicKey: self.publicKey,
             isLoadShedderResponse: false,
-            isFallbackUrlResponse: false
+            isFallbackUrlResponse: false,
+            iamEnabled: false
         )
 
         expect(verifiedResponse.verificationResult) == .verified
@@ -790,7 +818,8 @@ class SigningTests: TestCase {
             requestHeaders: [:],
             publicKey: self.publicKey,
             isLoadShedderResponse: false,
-            isFallbackUrlResponse: false
+            isFallbackUrlResponse: false,
+            iamEnabled: false
         )
 
         expect(verifiedResponse.verificationResult) == .notRequested
@@ -813,6 +842,7 @@ class SigningTests: TestCase {
         ]
 
         let signature = try self.sign(parameters: .init(path: request.path,
+                                                        iamEnabled: false,
                                                         message: message.asData,
                                                         requestHeaders: requestHeaders,
                                                         nonce: nonce.asData,
@@ -840,7 +870,8 @@ class SigningTests: TestCase {
             requestHeaders: requestHeaders,
             publicKey: self.publicKey,
             isLoadShedderResponse: false,
-            isFallbackUrlResponse: true
+            isFallbackUrlResponse: true,
+            iamEnabled: false
         )
 
         expect(verifiedResponse.verificationResult) == .verified
@@ -858,6 +889,7 @@ class SigningTests: TestCase {
         ]
 
         let signature = try self.sign(parameters: .init(path: request.path,
+                                                        iamEnabled: false,
                                                         message: message.asData,
                                                         requestHeaders: requestHeaders,
                                                         nonce: nonce.asData,
@@ -885,7 +917,8 @@ class SigningTests: TestCase {
             requestHeaders: requestHeaders,
             publicKey: self.publicKey,
             isLoadShedderResponse: false,
-            isFallbackUrlResponse: true // Mismatch with useFallbackPath: false in signing
+            isFallbackUrlResponse: true, // Mismatch with useFallbackPath: false in signing
+            iamEnabled: false
         )
 
         expect(verifiedResponse.verificationResult) == .failed
@@ -902,6 +935,7 @@ class SigningTests: TestCase {
         let signatureWithFallback = try self.sign(
             parameters: .init(
                 path: offeringsPath,
+                iamEnabled: false,
                 message: message.asData,
                 nonce: nil,
                 etag: nil,
@@ -921,6 +955,7 @@ class SigningTests: TestCase {
             signature: fullSignatureWithFallback.base64EncodedString(),
             with: .init(
                 path: offeringsPath,
+                iamEnabled: false,
                 message: message.asData,
                 nonce: nil,
                 etag: nil,
@@ -942,6 +977,7 @@ class SigningTests: TestCase {
         let signatureWithFallback = try self.sign(
             parameters: .init(
                 path: productEntitlementMappingPath,
+                iamEnabled: false,
                 message: message.asData,
                 nonce: nil,
                 etag: nil,
@@ -961,6 +997,7 @@ class SigningTests: TestCase {
             signature: fullSignatureWithFallback.base64EncodedString(),
             with: .init(
                 path: productEntitlementMappingPath,
+                iamEnabled: false,
                 message: message.asData,
                 nonce: nil,
                 etag: nil,
@@ -982,6 +1019,7 @@ class SigningTests: TestCase {
         let signatureRegular = try self.sign(
             parameters: .init(
                 path: offeringsPath,
+                iamEnabled: false,
                 message: message.asData,
                 nonce: nil,
                 etag: nil,
@@ -1001,6 +1039,7 @@ class SigningTests: TestCase {
             signature: fullSignatureWithRegular.base64EncodedString(),
             with: .init(
                 path: offeringsPath,
+                iamEnabled: false,
                 message: message.asData,
                 nonce: nil,
                 etag: nil,
@@ -1022,6 +1061,7 @@ class SigningTests: TestCase {
         let signatureRegular = try self.sign(
             parameters: .init(
                 path: offeringsPath,
+                iamEnabled: false,
                 message: message.asData,
                 nonce: nil,
                 etag: nil,
@@ -1041,6 +1081,7 @@ class SigningTests: TestCase {
             signature: fullSignatureWithRegular.base64EncodedString(),
             with: .init(
                 path: offeringsPath,
+                iamEnabled: false,
                 message: message.asData,
                 nonce: nil,
                 etag: nil,
@@ -1063,6 +1104,7 @@ class SigningTests: TestCase {
         let signatureWithFallback = try self.sign(
             parameters: .init(
                 path: offeringsPath,
+                iamEnabled: false,
                 message: message.asData,
                 nonce: nil,
                 etag: etag,
@@ -1082,6 +1124,7 @@ class SigningTests: TestCase {
             signature: fullSignatureWithFallback.base64EncodedString(),
             with: .init(
                 path: offeringsPath,
+                iamEnabled: false,
                 message: message.asData,
                 nonce: nil,
                 etag: etag,
@@ -1107,7 +1150,7 @@ private extension SigningTests {
     }
 
     func sign(key: PrivateKey, parameters: Signing.SignatureParameters, salt: Data) throws -> Data {
-        return try key.signature(for: parameters.signature(salt: salt, apiKey: Self.apiKey))
+        return try key.signature(for: parameters.signature(salt: salt, authValue: Self.apiKey))
     }
 
     static func fullSignature(intermediateKey: Data, salt: String, signature: Data) -> Data {

--- a/Tests/UnitTests/Security/SigningTests.swift
+++ b/Tests/UnitTests/Security/SigningTests.swift
@@ -1135,6 +1135,204 @@ class SigningTests: TestCase {
         )) == true
     }
 
+    // MARK: - IAM
+
+    func testResponseVerificationWithIAMEnabledUsesIAMRelativePathForSignature() throws {
+        let message = "Hello World"
+        let nonce = "0123456789ab"
+        let requestDate = Date().millisecondsSince1970
+        let intermediateKey = try self.createIntermediatePublicKeyData(expiration: Self.intermediateKeyFutureExpiration)
+        let salt = Self.createSalt()
+        let request = HTTPRequest(method: .get, path: .getCustomerInfo(appUserID: "user"), nonce: nonce.asData)
+        let requestHeaders: HTTPRequest.Headers = [:]
+
+        // The backend signs using the IAM relative path ("/v1/customer") once IAM is enabled,
+        // rather than the classic "/v1/subscribers/{id}" path.
+        let signature = try self.sign(parameters: .init(path: request.path,
+                                                        iamEnabled: true,
+                                                        message: message.asData,
+                                                        requestHeaders: requestHeaders,
+                                                        nonce: nonce.asData,
+                                                        etag: nil,
+                                                        requestDate: requestDate,
+                                                        useFallbackPath: false),
+                                      salt: salt.asData)
+        let fullSignature = Self.fullSignature(
+            intermediateKey: intermediateKey,
+            salt: salt,
+            signature: signature
+        )
+
+        let response = HTTPResponse<Data?>(
+            httpStatusCode: .success,
+            responseHeaders: [
+                HTTPClient.ResponseHeader.signature.rawValue: fullSignature.base64EncodedString(),
+                HTTPClient.ResponseHeader.requestDate.rawValue: String(requestDate)
+            ],
+            body: message.asData
+        )
+
+        let verifiedWithIAMEnabled = response.verify(
+            signing: self.signing,
+            request: request,
+            requestHeaders: requestHeaders,
+            publicKey: self.publicKey,
+            isLoadShedderResponse: false,
+            isFallbackUrlResponse: false,
+            iamEnabled: true
+        )
+        expect(verifiedWithIAMEnabled.verificationResult) == .verified
+
+        // The same signature does not verify against the classic (non-IAM) relative path, since
+        // the bytes that were signed don't match.
+        let verifiedWithIAMDisabled = response.verify(
+            signing: self.signing,
+            request: request,
+            requestHeaders: requestHeaders,
+            publicKey: self.publicKey,
+            isLoadShedderResponse: false,
+            isFallbackUrlResponse: false,
+            iamEnabled: false
+        )
+        expect(verifiedWithIAMDisabled.verificationResult) == .failed
+    }
+
+    func testVerificationUsesBearerTokenFromHeadersInsteadOfAPIKeyWhenPresent() throws {
+        let message = "Hello World"
+        let requestDate = Date().millisecondsSince1970
+        let intermediateKey = try self.createIntermediatePublicKeyData(expiration: Self.intermediateKeyFutureExpiration)
+        let salt = Self.createSalt()
+        let request = HTTPRequest(method: .get, path: .health, nonce: nil)
+        let accessToken = "iam-access-token-123"
+        let requestHeaders: HTTPRequest.Headers = [
+            HTTPClient.RequestHeader.authorization.rawValue: "Bearer \(accessToken)"
+        ]
+
+        let parameters: Signing.SignatureParameters = .init(
+            path: request.path,
+            iamEnabled: true,
+            message: message.asData,
+            requestHeaders: requestHeaders,
+            nonce: nil,
+            etag: nil,
+            requestDate: requestDate,
+            useFallbackPath: false
+        )
+
+        // The client authenticated this request with its IAM access token rather than the SDK's
+        // API key, so the backend signs the response using that same access token as the auth value.
+        let signature = try self.privateIntermediateKey.signature(
+            for: parameters.signature(salt: salt.asData, authValue: accessToken)
+        )
+        let fullSignature = Self.fullSignature(
+            intermediateKey: intermediateKey,
+            salt: salt,
+            signature: signature
+        )
+
+        let response = HTTPResponse<Data?>(
+            httpStatusCode: .success,
+            responseHeaders: [
+                HTTPClient.ResponseHeader.signature.rawValue: fullSignature.base64EncodedString(),
+                HTTPClient.ResponseHeader.requestDate.rawValue: String(requestDate)
+            ],
+            body: message.asData
+        )
+        let verifiedResponse = response.verify(
+            signing: self.signing,
+            request: request,
+            requestHeaders: requestHeaders,
+            publicKey: self.publicKey,
+            isLoadShedderResponse: false,
+            isFallbackUrlResponse: false,
+            iamEnabled: true
+        )
+
+        expect(verifiedResponse.verificationResult) == .verified
+    }
+
+    func testVerificationFailsWhenSignedWithAPIKeyButRequestHasBearerToken() throws {
+        let message = "Hello World"
+        let requestDate = Date().millisecondsSince1970
+        let intermediateKey = try self.createIntermediatePublicKeyData(expiration: Self.intermediateKeyFutureExpiration)
+        let salt = Self.createSalt()
+        let request = HTTPRequest(method: .get, path: .health, nonce: nil)
+        let requestHeaders: HTTPRequest.Headers = [
+            HTTPClient.RequestHeader.authorization.rawValue: "Bearer some-access-token"
+        ]
+
+        let parameters: Signing.SignatureParameters = .init(
+            path: request.path,
+            iamEnabled: true,
+            message: message.asData,
+            requestHeaders: requestHeaders,
+            nonce: nil,
+            etag: nil,
+            requestDate: requestDate,
+            useFallbackPath: false
+        )
+
+        // Signed using the SDK's API key, even though the request headers carry a bearer token.
+        // Verification must prefer the header's bearer token as the auth value, so this signature
+        // should fail to verify.
+        let signature = try self.privateIntermediateKey.signature(
+            for: parameters.signature(salt: salt.asData, authValue: Self.apiKey)
+        )
+        let fullSignature = Self.fullSignature(
+            intermediateKey: intermediateKey,
+            salt: salt,
+            signature: signature
+        )
+
+        let response = HTTPResponse<Data?>(
+            httpStatusCode: .success,
+            responseHeaders: [
+                HTTPClient.ResponseHeader.signature.rawValue: fullSignature.base64EncodedString(),
+                HTTPClient.ResponseHeader.requestDate.rawValue: String(requestDate)
+            ],
+            body: message.asData
+        )
+        let verifiedResponse = response.verify(
+            signing: self.signing,
+            request: request,
+            requestHeaders: requestHeaders,
+            publicKey: self.publicKey,
+            isLoadShedderResponse: false,
+            isFallbackUrlResponse: false,
+            iamEnabled: true
+        )
+
+        expect(verifiedResponse.verificationResult) == .failed
+    }
+
+    func testDebugDescriptionUsesIAMRelativePathWhenIAMEnabled() {
+        let parameters: Signing.SignatureParameters = .init(
+            path: .getCustomerInfo(appUserID: "user"),
+            iamEnabled: true,
+            message: nil,
+            requestHeaders: [:],
+            nonce: nil,
+            etag: nil,
+            requestDate: 0
+        )
+
+        expect(parameters.debugDescription).to(contain("path: '/v1/customer'"))
+    }
+
+    func testDebugDescriptionUsesRegularRelativePathWhenIAMDisabled() {
+        let parameters: Signing.SignatureParameters = .init(
+            path: .getCustomerInfo(appUserID: "user"),
+            iamEnabled: false,
+            message: nil,
+            requestHeaders: [:],
+            nonce: nil,
+            etag: nil,
+            requestDate: 0
+        )
+
+        expect(parameters.debugDescription).to(contain("path: '/v1/subscribers/user'"))
+    }
+
 }
 
 private extension SigningTests {

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -30,6 +30,7 @@ class BackendSubscriberAttributesTests: TestCase {
 
     private var dateProvider: MockDateProvider!
     private var mockETagManager: MockETagManager!
+    private var mockTokenManager: MockTokenManager!
     private var mockDiagnosticsTracker: DiagnosticsTrackerType?
 
     private static let apiKey = "the api key"
@@ -646,12 +647,14 @@ class BackendSubscriberAttributesTests: TestCase {
 
     final func createClient(_ file: StaticString) -> MockHTTPClient {
         self.mockETagManager = MockETagManager()
+        self.mockTokenManager = MockTokenManager()
         if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
             self.mockDiagnosticsTracker = MockDiagnosticsTracker()
         }
 
         return MockHTTPClient(systemInfo: self.systemInfo,
                               eTagManager: self.mockETagManager,
+                              tokenManager: self.mockTokenManager,
                               diagnosticsTracker: self.mockDiagnosticsTracker,
                               sourceTestFile: file)
     }


### PR DESCRIPTION
Adds a flag to requests to allow the HTTP Client to dynamically alter the path based on whether IAM is enabled or not. Updates signature verification to support this

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes request URLs and cryptographic response-signature inputs (path + auth material) based on IAM enablement. Incorrect path or token handling would break API calls or signature verification.
> 
> **Overview**
> When IAM (`TokenManager`) is enabled, `HTTPClient` now builds requests against token-authenticated **IAM paths** (e.g. `/v1/customer` instead of `/v1/subscribers/{id}`) instead of the classic subscriber-id URLs.
> 
> `HTTPRequest.Path` gains `relativeIAMPath` / `iamPathComponent` mappings (login is explicitly disallowed). Response signature verification follows the same switch: it hashes the IAM path and uses the request’s **Bearer token** as the signed auth value when present, falling back to the API key otherwise. Verification also reads headers from the actual `URLRequest` so they match what was sent.
> 
> Adds `IdentityTests` plus coverage for IAM URL resolution, bearer header parsing, and IAM-aware signing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d45093ec48333e77fbe208406a9c31547a2542ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->