### PR TITLE
feat(Checkpoints): validate checkpoint identifiers

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1398,6 +1398,7 @@
 		73A690000000000000000001 /* ObjCCheckpointTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A690000000000000000011 /* ObjCCheckpointTypes.swift */; };
 		73A640000000000000000001 /* CheckpointCallStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A640000000000000000011 /* CheckpointCallStore.swift */; };
 		73A660000000000000000001 /* CheckpointError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A660000000000000000011 /* CheckpointError.swift */; };
+		73A670000000000000000001 /* CheckpointIdentifierValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A670000000000000000011 /* CheckpointIdentifierValidator.swift */; };
 		73A640000000000000000003 /* CheckpointWorkflowPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A640000000000000000013 /* CheckpointWorkflowPresenter.swift */; };
 		73A640000000000000000004 /* CheckpointWorkflowExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A640000000000000000014 /* CheckpointWorkflowExecutor.swift */; };
 		73A640000000000000000005 /* CheckpointsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A640000000000000000015 /* CheckpointsManager.swift */; };
@@ -1990,11 +1991,13 @@
 		73A690000000000000000011 /* ObjCCheckpointTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCCheckpointTypes.swift; sourceTree = "<group>"; };
 		73A640000000000000000011 /* CheckpointCallStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckpointCallStore.swift; sourceTree = "<group>"; };
 		73A660000000000000000011 /* CheckpointError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckpointError.swift; sourceTree = "<group>"; };
+		73A670000000000000000011 /* CheckpointIdentifierValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckpointIdentifierValidator.swift; sourceTree = "<group>"; };
 		73A640000000000000000013 /* CheckpointWorkflowPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckpointWorkflowPresenter.swift; sourceTree = "<group>"; };
 		73A640000000000000000014 /* CheckpointWorkflowExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckpointWorkflowExecutor.swift; sourceTree = "<group>"; };
 		73A640000000000000000015 /* CheckpointsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckpointsManager.swift; sourceTree = "<group>"; };
 		73A650000000000000000011 /* CheckpointWorkflowPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckpointWorkflowPresenterTests.swift; sourceTree = "<group>"; };
 		73A650000000000000000012 /* CheckpointsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckpointsManagerTests.swift; sourceTree = "<group>"; };
+		73A650000000000000000013 /* CheckpointIdentifierValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckpointIdentifierValidatorTests.swift; sourceTree = "<group>"; };
 		73A620000000000000000011 /* CheckpointValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckpointValueTests.swift; sourceTree = "<group>"; };
 		73A630000000000000000011 /* NSNumber+JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSNumber+JSON.swift"; sourceTree = "<group>"; };
 		350A1B84226E3E8700CCA10F /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
@@ -3532,6 +3535,7 @@
 				73A690000000000000000011 /* ObjCCheckpointTypes.swift */,
 				73A640000000000000000011 /* CheckpointCallStore.swift */,
 				73A660000000000000000011 /* CheckpointError.swift */,
+				73A670000000000000000011 /* CheckpointIdentifierValidator.swift */,
 				73A640000000000000000014 /* CheckpointWorkflowExecutor.swift */,
 				73A640000000000000000013 /* CheckpointWorkflowPresenter.swift */,
 				73A640000000000000000015 /* CheckpointsManager.swift */,
@@ -3545,6 +3549,7 @@
 			children = (
 				73A650000000000000000011 /* CheckpointWorkflowPresenterTests.swift */,
 				73A650000000000000000012 /* CheckpointsManagerTests.swift */,
+				73A650000000000000000013 /* CheckpointIdentifierValidatorTests.swift */,
 			);
 			path = Checkpoints;
 			sourceTree = "<group>";
@@ -8380,6 +8385,7 @@
 				73A690000000000000000001 /* ObjCCheckpointTypes.swift in Sources */,
 				73A640000000000000000001 /* CheckpointCallStore.swift in Sources */,
 				73A660000000000000000001 /* CheckpointError.swift in Sources */,
+				73A670000000000000000001 /* CheckpointIdentifierValidator.swift in Sources */,
 				73A640000000000000000004 /* CheckpointWorkflowExecutor.swift in Sources */,
 				73A640000000000000000003 /* CheckpointWorkflowPresenter.swift in Sources */,
 				73A640000000000000000005 /* CheckpointsManager.swift in Sources */,

