### PR TITLE
Properly publish API modifications (no add/delete) in the SDK API feed

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2633,7 +2633,8 @@ platform :ios do
       options[:labels],
       source: source,
       new_declarations: ApiDiffHelper.added_declarations(options[:reports_by_target]),
-      modules: modules
+      modules: modules,
+      modifications: ApiDiffHelper.modified_declarations(options[:reports_by_target])
     )
     fingerprint = ApiDiffHelper.announcement_fingerprint(summary)
 

--- a/fastlane/api_diff_helper.rb
+++ b/fastlane/api_diff_helper.rb
@@ -574,6 +574,38 @@ module ApiDiffHelper
     end.reject { |declaration| declaration.to_s.empty? }.uniq.sort
   end
 
+  ATTRIBUTE_SUMMARY_WIDTH = 40
+
+  # `message:` carries a whole sentence, so the attribute and its first arguments are the news.
+  def summarize_attribute(attribute)
+    short = attribute.to_s.sub(/,\s*message:.*/, "…)")
+
+    short.length > ATTRIBUTE_SUMMARY_WIDTH ? "#{short[0, ATTRIBUTE_SUMMARY_WIDTH - 1]}…" : short
+  end
+
+  def attribute_changes(declaration)
+    declaration.to_s.lines.map(&:strip).filter_map do |line|
+      match = ATTRIBUTE_CHANGE_LINE.match(line)
+      next unless match
+
+      verb, attribute = match.captures
+      "#{verb.downcase} #{summarize_attribute(attribute)}"
+    end
+  end
+
+  # A modification is neither an addition nor necessarily a break: an attribute-only one is waved
+  # through by the gate, and without this it reached the feed as a headline and nothing else.
+  def modified_declarations(reports_by_target)
+    reports_by_target.values.compact.flat_map do |report|
+      next [] unless api_changes_reported?(report)
+
+      parse_report(report).select { |change| change.kind == :modified }.map do |change|
+        { summary: attribute_changes(change.declaration).join(", "),
+          declaration: significant_first_line(change.declaration) }
+      end
+    end.reject { |change| change[:declaration].empty? }.uniq
+  end
+
   SDK_PLATFORM_LABEL = "iOS :ios:".freeze
 
   # last_announcement matches on this, so the headline and the dedup key cannot drift apart.
@@ -604,21 +636,33 @@ module ApiDiffHelper
 
   # Not all breaks are removals, so each carries its reason; additions match the `+` Android uses.
   # An enum case or protocol requirement is both an addition and a break, so it is listed once.
-  def slack_declaration_lines(breaks, new_declarations)
+  def slack_declaration_lines(breaks, new_declarations, modifications = [])
     break_lines = breaks.map do |change|
       owner = change[:owner] ? " in #{change[:owner]}" : ""
       "- #{BREAK_REASONS.fetch(change[:reason], change[:reason])}#{owner}: #{change[:declaration]}"
     end
     broken = breaks.map { |change| change[:declaration] }
 
-    break_lines + (new_declarations - broken).map { |declaration| "+ #{declaration}" }
+    break_lines +
+      modifications.map { |change| "~ #{[change[:summary], change[:declaration]].reject(&:empty?).join(': ')}" } +
+      (new_declarations - broken).map { |declaration| "+ #{declaration}" }
   end
 
-  def slack_summary(breaks, labels, source:, new_declarations: [], modules: [])
+  # A modification the gate already reports as a break needs no second line.
+  def unbroken_modifications(modifications, breaks)
+    broken = breaks.map { |change| change[:declaration] }
+
+    modifications.reject { |change| broken.include?(change[:declaration]) }
+  end
+
+  def slack_summary(breaks, labels, source:, new_declarations: [], modules: [], modifications: [])
+    changed = unbroken_modifications(modifications, breaks)
     headline = if breaks.any?
                  gate_blocked?(breaks, labels) ? ":warning: *Breaking public API changes*" : ":warning: *Breaking public API changes* (allowed by label)"
-               else
+               elsif new_declarations.any?
                  ":sparkles: *New public API*"
+               else
+                 ":pencil2: *Public API changed*"
                end
     headline = [headline, announcement_identity(modules)].join(" · ")
 
@@ -628,9 +672,10 @@ module ApiDiffHelper
     counts = []
     counts << "#{breaks.count} potential break#{'s' if breaks.count != 1}" if breaks.any?
     counts << "#{new_declarations.count} new declaration#{'s' if new_declarations.count != 1}" if new_declarations.any?
+    counts << "#{changed.count} modification#{'s' if changed.count != 1}" if changed.any?
     lines << counts.join(", ") if counts.any?
 
-    declaration_lines = slack_declaration_lines(breaks, new_declarations)
+    declaration_lines = slack_declaration_lines(breaks, new_declarations, changed)
     lines << slack_declaration_block(declaration_lines) if declaration_lines.any?
 
     lines.join("\n")

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -1679,6 +1679,56 @@ class ApiDiffHelperTest < Minitest::Test
     refute_includes body, ":warning: No Slack credentials"
   end
 
