### PR TITLE
Read the SDK API feed channel from the CI context

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -2065,8 +2065,6 @@ jobs:
             bundle exec fastlane ios generate_swiftinterface scheme:RevenueCat
       - run:
           name: Check RevenueCat API changes
-          environment:
-            SLACK_CHANNEL_SDK_NEW_API: "#feed-sdk-new-api"
           command: |
             bundle exec fastlane ios check_api_changes scheme:RevenueCat
       - store_artifacts:
@@ -2116,8 +2114,6 @@ jobs:
             bundle exec fastlane ios generate_swiftinterface scheme:RevenueCatUI
       - run:
           name: Check RevenueCatUI API changes
-          environment:
-            SLACK_CHANNEL_SDK_NEW_API: "#feed-sdk-new-api"
           command: |
             bundle exec fastlane ios check_api_changes scheme:RevenueCatUI
       - store_artifacts:


### PR DESCRIPTION
- Follow-up to #7431: the api-diff jobs pinned `SLACK_CHANNEL_SDK_NEW_API: "#feed-sdk-new-api"` as a step-level `environment:`, which overrides the context.

<details><summary>Agent description</summary>

### Motivation

`#7431` added dedup that reads the feed channel with `conversations.history`, which takes a channel ID and rejects a `#name`. The two api-diff steps set the channel inline, and a step-level `environment:` wins over any context value, so the read would always have failed the ID check and fallen back to the fingerprint marker on the PR comment. `purchases-android` never had this problem: `#3976` deliberately left the channel to the context.

### Description

- Removes the `environment:` block from the RevenueCat and RevenueCatUI `check_api_changes` steps.

Not visible in the diff: keeping the channel out of the repo is also why it is not simply replaced with the ID here.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change with no SDK or runtime impact; it fixes Slack dedup for API-diff jobs by restoring context-provided channel configuration.
> 
> **Overview**
> Removes the step-level `environment` block that set `SLACK_CHANNEL_SDK_NEW_API` to `#feed-sdk-new-api` on the **RevenueCat** and **RevenueCatUI** `check_api_changes` CircleCI steps.
> 
> Those inline values **overrode** the `slack-secrets-ios` context, so dedup logic that reads the feed via `conversations.history` always saw a channel **name** instead of an ID, failed validation, and fell back to PR-comment fingerprint checks instead of the Slack feed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64976d3edf9f7e77090ad1cfe4949508f725c34e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->