### PR TITLE
Inject and refresh IAM tokens

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -620,7 +620,6 @@
 		55DACE94302E2BBB005EE017 /* MockAuthenticationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE8D302E2BBB005EE017 /* MockAuthenticationDelegate.swift */; };
 		55DACE95302E2BBB005EE017 /* MockSecureItemStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE8F302E2BBB005EE017 /* MockSecureItemStorage.swift */; };
 		55DACE97302E320C005EE017 /* MockTokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE96302E320C005EE017 /* MockTokenManager.swift */; };
-		5B6786F455CB4A59F26BFA46 /* MockTokenAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A3DB72A2707F75F2BDC90D7 /* MockTokenAPI.swift */; };
 		55DACE98302E320C005EE017 /* MockTokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE96302E320C005EE017 /* MockTokenManager.swift */; };
 		55DACEAC302E837B005EE017 /* TokenManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACEAB302E837B005EE017 /* TokenManagerTests.swift */; };
 		55DACFD230366629005EE017 /* AuthenticationStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACFCC30366625005EE017 /* AuthenticationStrings.swift */; };
@@ -646,7 +645,6 @@
 		5733B18E27FF586A00EC2045 /* BackendError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733B18D27FF586A00EC2045 /* BackendError.swift */; };
 		5733B1A427FF9F8300EC2045 /* NetworkErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733B1A327FF9F8300EC2045 /* NetworkErrorTests.swift */; };
 		5733B1A827FFBCC800EC2045 /* BackendErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733B1A727FFBCC800EC2045 /* BackendErrorTests.swift */; };
-		DECC43B62EBDF0A4BD1D06EB /* BackendErrorCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C9437E0657539E96AADEFB /* BackendErrorCodeTests.swift */; };
 		5733B1AA27FFBCF900EC2045 /* BaseErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733B1A927FFBCF900EC2045 /* BaseErrorTests.swift */; };
 		5733D00928CFA7A4008638D8 /* MockPaymentQueueWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733D00828CFA7A4008638D8 /* MockPaymentQueueWrapper.swift */; };
 		5733D01128D00354008638D8 /* PromotionalOfferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733D01028D00354008638D8 /* PromotionalOfferTests.swift */; };
@@ -769,8 +767,6 @@
 		5796A38827D6B85900653165 /* BackendPostReceiptDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A38727D6B85900653165 /* BackendPostReceiptDataTests.swift */; };
 		5796A38A27D6B96300653165 /* BackendGetCustomerInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A38927D6B96300653165 /* BackendGetCustomerInfoTests.swift */; };
 		5796A38C27D6BA1600653165 /* BackendLoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A38B27D6BA1600653165 /* BackendLoginTests.swift */; };
-		603D49296E6E69D1D8E06EFE /* BackendTokenLoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64FEF3704AAACD669F3BF4E0 /* BackendTokenLoginTests.swift */; };
-		3333EEA00681B5A32D463CC9 /* BackendTokenRevocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E927212FE6045350AC196C1 /* BackendTokenRevocationTests.swift */; };
 		5796A39027D6BCD100653165 /* BackendGetIntroEligibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A38F27D6BCD100653165 /* BackendGetIntroEligibilityTests.swift */; };
 		5796A39427D6BD6900653165 /* BackendGetOfferingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A39327D6BD6900653165 /* BackendGetOfferingsTests.swift */; };
 		5796A39627D6BDAB00653165 /* BackendPostOfferForSigningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A39527D6BDAB00653165 /* BackendPostOfferForSigningTests.swift */; };
@@ -2366,7 +2362,6 @@
 		55DACE8E302E2BBB005EE017 /* MockInternalAuthenticatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInternalAuthenticatorDelegate.swift; sourceTree = "<group>"; };
 		55DACE8F302E2BBB005EE017 /* MockSecureItemStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSecureItemStorage.swift; sourceTree = "<group>"; };
 		55DACE96302E320C005EE017 /* MockTokenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTokenManager.swift; sourceTree = "<group>"; };
-		2A3DB72A2707F75F2BDC90D7 /* MockTokenAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTokenAPI.swift; sourceTree = "<group>"; };
 		55DACEAB302E837B005EE017 /* TokenManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenManagerTests.swift; sourceTree = "<group>"; };
 		55DACFCC30366625005EE017 /* AuthenticationStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationStrings.swift; sourceTree = "<group>"; };
 		55FCA85B959807F2D3DD175A /* TransactionReason.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TransactionReason.swift; sourceTree = "<group>"; };
@@ -2394,7 +2389,6 @@
 		5733B18D27FF586A00EC2045 /* BackendError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendError.swift; sourceTree = "<group>"; };
 		5733B1A327FF9F8300EC2045 /* NetworkErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorTests.swift; sourceTree = "<group>"; };
 		5733B1A727FFBCC800EC2045 /* BackendErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendErrorTests.swift; sourceTree = "<group>"; };
-		71C9437E0657539E96AADEFB /* BackendErrorCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendErrorCodeTests.swift; sourceTree = "<group>"; };
 		5733B1A927FFBCF900EC2045 /* BaseErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseErrorTests.swift; sourceTree = "<group>"; };
 		5733D00828CFA7A4008638D8 /* MockPaymentQueueWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPaymentQueueWrapper.swift; sourceTree = "<group>"; };
 		5733D01028D00354008638D8 /* PromotionalOfferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionalOfferTests.swift; sourceTree = "<group>"; };
@@ -2510,8 +2504,6 @@
 		5796A38727D6B85900653165 /* BackendPostReceiptDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendPostReceiptDataTests.swift; sourceTree = "<group>"; };
 		5796A38927D6B96300653165 /* BackendGetCustomerInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendGetCustomerInfoTests.swift; sourceTree = "<group>"; };
 		5796A38B27D6BA1600653165 /* BackendLoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendLoginTests.swift; sourceTree = "<group>"; };
-		64FEF3704AAACD669F3BF4E0 /* BackendTokenLoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendTokenLoginTests.swift; sourceTree = "<group>"; };
-		7E927212FE6045350AC196C1 /* BackendTokenRevocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendTokenRevocationTests.swift; sourceTree = "<group>"; };
 		5796A38F27D6BCD100653165 /* BackendGetIntroEligibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendGetIntroEligibilityTests.swift; sourceTree = "<group>"; };
 		5796A39327D6BD6900653165 /* BackendGetOfferingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendGetOfferingsTests.swift; sourceTree = "<group>"; };
 		5796A39527D6BDAB00653165 /* BackendPostOfferForSigningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendPostOfferForSigningTests.swift; sourceTree = "<group>"; };

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -620,6 +620,7 @@
 		55DACE94302E2BBB005EE017 /* MockAuthenticationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE8D302E2BBB005EE017 /* MockAuthenticationDelegate.swift */; };
 		55DACE95302E2BBB005EE017 /* MockSecureItemStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE8F302E2BBB005EE017 /* MockSecureItemStorage.swift */; };
 		55DACE97302E320C005EE017 /* MockTokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE96302E320C005EE017 /* MockTokenManager.swift */; };
+		5B6786F455CB4A59F26BFA46 /* MockTokenAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A3DB72A2707F75F2BDC90D7 /* MockTokenAPI.swift */; };
 		55DACE98302E320C005EE017 /* MockTokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACE96302E320C005EE017 /* MockTokenManager.swift */; };
 		55DACEAC302E837B005EE017 /* TokenManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACEAB302E837B005EE017 /* TokenManagerTests.swift */; };
 		55DACFD230366629005EE017 /* AuthenticationStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACFCC30366625005EE017 /* AuthenticationStrings.swift */; };