--- a/RevenueCatUI/Checkpoints/CheckpointError.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointError.swift
@@ -17,7 +17,6 @@ import Foundation
 
 enum CheckpointError: Error {
 
-    case invalidIdentifier(String)
     case missingPresenter
     case operationAlreadyInProgress
     case noPresentationContext
@@ -33,7 +32,7 @@ extension CheckpointError: CustomNSError {
 
     var errorCode: Int {
         switch self {
-        case .invalidIdentifier, .missingPresenter, .noPresentationContext, .presentationFailed:
+        case .missingPresenter, .noPresentationContext, .presentationFailed:
             return ErrorCode.configurationError.rawValue
         case .operationAlreadyInProgress:
             return ErrorCode.operationAlreadyInProgressForProductError.rawValue
@@ -46,9 +45,6 @@ extension CheckpointError: CustomNSError {
 
     private var errorDescription: String {
         switch self {
-        case .invalidIdentifier(let identifier):
-            return "Checkpoint identifier '\(identifier)' is invalid. Identifiers must start with a letter, " +
-                "contain only ASCII letters, numbers, underscores, and hyphens, and be no more than 100 characters."
         case .missingPresenter:
             return "Cannot present checkpoint UI: no presentation handler was supplied."
         case .operationAlreadyInProgress:

--- a/RevenueCatUI/Checkpoints/CheckpointError.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointError.swift
@@ -17,6 +17,7 @@ import Foundation
 
 enum CheckpointError: Error {
 
+    case invalidIdentifier(String)
     case missingPresenter
     case operationAlreadyInProgress
     case noPresentationContext
@@ -32,7 +33,7 @@ extension CheckpointError: CustomNSError {
 
     var errorCode: Int {
         switch self {
-        case .missingPresenter, .noPresentationContext, .presentationFailed:
+        case .invalidIdentifier, .missingPresenter, .noPresentationContext, .presentationFailed:
             return ErrorCode.configurationError.rawValue
         case .operationAlreadyInProgress:
             return ErrorCode.operationAlreadyInProgressForProductError.rawValue
@@ -45,6 +46,9 @@ extension CheckpointError: CustomNSError {
 
     private var errorDescription: String {
         switch self {
+        case .invalidIdentifier(let identifier):
+            return "Checkpoint identifier '\(identifier)' is invalid. Identifiers must start with a letter, " +
+                "contain only ASCII letters, numbers, underscores, and hyphens, and be no more than 100 characters."
         case .missingPresenter:
             return "Cannot present checkpoint UI: no presentation handler was supplied."
         case .operationAlreadyInProgress:

--- a/RevenueCatUI/Checkpoints/CheckpointIdentifierValidator.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointIdentifierValidator.swift
@@ -1,0 +1,43 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CheckpointIdentifierValidator.swift
+//
+//  Created by Rick van der Linden.
+//
+
+enum CheckpointIdentifierValidator {
+
+    static func isValid(_ identifier: String) -> Bool {
+        let characters = identifier.utf8
+
+        guard
+            (1...100).contains(characters.count),
+            let firstCharacter = characters.first,
+            Self.isASCIILetter(firstCharacter)
+        else {
+            return false
+        }
+
+        return characters.dropFirst().allSatisfy(Self.isAllowedCharacter)
+    }
+
+    private static func isAllowedCharacter(_ character: UInt8) -> Bool {
+        return Self.isASCIILetter(character)
+            || (UInt8(ascii: "0")...UInt8(ascii: "9")).contains(character)
+            || character == UInt8(ascii: "_")
+            || character == UInt8(ascii: "-")
+    }
+
+    private static func isASCIILetter(_ character: UInt8) -> Bool {
+        return (UInt8(ascii: "a")...UInt8(ascii: "z")).contains(character)
+            || (UInt8(ascii: "A")...UInt8(ascii: "Z")).contains(character)
+    }
+
+}

--- a/RevenueCatUI/Checkpoints/CheckpointIdentifierValidator.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointIdentifierValidator.swift
@@ -14,11 +14,13 @@
 
 enum CheckpointIdentifierValidator {
 
+    static let maxLength = 255
+
     static func isValid(_ identifier: String) -> Bool {
         let characters = identifier.utf8
 
         guard
-            (1...100).contains(characters.count),
+            (1...Self.maxLength).contains(characters.count),
             let firstCharacter = characters.first,
             Self.isASCIILetter(firstCharacter)
         else {
@@ -26,6 +28,12 @@ enum CheckpointIdentifierValidator {
         }
 
         return characters.dropFirst().allSatisfy(Self.isAllowedCharacter)
+    }
+
+    static func invalidIdentifierLogMessage(_ identifier: String) -> String {
+        return "Dropping invalid checkpoint identifier '\(identifier)'. Identifiers must start with a letter, " +
+            "contain only ASCII letters, numbers, underscores, and hyphens, and be no more than " +
+            "\(Self.maxLength) characters."
     }
 
     private static func isAllowedCharacter(_ character: UInt8) -> Bool {

--- a/RevenueCatUI/Checkpoints/Checkpoints.swift
+++ b/RevenueCatUI/Checkpoints/Checkpoints.swift
@@ -116,6 +116,8 @@ public final class CheckpointNoActionReason: Equatable, Hashable, CustomStringCo
     public static let disabled = CheckpointNoActionReason(value: "DISABLED")
     /// The checkpoint identifier is not configured.
     public static let unknownCheckpoint = CheckpointNoActionReason(value: "UNKNOWN_CHECKPOINT")
+    /// The checkpoint identifier is invalid.
+    public static let invalidCheckpointIdentifier = CheckpointNoActionReason(value: "INVALID_CHECKPOINT_IDENTIFIER")
 
     init(value: String) {
         self.value = value

--- a/RevenueCatUI/Checkpoints/CheckpointsManager.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointsManager.swift
@@ -76,6 +76,10 @@ final class CheckpointsManager {
         identifier: String,
         params: CheckpointParams
     ) async throws -> CheckpointResult {
+        guard CheckpointIdentifierValidator.isValid(identifier) else {
+            throw CheckpointError.invalidIdentifier(identifier)
+        }
+
         let checkpoint = CheckpointInfo(identifier: identifier, params: params)
         self.listener?.onCheckpointHit(checkpoint)
 

--- a/RevenueCatUI/Checkpoints/CheckpointsManager.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointsManager.swift
@@ -77,7 +77,11 @@ final class CheckpointsManager {
         params: CheckpointParams
     ) async throws -> CheckpointResult {
         guard CheckpointIdentifierValidator.isValid(identifier) else {
-            throw CheckpointError.invalidIdentifier(identifier)
+            Logger.error(CheckpointIdentifierValidator.invalidIdentifierLogMessage(identifier))
+            return CheckpointNoActionResult(
+                checkpoint: CheckpointInfo(identifier: identifier, params: params),
+                reason: .invalidCheckpointIdentifier
+            )
         }
 
         let checkpoint = CheckpointInfo(identifier: identifier, params: params)

--- a/RevenueCatUI/Checkpoints/CheckpointsManager.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointsManager.swift
@@ -76,16 +76,18 @@ final class CheckpointsManager {
         identifier: String,
         params: CheckpointParams
     ) async throws -> CheckpointResult {
-        guard CheckpointIdentifierValidator.isValid(identifier) else {
-            Logger.error(CheckpointIdentifierValidator.invalidIdentifierLogMessage(identifier))
-            return CheckpointNoActionResult(
-                checkpoint: CheckpointInfo(identifier: identifier, params: params),
-                reason: .invalidCheckpointIdentifier
-            )
-        }
-
         let checkpoint = CheckpointInfo(identifier: identifier, params: params)
         self.listener?.onCheckpointHit(checkpoint)
+
+        guard CheckpointIdentifierValidator.isValid(identifier) else {
+            Logger.error(CheckpointIdentifierValidator.invalidIdentifierLogMessage(identifier))
+            let result = CheckpointNoActionResult(
+                checkpoint: checkpoint,
+                reason: .invalidCheckpointIdentifier
+            )
+            self.listener?.onCheckpointCompleted(checkpoint, result: result)
+            return result
+        }
 
         let result: CheckpointResult
         switch try await self.resolveCheckpoint(identifier, params) {

--- a/RevenueCatUI/Checkpoints/Purchases+Checkpoints.swift
+++ b/RevenueCatUI/Checkpoints/Purchases+Checkpoints.swift
@@ -33,7 +33,7 @@ public extension Purchases {
     /// The call resolves when the experience finishes.
     /// - Parameters:
     ///   - identifier: The checkpoint identifier configured in the RevenueCat dashboard. It must start with a letter,
-    ///     contain only ASCII letters, numbers, underscores, and hyphens, and be no more than 100 characters.
+    ///     contain only ASCII letters, numbers, underscores, and hyphens, and be no more than 255 characters.
     ///   - params: Optional per-call parameters.
     ///   - completion: Called with the result, or an error if the checkpoint could not be handled.
     func checkpoint(
@@ -54,7 +54,7 @@ public extension Purchases {
     /// The call resolves when the experience finishes.
     /// - Parameters:
     ///   - identifier: The checkpoint identifier configured in the RevenueCat dashboard. It must start with a letter,
-    ///     contain only ASCII letters, numbers, underscores, and hyphens, and be no more than 100 characters.
+    ///     contain only ASCII letters, numbers, underscores, and hyphens, and be no more than 255 characters.
     ///   - params: Optional per-call parameters.
     /// - Returns: The result for this checkpoint.
     /// - Throws: An error if the checkpoint could not be handled.
@@ -77,7 +77,7 @@ public extension Purchases {
 public extension Purchases {
 
     /// Objective-C-compatible checkpoint API. The identifier must start with a letter and contain only ASCII letters,
-    /// numbers, underscores, and hyphens, and be no more than 100 characters.
+    /// numbers, underscores, and hyphens, and be no more than 255 characters.
     @_disfavoredOverload
     @objc(checkpointWithIdentifier:params:completion:)
     func checkpoint(

--- a/RevenueCatUI/Checkpoints/Purchases+Checkpoints.swift
+++ b/RevenueCatUI/Checkpoints/Purchases+Checkpoints.swift
@@ -32,7 +32,8 @@ public extension Purchases {
     /// Depending on the configured targeting rules, this may auto-present an experience or do nothing.
     /// The call resolves when the experience finishes.
     /// - Parameters:
-    ///   - identifier: The checkpoint identifier configured in the RevenueCat dashboard.
+    ///   - identifier: The checkpoint identifier configured in the RevenueCat dashboard. It must start with a letter,
+    ///     contain only ASCII letters, numbers, underscores, and hyphens, and be no more than 100 characters.
     ///   - params: Optional per-call parameters.
     ///   - completion: Called with the result, or an error if the checkpoint could not be handled.
     func checkpoint(
@@ -52,7 +53,8 @@ public extension Purchases {
     /// Depending on the configured targeting rules, this may auto-present an experience or do nothing.
     /// The call resolves when the experience finishes.
     /// - Parameters:
-    ///   - identifier: The checkpoint identifier configured in the RevenueCat dashboard.
+    ///   - identifier: The checkpoint identifier configured in the RevenueCat dashboard. It must start with a letter,
+    ///     contain only ASCII letters, numbers, underscores, and hyphens, and be no more than 100 characters.
     ///   - params: Optional per-call parameters.
     /// - Returns: The result for this checkpoint.
     /// - Throws: An error if the checkpoint could not be handled.
@@ -74,7 +76,8 @@ public extension Purchases {
 @available(iOS 15.0, *)
 public extension Purchases {
 
-    /// Objective-C-compatible checkpoint API.
+    /// Objective-C-compatible checkpoint API. The identifier must start with a letter and contain only ASCII letters,
+    /// numbers, underscores, and hyphens, and be no more than 100 characters.
     @_disfavoredOverload
     @objc(checkpointWithIdentifier:params:completion:)
     func checkpoint(

--- a/Sources/Misc/CustomVariableKeyValidator.swift
+++ b/Sources/Misc/CustomVariableKeyValidator.swift
@@ -16,13 +16,13 @@ import Foundation
 
 private enum CustomVariableKeyValidatorStrings: LogMessage {
 
-    case invalidKey(String)
+    case invalidKey(String, maxLength: Int)
 
     var description: String {
         switch self {
-        case .invalidKey(let key):
+        case let .invalidKey(key, maxLength):
             return "Custom variable key '\(key)' is invalid and will be ignored. " +
-                "Keys must be 1–256 characters and contain only ASCII letters, numbers, and underscores."
+                "Keys must be 1–\(maxLength) characters and contain only ASCII letters, numbers, and underscores."
         }
     }
 
@@ -34,11 +34,13 @@ private enum CustomVariableKeyValidatorStrings: LogMessage {
 @_spi(Internal)
 public struct CustomVariableKeyValidator {
 
+    private static let maxLength = 255
+
     private init() {}
 
     /// Returns whether a key can be addressed using a `custom.<key>` path.
     public static func isValidKey(_ key: String) -> Bool {
-        guard (1...256).contains(key.utf8.count) else { return false }
+        guard (1...Self.maxLength).contains(key.utf8.count) else { return false }
 
         return key.utf8.allSatisfy { character in
             switch character {
@@ -58,7 +60,7 @@ public struct CustomVariableKeyValidator {
         return variables.filter { key, _ in
             guard Self.isValidKey(key) else {
                 #if DEBUG
-                Logger.warn(CustomVariableKeyValidatorStrings.invalidKey(key))
+                Logger.warn(CustomVariableKeyValidatorStrings.invalidKey(key, maxLength: Self.maxLength))
                 #endif
                 return false
             }

--- a/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
+++ b/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
@@ -86,4 +86,5 @@ func checkCheckpointAPI(_ purchases: Purchases) {
     let _: CheckpointNoActionReason = .configurationUnavailable
     let _: CheckpointNoActionReason = .disabled
     let _: CheckpointNoActionReason = .unknownCheckpoint
+    let _: CheckpointNoActionReason = .invalidCheckpointIdentifier
 }

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointIdentifierValidatorTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointIdentifierValidatorTests.swift
@@ -20,101 +20,47 @@ import XCTest
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 final class CheckpointIdentifierValidatorTests: TestCase {
 
-    func testValidCheckpointIdentifiersReachResolution() async throws {
-        var resolvedIdentifiers: [String] = []
-        let manager = CheckpointsManager { identifier, _ in
-            resolvedIdentifiers.append(identifier)
-            return .noAction(.noMatch)
-        }
+    func testValidCheckpointIdentifiers() {
         let validIdentifiers = [
             "a",
             "Z",
             "checkout",
             "checkout_123",
             "checkout-complete",
-            "a" + String(repeating: "1", count: 99)
+            "A-1_b",
+            "a" + String(repeating: "1", count: CheckpointIdentifierValidator.maxLength - 1)
         ]
 
         for identifier in validIdentifiers {
-            _ = try await manager.checkpoint(identifier: identifier, params: .init())
+            XCTAssertTrue(
+                CheckpointIdentifierValidator.isValid(identifier),
+                "Expected '\(identifier)' to be valid"
+            )
         }
-
-        XCTAssertEqual(resolvedIdentifiers, validIdentifiers)
     }
 
-    func testInvalidCheckpointIdentifiersFailBeforeListenerOrResolution() async {
-        var resolutionCount = 0
-        let manager = CheckpointsManager { _, _ in
-            resolutionCount += 1
-            return .noAction(.noMatch)
-        }
-        let listener = CheckpointListenerRecorder()
-        manager.listener = listener
+    func testInvalidCheckpointIdentifiers() {
         let invalidIdentifiers = [
             "",
             "1checkout",
             "_checkout",
             "-checkout",
             "check out",
+            " checkout",
+            "checkout ",
+            "checkout\n",
             "check.out",
             "chéckout",
-            "a" + String(repeating: "1", count: 100)
+            "checkout😀",
+            "a" + String(repeating: "1", count: CheckpointIdentifierValidator.maxLength)
         ]
 
         for identifier in invalidIdentifiers {
-            do {
-                _ = try await manager.checkpoint(identifier: identifier, params: .init())
-                XCTFail("Expected '\(identifier)' to be rejected")
-            } catch let error as CheckpointError {
-                guard case .invalidIdentifier(let rejectedIdentifier) = error else {
-                    return XCTFail("Expected invalidIdentifier, got \(error)")
-                }
-
-                XCTAssertEqual(rejectedIdentifier, identifier)
-                XCTAssertEqual(error.errorCode, ErrorCode.configurationError.rawValue)
-            } catch {
-                XCTFail("Expected CheckpointError, got \(error)")
-            }
+            XCTAssertFalse(
+                CheckpointIdentifierValidator.isValid(identifier),
+                "Expected '\(identifier)' to be invalid"
+            )
         }
-
-        XCTAssertEqual(resolutionCount, 0)
-        XCTAssertEqual(listener.eventCount, 0)
-    }
-
-    func testCompletionAPIForwardsInvalidIdentifierError() {
-        let completion = self.expectation(description: "Checkpoint fails")
-        var resolutionCount = 0
-        let manager = CheckpointsManager { _, _ in
-            resolutionCount += 1
-            return .noAction(.noMatch)
-        }
-
-        manager.checkpoint(identifier: "invalid checkpoint", params: .init()) { result in
-            guard case let .failure(error) = result else {
-                return XCTFail("Expected invalid identifier error")
-            }
-
-            XCTAssertEqual(error.code, ErrorCode.configurationError.rawValue)
-            XCTAssertEqual(resolutionCount, 0)
-            completion.fulfill()
-        }
-
-        self.waitForExpectations(timeout: 1)
-    }
-
-}
-
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-private final class CheckpointListenerRecorder: CheckpointListener {
-
-    private(set) var eventCount = 0
-
-    func onCheckpointHit(_ checkpoint: CheckpointInfo) {
-        self.eventCount += 1
-    }
-
-    func onCheckpointCompleted(_ checkpoint: CheckpointInfo, result: CheckpointResult) {
-        self.eventCount += 1
     }
 
 }

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointIdentifierValidatorTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointIdentifierValidatorTests.swift
@@ -1,0 +1,120 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CheckpointIdentifierValidatorTests.swift
+//
+//  Created by Rick van der Linden.
+//
+
+@_spi(Internal) @testable import RevenueCat
+@_spi(CheckpointsInternal) @_spi(Internal) @testable import RevenueCatUI
+import XCTest
+
+@MainActor
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+final class CheckpointIdentifierValidatorTests: TestCase {
+
+    func testValidCheckpointIdentifiersReachResolution() async throws {
+        var resolvedIdentifiers: [String] = []
+        let manager = CheckpointsManager { identifier, _ in
+            resolvedIdentifiers.append(identifier)
+            return .noAction(.noMatch)
+        }
+        let validIdentifiers = [
+            "a",
+            "Z",
+            "checkout",
+            "checkout_123",
+            "checkout-complete",
+            "a" + String(repeating: "1", count: 99)
+        ]
+
+        for identifier in validIdentifiers {
+            _ = try await manager.checkpoint(identifier: identifier, params: .init())
+        }
+
+        XCTAssertEqual(resolvedIdentifiers, validIdentifiers)
+    }
+
+    func testInvalidCheckpointIdentifiersFailBeforeListenerOrResolution() async {
+        var resolutionCount = 0
+        let manager = CheckpointsManager { _, _ in
+            resolutionCount += 1
+            return .noAction(.noMatch)
+        }
+        let listener = CheckpointListenerRecorder()
+        manager.listener = listener
+        let invalidIdentifiers = [
+            "",
+            "1checkout",
+            "_checkout",
+            "-checkout",
+            "check out",
+            "check.out",
+            "chéckout",
+            "a" + String(repeating: "1", count: 100)
+        ]
+
+        for identifier in invalidIdentifiers {
+            do {
+                _ = try await manager.checkpoint(identifier: identifier, params: .init())
+                XCTFail("Expected '\(identifier)' to be rejected")
+            } catch let error as CheckpointError {
+                guard case .invalidIdentifier(let rejectedIdentifier) = error else {
+                    return XCTFail("Expected invalidIdentifier, got \(error)")
+                }
+
+                XCTAssertEqual(rejectedIdentifier, identifier)
+                XCTAssertEqual(error.errorCode, ErrorCode.configurationError.rawValue)
+            } catch {
+                XCTFail("Expected CheckpointError, got \(error)")
+            }
+        }
+
+        XCTAssertEqual(resolutionCount, 0)
+        XCTAssertEqual(listener.eventCount, 0)
+    }
+
+    func testCompletionAPIForwardsInvalidIdentifierError() {
+        let completion = self.expectation(description: "Checkpoint fails")
+        var resolutionCount = 0
+        let manager = CheckpointsManager { _, _ in
+            resolutionCount += 1
+            return .noAction(.noMatch)
+        }
+
+        manager.checkpoint(identifier: "invalid checkpoint", params: .init()) { result in
+            guard case let .failure(error) = result else {
+                return XCTFail("Expected invalid identifier error")
+            }
+
+            XCTAssertEqual(error.code, ErrorCode.configurationError.rawValue)
+            XCTAssertEqual(resolutionCount, 0)
+            completion.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 1)
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private final class CheckpointListenerRecorder: CheckpointListener {
+
+    private(set) var eventCount = 0
+
+    func onCheckpointHit(_ checkpoint: CheckpointInfo) {
+        self.eventCount += 1
+    }
+
+    func onCheckpointCompleted(_ checkpoint: CheckpointInfo, result: CheckpointResult) {
+        self.eventCount += 1
+    }
+
+}

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
@@ -272,7 +272,7 @@ final class CheckpointsManagerTests: TestCase {
         XCTAssertEqual(listener.events, [.hit("A-1_b"), .completed("A-1_b")])
     }
 
-    func testInvalidCheckpointIdentifierIsLoggedAndDroppedBeforeListenerOrResolution() async throws {
+    func testInvalidCheckpointIdentifierIsLoggedAndReportedToListenerWithoutResolution() async throws {
         let invalidIdentifier = " checkout😀"
         var resolutionCount = 0
         let manager = CheckpointsManager { _, _ in
@@ -291,7 +291,7 @@ final class CheckpointsManagerTests: TestCase {
         XCTAssertEqual(noActionResult.reason, .invalidCheckpointIdentifier)
         XCTAssertEqual(noActionResult.checkpoint.identifier, invalidIdentifier)
         XCTAssertEqual(resolutionCount, 0)
-        XCTAssertTrue(listener.events.isEmpty)
+        XCTAssertEqual(listener.events, [.hit(invalidIdentifier), .completed(invalidIdentifier)])
         self.logger.verifyMessageWasLogged(
             CheckpointIdentifierValidator.invalidIdentifierLogMessage(invalidIdentifier),
             level: .error

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
@@ -56,6 +56,22 @@ final class CheckpointsManagerTests: TestCase {
         XCTAssertEqual(params.value.customVariables, ["valid": .string("value")])
     }
 
+    func testObjectiveCResultWrapsInvalidIdentifierNoActionResult() throws {
+        let identifier = "invalid checkpoint"
+        let checkpoint = CheckpointInfo(identifier: identifier, params: .init())
+        let result = CheckpointNoActionResult(
+            checkpoint: checkpoint,
+            reason: .invalidCheckpointIdentifier
+        )
+
+        let objcResult = try XCTUnwrap(
+            ObjCCheckpointResult.wrapping(result) as? ObjCCheckpointNoActionResult
+        )
+
+        XCTAssertEqual(objcResult.checkpoint.identifier, identifier)
+        XCTAssertEqual(objcResult.reason.value, "INVALID_CHECKPOINT_IDENTIFIER")
+    }
+
     #endif
 
     func testCheckpointParamsConvertCustomVariableValuesForCoreResolution() {
@@ -235,6 +251,68 @@ final class CheckpointsManagerTests: TestCase {
                 return XCTFail("Expected a no-action result")
             }
             XCTAssertEqual(noAction.reason, .disabled)
+            completion.fulfill()
+        }
+
+        self.waitForExpectations(timeout: 1)
+    }
+
+    func testValidCheckpointIdentifierReachesListenerAndResolution() async throws {
+        var resolvedIdentifiers: [String] = []
+        let manager = CheckpointsManager { identifier, _ in
+            resolvedIdentifiers.append(identifier)
+            return .noAction(.noMatch)
+        }
+        let listener = ListenerRecorder()
+        manager.listener = listener
+
+        _ = try await manager.checkpoint(identifier: "A-1_b", params: .init())
+
+        XCTAssertEqual(resolvedIdentifiers, ["A-1_b"])
+        XCTAssertEqual(listener.events, [.hit("A-1_b"), .completed("A-1_b")])
+    }
+
+    func testInvalidCheckpointIdentifierIsLoggedAndDroppedBeforeListenerOrResolution() async throws {
+        let invalidIdentifier = " checkout😀"
+        var resolutionCount = 0
+        let manager = CheckpointsManager { _, _ in
+            resolutionCount += 1
+            return .noAction(.noMatch)
+        }
+        let listener = ListenerRecorder()
+        manager.listener = listener
+
+        let result = try await manager.checkpoint(identifier: invalidIdentifier, params: .init())
+
+        guard let noActionResult = result as? CheckpointNoActionResult else {
+            return XCTFail("Expected a no-action result")
+        }
+
+        XCTAssertEqual(noActionResult.reason, .invalidCheckpointIdentifier)
+        XCTAssertEqual(noActionResult.checkpoint.identifier, invalidIdentifier)
+        XCTAssertEqual(resolutionCount, 0)
+        XCTAssertTrue(listener.events.isEmpty)
+        self.logger.verifyMessageWasLogged(
+            CheckpointIdentifierValidator.invalidIdentifierLogMessage(invalidIdentifier),
+            level: .error
+        )
+    }
+
+    func testCompletionAPIReturnsInvalidIdentifierNoActionResult() {
+        let completion = self.expectation(description: "Checkpoint completes")
+        var resolutionCount = 0
+        let manager = CheckpointsManager { _, _ in
+            resolutionCount += 1
+            return .noAction(.noMatch)
+        }
+
+        manager.checkpoint(identifier: "invalid checkpoint", params: .init()) { result in
+            guard case let .success(noAction as CheckpointNoActionResult) = result else {
+                return XCTFail("Expected an invalid-identifier no-action result")
+            }
+
+            XCTAssertEqual(noAction.reason, .invalidCheckpointIdentifier)
+            XCTAssertEqual(resolutionCount, 0)
             completion.fulfill()
         }
 

--- a/Tests/UnitTests/LocalRules/CustomVariableKeyValidatorTests.swift
+++ b/Tests/UnitTests/LocalRules/CustomVariableKeyValidatorTests.swift
@@ -33,7 +33,7 @@ struct CustomVariableKeyValidatorTests {
             "a",
             "123key",
             "_key",
-            String(repeating: "a", count: 256)
+            String(repeating: "a", count: 255)
         ]
 
         #expect(validKeys.allSatisfy { CustomVariableKeyValidator.isValidKey($0) })
@@ -48,7 +48,7 @@ struct CustomVariableKeyValidatorTests {
             "key.name",
             "key!",
             "kéy",
-            String(repeating: "a", count: 257)
+            String(repeating: "a", count: 256)
         ]
 
         #expect(invalidKeys.allSatisfy { !CustomVariableKeyValidator.isValidKey($0) })


### PR DESCRIPTION
## Description
Adds validation for checkpoint identifiers passed to the `.checkpoint()` method. Invalid identifiers are logged and dropped before listener callbacks, resolution, or UI work, returning a no-action result with `.invalidCheckpointIdentifier`. The behavior is identical between DEBUG and release.

As discussed the following validations are applied:
- Between 1 and 255 characters
- Start with an ASCII letter
- Contain only:
  - ASCII letters `A-Z`, `a-z`
  - Numbers `0-9`
  - Hyphens `-`
  - Underscores `_`
- No spaces, periods, or special characters

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime behavior for previously accepted invalid checkpoint names (no resolution instead of unknown/no-match), which could surprise integrators but avoids misconfigured dashboard IDs driving work.
> 
> **Overview**
> **Checkpoint identifiers** are now validated before resolution or UI. Invalid IDs still trigger `onCheckpointHit` and `onCheckpointCompleted`, but skip resolution and return a no-action result with **`invalidCheckpointIdentifier`** (logged at error level). Rules: 1–255 characters, must start with an ASCII letter, and only ASCII letters, digits, `_`, and `-`.
> 
> Adds **`CheckpointIdentifierValidator`** and documents the rules on the Swift and Objective-C `checkpoint` APIs. **`CustomVariableKeyValidator`** max key length is aligned from 256 to **255** characters (with updated debug log text). Tests cover the validator, manager paths, ObjC wrapping, and API surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 862b0b8f94123c13eaf65bbbf40478f636b62335. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