+  # A PR whose only interface delta is an added attribute reached the feed as a headline and a link,
+  # with the headline claiming new API. See purchases-ios#7439.
+  def test_slack_summary_reports_an_attribute_only_modification
+    modifications = ApiDiffHelper.modified_declarations({ "RevenueCat iOS" => DEPRECATED_ATTRIBUTE_ADDED_REPORT })
+
+    message = ApiDiffHelper.slack_summary([], [], source: "<url|#7439>", modules: ["RevenueCat"], modifications: modifications)
+
+    assert message.start_with?(":pencil2: *Public API changed* · iOS :ios: · `RevenueCat`")
+    assert_includes message, "1 modification"
+    assert_includes message, "~ added @available(*, deprecated…): "
+    assert_includes message, "purchaseDate(forEntitlement"
+    refute_includes message, ":sparkles:"
+  end
+
+  def test_modified_declarations_summarizes_a_removed_attribute
+    modifications = ApiDiffHelper.modified_declarations({ "RevenueCat iOS" => OBJC_REMOVED_FROM_METHOD_REPORT })
+
+    assert_equal 1, modifications.count
+    assert_equal "removed @objc", modifications.first[:summary]
+    assert_includes modifications.first[:declaration], "expirationDate(forProductIdentifier"
+  end
+
+  # Removing @objc is a break, and the gate already lists it; a second `~` line would repeat it.
+  def test_slack_summary_lists_a_breaking_modification_once
+    modifications = ApiDiffHelper.modified_declarations({ "RevenueCat iOS" => OBJC_REMOVED_FROM_METHOD_REPORT })
+    breaks = Dir.mktmpdir do |dir|
+      path = File.join(dir, "revenuecat-api-ios.swiftinterface")
+      File.write(path, "final public class CustomerInfo {}")
+      ApiDiffHelper.breaking_changes(OBJC_REMOVED_FROM_METHOD_REPORT, path)
+    end
+
+    message = ApiDiffHelper.slack_summary(breaks, [], source: "", modules: ["RevenueCat"], modifications: modifications)
+
+    assert_equal 1, message.scan("expirationDate(forProductIdentifier").count
+    refute_includes message, "modification"
+  end
+
+  def test_slack_summary_still_leads_with_new_api_when_something_was_added
+    modifications = ApiDiffHelper.modified_declarations({ "RevenueCat iOS" => DEPRECATED_ATTRIBUTE_ADDED_REPORT })
+
+    message = ApiDiffHelper.slack_summary(
+      [], [], source: "", new_declarations: ["public func a()"], modules: ["RevenueCat"], modifications: modifications
+    )
+
+    assert message.start_with?(":sparkles: *New public API*")
+    assert_includes message, "1 new declaration, 1 modification"
+    assert_includes message, "+ public func a()"
+    assert_includes message, "~ added @available"
+  end
+
   def test_slack_summary_labels_the_platform_and_modules
     message = ApiDiffHelper.slack_summary([], [], source: "<url|#42>", new_declarations: ["public func a()"], modules: ["RevenueCatUI"])
 


### PR DESCRIPTION
- The feed carried messages with a headline and a link and nothing else, for example [#7439](https://github.com/RevenueCat/purchases-ios/pull/7439) and [#7440](https://github.com/RevenueCat/purchases-ios/pull/7440). Their whole interface delta was one modification: an `@available(*, deprecated, …)` added to `logIn(_:)`.
- A modification is neither an addition nor necessarily a break (attribute-only ones are waved through by the gate), so nothing rendered, and the headline claimed new public API.
- Modifications now render as `~ added @available(*, deprecated…): final public func logIn(…)`, counted as "N modifications".
- The headline is `:pencil2: *Public API changed*` when nothing was added and nothing broke; additions and breaks keep their existing headlines.
- A modification the gate already reports as a break stays a single line, no `~` twin.

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

<details><summary>Agent description</summary>

### Motivation

`slack_summary` renders additions and breaks. `:modified` changes fall through both: `added_declarations` filters for `:added`, and `modification_attribute_only?` deliberately keeps an added `@objc`, `@discardableResult`, `@inlinable` or deprecation off the breaking list. The result is a message with no counts line and no code block, under a `:sparkles: *New public API*` headline that misreports what happened.

`purchases-android` has no equivalent gap: it takes every `+` and `-` line straight from the metalava diff, so an attribute change shows up as a removal plus an addition.

### Description

- `modified_declarations` mirrors `added_declarations`, returning the changed attributes and the declaration they sit on.
- `summarize_attribute` drops the `message:` argument, since it carries a whole sentence and the attribute plus its first arguments are the news, then caps what is left.
- `unbroken_modifications` keeps a modification the gate already lists as a break from being printed twice.

Not visible in the diff: `DEPRECATED_ATTRIBUTE_ADDED_REPORT` is the fixture behind the new tests and matches the report that produced the empty #7439 message, so the tests are the real case rather than a synthetic one.

Worth noting separately: the reason those PRs report an interface change at all while touching no `api/` file is that the gate diffs against the merge base with `main`, so a stacked PR inherits its ancestors' API changes. That is unchanged here.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only Fastlane Slack/API-diff notification formatting and tests; no SDK runtime or gate blocking logic changes beyond richer feed content.
> 
> **Overview**
> Fixes **empty or misleading Slack SDK API feed posts** when a PR’s only public API delta is an **attribute modification** (e.g. adding `@available(*, deprecated, …)`), which the gate treats as non-breaking but was neither counted as new API nor shown in the message—while the headline still said **New public API**.
> 
> **`ApiDiffHelper`** now collects `:modified` entries via `modified_declarations`, summarizes attribute add/remove lines (truncating long `message:` text), and renders them in Slack as `~ added @available(*, deprecated…): <declaration>`. Modification count appears in the summary line; if there are no breaks and no additions, the headline becomes **:pencil2: Public API changed**. Modifications already reported as breaks (e.g. `@objc` removed) are **not** duplicated via `unbroken_modifications`.
> 
> The **`notify_api_changes_on_slack`** lane passes `modified_declarations` into `slack_summary`. Unit tests cover the #7439-style case and break deduplication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d533a56de513ebe697ba69e9945e7553b8ad1bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->