### PR TITLE
Test conditional non-exhaustive enums across Xcode versions

### DIFF
--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.2.3
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import class Foundation.ProcessInfo
@@ -144,6 +144,5 @@ let package = Package(
                         .copy("Resources/background.heic"),
                         .copy("PaywallsV2/__PreviewResources__")
                     ])
-    ],
-    swiftLanguageModes: [.v5]
+    ]
 )

--- a/Sources/Support/SwiftVersionCheck.swift
+++ b/Sources/Support/SwiftVersionCheck.swift
@@ -17,3 +17,15 @@ import Foundation
 // See https://xcodereleases.com and https://swiftversion.net
 #error("RevenueCat requires Xcode 14.3.1 with Swift 5.8 to compile.")
 #endif
+
+/// Temporary public API used to validate conditional `@nonexhaustive` support across CI toolchains.
+/// This must not be included in a release.
+#if compiler(>=6.2.3)
+@nonexhaustive(warn)
+#endif
+public enum TemporaryNonExhaustiveEnum { // swiftlint:disable:this no_new_public_enums
+
+    /// A known value used by the compatibility test.
+    case known
+
+}


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Explore adopting Swift 6.2.3's `@nonexhaustive` support without dropping the SDK's older-Xcode CI coverage. This draft lets the existing Xcode matrix validate both SwiftPM's version-specific manifest selection and parsing of the guarded attribute.

### Description
The default manifest now uses PackageDescription 6.2.3 while explicitly keeping the SDK in Swift 5 language mode. The previous 5.9 manifest is preserved as a version-specific fallback, alongside the unchanged 5.8 manifest.

A temporary public enum uses `@nonexhaustive(warn)` behind `#if compiler(>=6.2.3)`. It is intentionally placed in an existing Xcode-project source file so both SwiftPM and Xcode builds compile it. **The temporary enum must be removed before this work ships.**

Locally verified with Swift 6.3.3 using a release build, targeted SwiftLint, and a separately compiled consumer that receives the expected missing-catch-all warning. The existing Xcode 14.3.1, 15.4, 16.4, and 26.x jobs exercise the active and inactive compiler branches.
