### PR TITLE
feat(checkpoints): Add date and record collection rules dimension values

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		D17A00000000000000000001 /* StoreDimensionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17A00000000000000000002 /* StoreDimensionProvider.swift */; };
 		D17A00000000000000000003 /* StoreDimensionProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17A00000000000000000004 /* StoreDimensionProviderTests.swift */; };
+		D18A00000000000000000003 /* DimensionValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D18A00000000000000000004 /* DimensionValueTests.swift */; };
 		C05A00000000000000000001 /* CustomVariableKeyValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05A00000000000000000002 /* CustomVariableKeyValidator.swift */; };
 		C05A00000000000000000003 /* CustomVariableKeyValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05A00000000000000000004 /* CustomVariableKeyValidatorTests.swift */; };
 		A0D100000000000000000001 /* LocalRulesEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D200000000000000000001 /* LocalRulesEvaluator.swift */; };
@@ -1596,6 +1597,7 @@
 /* Begin PBXFileReference section */
 		D17A00000000000000000002 /* StoreDimensionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreDimensionProvider.swift; sourceTree = "<group>"; };
 		D17A00000000000000000004 /* StoreDimensionProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreDimensionProviderTests.swift; sourceTree = "<group>"; };
+		D18A00000000000000000004 /* DimensionValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DimensionValueTests.swift; sourceTree = "<group>"; };
 		C05A00000000000000000002 /* CustomVariableKeyValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomVariableKeyValidator.swift; sourceTree = "<group>"; };
 		C05A00000000000000000004 /* CustomVariableKeyValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomVariableKeyValidatorTests.swift; sourceTree = "<group>"; };
 		A0D200000000000000000001 /* LocalRulesEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalRulesEvaluator.swift; sourceTree = "<group>"; };
@@ -3303,6 +3305,7 @@
 				A0D200000000000000000005 /* LocalRulesEvaluatorTests.swift */,
 				A0D200000000000000000007 /* DeviceDimensionProviderTests.swift */,
 				D17A00000000000000000004 /* StoreDimensionProviderTests.swift */,
+				D18A00000000000000000004 /* DimensionValueTests.swift */,
 			);
 			path = LocalRules;
 			sourceTree = "<group>";
@@ -8328,6 +8331,7 @@
 				A0D100000000000000000005 /* LocalRulesEvaluatorTests.swift in Sources */,
 				A0D100000000000000000007 /* DeviceDimensionProviderTests.swift in Sources */,
 				D17A00000000000000000003 /* StoreDimensionProviderTests.swift in Sources */,
