### PR TITLE
Implement IAM Login Operations

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -600,9 +600,13 @@
 		551800772FF46C8A0055FD1B /* KeychainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551800762FF46C8A0055FD1B /* KeychainTests.swift */; };
 		552CE0E12FD323EF006E41B4 /* Purchases+PreviewPaywall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 552CE0E02FD323EF006E41B4 /* Purchases+PreviewPaywall.swift */; };
 		552CE1022FEF22AC006E41B4 /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 552CE1012FEF22AC006E41B4 /* Keychain.swift */; };
+		55DACDE4302BC2C3005EE017 /* TokenAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDE3302BC2C3005EE017 /* TokenAPI.swift */; };
 		55DACDEC302BC2D1005EE017 /* TokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDEA302BC2D1005EE017 /* TokenManager.swift */; };
 		55DACDED302BC2D1005EE017 /* URLMessage+Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDEB302BC2D1005EE017 /* URLMessage+Description.swift */; };
 		55DACDEF302BC2DF005EE017 /* Identity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDEE302BC2DF005EE017 /* Identity.swift */; };
+		55DACDF1302BC2EE005EE017 /* TokenOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDF0302BC2EE005EE017 /* TokenOperations.swift */; };
+		55DACDF3302BC30A005EE017 /* IAMCallbacks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDF2302BC30A005EE017 /* IAMCallbacks.swift */; };
+		55DACDF5302BC31E005EE017 /* IAMResponses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDF4302BC31E005EE017 /* IAMResponses.swift */; };
 		55DACDF7302BC331005EE017 /* JWT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDF6302BC331005EE017 /* JWT.swift */; };
 		55DACDFA302BC356005EE017 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDF8302BC356005EE017 /* Authentication.swift */; };
 		55DACDFC302BC381005EE017 /* AnyCodingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDFB302BC381005EE017 /* AnyCodingKey.swift */; };
@@ -615,6 +619,7 @@
 		55DACE94302E2BBB005EE017 /* MockAuthenticationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE8D302E2BBB005EE017 /* MockAuthenticationDelegate.swift */; };
 		55DACE95302E2BBB005EE017 /* MockSecureItemStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE8F302E2BBB005EE017 /* MockSecureItemStorage.swift */; };
 		55DACE97302E320C005EE017 /* MockTokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE96302E320C005EE017 /* MockTokenManager.swift */; };
+		5B6786F455CB4A59F26BFA46 /* MockTokenAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A3DB72A2707F75F2BDC90D7 /* MockTokenAPI.swift */; };
 		55DACE98302E320C005EE017 /* MockTokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE96302E320C005EE017 /* MockTokenManager.swift */; };
 		55DACEAC302E837B005EE017 /* TokenManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACEAB302E837B005EE017 /* TokenManagerTests.swift */; };
 		55DACFD230366629005EE017 /* AuthenticationStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACFCC30366625005EE017 /* AuthenticationStrings.swift */; };
@@ -639,6 +644,7 @@
 		5733B18E27FF586A00EC2045 /* BackendError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733B18D27FF586A00EC2045 /* BackendError.swift */; };
 		5733B1A427FF9F8300EC2045 /* NetworkErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733B1A327FF9F8300EC2045 /* NetworkErrorTests.swift */; };
 		5733B1A827FFBCC800EC2045 /* BackendErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733B1A727FFBCC800EC2045 /* BackendErrorTests.swift */; };
+		DECC43B62EBDF0A4BD1D06EB /* BackendErrorCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C9437E0657539E96AADEFB /* BackendErrorCodeTests.swift */; };
 		5733B1AA27FFBCF900EC2045 /* BaseErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733B1A927FFBCF900EC2045 /* BaseErrorTests.swift */; };
 		5733D00928CFA7A4008638D8 /* MockPaymentQueueWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733D00828CFA7A4008638D8 /* MockPaymentQueueWrapper.swift */; };
 		5733D01128D00354008638D8 /* PromotionalOfferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733D01028D00354008638D8 /* PromotionalOfferTests.swift */; };
@@ -761,6 +767,8 @@
 		5796A38827D6B85900653165 /* BackendPostReceiptDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A38727D6B85900653165 /* BackendPostReceiptDataTests.swift */; };
 		5796A38A27D6B96300653165 /* BackendGetCustomerInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A38927D6B96300653165 /* BackendGetCustomerInfoTests.swift */; };
 		5796A38C27D6BA1600653165 /* BackendLoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A38B27D6BA1600653165 /* BackendLoginTests.swift */; };
+		603D49296E6E69D1D8E06EFE /* BackendTokenLoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64FEF3704AAACD669F3BF4E0 /* BackendTokenLoginTests.swift */; };
+		3333EEA00681B5A32D463CC9 /* BackendTokenRevocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E927212FE6045350AC196C1 /* BackendTokenRevocationTests.swift */; };
 		5796A39027D6BCD100653165 /* BackendGetIntroEligibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A38F27D6BCD100653165 /* BackendGetIntroEligibilityTests.swift */; };
 		5796A39427D6BD6900653165 /* BackendGetOfferingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A39327D6BD6900653165 /* BackendGetOfferingsTests.swift */; };
 		5796A39627D6BDAB00653165 /* BackendPostOfferForSigningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A39527D6BDAB00653165 /* BackendPostOfferForSigningTests.swift */; };
@@ -2336,9 +2344,13 @@
 		552CE0E02FD323EF006E41B4 /* Purchases+PreviewPaywall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Purchases+PreviewPaywall.swift"; sourceTree = "<group>"; };
 		552CE0E72FD32413006E41B4 /* Purchases+PreviewPaywallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Purchases+PreviewPaywallTests.swift"; sourceTree = "<group>"; };
 		552CE1012FEF22AC006E41B4 /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
+		55DACDE3302BC2C3005EE017 /* TokenAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenAPI.swift; sourceTree = "<group>"; };
 		55DACDEA302BC2D1005EE017 /* TokenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenManager.swift; sourceTree = "<group>"; };
 		55DACDEB302BC2D1005EE017 /* URLMessage+Description.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLMessage+Description.swift"; sourceTree = "<group>"; };
 		55DACDEE302BC2DF005EE017 /* Identity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identity.swift; sourceTree = "<group>"; };
+		55DACDF0302BC2EE005EE017 /* TokenOperations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenOperations.swift; sourceTree = "<group>"; };
+		55DACDF2302BC30A005EE017 /* IAMCallbacks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAMCallbacks.swift; sourceTree = "<group>"; };
+		55DACDF4302BC31E005EE017 /* IAMResponses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAMResponses.swift; sourceTree = "<group>"; };
 		55DACDF6302BC331005EE017 /* JWT.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWT.swift; sourceTree = "<group>"; };
 		55DACDF8302BC356005EE017 /* Authentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authentication.swift; sourceTree = "<group>"; };
 		55DACDFB302BC381005EE017 /* AnyCodingKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCodingKey.swift; sourceTree = "<group>"; };
@@ -2348,6 +2360,7 @@
 		55DACE8E302E2BBB005EE017 /* MockInternalAuthenticatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInternalAuthenticatorDelegate.swift; sourceTree = "<group>"; };
 		55DACE8F302E2BBB005EE017 /* MockSecureItemStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSecureItemStorage.swift; sourceTree = "<group>"; };
 		55DACE96302E320C005EE017 /* MockTokenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTokenManager.swift; sourceTree = "<group>"; };
+		2A3DB72A2707F75F2BDC90D7 /* MockTokenAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTokenAPI.swift; sourceTree = "<group>"; };
 		55DACEAB302E837B005EE017 /* TokenManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenManagerTests.swift; sourceTree = "<group>"; };
 		55DACFCC30366625005EE017 /* AuthenticationStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationStrings.swift; sourceTree = "<group>"; };
 		55FCA85B959807F2D3DD175A /* TransactionReason.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TransactionReason.swift; sourceTree = "<group>"; };
@@ -2375,6 +2388,7 @@
 		5733B18D27FF586A00EC2045 /* BackendError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendError.swift; sourceTree = "<group>"; };
 		5733B1A327FF9F8300EC2045 /* NetworkErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorTests.swift; sourceTree = "<group>"; };
 		5733B1A727FFBCC800EC2045 /* BackendErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendErrorTests.swift; sourceTree = "<group>"; };
+		71C9437E0657539E96AADEFB /* BackendErrorCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendErrorCodeTests.swift; sourceTree = "<group>"; };
 		5733B1A927FFBCF900EC2045 /* BaseErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseErrorTests.swift; sourceTree = "<group>"; };
 		5733D00828CFA7A4008638D8 /* MockPaymentQueueWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPaymentQueueWrapper.swift; sourceTree = "<group>"; };
 		5733D01028D00354008638D8 /* PromotionalOfferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionalOfferTests.swift; sourceTree = "<group>"; };
@@ -2490,6 +2504,8 @@
 		5796A38727D6B85900653165 /* BackendPostReceiptDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendPostReceiptDataTests.swift; sourceTree = "<group>"; };
 		5796A38927D6B96300653165 /* BackendGetCustomerInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendGetCustomerInfoTests.swift; sourceTree = "<group>"; };
 		5796A38B27D6BA1600653165 /* BackendLoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendLoginTests.swift; sourceTree = "<group>"; };
+		64FEF3704AAACD669F3BF4E0 /* BackendTokenLoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendTokenLoginTests.swift; sourceTree = "<group>"; };
+		7E927212FE6045350AC196C1 /* BackendTokenRevocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendTokenRevocationTests.swift; sourceTree = "<group>"; };
 		5796A38F27D6BCD100653165 /* BackendGetIntroEligibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendGetIntroEligibilityTests.swift; sourceTree = "<group>"; };
 		5796A39327D6BD6900653165 /* BackendGetOfferingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendGetOfferingsTests.swift; sourceTree = "<group>"; };
 		5796A39527D6BDAB00653165 /* BackendPostOfferForSigningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendPostOfferForSigningTests.swift; sourceTree = "<group>"; };
@@ -4570,6 +4586,7 @@
 				55DACE8E302E2BBB005EE017 /* MockInternalAuthenticatorDelegate.swift */,
 				55DACE8F302E2BBB005EE017 /* MockSecureItemStorage.swift */,
 				55DACE96302E320C005EE017 /* MockTokenManager.swift */,
+				2A3DB72A2707F75F2BDC90D7 /* MockTokenAPI.swift */,
 				1E3084A330178A6E00236A34 /* MockSourceHealthChecker.swift */,
 				900D27022F96929800D32EDF /* MockAdsAPI.swift */,
 				1699BC6C2EEC6EAF002001FB /* MockUnderlyingSynchronizedFileCache.swift */,
@@ -4990,6 +5007,7 @@
 				B378156B285A9729000A7B93 /* OfferingsAPI.swift */,
 				57488BC529CB7BDC0000EE7E /* OfflineEntitlementsAPI.swift */,
 				5723FBBD28EDE1360003BA16 /* InternalAPI.swift */,
+				55DACDE3302BC2C3005EE017 /* TokenAPI.swift */,
 				1ED4CA542CC157A20021AB8F /* RedeemWebPurchaseAPI.swift */,
 				FDE57AA12DF88ACA00101CE2 /* VirtualCurrenciesAPI.swift */,
 				751192DF2E39149200E583CC /* WebBillingAPI.swift */,
@@ -5045,6 +5063,7 @@
 				A1B2C3D42FE2000000000007 /* RemoteConfig */,
 				5733B1A327FF9F8300EC2045 /* NetworkErrorTests.swift */,
 				5733B1A727FFBCC800EC2045 /* BackendErrorTests.swift */,
+				71C9437E0657539E96AADEFB /* BackendErrorCodeTests.swift */,
 				A1B2C3D42FE9000000000003 /* GenerationGuardedCacheTests.swift */,
 				371E0615EDF883698273BC59 /* UiConfigProviderTests.swift */,
 				FFB683A085B695768EAB9AA5 /* WorkflowsConfigProviderTests.swift */,
@@ -5539,6 +5558,8 @@
 				755C26A52E310B7B006DD0AE /* BackendGetWebBillingProductsTests.swift */,
 				579D2E3928F0BF5A0094B36F /* BackendInternalTests.swift */,
 				5796A38B27D6BA1600653165 /* BackendLoginTests.swift */,
+				64FEF3704AAACD669F3BF4E0 /* BackendTokenLoginTests.swift */,
+				7E927212FE6045350AC196C1 /* BackendTokenRevocationTests.swift */,
 				1DEF759D2ECF13C000614CB2 /* BackendPostCreateTicketTests.swift */,
 				57488BF129CB84D40000EE7E /* BackendOfflineEntitlementsTests.swift */,
 				A56C2E002819C33500995421 /* BackendPostAdServicesTokenTests.swift */,
@@ -5736,6 +5757,7 @@
 		57D5412C27F63108004CC35C /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				55DACDF4302BC31E005EE017 /* IAMResponses.swift */,
 				53A8DCC22E0EA4F600FEABEA /* HealthReportAvailabilityResponse.swift */,
 				03A98D2E2D240C2D009BCA61 /* RevenueCatUI */,
 				3592E88D2C2ED5B200D7F91D /* CustomerCenterConfigResponse.swift */,
@@ -6683,6 +6705,7 @@
 				57045B3B29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift */,
 				FDE57A9D2DF8783000101CE2 /* VirtualCurrenciesCallback.swift */,
 				FCF81FAC33B948F0947AE312 /* RemoteConfigCallback.swift */,
+				55DACDF2302BC30A005EE017 /* IAMCallbacks.swift */,
 			);
 			path = Caching;
 			sourceTree = "<group>";
