### PR TITLE
Track checkpoint hits through the analytics events pipeline

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -446,7 +446,9 @@
 		3B41364A5DFC4039B3026F40 /* RemoteConfigAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A2DB969D72432B87F48C5F /* RemoteConfigAPI.swift */; };
 		3D3FCA672E03ABA71D7C0AF3 /* PackageComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5FC914F4E87D00963A8F1D /* PackageComponentTests.swift */; };
 		C0DE00000000000000000102 /* CheckpointWorkflowResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000202 /* CheckpointWorkflowResolver.swift */; };
+		C0DE00000000000000000106 /* CheckpointEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000206 /* CheckpointEvent.swift */; };
 		C0DE00000000000000000105 /* CheckpointWorkflowResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000205 /* CheckpointWorkflowResolverTests.swift */; };
+		C0DE00000000000000000108 /* CheckpointEventsRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000208 /* CheckpointEventsRequestTests.swift */; };
 		42F1DF385E3C1F9903A07FBF /* ProductsFetcherSK1.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB3CBAA73855779FE828CE2 /* ProductsFetcherSK1.swift */; };
 		451441F0014BC13272B179CC /* View+ExitOfferPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE8FCE0314FF930204BE4D33 /* View+ExitOfferPresentation.swift */; };
 		49554883F2D5ED48F0907FB9 /* ExitOfferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D26169F24D341F77345716D /* ExitOfferTests.swift */; };
@@ -554,6 +556,7 @@
 		4FF6E4B92B069B8C000141ED /* HTTPRequest+Signing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF6E4B82B069B8C000141ED /* HTTPRequest+Signing.swift */; };
 		4FF8464D2A32554300617F00 /* DiagnosticsStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF8464C2A32554300617F00 /* DiagnosticsStrings.swift */; };
 		4FFCED882AA941D200118EF4 /* FeatureEventsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFCED852AA941D200118EF4 /* FeatureEventsRequest.swift */; };
+		C0DE00000000000000000107 /* FeatureEventsRequest+CheckpointEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000207 /* FeatureEventsRequest+CheckpointEvent.swift */; };
 		4FFCED892AA941D200118EF4 /* FeatureEventHTTPRequestPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFCED862AA941D200118EF4 /* FeatureEventHTTPRequestPath.swift */; };
 		4FFFE6C42AA9464100B2955C /* EventsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFFE6C32AA9464100B2955C /* EventsManager.swift */; };
 		4FFFE6CA2AA946A700B2955C /* MockInternalAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFFE6C92AA946A700B2955C /* MockInternalAPI.swift */; };
@@ -1172,6 +1175,7 @@
 		90A1B2C72F96927E00D32EDF /* AdRewardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90A1B2C62F96927E00D32EDF /* AdRewardTests.swift */; };
 		923A22C9437BD0A6223B866D /* RulesEngineEvaluate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F7428736E4FABCF7AD45798 /* RulesEngineEvaluate.swift */; };
 		94BA76C3AAF699D59AA685FC /* PurchasesWorkflowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78B1498BA2288B4643B248A5 /* PurchasesWorkflowTests.swift */; };
+		C0DE00000000000000000109 /* PurchasesCheckpointEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000209 /* PurchasesCheckpointEventsTests.swift */; };
 		961B6FC99052B19102AE5AEC /* WorkflowNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A10AD61D82EB73FC5338DA2 /* WorkflowNavigator.swift */; };
 		97B9F00926E0977B0DAAD7D7 /* EnvironmentValues+Workflow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C553D7740916F157FA16753 /* EnvironmentValues+Workflow.swift */; };
 		986C48FD2F55A58C00D8CEA5 /* PaywallSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B1D7B32F2A213800A77E21 /* PaywallSource.swift */; };
@@ -2231,6 +2235,7 @@
 		4FF6E4B82B069B8C000141ED /* HTTPRequest+Signing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HTTPRequest+Signing.swift"; sourceTree = "<group>"; };
 		4FF8464C2A32554300617F00 /* DiagnosticsStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsStrings.swift; sourceTree = "<group>"; };
 		4FFCED852AA941D200118EF4 /* FeatureEventsRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeatureEventsRequest.swift; sourceTree = "<group>"; };
+		C0DE00000000000000000207 /* FeatureEventsRequest+CheckpointEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FeatureEventsRequest+CheckpointEvent.swift"; sourceTree = "<group>"; };
 		4FFCED862AA941D200118EF4 /* FeatureEventHTTPRequestPath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeatureEventHTTPRequestPath.swift; sourceTree = "<group>"; };
 		4FFD88BE2A4B56E2008E98AC /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
 		4FFFE6C32AA9464100B2955C /* EventsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventsManager.swift; sourceTree = "<group>"; };
@@ -2645,6 +2650,7 @@
 		77BA1AB02CCBAB80009BF0EA /* RootViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewModel.swift; sourceTree = "<group>"; };
 		77BA1AB22CCBB6EE009BF0EA /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		78B1498BA2288B4643B248A5 /* PurchasesWorkflowTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PurchasesWorkflowTests.swift; sourceTree = "<group>"; };
+		C0DE00000000000000000209 /* PurchasesCheckpointEventsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PurchasesCheckpointEventsTests.swift; sourceTree = "<group>"; };
 		7AA86A1D9F5AE92988B20230 /* WorkflowContextTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowContextTests.swift; sourceTree = "<group>"; };
 		7F8F8AD16519E1EFCE1B99F4 /* ValueTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ValueTests.swift; sourceTree = "<group>"; };
 		800A129055A298C390AED0B5 /* WorkflowPaywallView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowPaywallView.swift; sourceTree = "<group>"; };
@@ -2659,7 +2665,9 @@
 		80CDB7B52E69C35100D7DB9E /* CustomerCenterStylingUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerCenterStylingUtilities.swift; sourceTree = "<group>"; };
 		80E80EF026970DC3008F245A /* ReceiptFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptFetcher.swift; sourceTree = "<group>"; };
 		C0DE00000000000000000202 /* CheckpointWorkflowResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CheckpointWorkflowResolver.swift; sourceTree = "<group>"; };
+		C0DE00000000000000000206 /* CheckpointEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CheckpointEvent.swift; sourceTree = "<group>"; };
 		C0DE00000000000000000205 /* CheckpointWorkflowResolverTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CheckpointWorkflowResolverTests.swift; sourceTree = "<group>"; };
+		C0DE00000000000000000208 /* CheckpointEventsRequestTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CheckpointEventsRequestTests.swift; sourceTree = "<group>"; };
 		830003FE2E26161D00143F9F /* PlatformFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformFont.swift; sourceTree = "<group>"; };
 		830004002E261ABE00143F9F /* PlatformImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformImage.swift; sourceTree = "<group>"; };
 		831660B52E3AAA4900855312 /* FixMacButtonsModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixMacButtonsModifier.swift; sourceTree = "<group>"; };
@@ -3515,6 +3523,7 @@
 			children = (
 				346145E8EF291B0E8BB68D12 /* Checkpoints.swift */,
 				C0DE00000000000000000202 /* CheckpointWorkflowResolver.swift */,