+				D18A00000000000000000003 /* DimensionValueTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/LocalRules/DimensionProvider.swift
+++ b/Sources/LocalRules/DimensionProvider.swift
@@ -44,7 +44,7 @@ enum DimensionValue: Equatable, Sendable {
     /// Records are only expressible inside a collection. Collection operators
     /// evaluate each record in its own scope, so a record must contain every
     /// value needed to evaluate it.
-    indirect case objectList([[String: DimensionValue]])
+    case objectList([[String: DimensionValue]])
 }
 
 /// Supplies one current subtree of dimensions.

--- a/Sources/LocalRules/DimensionProvider.swift
+++ b/Sources/LocalRules/DimensionProvider.swift
@@ -24,7 +24,7 @@ enum DimensionNamespace: String, CaseIterable, Sendable {
     case client
 }
 
-/// A scalar dimension exposed to the local rules engine.
+/// A dimension exposed to the local rules engine.
 ///
 /// This keeps providers independent from the RulesEngine representation.
 enum DimensionValue: Equatable, Sendable {
@@ -33,6 +33,18 @@ enum DimensionValue: Equatable, Sendable {
     case bool(Bool)
     case int(Int64)
     case double(Double)
+
+    /// A date that can be compared and ordered by local rules.
+    ///
+    /// Dates are exposed to the rules engine as Unix epoch milliseconds.
+    case date(Date)
+
+    /// A collection of records that can be inspected by local rules.
+    ///
+    /// Records are only expressible inside a collection. Collection operators
+    /// evaluate each record in its own scope, so a record must contain every
+    /// value needed to evaluate it.
+    indirect case objectList([[String: DimensionValue]])
 }
 
 /// Supplies one current subtree of dimensions.
@@ -44,7 +56,7 @@ protocol DimensionProvider: Sendable {
     /// Root namespace containing the returned dimensions.
     var namespace: DimensionNamespace { get }
 
-    /// Returns the complete current set of scalar dimensions relative to ``namespace``.
+    /// Returns the complete current set of dimensions relative to ``namespace``.
     ///
     /// Keys are lower camel-case names such as `appVersion`. The resolver
     /// adds the provider's namespace. Missing individual values must be

--- a/Sources/LocalRules/DimensionResolver.swift
+++ b/Sources/LocalRules/DimensionResolver.swift
@@ -98,7 +98,7 @@ struct DimensionResolver: Sendable {
 
 private extension DimensionValue {
 
-    /// Converts a provider scalar into its RulesEngine equivalent.
+    /// Converts a provider value into its RulesEngine equivalent.
     ///
     /// For example, `.double(3)` becomes `.float(3)`.
     var rulesEngineValue: RulesEngine.Value {
@@ -107,6 +107,11 @@ private extension DimensionValue {
         case .bool(let value): return .bool(value)
         case .int(let value): return .int(value)
         case .double(let value): return .float(value)
+        case .date(let value): return .int(Int64(value.timeIntervalSince1970 * 1_000))
+        case .objectList(let values):
+            return .array(values.map { value in
+                .object(value.mapValues(\.rulesEngineValue))
+            })
         }
     }
 }

--- a/Tests/UnitTests/LocalRules/DimensionValueTests.swift
+++ b/Tests/UnitTests/LocalRules/DimensionValueTests.swift
@@ -1,0 +1,142 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  DimensionValueTests.swift
+//
+//  Created by Rick van der Linden on 8/19/26.
+//
+
+// Swift Testing is only available with the Xcode 16+ toolchain
+#if compiler(>=5.9)
+#if canImport(Testing)
+
+import Foundation
+import Testing
+
+@testable import RevenueCat
+
+@Suite("Dimension values")
+struct DimensionValueTests {
+
+    @Test
+    func dateAndObjectListConvertToRulesEngineValues() async throws {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let snapshot = try await Self.snapshot([
+            "date": .date(date),
+            "records": .objectList([
+                [
+                    "id": .string("one"),
+                    "createdAt": .date(date)
+                ]
+            ])
+        ])
+
+        #expect(snapshot.values == [
+            "device": .object([
+                "date": .int(1_700_000_000_000),
+                "records": .array([
+                    .object([
+                        "id": .string("one"),
+                        "createdAt": .int(1_700_000_000_000)
+                    ])
+                ])
+            ])
+        ])
+    }
+
+    @Test
+    func dateDimensionIsOrderedByPredicate() async throws {
+        let snapshot = try await Self.snapshot([
+            "expiresAt": .date(Date(timeIntervalSince1970: 1_700_000_000))
+        ])
+
+        #expect(try RulesEngine.Evaluator.evaluate(
+            predicate: try RulesEngine.Value.fromJSONString(
+                #"{">":[{"var":"device.expiresAt"},1699999999999]}"#
+            ),
+            variables: snapshot.values
+        ))
+        #expect(try !RulesEngine.Evaluator.evaluate(
+            predicate: try RulesEngine.Value.fromJSONString(
+                #"{">":[{"var":"device.expiresAt"},1700000000001]}"#
+            ),
+            variables: snapshot.values
+        ))
+    }
+
+    @Test
+    func objectListIsEvaluatedOneRecordAtATime() async throws {
+        let snapshot = try await Self.snapshot([
+            "purchases": .objectList([
+                [
+                    "productId": .string("plus"),
+                    "isActive": .bool(false)
+                ],
+                [
+                    "productId": .string("pro"),
+                    "isActive": .bool(true)
+                ]
+            ])
+        ])
+
+        let active = try RulesEngine.Value.fromJSONString(
+            #"{"some":[{"var":"device.purchases"},{"and":[{"==":[{"var":"productId"},"pro"]},{"var":"isActive"}]}]}"#
+        )
+        #expect(try RulesEngine.Evaluator.evaluate(predicate: active, variables: snapshot.values))
+
+        let inactive = try RulesEngine.Value.fromJSONString(
+            #"{"some":[{"var":"device.purchases"},{"and":[{"==":[{"var":"productId"},"plus"]},{"var":"isActive"}]}]}"#
+        )
+        #expect(try !RulesEngine.Evaluator.evaluate(predicate: inactive, variables: snapshot.values))
+
+        let byIndex = try RulesEngine.Value.fromJSONString(
+            #"{"==":[{"var":"device.purchases.1.productId"},"pro"]}"#
+        )
+        #expect(try RulesEngine.Evaluator.evaluate(predicate: byIndex, variables: snapshot.values))
+    }
+
+    @Test
+    func emptyObjectListRemainsPresentAsEmptyArray() async throws {
+        let snapshot = try await Self.snapshot([
+            "purchases": .objectList([])
+        ])
+
+        #expect(snapshot.values == [
+            "device": .object(["purchases": .array([])])
+        ])
+
+        let none = try RulesEngine.Value.fromJSONString(
+            #"{"none":[{"var":"device.purchases"},{"var":"isActive"}]}"#
+        )
+        #expect(try RulesEngine.Evaluator.evaluate(predicate: none, variables: snapshot.values))
+    }
+
+    private static func snapshot(
+        _ values: [String: DimensionValue]
+    ) async throws -> DimensionSnapshot {
+        return try await DimensionResolver(
+            dimensionProviders: [StaticDimensionProvider(values: values)]
+        ).snapshot()
+    }
+
+}
+
+private struct StaticDimensionProvider: DimensionProvider {
+
+    let namespace: DimensionNamespace = .device
+    let values: [String: DimensionValue]
+
+    func dimensions(at _: Date) async throws -> [String: DimensionValue] {
+        return self.values
+    }
+
+}
+
+#endif
+#endif


### PR DESCRIPTION
### Description

`DimensionValue` was limited to basic primitives. This PR adds support for 2 more types: Dates and Records. These will be used in a follow-up PR.

Android equivalent: [RevenueCat/purchases-android#3978](https://github.com/RevenueCat/purchases-android/pull/3978)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive types and mapping in the local-rules dimension layer with unit tests; existing primitive dimensions are unchanged until providers adopt the new cases.
> 
> **Overview**
> Extends **`DimensionValue`** with **`date`** and **`objectList`** so local rules can compare timestamps and query record collections (e.g. purchases), ahead of providers that will supply them in a follow-up.
> 
> **`DimensionResolver`** now maps dates to **Unix epoch milliseconds** as rules-engine integers, and **`objectList`** to an array of objects with recursively converted fields—enabling predicates like ordering on `device.expiresAt`, **`some`/`none`** over lists, and indexed access such as `device.purchases.1.productId`.
> 
> Adds **`DimensionValueTests`** covering conversion snapshots, date comparison, per-record collection evaluation, and empty lists remaining as empty arrays.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 222cfcf0a967039c0f66c0299a3529e7bc4ee8a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->