@@ -6690,6 +6713,7 @@
 		B34605AA279A6E380031CA74 /* Operations */ = {
 			isa = PBXGroup;
 			children = (
+				55DACDF0302BC2EE005EE017 /* TokenOperations.swift */,
 				53A8DCC02E0EA49400FEABEA /* HealthReportAvailabilityOperation.swift */,
 				B34605AE279A6E380031CA74 /* Handling */,
 				3592E88B2C2ED58900D7F91D /* GetCustomerCenterConfigOperation.swift */,
@@ -7982,6 +8006,7 @@
 				576C8A8B27CFCB150058FA6E /* AnyEncodable.swift in Sources */,
 				35D0E5D026A5886C0099EAD8 /* ErrorUtils.swift in Sources */,
 				B372EC54268FEDC60099171E /* StoreProductDiscount.swift in Sources */,
+				55DACDE4302BC2C3005EE017 /* TokenAPI.swift in Sources */,
 				FDED7EC52F33DF0A00827E54 /* IsPurchaseAllowedByRestoreBehaviorCallback.swift in Sources */,
 				4F7D8E562A56290100F17FFC /* HTTPRequestBody.swift in Sources */,
 				9025C53D2EA66E2500845BCE /* PostFeatureEventsOperation.swift in Sources */,
@@ -8011,6 +8036,7 @@
 				2CC791642CC0493600FBE120 /* Border.swift in Sources */,
 				2CC791652CC0493600FBE120 /* Dimension.swift in Sources */,
 				2CC791672CC0493600FBE120 /* PaywallComponentBase.swift in Sources */,
+				55DACDF1302BC2EE005EE017 /* TokenOperations.swift in Sources */,
 				4F6BED592A26A14400CD9322 /* DebugView.swift in Sources */,
 				5733B18E27FF586A00EC2045 /* BackendError.swift in Sources */,
 				B39E811A268E849900D31189 /* AttributionNetwork.swift in Sources */,
@@ -8047,6 +8073,7 @@
 				FDAC7B592CF000000DFC0D9 /* WinBackEligibilityAdapters.swift in Sources */,
 				FDE57AA02DF8785000101CE2 /* VirtualCurrenciesResponse.swift in Sources */,
 				16A7F4C32E563B91001F9FC8 /* PaywallAnimation.swift in Sources */,
+				55DACDF5302BC31E005EE017 /* IAMResponses.swift in Sources */,
 				FDA6F96F2E035544008BF232 /* VirtualCurrencyStrings.swift in Sources */,
 				53AAD34F2E09857300605F51 /* PaymentAuthorizationProvider.swift in Sources */,
 				53A8DCC12E0EA49400FEABEA /* HealthReportAvailabilityOperation.swift in Sources */,
@@ -8077,6 +8104,7 @@
 				D4E5F60718293A4B5C03D02 /* CaseOperators.swift in Sources */,
 				E5F60718293A4B5C03D0102 /* LengthOperator.swift in Sources */,
 				B2C3D4E5F60718293A4B5C02 /* RootVarOperator.swift in Sources */,
+				55DACDF3302BC30A005EE017 /* IAMCallbacks.swift in Sources */,
 				1701E7CE20E0879817B3F61B /* RulesEngineLogger.swift in Sources */,
 				A91C0A012FEA000000000001 /* RulesEngineLoggerBridge.swift in Sources */,
 				A447209D359C42F9EC541F35 /* RulesEngine.swift in Sources */,
@@ -8272,6 +8300,7 @@
 				750B39FE2E40940F005E141D /* PurchasesOrchestratorSimulatedStoreTests.swift in Sources */,
 				4F6ABC7A2A81649800250E63 /* MockPaywallCacheWarming.swift in Sources */,
 				B31C8BEC285BD58F001017B7 /* MockIdentityAPI.swift in Sources */,
+				5B6786F455CB4A59F26BFA46 /* MockTokenAPI.swift in Sources */,
 				351B513D26D4491E00BD2BD7 /* MockDeviceCache.swift in Sources */,
 				57910CB329C3889B006209D5 /* DispatchTimeIntervalExtensionsTests.swift in Sources */,
 				351B515C26D44B7900BD2BD7 /* MockIntroEligibilityCalculator.swift in Sources */,
@@ -8376,6 +8405,7 @@
 				5796A3C027D7D64500653165 /* ResultExtensionsTests.swift in Sources */,
 				351B51A726D450D400BD2BD7 /* SystemInfoTests.swift in Sources */,
 				5733B1A827FFBCC800EC2045 /* BackendErrorTests.swift in Sources */,
+				DECC43B62EBDF0A4BD1D06EB /* BackendErrorCodeTests.swift in Sources */,
 				A1B2C3D42FE9000000000004 /* GenerationGuardedCacheTests.swift in Sources */,
 				AD787D4FC44F9C3638DCDEF9 /* UiConfigProviderTests.swift in Sources */,
 				E48EFFFF5FF27ECC25F4E308 /* WorkflowsConfigProviderTests.swift in Sources */,
@@ -8503,6 +8533,8 @@
 				57A1772B276A726C0052D3A8 /* SetExtensionsTests.swift in Sources */,
 				351B515A26D44B6200BD2BD7 /* MockAttributionFetcher.swift in Sources */,
 				5796A38C27D6BA1600653165 /* BackendLoginTests.swift in Sources */,
+				603D49296E6E69D1D8E06EFE /* BackendTokenLoginTests.swift in Sources */,
+				3333EEA00681B5A32D463CC9 /* BackendTokenRevocationTests.swift in Sources */,
 				351B51BD26D450E800BD2BD7 /* EntitlementInfosTests.swift in Sources */,
 				16BCA3702E4D9BA700B39E7F /* FileRepositoryTests.swift in Sources */,
 				5759B322296DEF56002472D5 /* OptionalExtensionsTests.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -350,6 +350,7 @@
 		2DF8D9550354ECBAE400C547 /* EvaluationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A76308A40945327EA3F6744 /* EvaluationError.swift */; };
 		2DFF6C56270CA28800ECAFAB /* MockRequestFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351B517926D44FF000BD2BD7 /* MockRequestFetcher.swift */; };
 		311ECA0E03DCCC0773C47BB3 /* AccessorOperatorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A19F2745D499D442517BEA4 /* AccessorOperatorsTests.swift */; };
+		3333EEA00681B5A32D463CC9 /* BackendTokenRevocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E927212FE6045350AC196C1 /* BackendTokenRevocationTests.swift */; };
 		35109DAB2BC6E436001030C8 /* BackendPostDiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35109DAA2BC6E436001030C8 /* BackendPostDiagnosticsTests.swift */; };
 		35109DB92BC8143E001030C8 /* DiagnosticsEventsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35109DB82BC8143E001030C8 /* DiagnosticsEventsRequest.swift */; };
 		351B513D26D4491E00BD2BD7 /* MockDeviceCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351B513C26D4491E00BD2BD7 /* MockDeviceCache.swift */; };
@@ -619,10 +620,10 @@
 		55DACE94302E2BBB005EE017 /* MockAuthenticationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE8D302E2BBB005EE017 /* MockAuthenticationDelegate.swift */; };
 		55DACE95302E2BBB005EE017 /* MockSecureItemStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE8F302E2BBB005EE017 /* MockSecureItemStorage.swift */; };
 		55DACE97302E320C005EE017 /* MockTokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE96302E320C005EE017 /* MockTokenManager.swift */; };
-		5B6786F455CB4A59F26BFA46 /* MockTokenAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A3DB72A2707F75F2BDC90D7 /* MockTokenAPI.swift */; };
 		55DACE98302E320C005EE017 /* MockTokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE96302E320C005EE017 /* MockTokenManager.swift */; };
 		55DACEAC302E837B005EE017 /* TokenManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACEAB302E837B005EE017 /* TokenManagerTests.swift */; };
 		55DACFD230366629005EE017 /* AuthenticationStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACFCC30366625005EE017 /* AuthenticationStrings.swift */; };
+		55DACF333034FA93005EE017 /* MockTokenAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A3DB72A2707F75F2BDC90D7 /* MockTokenAPI.swift */; };
 		57045B3829C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3729C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift */; };
 		57045B3A29C51751001A5417 /* GetProductEntitlementMappingOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3929C51751001A5417 /* GetProductEntitlementMappingOperation.swift */; };
 		57045B3C29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57045B3B29C51AF7001A5417 /* ProductEntitlementMappingCallback.swift */; };
@@ -644,7 +645,6 @@
 		5733B18E27FF586A00EC2045 /* BackendError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733B18D27FF586A00EC2045 /* BackendError.swift */; };
 		5733B1A427FF9F8300EC2045 /* NetworkErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733B1A327FF9F8300EC2045 /* NetworkErrorTests.swift */; };
 		5733B1A827FFBCC800EC2045 /* BackendErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733B1A727FFBCC800EC2045 /* BackendErrorTests.swift */; };
-		DECC43B62EBDF0A4BD1D06EB /* BackendErrorCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C9437E0657539E96AADEFB /* BackendErrorCodeTests.swift */; };
 		5733B1AA27FFBCF900EC2045 /* BaseErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733B1A927FFBCF900EC2045 /* BaseErrorTests.swift */; };
 		5733D00928CFA7A4008638D8 /* MockPaymentQueueWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733D00828CFA7A4008638D8 /* MockPaymentQueueWrapper.swift */; };
 		5733D01128D00354008638D8 /* PromotionalOfferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733D01028D00354008638D8 /* PromotionalOfferTests.swift */; };
@@ -767,8 +767,6 @@
 		5796A38827D6B85900653165 /* BackendPostReceiptDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A38727D6B85900653165 /* BackendPostReceiptDataTests.swift */; };
 		5796A38A27D6B96300653165 /* BackendGetCustomerInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A38927D6B96300653165 /* BackendGetCustomerInfoTests.swift */; };
 		5796A38C27D6BA1600653165 /* BackendLoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A38B27D6BA1600653165 /* BackendLoginTests.swift */; };
-		603D49296E6E69D1D8E06EFE /* BackendTokenLoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64FEF3704AAACD669F3BF4E0 /* BackendTokenLoginTests.swift */; };
-		3333EEA00681B5A32D463CC9 /* BackendTokenRevocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E927212FE6045350AC196C1 /* BackendTokenRevocationTests.swift */; };
 		5796A39027D6BCD100653165 /* BackendGetIntroEligibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A38F27D6BCD100653165 /* BackendGetIntroEligibilityTests.swift */; };
 		5796A39427D6BD6900653165 /* BackendGetOfferingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A39327D6BD6900653165 /* BackendGetOfferingsTests.swift */; };
 		5796A39627D6BDAB00653165 /* BackendPostOfferForSigningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A39527D6BDAB00653165 /* BackendPostOfferForSigningTests.swift */; };
@@ -964,7 +962,9 @@
 		57FFD2512922DBED00A9A878 /* MockStoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FFD2502922DBED00A9A878 /* MockStoreTransaction.swift */; };
 		57FFD2522922DBED00A9A878 /* MockStoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FFD2502922DBED00A9A878 /* MockStoreTransaction.swift */; };
 		5A6B1C303D4E5F60718293A4 /* IsPurchaseAllowedByRestoreBehaviorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A6B1C2F3D4E5F60718293A4 /* IsPurchaseAllowedByRestoreBehaviorResponse.swift */; };
+		5B6786F455CB4A59F26BFA46 /* MockTokenAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A3DB72A2707F75F2BDC90D7 /* MockTokenAPI.swift */; };
 		5FCB03AADDD3423993AD7C29 /* PaywallLoadingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFE7B86606D743B4929124FD /* PaywallLoadingKey.swift */; };
+		603D49296E6E69D1D8E06EFE /* BackendTokenLoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64FEF3704AAACD669F3BF4E0 /* BackendTokenLoginTests.swift */; };
 		61EE4C2C5BBB16033F83098A /* StringArrayOperatorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97B0456ECD1FA5A3F2687A6B /* StringArrayOperatorsTests.swift */; };
 		64A781633D11BBA74E63080B /* PredicateFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8601C6DF935577B45F4FAFDF /* PredicateFixtureTests.swift */; };
 		64AF814EEC17056C959AF793 /* ConditionalConfigurabilityPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55ACA2F51E289B5E660E362 /* ConditionalConfigurabilityPreview.swift */; };
@@ -1394,6 +1394,7 @@
 		DBD2A168300E81E20019DB7F /* VideoAudioSessionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD2A167300E81E20019DB7F /* VideoAudioSessionHandler.swift */; };
 		DBE7C6552F02D48900A28663 /* StoreProductDiscount+CustomerCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBE7C6542F02D48900A28663 /* StoreProductDiscount+CustomerCenter.swift */; };
 		DDD45A15A641C0FF0BEF6178 /* PaywallCountdownComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A05E9E1B04B32B832DB194 /* PaywallCountdownComponent.swift */; };
+		DECC43B62EBDF0A4BD1D06EB /* BackendErrorCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C9437E0657539E96AADEFB /* BackendErrorCodeTests.swift */; };
 		E1C0A001BEEF0001CCDD0001 /* PaywallHeaderComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C0A006BEEF0001CCDD0001 /* PaywallHeaderComponent.swift */; };
 		E1C0A002BEEF0001CCDD0001 /* HeaderComponentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C0A007BEEF0001CCDD0001 /* HeaderComponentViewModel.swift */; };
 		E1C0A003BEEF0001CCDD0001 /* HeaderComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C0A008BEEF0001CCDD0001 /* HeaderComponentView.swift */; };
