### PR TITLE
FIX(Paywalls): Render paywallsv2 without waiting for customer info to be ready

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -255,6 +255,11 @@ public struct PaywallView: View {
         return nil
     }
 
+    private var canRenderWithoutCustomerInfo: Bool {
+        guard self.mode == .fullScreen else { return false }
+        return self.workflowContext != nil || self.offering?.internalPaywallComponents != nil
+    }
+
     // swiftlint:disable:next missing_docs
     public var body: some View {
         self.content
@@ -277,10 +282,11 @@ public struct PaywallView: View {
             if let error = self.initializationError {
                 DebugErrorView(error.localizedDescription, releaseBehavior: .fatalError)
             } else if self.introEligibility.isConfigured, self.purchaseHandler.isConfigured {
-                if let offering = self.offering, let customerInfo = self.customerInfo {
+                if let offering = self.offering,
+                   self.customerInfo != nil || self.canRenderWithoutCustomerInfo {
                     self.paywallView(for: offering,
                                      workflowContext: self.workflowContext,
-                                     activelySubscribedProductIdentifiers: customerInfo.activeSubscriptions,
+                                     activelySubscribedProductIdentifiers: self.customerInfo?.activeSubscriptions ?? [],
                                      fonts: self.fonts,
                                      checker: self.introEligibility,
                                      purchaseHandler: self.purchaseHandler)
@@ -308,7 +314,7 @@ public struct PaywallView: View {
                                     self.workflowContext = paywallData.workflowContext
                                 }
 
-                                if self.customerInfo == nil {
+                                if self.customerInfo == nil, !self.canRenderWithoutCustomerInfo {
                                     self.customerInfo = try await Purchases.shared.customerInfo()
                                 }
                             } catch let error as NSError {

--- a/Tests/RevenueCatUITests/Templates/OtherPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/Templates/OtherPaywallViewTests.swift
@@ -63,6 +63,7 @@ class OtherPaywallViewTests: BaseSnapshotTest {
 }
 
 #if !os(tvOS)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private extension OtherPaywallViewTests {
 
     static func v2Offering(title: String) throws -> Offering {
@@ -106,6 +107,7 @@ private extension OtherPaywallViewTests {
 
 }
 
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private extension UIView {
 
     func containsText(_ text: String) -> Bool {

--- a/Tests/RevenueCatUITests/Templates/OtherPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/Templates/OtherPaywallViewTests.swift
@@ -7,7 +7,7 @@
 
 import Nimble
 @_spi(Internal) @testable import RevenueCat
-@testable import RevenueCatUI
+@_spi(Internal) @testable import RevenueCatUI
 import SnapshotTesting
 import SwiftUI
 #if canImport(UIKit)

--- a/Tests/RevenueCatUITests/Templates/OtherPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/Templates/OtherPaywallViewTests.swift
@@ -6,9 +6,14 @@
 //
 
 import Nimble
-import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 @testable import RevenueCatUI
 import SnapshotTesting
+import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
+import XCTest
 
 #if !os(watchOS) && !os(macOS)
 
@@ -30,6 +35,92 @@ class OtherPaywallViewTests: BaseSnapshotTest {
             .recordSnapshot(size: Self.footerSize)
     }
 
+    #if !os(tvOS)
+    func testFullScreenV2CanRenderWithoutCustomerInfo() throws {
+        guard !Purchases.isConfigured else {
+            throw XCTSkip("Test requires an empty CustomerInfo cache")
+        }
+
+        let title = "V2 paywall content"
+        let offering = try Self.v2Offering(title: title)
+        let view = PaywallView(
+            configuration: .init(
+                offering: offering,
+                customerInfo: nil,
+                mode: .fullScreen,
+                introEligibility: .producing(eligibility: .eligible),
+                purchaseHandler: .mock()
+            )
+        )
+
+        let (window, hostedView) = Self.host(view)
+        defer { window.isHidden = true }
+
+        expect(hostedView.containsText(title)).toEventually(beTrue())
+    }
+    #endif
+
 }
+
+#if !os(tvOS)
+private extension OtherPaywallViewTests {
+
+    static func v2Offering(title: String) throws -> Offering {
+        let data = PaywallComponentsData(
+            templateName: "test",
+            assetBaseURL: try XCTUnwrap(URL(string: "https://assets.revenuecat.com")),
+            componentsConfig: .init(
+                base: .init(
+                    stack: .init(components: [
+                        .text(.init(text: "title", color: .init(light: .hex("#000000"))))
+                    ]),
+                    stickyFooter: nil,
+                    background: .color(.init(light: .hex("#FFFFFF")))
+                )
+            ),
+            componentsLocalizations: [
+                "en_US": ["title": .string(title)]
+            ],
+            revision: 1,
+            defaultLocaleIdentifier: "en_US"
+        )
+
+        return Offering(
+            identifier: "v2-offering",
+            serverDescription: "V2 offering",
+            paywallComponents: .init(uiConfig: PreviewUIConfig.make(), data: data),
+            availablePackages: [],
+            webCheckoutUrl: nil
+        )
+    }
+
+    static func host<Content: View>(_ view: Content) -> (UIWindow, UIView) {
+        let controller = UIHostingController(rootView: view)
+        let window = UIWindow(frame: CGRect(origin: .zero, size: Self.fullScreenSize))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        controller.view.layoutIfNeeded()
+
+        return (window, controller.view)
+    }
+
+}
+
+private extension UIView {
+
+    func containsText(_ text: String) -> Bool {
+        if let label = self as? UILabel, label.text == text {
+            return true
+        }
+
+        if self.accessibilityLabel == text {
+            return true
+        }
+
+        return self.subviews.contains { $0.containsText(text) }
+    }
+
+}
+#endif
 
 #endif


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->
<!-- AI agents: fill in this template, and also follow the "Pull Requests" section in AGENTS.md. -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->
There is no need to render a loading state for a workflow or paywalls v2 view when the customer info is not immediately present. Having this here causes the fallback paywall to render as a loading screen during paywall presentation - some customers are experiencing quite a delay. This also aligns what Android does for v2 paywalls.

[linear issue PWENG-219](https://linear.app/revenuecat/issue/PWENG-219/ios-do-not-wait-for-customer-info)
### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

Skips that load if we're not in a v1 paywall

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall gating and subscription state used at first paint (empty active subscriptions when CustomerInfo is skipped), which could affect v2/workflow eligibility or UI until info loads elsewhere.
> 
> **Overview**
> **PaywallView** no longer blocks on `CustomerInfo` for full-screen **Paywalls v2** (components-based offering) or **workflow** paywalls when that data is already available.
> 
> A new `canRenderWithoutCustomerInfo` gate allows the paywall UI to show immediately with `activelySubscribedProductIdentifiers` defaulting to an empty set, and the async load path skips `Purchases.shared.customerInfo()` when that gate applies. **V1** full-screen paywalls and footer modes still wait for customer info as before.
> 
> Adds **`testFullScreenV2CanRenderWithoutCustomerInfo`** to assert v2 content appears without a configured Purchases cache or customer info.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14801d81a82a637f1f73c29da49bbd1c4fac54dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->