### PR TITLE
feat(checkpoints): Add the app's subscriber attributes as a rules dimension

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		D17A00000000000000000001 /* StoreDimensionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17A00000000000000000002 /* StoreDimensionProvider.swift */; };
 		D17A00000000000000000003 /* StoreDimensionProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17A00000000000000000004 /* StoreDimensionProviderTests.swift */; };
 		D18A00000000000000000003 /* DimensionValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D18A00000000000000000004 /* DimensionValueTests.swift */; };
+		D19A00000000000000000001 /* SubscriberAttributesDimensionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D19A00000000000000000002 /* SubscriberAttributesDimensionProvider.swift */; };
+		D19A00000000000000000003 /* SubscriberAttributesDimensionProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D19A00000000000000000004 /* SubscriberAttributesDimensionProviderTests.swift */; };
 		C05A00000000000000000001 /* CustomVariableKeyValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05A00000000000000000002 /* CustomVariableKeyValidator.swift */; };
 		C05A00000000000000000003 /* CustomVariableKeyValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05A00000000000000000004 /* CustomVariableKeyValidatorTests.swift */; };
 		A0D100000000000000000001 /* LocalRulesEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D200000000000000000001 /* LocalRulesEvaluator.swift */; };
@@ -1598,6 +1600,8 @@
 		D17A00000000000000000002 /* StoreDimensionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreDimensionProvider.swift; sourceTree = "<group>"; };
 		D17A00000000000000000004 /* StoreDimensionProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreDimensionProviderTests.swift; sourceTree = "<group>"; };
 		D18A00000000000000000004 /* DimensionValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DimensionValueTests.swift; sourceTree = "<group>"; };
+		D19A00000000000000000002 /* SubscriberAttributesDimensionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriberAttributesDimensionProvider.swift; sourceTree = "<group>"; };
+		D19A00000000000000000004 /* SubscriberAttributesDimensionProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriberAttributesDimensionProviderTests.swift; sourceTree = "<group>"; };
 		C05A00000000000000000002 /* CustomVariableKeyValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomVariableKeyValidator.swift; sourceTree = "<group>"; };
 		C05A00000000000000000004 /* CustomVariableKeyValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomVariableKeyValidatorTests.swift; sourceTree = "<group>"; };
 		A0D200000000000000000001 /* LocalRulesEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalRulesEvaluator.swift; sourceTree = "<group>"; };
@@ -3292,6 +3296,7 @@
 				A91C0A022FEA000000000001 /* RulesEngineLoggerBridge.swift */,
 				A0D200000000000000000006 /* DeviceDimensionProvider.swift */,
 				D17A00000000000000000002 /* StoreDimensionProvider.swift */,
+				D19A00000000000000000002 /* SubscriberAttributesDimensionProvider.swift */,
 				A0D200000000000000000002 /* DimensionProvider.swift */,
 				A0D200000000000000000003 /* DimensionResolver.swift */,
 			);
@@ -3306,6 +3311,7 @@
 				A0D200000000000000000007 /* DeviceDimensionProviderTests.swift */,
 				D17A00000000000000000004 /* StoreDimensionProviderTests.swift */,
 				D18A00000000000000000004 /* DimensionValueTests.swift */,
+				D19A00000000000000000004 /* SubscriberAttributesDimensionProviderTests.swift */,
 			);
 			path = LocalRules;
 			sourceTree = "<group>";
@@ -7897,6 +7903,7 @@
 				A0D100000000000000000001 /* LocalRulesEvaluator.swift in Sources */,
 				A0D100000000000000000006 /* DeviceDimensionProvider.swift in Sources */,
 				D17A00000000000000000001 /* StoreDimensionProvider.swift in Sources */,
+				D19A00000000000000000001 /* SubscriberAttributesDimensionProvider.swift in Sources */,
 				A0D100000000000000000002 /* DimensionProvider.swift in Sources */,
 				A0D100000000000000000003 /* DimensionResolver.swift in Sources */,
 				FA360650C0B87331F2EFF527 /* Checkpoints.swift in Sources */,
@@ -8332,6 +8339,7 @@
 				A0D100000000000000000007 /* DeviceDimensionProviderTests.swift in Sources */,
 				D17A00000000000000000003 /* StoreDimensionProviderTests.swift in Sources */,
 				D18A00000000000000000003 /* DimensionValueTests.swift in Sources */,