@@ -645,6 +646,7 @@
 		5733B18E27FF586A00EC2045 /* BackendError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733B18D27FF586A00EC2045 /* BackendError.swift */; };
 		5733B1A427FF9F8300EC2045 /* NetworkErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733B1A327FF9F8300EC2045 /* NetworkErrorTests.swift */; };
 		5733B1A827FFBCC800EC2045 /* BackendErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733B1A727FFBCC800EC2045 /* BackendErrorTests.swift */; };
+		DECC43B62EBDF0A4BD1D06EB /* BackendErrorCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C9437E0657539E96AADEFB /* BackendErrorCodeTests.swift */; };
 		5733B1AA27FFBCF900EC2045 /* BaseErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733B1A927FFBCF900EC2045 /* BaseErrorTests.swift */; };
 		5733D00928CFA7A4008638D8 /* MockPaymentQueueWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733D00828CFA7A4008638D8 /* MockPaymentQueueWrapper.swift */; };
 		5733D01128D00354008638D8 /* PromotionalOfferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733D01028D00354008638D8 /* PromotionalOfferTests.swift */; };
@@ -767,6 +769,8 @@
 		5796A38827D6B85900653165 /* BackendPostReceiptDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A38727D6B85900653165 /* BackendPostReceiptDataTests.swift */; };
 		5796A38A27D6B96300653165 /* BackendGetCustomerInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A38927D6B96300653165 /* BackendGetCustomerInfoTests.swift */; };
 		5796A38C27D6BA1600653165 /* BackendLoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A38B27D6BA1600653165 /* BackendLoginTests.swift */; };
+		603D49296E6E69D1D8E06EFE /* BackendTokenLoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64FEF3704AAACD669F3BF4E0 /* BackendTokenLoginTests.swift */; };
+		3333EEA00681B5A32D463CC9 /* BackendTokenRevocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E927212FE6045350AC196C1 /* BackendTokenRevocationTests.swift */; };
 		5796A39027D6BCD100653165 /* BackendGetIntroEligibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A38F27D6BCD100653165 /* BackendGetIntroEligibilityTests.swift */; };
 		5796A39427D6BD6900653165 /* BackendGetOfferingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A39327D6BD6900653165 /* BackendGetOfferingsTests.swift */; };
 		5796A39627D6BDAB00653165 /* BackendPostOfferForSigningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A39527D6BDAB00653165 /* BackendPostOfferForSigningTests.swift */; };