@@ -1875,6 +1876,7 @@
 		26AAFBADBA3F4E339D041135 /* WorkflowStepEventCoordinatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowStepEventCoordinatorTests.swift; sourceTree = "<group>"; };
 		28661C6CE3F64078A0138080 /* WebViewOriginPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewOriginPolicy.swift; sourceTree = "<group>"; };
 		297C50EBB2B69A3F77D13E69 /* Operators.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Operators.swift; sourceTree = "<group>"; };
+		2A3DB72A2707F75F2BDC90D7 /* MockTokenAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTokenAPI.swift; sourceTree = "<group>"; };
 		2A5E77D02F10B3B500BC5900 /* RevocationReason.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RevocationReason.swift; sourceTree = "<group>"; };
 		2C08B2E82CD40DBF0024857B /* ButtonComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonComponentTests.swift; sourceTree = "<group>"; };
 		2C08B3062CD55D590024857B /* FlexHStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlexHStack.swift; sourceTree = "<group>"; };
@@ -2360,7 +2362,6 @@
 		55DACE8E302E2BBB005EE017 /* MockInternalAuthenticatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInternalAuthenticatorDelegate.swift; sourceTree = "<group>"; };
 		55DACE8F302E2BBB005EE017 /* MockSecureItemStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSecureItemStorage.swift; sourceTree = "<group>"; };
 		55DACE96302E320C005EE017 /* MockTokenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTokenManager.swift; sourceTree = "<group>"; };
-		2A3DB72A2707F75F2BDC90D7 /* MockTokenAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTokenAPI.swift; sourceTree = "<group>"; };
 		55DACEAB302E837B005EE017 /* TokenManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenManagerTests.swift; sourceTree = "<group>"; };
 		55DACFCC30366625005EE017 /* AuthenticationStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationStrings.swift; sourceTree = "<group>"; };
 		55FCA85B959807F2D3DD175A /* TransactionReason.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TransactionReason.swift; sourceTree = "<group>"; };
@@ -2388,7 +2389,6 @@
 		5733B18D27FF586A00EC2045 /* BackendError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendError.swift; sourceTree = "<group>"; };
 		5733B1A327FF9F8300EC2045 /* NetworkErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorTests.swift; sourceTree = "<group>"; };
 		5733B1A727FFBCC800EC2045 /* BackendErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendErrorTests.swift; sourceTree = "<group>"; };
-		71C9437E0657539E96AADEFB /* BackendErrorCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendErrorCodeTests.swift; sourceTree = "<group>"; };
 		5733B1A927FFBCF900EC2045 /* BaseErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseErrorTests.swift; sourceTree = "<group>"; };
 		5733D00828CFA7A4008638D8 /* MockPaymentQueueWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPaymentQueueWrapper.swift; sourceTree = "<group>"; };
 		5733D01028D00354008638D8 /* PromotionalOfferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionalOfferTests.swift; sourceTree = "<group>"; };
@@ -2504,8 +2504,6 @@
 		5796A38727D6B85900653165 /* BackendPostReceiptDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendPostReceiptDataTests.swift; sourceTree = "<group>"; };
 		5796A38927D6B96300653165 /* BackendGetCustomerInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendGetCustomerInfoTests.swift; sourceTree = "<group>"; };
 		5796A38B27D6BA1600653165 /* BackendLoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendLoginTests.swift; sourceTree = "<group>"; };
-		64FEF3704AAACD669F3BF4E0 /* BackendTokenLoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendTokenLoginTests.swift; sourceTree = "<group>"; };
-		7E927212FE6045350AC196C1 /* BackendTokenRevocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendTokenRevocationTests.swift; sourceTree = "<group>"; };
 		5796A38F27D6BCD100653165 /* BackendGetIntroEligibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendGetIntroEligibilityTests.swift; sourceTree = "<group>"; };
 		5796A39327D6BD6900653165 /* BackendGetOfferingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendGetOfferingsTests.swift; sourceTree = "<group>"; };
 		5796A39527D6BDAB00653165 /* BackendPostOfferForSigningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendPostOfferForSigningTests.swift; sourceTree = "<group>"; };
@@ -2687,12 +2685,14 @@
 		5C3DF79A7BCAA00FD8DCBD07 /* PublishedWorkflowCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishedWorkflowCodableTests.swift; sourceTree = "<group>"; };
 		5E8F7749E65DE2FD7FDCB105 /* WorkflowStepEventTracker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowStepEventTracker.swift; sourceTree = "<group>"; };
 		61F92C8B490F4B78AC8B1AAF /* ErrorCode+Conformances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ErrorCode+Conformances.swift"; sourceTree = "<group>"; };
+		64FEF3704AAACD669F3BF4E0 /* BackendTokenLoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendTokenLoginTests.swift; sourceTree = "<group>"; };
 		65279ABC122869A50AEB8A27 /* ExitOffer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExitOffer.swift; sourceTree = "<group>"; };
 		686562C08D953A27986DB276 /* PaywallWebViewValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallWebViewValueTests.swift; sourceTree = "<group>"; };
 		6A10AD61D82EB73FC5338DA2 /* WorkflowNavigator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowNavigator.swift; sourceTree = "<group>"; };
 		6E52F908EB90930822406495 /* WorkflowManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowManager.swift; sourceTree = "<group>"; };
 		6EFD5F7BD8404B6E828C4E10 /* WorkflowPaywallViewTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowPaywallViewTests.swift; sourceTree = "<group>"; };
 		6F6E5F9ABE99E8F2BC1DE237 /* WebViewComponentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewComponentViewModel.swift; sourceTree = "<group>"; };
+		71C9437E0657539E96AADEFB /* BackendErrorCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendErrorCodeTests.swift; sourceTree = "<group>"; };
 		72CC1CD0385BF18D1392EB43 /* WebViewSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewSession.swift; sourceTree = "<group>"; };
 		750B39FD2E40940F005E141D /* PurchasesOrchestratorSimulatedStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesOrchestratorSimulatedStoreTests.swift; sourceTree = "<group>"; };
 		751192DC2E39147600E583CC /* MockWebBillingAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWebBillingAPI.swift; sourceTree = "<group>"; };
@@ -2757,6 +2757,7 @@
 		78B1498BA2288B4643B248A5 /* PurchasesWorkflowTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PurchasesWorkflowTests.swift; sourceTree = "<group>"; };
 		C0DE00000000000000000209 /* PurchasesCheckpointEventsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PurchasesCheckpointEventsTests.swift; sourceTree = "<group>"; };
 		7AA86A1D9F5AE92988B20230 /* WorkflowContextTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowContextTests.swift; sourceTree = "<group>"; };
+		7E927212FE6045350AC196C1 /* BackendTokenRevocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendTokenRevocationTests.swift; sourceTree = "<group>"; };
 		7F8F8AD16519E1EFCE1B99F4 /* ValueTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ValueTests.swift; sourceTree = "<group>"; };
 		800A129055A298C390AED0B5 /* WorkflowPaywallView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowPaywallView.swift; sourceTree = "<group>"; };
 		802593742FE06CDA005AF6DF /* StateUpdate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateUpdate.swift; sourceTree = "<group>"; };
@@ -7454,6 +7455,7 @@
 			files = (
 				1E3084A430178A6E00236A34 /* MockSourceHealthChecker.swift in Sources */,
 				2D9C5ECA26F2805C0057FC45 /* ProductsManagerTests.swift in Sources */,
+				55DACF333034FA93005EE017 /* MockTokenAPI.swift in Sources */,
 				75A3B2B22F16B458001C4CA7 /* MockLargeItemCache.swift in Sources */,
 				3543914526F926D900E669DF /* SKProductSubscriptionDurationExtensions.swift in Sources */,
 				AC17E0A7E0000000000000A2 /* MockAsyncGate.swift in Sources */,