+				C0DE00000000000000000206 /* CheckpointEvent.swift */,
 			);
 			name = Checkpoints;
 			path = Checkpoints;
@@ -3550,6 +3559,7 @@
 			children = (
 				73A620000000000000000011 /* CheckpointValueTests.swift */,
 				C0DE00000000000000000205 /* CheckpointWorkflowResolverTests.swift */,
+				C0DE00000000000000000208 /* CheckpointEventsRequestTests.swift */,
 			);
 			path = Checkpoints;
 			sourceTree = "<group>";
@@ -5285,6 +5295,7 @@
 				57E415F02846997B00EA5460 /* PurchasesAttributionDataTests.swift */,
 				57E415FE28469EAB00EA5460 /* PurchasesGetProductsTests.swift */,
 				78B1498BA2288B4643B248A5 /* PurchasesWorkflowTests.swift */,
+				C0DE00000000000000000209 /* PurchasesCheckpointEventsTests.swift */,
 				57FDAA952846BDE2009A48F1 /* PurchasesTransactionHandlingTests.swift */,
 				57FDAA992846C2BD009A48F1 /* PurchasesDelegateTests.swift */,
 				57DBFA5C28AADA43002D18CA /* PurchasesLogInTests.swift */,
@@ -6281,6 +6292,7 @@
 			isa = PBXGroup;
 			children = (
 				4FFCED852AA941D200118EF4 /* FeatureEventsRequest.swift */,
+				C0DE00000000000000000207 /* FeatureEventsRequest+CheckpointEvent.swift */,
 				DB001003AAAA0001AAAA0001 /* FeatureEventsRequest+WorkflowEvent.swift */,
 				4FFCED862AA941D200118EF4 /* FeatureEventHTTPRequestPath.swift */,
 				9025C53C2EA66E2500845BCE /* PostFeatureEventsOperation.swift */,
@@ -7693,6 +7705,7 @@
 				678DA8034D806EABC46A0960 /* WorkflowManager.swift in Sources */,
 				B34605CB279A6E380031CA74 /* PostReceiptDataOperation.swift in Sources */,
 				4FFCED882AA941D200118EF4 /* FeatureEventsRequest.swift in Sources */,
+				C0DE00000000000000000107 /* FeatureEventsRequest+CheckpointEvent.swift in Sources */,
 				DB001004AAAA0001AAAA0001 /* FeatureEventsRequest+WorkflowEvent.swift in Sources */,
 				354895D4267AE4B4001DC5B1 /* AttributionKey.swift in Sources */,
 				F5714EA826D7A83A00635477 /* Store+Extensions.swift in Sources */,
@@ -7876,6 +7889,7 @@
 				A0D100000000000000000003 /* DimensionResolver.swift in Sources */,
 				FA360650C0B87331F2EFF527 /* Checkpoints.swift in Sources */,
 				C0DE00000000000000000102 /* CheckpointWorkflowResolver.swift in Sources */,
+				C0DE00000000000000000106 /* CheckpointEvent.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7958,6 +7972,7 @@
 				16E4A3C89791426AAD027A49 /* PlatformInfoTests.swift in Sources */,
 				57E415FF28469EAB00EA5460 /* PurchasesGetProductsTests.swift in Sources */,
 				94BA76C3AAF699D59AA685FC /* PurchasesWorkflowTests.swift in Sources */,
+				C0DE00000000000000000109 /* PurchasesCheckpointEventsTests.swift in Sources */,
 				900D270E2F96A00000D32EDF /* PurchasesRewardVerificationTests.swift in Sources */,
 				57045B3829C514A8001A5417 /* ProductEntitlementMappingDecodingTests.swift in Sources */,
 				351B514726D44A0D00BD2BD7 /* MockSystemInfo.swift in Sources */,
@@ -8134,6 +8149,7 @@
 				75978D092F277258008C916B /* CodableIdempotencyTests.swift in Sources */,
 				579189E928F47E8D00BF4963 /* PurchasesDiagnosticsTests.swift in Sources */,
 				C0DE00000000000000000105 /* CheckpointWorkflowResolverTests.swift in Sources */,
+				C0DE00000000000000000108 /* CheckpointEventsRequestTests.swift in Sources */,
 				351B51B626D450E800BD2BD7 /* ReceiptFetcherTests.swift in Sources */,
 				4F3D56632A1E66A10070105A /* CustomerInfoManagerPostReceiptTests.swift in Sources */,
 				5796A3C027D7D64500653165 /* ResultExtensionsTests.swift in Sources */,

--- a/Sources/Checkpoints/CheckpointEvent.swift
+++ b/Sources/Checkpoints/CheckpointEvent.swift
@@ -1,0 +1,34 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CheckpointEvent.swift
+
+import Foundation
+
+/// Records that a checkpoint was hit. Sent through the shared feature events pipeline, which is also how the
+/// backend learns the checkpoint exists: hits register it, there is no separate registration call.
+struct CheckpointEvent: FeatureEvent {
+
+    var feature: Feature { .checkpoints }
+
+    var eventDiscriminator: String? { nil }
+
+    let id: UUID
+    let identifier: String
+    let date: Date
+
+    init(id: UUID = .init(), identifier: String, date: Date) {
+        self.id = id
+        self.identifier = identifier
+        self.date = date
+    }
+
+}
+
+extension CheckpointEvent: Equatable, Codable, Sendable {}

--- a/Sources/Checkpoints/CheckpointEvent.swift
+++ b/Sources/Checkpoints/CheckpointEvent.swift
@@ -11,24 +11,56 @@
 
 import Foundation
 
-/// Records that a checkpoint was hit. Sent through the shared feature events pipeline, which is also how the
-/// backend learns the checkpoint exists: hits register it, there is no separate registration call.
-struct CheckpointEvent: FeatureEvent {
+/// Checkpoint events. Sent through the shared feature events pipeline, which is also how the backend learns
+/// a checkpoint exists: hits register it, there is no separate registration call.
+enum CheckpointEvent: FeatureEvent {
 
     var feature: Feature { .checkpoints }
 
     var eventDiscriminator: String? { nil }
 
-    let id: UUID
-    let identifier: String
-    let date: Date
+    /// A checkpoint was hit.
+    case hit(Data)
 
-    init(id: UUID = .init(), identifier: String, date: Date) {
-        self.id = id
-        self.identifier = identifier
-        self.date = date
+}
+
+extension CheckpointEvent {
+
+    /// The content of a ``CheckpointEvent``.
+    struct Data {
+
+        var id: UUID
+        var identifier: String
+        var date: Date
+
+        init(id: UUID = .init(), identifier: String, date: Date) {
+            self.id = id
+            self.identifier = identifier
+            self.date = date
+        }
+
     }
 
 }
 
+extension CheckpointEvent {
+
+    /// - Returns: the underlying ``CheckpointEvent/Data-swift.struct`` for this event.
+    var data: Data {
+        switch self {
+        case let .hit(data): return data
+        }
+    }
+
+    /// The value khepri discriminates the analytics events union on. Single source of truth for both the wire
+    /// format and ``FeatureEvent/toMap()``, so a new case has to be given one here before it compiles.
+    var eventType: String {
+        switch self {
+        case .hit: return "checkpoint_hit"
+        }
+    }
+
+}
+
+extension CheckpointEvent.Data: Equatable, Codable, Sendable {}
 extension CheckpointEvent: Equatable, Codable, Sendable {}

--- a/Sources/Events/FeatureEvents/FeatureEvent.swift
+++ b/Sources/Events/FeatureEvents/FeatureEvent.swift
@@ -275,10 +275,10 @@ private extension CheckpointEvent {
     func checkpointEventMap() -> [String: Any] {
         return [
             "discriminator": "checkpoint",
-            "type": "checkpoint_hit",
-            "id": self.id.uuidString,
-            "timestamp": self.date.millisecondsSince1970,
-            "identifier": self.identifier
+            "type": self.eventType,
+            "id": self.data.id.uuidString,
+            "timestamp": self.data.date.millisecondsSince1970,
+            "identifier": self.data.identifier
         ]
     }
 

--- a/Sources/Events/FeatureEvents/FeatureEvent.swift
+++ b/Sources/Events/FeatureEvents/FeatureEvent.swift
@@ -54,6 +54,8 @@ extension FeatureEvent {
             return event.customPaywallEventMap()
         case let event as WorkflowEvent:
             return event.workflowEventMap()
+        case let event as CheckpointEvent:
+            return event.checkpointEventMap()
         default:
             return [
                 "discriminator": "unknown",
@@ -264,6 +266,20 @@ private extension WorkflowEvent {
         if let isLastVariantStep = self.data.isLastVariantStep { result["is_last_variant_step"] = isLastVariantStep }
 
         return result
+    }
+
+}
+
+private extension CheckpointEvent {
+
+    func checkpointEventMap() -> [String: Any] {
+        return [
+            "discriminator": "checkpoint",
+            "type": "checkpoint_hit",
+            "id": self.id.uuidString,
+            "timestamp": self.date.millisecondsSince1970,
+            "identifier": self.identifier
+        ]
     }
 
 }

--- a/Sources/Events/FeatureEvents/Networking/FeatureEventsRequest+CheckpointEvent.swift
+++ b/Sources/Events/FeatureEvents/Networking/FeatureEventsRequest+CheckpointEvent.swift
@@ -1,0 +1,95 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  FeatureEventsRequest+CheckpointEvent.swift
+
+import Foundation
+
+/// Type alias to avoid naming conflict inside `FeatureEventsRequest.CheckpointEvent`.
+private typealias StoredCheckpointEvent = CheckpointEvent
+
+extension FeatureEventsRequest {
+
+    /// Khepri-compatible wire format for checkpoint hits.
+    struct CheckpointEvent {
+
+        let id: String
+        let version: Int
+        let type: String
+        let identifier: String
+        let appUserID: String
+        let sessionID: String?
+        let timestamp: UInt64
+
+    }
+
+}
+
+extension FeatureEventsRequest.CheckpointEvent {
+
+    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+    init?(storedEvent: StoredFeatureEvent) {
+        guard storedEvent.feature == .checkpoints else { return nil }
+
+        guard let jsonData = storedEvent.encodedEvent.data(using: .utf8) else {
+            Logger.error(Strings.paywalls.event_cannot_get_encoded_event)
+            return nil
+        }
+
+        do {
+            let event = try JSONDecoder.default.decode(StoredCheckpointEvent.self, from: jsonData)
+
+            self.init(
+                id: event.id.uuidString,
+                version: Self.schemaVersion,
+                type: Self.typeValue,
+                identifier: event.identifier,
+                appUserID: storedEvent.userID,
+                sessionID: storedEvent.appSessionID?.uuidString,
+                timestamp: event.date.millisecondsSince1970
+            )
+        } catch {
+            Logger.error(Strings.paywalls.event_cannot_deserialize(error))
+            return nil
+        }
+    }
+
+    private static let schemaVersion = 1
+    private static let typeValue = "checkpoint_hit"
+
+}
+
+// MARK: - Encodable
+
+extension FeatureEventsRequest.CheckpointEvent: Encodable {
+
+    private enum CodingKeys: String, CodingKey {
+
+        case id
+        case version
+        case type
+        case identifier
+        case appUserID = "app_user_id"
+        case sessionID = "session_id"
+        case timestamp
+
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.id, forKey: .id)
+        try container.encode(self.version, forKey: .version)
+        try container.encode(self.type, forKey: .type)
+        try container.encode(self.identifier, forKey: .identifier)
+        try container.encode(self.appUserID, forKey: .appUserID)
+        try container.encodeIfPresent(self.sessionID, forKey: .sessionID)
+        try container.encode(self.timestamp, forKey: .timestamp)
+    }
+
+}

--- a/Sources/Events/FeatureEvents/Networking/FeatureEventsRequest+CheckpointEvent.swift
+++ b/Sources/Events/FeatureEvents/Networking/FeatureEventsRequest+CheckpointEvent.swift
@@ -46,13 +46,13 @@ extension FeatureEventsRequest.CheckpointEvent {
             let event = try JSONDecoder.default.decode(StoredCheckpointEvent.self, from: jsonData)
 
             self.init(
-                id: event.id.uuidString,
+                id: event.data.id.uuidString,
                 version: Self.schemaVersion,
-                type: Self.typeValue,
-                identifier: event.identifier,
+                type: event.eventType,
+                identifier: event.data.identifier,
                 appUserID: storedEvent.userID,
                 sessionID: storedEvent.appSessionID?.uuidString,
-                timestamp: event.date.millisecondsSince1970
+                timestamp: event.data.date.millisecondsSince1970
             )
         } catch {
             Logger.error(Strings.paywalls.event_cannot_deserialize(error))
@@ -61,7 +61,6 @@ extension FeatureEventsRequest.CheckpointEvent {
     }
 
     private static let schemaVersion = 1
-    private static let typeValue = "checkpoint_hit"
 
 }
 

--- a/Sources/Events/FeatureEvents/Networking/FeatureEventsRequest.swift
+++ b/Sources/Events/FeatureEvents/Networking/FeatureEventsRequest.swift
@@ -55,6 +55,11 @@ struct FeatureEventsRequest {
                     return nil
                 }
                 return AnyEncodable(event)
+            case .checkpoints:
+                guard let event = FeatureEventsRequest.CheckpointEvent(storedEvent: storedEvent) else {
+                    return nil
+                }
+                return AnyEncodable(event)
             }
         })
     }

