### PR TITLE
Chore: Convert to Set to Array on WebBunbleEventBus

### DIFF
--- a/Sources/Paywalls/WebBundleEventBus.swift
+++ b/Sources/Paywalls/WebBundleEventBus.swift
@@ -31,8 +31,8 @@ import Foundation
         self.publisher = subject.eraseToAnyPublisher()
     }
 
-    /// Replaces the current URL set and notifies subscribers.
-    public func publish(_ urls: Set<URLWithValidation>) {
+    /// Replaces the current URLs and notifies subscribers.
+    public func publish(_ urls: [URLWithValidation]) {
         self.subject.send(.receivedAssetURLs(urls))
     }
 
@@ -50,6 +50,6 @@ import Foundation
 
 @_spi(Internal) public enum WebBundleEvent: Equatable, Sendable {
     case empty
-    case receivedAssetURLs(Set<URLWithValidation>)
+    case receivedAssetURLs([URLWithValidation])
     case cacheClearRequested
 }

--- a/Tests/UnitTests/Paywalls/WebBundleEventBusTests.swift
+++ b/Tests/UnitTests/Paywalls/WebBundleEventBusTests.swift
@@ -36,8 +36,8 @@ final class WebBundleEventBusTests: TestCase {
         super.tearDown()
     }
 
-    func testLateSubscriberReceivesLastPublishedSet() async {
-        let urls: Set<URLWithValidation> = [
+    func testLateSubscriberReceivesLastPublishedURLs() async {
+        let urls: [URLWithValidation] = [
             .init(url: URL(string: "https://example.com/a")!, checksum: nil),
             .init(url: URL(string: "https://example.com/b")!, checksum: nil)
         ]
@@ -52,10 +52,10 @@ final class WebBundleEventBusTests: TestCase {
     }
 
     func testPublishingReplacesPreviousValueForSubsequentSubscribers() async {
-        let first: Set<URLWithValidation> = [
+        let first: [URLWithValidation] = [
             .init(url: URL(string: "https://example.com/first")!, checksum: nil)
         ]
-        let second: Set<URLWithValidation> = [
+        let second: [URLWithValidation] = [
             .init(url: URL(string: "https://example.com/second")!, checksum: nil)
         ]
 
@@ -70,7 +70,7 @@ final class WebBundleEventBusTests: TestCase {
         expect(received) == .receivedAssetURLs(second)
     }
 
-    func testInitialSubscriberReceivesEmptySet() {
+    func testInitialSubscriberReceivesEmpty() {
         var received: WebBundleEvent?
         self.bus.publisher
             .sink { received = $0 }
@@ -89,8 +89,8 @@ final class WebBundleEventBusTests: TestCase {
         expect(received) == .cacheClearRequested
     }
 
-    func testEmptyReplacesCurrentValueWithEmptySet() async {
-        let urls: Set<URLWithValidation> = [
+    func testEmptyReplacesCurrentValueWithEmpty() async {
+        let urls: [URLWithValidation] = [
             .init(url: URL(string: "https://example.com/a")!, checksum: nil),
             .init(url: URL(string: "https://example.com/b")!, checksum: nil)
         ]
@@ -108,10 +108,10 @@ final class WebBundleEventBusTests: TestCase {
     }
 
     func testSubscriberCanPublishInResponseToValue() async {
-        let first: Set<URLWithValidation> = [
+        let first: [URLWithValidation] = [
             .init(url: URL(string: "https://example.com/first")!, checksum: nil)
         ]
-        let second: Set<URLWithValidation> = [
+        let second: [URLWithValidation] = [
             .init(url: URL(string: "https://example.com/second")!, checksum: nil)
         ]
         let receivedSecond = self.expectation(description: "Received second publication")


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->
<!-- AI agents: fill in this template, and also follow the "Pull Requests" section in AGENTS.md. -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->
We want to preserve order

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

Convert the set to an array type instead

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal SPI-only type change on a paywall event bus with matching unit tests; no auth or payment logic touched.
> 
> **Overview**
> **`WebBundleEventBus`** now carries discovered paywall asset URLs as an **ordered array** instead of a **`Set`**, so subscribers see the same sequence as cache warming produced.
> 
> `publish(_:)` and **`WebBundleEvent.receivedAssetURLs`** both take **`[URLWithValidation]`**; unit tests were updated to match (including a few test name tweaks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef1cb0bee7fe9a2a4f46df52a1b9521e11c2ccf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->