@@ -2362,6 +2366,7 @@
 		55DACE8E302E2BBB005EE017 /* MockInternalAuthenticatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInternalAuthenticatorDelegate.swift; sourceTree = "<group>"; };
 		55DACE8F302E2BBB005EE017 /* MockSecureItemStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSecureItemStorage.swift; sourceTree = "<group>"; };
 		55DACE96302E320C005EE017 /* MockTokenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTokenManager.swift; sourceTree = "<group>"; };
+		2A3DB72A2707F75F2BDC90D7 /* MockTokenAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTokenAPI.swift; sourceTree = "<group>"; };
 		55DACEAB302E837B005EE017 /* TokenManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenManagerTests.swift; sourceTree = "<group>"; };
 		55DACFCC30366625005EE017 /* AuthenticationStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationStrings.swift; sourceTree = "<group>"; };
 		55FCA85B959807F2D3DD175A /* TransactionReason.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TransactionReason.swift; sourceTree = "<group>"; };
@@ -2389,6 +2394,7 @@
 		5733B18D27FF586A00EC2045 /* BackendError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendError.swift; sourceTree = "<group>"; };
 		5733B1A327FF9F8300EC2045 /* NetworkErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorTests.swift; sourceTree = "<group>"; };
 		5733B1A727FFBCC800EC2045 /* BackendErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendErrorTests.swift; sourceTree = "<group>"; };
+		71C9437E0657539E96AADEFB /* BackendErrorCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendErrorCodeTests.swift; sourceTree = "<group>"; };
 		5733B1A927FFBCF900EC2045 /* BaseErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseErrorTests.swift; sourceTree = "<group>"; };
 		5733D00828CFA7A4008638D8 /* MockPaymentQueueWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPaymentQueueWrapper.swift; sourceTree = "<group>"; };
 		5733D01028D00354008638D8 /* PromotionalOfferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionalOfferTests.swift; sourceTree = "<group>"; };
@@ -2504,6 +2510,8 @@
 		5796A38727D6B85900653165 /* BackendPostReceiptDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendPostReceiptDataTests.swift; sourceTree = "<group>"; };
 		5796A38927D6B96300653165 /* BackendGetCustomerInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendGetCustomerInfoTests.swift; sourceTree = "<group>"; };
 		5796A38B27D6BA1600653165 /* BackendLoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendLoginTests.swift; sourceTree = "<group>"; };
+		64FEF3704AAACD669F3BF4E0 /* BackendTokenLoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendTokenLoginTests.swift; sourceTree = "<group>"; };
+		7E927212FE6045350AC196C1 /* BackendTokenRevocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendTokenRevocationTests.swift; sourceTree = "<group>"; };
 		5796A38F27D6BCD100653165 /* BackendGetIntroEligibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendGetIntroEligibilityTests.swift; sourceTree = "<group>"; };
 		5796A39327D6BD6900653165 /* BackendGetOfferingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendGetOfferingsTests.swift; sourceTree = "<group>"; };
 		5796A39527D6BDAB00653165 /* BackendPostOfferForSigningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendPostOfferForSigningTests.swift; sourceTree = "<group>"; };

--- a/Sources/Authentication/Authentication.swift
+++ b/Sources/Authentication/Authentication.swift
@@ -18,6 +18,15 @@ public protocol AuthenticationDelegate: NSObjectProtocol {
 
     /// The SDK encountered an unrecoverable authentication error while performing other operations
     ///
+    /// This method is invoked when an attempt to refresh the session tokens fails, and the error corresponds
+    /// to that error. Therefore, a single call into the SDK may result in *two* errors being reported. For example,
+    /// if a call to ``Purchases.customerInfo()`` attempts causes the SDK to refresh its session tokens
+    /// and that attempt fails, then this delegate method is invoked with the error from attempting to refresh
+    /// the tokens, and the overall call to `customerInfo()` reports that the overall operation failed.
+    ///
+    /// This method is *not* invoked when ``Authentication.logIn(using:)`` or
+    /// ``Authentication.logOut()`` fail, as both of those methods report any failures directly.
+    ///
     /// - Parameter error: The ``PublicError`` indicating why authentication has failed
     func authenticatorDidEncounterError(_ error: PublicError)
 }

--- a/Sources/Authentication/Authentication.swift
+++ b/Sources/Authentication/Authentication.swift
@@ -52,6 +52,8 @@ public final class Authentication: NSObject {
     /// to the delegate to prevent it from being unintentionally deallocated.
     @objc public weak var delegate: AuthenticationDelegate?
 
+    private let ongoingUserInitiatedRequestCount = Atomic(0)
+
     internal init(backend: Backend,
                   identityManager: IdentityManager,
                   tokenManager: TokenManager,
@@ -108,7 +110,10 @@ public final class Authentication: NSObject {
 
         let normalizedAppUserID = appUserID.trimmingWhitespacesAndNewLines
 
+        self.ongoingUserInitiatedRequestCount.increment()
         self.identityManager.logIn(appUserID: normalizedAppUserID) { result in
+            self.ongoingUserInitiatedRequestCount.decrement()
+            
             self.operationDispatcher.dispatchOnMainThread {
                 if case let .success(values) = result {
                     self.internalDelegate?.authenticatorDidLogIn(info: values.info)
@@ -184,6 +189,11 @@ public final class Authentication: NSObject {
 
     // MARK: - Internals
 
+    internal func logInIfNeeded(completion: ((CustomerInfo?, PublicError?) -> Void)? = nil) {
+        guard identityManager.needsIAMLogin else { return }
+        self.logIn(using: .anonymous, userInitiated: false, completion: completion)
+    }
+
     internal func logIn(using identity: Identity,
                         userInitiated: Bool,
                         completion: ((CustomerInfo?, PublicError?) -> Void)?) {
@@ -196,7 +206,10 @@ public final class Authentication: NSObject {
             return
         }
 
+        if userInitiated { self.ongoingUserInitiatedRequestCount.increment() }
         self.identityManager.logIn(identity: identity) { result in
+            if userInitiated { self.ongoingUserInitiatedRequestCount.decrement() }
+
             if let completion {
                 self.operationDispatcher.dispatchOnMainThread {
                     completion(result.value?.info, result.error?.asPublicError)
@@ -226,7 +239,10 @@ public final class Authentication: NSObject {
             return
         }
 
+        if userInitiated { self.ongoingUserInitiatedRequestCount.increment() }
         self.identityManager.logOut { error in
+            if userInitiated { self.ongoingUserInitiatedRequestCount.decrement() }
+
             if let error {
                 if let completion = completion {
                     self.operationDispatcher.dispatchOnMainThread {
@@ -256,6 +272,9 @@ public final class Authentication: NSObject {
 
     internal func reportAuthenticationError(_ error: PublicError) {
         guard let delegate else { return }
+
+        // if we currently have user initiated requests going, then skip reporting this error via the delegate
+        if self.ongoingUserInitiatedRequestCount.value > 0 { return }
 
         self.operationDispatcher.dispatchOnMainThread {
             delegate.authenticatorDidEncounterError(error)

--- a/Sources/Authentication/Authentication.swift
+++ b/Sources/Authentication/Authentication.swift
@@ -122,7 +122,7 @@ public final class Authentication: NSObject {
         self.ongoingUserInitiatedRequestCount.increment()
         self.identityManager.logIn(appUserID: normalizedAppUserID) { result in
             self.ongoingUserInitiatedRequestCount.decrement()
-            
+
             self.operationDispatcher.dispatchOnMainThread {
                 if case let .success(values) = result {
                     self.internalDelegate?.authenticatorDidLogIn(info: values.info)

--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -86,8 +86,16 @@ class IdentityManager: CurrentUserProvider {
 
         lazy var currentAppUserIDLooksAnonymous = Self.userIsAnonymous(userID)
         lazy var isLegacyAnonymousAppUserID = userID == self.deviceCache.cachedLegacyAppUserID
+        lazy var isAnonymousIdentity = tokenManager.isCurrentIdentityAnonymous
 
-        return currentAppUserIDLooksAnonymous || isLegacyAnonymousAppUserID
+        return currentAppUserIDLooksAnonymous || isLegacyAnonymousAppUserID || isAnonymousIdentity
+    }
+
+    var needsIAMLogin: Bool {
+        guard tokenManager.enabled else { return false }
+        guard currentUserIsAnonymous else { return false }
+        if tokenManager.hasCurrentAccessToken { return false }
+        return true
     }
 
     func logIn(appUserID: String, completion: @escaping IdentityAPI.LogInResponseHandler) {

--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -118,11 +118,6 @@ class IdentityManager: CurrentUserProvider {
             return
         }
 
-        if self.currentUserIsAnonymous {
-            completion(ErrorUtils.logOutAnonymousUserError())
-            return
-        }
-
         self.attributeSyncing.syncSubscriberAttributes(currentAppUserID: self.currentAppUserID) {
             if self.tokenManager.enabled {
                 self.performTokenRevocation(for: self.currentAppUserID, completion: completion)
@@ -249,6 +244,11 @@ private extension IdentityManager {
 
     func performLogOut(completion: @escaping (PurchasesError?) -> Void) {
         Logger.info(Strings.identity.log_out_called_for_user)
+
+        if self.currentUserIsAnonymous {
+            completion(ErrorUtils.logOutAnonymousUserError())
+            return
+        }
 
         let newUserID = Self.generateRandomID()
         self.resetCacheAndSave(newUserID: newUserID)

--- a/Sources/Logging/Strings/NetworkStrings.swift
+++ b/Sources/Logging/Strings/NetworkStrings.swift
@@ -40,6 +40,7 @@ enum NetworkStrings {
     case parsing_json_error(error: Error)
     case serial_request_done(httpMethod: String?, path: String?, queuedRequestsCount: Int)
     case serial_request_queued(httpMethod: String, path: String, queuedRequestsCount: Int)
+    case serial_request_paused(httpMethod: String, path: String)
     case starting_next_request(request: String)
     case starting_request(httpMethod: String, path: String)
     case retrying_request(httpMethod: String, path: String)
@@ -118,6 +119,9 @@ extension NetworkStrings: LogMessage {
         case let .serial_request_queued(httpMethod, path, queuedRequestsCount):
             return "There's a request currently running and \(queuedRequestsCount) requests left in the queue, " +
                 "queueing \(httpMethod) \(path)"
+
+        case let .serial_request_paused(httpMethod, path):
+            return "Requests are currently paused, queueing \(httpMethod) \(path)"
 
         case .starting_next_request(let request):
             return "Starting the next request in the queue, \(request)"

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -90,6 +90,8 @@ class HTTPClient {
         with verificationMode: Signing.ResponseVerificationMode? = nil,
         completionHandler: Completion<Value>?
     ) {
+        // NOTE: these authHeaders will not include any token-based Authorization headers
+        // Those are applied immediately before the request begins executing
         self.perform(request: .init(httpRequest: request,
                                     authHeaders: self.authHeaders,
                                     defaultHeaders: self.defaultHeaders,
@@ -261,10 +263,11 @@ internal extension HTTPClient {
 internal extension HTTPClient {
 
     struct State {
+        var paused: Bool
         var queuedRequests: [Request]
         var currentSerialRequest: Request?
 
-        static let initial: Self = .init(queuedRequests: [], currentSerialRequest: nil)
+        static let initial: Self = .init(paused: false, queuedRequests: [], currentSerialRequest: nil)
     }
 
     /// The API-source resolution state of a request, modeled as one value so an inconsistent
@@ -438,6 +441,12 @@ private extension HTTPClient {
                     Logger.debug(Strings.network.serial_request_queued(httpMethod: request.method.httpMethod,
                                                                        path: request.path,
                                                                        queuedRequestsCount: $0.queuedRequests.count))
+
+                    $0.queuedRequests.append(request)
+                    return true
+                } else if $0.paused == true {
+                    Logger.debug(Strings.network.serial_request_paused(httpMethod: request.method.httpMethod,
+                                                                       path: request.path))
 
                     $0.queuedRequests.append(request)
                     return true
@@ -663,8 +672,16 @@ private extension HTTPClient {
                     return
                 }
 
-                var retryScheduled = self.retryRequestWithNextFallbackHostIfNeeded(request: request,
+                // if we got back a 401 Unauthorized and we are running with access token support,
+                // then get a new access token and try again
+                var retryScheduled = self.reauthorizeRequestIfNeeded(request: request,
+                                                                     basedOn: response,
+                                                                     response: httpURLResponse)
+
+                if !retryScheduled {
+                    retryScheduled = self.retryRequestWithNextFallbackHostIfNeeded(request: request,
                                                                                    error: error)
+                }
 
                 if !retryScheduled {
                     retryScheduled = self.retryRequestIfNeeded(request: request,
@@ -749,6 +766,8 @@ private extension HTTPClient {
 
     func beginNextRequest() {
         let nextRequest: Request? = self.state.modify {
+            if $0.paused == true { return nil }
+
             Logger.debug(Strings.network.serial_request_done(httpMethod: $0.currentSerialRequest?.method.httpMethod,
                                                              path: $0.currentSerialRequest?.path,
                                                              queuedRequestsCount: $0.queuedRequests.count))
@@ -881,16 +900,26 @@ private extension HTTPClient {
     }
 
     private func headers(for request: Request, urlRequest: URLRequest) -> HTTPClient.RequestHeaders {
+        var headers = request.headers
         if request.httpRequest.path.shouldSendEtag {
             let eTagHeader = self.eTagManager.eTagHeader(
                 for: urlRequest,
                 withSignatureVerification: request.verificationMode.isEnabled,
                 refreshETag: request.retried
             )
-            return request.headers.merging(eTagHeader)
-        } else {
-            return request.headers
+            headers = headers.merging(eTagHeader)
         }
+
+        if request.httpRequest.path.authenticated {
+            // NOTE: it's almost guaranteed that the request will already have an "Authorization" header,
+            // because it's how the API key is sent up
+            // if the TokenManager produces a new authorization header, it will override
+            // any existing authorization header present
+            let authorization = self.tokenManager.authorizationHeaders(for: request)
+            headers = headers.merging(authorization)
+        }
+
+        return headers
     }
 
     private func signing(for request: HTTPRequest) -> SigningType {
@@ -946,6 +975,87 @@ private extension HTTPClient {
             }
         }
     }
+}
+
+// MARK: - Request Reauthorize Logic
+extension HTTPClient {
+
+    internal func reauthorizeRequestIfNeeded(request: HTTPClient.Request,
+                                             basedOn originalResult: VerifiedHTTPResponse<Data>.Result,
+                                             response: HTTPURLResponse?) -> Bool {
+
+        let reauthAction = self.tokenManager.tokenRefreshRequest(for: request,
+                                                                 response: response,
+                                                                 duplicateRequestHandler: { wasSuccessful in
+            self.reauthorizationDidComplete(wasSuccessful: wasSuccessful,
+                                            originalRequest: request,
+                                            originalResult: originalResult)
+        })
+
+        switch reauthAction {
+        case .noAction:
+            return false
+        case .refresh(let reauthRequest):
+            let clientRequest = Request(httpRequest: reauthRequest,
+                                        authHeaders: self.authHeaders,
+                                        defaultHeaders: self.defaultHeaders,
+                                        verificationMode: self.systemInfo.responseVerificationMode,
+                                        preferIAMPath: self.tokenManager.enabled,
+                                        internalSettings: self.systemInfo.dangerousSettings.internalSettings,
+                                        completionHandler: { (result: VerifiedHTTPResponse<TokenResponse>.Result) in
+                let wasSuccessful = self.tokenManager.handleTokenRefreshResponse(result)
+                self.reauthorizationDidComplete(wasSuccessful: wasSuccessful,
+                                                originalRequest: request,
+                                                originalResult: originalResult)
+            })
+
+            self.state.modify {
+                $0.queuedRequests.insert(clientRequest, at: 0)
+            }
+            return true
+        case .waitingForOtherRequest:
+            self.state.modify {
+                $0.paused = true
+            }
+            // return true to indicate that the request *will* be retried
+            return true
+        }
+    }
+
+    private func reauthorizationDidComplete(wasSuccessful: Bool,
+                                            originalRequest: HTTPClient.Request,
+                                            originalResult: VerifiedHTTPResponse<Data>.Result) {
+        let needsToRestart: Bool
+
+        if wasSuccessful {
+            let retried = originalRequest.retriedRequest()
+
+            needsToRestart = self.state.modify {
+                let shouldRestart = ($0.paused == true)
+                $0.paused = false
+                $0.queuedRequests.insert(retried, at: 0)
+                return shouldRestart
+            }
+        } else {
+            // the token manager did not get new tokens
+            // therefore, the original request should be failed
+
+            needsToRestart = self.state.modify {
+                let shouldRestart = ($0.paused == true)
+                $0.paused = false
+                return shouldRestart
+            }
+            // the original request needs to be failed
+            // re-use the original 401 Unauthorized
+            originalRequest.completionHandler?(originalResult)
+        }
+
+        if needsToRestart {
+            self.beginNextRequest()
+        }
+
+    }
+
 }
 
 // MARK: - Request Retry Logic

--- a/Sources/Networking/HTTPClient/TokenManager.swift
+++ b/Sources/Networking/HTTPClient/TokenManager.swift
@@ -23,12 +23,19 @@ class TokenManager {
         }
     }
 
+    private struct CurrentTokenRefreshState {
+        let request: HTTPRequest
+        var completions: [(Bool) -> Void]
+    }
+
     let enabled: Bool
     private let storage: any SecureItemStorage
 
     weak var currentUserProvider: CurrentUserProvider?
 
     private var currentUser: String? { currentUserProvider?.currentAppUserID }
+
+    private let currentRefreshState: Atomic<CurrentTokenRefreshState?> = Atomic(nil)
 
     init(enabled: Bool, storage: any SecureItemStorage) {
         self.enabled = enabled
@@ -113,6 +120,104 @@ class TokenManager {
 
     func deleteAccessToken(for userID: String) {
         storage.setString(nil, for: .access(userID))
+    }
+
+    func authorizationHeaders(for urlRequest: HTTPClient.Request) -> [String: String] {
+        guard enabled else { return [:] }
+        guard let currentAccessToken else { return [:] }
+
+        // /auth/* paths want the API key
+        if urlRequest.httpRequest.path.isIAMPath { return [:] }
+
+        return [
+            HTTPClient.RequestHeader.authorization.rawValue: "Bearer \(currentAccessToken)"
+        ]
+    }
+
+    // MARK: - Refreshing Tokens
+
+    enum TokenRefreshAction {
+        case noAction
+        case refresh(HTTPRequest)
+        case waitingForOtherRequest
+    }
+
+    func tokenRefreshRequest(for initialRequest: HTTPClient.Request,
+                             response: HTTPURLResponse?,
+                             duplicateRequestHandler: @escaping (Bool) -> Void)
+    -> TokenRefreshAction {
+
+        guard self.enabled else { return .noAction }
+
+        // IAM requests do not trigger a token refresh
+        if initialRequest.httpRequest.path.isIAMPath { return .noAction }
+
+        // retried requests do not trigger a token refresh
+        // this is based on the assumption that the request was retried because it previously failed
+        // this check prevents us from getting caught in infinite re-auth loops
+        guard initialRequest.retried == false else { return .noAction }
+
+        // only "401 Unauthorized" responses will trigger a refresh
+        guard let response else { return .noAction }
+        guard response.httpStatusCode == .unauthorized else { return .noAction }
+
+        // we can only refresh if we have a refresh token
+        guard let currentRefreshToken else { return .noAction }
+
+        return self.currentRefreshState.modify {
+            if $0 != nil {
+                $0?.completions.append(duplicateRequestHandler)
+                return .waitingForOtherRequest
+            } else {
+                let body = TokenRefreshOperation.Body(refreshToken: currentRefreshToken)
+                let request = HTTPRequest(method: .post(body), path: .tokenRefresh, isRetryable: false)
+                $0 = .init(request: request, completions: [])
+                return .refresh(request)
+            }
+        }
+    }
+
+    func handleTokenRefreshResponse(_ result: VerifiedHTTPResponse<TokenResponse>.Result) -> Bool {
+        guard self.enabled else { return false }
+
+        // make sure this response is a successful one
+        let didHandle: Bool
+        let reportedError: PublicError?
+        switch result {
+        case .success(let response):
+            if response.httpStatusCode == .success {
+                let tokens = response.body
+
+                self.currentRefreshToken = tokens.refreshToken
+                self.currentAccessToken = tokens.accessToken
+                self.currentIDToken = tokens.idToken
+
+                reportedError = nil
+                didHandle = true
+            } else {
+                // a non-successful response that somehow didn't get turned into an actual error
+                reportedError = ErrorUtils.unknownError().asPublicError
+                didHandle = false
+            }
+        case .failure(let error):
+            reportedError = error.asPublicError
+            didHandle = false
+        }
+
+        let handlers = self.currentRefreshState.modify { state in
+            let handlers = state?.completions ?? []
+            state = nil
+            return handlers
+        }
+
+        defer {
+            if let reportedError, let reportError {
+                reportError(reportedError)
+            }
+        }
+
+        handlers.forEach { $0(didHandle) }
+        return didHandle
     }
 
 }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1141,6 +1141,12 @@ public extension Purchases {
         return try await self.offeringsAsync(fetchPolicy: fetchPolicy)
     }
 
+    fileprivate func logInIfNeeded() {
+        #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+        self.authentication.logInIfNeeded()
+        #endif
+    }
+
 }
 
 #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
@@ -2853,7 +2859,7 @@ private extension Purchases {
         // if IAM is enabled and we don't have tokens for the current (anonymous) user,
         // then attempt to get them. If this fails, this will invoke the authentication delegate's
         // callback about failure, because it was not explicitly user-initiated
-        self.authentication.logInIfNeeded()
+        self.logInIfNeeded()
 
         // Note: it's important that we observe "will enter foreground" instead of
         // "did become active" so that we don't trigger cache updates in the middle
@@ -2922,7 +2928,7 @@ private extension Purchases {
         self.systemInfo.isApplicationBackgrounded { [weak self] isBackgrounded in
             guard !isBackgrounded, let self = self else { return }
 
-            self.authentication.logInIfNeeded()
+            self.logInIfNeeded()
 
             self.operationDispatcher.dispatchOnWorkerThread { [weak self] in
                 self?.updateAllCaches(

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -2850,6 +2850,11 @@ private extension Purchases {
 
         self.systemInfo.isAppBackgroundedState = false
 
+        // if IAM is enabled and we don't have tokens for the current (anonymous) user,
+        // then attempt to get them. If this fails, this will invoke the authentication delegate's
+        // callback about failure, because it was not explicitly user-initiated
+        self.authentication.logInIfNeeded()
+
         // Note: it's important that we observe "will enter foreground" instead of
         // "did become active" so that we don't trigger cache updates in the middle
         // of purchases due to pop-ups stealing focus from the app.
@@ -2916,6 +2921,8 @@ private extension Purchases {
     private func performInitialForegroundSetup() {
         self.systemInfo.isApplicationBackgrounded { [weak self] isBackgrounded in
             guard !isBackgrounded, let self = self else { return }
+
+            self.authentication.logInIfNeeded()
 
             self.operationDispatcher.dispatchOnWorkerThread { [weak self] in
                 self?.updateAllCaches(

--- a/Tests/UnitTests/Authentication/AuthenticationTests.swift
+++ b/Tests/UnitTests/Authentication/AuthenticationTests.swift
@@ -27,6 +27,12 @@ class AuthenticationTests: TestCase {
     private var authenticationDelegate: MockAuthenticationDelegate!
     private var secureItemStorage: MockSecureItemStorage!
     private var tokenManager: TokenManager!
+    // `Authentication` only holds a *weak* reference to itself inside the closure it hands to
+    // `tokenManager.reportError`, so tests that don't otherwise keep the `Authentication` returned by
+    // `makeAuthentication()` alive would see it deallocated immediately, silently turning that closure
+    // into a no-op. Stashing it here keeps it alive for the lifetime of the test regardless of whether
+    // the caller captures the return value.
+    private var authentication: Authentication!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -59,6 +65,7 @@ class AuthenticationTests: TestCase {
                                             systemInfo: systemInfo,
                                             internalDelegate: self.internalDelegate)
         authentication.delegate = self.authenticationDelegate
+        self.authentication = authentication
         return authentication
     }
 

--- a/Tests/UnitTests/Authentication/AuthenticationTests.swift
+++ b/Tests/UnitTests/Authentication/AuthenticationTests.swift
@@ -26,6 +26,7 @@ class AuthenticationTests: TestCase {
     private var internalDelegate: MockInternalAuthenticatorDelegate!
     private var authenticationDelegate: MockAuthenticationDelegate!
     private var secureItemStorage: MockSecureItemStorage!
+    private var tokenManager: TokenManager!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -47,6 +48,7 @@ class AuthenticationTests: TestCase {
         customEntitlementComputation: Bool = false
     ) -> Authentication {
         let tokenManager = TokenManager(enabled: tokenManagerEnabled, storage: self.secureItemStorage)
+        self.tokenManager = tokenManager
         let systemInfo = MockSystemInfo(finishTransactions: false,
                                         customEntitlementsComputation: customEntitlementComputation)
 
@@ -388,6 +390,99 @@ class AuthenticationTests: TestCase {
 
         expect(self.operationDispatcher.invokedDispatchOnMainThread) == true
         expect(self.authenticationDelegate.invokedAuthenticatorDidEncounterErrorParametersList) == [error]
+    }
+
+    // MARK: - logInIfNeeded(completion:)
+
+    func testLogInIfNeededDoesNothingWhenIdentityManagerDoesNotNeedIAMLogin() {
+        let authentication = self.makeAuthentication(tokenManagerEnabled: true)
+        self.identityManager.mockNeedsIAMLogin = false
+
+        var completionCalled = false
+        authentication.logInIfNeeded { _, _ in completionCalled = true }
+
+        expect(completionCalled) == false
+        expect(self.identityManager.invokedLogInWithIdentity) == false
+    }
+
+    func testLogInIfNeededLogsInAnonymouslyWhenIdentityManagerNeedsIAMLogin() throws {
+        let authentication = self.makeAuthentication(tokenManagerEnabled: true)
+        self.identityManager.mockNeedsIAMLogin = true
+        let expectedInfo = try CustomerInfo(data: Self.customerInfoData(originalAppUserId: "logged-in-user"))
+        self.identityManager.mockLogInWithIdentityResult = .success((expectedInfo, false))
+
+        authentication.logInIfNeeded()
+
+        expect(self.identityManager.invokedLogInWithIdentityCount) == 1
+        expect(self.identityManager.invokedLogInWithIdentityParametersList.first?.identitySource) == .anonymous
+    }
+
+    func testLogInIfNeededReportsErrorToDelegateWhenTheBackgroundLoginFails() {
+        // `logInIfNeeded` always performs a non-user-initiated login, so a failure needs to be
+        // surfaced through the delegate rather than only through a completion handler (which callers
+        // of this internal API may not even provide, since it's invoked from app lifecycle hooks).
+        let authentication = self.makeAuthentication(tokenManagerEnabled: true)
+        self.identityManager.mockNeedsIAMLogin = true
+        let backendError = BackendError.networkError(.offlineConnection())
+        self.identityManager.mockLogInWithIdentityResult = .failure(backendError)
+
+        authentication.logInIfNeeded()
+
+        expect(self.authenticationDelegate.invokedAuthenticatorDidEncounterError) == true
+        expect(self.authenticationDelegate.invokedAuthenticatorDidEncounterErrorParametersList.last).to(
+            matchError(backendError.asPurchasesError)
+        )
+    }
+
+    // MARK: - Token refresh failure reporting
+
+    /// These tests exercise the wiring set up in `Authentication.init`, where `tokenManager.reportError`
+    /// is connected to `reportAuthenticationError(_:)`. This is how failures to refresh an expired access
+    /// token (which happen deep inside `HTTPClient`, well outside of any explicit, user-initiated call)
+    /// make their way to the `AuthenticationDelegate`.
+    func testAuthenticationDelegateIsInvokedWhenTokenRefreshFails() {
+        _ = self.makeAuthentication(tokenManagerEnabled: true)
+        let networkError = NetworkError.networkError(NSError(domain: "AuthenticationTests", code: 401))
+
+        let didHandle = self.tokenManager.handleTokenRefreshResponse(.failure(networkError))
+
+        expect(didHandle) == false
+        expect(self.operationDispatcher.invokedDispatchOnMainThread) == true
+        expect(self.authenticationDelegate.invokedAuthenticatorDidEncounterError) == true
+        expect(self.authenticationDelegate.invokedAuthenticatorDidEncounterErrorParametersList.last).to(
+            matchError(networkError.asPublicError)
+        )
+    }
+
+    func testAuthenticationDelegateIsNotInvokedWhenTokenRefreshSucceeds() {
+        _ = self.makeAuthentication(tokenManagerEnabled: true)
+        let response = VerifiedHTTPResponse<TokenResponse>(
+            httpStatusCode: .success,
+            responseHeaders: [:],
+            body: TokenResponse(accessToken: "new-access-token",
+                                idToken: "new-id-token",
+                                refreshToken: "new-refresh-token",
+                                scope: "openid",
+                                expiresIn: 3600),
+            verificationResult: .notRequested,
+            isLoadShedderResponse: false,
+            isFallbackUrlResponse: false
+        )
+
+        let didHandle = self.tokenManager.handleTokenRefreshResponse(.success(response))
+
+        expect(didHandle) == true
+        expect(self.authenticationDelegate.invokedAuthenticatorDidEncounterError) == false
+    }
+
+    func testAuthenticationDelegateIsNotInvokedForTokenRefreshFailureWhenNoDelegateIsSet() {
+        let authentication = self.makeAuthentication(tokenManagerEnabled: true)
+        authentication.delegate = nil
+        let networkError = NetworkError.networkError(NSError(domain: "AuthenticationTests", code: 401))
+
+        _ = self.tokenManager.handleTokenRefreshResponse(.failure(networkError))
+
+        expect(self.authenticationDelegate.invokedAuthenticatorDidEncounterError) == false
     }
 
 }

--- a/Tests/UnitTests/Identity/IdentityManagerTests.swift
+++ b/Tests/UnitTests/Identity/IdentityManagerTests.swift
@@ -791,6 +791,65 @@ class IdentityManagerTests: TestCase {
         expect(manager.currentAppUserID) == originalUserID
     }
 
+    // MARK: - currentUserIsAnonymous (IAM identity)
+
+    func testCurrentUserIsAnonymousIsTrueWhenTokenManagerReportsAnonymousIdentity() throws {
+        self.mockTokenManager = MockTokenManager(enabled: true)
+        self.mockTokenManager.stubbedCurrentIDToken = try Self.makeAnonymousIDToken()
+
+        let manager = create(appUserID: "explicit-user")
+
+        expect(IdentityManager.userIsAnonymous(manager.currentAppUserID)) == false
+        expect(manager.currentUserIsAnonymous) == true
+    }
+
+    func testCurrentUserIsAnonymousIsFalseWhenTheTokenManagerDoesNotReportAnAnonymousIdentity() {
+        self.mockTokenManager = MockTokenManager(enabled: true)
+
+        let manager = create(appUserID: "explicit-user")
+
+        expect(manager.currentUserIsAnonymous) == false
+    }
+
+    // MARK: - needsIAMLogin
+
+    func testNeedsIAMLoginIsFalseWhenTheTokenManagerIsDisabled() {
+        self.mockTokenManager = MockTokenManager(enabled: false)
+
+        let manager = create(appUserID: nil)
+
+        assertCorrectlyIdentifiedWithAnonymous(manager)
+        expect(manager.needsIAMLogin) == false
+    }
+
+    func testNeedsIAMLoginIsFalseWhenTheCurrentUserIsNotAnonymous() {
+        self.mockTokenManager = MockTokenManager(enabled: true)
+
+        let manager = create(appUserID: "explicit-user")
+
+        expect(manager.currentUserIsAnonymous) == false
+        expect(manager.needsIAMLogin) == false
+    }
+
+    func testNeedsIAMLoginIsFalseWhenThereIsAlreadyACurrentAccessToken() {
+        self.mockTokenManager = MockTokenManager(enabled: true)
+        self.mockTokenManager.stubbedCurrentAccessToken = "existing-access-token"
+
+        let manager = create(appUserID: nil)
+
+        assertCorrectlyIdentifiedWithAnonymous(manager)
+        expect(manager.needsIAMLogin) == false
+    }
+
+    func testNeedsIAMLoginIsTrueWhenEnabledAnonymousAndMissingAnAccessToken() {
+        self.mockTokenManager = MockTokenManager(enabled: true)
+
+        let manager = create(appUserID: nil)
+
+        assertCorrectlyIdentifiedWithAnonymous(manager)
+        expect(manager.needsIAMLogin) == true
+    }
+
 }
 
 private extension IdentityManagerTests {
@@ -807,6 +866,24 @@ private extension IdentityManagerTests {
             expect(IdentityManager.userIsAnonymous(self.mockDeviceCache.userIDStoredInCache!)) == true
         }
         expect(manager.currentUserIsAnonymous) == true
+    }
+
+    /// Builds an unsigned (`alg: "none"`) JWT string whose `amr` claim marks every identity source as
+    /// anonymous, suitable for driving `TokenManager.isCurrentIdentityAnonymous` (and, in turn,
+    /// `IdentityManager.currentUserIsAnonymous`) to `true` via `MockTokenManager.stubbedCurrentIDToken`.
+    static func makeAnonymousIDToken() throws -> String {
+        let header = try JSONSerialization.data(withJSONObject: ["alg": "none", "typ": "JWT"])
+        let payload = try JSONSerialization.data(withJSONObject: ["amr": ["anonymous"]])
+        let signature = try XCTUnwrap("signature-bytes".data(using: .utf8))
+
+        return [header, payload, signature]
+            .map {
+                $0.base64EncodedString()
+                    .replacingOccurrences(of: "+", with: "-")
+                    .replacingOccurrences(of: "/", with: "_")
+                    .replacingOccurrences(of: "=", with: "")
+            }
+            .joined(separator: ".")
     }
 
 }

--- a/Tests/UnitTests/Mocks/MockIdentityManager.swift
+++ b/Tests/UnitTests/Mocks/MockIdentityManager.swift
@@ -52,6 +52,12 @@ class MockIdentityManager: IdentityManager {
         return mockIsAnonymous
     }
 
+    var mockNeedsIAMLogin = false
+
+    override var needsIAMLogin: Bool {
+        return mockNeedsIAMLogin
+    }
+
     // MARK: - LogIn
 
     var mockLogInResult: IdentityAPI.LogInResponse!

--- a/Tests/UnitTests/Networking/TokenManagerTests.swift
+++ b/Tests/UnitTests/Networking/TokenManagerTests.swift
@@ -386,6 +386,260 @@ class TokenManagerTests: TestCase {
         expect(manager.currentIdentitySource) == .oidc
     }
 
+    // MARK: - authorizationHeaders(for:)
+
+    func testAuthorizationHeadersIsEmptyWhenDisabled() {
+        let manager = TokenManager(enabled: false, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.currentAccessToken = "access-token"
+
+        expect(manager.authorizationHeaders(for: Self.makeRequest())).to(beEmpty())
+    }
+
+    func testAuthorizationHeadersIsEmptyWhenThereIsNoAccessToken() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+
+        expect(manager.authorizationHeaders(for: Self.makeRequest())).to(beEmpty())
+    }
+
+    func testAuthorizationHeadersIsEmptyForIAMPathsEvenWithAnAccessToken() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.currentAccessToken = "access-token"
+
+        expect(manager.authorizationHeaders(for: Self.makeRequest(path: .tokenRefresh))).to(beEmpty())
+    }
+
+    func testAuthorizationHeadersReturnsBearerTokenForNonIAMPathsWithAnAccessToken() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.currentAccessToken = "access-token"
+
+        expect(manager.authorizationHeaders(for: Self.makeRequest())) == [
+            HTTPClient.RequestHeader.authorization.rawValue: "Bearer access-token"
+        ]
+    }
+
+    // MARK: - tokenRefreshRequest(for:response:duplicateRequestHandler:)
+
+    func testTokenRefreshRequestReturnsNoActionWhenDisabled() {
+        let manager = TokenManager(enabled: false, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.currentRefreshToken = "refresh-token"
+
+        let action = manager.tokenRefreshRequest(for: Self.makeRequest(),
+                                                 response: Self.unauthorizedResponse) { _ in }
+
+        expect(Self.isNoAction(action)) == true
+    }
+
+    func testTokenRefreshRequestReturnsNoActionForIAMPaths() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.currentRefreshToken = "refresh-token"
+
+        let action = manager.tokenRefreshRequest(for: Self.makeRequest(path: .tokenRefresh),
+                                                 response: Self.unauthorizedResponse) { _ in }
+
+        expect(Self.isNoAction(action)) == true
+    }
+
+    func testTokenRefreshRequestReturnsNoActionWhenTheRequestHasAlreadyBeenRetried() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.currentRefreshToken = "refresh-token"
+
+        let action = manager.tokenRefreshRequest(for: Self.makeRequest().retriedRequest(),
+                                                 response: Self.unauthorizedResponse) { _ in }
+
+        expect(Self.isNoAction(action)) == true
+    }
+
+    func testTokenRefreshRequestReturnsNoActionWhenThereIsNoResponse() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.currentRefreshToken = "refresh-token"
+
+        let action = manager.tokenRefreshRequest(for: Self.makeRequest(), response: nil) { _ in }
+
+        expect(Self.isNoAction(action)) == true
+    }
+
+    func testTokenRefreshRequestReturnsNoActionWhenTheResponseIsNotUnauthorized() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.currentRefreshToken = "refresh-token"
+
+        let action = manager.tokenRefreshRequest(for: Self.makeRequest(),
+                                                 response: Self.successResponse) { _ in }
+
+        expect(Self.isNoAction(action)) == true
+    }
+
+    func testTokenRefreshRequestReturnsNoActionWhenThereIsNoRefreshToken() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+
+        let action = manager.tokenRefreshRequest(for: Self.makeRequest(),
+                                                 response: Self.unauthorizedResponse) { _ in }
+
+        expect(Self.isNoAction(action)) == true
+    }
+
+    func testTokenRefreshRequestReturnsARefreshRequestUsingTheCurrentRefreshToken() throws {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.currentRefreshToken = "current-refresh-token"
+
+        let action = manager.tokenRefreshRequest(for: Self.makeRequest(),
+                                                 response: Self.unauthorizedResponse) { _ in }
+
+        guard case let .refresh(refreshRequest) = action else {
+            fail("Expected .refresh, got \(action)")
+            return
+        }
+        expect(refreshRequest.path as? HTTPRequest.Path) == .tokenRefresh
+        expect(refreshRequest.isRetryable) == false
+        let body = try XCTUnwrap(refreshRequest.requestBody as? TokenRefreshOperation.Body)
+        expect(body.refreshToken) == "current-refresh-token"
+    }
+
+    func testTokenRefreshRequestReturnsWaitingForOtherRequestWhileARefreshIsInFlight() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.currentRefreshToken = "current-refresh-token"
+
+        let firstAction = manager.tokenRefreshRequest(for: Self.makeRequest(),
+                                                       response: Self.unauthorizedResponse) { _ in }
+        expect(Self.isRefresh(firstAction)) == true
+
+        var duplicateHandlerResult: Bool?
+        let secondAction = manager.tokenRefreshRequest(
+            for: Self.makeRequest(path: .getOfferings(appUserID: "user")),
+            response: Self.unauthorizedResponse
+        ) { wasSuccessful in
+            duplicateHandlerResult = wasSuccessful
+        }
+
+        guard case .waitingForOtherRequest = secondAction else {
+            fail("Expected the second call to wait for the first, got \(secondAction)")
+            return
+        }
+        expect(duplicateHandlerResult).to(beNil())
+
+        _ = manager.handleTokenRefreshResponse(.success(Self.makeTokenResponse()))
+
+        expect(duplicateHandlerResult) == true
+    }
+
+    func testTokenRefreshRequestStartsANewRefreshAfterThePreviousOneCompletes() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.currentRefreshToken = "current-refresh-token"
+
+        let firstAction = manager.tokenRefreshRequest(for: Self.makeRequest(),
+                                                       response: Self.unauthorizedResponse) { _ in }
+        expect(Self.isRefresh(firstAction)) == true
+
+        _ = manager.handleTokenRefreshResponse(.success(Self.makeTokenResponse()))
+
+        let secondAction = manager.tokenRefreshRequest(for: Self.makeRequest(),
+                                                        response: Self.unauthorizedResponse) { _ in }
+
+        expect(Self.isRefresh(secondAction)) == true
+    }
+
+    // MARK: - handleTokenRefreshResponse(_:)
+
+    func testHandleTokenRefreshResponseReturnsFalseAndDoesNothingWhenDisabled() {
+        let manager = TokenManager(enabled: false, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        var reportedError: PublicError?
+        manager.reportError = { reportedError = $0 }
+
+        let didHandle = manager.handleTokenRefreshResponse(.failure(Self.makeNetworkError()))
+
+        expect(didHandle) == false
+        expect(reportedError).to(beNil())
+    }
+
+    func testHandleTokenRefreshResponseSavesTokensAndReturnsTrueOnSuccess() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        var reportedError: PublicError?
+        manager.reportError = { reportedError = $0 }
+
+        let didHandle = manager.handleTokenRefreshResponse(.success(Self.makeTokenResponse(
+            accessToken: "new-access",
+            idToken: "new-id",
+            refreshToken: "new-refresh"
+        )))
+
+        expect(didHandle) == true
+        expect(reportedError).to(beNil())
+        expect(manager.currentAccessToken) == "new-access"
+        expect(manager.currentIDToken) == "new-id"
+        expect(manager.currentRefreshToken) == "new-refresh"
+    }
+
+    func testHandleTokenRefreshResponseReportsTheErrorAndReturnsFalseOnFailure() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.currentAccessToken = "old-access"
+        var reportedError: PublicError?
+        manager.reportError = { reportedError = $0 }
+        let networkError = Self.makeNetworkError()
+
+        let didHandle = manager.handleTokenRefreshResponse(.failure(networkError))
+
+        expect(didHandle) == false
+        expect(reportedError).to(matchError(networkError.asPublicError))
+        // a failed refresh should not clear out whatever access token was already stored
+        expect(manager.currentAccessToken) == "old-access"
+    }
+
+    func testHandleTokenRefreshResponseReportsAnErrorWhenTheResponseIsNotSuccessful() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        var reportedError: PublicError?
+        manager.reportError = { reportedError = $0 }
+        let response = VerifiedHTTPResponse<TokenResponse>(
+            httpStatusCode: .unauthorized,
+            responseHeaders: [:],
+            body: TokenResponse(accessToken: "access-token",
+                                idToken: "id-token",
+                                refreshToken: "refresh-token",
+                                scope: "openid",
+                                expiresIn: 3600),
+            verificationResult: .notRequested,
+            isLoadShedderResponse: false,
+            isFallbackUrlResponse: false
+        )
+
+        let didHandle = manager.handleTokenRefreshResponse(.success(response))
+
+        expect(didHandle) == false
+        expect(reportedError).toNot(beNil())
+    }
+
+    func testHandleTokenRefreshResponseNotifiesDuplicateRequestHandlersOnFailure() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        manager.currentUserProvider = self.userProvider
+        manager.currentRefreshToken = "current-refresh-token"
+
+        _ = manager.tokenRefreshRequest(for: Self.makeRequest(), response: Self.unauthorizedResponse) { _ in }
+        var duplicateResult: Bool?
+        _ = manager.tokenRefreshRequest(for: Self.makeRequest(path: .getOfferings(appUserID: "user")),
+                                        response: Self.unauthorizedResponse) { wasSuccessful in
+            duplicateResult = wasSuccessful
+        }
+
+        _ = manager.handleTokenRefreshResponse(.failure(Self.makeNetworkError()))
+
+        expect(duplicateResult) == false
+    }
+
 }
 
 private extension TokenManagerTests {
@@ -415,6 +669,67 @@ private extension TokenManagerTests {
             .replacingOccurrences(of: "+", with: "-")
             .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "=", with: "")
+    }
+
+    // MARK: - Test helpers for `authorizationHeaders`/`tokenRefreshRequest`/`handleTokenRefreshResponse`
+
+    static var mockURL: URL {
+        // swiftlint:disable:next force_unwrapping
+        URL(string: "https://api.revenuecat.com/v1/subscribers/user")!
+    }
+
+    static var unauthorizedResponse: HTTPURLResponse? {
+        HTTPURLResponse(url: Self.mockURL, statusCode: 401, httpVersion: nil, headerFields: nil)
+    }
+
+    static var successResponse: HTTPURLResponse? {
+        HTTPURLResponse(url: Self.mockURL, statusCode: 200, httpVersion: nil, headerFields: nil)
+    }
+
+    /// Builds a minimal `HTTPClient.Request` for exercising `TokenManager` methods that take one,
+    /// without needing to spin up a full `HTTPClient`.
+    static func makeRequest(path: HTTPRequest.Path = .getCustomerInfo(appUserID: "user")) -> HTTPClient.Request {
+        let httpRequest = HTTPRequest(method: .get, path: path)
+        return HTTPClient.Request(httpRequest: httpRequest,
+                                  authHeaders: [:],
+                                  defaultHeaders: [:],
+                                  verificationMode: .disabled,
+                                  preferIAMPath: false,
+                                  internalSettings: DangerousSettings.Internal.default,
+                                  completionHandler: { (_: VerifiedHTTPResponse<Data>.Result) in })
+    }
+
+    static func makeTokenResponse(
+        accessToken: String = "access-token",
+        idToken: String? = "id-token",
+        refreshToken: String? = "refresh-token"
+    ) -> VerifiedHTTPResponse<TokenResponse> {
+        return VerifiedHTTPResponse<TokenResponse>(
+            httpStatusCode: .success,
+            responseHeaders: [:],
+            body: TokenResponse(accessToken: accessToken,
+                                idToken: idToken,
+                                refreshToken: refreshToken,
+                                scope: "openid",
+                                expiresIn: 3600),
+            verificationResult: .notRequested,
+            isLoadShedderResponse: false,
+            isFallbackUrlResponse: false
+        )
+    }
+
+    static func makeNetworkError() -> NetworkError {
+        return NetworkError.networkError(NSError(domain: "TokenManagerTests", code: 401))
+    }
+
+    static func isNoAction(_ action: TokenManager.TokenRefreshAction) -> Bool {
+        if case .noAction = action { return true }
+        return false
+    }
+
+    static func isRefresh(_ action: TokenManager.TokenRefreshAction) -> Bool {
+        if case .refresh = action { return true }
+        return false
     }
 
 }

--- a/Tests/UnitTests/Networking/TokenManagerTests.swift
+++ b/Tests/UnitTests/Networking/TokenManagerTests.swift
@@ -511,7 +511,7 @@ class TokenManagerTests: TestCase {
         manager.currentRefreshToken = "current-refresh-token"
 
         let firstAction = manager.tokenRefreshRequest(for: Self.makeRequest(),
-                                                       response: Self.unauthorizedResponse) { _ in }
+                                                      response: Self.unauthorizedResponse) { _ in }
         expect(Self.isRefresh(firstAction)) == true
 
         var duplicateHandlerResult: Bool?
@@ -539,13 +539,13 @@ class TokenManagerTests: TestCase {
         manager.currentRefreshToken = "current-refresh-token"
 
         let firstAction = manager.tokenRefreshRequest(for: Self.makeRequest(),
-                                                       response: Self.unauthorizedResponse) { _ in }
+                                                      response: Self.unauthorizedResponse) { _ in }
         expect(Self.isRefresh(firstAction)) == true
 
         _ = manager.handleTokenRefreshResponse(.success(Self.makeTokenResponse()))
 
         let secondAction = manager.tokenRefreshRequest(for: Self.makeRequest(),
-                                                        response: Self.unauthorizedResponse) { _ in }
+                                                       response: Self.unauthorizedResponse) { _ in }
 
         expect(Self.isRefresh(secondAction)) == true
     }


### PR DESCRIPTION
Inject the IAM access token into outgoing requests. When any non-token response is a `401 Unauthorized`, attempt to refresh tokens and try the request again.

Includes a slight behavioral change to HTTPClient to allow clients to be _paused_; this is used only while refreshing tokens, so that only a single client can be requesting new tokens at a time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication, token storage, and the HTTP serial pipeline (pause/retry on 401). Bugs here can stall all network traffic, loop reauth, or leak/override Authorization headers.
> 
> **Overview**
> Attaches IAM access tokens to authenticated API requests and automatically refreshes them when a non-IAM call returns **401 Unauthorized**, then retries the original request.
> 
> `TokenManager` now supplies `Bearer` headers (overriding the API-key Authorization on authenticated paths) and coalesces concurrent refresh attempts. `HTTPClient` can **pause** the serial queue while a refresh is in flight so only one token request runs; failed refresh fails the original 401, successful refresh unpauses and retries.
> 
> Anonymous IAM users without tokens are logged in on app start / foreground via `logInIfNeeded`. Delegate auth errors are suppressed while a user-initiated login/logout is in progress. Logout no longer short-circuits anonymous users until after token revocation, and anonymous identity is also inferred from the ID token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60cc81c0fe67e9f2916714874f95f71abca392b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->