--- a/Sources/Authentication/Authentication.swift
+++ b/Sources/Authentication/Authentication.swift
@@ -189,7 +189,9 @@ public final class Authentication: NSObject {
                         completion: ((CustomerInfo?, PublicError?) -> Void)?) {
         guard tokenManager.enabled else {
             let error = NewErrorUtils.unsupportedError(message: "Token login requires .with(iamEnabled: true)")
-            completion?(nil, error.asPublicError)
+            self.operationDispatcher.dispatchOnMainThread {
+                completion?(nil, error.asPublicError)
+            }
             if userInitiated == false { self.reportAuthenticationError(error.asPublicError) }
             return
         }
@@ -217,7 +219,9 @@ public final class Authentication: NSObject {
     internal func logOut(userInitiated: Bool, completion: ((CustomerInfo?, PublicError?) -> Void)?) {
         guard !self.systemInfo.dangerousSettings.customEntitlementComputation else {
             let error = NewErrorUtils.featureNotAvailableInCustomEntitlementsComputationModeError().asPublicError
-            completion?(nil, error)
+            self.operationDispatcher.dispatchOnMainThread {
+                completion?(nil, error)
+            }
             if userInitiated == false { self.reportAuthenticationError(error) }
             return
         }

--- a/Sources/Authentication/Authentication.swift
+++ b/Sources/Authentication/Authentication.swift
@@ -65,6 +65,10 @@ public final class Authentication: NSObject {
         self.systemInfo = systemInfo
         self.internalDelegate = internalDelegate
         super.init()
+
+        tokenManager.reportError = { [weak self] in
+            self?.reportAuthenticationError($0)
+        }
     }
 
     /// Provide an app-specific alias for the current user
@@ -113,6 +117,18 @@ public final class Authentication: NSObject {
             }
         }
 
+    }
+
+    /// Log in to the SDK using the provided identity token
+    ///
+    /// - Warning: If the SDK is already logged in using a non-anonymous identity,
+    /// then a subsequent invocation of this method will *link* the two identities together.
+    /// - Parameters:
+    ///   - token: The ``Identity`` token for the user
+    ///   - completion: A handler invoked after logging in has finished.
+    @objc(logInUsingToken:completion:)
+    public func logIn(using token: Identity, completion: @escaping (CustomerInfo?, PublicError?) -> Void) {
+        self.logIn(using: token, userInitiated: true, completion: completion)
     }
 
     /// Log the current identity out
@@ -167,6 +183,36 @@ public final class Authentication: NSObject {
     }
 
     // MARK: - Internals
+
+    internal func logIn(using identity: Identity,
+                        userInitiated: Bool,
+                        completion: ((CustomerInfo?, PublicError?) -> Void)?) {
+        guard tokenManager.enabled else {
+            let error = NewErrorUtils.unsupportedError(message: "Token login requires .with(iamEnabled: true)")
+            completion?(nil, error.asPublicError)
+            if userInitiated == false { self.reportAuthenticationError(error.asPublicError) }
+            return
+        }
+
+        self.identityManager.logIn(identity: identity) { result in
+            if let completion {
+                self.operationDispatcher.dispatchOnMainThread {
+                    completion(result.value?.info, result.error?.asPublicError)
+                }
+            }
+
+            switch result {
+            case .success(let result):
+                self.internalDelegate?.authenticatorDidLogIn(info: result.info)
+            case .failure(let error):
+                if userInitiated == false {
+                    self.reportAuthenticationError(error.asPublicError)
+                }
+            }
+
+        }
+
+    }
 
     internal func logOut(userInitiated: Bool, completion: ((CustomerInfo?, PublicError?) -> Void)?) {
         guard !self.systemInfo.dangerousSettings.customEntitlementComputation else {

--- a/Sources/Error Handling/BackendError.swift
+++ b/Sources/Error Handling/BackendError.swift
@@ -12,6 +12,7 @@
 //  Created by Nacho Soto on 4/7/22.
 
 // swiftlint:disable multiline_parameters
+// swiftlint:disable file_length
 
 import Foundation
 
@@ -28,6 +29,7 @@ enum BackendError: Error, Equatable {
     case invalidAppleSubscriptionKey(Source)
     case unexpectedBackendResponse(UnexpectedBackendResponseError, extraContext: String?, Source)
     case invalidWebRedemptionToken
+    case invalidAuthorizationToken(Source)
     case purchaseBelongsToOtherUser
     case expiredWebRedemptionToken(obfuscatedEmail: String)
     case unsupportedInUIPreviewMode(Source)
@@ -94,6 +96,12 @@ extension BackendError {
         file: String = #fileID, function: String = #function, line: UInt = #line
     ) -> Self {
         return .unsupportedInUIPreviewMode(.init(file: file, function: function, line: line))
+    }
+
+    static func invalidAuthorizationToken(
+        file: String = #fileID, function: String = #function, line: UInt = #line
+    ) -> Self {
+        return .invalidAuthorizationToken(.init(file: file, function: function, line: line))
     }
 
 }
@@ -163,6 +171,10 @@ extension BackendError: PurchasesErrorConvertible {
             let code = BackendErrorCode.invalidWebRedemptionToken
             return ErrorUtils.backendError(withBackendCode: code,
                                            originalBackendErrorCode: code.rawValue)
+        case .invalidAuthorizationToken:
+            let code = BackendErrorCode.invalidAuthToken
+            return ErrorUtils.backendError(withBackendCode: code,
+                                           originalBackendErrorCode: code.rawValue)
         case .purchaseBelongsToOtherUser:
             let code = BackendErrorCode.purchaseBelongsToOtherUser
             return ErrorUtils.backendError(withBackendCode: code,
@@ -223,6 +235,7 @@ extension BackendError {
              .missingCachedCustomerInfo,
              .unexpectedBackendResponse,
              .invalidWebRedemptionToken,
+             .invalidAuthorizationToken,
              .purchaseBelongsToOtherUser,
              .expiredWebRedemptionToken,
              .unsupportedInUIPreviewMode,
@@ -248,6 +261,7 @@ extension BackendError {
                 .missingTransactionProductIdentifier,
                 .missingCachedCustomerInfo,
                 .invalidWebRedemptionToken,
+                .invalidAuthorizationToken,
                 .purchaseBelongsToOtherUser,
                 .expiredWebRedemptionToken,
                 .unsupportedInUIPreviewMode,

--- a/Sources/Error Handling/BackendErrorCode.swift
+++ b/Sources/Error Handling/BackendErrorCode.swift
@@ -51,6 +51,9 @@ enum BackendErrorCode: Int, Error {
     case purchaseBelongsToOtherUser = 7852
     case expiredWebRedemptionToken = 7853
 
+    case invalidIAMToken = 7981
+    case cannotAliasToAuthenticatedUser = 8077
+
     /**
      * - Parameter code: Generally comes from the backend in json. This may be a String, or an Int, or nothing.
      */
@@ -87,6 +90,7 @@ extension BackendErrorCode: ExpressibleByIntegerLiteral {
 extension BackendErrorCode {
 
     // swiftlint:disable cyclomatic_complexity
+    // swiftlint:disable function_body_length
     /// Turns ``BackendErrorCode``(RCBackendErrorCode) codes into ``ErrorCode``(RCPurchasesErrorCode) error codes
     func toPurchasesErrorCode() -> ErrorCode {
     // swiftlint:enable cyclomatic_complexity
@@ -102,7 +106,8 @@ extension BackendErrorCode {
             return .invalidReceiptError
         case .invalidAppStoreSharedSecret,
              .invalidAuthToken,
-             .invalidAPIKey:
+             .invalidAPIKey,
+             .invalidIAMToken:
             return .invalidCredentialsError
         case .invalidPaymentModeOrIntroPriceNotProvided,
              .productIdForGoogleReceiptNotProvided:
@@ -117,7 +122,8 @@ extension BackendErrorCode {
         case .invalidSubscriberAttributes,
              .invalidSubscriberAttributesBody:
             return .invalidSubscriberAttributesError
-        case .couldNotCreateAlias:
+        case .couldNotCreateAlias,
+            .cannotAliasToAuthenticatedUser:
             return .configurationError
         case .requestAlreadyInProgress,
              .subscriberAttributesAreBeingUpdated:

--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -118,6 +118,11 @@ class IdentityManager: CurrentUserProvider {
             return
         }
 
+        if self.currentUserIsAnonymous {
+            completion(ErrorUtils.logOutAnonymousUserError())
+            return
+        }
+
         self.attributeSyncing.syncSubscriberAttributes(currentAppUserID: self.currentAppUserID) {
             if self.tokenManager.enabled {
                 self.performTokenRevocation(for: self.currentAppUserID, completion: completion)
@@ -244,11 +249,6 @@ private extension IdentityManager {
 
     func performLogOut(completion: @escaping (PurchasesError?) -> Void) {
         Logger.info(Strings.identity.log_out_called_for_user)
-
-        if self.currentUserIsAnonymous {
-            completion(ErrorUtils.logOutAnonymousUserError())
-            return
-        }
 
         let newUserID = Self.generateRandomID()
         self.resetCacheAndSave(newUserID: newUserID)

--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -101,6 +101,17 @@ class IdentityManager: CurrentUserProvider {
         }
     }
 
+    func logIn(identity: Identity, completion: @escaping IdentityAPI.LogInResponseHandler) {
+        guard self.currentAppUserID != Self.uiPreviewModeAppUserID else {
+            completion(.failure(.unsupportedInUIPreviewMode()))
+            return
+        }
+
+        self.attributeSyncing.syncSubscriberAttributes(currentAppUserID: self.currentAppUserID) {
+            self.performLogIn(identity: identity, completion: completion)
+        }
+    }
+
     func logOut(completion: @escaping (PurchasesError?) -> Void) {
         guard self.currentAppUserID != Self.uiPreviewModeAppUserID else {
             completion(ErrorUtils.unsupportedInUIPreviewModeError())
@@ -108,7 +119,24 @@ class IdentityManager: CurrentUserProvider {
         }
 
         self.attributeSyncing.syncSubscriberAttributes(currentAppUserID: self.currentAppUserID) {
-            self.performLogOut(completion: completion)
+            if self.tokenManager.enabled {
+                self.performTokenRevocation(for: self.currentAppUserID, completion: completion)
+            } else {
+                self.performLogOut(completion: completion)
+            }
+        }
+    }
+
+    func revokeCurrentAccessToken(completion: @escaping (PurchasesError?) -> Void) {
+        guard self.currentAppUserID != Self.uiPreviewModeAppUserID else {
+            completion(ErrorUtils.unsupportedInUIPreviewModeError())
+            return
+        }
+
+        if self.tokenManager.enabled {
+            self.performAccessTokenRevocation(for: self.currentAppUserID, completion: completion)
+        } else {
+            completion(nil)
         }
     }
 
@@ -153,7 +181,7 @@ private extension IdentityManager {
         guard newAppUserID != oldAppUserID else {
             Logger.warn(Strings.identity.logging_in_with_same_appuserid)
             self.customerInfoManager.customerInfo(appUserID: oldAppUserID,
-                                                  fetchPolicy: .cachedOrFetched) { @Sendable result in
+                                                  fetchPolicy: .fetchCurrent) { @Sendable result in
                 completion(
                     result.map { (info: $0, created: false) }
                 )
@@ -174,7 +202,47 @@ private extension IdentityManager {
         }
     }
 
-    func performLogOut(completion: (PurchasesError?) -> Void) {
+    func performLogIn(identity: Identity, completion: @escaping IdentityAPI.LogInResponseHandler) {
+        let oldAppUserID = self.currentAppUserID
+
+        self.backend.token.logIn(currentAppUserID: oldAppUserID, identity: identity) { result in
+            switch result {
+            case .success(let (_, newAppUserID)):
+                self.remoteConfigManager?.clearCache(forAppUserID: newAppUserID)
+                self.deviceCache.clearCaches(oldAppUserID: oldAppUserID, andSaveWithNewUserID: newAppUserID)
+                self.copySubscriberAttributesToNewUserIfOldIsAnonymous(oldAppUserID: oldAppUserID,
+                                                                       newAppUserID: newAppUserID)
+
+                self.customerInfoManager.customerInfo(appUserID: newAppUserID,
+                                                      fetchPolicy: .cachedOrFetched,
+                                                      completion: { result in
+
+                    let mapped = result.map { (info: $0, created: false) }
+                    completion(mapped)
+                })
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func performAccessTokenRevocation(for appUserID: String, completion: @escaping (PurchasesError?) -> Void) {
+        self.backend.token.revokeAccessTokens(for: appUserID) { error in
+            completion(error?.asPurchasesError)
+        }
+    }
+
+    func performTokenRevocation(for appUserID: String, completion: @escaping (PurchasesError?) -> Void) {
+        self.backend.token.revokeTokens(for: appUserID) { error in
+            if let purchasesError = error?.asPurchasesError {
+                completion(purchasesError)
+            } else {
+                self.performLogOut(completion: completion)
+            }
+        }
+    }
+
+    func performLogOut(completion: @escaping (PurchasesError?) -> Void) {
         Logger.info(Strings.identity.log_out_called_for_user)
 
         if self.currentUserIsAnonymous {
@@ -182,9 +250,18 @@ private extension IdentityManager {
             return
         }
 
-        self.resetCacheAndSave(newUserID: Self.generateRandomID())
+        let newUserID = Self.generateRandomID()
+        self.resetCacheAndSave(newUserID: newUserID)
         Logger.info(Strings.identity.log_out_success)
-        completion(nil)
+
+        if self.tokenManager.enabled {
+            // immediately get tokens for the new user id
+            self.performLogIn(identity: .anonymous, completion: { result in
+                completion(result.error?.asPurchasesError)
+            })
+        } else {
+            completion(nil)
+        }
     }
 }
 

--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -186,7 +186,7 @@ private extension IdentityManager {
         guard newAppUserID != oldAppUserID else {
             Logger.warn(Strings.identity.logging_in_with_same_appuserid)
             self.customerInfoManager.customerInfo(appUserID: oldAppUserID,
-                                                  fetchPolicy: .fetchCurrent) { @Sendable result in
+                                                  fetchPolicy: .cachedOrFetched) { @Sendable result in
                 completion(
                     result.map { (info: $0, created: false) }
                 )

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -16,6 +16,7 @@ import Foundation
 class Backend {
 
     let identity: IdentityAPI
+    let token: TokenAPI
     let offerings: OfferingsAPI
     let webBilling: WebBillingAPI
     let offlineEntitlements: OfflineEntitlementsAPI
@@ -93,6 +94,7 @@ class Backend {
                      attributionFetcher: AttributionFetcher) {
         let customer = CustomerAPI(backendConfig: backendConfig, attributionFetcher: attributionFetcher)
         let identity = IdentityAPI(backendConfig: backendConfig)
+        let token = TokenAPI(backendConfig: backendConfig)
         let offerings = OfferingsAPI(backendConfig: backendConfig)
         let webBilling = WebBillingAPI(backendConfig: backendConfig)
         let offlineEntitlements = OfflineEntitlementsAPI(backendConfig: backendConfig)
@@ -106,6 +108,7 @@ class Backend {
         self.init(backendConfig: backendConfig,
                   customerAPI: customer,
                   identityAPI: identity,
+                  tokenAPI: token,
                   offeringsAPI: offerings,
                   webBillingAPI: webBilling,
                   offlineEntitlements: offlineEntitlements,
@@ -120,6 +123,7 @@ class Backend {
     required init(backendConfig: BackendConfiguration,
                   customerAPI: CustomerAPI,
                   identityAPI: IdentityAPI,
+                  tokenAPI: TokenAPI,
                   offeringsAPI: OfferingsAPI,
                   webBillingAPI: WebBillingAPI,
                   offlineEntitlements: OfflineEntitlementsAPI,
@@ -133,6 +137,7 @@ class Backend {
 
         self.customer = customerAPI
         self.identity = identityAPI
+        self.token = tokenAPI
         self.offerings = offeringsAPI
         self.webBilling = webBillingAPI
         self.offlineEntitlements = offlineEntitlements

--- a/Sources/Networking/Caching/IAMCallbacks.swift
+++ b/Sources/Networking/Caching/IAMCallbacks.swift
@@ -1,0 +1,20 @@
+//
+//  IAMCallbacks.swift
+//  RevenueCat
+//
+//  Created by Dave DeLong on 7/13/26.
+//
+
+import Foundation
+
+struct TokenCallback: CacheKeyProviding {
+
+    let cacheKey: String
+    let completion: TokenAPI.TokenResponseHandler
+
+}
+
+struct TokenRevokeCallback: CacheKeyProviding {
+    let cacheKey: String
+    let completion: (BackendError?) -> Void
+}

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -189,6 +189,9 @@ extension HTTPRequest {
         case rewardVerificationStatus(appUserID: String, clientTransactionID: String)
         case remoteConfig(domain: String)
 
+        case tokenLogin
+        case tokenRefresh
+        case tokenLogOut
     }
 
     enum FallbackPath: Hashable {
@@ -285,7 +288,10 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .postCreateTicket,
                 .isPurchaseAllowedByRestoreBehavior,
                 .rewardVerificationStatus,
-                .remoteConfig:
+                .remoteConfig,
+                .tokenLogin,
+                .tokenRefresh,
+                .tokenLogOut:
             return true
 
         case .health,
@@ -312,7 +318,10 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .appHealthReport,
                 .postCreateTicket,
                 .isPurchaseAllowedByRestoreBehavior,
-                .rewardVerificationStatus:
+                .rewardVerificationStatus,
+                .tokenLogin,
+                .tokenRefresh,
+                .tokenLogOut:
             return true
         case .remoteConfig,
              .health,
@@ -343,7 +352,10 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .postOfferForSigning,
                 .postRedeemWebPurchase,
                 .getCustomerCenterConfig,
-                .postCreateTicket:
+                .postCreateTicket,
+                .tokenLogin,
+                .tokenRefresh,
+                .tokenLogOut:
             return false
         }
     }
@@ -358,7 +370,10 @@ extension HTTPRequest.Path: HTTPRequestPath {
                 .appHealthReportAvailability,
                 .isPurchaseAllowedByRestoreBehavior,
                 .remoteConfig,
-                .rewardVerificationStatus:
+                .rewardVerificationStatus,
+                .tokenLogin,
+                .tokenRefresh,
+                .tokenLogOut:
             return true
         case .getOfferings,
                 .getIntroEligibility,
@@ -456,6 +471,15 @@ extension HTTPRequest.Path: HTTPRequestPath {
 
         case let .remoteConfig(domain):
             return "config/\(Self.escape(domain))"
+
+        case .tokenLogin:
+            return "/auth/login"
+
+        case .tokenRefresh:
+            return "/auth/token"
+
+        case .tokenLogOut:
+            return "/auth/revoke"
         }
     }
 
@@ -506,6 +530,12 @@ extension HTTPRequest.Path: HTTPRequestPath {
             return self.pathComponent
         case .remoteConfig:
             return self.pathComponent
+        case .tokenLogin:
+            return "/auth/login"
+        case .tokenRefresh:
+            return "/auth/token"
+        case .tokenLogOut:
+            return "/auth/revoke"
         }
     }
 
@@ -569,6 +599,15 @@ extension HTTPRequest.Path: HTTPRequestPath {
 
         case .remoteConfig:
             return "remote_config"
+
+        case .tokenLogin:
+            return "token_login"
+
+        case .tokenRefresh:
+            return "token_refresh"
+
+        case .tokenLogOut:
+            return "token_logout"
         }
     }
 
@@ -582,6 +621,14 @@ extension HTTPRequest.Path: HTTPRequestPath {
             ]
         default:
             return [:]
+        }
+    }
+
+    var isIAMPath: Bool {
+        switch self {
+        case .tokenLogin, .tokenRefresh, .tokenLogOut:
+            return true
+        default: return false
         }
     }
 

--- a/Sources/Networking/HTTPClient/TokenManager.swift
+++ b/Sources/Networking/HTTPClient/TokenManager.swift
@@ -39,6 +39,23 @@ class TokenManager {
 
     var hasCurrentAccessToken: Bool { currentAccessToken != nil }
 
+    var currentIdentitySources: [IdentitySource]? {
+        guard let currentIDToken else { return nil }
+        guard let jwt = try? JWT(from: currentIDToken) else { return nil }
+        return jwt.amr?.compactMap { IdentitySource.source(with: $0) }
+    }
+
+    var isCurrentIdentityAnonymous: Bool {
+        // returns true iff all (1+) the identity sources are "anonymous"
+        guard let sources = currentIdentitySources else { return false }
+        if sources.isEmpty { return false }
+        return sources.allSatisfy { $0 == .anonymous }
+    }
+
+    var currentIdentitySource: IdentitySource? {
+        currentIdentitySources?.last
+    }
+
     var currentRefreshToken: String? {
         get {
             guard enabled == true else { return nil }

--- a/Sources/Networking/IdentityAPI.swift
+++ b/Sources/Networking/IdentityAPI.swift
@@ -14,11 +14,11 @@
 import Foundation
 
 class IdentityAPI {
-
     typealias LogInResponse = Result<(info: CustomerInfo, created: Bool), BackendError>
     typealias LogInResponseHandler = (LogInResponse) -> Void
 
     private let logInCallbacksCache: CallbackCache<LogInCallback>
+
     private let backendConfig: BackendConfiguration
 
     init(backendConfig: BackendConfiguration) {
@@ -31,6 +31,7 @@ class IdentityAPI {
                completion: @escaping LogInResponseHandler) {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
                                                                 appUserID: currentAppUserID)
+
         let factory = LogInOperation.createFactory(configuration: config,
                                                    newAppUserID: newAppUserID,
                                                    loginCallbackCache: self.logInCallbacksCache)

--- a/Sources/Networking/Operations/TokenOperations.swift
+++ b/Sources/Networking/Operations/TokenOperations.swift
@@ -1,0 +1,365 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  TokenTokenLogInOperation.swift
+//
+
+import Foundation
+
+final class TokenLogInOperation: CacheableNetworkOperation {
+
+    private let tokenCallbackCache: CallbackCache<TokenCallback>
+    private let configuration: UserSpecificConfiguration
+    private let token: IdentityAuthToken
+    private let linkToID: String?
+
+    static func createFactory(
+        configuration: UserSpecificConfiguration,
+        token: IdentityAuthToken,
+        linkToIDToken: String?,
+        tokenCallbackCache: CallbackCache<TokenCallback>
+    ) -> CacheableNetworkOperationFactory<TokenLogInOperation> {
+        return .init({
+            .init(
+                configuration: configuration,
+                token: token,
+                linkToIDToken: linkToIDToken,
+                tokenCallbackCache: tokenCallbackCache,
+                cacheKey: $0
+            ) },
+                     individualizedCacheKeyPart: token.cacheIdentifier)
+    }
+
+    private init(
+        configuration: UserSpecificConfiguration,
+        token: IdentityAuthToken,
+        linkToIDToken: String?,
+        tokenCallbackCache: CallbackCache<TokenCallback>,
+        cacheKey: String
+    ) {
+        self.configuration = configuration
+        self.token = token
+        self.linkToID = linkToIDToken
+        self.tokenCallbackCache = tokenCallbackCache
+
+        super.init(configuration: configuration, cacheKey: cacheKey)
+    }
+
+    override func begin(completion: @escaping () -> Void) {
+        self.logIn(completion: completion)
+    }
+
+}
+
+// Restating inherited @unchecked Sendable from Foundation's Operation
+extension TokenLogInOperation: @unchecked Sendable {}
+
+private extension TokenLogInOperation {
+
+    func logIn(completion: @escaping () -> Void) {
+        guard self.token.validate() else {
+            self.tokenCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
+                callback.completion(.failure(.invalidAuthorizationToken()))
+            }
+            completion()
+
+            return
+        }
+
+        let body: any HTTPRequestBody
+        switch token {
+        case .anonymous:
+            body = AnonymousBody(method: "anonymous",
+                                 scope: "openid offline_access")
+        case .oidc(let token):
+            body = StandardBody(method: "oidc",
+                                scope: "openid offline_access",
+                                idToken: String(bytes: token, encoding: .utf8) ?? token.base64EncodedString(),
+                                linkToID: linkToID)
+        case .google(let token):
+            body = StandardBody(method: "google",
+                                scope: "openid offline_access",
+                                idToken: String(bytes: token, encoding: .utf8) ?? token.base64EncodedString(),
+                                linkToID: linkToID)
+        case .signInWithApple(let token):
+            body = StandardBody(method: "apple",
+                                scope: "openid offline_access",
+                                idToken: String(bytes: token, encoding: .utf8) ?? token.base64EncodedString(),
+                                linkToID: linkToID)
+        case .facebook(let token, let email):
+            body = FacebookBody(method: "facebook",
+                                scope: "openid offline_access",
+                                idToken: String(bytes: token, encoding: .utf8) ?? token.base64EncodedString(),
+                                email: email,
+                                linkToID: linkToID)
+        case .firebase(let token):
+            body = StandardBody(method: "firebase",
+                                scope: "openid offline_access",
+                                idToken: String(bytes: token, encoding: .utf8) ?? token.base64EncodedString(),
+                                linkToID: linkToID)
+        }
+
+        let request = HTTPRequest(method: .post(body), path: .tokenLogin)
+
+        self.httpClient.perform(request) { (response: VerifiedHTTPResponse<TokenResponse>.Result) in
+            self.tokenCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callbackObject in
+                self.handleLogin(response, completion: callbackObject.completion)
+            }
+
+            completion()
+        }
+    }
+
+    func handleLogin(_ result: VerifiedHTTPResponse<TokenResponse>.Result,
+                     completion: TokenAPI.TokenResponseHandler) {
+        let finalResult: TokenAPI.TokenResult
+
+        switch result {
+        case .success(let response):
+            do {
+                let jwt = try JWT(from: response.body.accessToken)
+                guard let userID = jwt.appUserID else {
+                    throw BackendError.unexpectedBackendResponse(.loginResponseDecoding,
+                                                                 extraContext: "JWT missing RC user ID")
+                }
+
+                finalResult = .success((response.body, userID))
+                Logger.user(Strings.identity.login_success)
+            } catch let error as BackendError {
+                finalResult = .failure(error)
+            } catch {
+                finalResult = .failure(BackendError.unexpectedBackendResponse(.loginResponseDecoding))
+            }
+        case .failure(let networkError):
+            finalResult = .failure(BackendError.networkError(networkError))
+        }
+
+        completion(finalResult)
+    }
+}
+
+final class TokenRevocationOperation: CacheableNetworkOperation, @unchecked Sendable {
+
+    private let callbackCache: CallbackCache<TokenRevokeCallback>
+    private let configuration: UserSpecificConfiguration
+    private let token: String
+    private let tokenTypeHint: String
+    private let appUserID: String
+
+    static func createFactory(
+        configuration: UserSpecificConfiguration,
+        refreshToken: String,
+        appUserID: String,
+        callbackCache: CallbackCache<TokenRevokeCallback>
+    ) -> CacheableNetworkOperationFactory<TokenRevocationOperation> {
+        return .init({
+            .init(
+                configuration: configuration,
+                token: refreshToken,
+                tokenTypeHint: "refresh_token",
+                appUserID: appUserID,
+                callbackCache: callbackCache,
+                cacheKey: $0
+            ) },
+                     individualizedCacheKeyPart: appUserID)
+    }
+
+    static func createFactory(
+        configuration: UserSpecificConfiguration,
+        accessToken: String,
+        appUserID: String,
+        callbackCache: CallbackCache<TokenRevokeCallback>
+    ) -> CacheableNetworkOperationFactory<TokenRevocationOperation> {
+        return .init({
+            .init(
+                configuration: configuration,
+                token: accessToken,
+                tokenTypeHint: "access_token",
+                appUserID: appUserID,
+                callbackCache: callbackCache,
+                cacheKey: $0
+            ) },
+                     individualizedCacheKeyPart: appUserID)
+    }
+
+    private init(
+        configuration: UserSpecificConfiguration,
+        token: String,
+        tokenTypeHint: String,
+        appUserID: String,
+        callbackCache: CallbackCache<TokenRevokeCallback>,
+        cacheKey: String
+    ) {
+        self.configuration = configuration
+        self.token = token
+        self.tokenTypeHint = tokenTypeHint
+        self.appUserID = appUserID
+        self.callbackCache = callbackCache
+
+        super.init(configuration: configuration, cacheKey: cacheKey)
+    }
+
+    override func begin(completion: @escaping () -> Void) {
+        guard self.token.isNotEmpty else {
+            self.callbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
+                callback.completion(BackendError.missingAppUserID())
+            }
+            completion()
+
+            return
+        }
+
+        let body = Body(token: token, tokenTypeHint: tokenTypeHint)
+
+        let request = HTTPRequest(method: .post(body), path: .tokenLogOut)
+
+        self.httpClient.perform(request) { (response: VerifiedHTTPResponse<Data>.Result) in
+            self.callbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callbackObject in
+                let mappedResponse = response.mapError(BackendError.networkError)
+                callbackObject.completion(mappedResponse.error)
+            }
+
+            completion()
+        }
+    }
+}
+
+// MARK: - Request Bodies
+
+extension TokenLogInOperation {
+
+    struct AnonymousBody: Encodable, HTTPRequestBody {
+
+        // Note: These keys need to be explicitly declared using snake_case
+        // because the CodingKeys are also used for request signing via `contentForSignature`.
+        // swiftlint:disable:next nesting
+        private enum CodingKeys: String, CodingKey {
+            case method
+            case scope
+        }
+
+        let method: String
+        let scope: String
+
+        var contentForSignature: [(key: String, value: String?)] {
+            return [
+                (Self.CodingKeys.method.stringValue, self.method),
+                (Self.CodingKeys.scope.stringValue, self.scope)
+            ]
+        }
+
+    }
+
+    struct StandardBody: Encodable, HTTPRequestBody {
+
+        // Note: These keys need to be explicitly declared using snake_case
+        // because the CodingKeys are also used for request signing via `contentForSignature`.
+        // swiftlint:disable:next nesting
+        private enum CodingKeys: String, CodingKey {
+            case method = "method"
+            case scope = "scope"
+            case idToken = "id_token"
+            case linkToID = "link_to_id"
+        }
+
+        let method: String
+        let scope: String
+        let idToken: String
+        let linkToID: String?
+
+        var contentForSignature: [(key: String, value: String?)] {
+            return [
+                (Self.CodingKeys.method.stringValue, self.method),
+                (Self.CodingKeys.scope.stringValue, self.scope),
+                (Self.CodingKeys.idToken.stringValue, self.idToken),
+                (Self.CodingKeys.linkToID.stringValue, self.linkToID)
+            ]
+        }
+
+    }
+
+    struct FacebookBody: Encodable, HTTPRequestBody {
+
+        // swiftlint:disable:next nesting
+        private enum CodingKeys: String, CodingKey {
+            case method = "method"
+            case scope = "scope"
+            case idToken = "id_token"
+            case email = "email"
+            case linkToID = "link_to_id"
+        }
+
+        let method: String
+        let scope: String
+        let idToken: String
+        let email: String?
+        let linkToID: String?
+
+        var contentForSignature: [(key: String, value: String?)] {
+            return [
+                (Self.CodingKeys.method.stringValue, self.method),
+                (Self.CodingKeys.scope.stringValue, self.scope),
+                (Self.CodingKeys.idToken.stringValue, self.idToken),
+                (Self.CodingKeys.email.stringValue, self.email),
+                (Self.CodingKeys.linkToID.stringValue, self.linkToID)
+            ]
+        }
+
+    }
+
+}
+
+// this is an enum because "TokenRefreshOperations" don't exist like the TokenLogInOperation.
+// token refreshing happens directly in the TokenManager. This enum exists for
+// namespacing consistency and recognizability.
+enum TokenRefreshOperation {
+
+    struct Body: Encodable, HTTPRequestBody {
+        // swiftlint:disable:next nesting
+        private enum CodingKeys: String, CodingKey {
+            case grantType = "grant_type"
+            case refreshToken = "refresh_token"
+        }
+
+        var grantType = "refresh_token"
+        let refreshToken: String
+
+        var contentForSignature: [(key: String, value: String?)] {
+            return [
+                (Self.CodingKeys.grantType.stringValue, self.grantType),
+                (Self.CodingKeys.refreshToken.stringValue, self.refreshToken)
+            ]
+        }
+    }
+
+}
+
+extension TokenRevocationOperation {
+
+    struct Body: Encodable, HTTPRequestBody {
+
+        // swiftlint:disable:next nesting
+        private enum CodingKeys: String, CodingKey {
+            case token = "token"
+            case tokenTypeHint = "token_type_hint"
+        }
+
+        let token: String
+        let tokenTypeHint: String
+
+        var contentForSignature: [(key: String, value: String?)] {
+            return [
+                (Self.CodingKeys.token.stringValue, self.token),
+                (Self.CodingKeys.tokenTypeHint.stringValue, self.tokenTypeHint)
+            ]
+        }
+
+    }
+
+}

--- a/Sources/Networking/Responses/IAMResponses.swift
+++ b/Sources/Networking/Responses/IAMResponses.swift
@@ -1,0 +1,16 @@
+//
+//  IAMResponses.swift
+//  RevenueCat
+//
+//  Created by Dave DeLong on 7/13/26.
+//
+
+import Foundation
+
+struct TokenResponse: Decodable, HTTPResponseBody {
+    let accessToken: String
+    let idToken: String?
+    let refreshToken: String?
+    let scope: String
+    let expiresIn: Int
+}

--- a/Sources/Networking/TokenAPI.swift
+++ b/Sources/Networking/TokenAPI.swift
@@ -1,0 +1,107 @@
+//
+//  TokenAPI.swift
+//  RevenueCat
+//
+//  Created by Dave DeLong on 7/13/26.
+//
+
+import Foundation
+
+class TokenAPI {
+    typealias TokenResult = Result<(TokenResponse, String), BackendError>
+    typealias TokenResponseHandler = (TokenResult) -> Void
+
+    private let tokenCallbacksCache: CallbackCache<TokenCallback>
+    private let revokeCallbacksCache: CallbackCache<TokenRevokeCallback>
+
+    private let tokenManager: TokenManager
+    private let backendConfig: BackendConfiguration
+
+    var enabled: Bool { tokenManager.enabled }
+
+    init(backendConfig: BackendConfiguration) {
+        self.backendConfig = backendConfig
+        self.tokenManager = backendConfig.httpClient.tokenManager
+        self.tokenCallbacksCache = CallbackCache<TokenCallback>()
+        self.revokeCallbacksCache = CallbackCache<TokenRevokeCallback>()
+    }
+
+    func logIn(currentAppUserID: String, identity: Identity, completion: @escaping TokenResponseHandler) {
+        let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
+                                                                appUserID: currentAppUserID)
+
+        let linkToID = tokenManager.idToken(for: currentAppUserID)
+        let factory = TokenLogInOperation.createFactory(configuration: config,
+                                                        token: identity.authToken,
+                                                        linkToIDToken: linkToID,
+                                                        tokenCallbackCache: self.tokenCallbacksCache)
+
+        let tokenCallback = TokenCallback(cacheKey: factory.cacheKey) { result in
+            if case .success(let (token, userID)) = result {
+                self.tokenManager.saveTokens(refreshToken: token.refreshToken,
+                                             accessToken: token.accessToken,
+                                             idToken: token.idToken,
+                                             for: userID)
+            }
+
+            completion(result)
+        }
+        let cacheStatus = self.tokenCallbacksCache.add(tokenCallback)
+
+        self.backendConfig.operationQueue.addCacheableOperation(with: factory, cacheStatus: cacheStatus)
+    }
+
+    func revokeTokens(for appUserID: String, completion: @escaping (BackendError?) -> Void) {
+        if let refreshToken = tokenManager.currentRefreshToken {
+            let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
+                                                                    appUserID: appUserID)
+
+            let factory = TokenRevocationOperation.createFactory(configuration: config,
+                                                                 refreshToken: refreshToken,
+                                                                 appUserID: appUserID,
+                                                                 callbackCache: self.revokeCallbacksCache)
+
+            let revokeCallback = TokenRevokeCallback(cacheKey: factory.cacheKey) { error in
+                if error == nil {
+                    self.tokenManager.deleteTokens(for: appUserID)
+                }
+                completion(error)
+            }
+            let cacheStatus = self.revokeCallbacksCache.add(revokeCallback)
+
+            self.backendConfig.operationQueue.addCacheableOperation(with: factory, cacheStatus: cacheStatus)
+        } else {
+            tokenManager.deleteTokens(for: appUserID)
+            completion(nil)
+        }
+    }
+
+    func revokeAccessTokens(for appUserID: String, completion: @escaping (BackendError?) -> Void) {
+        if let accessToken = tokenManager.currentAccessToken {
+            let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
+                                                                    appUserID: appUserID)
+
+            let factory = TokenRevocationOperation.createFactory(configuration: config,
+                                                                 accessToken: accessToken,
+                                                                 appUserID: appUserID,
+                                                                 callbackCache: self.revokeCallbacksCache)
+
+            let revokeCallback = TokenRevokeCallback(cacheKey: factory.cacheKey) { error in
+                if error == nil {
+                    self.tokenManager.deleteAccessToken(for: appUserID)
+                }
+                completion(error)
+            }
+            let cacheStatus = self.revokeCallbacksCache.add(revokeCallback)
+
+            self.backendConfig.operationQueue.addCacheableOperation(with: factory, cacheStatus: cacheStatus)
+        } else {
+            completion(nil)
+        }
+    }
+
+}
+
+// @unchecked because:
+// - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.
+extension TokenAPI: @unchecked Sendable {}

--- a/Tests/UnitTests/Authentication/AuthenticationTests.swift
+++ b/Tests/UnitTests/Authentication/AuthenticationTests.swift
@@ -184,6 +184,72 @@ class AuthenticationTests: TestCase {
         self.logger.verifyMessageWasLogged(Strings.identity.logging_in_with_static_string, level: .warn)
     }
 
+    // MARK: - logIn(using:completion:)
+
+    func testLogInUsingIdentityReturnsUnsupportedErrorWhenTokenManagerIsDisabled() {
+        let authentication = self.makeAuthentication(tokenManagerEnabled: false)
+
+        var receivedInfo: CustomerInfo?
+        var receivedError: PublicError?
+
+        authentication.logIn(using: .anonymous) { info, error in
+            receivedInfo = info
+            receivedError = error
+        }
+
+        expect(receivedInfo).to(beNil())
+        expect(receivedError).to(matchError(ErrorCode.unsupportedError))
+        expect(self.identityManager.invokedLogInWithIdentity) == false
+    }
+
+    func testLogInUsingIdentitySucceedsAndNotifiesInternalDelegate() throws {
+        let authentication = self.makeAuthentication(tokenManagerEnabled: true)
+        let expectedInfo = try CustomerInfo(data: Self.customerInfoData(originalAppUserId: "logged-in-user"))
+        self.identityManager.mockLogInWithIdentityResult = .success((expectedInfo, false))
+
+        var receivedInfo: CustomerInfo?
+        var receivedError: PublicError?
+
+        authentication.logIn(using: .anonymous) { info, error in
+            receivedInfo = info
+            receivedError = error
+        }
+
+        expect(receivedInfo) == expectedInfo
+        expect(receivedError).to(beNil())
+        expect(self.identityManager.invokedLogInWithIdentityCount) == 1
+        expect(self.identityManager.invokedLogInWithIdentityParametersList.first?.identitySource) == .anonymous
+        expect(self.internalDelegate.invokedAuthenticatorDidLogIn) == true
+    }
+
+    func testLogInUsingIdentityFailureDoesNotNotifyInternalDelegate() {
+        let authentication = self.makeAuthentication(tokenManagerEnabled: true)
+        let backendError = BackendError.networkError(.offlineConnection())
+        self.identityManager.mockLogInWithIdentityResult = .failure(backendError)
+
+        var receivedInfo: CustomerInfo?
+        var receivedError: PublicError?
+
+        authentication.logIn(using: .anonymous) { info, error in
+            receivedInfo = info
+            receivedError = error
+        }
+
+        expect(receivedInfo).to(beNil())
+        expect(receivedError).to(matchError(backendError.asPurchasesError))
+        expect(self.internalDelegate.invokedAuthenticatorDidLogIn) == false
+    }
+
+    func testLogInUsingIdentityPassesTheProvidedIdentityToTheIdentityManager() {
+        let authentication = self.makeAuthentication(tokenManagerEnabled: true)
+        self.identityManager.mockLogInWithIdentityResult = .failure(.missingAppUserID())
+
+        authentication.logIn(using: .signInWithApple(Data("identity-token".utf8))) { _, _ in }
+
+        expect(self.identityManager.invokedLogInWithIdentityParametersList.first?.identitySource)
+            == .signInWithApple
+    }
+
     // MARK: - logOut(completion:)
 
     func testLogOutCallsLogOutWithUserInitiatedTrueAndForwardsResult() throws {

--- a/Tests/UnitTests/Identity/IdentityManagerTests.swift
+++ b/Tests/UnitTests/Identity/IdentityManagerTests.swift
@@ -6,7 +6,7 @@
 import Nimble
 import XCTest
 
-@testable @_spi(Internal) import RevenueCat
+@testable @_spi(Internal) @_spi(Experimental) import RevenueCat
 
 class IdentityManagerTests: TestCase {
 
@@ -17,6 +17,7 @@ class IdentityManagerTests: TestCase {
     private var mockAttributeSyncing: MockAttributeSyncing!
 
     private var mockIdentityAPI: MockIdentityAPI!
+    private var mockTokenAPI: MockTokenAPI!
     private var mockCustomerInfo: CustomerInfo!
     private var mockSystemInfo: MockSystemInfo!
 
@@ -35,6 +36,7 @@ class IdentityManagerTests: TestCase {
         try super.setUpWithError()
 
         self.mockIdentityAPI = try XCTUnwrap(mockBackend.identity as? MockIdentityAPI)
+        self.mockTokenAPI = try XCTUnwrap(mockBackend.token as? MockTokenAPI)
         self.mockCustomerInfo = .emptyInfo
 
         self.mockSystemInfo = MockSystemInfo(finishTransactions: false)
@@ -429,6 +431,201 @@ class IdentityManagerTests: TestCase {
         }
 
         expect(self.mockDeviceCache.invokedCopySubscriberAttributes) == false
+    }
+
+    // MARK: - LogIn with Identity (IAM)
+
+    func testLogInWithIdentityFailsInUIPreviewMode() {
+        let dangerousSettings = DangerousSettings(uiPreviewMode: true)
+        self.mockSystemInfo = MockSystemInfo(
+            platformInfo: nil,
+            finishTransactions: false,
+            dangerousSettings: dangerousSettings
+        )
+        let manager = create(appUserID: nil)
+
+        let receivedResult = waitUntilValue { completed in
+            manager.logIn(identity: .anonymous, completion: completed)
+        }
+
+        expect(receivedResult?.error) == .unsupportedInUIPreviewMode()
+        expect(self.mockTokenAPI.invokedLogIn) == false
+    }
+
+    func testLogInWithIdentitySyncsAttributes() {
+        let manager = self.create(appUserID: "old_user")
+
+        manager.logIn(identity: .anonymous) { _ in }
+
+        expect(self.mockAttributeSyncing.invokedSyncAttributesUserIDs) == ["old_user"]
+    }
+
+    func testLogInWithIdentityCallsTokenAPILoginWithTheCurrentAppUserID() {
+        let manager = self.create(appUserID: nil)
+        self.mockDeviceCache.stubbedAppUserID = "old_user"
+        self.mockTokenAPI.stubbedLogInCompletionResult = .failure(.missingAppUserID())
+
+        waitUntil { completed in
+            manager.logIn(identity: .anonymous) { _ in completed() }
+        }
+
+        expect(self.mockTokenAPI.invokedLogInCount) == 1
+        expect(self.mockTokenAPI.invokedLogInParameters?.currentAppUserID) == "old_user"
+    }
+
+    func testLogInWithIdentityPassesTokenAPIErrors() {
+        let manager = self.create(appUserID: nil)
+        self.mockDeviceCache.stubbedAppUserID = "old_user"
+        let stubbedError: BackendError = .missingAppUserID()
+        self.mockTokenAPI.stubbedLogInCompletionResult = .failure(stubbedError)
+
+        let receivedResult = waitUntilValue { completed in
+            manager.logIn(identity: .anonymous, completion: completed)
+        }
+
+        expect(receivedResult?.error) == stubbedError
+        expect(self.mockDeviceCache.invokedClearCachesForAppUserID) == false
+    }
+
+    func testLogInWithIdentityClearsCachesAndFetchesCustomerInfoOnSuccess() {
+        let manager = self.create(appUserID: nil)
+        self.mockDeviceCache.stubbedAppUserID = "old_user"
+        let tokenResponse = TokenResponse(accessToken: "access-token",
+                                          idToken: "id-token",
+                                          refreshToken: "refresh-token",
+                                          scope: "openid offline_access",
+                                          expiresIn: 3600)
+        self.mockTokenAPI.stubbedLogInCompletionResult = .success((tokenResponse, "new_user_id"))
+        self.mockCustomerInfoManager.stubbedCustomerInfoResult = .success(mockCustomerInfo)
+
+        let receivedResult = waitUntilValue { completed in
+            manager.logIn(identity: .anonymous, completion: completed)
+        }
+
+        expect(receivedResult?.value?.info) == mockCustomerInfo
+        expect(self.mockDeviceCache.invokedClearCachesForAppUserID) == true
+        expect(self.mockCustomerInfoManager.invokedCustomerInfoParameters?.appUserID) == "new_user_id"
+    }
+
+    func testLogInWithIdentityCopiesAttributesToNewUserIfPreviousUserWasAnonymous() {
+        let manager = self.create(appUserID: nil)
+        let anonymousUserID = manager.currentAppUserID
+        let tokenResponse = TokenResponse(accessToken: "access-token",
+                                          idToken: nil,
+                                          refreshToken: "refresh-token",
+                                          scope: "openid offline_access",
+                                          expiresIn: 3600)
+        self.mockTokenAPI.stubbedLogInCompletionResult = .success((tokenResponse, "new_user_id"))
+        self.mockCustomerInfoManager.stubbedCustomerInfoResult = .success(mockCustomerInfo)
+
+        waitUntil { completed in
+            manager.logIn(identity: .anonymous) { _ in completed() }
+        }
+
+        expect(self.mockDeviceCache.invokedCopySubscriberAttributesCount) == 1
+        expect(self.mockDeviceCache.invokedCopySubscriberAttributesParameters?.oldAppUserID) == anonymousUserID
+        expect(self.mockDeviceCache.invokedCopySubscriberAttributesParameters?.newAppUserID) == "new_user_id"
+    }
+
+    // MARK: - RevokeCurrentAccessToken
+
+    func testRevokeCurrentAccessTokenFailsInUIPreviewMode() {
+        let dangerousSettings = DangerousSettings(uiPreviewMode: true)
+        self.mockSystemInfo = MockSystemInfo(
+            platformInfo: nil,
+            finishTransactions: false,
+            dangerousSettings: dangerousSettings
+        )
+        let manager = create(appUserID: "my_user_id")
+
+        let receivedError = waitUntilValue { completed in
+            manager.revokeCurrentAccessToken { error in completed(error as NSError?) }
+        }
+
+        expect(receivedError?.code) == ErrorCode.unsupportedError.rawValue
+        expect(self.mockTokenAPI.invokedRevokeAccessTokens) == false
+    }
+
+    func testRevokeCurrentAccessTokenDoesNothingWhenTokenManagerIsDisabled() {
+        let manager = self.create(appUserID: nil)
+        self.mockDeviceCache.stubbedAppUserID = "myUser"
+
+        let receivedError = waitUntilValue { completed in
+            manager.revokeCurrentAccessToken(completion: completed)
+        }
+
+        expect(receivedError).to(beNil())
+        expect(self.mockTokenAPI.invokedRevokeAccessTokens) == false
+    }
+
+    func testRevokeCurrentAccessTokenCallsTokenAPIWhenTokenManagerIsEnabled() {
+        self.mockTokenManager = MockTokenManager(enabled: true)
+        let manager = self.create(appUserID: nil)
+        self.mockDeviceCache.stubbedAppUserID = "myUser"
+
+        let receivedError = waitUntilValue { completed in
+            manager.revokeCurrentAccessToken(completion: completed)
+        }
+
+        expect(receivedError).to(beNil())
+        expect(self.mockTokenAPI.invokedRevokeAccessTokensCount) == 1
+        expect(self.mockTokenAPI.invokedRevokeAccessTokensParametersList) == ["myUser"]
+    }
+
+    func testRevokeCurrentAccessTokenPassesThroughTokenAPIErrors() {
+        self.mockTokenManager = MockTokenManager(enabled: true)
+        let manager = self.create(appUserID: nil)
+        self.mockDeviceCache.stubbedAppUserID = "myUser"
+        self.mockTokenAPI.stubbedRevokeAccessTokensResult = .missingAppUserID()
+
+        let receivedError = waitUntilValue { completed in
+            manager.revokeCurrentAccessToken { error in completed(error as NSError?) }
+        }
+
+        expect(receivedError?.code) == ErrorCode.invalidAppUserIdError.rawValue
+    }
+
+    // MARK: - LogOut with IAM enabled
+
+    func testLogOutDoesNotRevokeTokensWhenTokenManagerIsDisabled() {
+        let manager = self.create(appUserID: nil)
+        self.mockDeviceCache.stubbedAppUserID = "myUser"
+
+        waitUntil { completed in
+            manager.logOut { _ in completed() }
+        }
+
+        expect(self.mockTokenAPI.invokedRevokeTokens) == false
+    }
+
+    func testLogOutRevokesTokensForTheCurrentUserWhenTokenManagerIsEnabled() {
+        self.mockTokenManager = MockTokenManager(enabled: true)
+        let manager = self.create(appUserID: nil)
+        self.mockDeviceCache.stubbedAppUserID = "myUser"
+        // Short-circuits `performLogOut`/`performLogIn` so this test only exercises the revocation call.
+        self.mockTokenAPI.stubbedRevokeTokensResult = .missingAppUserID()
+
+        waitUntil { completed in
+            manager.logOut { _ in completed() }
+        }
+
+        expect(self.mockTokenAPI.invokedRevokeTokensCount) == 1
+        expect(self.mockTokenAPI.invokedRevokeTokensParametersList) == ["myUser"]
+    }
+
+    func testLogOutPassesThroughTokenRevocationErrorsWithoutLoggingOut() {
+        self.mockTokenManager = MockTokenManager(enabled: true)
+        let manager = self.create(appUserID: nil)
+        self.mockDeviceCache.stubbedAppUserID = "myUser"
+        self.mockTokenAPI.stubbedRevokeTokensResult = .missingAppUserID()
+
+        let receivedError = waitUntilValue { completed in
+            manager.logOut { error in completed(error as NSError?) }
+        }
+
+        expect(receivedError?.code) == ErrorCode.invalidAppUserIdError.rawValue
+        // The cache was not reset for a new (anonymous) user because revocation failed.
+        expect(self.mockDeviceCache.invokedClearCachesForAppUserID) == false
     }
 
     // MARK: - Switch user

--- a/Tests/UnitTests/Mocks/MockBackend.swift
+++ b/Tests/UnitTests/Mocks/MockBackend.swift
@@ -56,6 +56,7 @@ class MockBackend: Backend {
         self.init(backendConfig: backendConfig,
                   customerAPI: customer,
                   identityAPI: identity,
+                  tokenAPI: MockTokenAPI(backendConfig: backendConfig),
                   offeringsAPI: offerings,
                   webBillingAPI: webBilling,
                   offlineEntitlements: offlineEntitlements,

--- a/Tests/UnitTests/Mocks/MockIdentityManager.swift
+++ b/Tests/UnitTests/Mocks/MockIdentityManager.swift
@@ -3,7 +3,7 @@
 // Copyright (c) 2020 Purchases. All rights reserved.
 //
 
-@testable import RevenueCat
+@testable @_spi(Experimental) import RevenueCat
 
 class MockIdentityManager: IdentityManager {
 
@@ -65,6 +65,21 @@ class MockIdentityManager: IdentityManager {
         self.invokedLogInParametersList.append(appUserID)
 
         completion(self.mockLogInResult)
+    }
+
+    // MARK: - LogIn (Identity / IAM)
+
+    var mockLogInWithIdentityResult: IdentityAPI.LogInResponse!
+    var invokedLogInWithIdentity = false
+    var invokedLogInWithIdentityCount = 0
+    var invokedLogInWithIdentityParametersList: [Identity] = []
+
+    override func logIn(identity: Identity, completion: @escaping IdentityAPI.LogInResponseHandler) {
+        self.invokedLogInWithIdentity = true
+        self.invokedLogInWithIdentityCount += 1
+        self.invokedLogInWithIdentityParametersList.append(identity)
+
+        completion(self.mockLogInWithIdentityResult)
     }
 
     // MARK: - LogOut

--- a/Tests/UnitTests/Mocks/MockIdentityManager.swift
+++ b/Tests/UnitTests/Mocks/MockIdentityManager.swift
@@ -3,7 +3,7 @@
 // Copyright (c) 2020 Purchases. All rights reserved.
 //
 
-@testable @_spi(Experimental) import RevenueCat
+@testable @_spi(Internal) import RevenueCat
 
 class MockIdentityManager: IdentityManager {
 

--- a/Tests/UnitTests/Mocks/MockTokenAPI.swift
+++ b/Tests/UnitTests/Mocks/MockTokenAPI.swift
@@ -12,7 +12,7 @@
 //  Created by RevenueCat on 8/18/26.
 
 import Foundation
-@testable @_spi(Experimental) import RevenueCat
+@testable @_spi(Internal) import RevenueCat
 
 class MockTokenAPI: TokenAPI {
 

--- a/Tests/UnitTests/Mocks/MockTokenAPI.swift
+++ b/Tests/UnitTests/Mocks/MockTokenAPI.swift
@@ -1,0 +1,71 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MockTokenAPI.swift
+//
+//  Created by RevenueCat on 8/18/26.
+
+import Foundation
+@testable @_spi(Experimental) import RevenueCat
+
+class MockTokenAPI: TokenAPI {
+
+    public convenience init() {
+        self.init(backendConfig: MockBackendConfiguration())
+    }
+
+    // MARK: - logIn(currentAppUserID:identity:completion:)
+
+    var invokedLogIn = false
+    var invokedLogInCount = 0
+    var invokedLogInParameters: (currentAppUserID: String, identity: Identity)?
+    var invokedLogInParametersList: [(currentAppUserID: String, identity: Identity)] = []
+    var stubbedLogInCompletionResult: TokenResult?
+
+    override func logIn(currentAppUserID: String, identity: Identity, completion: @escaping TokenResponseHandler) {
+        invokedLogIn = true
+        invokedLogInCount += 1
+        invokedLogInParameters = (currentAppUserID, identity)
+        invokedLogInParametersList.append((currentAppUserID, identity))
+        if let result = stubbedLogInCompletionResult {
+            completion(result)
+        }
+    }
+
+    // MARK: - revokeTokens(for:completion:)
+
+    var invokedRevokeTokens = false
+    var invokedRevokeTokensCount = 0
+    var invokedRevokeTokensParametersList: [String] = []
+    var stubbedRevokeTokensResult: BackendError?
+
+    override func revokeTokens(for appUserID: String, completion: @escaping (BackendError?) -> Void) {
+        invokedRevokeTokens = true
+        invokedRevokeTokensCount += 1
+        invokedRevokeTokensParametersList.append(appUserID)
+        completion(stubbedRevokeTokensResult)
+    }
+
+    // MARK: - revokeAccessTokens(for:completion:)
+
+    var invokedRevokeAccessTokens = false
+    var invokedRevokeAccessTokensCount = 0
+    var invokedRevokeAccessTokensParametersList: [String] = []
+    var stubbedRevokeAccessTokensResult: BackendError?
+
+    override func revokeAccessTokens(for appUserID: String, completion: @escaping (BackendError?) -> Void) {
+        invokedRevokeAccessTokens = true
+        invokedRevokeAccessTokensCount += 1
+        invokedRevokeAccessTokensParametersList.append(appUserID)
+        completion(stubbedRevokeAccessTokensResult)
+    }
+
+}
+
+extension MockTokenAPI: @unchecked Sendable {}

--- a/Tests/UnitTests/Networking/Backend/BackendTokenLoginTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendTokenLoginTests.swift
@@ -1,0 +1,218 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  BackendTokenLoginTests.swift
+//
+//  Created by RevenueCat on 8/18/26.
+
+import Foundation
+import Nimble
+import XCTest
+
+@testable @_spi(Experimental) import RevenueCat
+
+class BaseBackendTokenLoginTests: BaseBackendTests {
+
+    override func createClient() -> MockHTTPClient {
+        super.createClient(#file)
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        // These tests assert on the decoded response/request bodies directly, and there's no
+        // recorded snapshot fixture for the new token endpoints.
+        self.httpClient.disableSnapshotTesting()
+    }
+
+}
+
+class BackendTokenLoginTests: BaseBackendTokenLoginTests {
+
+    func testLoginFailsWithoutANetworkCallWhenTheIdentityTokenIsInvalid() {
+        // An empty token payload fails `IdentityAuthToken.validate()` before any request is made.
+        let receivedResult = waitUntilValue { completed in
+            self.token.logIn(currentAppUserID: "old-user", identity: .signInWithApple(Data()), completion: completed)
+        }
+
+        expect(receivedResult?.error) == .invalidAuthorizationToken()
+        expect(self.httpClient.calls).to(beEmpty())
+    }
+
+    func testLoginPassesNetworkErrorIfCouldntCommunicate() {
+        let stubbedError: NetworkError = .unexpectedResponse(nil)
+        self.mockTokenLoginRequest(error: stubbedError)
+
+        let receivedResult = waitUntilValue { completed in
+            self.token.logIn(currentAppUserID: "old-user", identity: .anonymous, completion: completed)
+        }
+
+        expect(receivedResult?.error) == .networkError(stubbedError)
+    }
+
+    func testLoginFailsWhenTheAccessTokenIsNotAValidJWT() {
+        self.mockTokenLoginRequest(response: [
+            "access_token": "not-a-jwt",
+            "scope": "openid offline_access",
+            "expires_in": 3600
+        ])
+
+        let receivedResult = waitUntilValue { completed in
+            self.token.logIn(currentAppUserID: "old-user", identity: .anonymous, completion: completed)
+        }
+
+        expect(receivedResult?.error) == .unexpectedBackendResponse(.loginResponseDecoding)
+    }
+
+    func testLoginFailsWhenTheAccessTokenJWTIsMissingTheAppUserIDClaim() throws {
+        let accessToken = try Self.makeAccessToken(appUserID: nil, extraClaims: ["sub": "abc"])
+        self.mockTokenLoginRequest(response: [
+            "access_token": accessToken,
+            "scope": "openid offline_access",
+            "expires_in": 3600
+        ])
+
+        let receivedResult = waitUntilValue { completed in
+            self.token.logIn(currentAppUserID: "old-user", identity: .anonymous, completion: completed)
+        }
+
+        expect(receivedResult?.error) == .unexpectedBackendResponse(.loginResponseDecoding,
+                                                                    extraContext: "JWT missing RC user ID")
+    }
+
+    func testLoginSucceedsAndSavesTokensForAnAnonymousIdentity() throws {
+        let accessToken = try Self.makeAccessToken(appUserID: "rc-user-id")
+        self.mockTokenLoginRequest(response: [
+            "access_token": accessToken,
+            "refresh_token": "refresh-token-value",
+            "id_token": "id-token-value",
+            "scope": "openid offline_access",
+            "expires_in": 3600
+        ])
+
+        let receivedResult = waitUntilValue { completed in
+            self.token.logIn(currentAppUserID: "old-user", identity: .anonymous, completion: completed)
+        }
+
+        expect(receivedResult?.value?.1) == "rc-user-id"
+        expect(receivedResult?.value?.0.accessToken) == accessToken
+
+        let tokenManager = try XCTUnwrap(self.httpClient.tokenManager as? MockTokenManager)
+        expect(tokenManager.invokedSaveTokens) == true
+        expect(tokenManager.invokedSaveTokensParametersList.last?.userID) == "rc-user-id"
+        expect(tokenManager.invokedSaveTokensParametersList.last?.accessToken) == accessToken
+        expect(tokenManager.invokedSaveTokensParametersList.last?.refreshToken) == "refresh-token-value"
+        expect(tokenManager.invokedSaveTokensParametersList.last?.idToken) == "id-token-value"
+    }
+
+    func testLoginDoesNotSaveTokensWhenItFails() {
+        self.mockTokenLoginRequest(error: .unexpectedResponse(nil))
+
+        waitUntil { completed in
+            self.token.logIn(currentAppUserID: "old-user", identity: .anonymous) { _ in completed() }
+        }
+
+        let tokenManager = self.httpClient.tokenManager as? MockTokenManager
+        expect(tokenManager?.invokedSaveTokens) == false
+    }
+
+    func testLoginIncludesTheLinkToIDTokenFromThePreviousUser() throws {
+        let tokenManager = try XCTUnwrap(self.httpClient.tokenManager as? MockTokenManager)
+        tokenManager.stubbedIDToken = "existing-id-token"
+
+        let accessToken = try Self.makeAccessToken(appUserID: "rc-user-id")
+        self.mockTokenLoginRequest(response: [
+            "access_token": accessToken,
+            "scope": "openid offline_access",
+            "expires_in": 3600
+        ])
+
+        waitUntil { completed in
+            self.token.logIn(currentAppUserID: "old-user",
+                             identity: .signInWithApple(Data("apple-identity-token".utf8))) { _ in completed() }
+        }
+
+        expect(tokenManager.invokedIDTokenForParametersList) == ["old-user"]
+
+        let body = try XCTUnwrap(self.httpClient.calls.last?.request.requestBody as? TokenLogInOperation.StandardBody)
+        expect(body.method) == "apple"
+        expect(body.linkToID) == "existing-id-token"
+    }
+
+    func testLoginCachesForTheSameIdentityAndCurrentAppUserID() throws {
+        let accessToken = try Self.makeAccessToken(appUserID: "rc-user-id")
+        self.mockTokenLoginRequest(response: [
+            "access_token": accessToken,
+            "scope": "openid offline_access",
+            "expires_in": 3600
+        ])
+
+        self.token.logIn(currentAppUserID: "old-user", identity: .anonymous) { _ in }
+        self.token.logIn(currentAppUserID: "old-user", identity: .anonymous) { _ in }
+
+        expect(self.httpClient.calls).toEventually(haveCount(1))
+    }
+
+    func testLoginDoesNotCacheForDifferentIdentityTokens() throws {
+        let accessToken = try Self.makeAccessToken(appUserID: "rc-user-id")
+        self.mockTokenLoginRequest(response: [
+            "access_token": accessToken,
+            "scope": "openid offline_access",
+            "expires_in": 3600
+        ])
+
+        self.token.logIn(currentAppUserID: "old-user",
+                         identity: .signInWithApple(Data("token-a".utf8))) { _ in }
+        self.token.logIn(currentAppUserID: "old-user",
+                         identity: .signInWithApple(Data("token-b".utf8))) { _ in }
+
+        expect(self.httpClient.calls).toEventually(haveCount(2))
+    }
+
+}
+
+private extension BaseBackendTokenLoginTests {
+
+    func mockTokenLoginRequest(response: [String: Any], statusCode: HTTPStatusCode = .success) {
+        let mockResponse = MockHTTPClient.Response(statusCode: statusCode, response: response)
+        self.httpClient.mock(requestPath: .tokenLogin, response: mockResponse)
+    }
+
+    func mockTokenLoginRequest(error: NetworkError) {
+        self.httpClient.mock(requestPath: .tokenLogin, response: .init(error: error))
+    }
+
+    /// Builds an unsigned (`alg: "none"`) JWT string, suitable for exercising `TokenLogInOperation`'s
+    /// response handling, which doesn't validate the JWT's signature.
+    static func makeAccessToken(appUserID: String?, extraClaims: [String: Any] = [:]) throws -> String {
+        var payload = extraClaims
+        if let appUserID {
+            payload["rc.app_user_id"] = appUserID
+        }
+        return try Self.makeToken(header: ["alg": "none", "typ": "JWT"], payload: payload)
+    }
+
+    static func makeToken(header: [String: Any], payload: [String: Any]) throws -> String {
+        let headerData = try JSONSerialization.data(withJSONObject: header)
+        let payloadData = try JSONSerialization.data(withJSONObject: payload)
+        let signatureData = try XCTUnwrap("signature-bytes".data(using: .utf8))
+
+        return [headerData, payloadData, signatureData]
+            .map { Self.base64URLString(from: $0) }
+            .joined(separator: ".")
+    }
+
+    static func base64URLString(from data: Data) -> String {
+        return data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+}

--- a/Tests/UnitTests/Networking/Backend/BackendTokenLoginTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendTokenLoginTests.swift
@@ -15,7 +15,7 @@ import Foundation
 import Nimble
 import XCTest
 
-@testable @_spi(Experimental) import RevenueCat
+@testable @_spi(Internal) import RevenueCat
 
 class BaseBackendTokenLoginTests: BaseBackendTests {
 

--- a/Tests/UnitTests/Networking/Backend/BackendTokenRevocationTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendTokenRevocationTests.swift
@@ -1,0 +1,130 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  BackendTokenRevocationTests.swift
+//
+//  Created by RevenueCat on 8/18/26.
+
+import Foundation
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+class BaseBackendTokenRevocationTests: BaseBackendTests {
+
+    override func createClient() -> MockHTTPClient {
+        super.createClient(#file)
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        // These tests assert on the decoded request bodies directly, and there's no recorded
+        // snapshot fixture for the new token endpoints.
+        self.httpClient.disableSnapshotTesting()
+    }
+
+    var tokenManager: MockTokenManager {
+        // swiftlint:disable:next force_cast
+        return self.httpClient.tokenManager as! MockTokenManager
+    }
+
+}
+
+class BackendTokenRevocationTests: BaseBackendTokenRevocationTests {
+
+    // MARK: - revokeTokens(for:completion:)
+
+    func testRevokeTokensDeletesLocallyWithoutANetworkCallWhenThereIsNoRefreshToken() {
+        self.tokenManager.stubbedCurrentRefreshToken = nil
+
+        let receivedError = waitUntilValue { completed in
+            self.token.revokeTokens(for: "user-id", completion: completed)
+        }
+
+        expect(receivedError).to(beNil())
+        expect(self.httpClient.calls).to(beEmpty())
+        expect(self.tokenManager.invokedDeleteTokensParametersList) == ["user-id"]
+    }
+
+    func testRevokeTokensSendsTheRefreshTokenAndDeletesLocalTokensOnSuccess() throws {
+        self.tokenManager.stubbedCurrentRefreshToken = "refresh-token-value"
+        self.httpClient.mock(requestPath: .tokenLogOut, response: .init(statusCode: .success))
+
+        let receivedError = waitUntilValue { completed in
+            self.token.revokeTokens(for: "user-id", completion: completed)
+        }
+
+        expect(receivedError).to(beNil())
+        expect(self.httpClient.calls).to(haveCount(1))
+        expect(self.tokenManager.invokedDeleteTokensParametersList) == ["user-id"]
+
+        let body = try XCTUnwrap(self.httpClient.calls.first?.request.requestBody as? TokenRevocationOperation.Body)
+        expect(body.token) == "refresh-token-value"
+        expect(body.tokenTypeHint) == "refresh_token"
+    }
+
+    func testRevokeTokensPassesNetworkErrorsAndDoesNotDeleteLocalTokens() {
+        self.tokenManager.stubbedCurrentRefreshToken = "refresh-token-value"
+        let stubbedError: NetworkError = .unexpectedResponse(nil)
+        self.httpClient.mock(requestPath: .tokenLogOut, response: .init(error: stubbedError))
+
+        let receivedError = waitUntilValue { completed in
+            self.token.revokeTokens(for: "user-id", completion: completed)
+        }
+
+        expect(receivedError) == .networkError(stubbedError)
+        expect(self.tokenManager.invokedDeleteTokens) == false
+    }
+
+    // MARK: - revokeAccessTokens(for:completion:)
+
+    func testRevokeAccessTokensDoesNothingWithoutANetworkCallWhenThereIsNoAccessToken() {
+        self.tokenManager.stubbedCurrentAccessToken = nil
+
+        let receivedError = waitUntilValue { completed in
+            self.token.revokeAccessTokens(for: "user-id", completion: completed)
+        }
+
+        expect(receivedError).to(beNil())
+        expect(self.httpClient.calls).to(beEmpty())
+        expect(self.tokenManager.invokedDeleteAccessToken) == false
+    }
+
+    func testRevokeAccessTokensSendsTheAccessTokenAndDeletesItLocallyOnSuccess() throws {
+        self.tokenManager.stubbedCurrentAccessToken = "access-token-value"
+        self.httpClient.mock(requestPath: .tokenLogOut, response: .init(statusCode: .success))
+
+        let receivedError = waitUntilValue { completed in
+            self.token.revokeAccessTokens(for: "user-id", completion: completed)
+        }
+
+        expect(receivedError).to(beNil())
+        expect(self.tokenManager.invokedDeleteAccessTokenParametersList) == ["user-id"]
+
+        let body = try XCTUnwrap(self.httpClient.calls.first?.request.requestBody as? TokenRevocationOperation.Body)
+        expect(body.token) == "access-token-value"
+        expect(body.tokenTypeHint) == "access_token"
+    }
+
+    func testRevokeAccessTokensPassesNetworkErrorsAndDoesNotDeleteItLocally() {
+        self.tokenManager.stubbedCurrentAccessToken = "access-token-value"
+        let stubbedError: NetworkError = .unexpectedResponse(nil)
+        self.httpClient.mock(requestPath: .tokenLogOut, response: .init(error: stubbedError))
+
+        let receivedError = waitUntilValue { completed in
+            self.token.revokeAccessTokens(for: "user-id", completion: completed)
+        }
+
+        expect(receivedError) == .networkError(stubbedError)
+        expect(self.tokenManager.invokedDeleteAccessToken) == false
+    }
+
+}

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -32,6 +32,7 @@ class BaseBackendTests: TestCase {
     private(set) var webBilling: WebBillingAPI!
     private(set) var offlineEntitlements: OfflineEntitlementsAPI!
     private(set) var identity: IdentityAPI!
+    private(set) var token: TokenAPI!
     private(set) var internalAPI: InternalAPI!
     private(set) var customerCenterConfig: CustomerCenterConfigAPI!
     private(set) var redeemWebPurchaseAPI: RedeemWebPurchaseAPI!
@@ -88,6 +89,7 @@ class BaseBackendTests: TestCase {
 
         let customer = CustomerAPI(backendConfig: backendConfig, attributionFetcher: attributionFetcher)
         self.identity = IdentityAPI(backendConfig: backendConfig)
+        self.token = TokenAPI(backendConfig: backendConfig)
         self.offerings = OfferingsAPI(backendConfig: backendConfig)
         self.webBilling = WebBillingAPI(backendConfig: backendConfig)
         self.offlineEntitlements = OfflineEntitlementsAPI(backendConfig: backendConfig)
@@ -101,6 +103,7 @@ class BaseBackendTests: TestCase {
         self.backend = Backend(backendConfig: backendConfig,
                                customerAPI: customer,
                                identityAPI: self.identity,
+                               tokenAPI: self.token,
                                offeringsAPI: self.offerings,
                                webBillingAPI: self.webBilling,
                                offlineEntitlements: self.offlineEntitlements,

--- a/Tests/UnitTests/Networking/BackendErrorCodeTests.swift
+++ b/Tests/UnitTests/Networking/BackendErrorCodeTests.swift
@@ -1,0 +1,49 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  BackendErrorCodeTests.swift
+//
+//  Created by RevenueCat on 8/18/26.
+
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+class BackendErrorCodeTests: TestCase {
+
+    // MARK: - invalidIAMToken
+
+    func testInvalidIAMTokenDecodesFromItsRawIntValue() {
+        expect(BackendErrorCode(code: 7981)) == .invalidIAMToken
+    }
+
+    func testInvalidIAMTokenDecodesFromItsRawStringValue() {
+        expect(BackendErrorCode(code: "7981")) == .invalidIAMToken
+    }
+
+    func testInvalidIAMTokenMapsToInvalidCredentialsError() {
+        expect(BackendErrorCode.invalidIAMToken.toPurchasesErrorCode()) == .invalidCredentialsError
+    }
+
+    // MARK: - cannotAliasToAuthenticatedUser
+
+    func testCannotAliasToAuthenticatedUserDecodesFromItsRawIntValue() {
+        expect(BackendErrorCode(code: 8077)) == .cannotAliasToAuthenticatedUser
+    }
+
+    func testCannotAliasToAuthenticatedUserDecodesFromItsRawStringValue() {
+        expect(BackendErrorCode(code: "8077")) == .cannotAliasToAuthenticatedUser
+    }
+
+    func testCannotAliasToAuthenticatedUserMapsToConfigurationError() {
+        expect(BackendErrorCode.cannotAliasToAuthenticatedUser.toPurchasesErrorCode()) == .configurationError
+    }
+
+}

--- a/Tests/UnitTests/Networking/BackendErrorTests.swift
+++ b/Tests/UnitTests/Networking/BackendErrorTests.swift
@@ -35,6 +35,12 @@ class BackendErrorTests: BaseErrorTests {
         verifyPurchasesError(error, expectedCode: .invalidAppUserIdError)
     }
 
+    func testInvalidAuthorizationToken() {
+        let error: BackendError = .invalidAuthorizationToken()
+
+        verifyPurchasesError(error, expectedCode: .invalidCredentialsError)
+    }
+
     func testEmptySubscriberAttributes() {
         let error: BackendError = .emptySubscriberAttributes()
 

--- a/Tests/UnitTests/Networking/BackendErrorTests.swift
+++ b/Tests/UnitTests/Networking/BackendErrorTests.swift
@@ -37,8 +37,19 @@ class BackendErrorTests: BaseErrorTests {
 
     func testInvalidAuthorizationToken() {
         let error: BackendError = .invalidAuthorizationToken()
+        // `.invalidAuthorizationToken` is mapped to
+        // `ErrorUtils.backendError(withBackendCode: .invalidAuthToken, originalBackendErrorCode: ...)`,
+        // which always attaches the `BackendErrorCode` itself as the underlying error, via
+        // `ErrorUtils.backendUnderlyingError`. Mirror that construction exactly here.
+        let underlyingError = BackendErrorCode.invalidAuthToken
+            .addingUserInfo([
+                NSLocalizedDescriptionKey as NSError.UserInfoKey: "",
+                .backendErrorCode: BackendErrorCode.invalidAuthToken.rawValue
+            ])
 
-        verifyPurchasesError(error, expectedCode: .invalidCredentialsError)
+        verifyPurchasesError(error,
+                             expectedCode: .invalidCredentialsError,
+                             underlyingError: underlyingError)
     }
 
     func testEmptySubscriberAttributes() {

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -497,6 +497,132 @@ class HTTPRequestTests: TestCase {
         expect(path.relativeIAMPath) == path.relativePath
     }
 
+    // MARK: - Token (IAM auth) paths
+
+    private static let tokenPaths: [HTTPRequest.Path] = [
+        .tokenLogin,
+        .tokenRefresh,
+        .tokenLogOut
+    ]
+
+    private static let expectedTokenPathComponents: [HTTPRequest.Path: String] = [
+        .tokenLogin: "/auth/login",
+        .tokenRefresh: "/auth/token",
+        .tokenLogOut: "/auth/revoke"
+    ]
+
+    private static let expectedTokenPathNames: [HTTPRequest.Path: String] = [
+        .tokenLogin: "token_login",
+        .tokenRefresh: "token_refresh",
+        .tokenLogOut: "token_logout"
+    ]
+
+    func testTokenPathsHaveALeadingSlashUnlikeOtherPaths() {
+        // Unlike the rest of `HTTPRequest.Path`, the token (IAM auth) endpoints live outside `/v1`,
+        // so their `pathComponent` includes its own leading slash.
+        for path in Self.tokenPaths {
+            expect(path.pathComponent).to(
+                beginWith("/"),
+                description: "Path '\(path)' should have a leading slash"
+            )
+        }
+    }
+
+    func testTokenPathComponentsMatchExpectedValues() {
+        for (path, expectedComponent) in Self.expectedTokenPathComponents {
+            expect(path.pathComponent) == expectedComponent
+        }
+    }
+
+    func testTokenPathsRelativePathIsNotPrefixedWithV1() {
+        // `relativePath` only prepends `/v1` when the `pathComponent` doesn't already have a
+        // leading slash, so the token endpoints' relative path is identical to their path component.
+        for (path, expectedComponent) in Self.expectedTokenPathComponents {
+            expect(path.relativePath) == expectedComponent
+        }
+    }
+
+    func testTokenPathsRelativeIAMPathMatchesRelativePath() {
+        for path in Self.tokenPaths {
+            expect(path.relativeIAMPath) == path.relativePath
+        }
+    }
+
+    func testTokenPathNamesMatchExpectedValues() {
+        for (path, expectedName) in Self.expectedTokenPathNames {
+            expect(path.name) == expectedName
+        }
+    }
+
+    func testTokenPathsAreAuthenticated() {
+        for path in Self.tokenPaths {
+            expect(path.authenticated).to(
+                beTrue(),
+                description: "Path '\(path)' should be authenticated"
+            )
+        }
+    }
+
+    func testTokenPathsSendETag() {
+        for path in Self.tokenPaths {
+            expect(path.shouldSendEtag).to(
+                beTrue(),
+                description: "Path '\(path)' should send etag"
+            )
+        }
+    }
+
+    func testTokenPathsDoNotSupportSignatureVerification() {
+        for path in Self.tokenPaths {
+            expect(path.supportsSignatureVerification).to(
+                beFalse(),
+                description: "Path '\(path)' should not support signature verification"
+            )
+        }
+    }
+
+    func testTokenPathsRequireNonceForSigning() {
+        for path in Self.tokenPaths {
+            expect(path.needsNonceForSigning).to(
+                beTrue(),
+                description: "Path '\(path)' should require a nonce for signing"
+            )
+        }
+    }
+
+    func testTokenPathsAreIAMPaths() {
+        for path in Self.tokenPaths {
+            expect(path.isIAMPath).to(
+                beTrue(),
+                description: "Path '\(path)' should be reported as an IAM path"
+            )
+        }
+    }
+
+    func testTokenPathsUseAPISources() {
+        for path in Self.tokenPaths {
+            expect(path.usesAPISources).to(beTrue(), description: "Path '\(path)' should use API sources")
+        }
+    }
+
+    func testTokenPathsHaveNoFallbackUrls() {
+        for path in Self.tokenPaths {
+            expect(path.fallbackUrls).to(beEmpty())
+        }
+    }
+
+    func testTokenLoginURLResolvesOutsideOfTheV1Namespace() {
+        let url = HTTPRequest.Path.tokenLogin.url(preferIAMPath: false)
+
+        expect(url?.absoluteString) == "https://api.revenuecat.com/auth/login"
+    }
+
+    func testTokenPathsURLIsTheSameRegardlessOfIAMPreference() {
+        for path in Self.tokenPaths {
+            expect(path.url(preferIAMPath: true)?.absoluteString) == path.url(preferIAMPath: false)?.absoluteString
+        }
+    }
+
     // MARK: - Bearer authorization header
 
     func testBearerAuthorizationValueIsNilWhenNoAuthorizationHeaderIsSet() {

--- a/Tests/UnitTests/Networking/TokenManagerTests.swift
+++ b/Tests/UnitTests/Networking/TokenManagerTests.swift
@@ -279,4 +279,142 @@ class TokenManagerTests: TestCase {
         expect(receivedError) == expectedError
     }
 
+    // MARK: - currentIdentitySources
+
+    func testCurrentIdentitySourcesIsNilWhenThereIsNoCurrentIDToken() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+
+        expect(manager.currentIdentitySources).to(beNil())
+    }
+
+    func testCurrentIdentitySourcesIsNilWhenTheIDTokenIsNotAValidJWT() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.currentIDToken = "not-a-jwt"
+
+        expect(manager.currentIdentitySources).to(beNil())
+    }
+
+    func testCurrentIdentitySourcesIsNilWhenTheAmrClaimIsMissing() throws {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.currentIDToken = try Self.makeIDToken(payload: ["sub": "abc"])
+
+        expect(manager.currentIdentitySources).to(beNil())
+    }
+
+    func testCurrentIdentitySourcesParsesKnownSourcesFromTheAmrClaim() throws {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.currentIDToken = try Self.makeIDToken(amr: ["oidc", "google"])
+
+        expect(manager.currentIdentitySources) == [.oidc, .google]
+    }
+
+    func testCurrentIdentitySourcesFiltersOutUnrecognizedAmrValues() throws {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.currentIDToken = try Self.makeIDToken(amr: ["some-unknown-value", "anonymous"])
+
+        expect(manager.currentIdentitySources) == [.anonymous]
+    }
+
+    func testCurrentIdentitySourcesIsEmptyArrayWhenAmrClaimIsEmpty() throws {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.currentIDToken = try Self.makeIDToken(amr: [])
+
+        expect(manager.currentIdentitySources) == []
+    }
+
+    // MARK: - isCurrentIdentityAnonymous
+
+    func testIsCurrentIdentityAnonymousIsFalseWhenThereAreNoIdentitySources() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+
+        expect(manager.isCurrentIdentityAnonymous) == false
+    }
+
+    func testIsCurrentIdentityAnonymousIsFalseWhenTheAmrClaimIsEmpty() throws {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.currentIDToken = try Self.makeIDToken(amr: [])
+
+        expect(manager.isCurrentIdentityAnonymous) == false
+    }
+
+    func testIsCurrentIdentityAnonymousIsTrueWhenEveryIdentitySourceIsAnonymous() throws {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.currentIDToken = try Self.makeIDToken(amr: ["anonymous", "anonymous"])
+
+        expect(manager.isCurrentIdentityAnonymous) == true
+    }
+
+    func testIsCurrentIdentityAnonymousIsFalseWhenAnyIdentitySourceIsNotAnonymous() throws {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.currentIDToken = try Self.makeIDToken(amr: ["anonymous", "oidc"])
+
+        expect(manager.isCurrentIdentityAnonymous) == false
+    }
+
+    // MARK: - currentIdentitySource
+
+    func testCurrentIdentitySourceIsNilWhenThereAreNoIdentitySources() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+
+        expect(manager.currentIdentitySource).to(beNil())
+    }
+
+    func testCurrentIdentitySourceIsNilWhenTheAmrClaimIsEmpty() throws {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.currentIDToken = try Self.makeIDToken(amr: [])
+
+        expect(manager.currentIdentitySource).to(beNil())
+    }
+
+    func testCurrentIdentitySourceReturnsTheLastIdentitySource() throws {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.currentIDToken = try Self.makeIDToken(amr: ["anonymous", "oidc"])
+
+        expect(manager.currentIdentitySource) == .oidc
+    }
+
+}
+
+private extension TokenManagerTests {
+
+    /// Builds an unsigned (`alg: "none"`) JWT string with the given payload, suitable for exercising
+    /// `TokenManager`'s ID-token-derived properties, which don't validate the JWT's signature.
+    static func makeIDToken(amr: [String]? = nil, payload: [String: Any] = [:]) throws -> String {
+        var payload = payload
+        if let amr {
+            payload["amr"] = amr
+        }
+        return try Self.makeToken(header: ["alg": "none", "typ": "JWT"], payload: payload)
+    }
+
+    static func makeToken(header: [String: Any], payload: [String: Any]) throws -> String {
+        let headerData = try JSONSerialization.data(withJSONObject: header)
+        let payloadData = try JSONSerialization.data(withJSONObject: payload)
+        let signatureData = try XCTUnwrap("signature-bytes".data(using: .utf8))
+
+        return [headerData, payloadData, signatureData]
+            .map { Self.base64URLString(from: $0) }
+            .joined(separator: ".")
+    }
+
+    static func base64URLString(from data: Data) -> String {
+        return data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
 }

--- a/Tests/UnitTests/Networking/TokenManagerTests.swift
+++ b/Tests/UnitTests/Networking/TokenManagerTests.swift
@@ -14,7 +14,7 @@
 import Nimble
 import XCTest
 
-@testable import RevenueCat
+@testable @_spi(Experimental) import RevenueCat
 
 class TokenManagerTests: TestCase {
 

--- a/Tests/UnitTests/Networking/TokenManagerTests.swift
+++ b/Tests/UnitTests/Networking/TokenManagerTests.swift
@@ -14,7 +14,7 @@
 import Nimble
 import XCTest
 
-@testable @_spi(Experimental) import RevenueCat
+@testable @_spi(Internal) import RevenueCat
 
 class TokenManagerTests: TestCase {
 

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -505,6 +505,7 @@ extension BasePurchasesTests {
                          mockAdsAPI: MockAdsAPI) {
             let customer = CustomerAPI(backendConfig: backendConfig, attributionFetcher: attributionFetcher)
             let identity = IdentityAPI(backendConfig: backendConfig)
+            let token = TokenAPI(backendConfig: backendConfig)
             let offerings = OfferingsAPI(backendConfig: backendConfig)
             let webBilling = WebBillingAPI(backendConfig: backendConfig)
             let offlineEntitlements = OfflineEntitlementsAPI(backendConfig: backendConfig)
@@ -517,6 +518,7 @@ extension BasePurchasesTests {
             self.init(backendConfig: backendConfig,
                       customerAPI: customer,
                       identityAPI: identity,
+                      tokenAPI: token,
                       offeringsAPI: offerings,
                       webBillingAPI: webBilling,
                       offlineEntitlements: offlineEntitlements,


### PR DESCRIPTION
This implements the logIn, logOut, and revoke functionality for IAM support. Tokens are retrieved and saved into the secure storage, but aren't applied to HTTP requests (that's the last PR).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication, identity linking, token storage, and logout/revocation. Incorrect token handling or identity linking could leak sessions or fail to log users out.
> 
> **Overview**
> Adds IAM token login/logout/revocation so the SDK can authenticate with identity tokens (anonymous, Apple, Google, OIDC, Facebook, Firebase), persist tokens in secure storage, and revoke them on logout. Tokens are stored but not yet attached to HTTP requests.
> 
> Public `Authentication.logIn(using:)` requires IAM enabled. `IdentityManager` now logs in via a new `TokenAPI` (`POST /auth/login`), links to the previous ID token when present, and on logout revokes refresh tokens (`POST /auth/revoke`) before resetting to a new anonymous identity. Access-token-only revocation is also supported.
> 
> Adds backend error mapping for invalid IAM tokens and aliasing to an authenticated user, plus identity-source helpers on `TokenManager` from the ID token `amr` claim.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 283f600dcee60001f5ae8602bc8dfe958b367772. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->