### PR TITLE
Announce a public API change in the SDK API feed once per PR

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2535,8 +2535,6 @@ platform :ios do
 
     # Informational: a GitHub or Slack outage must not decide whether the gate fails.
     begin
-      # The comment records that the change was announced, so the announcement has to happen first:
-      # the fallback reads the marker the previous run left, which this run's comment overwrites.
       announcement = notify_api_changes_on_slack(
         reports_by_target: reports_by_target,
         breaks: all_breaks,
@@ -2611,10 +2609,7 @@ platform :ios do
     end
   end
 
-  # Returns { fingerprint:, notice: }. The fingerprint is set once the summary is in the channel,
-  # whether this run put it there or a previous one did, and the comment records it so the next run
-  # recognises it without reading the channel. A notice is reported in the PR comment so a missing
-  # credential or a duplicate risk is visible without failing the gate.
+  # Returns { fingerprint:, notice: }; the notice ends up in the PR comment.
   private_lane :notify_api_changes_on_slack do |options|
     breaks = options[:breaks]
     changed_targets = options[:reports_by_target].select { |_t, r| ApiDiffHelper.api_changes_reported?(r) }
@@ -2654,12 +2649,7 @@ platform :ios do
     state, history_error = ApiDiffHelper.announcement_state(
       summary, bot_token: bot_token, channel: channel, source: source, modules: modules
     )
-    announced = state == :same
-    # Nothing the channel can tell us: the marker the last announcement left on the comment records
-    # the same thing, the last summary that made it out.
-    announced = ApiDiffHelper.announced_in_comment?(api_diff_comment_body_on_pr, fingerprint) if state == :unknown
-
-    if announced
+    if ApiDiffHelper.already_announced?(state, fingerprint) { api_diff_comment_body_on_pr }
       UI.message("This API change is already in the SDK API feed, not posting it again")
       next({ fingerprint: fingerprint, notice: nil })
     end
@@ -2671,7 +2661,6 @@ platform :ios do
       UI.success("Posted the API change summary to Slack")
       { fingerprint: fingerprint, notice: notice }
     rescue StandardError => e
-      # A failed announcement must not record the fingerprint, or the next run stays silent too.
       UI.important("Could not announce the API change: #{e.message}")
       { fingerprint: nil, notice: "This change was not announced in the SDK API feed: #{e.message}." }
     end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2535,20 +2535,23 @@ platform :ios do
 
     # Informational: a GitHub or Slack outage must not decide whether the gate fails.
     begin
-      # notify_api_changes_on_slack bails out when there is nothing to announce, so the notice must
-      # not claim a change went unannounced.
-      announceable = all_breaks.any? || ApiDiffHelper.changed_modules(reports_by_target).any?
-      slack_notice = announceable ? api_slack_unreachable_notice : nil
+      # The comment records that the change was announced, so the announcement has to happen first:
+      # the fallback reads the marker the previous run left, which this run's comment overwrites.
+      announcement = notify_api_changes_on_slack(
+        reports_by_target: reports_by_target,
+        breaks: all_breaks,
+        labels: labels
+      )
       schemes.each do |scheme|
         upsert_api_diff_comment(
           scheme: scheme,
           reports_by_target: reports_by_target.select { |target, _r| target.start_with?("#{scheme} ") },
           breaks: all_breaks,
           labels: labels,
-          notice: slack_notice
+          notice: announcement[:notice],
+          announced_fingerprint: announcement[:fingerprint]
         )
       end
-      notify_api_changes_on_slack(reports_by_target: reports_by_target, breaks: all_breaks, labels: labels)
     rescue StandardError => e
       UI.important("Could not publish the API diff report: #{e.message}")
     end
@@ -2572,29 +2575,23 @@ platform :ios do
     end
 
     repo = "RevenueCat/#{REPO_NAME}"
-    existing_id = find_pr_comment_with_marker(repo, pr_number, token, ApiDiffHelper::API_DIFF_COMMENT_MARKER)
+    existing = find_pr_comment(repo, pr_number, token, ApiDiffHelper::API_DIFF_COMMENT_MARKER)
 
     section = ApiDiffHelper.api_diff_comment_section(
       options[:scheme], options[:reports_by_target], options[:breaks], options[:labels],
-      notice: options[:notice]
+      notice: options[:notice], announced_fingerprint: options[:announced_fingerprint]
     )
 
-    if existing_id
+    if existing
       # The other module's job owns its own section of this comment.
-      existing = github_api(
-        server_url: 'https://api.github.com',
-        api_token: token,
-        http_method: 'GET',
-        path: "/repos/#{repo}/issues/comments/#{existing_id}"
-      )
-      body = ApiDiffHelper.merge_api_diff_comment(existing[:json]["body"], options[:scheme], section)
+      body = ApiDiffHelper.merge_api_diff_comment(existing["body"], options[:scheme], section)
 
-      UI.message("Updating API diff comment #{existing_id}")
+      UI.message("Updating API diff comment #{existing['id']}")
       github_api(
         server_url: 'https://api.github.com',
         api_token: token,
         http_method: 'PATCH',
-        path: "/repos/#{repo}/issues/comments/#{existing_id}",
+        path: "/repos/#{repo}/issues/comments/#{existing['id']}",
         body: { body: body }
       )
     else
@@ -2609,48 +2606,82 @@ platform :ios do
     end
   end
 
+  # Returns { fingerprint:, notice: }. The fingerprint is set once the summary is in the channel,
+  # whether this run put it there or a previous one did, and the comment records it so the next run
+  # recognises it without reading the channel. A notice is reported in the PR comment so a missing
+  # credential or a duplicate risk is visible without failing the gate.
   private_lane :notify_api_changes_on_slack do |options|
     breaks = options[:breaks]
     changed_targets = options[:reports_by_target].select { |_t, r| ApiDiffHelper.api_changes_reported?(r) }
 
     if breaks.empty? && changed_targets.empty?
       UI.message("No public API changes, nothing to post to Slack")
-      next
+      next({ fingerprint: nil, notice: nil })
     end
 
+    bot_token = ENV["SLACK_ACCESS_TOKEN_CIRCLE_CI_NOTIFY_ORB_IOS"]
+    channel = ENV["SLACK_CHANNEL_SDK_NEW_API"]
+
+    source = api_gate_pr_link
+    modules = ApiDiffHelper.changed_modules(options[:reports_by_target])
+
+    summary = ApiDiffHelper.slack_summary(
+      breaks,
+      options[:labels],
+      source: source,
+      new_declarations: ApiDiffHelper.added_declarations(options[:reports_by_target]),
+      modules: modules
+    )
+    fingerprint = ApiDiffHelper.announcement_fingerprint(summary)
+
     request = ApiDiffHelper.slack_post_request(
-      ApiDiffHelper.slack_summary(
-        breaks,
-        options[:labels],
-        source: api_gate_pr_link,
-        new_declarations: ApiDiffHelper.added_declarations(options[:reports_by_target]),
-        modules: ApiDiffHelper.changed_modules(options[:reports_by_target])
-      ),
+      summary,
       webhook_url: ENV["SLACK_URL_SDK_NEW_API"],
-      bot_token: ENV["SLACK_ACCESS_TOKEN_CIRCLE_CI_NOTIFY_ORB_IOS"],
-      channel: ENV["SLACK_CHANNEL_SDK_NEW_API"]
+      bot_token: bot_token,
+      channel: channel
     )
 
     if request.nil?
       UI.important("No Slack credential reachable. Expected SLACK_ACCESS_TOKEN_CIRCLE_CI_NOTIFY_ORB_IOS from the slack-secrets context plus SLACK_CHANNEL_SDK_NEW_API, or SLACK_URL_SDK_NEW_API. Skipping.")
-      next
+      next({ fingerprint: nil, notice: ApiDiffHelper::SLACK_UNREACHABLE_NOTICE })
     end
 
-    ApiDiffHelper.post_slack_message(request)
-    UI.success("Posted the API change summary to Slack")
+    state, history_error = ApiDiffHelper.announcement_state(
+      summary, bot_token: bot_token, channel: channel, source: source, modules: modules
+    )
+    announced = state == :same
+    # Nothing the channel can tell us: the marker the last announcement left on the comment records
+    # the same thing, the last summary that made it out.
+    announced = ApiDiffHelper.announced_in_comment?(api_diff_comment_body_on_pr, fingerprint) if state == :unknown
+
+    if announced
+      UI.message("This API change is already in the SDK API feed, not posting it again")
+      next({ fingerprint: fingerprint, notice: nil })
+    end
+
+    notice = "Could not read the SDK API feed, so this change may be announced twice: #{history_error}." if history_error
+
+    begin
+      ApiDiffHelper.post_slack_message(request)
+      UI.success("Posted the API change summary to Slack")
+      { fingerprint: fingerprint, notice: notice }
+    rescue StandardError => e
+      # A failed announcement must not record the fingerprint, or the next run stays silent too.
+      UI.important("Could not announce the API change: #{e.message}")
+      { fingerprint: nil, notice: "This change was not announced in the SDK API feed: #{e.message}." }
+    end
   end
 
-  # Reported in the PR comment so a missing credential is visible without failing the gate.
-  private_lane :api_slack_unreachable_notice do
-    reachable = ApiDiffHelper.slack_credentials_reachable?(
-      webhook_url: ENV["SLACK_URL_SDK_NEW_API"],
-      bot_token: ENV["SLACK_ACCESS_TOKEN_CIRCLE_CI_NOTIFY_ORB_IOS"],
-      channel: ENV["SLACK_CHANNEL_SDK_NEW_API"]
+  private_lane :api_diff_comment_body_on_pr do
+    pr_number = detect_pr_number
+    token = ENV["DANGER_GITHUB_API_TOKEN"]
+    next "" if pr_number.nil? || token.nil? || token.empty?
+
+    comment = find_pr_comment(
+      "RevenueCat/#{REPO_NAME}", pr_number, token, ApiDiffHelper::API_DIFF_COMMENT_MARKER
     )
 
-    next nil if reachable
-
-    ApiDiffHelper::SLACK_UNREACHABLE_NOTICE
+    comment ? comment["body"].to_s : ""
   end
 
   private_lane :api_gate_pr_link do
@@ -2955,6 +2986,10 @@ def update_paywall_preview_resources_commit(hash)
 end
 
 def find_pr_comment_with_marker(repo, pr_number, token, marker)
+  find_pr_comment(repo, pr_number, token, marker)&.fetch("id")
+end
+
+def find_pr_comment(repo, pr_number, token, marker)
   # A missed marker posts a duplicate instead of updating.
   page = 1
 
@@ -2967,7 +3002,7 @@ def find_pr_comment_with_marker(repo, pr_number, token, marker)
     )
     comments = resp[:json] || []
     comment = comments.find { |c| c["body"].to_s.include?(marker) }
-    return comment["id"] if comment
+    return comment if comment
     return nil if comments.count < 100
 
     page += 1

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2580,9 +2580,12 @@ platform :ios do
       next
     end
 
+    announced_fingerprint = options[:announced_fingerprint] ||
+                            ApiDiffHelper.announced_fingerprint_in(existing&.dig("body"), options[:scheme])
+
     section = ApiDiffHelper.api_diff_comment_section(
       options[:scheme], options[:reports_by_target], options[:breaks], options[:labels],
-      notice: options[:notice], announced_fingerprint: options[:announced_fingerprint]
+      notice: options[:notice], announced_fingerprint: announced_fingerprint
     )
 
     if existing

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2577,6 +2577,11 @@ platform :ios do
     repo = "RevenueCat/#{REPO_NAME}"
     existing = find_pr_comment(repo, pr_number, token, ApiDiffHelper::API_DIFF_COMMENT_MARKER)
 
+    unless ApiDiffHelper.comment_needed?(options[:reports_by_target], options[:breaks], existing&.dig("body"), options[:scheme])
+      UI.message("No public API changes and none reported before, skipping the API diff comment")
+      next
+    end
+
     section = ApiDiffHelper.api_diff_comment_section(
       options[:scheme], options[:reports_by_target], options[:breaks], options[:labels],
       notice: options[:notice], announced_fingerprint: options[:announced_fingerprint]

--- a/fastlane/api_diff_helper.rb
+++ b/fastlane/api_diff_helper.rb
@@ -1,6 +1,7 @@
 # Helper module for API diff functionality
 # Used by generate_swiftinterface and check_api_changes lanes
 
+require 'digest'
 require 'fileutils'
 require 'json'
 require 'net/http'
@@ -469,10 +470,24 @@ module ApiDiffHelper
     end
   end
 
-  def api_diff_comment_section(module_name, reports_by_target, breaks, labels, notice: nil)
-    inner = api_diff_comment_body(reports_by_target, breaks, labels, heading: "### #{module_name}", notice: notice)
+  def announced_marker(fingerprint)
+    "<!-- api-diff-announced:#{fingerprint} -->"
+  end
 
-    [api_diff_section_open(module_name), inner, api_diff_section_close(module_name)].join("\n")
+  def announcement_fingerprint(message)
+    Digest::SHA256.hexdigest(message.to_s)[0, 12]
+  end
+
+  def announced_in_comment?(comment_body, fingerprint)
+    comment_body.to_s.include?(announced_marker(fingerprint))
+  end
+
+  def api_diff_comment_section(module_name, reports_by_target, breaks, labels, notice: nil, announced_fingerprint: nil)
+    inner = api_diff_comment_body(reports_by_target, breaks, labels, heading: "### #{module_name}", notice: notice)
+    parts = [api_diff_section_open(module_name), inner]
+    parts << announced_marker(announced_fingerprint) if announced_fingerprint
+
+    (parts << api_diff_section_close(module_name)).join("\n")
   end
 
   def api_diff_comment_body(reports_by_target, breaks, labels, heading: nil, notice: nil)
@@ -595,10 +610,6 @@ module ApiDiffHelper
   end
 
 
-  def slack_credentials_reachable?(webhook_url: nil, bot_token: nil, channel: nil)
-    !webhook_url.to_s.empty? || (!bot_token.to_s.empty? && !channel.to_s.empty?)
-  end
-
   SLACK_UNREACHABLE_NOTICE = "No Slack credentials were reachable, so this change was not announced in the SDK API feed.".freeze
 
   def slack_post_request(message, webhook_url: nil, bot_token: nil, channel: nil)
@@ -617,6 +628,64 @@ module ApiDiffHelper
       headers: { "Content-Type" => "application/json", "Authorization" => "Bearer #{bot_token}" },
       body: { channel: channel, text: message }
     }
+  end
+
+  SLACK_HISTORY_LIMIT = 100
+
+  # conversations.history takes a channel ID, never a `#name`.
+  CHANNEL_ID = /\A[CGD][A-Z0-9]+\z/.freeze
+
+  def slack_history_request(channel, bot_token:, limit: SLACK_HISTORY_LIMIT)
+    {
+      url: "https://slack.com/api/conversations.history?channel=#{channel}&limit=#{limit}",
+      headers: { "Authorization" => "Bearer #{bot_token}" }
+    }
+  end
+
+  # `getter` exists so the tests can exercise this without a network.
+  def recent_slack_messages(request, getter: nil)
+    getter ||= ->(url, headers) { Net::HTTP.get_response(URI.parse(url), headers) }
+
+    response = getter.call(request[:url], request[:headers])
+    raise "Slack returned #{response.code}: #{response.body}" unless (200..299).cover?(response.code.to_i)
+
+    parsed = JSON.parse(response.body.to_s)
+    raise "Slack rejected conversations.history: #{parsed['error']}" unless parsed["ok"]
+
+    parsed["messages"].to_a.map { |message| message["text"].to_s }
+  end
+
+  # conversations.history answers newest first, so the first match is the channel's last word about
+  # this PR. Each job speaks for one scheme only, so the module is part of the identity: without it
+  # the RevenueCat job would compare itself against RevenueCatUI's message and both would repost
+  # on every run. The trailing backtick keeps `RevenueCat` from matching `RevenueCatUI`.
+  def last_announcement(texts, source, modules)
+    return nil if source.to_s.empty?
+
+    identity = [SDK_PLATFORM_LABEL, *modules.map { |name| "`#{name}`" }].join(" · ")
+
+    texts.find { |text| text.include?(source) && text.include?(identity) }
+  end
+
+  # A webhook cannot read the channel, and conversations.history needs an ID rather than a name, so
+  # both fall through to the fingerprint the last announcement left on the PR comment. Comparing
+  # against the last announcement rather than the whole window keeps a PR that reverts to an
+  # earlier surface announced: the channel's newest word on it has to be the current one.
+  # Returns [:same | :different | :unknown, why_unknown].
+  def announcement_state(message, bot_token:, channel:, source:, modules:, getter: nil)
+    return [:unknown, "no bot token, so the SDK API feed cannot be read"] if bot_token.to_s.empty?
+
+    unless CHANNEL_ID.match?(channel.to_s)
+      return [:unknown, "#{channel} is a channel name, and conversations.history needs the channel ID"]
+    end
+
+    request = slack_history_request(channel, bot_token: bot_token)
+    last = last_announcement(recent_slack_messages(request, getter: getter), source, modules)
+    return [:unknown, nil] if last.nil?
+
+    [last == message ? :same : :different, nil]
+  rescue StandardError => e
+    [:unknown, e.message]
   end
 
   # `poster` exists so the tests can exercise the response handling without a network.

--- a/fastlane/api_diff_helper.rb
+++ b/fastlane/api_diff_helper.rb
@@ -478,6 +478,18 @@ module ApiDiffHelper
     Digest::SHA256.hexdigest(message.to_s)[0, 12]
   end
 
+  ANNOUNCED_MARKER_PATTERN = /<!-- api-diff-announced:([0-9a-f]+) -->/.freeze
+
+  # The marker records the last summary that reached the channel, which a run with nothing to
+  # announce, or one whose post failed, did not change.
+  def announced_fingerprint_in(comment_body, module_name)
+    open_tag = Regexp.escape(api_diff_section_open(module_name))
+    close_tag = Regexp.escape(api_diff_section_close(module_name))
+    section = comment_body.to_s[/#{open_tag}.*?#{close_tag}/m]
+
+    section && ANNOUNCED_MARKER_PATTERN.match(section)&.captures&.first
+  end
+
   # The comment body is only read for :unknown, so the caller passes a block that fetches it.
   def already_announced?(state, fingerprint)
     return true if state == :same

--- a/fastlane/api_diff_helper.rb
+++ b/fastlane/api_diff_helper.rb
@@ -478,12 +478,14 @@ module ApiDiffHelper
     Digest::SHA256.hexdigest(message.to_s)[0, 12]
   end
 
-  def announced_in_comment?(comment_body, fingerprint)
-    comment_body.to_s.include?(announced_marker(fingerprint))
+  # The comment body is only read for :unknown, so the caller passes a block that fetches it.
+  def already_announced?(state, fingerprint)
+    return true if state == :same
+    return false unless state == :unknown
+
+    yield.to_s.include?(announced_marker(fingerprint))
   end
 
-  # Most PRs never touch the public API, and "No public API changes" on all of them is noise. A PR
-  # that removed its changes keeps its section, so the same line reads as the all-clear it is.
   def comment_needed?(reports_by_target, breaks, existing_body, module_name)
     return true if breaks.any? || changed_modules(reports_by_target).any?
 
@@ -562,6 +564,11 @@ module ApiDiffHelper
 
   SDK_PLATFORM_LABEL = "iOS :ios:".freeze
 
+  # last_announcement matches on this, so the headline and the dedup key cannot drift apart.
+  def announcement_identity(modules)
+    [SDK_PLATFORM_LABEL, *modules.map { |name| "`#{name}`" }].join(" · ")
+  end
+
   SLACK_DECLARATION_LIMIT = 10
 
   # Slack stops wrapping code blocks past this; the full text is in the PR comment.
@@ -601,7 +608,7 @@ module ApiDiffHelper
                else
                  ":sparkles: *New public API*"
                end
-    headline = [headline, SDK_PLATFORM_LABEL, *modules.map { |name| "`#{name}`" }].join(" · ")
+    headline = [headline, announcement_identity(modules)].join(" · ")
 
     lines = [headline]
     lines << source unless source.to_s.empty?
@@ -650,7 +657,6 @@ module ApiDiffHelper
     }
   end
 
-  # `getter` exists so the tests can exercise this without a network.
   def recent_slack_messages(request, getter: nil)
     getter ||= ->(url, headers) { Net::HTTP.get_response(URI.parse(url), headers) }
 
@@ -663,22 +669,17 @@ module ApiDiffHelper
     parsed["messages"].to_a.map { |message| message["text"].to_s }
   end
 
-  # conversations.history answers newest first, so the first match is the channel's last word about
-  # this PR. Each job speaks for one scheme only, so the module is part of the identity: without it
-  # the RevenueCat job would compare itself against RevenueCatUI's message and both would repost
-  # on every run. The trailing backtick keeps `RevenueCat` from matching `RevenueCatUI`.
+  # conversations.history answers newest first, so the first match is the channel's last word. The
+  # trailing backtick in the identity keeps `RevenueCat` from matching `RevenueCatUI`.
   def last_announcement(texts, source, modules)
     return nil if source.to_s.empty?
 
-    identity = [SDK_PLATFORM_LABEL, *modules.map { |name| "`#{name}`" }].join(" · ")
+    identity = announcement_identity(modules)
 
     texts.find { |text| text.include?(source) && text.include?(identity) }
   end
 
-  # A webhook cannot read the channel, and conversations.history needs an ID rather than a name, so
-  # both fall through to the fingerprint the last announcement left on the PR comment. Comparing
-  # against the last announcement rather than the whole window keeps a PR that reverts to an
-  # earlier surface announced: the channel's newest word on it has to be the current one.
+  # A webhook cannot read the channel, and conversations.history needs an ID rather than a name.
   # Returns [:same | :different | :unknown, why_unknown].
   def announcement_state(message, bot_token:, channel:, source:, modules:, getter: nil)
     return [:unknown, "no bot token, so the SDK API feed cannot be read"] if bot_token.to_s.empty?

--- a/fastlane/api_diff_helper.rb
+++ b/fastlane/api_diff_helper.rb
@@ -482,6 +482,14 @@ module ApiDiffHelper
     comment_body.to_s.include?(announced_marker(fingerprint))
   end
 
+  # Most PRs never touch the public API, and "No public API changes" on all of them is noise. A PR
+  # that removed its changes keeps its section, so the same line reads as the all-clear it is.
+  def comment_needed?(reports_by_target, breaks, existing_body, module_name)
+    return true if breaks.any? || changed_modules(reports_by_target).any?
+
+    existing_body.to_s.include?(api_diff_section_open(module_name))
+  end
+
   def api_diff_comment_section(module_name, reports_by_target, breaks, labels, notice: nil, announced_fingerprint: nil)
     inner = api_diff_comment_body(reports_by_target, breaks, labels, heading: "### #{module_name}", notice: notice)
     parts = [api_diff_section_open(module_name), inner]

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -1529,6 +1529,28 @@ class ApiDiffHelperTest < Minitest::Test
     assert ApiDiffHelper.comment_needed?({}, [{ reason: :removed, owner: nil, declaration: "public func a()" }], nil, "RevenueCat")
   end
 
+  def test_announced_fingerprint_survives_a_run_with_nothing_to_announce
+    announced = ApiDiffHelper.merge_api_diff_comment(
+      nil, "RevenueCat",
+      ApiDiffHelper.api_diff_comment_section("RevenueCat", {}, [], [], announced_fingerprint: "abc123abc123")
+    )
+
+    assert_equal "abc123abc123", ApiDiffHelper.announced_fingerprint_in(announced, "RevenueCat")
+    assert_nil ApiDiffHelper.announced_fingerprint_in(announced, "RevenueCatUI")
+    assert_nil ApiDiffHelper.announced_fingerprint_in(nil, "RevenueCat")
+  end
+
+  # Another module's marker must not be mistaken for this module's.
+  def test_announced_fingerprint_is_read_from_this_modules_section
+    body = [
+      ApiDiffHelper.api_diff_comment_section("RevenueCat", {}, [], []),
+      ApiDiffHelper.api_diff_comment_section("RevenueCatUI", {}, [], [], announced_fingerprint: "def456def456")
+    ].join("\n")
+
+    assert_nil ApiDiffHelper.announced_fingerprint_in(body, "RevenueCat")
+    assert_equal "def456def456", ApiDiffHelper.announced_fingerprint_in(body, "RevenueCatUI")
+  end
+
   def test_already_announced_reads_the_comment_only_when_the_channel_said_nothing
     body = "## Public API changes\n#{ApiDiffHelper.announced_marker('abc123abc123')}\n"
 

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -1515,6 +1515,27 @@ class ApiDiffHelperTest < Minitest::Test
     refute_equal ApiDiffHelper.announcement_fingerprint(first), ApiDiffHelper.announcement_fingerprint(other)
   end
 
+  # Most PRs never touch the public API; a comment saying so on all of them is noise.
+  def test_no_comment_for_a_pull_request_that_never_touched_the_public_api
+    refute ApiDiffHelper.comment_needed?({ "RevenueCat iOS" => NO_CHANGES_OUTPUT }, [], nil, "RevenueCat")
+    refute ApiDiffHelper.comment_needed?({}, [], "<!-- api-diff-report -->", "RevenueCat")
+  end
+
+  # Removing the change is worth saying: this is where "No public API changes" is the all-clear.
+  def test_comment_survives_a_pull_request_that_removed_its_api_change
+    body = ApiDiffHelper.merge_api_diff_comment(
+      nil, "RevenueCat", ApiDiffHelper.api_diff_comment_section("RevenueCat", { "RevenueCat iOS" => SINGLE_ADDITION_OUTPUT }, [], [])
+    )
+
+    assert ApiDiffHelper.comment_needed?({ "RevenueCat iOS" => NO_CHANGES_OUTPUT }, [], body, "RevenueCat")
+    refute ApiDiffHelper.comment_needed?({ "RevenueCatUI iOS" => NO_CHANGES_OUTPUT }, [], body, "RevenueCatUI")
+  end
+
+  def test_comment_is_needed_whenever_there_is_anything_to_report
+    assert ApiDiffHelper.comment_needed?({ "RevenueCat iOS" => SINGLE_ADDITION_OUTPUT }, [], nil, "RevenueCat")
+    assert ApiDiffHelper.comment_needed?({}, [{ reason: :removed, owner: nil, declaration: "public func a()" }], nil, "RevenueCat")
+  end
+
   def test_announced_in_comment_matches_the_marker_this_run_would_write
     body = "## Public API changes\n#{ApiDiffHelper.announced_marker('abc123abc123')}\n"
 

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -1445,8 +1445,6 @@ class ApiDiffHelperTest < Minitest::Test
     assert_nil unusable
   end
 
-  # A PR that changes the API, changes it again, then reverts to the first state: the channel's
-  # newest word on it must be the current one, so this announces again.
   def test_announcement_state_is_different_when_the_pull_request_moved_on_and_back
     summary = announcement("public func a()")
 
@@ -1455,8 +1453,6 @@ class ApiDiffHelperTest < Minitest::Test
     assert_equal :different, state
   end
 
-  # Each scheme's job speaks only for its own module, so RevenueCatUI's message says nothing about
-  # what the RevenueCat job announced. `RevenueCat` must not match `RevenueCatUI` either.
   def test_announcement_state_ignores_another_modules_announcement
     summary = announcement("public func a()")
     other_module = announcement("public func a()", modules: ["RevenueCatUI"])
@@ -1486,7 +1482,6 @@ class ApiDiffHelperTest < Minitest::Test
     assert_match(/channel ID/, unusable)
   end
 
-  # A webhook has no token to read the channel with.
   def test_announcement_state_reports_a_missing_token
     state, unusable = ApiDiffHelper.announcement_state(
       "summary", bot_token: "", channel: "C1", source: "<url|#1>", modules: ["RevenueCat"]
@@ -1515,13 +1510,11 @@ class ApiDiffHelperTest < Minitest::Test
     refute_equal ApiDiffHelper.announcement_fingerprint(first), ApiDiffHelper.announcement_fingerprint(other)
   end
 
-  # Most PRs never touch the public API; a comment saying so on all of them is noise.
   def test_no_comment_for_a_pull_request_that_never_touched_the_public_api
     refute ApiDiffHelper.comment_needed?({ "RevenueCat iOS" => NO_CHANGES_OUTPUT }, [], nil, "RevenueCat")
     refute ApiDiffHelper.comment_needed?({}, [], "<!-- api-diff-report -->", "RevenueCat")
   end
 
-  # Removing the change is worth saying: this is where "No public API changes" is the all-clear.
   def test_comment_survives_a_pull_request_that_removed_its_api_change
     body = ApiDiffHelper.merge_api_diff_comment(
       nil, "RevenueCat", ApiDiffHelper.api_diff_comment_section("RevenueCat", { "RevenueCat iOS" => SINGLE_ADDITION_OUTPUT }, [], [])
@@ -1536,16 +1529,16 @@ class ApiDiffHelperTest < Minitest::Test
     assert ApiDiffHelper.comment_needed?({}, [{ reason: :removed, owner: nil, declaration: "public func a()" }], nil, "RevenueCat")
   end
 
-  def test_announced_in_comment_matches_the_marker_this_run_would_write
+  def test_already_announced_reads_the_comment_only_when_the_channel_said_nothing
     body = "## Public API changes\n#{ApiDiffHelper.announced_marker('abc123abc123')}\n"
 
-    assert ApiDiffHelper.announced_in_comment?(body, "abc123abc123")
-    refute ApiDiffHelper.announced_in_comment?(body, "def456def456")
-    refute ApiDiffHelper.announced_in_comment?(nil, "abc123abc123")
+    assert ApiDiffHelper.already_announced?(:same, "def456def456") { raise "must not read" }
+    refute ApiDiffHelper.already_announced?(:different, "abc123abc123") { raise "must not read" }
+    assert ApiDiffHelper.already_announced?(:unknown, "abc123abc123") { body }
+    refute ApiDiffHelper.already_announced?(:unknown, "def456def456") { body }
+    refute ApiDiffHelper.already_announced?(:unknown, "abc123abc123") { nil }
   end
 
-  # The fallback for a channel the token cannot read: the last announcement left its fingerprint
-  # in this module's section, and the next run recognises it there.
   def test_comment_section_carries_the_announced_fingerprint
     section = ApiDiffHelper.api_diff_comment_section(
       "RevenueCat", { "RevenueCat iOS" => SINGLE_ADDITION_OUTPUT }, [], [], announced_fingerprint: "abc123abc123"
@@ -1561,7 +1554,6 @@ class ApiDiffHelperTest < Minitest::Test
     refute_includes section, "api-diff-announced"
   end
 
-  # The marker lives inside the section, so the next run replaces it along with the report.
   def test_merging_a_section_replaces_a_stale_fingerprint
     announced = ApiDiffHelper.api_diff_comment_section("RevenueCat", {}, [], [], announced_fingerprint: "aaaaaaaaaaaa")
     body = ApiDiffHelper.merge_api_diff_comment(nil, "RevenueCat", announced)
@@ -1758,8 +1750,6 @@ class ApiDiffHelperTest < Minitest::Test
     assert_match(/ApiDiffHelper\.post_slack_message/, slack_lane)
   end
 
-  # The comment records the announcement, and the fallback recognises a change by the marker the
-  # previous run left in it, so writing the comment first would hide every repeat announcement.
   def test_the_announcement_happens_before_the_comment_is_written
     lane = File.read(File.expand_path("Fastfile", __dir__))
     publishing = lane[/# Informational: a GitHub or Slack outage.*?rescue StandardError/m]

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -1401,6 +1401,158 @@ class ApiDiffHelperTest < Minitest::Test
   end
 
 
+  # --- Announcing a change once ---
+
+  def history_getter(texts)
+    lambda do |_url, _headers|
+      SlackResponse.new("200", { ok: true, messages: texts.map { |text| { "text" => text } } }.to_json)
+    end
+  end
+
+  def test_slack_history_request_reads_the_channel_with_the_bot_token
+    request = ApiDiffHelper.slack_history_request("C1", bot_token: "xoxb-1")
+
+    assert_includes request[:url], "https://slack.com/api/conversations.history?channel=C1"
+    assert_equal "Bearer xoxb-1", request[:headers]["Authorization"]
+    assert_equal ["new", "old"], ApiDiffHelper.recent_slack_messages(request, getter: history_getter(["new", "old"]))
+  end
+
+  def test_recent_slack_messages_raises_when_the_token_cannot_read_the_channel
+    getter = ->(_url, _headers) { SlackResponse.new("200", '{"ok":false,"error":"missing_scope"}') }
+
+    error = assert_raises(RuntimeError) do
+      ApiDiffHelper.recent_slack_messages(ApiDiffHelper.slack_history_request("C1", bot_token: "xoxb-1"), getter: getter)
+    end
+    assert_match(/missing_scope/, error.message)
+  end
+
+  def announcement(declaration, source: "<url|#7355>", modules: ["RevenueCat"])
+    ApiDiffHelper.slack_summary([], [], source: source, new_declarations: [declaration], modules: modules)
+  end
+
+  def state_for(message, texts, source: "<url|#7355>", modules: ["RevenueCat"])
+    ApiDiffHelper.announcement_state(
+      message, bot_token: "xoxb-1", channel: "C1", source: source, modules: modules, getter: history_getter(texts)
+    )
+  end
+
+  def test_announcement_state_recognises_the_last_word_on_this_pull_request
+    summary = announcement("public func a()")
+
+    state, unusable = state_for(summary, [summary, announcement("public func older()")])
+
+    assert_equal :same, state
+    assert_nil unusable
+  end
+
+  # A PR that changes the API, changes it again, then reverts to the first state: the channel's
+  # newest word on it must be the current one, so this announces again.
+  def test_announcement_state_is_different_when_the_pull_request_moved_on_and_back
+    summary = announcement("public func a()")
+
+    state, _unusable = state_for(summary, [announcement("public func b()"), summary])
+
+    assert_equal :different, state
+  end
+
+  # Each scheme's job speaks only for its own module, so RevenueCatUI's message says nothing about
+  # what the RevenueCat job announced. `RevenueCat` must not match `RevenueCatUI` either.
+  def test_announcement_state_ignores_another_modules_announcement
+    summary = announcement("public func a()")
+    other_module = announcement("public func a()", modules: ["RevenueCatUI"])
+
+    state, unusable = state_for(summary, [other_module])
+
+    assert_equal :unknown, state
+    assert_nil unusable
+  end
+
+  def test_announcement_state_ignores_another_pull_requests_announcement
+    summary = announcement("public func a()")
+
+    state, _unusable = state_for(summary, [announcement("public func a()", source: "<url|#7354>")])
+
+    assert_equal :unknown, state
+  end
+
+  # chat.postMessage takes a `#name`, conversations.history does not.
+  def test_announcement_state_needs_the_channel_id
+    state, unusable = ApiDiffHelper.announcement_state(
+      "summary", bot_token: "xoxb-1", channel: "#feed", source: "<url|#1>", modules: ["RevenueCat"],
+      getter: ->(*) { raise "must not read" }
+    )
+
+    assert_equal :unknown, state
+    assert_match(/channel ID/, unusable)
+  end
+
+  # A webhook has no token to read the channel with.
+  def test_announcement_state_reports_a_missing_token
+    state, unusable = ApiDiffHelper.announcement_state(
+      "summary", bot_token: "", channel: "C1", source: "<url|#1>", modules: ["RevenueCat"]
+    )
+
+    assert_equal :unknown, state
+    assert_match(/cannot be read/, unusable)
+  end
+
+  def test_announcement_state_reports_a_failed_read
+    state, unusable = ApiDiffHelper.announcement_state(
+      "summary", bot_token: "xoxb-1", channel: "C1", source: "<url|#1>", modules: ["RevenueCat"],
+      getter: ->(*) { raise "slack is down" }
+    )
+
+    assert_equal :unknown, state
+    assert_equal "slack is down", unusable
+  end
+
+  def test_announcement_fingerprint_moves_with_the_summary
+    first = ApiDiffHelper.slack_summary([], [], source: "<url|#1>", new_declarations: ["public func a()"])
+    same = ApiDiffHelper.slack_summary([], [], source: "<url|#1>", new_declarations: ["public func a()"])
+    other = ApiDiffHelper.slack_summary([], [], source: "<url|#1>", new_declarations: ["public func b()"])
+
+    assert_equal ApiDiffHelper.announcement_fingerprint(first), ApiDiffHelper.announcement_fingerprint(same)
+    refute_equal ApiDiffHelper.announcement_fingerprint(first), ApiDiffHelper.announcement_fingerprint(other)
+  end
+
+  def test_announced_in_comment_matches_the_marker_this_run_would_write
+    body = "## Public API changes\n#{ApiDiffHelper.announced_marker('abc123abc123')}\n"
+
+    assert ApiDiffHelper.announced_in_comment?(body, "abc123abc123")
+    refute ApiDiffHelper.announced_in_comment?(body, "def456def456")
+    refute ApiDiffHelper.announced_in_comment?(nil, "abc123abc123")
+  end
+
+  # The fallback for a channel the token cannot read: the last announcement left its fingerprint
+  # in this module's section, and the next run recognises it there.
+  def test_comment_section_carries_the_announced_fingerprint
+    section = ApiDiffHelper.api_diff_comment_section(
+      "RevenueCat", { "RevenueCat iOS" => SINGLE_ADDITION_OUTPUT }, [], [], announced_fingerprint: "abc123abc123"
+    )
+
+    assert_includes section, ApiDiffHelper.announced_marker("abc123abc123")
+    assert section.rstrip.end_with?(ApiDiffHelper.api_diff_section_close("RevenueCat"))
+  end
+
+  def test_comment_section_omits_the_marker_when_nothing_was_announced
+    section = ApiDiffHelper.api_diff_comment_section("RevenueCat", { "RevenueCat iOS" => SINGLE_ADDITION_OUTPUT }, [], [])
+
+    refute_includes section, "api-diff-announced"
+  end
+
+  # The marker lives inside the section, so the next run replaces it along with the report.
+  def test_merging_a_section_replaces_a_stale_fingerprint
+    announced = ApiDiffHelper.api_diff_comment_section("RevenueCat", {}, [], [], announced_fingerprint: "aaaaaaaaaaaa")
+    body = ApiDiffHelper.merge_api_diff_comment(nil, "RevenueCat", announced)
+    reannounced = ApiDiffHelper.api_diff_comment_section("RevenueCat", {}, [], [], announced_fingerprint: "bbbbbbbbbbbb")
+
+    merged = ApiDiffHelper.merge_api_diff_comment(body, "RevenueCat", reannounced)
+
+    assert_includes merged, ApiDiffHelper.announced_marker("bbbbbbbbbbbb")
+    refute_includes merged, ApiDiffHelper.announced_marker("aaaaaaaaaaaa")
+  end
+
+
   # --- One comment, two jobs ---
 
   # Two jobs write this comment, one per module. Before sections existed, whichever finished
@@ -1476,14 +1628,6 @@ class ApiDiffHelperTest < Minitest::Test
 
     assert_includes message, "1 new declaration"
     assert_includes message, "apiDiffDemoPing"
-  end
-
-  def test_slack_credentials_reachable_needs_a_webhook_or_a_token_and_channel
-    assert ApiDiffHelper.slack_credentials_reachable?(webhook_url: "https://hooks.example/abc")
-    assert ApiDiffHelper.slack_credentials_reachable?(bot_token: "xoxb-1", channel: "#chan")
-    refute ApiDiffHelper.slack_credentials_reachable?(bot_token: "xoxb-1")
-    refute ApiDiffHelper.slack_credentials_reachable?(channel: "#chan")
-    refute ApiDiffHelper.slack_credentials_reachable?
   end
 
   def test_comment_body_carries_the_slack_notice
@@ -1591,6 +1735,17 @@ class ApiDiffHelperTest < Minitest::Test
     refute_nil slack_lane, "the notify_api_changes_on_slack lane moved; update this test"
     refute_match(/Net::HTTP/, slack_lane, "the HTTP post belongs in ApiDiffHelper")
     assert_match(/ApiDiffHelper\.post_slack_message/, slack_lane)
+  end
+
+  # The comment records the announcement, and the fallback recognises a change by the marker the
+  # previous run left in it, so writing the comment first would hide every repeat announcement.
+  def test_the_announcement_happens_before_the_comment_is_written
+    lane = File.read(File.expand_path("Fastfile", __dir__))
+    publishing = lane[/# Informational: a GitHub or Slack outage.*?rescue StandardError/m]
+
+    refute_nil publishing, "the publishing section of check_api_changes moved; update this test"
+    assert_operator publishing.index("upsert_api_diff_comment"), :>, publishing.index("notify_api_changes_on_slack"),
+                    "the comment must be written after the announcement it records"
   end
 
 


### PR DESCRIPTION
- The feed announced the same summary on every CI run of a PR touching the API surface: `#7422` and `#7410` got three or four identical messages each. Now it announces once per distinct summary, per module.
- Dedup compares against the channel's newest message about this PR and module, so a PR that reverts to a surface it announced earlier is announced again.
- When the channel says nothing, a `<!-- api-diff-announced:<hash> -->` marker in that module's comment section decides.
- Needs `channels:history` on the bot token and the channel ID, not `#name`, in `SLACK_CHANNEL_SDK_NEW_API`. Without either, dedup still works across pushes through the marker and the comment names the reason.
- The API diff comment is no longer posted on PRs that never touched the public API. A PR that removed its change keeps its section, so "No public API changes" still reads as the all-clear.
- Companion change on `purchases-android`: https://github.com/RevenueCat/purchases-android/pull/3991

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

<details><summary>Agent description</summary>

### Motivation

`notify_api_changes_on_slack` posted whenever a target reported changes, so every push and every rerun re-announced the same declarations. Two scheme jobs double that, and each push starts two pipelines on the same commit.

The comment alone cannot dedup the concurrent case: the sibling run's message is in the channel seconds before this one posts, while the comment is only written at the end of a run. The marker covers the case where the token cannot read the channel at all.

### Description

- `announcement_state` returns `:same` / `:different` / `:unknown`, and `already_announced?` composes it with the marker, reading the comment only for `:unknown`. Both live in the helper, so the policy is unit tested rather than exercised only in CI.
- Identity is the PR link plus `announcement_identity`, the one place the platform label and module tokens are built, since `slack_summary`'s headline and the dedup match have to stay in sync. The module belongs in it: each job speaks for one scheme, and without it the RevenueCat job would compare itself against RevenueCatUI's message and both would repost every run.
- The comment is now written after the announcement, so it can record whether it happened. A failed post records no fingerprint, so the next run retries. A source-scraping test guards that order, matching the existing guard on the label read.
- `find_pr_comment` returns the comment it already fetched instead of discarding all but the id, which removes a GitHub round trip from every api-diff job.
- `slack_credentials_reachable?` and `api_slack_unreachable_notice` are gone: `slack_post_request` already returns nil without a credential, and the notify lane now reports its own outcome instead of it being predicted beforehand.

Known gap: a PR that drops back to no API change has nothing to announce, so the channel keeps the last non-empty summary as its final word on it.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only CI fastlane and Slack/GitHub notification paths for the API gate, not shipped SDK code, but mis-dedup or skipped announcements could confuse release communication; Slack bot needs `channels:history` and a channel ID in env.
> 
> **Overview**
> **Stops repeat Slack posts** when the same PR reruns CI or pushes again: `notify_api_changes_on_slack` builds a summary fingerprint, checks Slack `conversations.history` for the latest message matching the PR link and module identity (`announcement_identity`), and skips posting when it matches. If history cannot be read (no bot token, channel name instead of ID, or API errors), dedup falls back to a hidden `<!-- api-diff-announced:<hash> -->` marker in that module’s GitHub API-diff comment section.
> 
> **Publishing order** is announcement first, then `upsert_api_diff_comment`, so successful posts record the fingerprint in the comment; failed posts leave no fingerprint so the next run retries. Notices in the comment explain unreachable Slack credentials or partial dedup risk instead of predicting failure up front.
> 
> **GitHub comment behavior**: API diff comments are skipped when there are no breaks/changes and no prior section for that module; if a PR later removes its API change, an existing section is kept so reviewers still see the all-clear. `find_pr_comment` returns the full comment body (not only the id), avoiding a second fetch when updating.
> 
> **Helper surface**: adds Slack history helpers, `announcement_state` / `already_announced?`, `comment_needed?`, and removes `slack_credentials_reachable?` and the `api_slack_unreachable_notice` lane. Unit tests cover history matching, fingerprints, and comment markers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5470218dac738d9e8f2e2f1e5630de1fab51f661. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->