--- a/Sources/Events/FeatureEvents/StoredFeatureEvent.swift
+++ b/Sources/Events/FeatureEvents/StoredFeatureEvent.swift
@@ -58,6 +58,7 @@ enum Feature: String, Codable {
     case customerCenter
     case customPaywalls
     case workflows
+    case checkpoints
 
 }
 

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -297,9 +297,22 @@ final class PurchasesOrchestrator {
         identifier: String,
         params: CheckpointParams
     ) async throws -> CheckpointResolution {
+        // Tracked before resolving, and regardless of the outcome: the hit is also how the backend learns the
+        // checkpoint exists, so it has to be reported even when nothing is configured for it yet.
+        await self.trackCheckpointHit(identifier: identifier)
+
         return try await self.checkpointResolver.resolve(
             identifier: identifier,
             params: params
+        )
+    }
+
+    private func trackCheckpointHit(identifier: String) async {
+        guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *),
+              let manager = self.eventsManager else { return }
+
+        await manager.track(
+            featureEvent: CheckpointEvent(identifier: identifier, date: self.dateProvider.now())
         )
     }
 

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -312,7 +312,7 @@ final class PurchasesOrchestrator {
               let manager = self.eventsManager else { return }
 
         await manager.track(
-            featureEvent: CheckpointEvent(identifier: identifier, date: self.dateProvider.now())
+            featureEvent: CheckpointEvent.hit(.init(identifier: identifier, date: self.dateProvider.now()))
         )
     }
 

