### PR TITLE
Rename the checkpoint event's `session_id` to `app_session_id`

### DIFF
--- a/Sources/Events/FeatureEvents/Networking/FeatureEventsRequest+CheckpointEvent.swift
+++ b/Sources/Events/FeatureEvents/Networking/FeatureEventsRequest+CheckpointEvent.swift
@@ -24,7 +24,7 @@ extension FeatureEventsRequest {
         let type: String
         let identifier: String
         let appUserID: String
-        let sessionID: String?
+        let appSessionID: String?
         let timestamp: UInt64
 
     }
@@ -51,7 +51,7 @@ extension FeatureEventsRequest.CheckpointEvent {
                 type: event.eventType,
                 identifier: event.data.identifier,
                 appUserID: storedEvent.userID,
-                sessionID: storedEvent.appSessionID?.uuidString,
+                appSessionID: storedEvent.appSessionID?.uuidString,
                 timestamp: event.data.date.millisecondsSince1970
             )
         } catch {
@@ -75,7 +75,7 @@ extension FeatureEventsRequest.CheckpointEvent: Encodable {
         case type
         case identifier
         case appUserID = "app_user_id"
-        case sessionID = "session_id"
+        case appSessionID = "app_session_id"
         case timestamp
 
     }
@@ -87,7 +87,7 @@ extension FeatureEventsRequest.CheckpointEvent: Encodable {
         try container.encode(self.type, forKey: .type)
         try container.encode(self.identifier, forKey: .identifier)
         try container.encode(self.appUserID, forKey: .appUserID)
-        try container.encodeIfPresent(self.sessionID, forKey: .sessionID)
+        try container.encodeIfPresent(self.appSessionID, forKey: .appSessionID)
         try container.encode(self.timestamp, forKey: .timestamp)
     }
 

--- a/Sources/Events/FeatureEvents/Networking/FeatureEventsRequest+CheckpointEvent.swift
+++ b/Sources/Events/FeatureEvents/Networking/FeatureEventsRequest+CheckpointEvent.swift
@@ -24,7 +24,7 @@ extension FeatureEventsRequest {
         let type: String
         let identifier: String
         let appUserID: String
-        let appSessionID: String?
+        let appSessionID: String
         let timestamp: UInt64
 
     }
@@ -36,6 +36,11 @@ extension FeatureEventsRequest.CheckpointEvent {
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
     init?(storedEvent: StoredFeatureEvent) {
         guard storedEvent.feature == .checkpoints else { return nil }
+
+        guard let appSessionID = storedEvent.appSessionID else {
+            Logger.error(Strings.paywalls.event_missing_app_session_id)
+            return nil
+        }
 
         guard let jsonData = storedEvent.encodedEvent.data(using: .utf8) else {
             Logger.error(Strings.paywalls.event_cannot_get_encoded_event)
@@ -51,7 +56,7 @@ extension FeatureEventsRequest.CheckpointEvent {
                 type: event.eventType,
                 identifier: event.data.identifier,
                 appUserID: storedEvent.userID,
-                appSessionID: storedEvent.appSessionID?.uuidString,
+                appSessionID: appSessionID.uuidString,
                 timestamp: event.data.date.millisecondsSince1970
             )
         } catch {
@@ -87,7 +92,7 @@ extension FeatureEventsRequest.CheckpointEvent: Encodable {
         try container.encode(self.type, forKey: .type)
         try container.encode(self.identifier, forKey: .identifier)
         try container.encode(self.appUserID, forKey: .appUserID)
-        try container.encodeIfPresent(self.appSessionID, forKey: .appSessionID)
+        try container.encode(self.appSessionID, forKey: .appSessionID)
         try container.encode(self.timestamp, forKey: .timestamp)
     }
 

--- a/Tests/UnitTests/Checkpoints/CheckpointEventsRequestTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointEventsRequestTests.swift
@@ -60,10 +60,10 @@ class CheckpointEventsRequestTests: TestCase {
         expect(json).toNot(contain("discriminator"))
     }
 
-    func testAppSessionIDAbsentFromJSONWhenMissing() throws {
-        let json = try self.encodedJSON(appSessionID: nil)
+    func testReturnsNilWhenAppSessionIDIsMissing() throws {
+        let stored = try self.storedEvent(appSessionID: nil)
 
-        expect(json).toNot(contain("app_session_id"))
+        expect(FeatureEventsRequest.CheckpointEvent(storedEvent: stored)).to(beNil())
     }
 
     func testReturnsNilForNonCheckpointStoredEvent() throws {
@@ -94,8 +94,8 @@ class CheckpointEventsRequestTests: TestCase {
         ))
     }
 
-    private func encodedJSON(appSessionID: UUID? = CheckpointEventsRequestTests.appSessionID) throws -> String {
-        let stored = try self.storedEvent(appSessionID: appSessionID)
+    private func encodedJSON() throws -> String {
+        let stored = try self.storedEvent()
         let request = try XCTUnwrap(FeatureEventsRequest.CheckpointEvent(storedEvent: stored))
         let encoder = JSONEncoder()
         encoder.outputFormatting = .sortedKeys

--- a/Tests/UnitTests/Checkpoints/CheckpointEventsRequestTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointEventsRequestTests.swift
@@ -37,7 +37,7 @@ class CheckpointEventsRequestTests: TestCase {
         expect(request.type) == "checkpoint_hit"
         expect(request.identifier) == "onboarding_complete"
         expect(request.appUserID) == Self.userID
-        expect(request.sessionID) == Self.appSessionID.uuidString
+        expect(request.appSessionID) == Self.appSessionID.uuidString
         expect(request.timestamp) == self.date.millisecondsSince1970
     }
 
@@ -49,7 +49,7 @@ class CheckpointEventsRequestTests: TestCase {
         expect(json).to(contain("\"type\":\"checkpoint_hit\""))
         expect(json).to(contain("\"identifier\":\"onboarding_complete\""))
         expect(json).to(contain("\"app_user_id\":\"\(Self.userID)\""))
-        expect(json).to(contain("\"session_id\":\"\(Self.appSessionID.uuidString)\""))
+        expect(json).to(contain("\"app_session_id\":\"\(Self.appSessionID.uuidString)\""))
         expect(json).to(contain("\"timestamp\":\(self.date.millisecondsSince1970)"))
     }
 
@@ -60,10 +60,10 @@ class CheckpointEventsRequestTests: TestCase {
         expect(json).toNot(contain("discriminator"))
     }
 
-    func testSessionIDAbsentFromJSONWhenMissing() throws {
+    func testAppSessionIDAbsentFromJSONWhenMissing() throws {
         let json = try self.encodedJSON(appSessionID: nil)
 
-        expect(json).toNot(contain("session_id"))
+        expect(json).toNot(contain("app_session_id"))
     }
 
     func testReturnsNilForNonCheckpointStoredEvent() throws {


### PR DESCRIPTION
Follow-up to #7447
Equivalent Android https://github.com/RevenueCat/purchases-android/pull/4039
Khepri PR https://github.com/RevenueCat/khepri/pull/24141

Rename `session_id` to `app_session_id` in checkpoint events