### PR TITLE
Fix font scaling setting on workflow paywalls

### DIFF
--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowScreenMapper.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowScreenMapper.swift
@@ -30,6 +30,7 @@ enum WorkflowScreenMapper {
             revision: screen.revision,
             defaultLocaleIdentifier: screen.defaultLocale,
             exitOffers: screen.exitOffers,
+            automaticallyScaleFontSize: screen.automaticallyScaleFontSize,
             stateDeclarations: screen.stateDeclarations
         )
         return .init(uiConfig: uiConfig, data: data)

--- a/Sources/Networking/Responses/WorkflowsResponse.swift
+++ b/Sources/Networking/Responses/WorkflowsResponse.swift
@@ -139,6 +139,10 @@ import Foundation
     var config: [String: AnyDecodable]
     public let offeringIdentifier: String?
     public let exitOffers: ExitOffers?
+    @DefaultDecodable.True
+    // swiftlint:disable:next identifier_name
+    var _automaticallyScaleFontSize: Bool
+    public var automaticallyScaleFontSize: Bool { _automaticallyScaleFontSize }
     /// Whole-map fallback to nil; the offerings path drops entries individually via
     /// `FailableStateDeclaration`.
     @IgnoreDecodeErrors<[String: PaywallComponent.StateDeclaration]?>
@@ -296,6 +300,8 @@ extension WorkflowScreen: Codable, Equatable, Sendable {
         case config
         case offeringIdentifier
         case exitOffers
+        // swiftlint:disable:next identifier_name
+        case _automaticallyScaleFontSize = "automaticallyScaleFontSize"
         // swiftlint:disable:next identifier_name
         case _stateDeclarations = "stateDeclarations"
     }

--- a/Sources/Networking/Responses/WorkflowsResponse.swift
+++ b/Sources/Networking/Responses/WorkflowsResponse.swift
@@ -162,6 +162,7 @@ import Foundation
         defaultLocale: PaywallComponent.LocaleID,
         offeringIdentifier: String?,
         exitOffers: ExitOffers? = nil,
+        automaticallyScaleFontSize: Bool = true,
         stateDeclarations: [String: PaywallComponent.StateDeclaration]? = nil
     ) {
         self.name = name
@@ -174,6 +175,7 @@ import Foundation
         self.config = [:]
         self.offeringIdentifier = offeringIdentifier
         self.exitOffers = exitOffers
+        self._automaticallyScaleFontSize = automaticallyScaleFontSize
         self._stateDeclarations = stateDeclarations
     }
 

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowScreenMapperTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowScreenMapperTests.swift
@@ -38,6 +38,15 @@ final class WorkflowScreenMapperTests: TestCase {
         expect(result.data.automaticallyScaleFontSize) == true
     }
 