--- a/Tests/UnitTests/Checkpoints/CheckpointEventsRequestTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointEventsRequestTests.swift
@@ -67,7 +67,7 @@ class CheckpointEventsRequestTests: TestCase {
     }
 
     func testReturnsNilForNonCheckpointStoredEvent() throws {
-        let event = CheckpointEvent(id: self.id, identifier: "onboarding_complete", date: self.date)
+        let event = CheckpointEvent.hit(.init(id: self.id, identifier: "onboarding_complete", date: self.date))
         let stored = try XCTUnwrap(StoredFeatureEvent(
             event: event,
             userID: Self.userID,
@@ -83,7 +83,7 @@ class CheckpointEventsRequestTests: TestCase {
 
     private func storedEvent(appSessionID: UUID? = CheckpointEventsRequestTests.appSessionID) throws
     -> StoredFeatureEvent {
-        let event = CheckpointEvent(id: self.id, identifier: "onboarding_complete", date: self.date)
+        let event = CheckpointEvent.hit(.init(id: self.id, identifier: "onboarding_complete", date: self.date))
 
         return try XCTUnwrap(StoredFeatureEvent(
             event: event,

--- a/Tests/UnitTests/Checkpoints/CheckpointEventsRequestTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointEventsRequestTests.swift
@@ -1,0 +1,106 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CheckpointEventsRequestTests.swift
+
+import Foundation
+import Nimble
+import XCTest
+
+@_spi(Internal) @testable import RevenueCat
+
+@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+class CheckpointEventsRequestTests: TestCase {
+
+    private static let userID = "app_user_id"
+    private static let appSessionID = UUID(uuidString: "315107f4-98bf-4b68-a582-eb27bcb6e111")!
+
+    private let id = UUID(uuidString: "498207f4-87af-4b57-a581-eb27bcc6e009")!
+    private let date = Date(timeIntervalSince1970: 1_699_270_688.995)
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+    }
+
+    func testWireFormatCarriesExpectedFields() throws {
+        let request = try XCTUnwrap(FeatureEventsRequest.CheckpointEvent(storedEvent: try self.storedEvent()))
+
+        expect(request.id) == self.id.uuidString
+        expect(request.version) == 1
+        expect(request.type) == "checkpoint_hit"
+        expect(request.identifier) == "onboarding_complete"
+        expect(request.appUserID) == Self.userID
+        expect(request.sessionID) == Self.appSessionID.uuidString
+        expect(request.timestamp) == self.date.millisecondsSince1970
+    }
+
+    func testKhepriCompatibleShape() throws {
+        let json = try self.encodedJSON()
+
+        expect(json).to(contain("\"id\":\"\(self.id.uuidString)\""))
+        expect(json).to(contain("\"version\":1"))
+        expect(json).to(contain("\"type\":\"checkpoint_hit\""))
+        expect(json).to(contain("\"identifier\":\"onboarding_complete\""))
+        expect(json).to(contain("\"app_user_id\":\"\(Self.userID)\""))
+        expect(json).to(contain("\"session_id\":\"\(Self.appSessionID.uuidString)\""))
+        expect(json).to(contain("\"timestamp\":\(self.date.millisecondsSince1970)"))
+    }
+
+    /// khepri discriminates the events union on `type`, so nothing downstream reads a `discriminator` key.
+    func testDiscriminatorAbsentFromJSON() throws {
+        let json = try self.encodedJSON()
+
+        expect(json).toNot(contain("discriminator"))
+    }
+
+    func testSessionIDAbsentFromJSONWhenMissing() throws {
+        let json = try self.encodedJSON(appSessionID: nil)
+
+        expect(json).toNot(contain("session_id"))
+    }
+
+    func testReturnsNilForNonCheckpointStoredEvent() throws {
+        let event = CheckpointEvent(id: self.id, identifier: "onboarding_complete", date: self.date)
+        let stored = try XCTUnwrap(StoredFeatureEvent(
+            event: event,
+            userID: Self.userID,
+            feature: .paywalls,
+            appSessionID: Self.appSessionID,
+            eventDiscriminator: nil
+        ))
+
+        expect(FeatureEventsRequest.CheckpointEvent(storedEvent: stored)).to(beNil())
+    }
+
+    // MARK: - Helpers
+
+    private func storedEvent(appSessionID: UUID? = CheckpointEventsRequestTests.appSessionID) throws
+    -> StoredFeatureEvent {
+        let event = CheckpointEvent(id: self.id, identifier: "onboarding_complete", date: self.date)
+
+        return try XCTUnwrap(StoredFeatureEvent(
+            event: event,
+            userID: Self.userID,
+            feature: .checkpoints,
+            appSessionID: appSessionID,
+            eventDiscriminator: nil
+        ))
+    }
+
+    private func encodedJSON(appSessionID: UUID? = CheckpointEventsRequestTests.appSessionID) throws -> String {
+        let stored = try self.storedEvent(appSessionID: appSessionID)
+        let request = try XCTUnwrap(FeatureEventsRequest.CheckpointEvent(storedEvent: stored))
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+
+        return try XCTUnwrap(String(data: encoder.encode(request), encoding: .utf8))
+    }
+
+}

--- a/Tests/UnitTests/Events/EventsManagerTests.swift
+++ b/Tests/UnitTests/Events/EventsManagerTests.swift
@@ -84,6 +84,24 @@ class EventsManagerTests: TestCase {
         ]
     }
 
+    func testTrackCheckpointEvent() async throws {
+        let event = CheckpointEvent(
+            identifier: "onboarding_complete",
+            date: Date(timeIntervalSince1970: 1_699_270_688.995)
+        )
+
+        await self.manager.track(featureEvent: event)
+
+        let events = await self.store.storedEvents
+        expect(events) == [
+            try XCTUnwrap(.init(event: event,
+                                userID: Self.userID,
+                                feature: .checkpoints,
+                                appSessionID: self.appSessionID,
+                                eventDiscriminator: nil))
+        ]
+    }
+
     /// We should remove this test once we support the purchase initiated event in the backend.
     func testTrackPurchaseInitiatedEventDoesNotStore() async throws {
         let event: PaywallEvent = .purchaseInitiated(.random(), .random())
@@ -120,6 +138,21 @@ class EventsManagerTests: TestCase {
         expect(map["display_mode"] as? String) == data.displayMode.identifier
         expect(map["locale"] as? String) == data.localeIdentifier
         expect(map["dark_mode"] as? Bool) == data.darkMode
+    }
+
+    func testCheckpointHitToMap() {
+        let event = CheckpointEvent(
+            identifier: "onboarding_complete",
+            date: Date(timeIntervalSince1970: 1_699_270_688.995)
+        )
+
+        let map = event.toMap()
+
+        expect(map["discriminator"] as? String) == "checkpoint"
+        expect(map["type"] as? String) == "checkpoint_hit"
+        expect(map["id"] as? String) == event.id.uuidString
+        expect(map["timestamp"] as? UInt64) == event.date.millisecondsSince1970
+        expect(map["identifier"] as? String) == "onboarding_complete"
     }
 
     func testPaywallCloseToMap() {

--- a/Tests/UnitTests/Events/EventsManagerTests.swift
+++ b/Tests/UnitTests/Events/EventsManagerTests.swift
@@ -85,9 +85,8 @@ class EventsManagerTests: TestCase {
     }
 
     func testTrackCheckpointEvent() async throws {
-        let event = CheckpointEvent(
-            identifier: "onboarding_complete",
-            date: Date(timeIntervalSince1970: 1_699_270_688.995)
+        let event = CheckpointEvent.hit(
+            .init(identifier: "onboarding_complete", date: Date(timeIntervalSince1970: 1_699_270_688.995))
         )
 
         await self.manager.track(featureEvent: event)
@@ -141,17 +140,16 @@ class EventsManagerTests: TestCase {
     }
 
     func testCheckpointHitToMap() {
-        let event = CheckpointEvent(
-            identifier: "onboarding_complete",
-            date: Date(timeIntervalSince1970: 1_699_270_688.995)
+        let event = CheckpointEvent.hit(
+            .init(identifier: "onboarding_complete", date: Date(timeIntervalSince1970: 1_699_270_688.995))
         )
 
         let map = event.toMap()
 
         expect(map["discriminator"] as? String) == "checkpoint"
         expect(map["type"] as? String) == "checkpoint_hit"
-        expect(map["id"] as? String) == event.id.uuidString
-        expect(map["timestamp"] as? UInt64) == event.date.millisecondsSince1970
+        expect(map["id"] as? String) == event.data.id.uuidString
+        expect(map["timestamp"] as? UInt64) == event.data.date.millisecondsSince1970
         expect(map["identifier"] as? String) == "onboarding_complete"
     }
 

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -272,7 +272,9 @@ class BasePurchasesTests: TestCase {
 
     func initializePurchasesInstance(
         appUserId: String?,
-        withDelegate: Bool = true
+        withDelegate: Bool = true,
+        checkpointResolver: CheckpointWorkflowResolver = DisabledCheckpointWorkflowResolver(),
+        dateProvider: DateProvider = DateProvider()
     ) {
         self.purchasesOrchestrator = PurchasesOrchestrator(
             productsManager: self.mockProductsManager,
@@ -297,7 +299,9 @@ class BasePurchasesTests: TestCase {
             diagnosticsTracker: self.diagnosticsTracker,
             winBackOfferEligibilityCalculator: self.mockWinBackOfferEligibilityCalculator,
             eventsManager: self.eventsManager,
-            webPurchaseRedemptionHelper: self.webPurchaseRedemptionHelper
+            webPurchaseRedemptionHelper: self.webPurchaseRedemptionHelper,
+            checkpointResolver: checkpointResolver,
+            dateProvider: dateProvider
         )
         self.trialOrIntroPriceEligibilityChecker = MockTrialOrIntroPriceEligibilityChecker(
             systemInfo: self.systemInfo,

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesCheckpointEventsTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesCheckpointEventsTests.swift
@@ -1,0 +1,95 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PurchasesCheckpointEventsTests.swift
+
+import Nimble
+import XCTest
+
+@_spi(Internal) @testable import RevenueCat
+
+@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+class PurchasesCheckpointEventsTests: BasePurchasesTests {
+
+    private static let hitDate = Date(timeIntervalSince1970: 1_699_270_688.995)
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+    }
+
+    func testResolvingCheckpointTracksHit() async throws {
+        self.setUpCheckpointPurchases()
+
+        _ = try await self.purchases.resolveCheckpoint(identifier: "onboarding_complete", params: .init())
+
+        let event = try await self.singleTrackedCheckpointEvent()
+        expect(event.identifier) == "onboarding_complete"
+        expect(event.date) == Self.hitDate
+    }
+
+    /// The hit is what tells the backend the checkpoint exists, so it has to be reported even when the SDK
+    /// has nothing configured to resolve it to.
+    func testTracksHitWhenNoWorkflowResolves() async throws {
+        self.setUpCheckpointPurchases()
+
+        let resolution = try await self.purchases.resolveCheckpoint(
+            identifier: "onboarding_complete",
+            params: .init()
+        )
+
+        guard case .noAction(.disabled) = resolution else {
+            fail("Expected resolution to report no action, got \(resolution)")
+            return
+        }
+        _ = try await self.singleTrackedCheckpointEvent()
+    }
+
+    func testTracksHitWhenResolutionFails() async throws {
+        self.setUpCheckpointPurchases(resolver: ThrowingCheckpointWorkflowResolver())
+
+        do {
+            _ = try await self.purchases.resolveCheckpoint(identifier: "onboarding_complete", params: .init())
+            fail("Expected resolution to throw")
+        } catch {}
+
+        _ = try await self.singleTrackedCheckpointEvent()
+    }
+
+    // MARK: - Helpers
+
+    private func setUpCheckpointPurchases(
+        resolver: CheckpointWorkflowResolver = DisabledCheckpointWorkflowResolver()
+    ) {
+        self.identityManager.mockIsAnonymous = false
+        self.initializePurchasesInstance(
+            appUserId: self.identityManager.currentAppUserID,
+            checkpointResolver: resolver,
+            dateProvider: MockDateProvider(stubbedNow: Self.hitDate)
+        )
+    }
+
+    private func singleTrackedCheckpointEvent() async throws -> CheckpointEvent {
+        let tracked = await (try self.mockEventsManager).trackedEvents
+        expect(tracked).to(haveCount(1))
+        return try XCTUnwrap(tracked.first as? CheckpointEvent)
+    }
+
+}
+
+@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+private final class ThrowingCheckpointWorkflowResolver: CheckpointWorkflowResolver {
+
+    private struct ResolutionError: Error {}
+
+    func resolve(identifier: String, params: CheckpointParams) async throws -> CheckpointResolution {
+        throw ResolutionError()
+    }
+
+}

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesCheckpointEventsTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesCheckpointEventsTests.swift
@@ -30,8 +30,8 @@ class PurchasesCheckpointEventsTests: BasePurchasesTests {
         _ = try await self.purchases.resolveCheckpoint(identifier: "onboarding_complete", params: .init())
 
         let event = try await self.singleTrackedCheckpointEvent()
-        expect(event.identifier) == "onboarding_complete"
-        expect(event.date) == Self.hitDate
+        expect(event.data.identifier) == "onboarding_complete"
+        expect(event.data.date) == Self.hitDate
     }
 
     /// The hit is what tells the backend the checkpoint exists, so it has to be reported even when the SDK


### PR DESCRIPTION
### Motivation
Counterpart of https://github.com/RevenueCat/purchases-android/pull/3994 (backend: https://github.com/RevenueCat/khepri/pull/24035).

We want a checkpoint to show up in the dashboard because someone hit it, not because someone remembered to declare it first.


<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: this PR
- Branch: `facu/checkpoint-hit-analytics-events`
- Author / human owner: @facumenzella
- Agent(s): Claude Code (Opus 5, 1M context)
- Session source: current conversation
- Generated: 2026-08-19
- Context document version: 2 (refreshed after review round 1)
- Head at last refresh: `5367156`

## Goal

Port purchases-android#3994 to iOS: send checkpoint hits through the existing batched feature-events endpoint so khepri can auto-register checkpoints and publish analytics.

## Initial Prompt

Port the Android checkpoint-hit analytics change to iOS, reading both the backend PR (khepri#24035) and the Android PR (purchases-android#3994) first (verbatim opener: "check https://github.com/RevenueCat/khepri/pull/24035 and https://github.com/RevenueCat/purchases-android/pull/3994 / we need the iOS flavour").

## Important Follow-up Prompts

- "ok let's draft comments for android, and then implement ios" — added a review-comment drafting pass on the Android PR before implementation.
- "In the pr description just say counterpart of <android pr>" — constrained the PR description to a pointer at the Android PR rather than a written-out summary.
- "check <this PR> toni and rick's comments" (review round 1) opened a review pass: report the inline threads before touching code.
- "let's address 1 then" scoped the round to rickvdl's enum request only, leaving the priority-event thread for a follow-up.
- "also compare against vegaro's android pr in case we're missing something" added a gap check of the iOS port against the current head of purchases-android#3994.

## Agent Contribution

- Read khepri#24035's `CheckpointHitEvent` and `AnalyticsEventsRequest` to derive the wire contract from the backend rather than from the Android diff.
- Implemented the iOS port (5 files changed, 2 added under `Sources/`).
- Wrote 9 tests across 2 new and 1 existing test file.
- Ran a negative check: removed the tracking call and confirmed all 3 orchestrator tests fail, then restored it.
- Established a baseline for pre-existing unit-test failures by stashing the change and re-running the failing classes on clean `main`.
- Drafted 6 review comments for purchases-android#3994 (not posted; for @facumenzella to post).
- Review round 1: answered rickvdl's "send the outcome along?" question from the merged khepri schema and from vegaro's reply to the same question on purchases-android#3994, rather than by opinion.
- Review round 1: refactored `CheckpointEvent` into an enum with a single `hit` case, collapsing two hardcoded `"checkpoint_hit"` literals into one exhaustive switch.
- Proved the exhaustiveness claim instead of asserting it: added a temporary second case, confirmed `swift build` failed at both switches, then removed it.
- Gap-checked the port against purchases-android#3994 at its current head and found nothing missing.
- Drafted (not posted) replies for the two open rickvdl threads.

## Human Decisions

- Approved the porting plan before implementation.
- Chose to draft Android review comments before implementing iOS.
- Constrained the PR description to a pointer at the Android PR, framing intent rather than describing the diff.
- The three "you decide" items in the plan (priority flush, identifier validation, tracking while disabled) were not answered up front; the agent proceeded on its stated recommendation for each, all of which stay faithful to Android. Review has since answered one, see Open Items.
- Review round 1: chose the enum-event shape (`case hit(Data)`) over a nested `enum EventType: String`, when both were put up with their tradeoffs.
- Review round 1: kept the round to the enum request, deferring the priority-event change.

## Key Implementation Decisions

- Decision: omit the `discriminator` key from the wire format.
  - Rationale: khepri's `AnalyticsEventsRequest` uses `Field(discriminator='type')` and `BaseEvent` is a plain pydantic `BaseModel` that ignores extras, so nothing reads it. Android emits it only because kotlinx polymorphic serialization adds a class discriminator.
  - Rejected: mirroring Android's `"discriminator":"checkpoint"` for wire parity.
- Decision: `CheckpointEvent` is plain `internal`, not `@_spi(Internal) public` like `WorkflowEvent`.
  - Rationale: tracked from SDK core, so nothing in RevenueCatUI needs it. Keeps `api/*.swiftinterface` and both APITesters untouched, and adds no public enum.
- Decision: flat wire struct modelled on `EventsRequest+CustomPaywallImpression.swift`, not on `FeatureEventsRequest+WorkflowEvent.swift`.
  - Rationale: khepri's `CheckpointHitEvent` is flat; the workflow event's `context`/`properties` envelope is specific to `WorkflowsEvent`.
- Decision: `await` the track call rather than firing a detached `Task`.
  - Rationale: makes the orchestrator tests deterministic. `EventsManager` is an actor whose flush releases across its network await, so an in-flight flush does not block the caller.
- Decision: add a `toMap()` case (no Android equivalent).
  - Rationale: `FeatureEvent.toMap()` has a `default:` arm returning `"unknown"`, so without a case every checkpoint hit reports as `unknown` to consumers of the `@_spi(Internal) public` `Purchases.eventsListener` hook.
- Decision: `isPriorityEvent` left at the default `false`.
  - Rationale: faithful to Android, and the priority flush is rate-limited to 5/60s which a first-launch checkpoint would burn.
  - Rejected: `true` (as `CustomPaywallEvent` does), which would get a newly integrated checkpoint to the dashboard sooner.
  - **Overtaken by review**: rickvdl raised it, tonidero answered "definitely yes ... it does mean that we will potentially do a ton more requests yeah, but I think we have to". Still `false` in the current diff, see Open Items.
- Decision: no client-side identifier validation.
  - Rationale: faithful to Android; called out in the description so both platforms decide together.
  - Risk: see Risks below.
- Decision: track unconditionally, before resolution.
  - Rationale: the hit is how khepri learns the checkpoint exists, so it must fire even when nothing is configured. Faithful to Android.
  - Confirmed in review: vegaro gave the same reasoning on purchases-android#3994, adding that `NoAction` covers disabled, unknown checkpoint, and no audience match, so it is not a success or error signal.
- Decision (review round 1): model `CheckpointEvent` as an enum with a single `case hit(Data)`, at rickvdl's request.
  - Rationale: mirrors `PaywallEvent`, `WorkflowEvent` and `CustomPaywallEvent`, including their synthesized `Codable` on the enum, and makes a future case (checkpoint results) fail to compile until both the wire format and `toMap()` account for it.
  - Rejected: a nested `enum EventType: String` on the existing struct. Smaller diff and closer to Android's `const val CHECKPOINT_EVENT_TYPE`, but a `rawValue` read is not compiler-enforced, which was the point of the request.
- Decision (review round 1): one `CheckpointEvent.eventType`, computed by exhaustive switch and read by both the wire format and `toMap()`.
  - Rationale: there were two hardcoded `"checkpoint_hit"` literals, the one in `toMap()` that rickvdl commented on plus `private static let typeValue` on the wire struct. That constant is now gone.
  - Note: iOS-only divergence. Android keeps a plain `const val`, and khepri types the field as `Literal['checkpoint_hit']`.

## Files / Symbols Touched

- `Sources/Checkpoints/CheckpointEvent.swift` (added)
  - Why: the event type.
  - Symbols: `CheckpointEvent` (enum, `case hit(Data)`), `CheckpointEvent.Data`, `CheckpointEvent.data`, `CheckpointEvent.eventType`
  - Review relevance: internal-only visibility. The `Codable` shape is what gets persisted to the event store, and moving from a struct to an enum changed it to Swift's synthesized case envelope, same as `WorkflowEvent`. No migration hazard: the event is new and unreleased.
- `Sources/Events/FeatureEvents/Networking/FeatureEventsRequest+CheckpointEvent.swift` (added)
  - Why: khepri-compatible wire format.
  - Symbols: `FeatureEventsRequest.CheckpointEvent`, `init?(storedEvent:)`
  - Review relevance: field names and types against khepri's `CheckpointHitEvent`; `session_id` sourced from `storedEvent.appSessionID`. The `type` field now comes from `event.eventType`.
- `Sources/Events/FeatureEvents/StoredFeatureEvent.swift`
  - Why: new `Feature` case.
  - Symbols: `Feature.checkpoints`
  - Review relevance: raw value `"checkpoints"` is persisted to disk; older builds decoding a newer store fall back to `.paywalls`.
- `Sources/Events/FeatureEvents/Networking/FeatureEventsRequest.swift`
  - Why: map stored checkpoint events to the wire type.
  - Symbols: `FeatureEventsRequest.init(events:)`
  - Review relevance: only exhaustive switch over `Feature` in the codebase (verified by grep).
- `Sources/Events/FeatureEvents/FeatureEvent.swift`
  - Why: `toMap()` case for the debug/hybrid listener.
  - Symbols: `FeatureEvent.toMap()`, `CheckpointEvent.checkpointEventMap()`
  - Review relevance: reads `self.eventType` and `self.data`, so it holds no type literal of its own.
- `Sources/Purchasing/Purchases/PurchasesOrchestrator.swift`
  - Why: the tracking call.
  - Symbols: `resolveCheckpoint(identifier:params:)`, `trackCheckpointHit(identifier:)`
  - Review relevance: `#available(iOS 15…)` guard, and that tracking precedes resolution.
- `Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift`
  - Why: expose `checkpointResolver` and `dateProvider` to subclasses.
  - Symbols: `initializePurchasesInstance(appUserId:withDelegate:checkpointResolver:dateProvider:)`
  - Review relevance: both new parameters default to the same values the orchestrator already used, so existing subclasses are unaffected.
- `Tests/UnitTests/Checkpoints/CheckpointEventsRequestTests.swift` (added), `Tests/UnitTests/Purchasing/Purchases/PurchasesCheckpointEventsTests.swift` (added), `Tests/UnitTests/Events/EventsManagerTests.swift`
  - Why: wire shape, orchestrator tracking, store persistence, `toMap()`.
- `RevenueCat.xcodeproj/project.pbxproj` (second commit)
  - Why: Danger flagged the committed project as out of sync; Tuist generates its own project and does not touch this one.
  - Review relevance: 16 insertions, 0 deletions, 4 entries per new file. Hand-inserted next to a sibling rather than via the `xcodeproj` gem, which re-sorted the whole build-file section (151 insertions / 135 deletions of pure churn).

## Dependencies / Config / Migrations

- No new dependencies. `Package.resolved` churn from `tuist install` was reverted and is not in the commit.
- New test files registered via `tuist generate`.
- No public API change, so no `api/*.swiftinterface` or APITester updates.
- Review round 1 added no files, so no `tuist generate` or `RevenueCat.xcodeproj` change was needed.

## Validation

- Commands run:
  - `swift build`: passed.
  - `swiftlint`: 0 violations.
  - `xcodebuild build-for-testing -workspace RevenueCat-Tuist.xcworkspace -scheme UnitTests -destination 'platform=iOS Simulator,name=iPhone 17'`: TEST BUILD SUCCEEDED.
  - `xcodebuild test … -only-testing:UnitTests/CheckpointEventsRequestTests -only-testing:UnitTests/PurchasesCheckpointEventsTests -only-testing:UnitTests/EventsManagerTests`: 72 tests, 0 failures.
  - `xcodebuild build -project RevenueCat.xcodeproj -target RevenueCat`: BUILD SUCCEEDED (proves the pbxproj edit is valid and the new sources are in the target).
- Manual verification:
  - Negative check: with `await self.trackCheckpointHit(identifier:)` removed, all 3 `PurchasesCheckpointEventsTests` failed; restored and they pass. The tests are not vacuous.
  - Blast radius of the `BasePurchasesTests` edit, checked empirically rather than by inspection: all 24 of its other subclasses were run on this branch with the new test class excluded, giving 292 passed / 1 failed, byte-identical to the same run at the parent commit `83f46dd6a` in a separate worktree. The one failure is pre-existing (see gaps).
- Review round 1 (head `5367156`):
  - `swift build`: passed. `swiftlint`: 0 violations across the 7 changed files.
  - `xcodebuild test -workspace RevenueCat-Tuist.xcworkspace -scheme UnitTests -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:UnitTests/CheckpointEventsRequestTests -only-testing:UnitTests/PurchasesCheckpointEventsTests -only-testing:UnitTests/EventsManagerTests`: 72 tests, 0 failures. Run twice, before and after merging `origin/main` into the branch, with the same result.
  - Exhaustiveness proof: with a temporary `case result(Data)` added, `swift build` reported `error: switch must be exhaustive` at `CheckpointEvent.swift:53` (`data`) and `:61` (`eventType`), in `Sources/` and in the `CustomEntitlementComputation` mirror. Removed it, build clean.
  - The remote branch already carried a `Merge branch 'main'` commit this worktree did not have, so it was merged in rather than rebased. Head `5367156` is that merge.
- CI:
  - Danger initially failed on `RevenueCat.xcodeproj` being out of sync; addressed in the second commit.
  - Green on `c2c22ef1e` apart from `Size Analysis | Emerge`. Pending on `5367156` at time of writing.

## Validation Gaps

- Nothing end to end. The wire shape is asserted against khepri's pydantic model as read from khepri#24035, not against a live request. khepri#24035 has since merged (2026-08-19), so the contract itself is now fixed.
- The persisted `Codable` shape is not pinned by an assertion on raw JSON. It is covered indirectly, since `CheckpointEventsRequestTests` encodes through `StoredFeatureEvent` and decodes back, so a broken round trip fails, but the exact on-disk keys are not asserted the way Android's `checkFileContents` does.
- `PurchasesGetOfferingsTests/testWarmsUpPaywallsCache` fails locally (`XCTUnwrap failed: expected non-nil value of type "URL"`). Pre-existing: it fails identically at the parent commit.
- A full local `UnitTests` run reports ~207 failures across `Backend*` and `CustomerInfo*` classes (snapshot `X-Installation-Method` mismatches and missing JSON fixtures). Pre-existing and environmental, confirmed by running the same classes on a clean checkout, but it means the full suite was never green locally.
- `PurchasesConfiguringTests/testHealthCheckIsEnqueuedAfterCacheOperations` failed once in 4 wide-scope runs on this branch and passed 3/3 in isolation. See Risks: it is a pre-existing race, not caused by this change, but worth a separate look.
- Only exercised on iOS 26 (iPhone 17 simulator). Other platforms not run locally.
- `Feature.checkpoints` decoding on an older build (which would fall back to `.paywalls`) is untested.

## Review Focus

- Do the wire field names and types match khepri's `CheckpointHitEvent` exactly, including `session_id` being nullable and `timestamp` in milliseconds?
- Is `storedEvent.appSessionID` the right source for `session_id`? khepri's transformer maps it to `app_session_id` on the streamed event, which is what suggested the app session rather than a per-checkpoint one.
- Should tracking really happen unconditionally, including when `remoteConfigEnabled` is false and the resolver is `DisabledCheckpointWorkflowResolver`?
- Is the enum's synthesized `Codable` envelope the right persisted shape, or is a custom encoding worth it?
- Should the `toMap()` addition be mirrored on Android, or dropped here for parity?
- `resolveCheckpoint` is now `async` work that awaits a file append before resolution begins. Acceptable added latency on the checkpoint path?

## Risks / Reviewer Notes

- Risk: an identifier khepri rejects drops the whole event batch.
  - Evidence: khepri validates the case-folded `identifier` as `^[a-z0-9_\-]+$` with `CHECKPOINT_IDENTIFIER_MAX_LENGTH = 255`, re-read from the merged khepri#24035. (An earlier version of this document said `^[a-z0-9_.\-]+$` at max 64, which was wrong: no dot is allowed, and the limit is much higher.) `AnalyticsEventsRequest.events` is validated as one list, so one bad event 422s the request. On iOS a 422 is `isSuccessfullySynced`, so `flushFeatureEventBatches` clears the batch rather than retrying, silently discarding co-batched paywall events.
  - Mitigation: none implemented (faithful to Android). Raised as a review comment on purchases-android#3994 so both platforms decide together. rickvdl raised the max-length half of this here and marked it settled once the limit was known.
- Risk: a checkpoint hit is emitted even when checkpoints are not enabled for the app.
  - Evidence: intentional. Auto-registration is how a checkpoint first reaches the dashboard.
  - Mitigation: covered by `testTracksHitWhenNoWorkflowResolves`.
- Risk: `PurchasesConfiguringTests/testHealthCheckIsEnqueuedAfterCacheOperations` is order-dependent and can fail when the suite's timing shifts.
  - Evidence: `MockBackend.callOrder` in `BasePurchasesTests` is a plain unsynchronized `var [MockBackendOperation]`, appended from `getCustomerInfo` and from the `async` health-report methods, so both its contents and its order depend on thread timing. The test then asserts `customerInfoIndex < healthAvailabilityIndex` over that array. Not caused by this change: excluding the new test class reproduces the parent commit's results exactly, and the wide-scope run passed 3 of 4 attempts with it included.
  - Mitigation: none here, deliberately out of scope. Flagging it for a separate PR rather than folding a shared test-infra fix into a port.
- Risk: one event per `resolveCheckpoint` call, with no client-side dedup.
  - Evidence: `CheckpointsManager.checkpoint(identifier:params:)` calls `resolveCheckpoint` exactly once per hit, so there is no double-fire. khepri derives a `fingerprint` to collapse retried deliveries, but repeated genuine hits are separate events by design.
  - Mitigation: none needed for retries; an app calling `resolveCheckpoint` in a hot path would generate proportional volume.

## Open Items

- `isPriorityEvent` is still `false`. tonidero asked for `true` and rickvdl raised it; not implemented in this diff.
- Whether the `toMap()` case should be mirrored on Android, or dropped here for parity.

## Non-goals / Out of Scope

- `customVariables` are not included in the event. Android drops them too; raised as a question on purchases-android#3994, where the thread closed with "we can add that later".
- No client-side identifier normalization or validation.
- No hybrid SDK (purchases-hybrid-common) wiring.

## Omitted Context

- Raw transcript, unrelated exploration, sensitive details, repetitive attempts, and chain-of-thought-style content were omitted.

</details>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the checkpoint resolution path to await event persistence first and batches hits with other feature events; an invalid identifier rejected by khepri could fail the whole batch and affect co-batched events.
> 
> **Overview**
> Adds **checkpoint hit analytics** so the backend can auto-register checkpoints when apps call `resolveCheckpoint`, without a separate registration API.
> 
> **Event model and pipeline:** Introduces internal `CheckpointEvent.hit` with feature `.checkpoints`, persisted like other feature events. `FeatureEventsRequest` encodes a flat khepri-compatible payload (`type: checkpoint_hit`, identifier, app user id, optional session id, timestamp in ms) and omits a wire `discriminator` key.
> 
> **Orchestrator behavior:** `PurchasesOrchestrator.resolveCheckpoint` now **awaits** `trackCheckpointHit` **before** workflow resolution, including when resolution is disabled, fails, or returns no action—so hits still register the checkpoint in the dashboard.
> 
> **Hybrid/debug:** `FeatureEvent.toMap()` includes checkpoint hits for the events listener hook.
> 
> Tests cover wire JSON shape, store persistence, orchestrator tracking on success/failure/no-action, and `toMap()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 536715616189a01cf16f9175f7313bab3eb98061. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