+				D19A00000000000000000003 /* SubscriberAttributesDimensionProviderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Caching/DeviceCache.swift
+++ b/Sources/Caching/DeviceCache.swift
@@ -326,6 +326,12 @@ class DeviceCache {
         }
     }
 
+    func subscriberAttributes(appUserID: String) -> SubscriberAttribute.Dictionary {
+        return self.userDefaults.read {
+            Self.storedSubscriberAttributes($0, appUserID: appUserID)
+        }
+    }
+
     func unsyncedAttributesByKey(appUserID: String) -> [String: SubscriberAttribute] {
         return self.userDefaults.read {
             Self.unsyncedAttributesByKey($0, appUserID: appUserID)

--- a/Sources/LocalRules/DimensionProvider.swift
+++ b/Sources/LocalRules/DimensionProvider.swift
@@ -20,6 +20,7 @@ enum DimensionNamespace: String, CaseIterable, Sendable {
     case custom
     case device
     case store
+    case subscriberAttributes
     case session
     case client
 }
@@ -38,6 +39,12 @@ enum DimensionValue: Equatable, Sendable {
     ///
     /// Dates are exposed to the rules engine as Unix epoch milliseconds.
     case date(Date)
+
+    /// A named group of values that rules can read through using a dot path.
+    ///
+    /// Unlike a record inside ``objectList(_:)``, reading an object does not
+    /// change the rule's evaluation scope.
+    indirect case object([String: DimensionValue])
 
     /// A collection of records that can be inspected by local rules.
     ///
@@ -59,7 +66,8 @@ protocol DimensionProvider: Sendable {
     /// Returns the complete current set of dimensions relative to ``namespace``.
     ///
     /// Keys are lower camel-case names such as `appVersion`. The resolver
-    /// adds the provider's namespace. Missing individual values must be
+    /// adds the provider's namespace and recursively ignores empty keys or keys
+    /// containing the `.` path separator. Missing individual values must be
     /// omitted. Throwing is reserved for a systemic failure to produce the
     /// provider's dimensions.
     ///

--- a/Sources/LocalRules/DimensionProvider.swift
+++ b/Sources/LocalRules/DimensionProvider.swift
@@ -66,9 +66,9 @@ protocol DimensionProvider: Sendable {
     /// Returns the complete current set of dimensions relative to ``namespace``.
     ///
     /// Keys are lower camel-case names such as `appVersion`. The resolver
-    /// adds the provider's namespace and recursively ignores empty keys or keys
-    /// containing the `.` path separator. Missing individual values must be
-    /// omitted. Throwing is reserved for a systemic failure to produce the
+    /// adds the provider's namespace and recursively ignores empty,
+    /// whitespace-only, or `.`-containing keys. Missing individual values must
+    /// be omitted. Throwing is reserved for a systemic failure to produce the
     /// provider's dimensions.
     ///
     /// `date` is the common reference date for the evaluation. It does not

--- a/Sources/LocalRules/DimensionResolver.swift
+++ b/Sources/LocalRules/DimensionResolver.swift
@@ -70,24 +70,31 @@ struct DimensionResolver: Sendable {
                 namespaceValues = existing
             }
 
-            for (name, value) in providerValues {
+            for (name, value) in DimensionValueConverter.convert(
+                providerValues,
+                parentPath: namespace
+            ) {
                 guard namespaceValues[name] == nil else {
                     throw DimensionResolutionError.conflictingValue(
                         path: "\(namespace).\(name)"
                     )
                 }
 
-                namespaceValues[name] = value.rulesEngineValue
+                namespaceValues[name] = value
             }
 
-            values[namespace] = .object(namespaceValues)
+            if !namespaceValues.isEmpty {
+                values[namespace] = .object(namespaceValues)
+            }
         }
 
         let validCustomVariables = CustomVariableKeyValidator.validateAndFilter(customVariables)
-        if !validCustomVariables.isEmpty {
-            values[DimensionNamespace.custom.rawValue] = .object(
-                validCustomVariables.mapValues(\.rulesEngineValue)
-            )
+        let customVariables = DimensionValueConverter.convert(
+            validCustomVariables,
+            parentPath: DimensionNamespace.custom.rawValue
+        )
+        if !customVariables.isEmpty {
+            values[DimensionNamespace.custom.rawValue] = .object(customVariables)
         }
 
         try Task.checkCancellation()
@@ -96,22 +103,49 @@ struct DimensionResolver: Sendable {
     }
 }
 
-private extension DimensionValue {
+private enum DimensionValueConverter {
 
-    /// Converts a provider value into its RulesEngine equivalent.
-    ///
-    /// For example, `.double(3)` becomes `.float(3)`.
-    var rulesEngineValue: RulesEngine.Value {
-        switch self {
+    static func convert(
+        _ dimensions: [String: DimensionValue],
+        parentPath: String
+    ) -> [String: RulesEngine.Value] {
+        return dimensions.reduce(into: [:]) { result, dimension in
+            let (name, value) = dimension
+            guard Self.isValidName(name) else {
+                Logger.warn(Strings.remoteConfig.invalidDimensionName(name, parentPath: parentPath))
+                return
+            }
+
+            guard let converted = Self.convert(value, path: "\(parentPath).\(name)") else {
+                return
+            }
+
+            result[name] = converted
+        }
+    }
+
+    /// Converts a provider value into its RulesEngine equivalent while filtering invalid nested names.
+    private static func convert(_ dimension: DimensionValue, path: String) -> RulesEngine.Value? {
+        switch dimension {
         case .string(let value): return .string(value)
         case .bool(let value): return .bool(value)
         case .int(let value): return .int(value)
         case .double(let value): return .float(value)
         case .date(let value): return .int(Int64(value.timeIntervalSince1970 * 1_000))
+        case .object(let value):
+            let converted = Self.convert(value, parentPath: path)
+            return converted.isEmpty ? nil : .object(converted)
         case .objectList(let values):
-            return .array(values.map { value in
-                .object(value.mapValues(\.rulesEngineValue))
+            return .array(values.enumerated().compactMap { index, value in
+                let converted = Self.convert(value, parentPath: "\(path).\(index)")
+                return converted.isEmpty ? nil : .object(converted)
             })
         }
     }
+
+    private static func isValidName(_ name: String) -> Bool {
+        return !name.isEmpty && !name.contains(Self.pathSeparator)
+    }
+
+    private static let pathSeparator: Character = "."
 }

--- a/Sources/LocalRules/DimensionResolver.swift
+++ b/Sources/LocalRules/DimensionResolver.swift
@@ -144,7 +144,7 @@ private enum DimensionValueConverter {
     }
 
     private static func isValidName(_ name: String) -> Bool {
-        return !name.isEmpty && !name.contains(Self.pathSeparator)
+        return name.notEmptyOrWhitespaces != nil && !name.contains(Self.pathSeparator)
     }
 
     private static let pathSeparator: Character = "."

--- a/Sources/LocalRules/SubscriberAttributesDimensionProvider.swift
+++ b/Sources/LocalRules/SubscriberAttributesDimensionProvider.swift
@@ -1,0 +1,68 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SubscriberAttributesDimensionProvider.swift
+//
+//  Created by Rick van der Linden on 8/19/26.
+//
+
+import Foundation
+
+/// Supplies the subscriber attributes stored for the current customer to the local rules engine.
+struct SubscriberAttributesDimensionProvider: DimensionProvider {
+
+    let namespace = DimensionNamespace.subscriberAttributes
+
+    private let attributesProvider: @Sendable () throws -> SubscriberAttribute.Dictionary
+
+    init(
+        deviceCache: DeviceCache,
+        currentUserProvider: any CurrentUserProvider
+    ) {
+        self.init {
+            deviceCache.subscriberAttributes(appUserID: currentUserProvider.currentAppUserID)
+        }
+    }
+
+    init(
+        attributesProvider: @escaping @Sendable () throws -> SubscriberAttribute.Dictionary
+    ) {
+        self.attributesProvider = attributesProvider
+    }
+
+    /// Reads attributes for each evaluation because an app can update them at any time.
+    ///
+    /// A failed read contributes no dimensions rather than preventing the other
+    /// dimensions from being evaluated.
+    func dimensions(at date: Date) async throws -> [String: DimensionValue] {
+        let attributes: SubscriberAttribute.Dictionary
+        do {
+            attributes = try self.attributesProvider()
+        } catch {
+            Logger.warn(Strings.remoteConfig.subscriberAttributesUnavailable(error))
+            return [:]
+        }
+
+        return attributes.values.reduce(into: [:]) { dimensions, attribute in
+            // An empty value represents a deleted attribute, whether or not its tombstone has been synced.
+            guard !attribute.value.isEmpty else { return }
+
+            dimensions[attribute.key] = .object([
+                Self.valueKey: .string(attribute.value),
+                Self.updatedAtKey: .date(attribute.setTime),
+                Self.evaluatedAtKey: .date(date)
+            ])
+        }
+    }
+
+    private static let evaluatedAtKey = "evaluatedAt"
+    private static let updatedAtKey = "updatedAt"
+    private static let valueKey = "value"
+
+}

--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -42,6 +42,8 @@ enum RemoteConfigStrings {
     case sourceUnhealthy(ref: String, hasNextSource: Bool)
     case storedBlob(String, byteCount: Int, URL)
     case storedInlineBlob(String, byteCount: Int)
+    case subscriberAttributesUnavailable(Error)
+    case invalidDimensionName(String, parentPath: String)
     case uiConfigDecodeFailed(Error)
     case uiConfigMissingRequiredPart
 
@@ -127,6 +129,11 @@ extension RemoteConfigStrings: LogMessage {
             return "Stored remote config blob '\(ref)' with \(byteCount) bytes downloaded from \(url.absoluteString)."
         case let .storedInlineBlob(ref, byteCount):
             return "Stored inline remote config blob '\(ref)' with \(byteCount) bytes."
+        case let .subscriberAttributesUnavailable(error):
+            return "The subscriber attributes are unavailable, so they cannot be evaluated: \(error)."
+        case let .invalidDimensionName(name, parentPath):
+            return "Ignoring dimension name '\(name)' under '\(parentPath)': " +
+                "a dimension name cannot be empty or contain '.'."
         case let .uiConfigDecodeFailed(error):
             return "Failed to decode merged ui_config: \(error.localizedDescription)"
         case .uiConfigMissingRequiredPart:

--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -133,7 +133,7 @@ extension RemoteConfigStrings: LogMessage {
             return "The subscriber attributes are unavailable, so they cannot be evaluated: \(error)."
         case let .invalidDimensionName(name, parentPath):
             return "Ignoring dimension name '\(name)' under '\(parentPath)': " +
-                "a dimension name cannot be empty or contain '.'."
+                "a dimension name cannot be empty, whitespace-only, or contain '.'."
         case let .uiConfigDecodeFailed(error):
             return "Failed to decode merged ui_config: \(error.localizedDescription)"
         case .uiConfigMissingRequiredPart:

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -656,7 +656,11 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             let localRulesEvaluator = LocalRulesEvaluator(
                 dimensionProviders: [
                     DeviceDimensionProvider(),
-                    StoreDimensionProvider()
+                    StoreDimensionProvider(),
+                    SubscriberAttributesDimensionProvider(
+                        deviceCache: deviceCache,
+                        currentUserProvider: identityManager
+                    )
                 ]
             )
             checkpointResolver = DefaultCheckpointWorkflowResolver(

--- a/Tests/UnitTests/LocalRules/DimensionValueTests.swift
+++ b/Tests/UnitTests/LocalRules/DimensionValueTests.swift
@@ -29,6 +29,10 @@ struct DimensionValueTests {
         let date = Date(timeIntervalSince1970: 1_700_000_000)
         let snapshot = try await Self.snapshot([
             "date": .date(date),
+            "record": .object([
+                "id": .string("one"),
+                "createdAt": .date(date)
+            ]),
             "records": .objectList([
                 [
                     "id": .string("one"),
@@ -40,6 +44,10 @@ struct DimensionValueTests {
         #expect(snapshot.values == [
             "device": .object([
                 "date": .int(1_700_000_000_000),
+                "record": .object([
+                    "id": .string("one"),
+                    "createdAt": .int(1_700_000_000_000)
+                ]),
                 "records": .array([
                     .object([
                         "id": .string("one"),
@@ -48,6 +56,27 @@ struct DimensionValueTests {
                 ])
             ])
         ])
+    }
+
+    @Test
+    func objectDimensionIsReadThroughByName() async throws {
+        let snapshot = try await Self.snapshot([
+            "goal": .object([
+                "value": .string("lose_weight"),
+                "updatedAt": .date(Date(timeIntervalSince1970: 1_700_000_000))
+            ])
+        ])
+
+        let predicate = try RulesEngine.Value.fromJSONString(
+            #"""
+            {"and":[
+                {"==":[{"var":"device.goal.value"},"lose_weight"]},
+                {">":[{"var":"device.goal.updatedAt"},1699999999999]}
+            ]}
+            """#
+        )
+
+        #expect(try RulesEngine.Evaluator.evaluate(predicate: predicate, variables: snapshot.values))
     }
 
     @Test

--- a/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
+++ b/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
@@ -143,10 +143,12 @@ struct LocalRulesEvaluatorTests {
             namespace: .device,
             snapshots: [[
                 "": .string("empty"),
+                " \n": .string("blank"),
                 "user.tier": .string("gold"),
                 "platform": .string("ios"),
                 "profile": .object([
                     "": .string("empty"),
+                    "\t": .string("blank"),
                     "account.tier": .string("gold"),
                     "name": .string("Rick"),
                     "preferences": .object([
@@ -160,6 +162,7 @@ struct LocalRulesEvaluatorTests {
                 "events": .objectList([
                     [
                         "": .string("empty"),
+                        " ": .string("blank"),
                         "event.name": .string("purchase"),
                         "name": .string("purchase")
                     ],

--- a/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
+++ b/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
@@ -138,6 +138,59 @@ struct LocalRulesEvaluatorTests {
     }
 
     @Test
+    func recursivelyOmitsInvalidProviderDimensionNames() async throws {
+        let provider = TestDimensionProvider(
+            namespace: .device,
+            snapshots: [[
+                "": .string("empty"),
+                "user.tier": .string("gold"),
+                "platform": .string("ios"),
+                "profile": .object([
+                    "": .string("empty"),
+                    "account.tier": .string("gold"),
+                    "name": .string("Rick"),
+                    "preferences": .object([
+                        "invalid.key": .bool(false),
+                        "notificationsEnabled": .bool(true)
+                    ])
+                ]),
+                "invalidObject": .object([
+                    "invalid.key": .string("value")
+                ]),
+                "events": .objectList([
+                    [
+                        "": .string("empty"),
+                        "event.name": .string("purchase"),
+                        "name": .string("purchase")
+                    ],
+                    [
+                        "invalid.key": .string("value")
+                    ]
+                ])
+            ]]
+        )
+
+        let snapshot = try await DimensionResolver(dimensionProviders: [provider]).snapshot()
+
+        guard case .object(let deviceValues) = snapshot.values["device"] else {
+            Issue.record("Expected device dimensions")
+            return
+        }
+        #expect(deviceValues == [
+            "platform": .string("ios"),
+            "profile": .object([
+                "name": .string("Rick"),
+                "preferences": .object([
+                    "notificationsEnabled": .bool(true)
+                ])
+            ]),
+            "events": .array([
+                .object(["name": .string("purchase")])
+            ])
+        ])
+    }
+
+    @Test
     func customVariablesAreAvailableInCustomNamespace() async throws {
         let evaluator = Self.evaluator(dimensionProviders: [])
 

--- a/Tests/UnitTests/LocalRules/SubscriberAttributesDimensionProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/SubscriberAttributesDimensionProviderTests.swift
@@ -1,0 +1,275 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SubscriberAttributesDimensionProviderTests.swift
+//
+//  Created by Rick van der Linden on 8/19/26.
+//
+
+// Swift Testing is only available with the Xcode 16+ toolchain
+#if compiler(>=5.9)
+#if canImport(Testing)
+
+import Foundation
+import Testing
+
+@testable import RevenueCat
+
+@Suite("Subscriber attributes dimension provider")
+struct SubscriberAttributesProviderTests {
+
+    @Test
+    func exposesEveryStoredAttributeUnderItsOriginalName() async throws {
+        let provider = Self.provider(
+            Self.attribute("$email", value: "jane@example.com"),
+            Self.attribute("goal", value: "lose_weight")
+        )
+
+        let dimensions = try await provider.dimensions(at: Self.evaluationDate)
+
+        #expect(provider.namespace == .subscriberAttributes)
+        #expect(Set(dimensions.keys) == ["$email", "goal"])
+    }
+
+    @Test
+    func exposesValueUpdatedAtAndEvaluatedAt() async throws {
+        let provider = Self.provider(Self.attribute("goal", value: "lose_weight"))
+
+        let dimensions = try await provider.dimensions(at: Self.evaluationDate)
+
+        #expect(dimensions == [
+            "goal": .object([
+                "value": .string("lose_weight"),
+                "updatedAt": .date(Self.setDate),
+                "evaluatedAt": .date(Self.evaluationDate)
+            ])
+        ])
+    }
+
+    @Test
+    func preservesAttributeValuesAsStrings() async throws {
+        let dimensions = try await Self.provider(
+            Self.attribute("seats", value: "3"),
+            Self.attribute("betaOptIn", value: "true"),
+            Self.attribute("sku", value: "0123")
+        ).dimensions(at: Self.evaluationDate)
+
+        #expect(Self.value(of: "seats", in: dimensions) == .string("3"))
+        #expect(Self.value(of: "betaOptIn", in: dimensions) == .string("true"))
+        #expect(Self.value(of: "sku", in: dimensions) == .string("0123"))
+    }
+
+    @Test
+    func omitsDeletedAttributesRegardlessOfSyncState() async throws {
+        let dimensions = try await Self.provider(
+            Self.attribute("pending", value: nil, isSynced: false),
+            Self.attribute("posted", value: nil, isSynced: true),
+            Self.attribute("goal", value: "lose_weight")
+        ).dimensions(at: Self.evaluationDate)
+
+        #expect(Set(dimensions.keys) == ["goal"])
+    }
+
+    @Test
+    func omitsEmptyAndUnreachableAttributeNames() async throws {
+        let snapshot = try await DimensionResolver(
+            dimensionProviders: [
+                Self.provider(
+                    Self.attribute("user.tier", value: "gold"),
+                    Self.attribute("", value: "anything"),
+                    Self.attribute("tier", value: "gold")
+                )
+            ]
+        ).snapshot()
+
+        guard case .object(let attributes) = snapshot.values["subscriberAttributes"] else {
+            Issue.record("Expected subscriber attribute dimensions")
+            return
+        }
+        #expect(Set(attributes.keys) == ["tier"])
+    }
+
+    @Test
+    func omitsNamespaceWhenThereAreNoAttributes() async throws {
+        let snapshot = try await DimensionResolver(
+            dimensionProviders: [Self.provider()]
+        ).snapshot()
+
+        #expect(snapshot.values[DimensionNamespace.subscriberAttributes.rawValue] == nil)
+    }
+
+    @Test
+    func readFailureLeavesOtherDimensionsAvailable() async throws {
+        let provider = SubscriberAttributesDimensionProvider {
+            throw TestError.unavailable
+        }
+        let snapshot = try await DimensionResolver(
+            dimensionProviders: [
+                SubscriberAttributesTestDeviceProvider(),
+                provider
+            ]
+        ).snapshot()
+
+        #expect(snapshot.values == [
+            "device": .object(["platform": .string("ios")])
+        ])
+    }
+
+    @Test
+    func readsAttributesForEveryEvaluation() async throws {
+        let attributes: Atomic<SubscriberAttribute.Dictionary> = .init([
+            "goal": Self.attribute("goal", value: "lose_weight")
+        ])
+        let provider = SubscriberAttributesDimensionProvider {
+            attributes.value
+        }
+
+        let first = try await provider.dimensions(at: Self.evaluationDate)
+        attributes.value = ["goal": Self.attribute("goal", value: "gain_muscle")]
+        let second = try await provider.dimensions(at: Self.evaluationDate)
+
+        #expect(Self.value(of: "goal", in: first) == .string("lose_weight"))
+        #expect(Self.value(of: "goal", in: second) == .string("gain_muscle"))
+    }
+
+    @Test
+    func readsAttributesForCurrentAppUserOnEveryEvaluation() async throws {
+        let deviceCache = DeviceCache(
+            systemInfo: MockSystemInfo(finishTransactions: false),
+            userDefaults: MockUserDefaults()
+        )
+        let currentUserProvider = MockCurrentUserProvider(mockAppUserID: "first-user")
+        deviceCache.store(
+            subscriberAttribute: Self.attribute("goal", value: "lose_weight"),
+            appUserID: "first-user"
+        )
+        deviceCache.store(
+            subscriberAttribute: Self.attribute("goal", value: "gain_muscle"),
+            appUserID: "second-user"
+        )
+        let provider = SubscriberAttributesDimensionProvider(
+            deviceCache: deviceCache,
+            currentUserProvider: currentUserProvider
+        )
+
+        let first = try await provider.dimensions(at: Self.evaluationDate)
+        currentUserProvider.mockAppUserID = "second-user"
+        let second = try await provider.dimensions(at: Self.evaluationDate)
+
+        #expect(Self.value(of: "goal", in: first) == .string("lose_weight"))
+        #expect(Self.value(of: "goal", in: second) == .string("gain_muscle"))
+    }
+
+    @Test
+    func attributesCanBeEvaluatedUsingSDKDimensionPaths() async throws {
+        let recentSetDate = Self.evaluationDate.addingTimeInterval(-86_400)
+        let evaluator = LocalRulesEvaluator(
+            dimensionProviders: [
+                Self.provider(
+                    Self.attribute("$email", value: "jane@example.com"),
+                    Self.attribute("seats", value: "3"),
+                    Self.attribute("goal", value: "lose_weight"),
+                    Self.attribute("tier", value: "gold", setTime: recentSetDate)
+                )
+            ],
+            dateProvider: MockDateProvider(stubbedNow: Self.evaluationDate)
+        )
+
+        let matchingPredicates = [
+            #"{"==":[{"var":"subscriberAttributes.$email.value"},"jane@example.com"]}"#,
+            #"{"==":[{"var":"subscriberAttributes.seats.value"},3]}"#,
+            #"{">":[{"var":"subscriberAttributes.seats.value"},2]}"#,
+            #"""
+            {"<":[
+                {"-":[{"var":"subscriberAttributes.tier.evaluatedAt"},
+                      {"var":"subscriberAttributes.tier.updatedAt"}]},
+                604800000
+            ]}
+            """#
+        ]
+        let nonMatchingPredicates = [
+            #"{"==":[{"var":"subscriberAttributes.goal.value"},"gain_muscle"]}"#,
+            #"{"!!":{"var":"subscriberAttributes.favoriteColor.value"}}"#,
+            #"{"!!":{"var":"subscriberAttributes.goal.isSynced"}}"#,
+            #"""
+            {"<":[
+                {"-":[{"var":"subscriberAttributes.goal.evaluatedAt"},
+                      {"var":"subscriberAttributes.goal.updatedAt"}]},
+                604800000
+            ]}
+            """#
+        ]
+
+        for predicate in matchingPredicates {
+            #expect(try await evaluator.match(in: [TestSubscriberAttributeRule(predicate: predicate)]) != nil)
+        }
+        for predicate in nonMatchingPredicates {
+            #expect(try await evaluator.match(in: [TestSubscriberAttributeRule(predicate: predicate)]) == nil)
+        }
+    }
+
+    private static let evaluationDate = Date(timeIntervalSince1970: 1_718_452_800)
+    private static let setDate = Date(timeIntervalSince1970: 1_714_780_800)
+
+    private static func attribute(
+        _ key: String,
+        value: String?,
+        isSynced: Bool = true,
+        setTime: Date = Self.setDate
+    ) -> SubscriberAttribute {
+        return SubscriberAttribute(
+            withKey: key,
+            value: value,
+            isSynced: isSynced,
+            setTime: setTime
+        )
+    }
+
+    private static func provider(
+        _ attributes: SubscriberAttribute...
+    ) -> SubscriberAttributesDimensionProvider {
+        return SubscriberAttributesDimensionProvider {
+            Dictionary(uniqueKeysWithValues: attributes.map { ($0.key, $0) })
+        }
+    }
+
+    private static func value(
+        of name: String,
+        in dimensions: [String: DimensionValue]
+    ) -> DimensionValue? {
+        guard case .object(let attribute) = dimensions[name] else { return nil }
+        return attribute["value"]
+    }
+
+}
+
+private struct TestSubscriberAttributeRule: LocalRule {
+
+    let predicate: String
+
+}
+
+private struct SubscriberAttributesTestDeviceProvider: DimensionProvider {
+
+    let namespace = DimensionNamespace.device
+
+    func dimensions(at _: Date) async throws -> [String: DimensionValue] {
+        return ["platform": .string("ios")]
+    }
+
+}
+
+private enum TestError: Error {
+
+    case unavailable
+
+}
+
+#endif
+#endif

--- a/Tests/UnitTests/SubscriberAttributes/DeviceCacheSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/DeviceCacheSubscriberAttributesTests.swift
@@ -221,6 +221,35 @@ class DeviceCacheSubscriberAttributesTests: TestCase {
         expect(self.deviceCache.subscriberAttribute(attributeKey: "doesn't exist", appUserID: "whoever")).to(beNil())
     }
 
+    func testSubscriberAttributesReturnsAllAttributesForUser() {
+        let appUserID = "waldo"
+        self.subscriberAttributeWeight.isSynced = true
+        self.deviceCache.store(
+            subscriberAttributesByKey: [
+                subscriberAttributeHeight.key: subscriberAttributeHeight,
+                subscriberAttributeWeight.key: subscriberAttributeWeight
+            ],
+            appUserID: appUserID
+        )
+        self.deviceCache.store(
+            subscriberAttribute: SubscriberAttribute(
+                withKey: "goal",
+                value: "lose_weight",
+                dateProvider: self.mockDateProvider
+            ),
+            appUserID: "another-user"
+        )
+
+        expect(self.deviceCache.subscriberAttributes(appUserID: appUserID)) == [
+            subscriberAttributeHeight.key: subscriberAttributeHeight,
+            subscriberAttributeWeight.key: subscriberAttributeWeight
+        ]
+    }
+
+    func testSubscriberAttributesReturnsEmptyIfNoneStored() {
+        expect(self.deviceCache.subscriberAttributes(appUserID: "waldo")).to(beEmpty())
+    }
+
     func testUnsyncedAttributesByKeyReturnsEmptyIfNoneStored() {
         expect(self.deviceCache.unsyncedAttributesByKey(appUserID: "waldo")).to(beEmpty())
     }


### PR DESCRIPTION
## Description
Implements exposing local subscriber attributes to the rules engine, making any locally set attribute available in the following format:

```json
{
  "subscriberAttributes": {
    "$email": {
      "evaluatedAt": 1718452800000,
      "updatedAt": 1714521600000,
      "value": "jane@example.com"
    },
    "goal": {
      "evaluatedAt": 1718452800000,
      "updatedAt": 1718366400000,
      "value": "lose_weight"
    },
    "seats": {
      "evaluatedAt": 1718452800000,
      "updatedAt": 1714780800000,
      "value": "3"
    }
  }
}
```

Android equivalent: [RevenueCat/purchases-android#3996](https://github.com/RevenueCat/purchases-android/pull/3996)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how local checkpoint/audience rules are evaluated by injecting user-specific subscriber data and tightening dimension key handling; attribute read failures are isolated but rule outcomes can change when attributes are present.
> 
> **Overview**
> Adds a **`subscriberAttributes`** rules namespace so checkpoint/audience predicates can use locally cached attributes (e.g. `subscriberAttributes.goal.value`, `updatedAt`, `evaluatedAt`). Attributes are read per evaluation for the **current app user**; empty/deleted values and invalid keys (empty, whitespace, or containing `.`) are omitted.
> 
> **Dimension plumbing:** `DimensionValue` gains an **`object`** case for nested groups without changing evaluation scope. `DimensionResolver` now converts dimensions through **`DimensionValueConverter**, which recursively filters bad keys, drops empty nested objects/lists, and skips empty provider namespaces.
> 
> **`DeviceCache`** adds **`subscriberAttributes(appUserID:)`** for bulk reads. **`Purchases`** wires **`SubscriberAttributesDimensionProvider`** into **`LocalRulesEvaluator`** when remote config is enabled. Attribute read failures log a warning and contribute no dimensions so other namespaces still evaluate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56d1f0c1b013e76cdc0732f206a0308b4b3098bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->