+    func testMapsAutomaticallyScaleFontSizeFromScreen() throws {
+        let screen = try Self.makeScreen(automaticallyScaleFontSize: false)
+        let uiConfig = try Self.makeUIConfig()
+
+        let result = WorkflowScreenMapper.toPaywallComponents(screen: screen, uiConfig: uiConfig)
+
+        expect(result.data.automaticallyScaleFontSize) == false
+    }
+
     func testPassesThroughUiConfig() throws {
         let screen = try Self.makeScreen()
         let uiConfig = try Self.makeUIConfig()
@@ -140,9 +149,16 @@ private extension WorkflowScreenMapperTests {
         assetBaseURL: String = "https://assets.pawwalls.com",
         revision: Int = 3,
         defaultLocale: String = "en_US",
+        automaticallyScaleFontSize: Bool? = nil,
         exitOfferOfferingId: String? = nil,
         stateDeclarationsJSON: String? = nil
     ) throws -> RevenueCat.WorkflowScreen {
+        var automaticallyScaleFontSizeFragment = ""
+        if let automaticallyScaleFontSize {
+            automaticallyScaleFontSizeFragment = """
+            , "automatically_scale_font_size": \(automaticallyScaleFontSize)
+            """
+        }
         var stateDeclarationsFragment = ""
         if let stateDeclarationsJSON {
             stateDeclarationsFragment = """
@@ -188,7 +204,7 @@ private extension WorkflowScreenMapperTests {
                         }
                     }
                 }
-            }\(exitOffersJSON)\(stateDeclarationsFragment)
+            }\(automaticallyScaleFontSizeFragment)\(exitOffersJSON)\(stateDeclarationsFragment)
         }
         """
         let data = try XCTUnwrap(json.data(using: .utf8))

--- a/Tests/UnitTests/Networking/Workflows/WorkflowResponseTests.swift
+++ b/Tests/UnitTests/Networking/Workflows/WorkflowResponseTests.swift
@@ -237,6 +237,22 @@ class WorkflowResponseTests: TestCase {
         expect(screen.automaticallyScaleFontSize) == true
     }
 
+    func testWorkflowScreenInitializerCanDisableAutomaticFontScaling() throws {
+        let decodedScreen = try Self.decodeWorkflowScreen()
+        let screen = WorkflowScreen(
+            name: decodedScreen.name,
+            templateName: decodedScreen.templateName,
+            assetBaseURL: decodedScreen.assetBaseURL,
+            componentsConfig: decodedScreen.componentsConfig,
+            componentsLocalizations: decodedScreen.componentsLocalizations,
+            defaultLocale: decodedScreen.defaultLocale,
+            offeringIdentifier: decodedScreen.offeringIdentifier,
+            automaticallyScaleFontSize: false
+        )
+
+        expect(screen.automaticallyScaleFontSize) == false
+    }
+
     func testDecodeWorkflowScreenWithExitOffers() throws {
         let json = """
         {

--- a/Tests/UnitTests/Networking/Workflows/WorkflowResponseTests.swift
+++ b/Tests/UnitTests/Networking/Workflows/WorkflowResponseTests.swift
@@ -225,6 +225,18 @@ class WorkflowResponseTests: TestCase {
         expect(screen.offeringIdentifier) == "default"
     }
 
+    func testDecodeWorkflowScreenAutomaticallyScaleFontSize() throws {
+        let screen = try Self.decodeWorkflowScreen(automaticallyScaleFontSize: false)
+
+        expect(screen.automaticallyScaleFontSize) == false
+    }
+
+    func testDecodeWorkflowScreenAutomaticallyScaleFontSizeDefaultsToTrue() throws {
+        let screen = try Self.decodeWorkflowScreen()
+
+        expect(screen.automaticallyScaleFontSize) == true
+    }
+
     func testDecodeWorkflowScreenWithExitOffers() throws {
         let json = """
         {
@@ -429,6 +441,41 @@ class WorkflowResponseTests: TestCase {
         expect(step.outputs).to(beEmpty())
         expect(step.triggerActions["btn_wagcLsIVjN"]) == .step(stepId: "ztBPCwD")
         expect(step.metadata).to(beNil())
+    }
+
+}
+
+private extension WorkflowResponseTests {
+
+    static func decodeWorkflowScreen(automaticallyScaleFontSize: Bool? = nil) throws -> WorkflowScreen {
+        var automaticallyScaleFontSizeFragment = ""
+        if let automaticallyScaleFontSize {
+            automaticallyScaleFontSizeFragment = """
+            , "automatically_scale_font_size": \(automaticallyScaleFontSize)
+            """
+        }
+        let json = """
+        {
+          "template_name": "tmpl",
+          "asset_base_url": "https://assets.revenuecat.com",
+          "default_locale": "en_US",
+          "components_localizations": {},
+          "components_config": {
+            "base": {
+              "stack": {
+                "type": "stack", "components": [],
+                "dimension": { "type": "vertical", "alignment": "center", "distribution": "center" },
+                "size": { "width": { "type": "fill" }, "height": { "type": "fill" } },
+                "padding": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 },
+                "margin": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 }
+              },
+              "background": { "type": "color", "value": { "light": { "type": "hex", "value": "#FFFFFF" } } }
+            }
+          }\(automaticallyScaleFontSizeFragment)
+        }
+        """.data(using: .utf8)!
+
+        return try JSONDecoder.default.decode(WorkflowScreen.self, from: json)
     }
 
 }


### PR DESCRIPTION
Workflow-backed paywalls drop `automatically_scale_font_size`, so disabling font scaling in the dashboard has no effect on iOS. This is the iOS counterpart to [purchases-android#3977](https://github.com/RevenueCat/purchases-android/pull/3977).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized networking and mapping change with a safe default; no auth or payment logic touched.
> 
> **Overview**
> Workflow paywalls now read **`automatically_scale_font_size`** from workflow screen payloads and pass it into **`PaywallComponentsData`**, so the dashboard toggle to disable Dynamic Type font scaling applies on iOS the same way as offering-backed paywalls.
> 
> **`WorkflowScreen`** decodes the field (default **`true`** when omitted) and **`WorkflowScreenMapper`** forwards **`screen.automaticallyScaleFontSize`** into the paywall components model used by **`PaywallsV2View`** / **`UIConfigProvider`**. Tests cover JSON decode, defaults, the SPI initializer, and mapper passthrough.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c97956e8b758c010daff8748f0564dd5a48863f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->