### PR TITLE
Raise an error for unresolved variables instead of degrading to null

### DIFF
--- a/Sources/RulesEngine/CustomOperators/CaseOperators.swift
+++ b/Sources/RulesEngine/CustomOperators/CaseOperators.swift
@@ -39,10 +39,10 @@ extension RulesEngine {
         /// for anything else.
         ///
         /// Non-strings are **not** coerced through `jsString`, even though JS
-        /// `String(x).toLowerCase()` would accept them. Coercion makes absent
-        /// data look like real data: a missing `var` resolves to `null`, so
-        /// `{"===": [{"rc.lower": {"var": "typo"}}, "null"]}` would quietly
-        /// match. Same reasoning as `rc.length` and `rc.entries`.
+        /// `String(x).toLowerCase()` would accept them. Coercion makes data of
+        /// the wrong shape look like real data: an explicit `null` would lower
+        /// to `"null"` and compare equal to that string. Same reasoning as
+        /// `rc.length` and `rc.entries`.
         private static func stringArgument(
             _ args: Value,
             vars: Scope,

--- a/Sources/RulesEngine/EvaluationError.swift
+++ b/Sources/RulesEngine/EvaluationError.swift
@@ -9,14 +9,28 @@ import Foundation
 extension RulesEngine {
 
     /// Errors surfaced by the rules engine.
-    ///
-    /// Note on missing variables: the evaluator does **not** raise an error
-    /// for them — per the JSON Logic spec, they resolve to `null` and a warning
-    /// is logged instead.
     enum EvaluationError: Error, Equatable, Sendable {
 
         /// The predicate JSON could not be parsed.
         case parse(message: String)
+
+        /// The predicate reads a variable that the evaluation scope does not
+        /// provide, and the rule supplies no default for it. Carries the
+        /// dot-path that failed to resolve.
+        ///
+        /// This is a deliberate divergence from `json-logic-js`, which resolves
+        /// an absent variable to `null`. That `null` then coerces to `0` in a
+        /// numeric comparison and `""` in a string one, so a rule can answer
+        /// `true` for a reason that has nothing to do with the user — a missing
+        /// `now` turns `{">": [expires, now]}` into `expires > 0`, which is true
+        /// for every subscription that ever existed. An absent variable means
+        /// "unknown", and unknown is not the same answer as "no", so the engine
+        /// refuses to guess and hands the decision to the caller.
+        ///
+        /// A rule that genuinely tolerates absence says so explicitly with the
+        /// spec's own escape hatch, `{"var": ["path", default]}`, which never
+        /// raises this error.
+        case unresolvedVariable(path: String)
 
         /// An operator was given arguments of the wrong shape (e.g. wrong arity)
         /// or types that cannot be reconciled.
@@ -38,6 +52,8 @@ extension RulesEngine.EvaluationError: CustomStringConvertible {
         switch self {
         case .parse(let message):
             return "failed to parse predicate JSON: \(message)"
+        case .unresolvedVariable(let path):
+            return "unresolved variable: \(path)"
         case .typeMismatch(let message):
             return "type mismatch: \(message)"
         case .unsupportedOperator(let name):

--- a/Sources/RulesEngine/Operators/AccessorOperators.swift
+++ b/Sources/RulesEngine/Operators/AccessorOperators.swift
@@ -18,6 +18,11 @@ extension RulesEngine {
         /// `not_found = (b === undefined) ? null : b`. `{"var": ""}` returns
         /// the entire data scope.
         ///
+        /// A path that does not resolve and carries no default throws
+        /// `EvaluationError.unresolvedVariable` rather than degrading to
+        /// `null`. A key that *is* present but holds an explicit `null` is a
+        /// known value, not a missing one, and resolves normally.
+        ///
         /// Per the JSON Logic spec, the path and default arguments are
         /// recursively evaluated before lookup (e.g.
         /// `{"var": {"var": "active_path_key"}}` resolves `active_path_key`
@@ -48,8 +53,7 @@ extension RulesEngine {
                 if case .undefined = defaultValue { return .null }
                 return defaultValue
             }
-            RulesEngine.logger.warn("missing variable: \(path)")
-            return .null
+            throw RulesEngine.EvaluationError.unresolvedVariable(path: path)
         }
 
         /// `{"missing": ["a", "b.c"]}` returns the array of keys whose `var`

--- a/Sources/RulesEngine/RulesEngineLogger.swift
+++ b/Sources/RulesEngine/RulesEngineLogger.swift
@@ -10,8 +10,7 @@ import Foundation
 protocol RulesEngineLogger: Sendable {
 
     /// Carries engine diagnostics for conditions the evaluator recovers from,
-    /// such as ignored extra operator arguments. Conditions that make a rule
-    /// unanswerable surface as `EvaluationError` instead.
+    /// such as ignored extra operator arguments.
     func warn(_ message: String)
 
     /// Carries pass-through output from the JSON Logic `log` operator.

--- a/Sources/RulesEngine/RulesEngineLogger.swift
+++ b/Sources/RulesEngine/RulesEngineLogger.swift
@@ -9,8 +9,9 @@ import Foundation
 /// Logging facade for the rules engine.
 protocol RulesEngineLogger: Sendable {
 
-    /// Carries engine diagnostics (missing variables, unsupported
-    /// operators, type mismatches).
+    /// Carries engine diagnostics for conditions the evaluator recovers from,
+    /// such as ignored extra operator arguments. Conditions that make a rule
+    /// unanswerable surface as `EvaluationError` instead.
     func warn(_ message: String)
 
     /// Carries pass-through output from the JSON Logic `log` operator.

--- a/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
@@ -427,9 +427,10 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
         XCTAssertEqual(Self.noActionReason(resolution), .noMatch)
     }
 
-    /// No dimension provider supplies `last_seen.*`, and `var` resolves a missing path to null instead of
-    /// throwing, so the predicate is merely false. That has to read as `noMatch`, not as a failure.
-    func testAudienceOnAnUnsuppliedVariableResolvesNoMatch() async throws {
+    /// No dimension provider supplies `last_seen.*`, so the lookup fails and the audience cannot be
+    /// answered at all. That is not the same answer as a customer who falls outside it, so it is reported
+    /// as unavailable rather than as `noMatch`.
+    func testAudienceOnAnUnsuppliedVariableIsNotReportedAsNoMatch() async throws {
         self.audiencesProvider.rulesByAudienceID = [
             "audience": try Self.servedRules(
                 #"{ "id": "audience", "rules": { "in": [{ "var": "last_seen.country" }, ["ES"]] } }"#
@@ -438,13 +439,13 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
 
         let resolution = try await self.resolve()
 
-        XCTAssertEqual(Self.noActionReason(resolution), .noMatch)
+        XCTAssertEqual(Self.noActionReason(resolution), .configurationUnavailable)
     }
 
-    /// The same unsupplied variable inverts under negation: `null == "NL"` is false, so `!` makes it true and
-    /// the audience matches *everyone*, including customers it was meant to exclude. An unresolvable path
-    /// doesn't fail closed, it makes the result arbitrary.
-    func testNegatedAudienceOnAnUnsuppliedVariableMatchesEveryone() async throws {
+    /// Negation used to invert an unsupplied variable into a match: `null == "NL"` was false, so `!` made it
+    /// true and the audience matched *everyone*, including the customers it was meant to exclude. The lookup
+    /// fails ahead of the negation now, so an unresolvable path can no longer manufacture a match.
+    func testNegatedAudienceOnAnUnsuppliedVariableDoesNotMatch() async throws {
         self.audiencesProvider.rulesByAudienceID = [
             "audience": try Self.servedRules(
                 #"{ "id": "audience", "rules": { "!": [{ "==": [{ "var": "last_seen.country" }, "NL"] }] } }"#
@@ -453,7 +454,8 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
 
         let resolution = try await self.resolve()
 
-        XCTAssertEqual(Self.resolvedWorkflow(resolution)?.workflow.id, self.workflowID)
+        XCTAssertNil(Self.resolvedWorkflow(resolution))
+        XCTAssertEqual(Self.noActionReason(resolution), .configurationUnavailable)
     }
 
     /// Decodes with the real `Audience` decoder, so what gets evaluated is the string a served payload

--- a/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
+++ b/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
@@ -322,7 +322,39 @@ struct LocalRulesEvaluatorTests {
     }
 
     @Test
-    func omittedVariableRetainsRulesEngineNullSemantics() async throws {
+    func omittedVariableSurfacesAsAnErrorRatherThanMatching() async throws {
+        // A dimension this SDK version cannot resolve makes the rule
+        // unanswerable. Reporting that is what lets the caller tell it apart
+        // from a rule that was evaluated and did not match.
+        let evaluator = Self.evaluator(dimensionProviders: [
+            TestDimensionProvider(
+                namespace: .device,
+                snapshots: [["known": .bool(true)]]
+            )
+        ])
+
+        do {
+            _ = try await evaluator.match(in: [
+                TestLocalRule(
+                    id: "reads-unknown-dimension",
+                    predicate: #"{"==":[{"var":"device.unknown"},null]}"#
+                )
+            ])
+            Issue.record("Expected predicate failure to be thrown")
+        } catch let error as LocalRulesEvaluationError {
+            #expect(error == .predicateEvaluation(
+                ruleIndex: 0,
+                error: .unresolvedVariable(path: "device.unknown")
+            ))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test
+    func ruleReadingAnOmittedVariableDoesNotBlockALaterMatch() async throws {
+        // The first rule cannot be answered, but that says nothing about the
+        // second, so evaluation carries on and a later match still wins.
         let evaluator = Self.evaluator(dimensionProviders: [
             TestDimensionProvider(
                 namespace: .device,
@@ -332,12 +364,16 @@ struct LocalRulesEvaluatorTests {
 
         let rule = try await evaluator.match(in: [
             TestLocalRule(
-                id: "missing-is-null",
+                id: "reads-unknown-dimension",
                 predicate: #"{"==":[{"var":"device.unknown"},null]}"#
+            ),
+            TestLocalRule(
+                id: "reads-known-dimension",
+                predicate: #"{"==":[{"var":"device.known"},true]}"#
             )
         ])
 
-        #expect(rule?.id == "missing-is-null")
+        #expect(rule?.id == "reads-known-dimension")
     }
 
     @Test

--- a/Tests/UnitTests/LocalRules/SubscriberAttributesDimensionProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/SubscriberAttributesDimensionProviderTests.swift
@@ -195,8 +195,10 @@ struct SubscriberAttributesProviderTests {
         ]
         let nonMatchingPredicates = [
             #"{"==":[{"var":"subscriberAttributes.goal.value"},"gain_muscle"]}"#,
-            #"{"!!":{"var":"subscriberAttributes.favoriteColor.value"}}"#,
-            #"{"!!":{"var":"subscriberAttributes.goal.isSynced"}}"#,
+            // An attribute the app never set on this device, and one the SDK does not expose. Both
+            // need a default, since reading a name that resolves to nothing is now an error.
+            #"{"!!":{"var":["subscriberAttributes.favoriteColor.value",false]}}"#,
+            #"{"!!":{"var":["subscriberAttributes.goal.isSynced",false]}}"#,
             #"""
             {"<":[
                 {"-":[{"var":"subscriberAttributes.goal.evaluatedAt"},

--- a/Tests/UnitTests/RulesEngine/AccessorOperatorsTests.swift
+++ b/Tests/UnitTests/RulesEngine/AccessorOperatorsTests.swift
@@ -71,14 +71,12 @@ final class AccessorOperatorsTests: XCTestCase {
 
     func testVarWithFractionalFloatPathDoesNotMatchAdjacentIndices() throws {
         // {"var": 1.5} must not silently collapse to "1" or "2" — its
-        // rendered path is "1.5", which doesn't resolve, so the lookup
-        // misses and warns. Guards against an over-eager rounding fix to
-        // `formatNumber`.
+        // rendered path is "1.5", which doesn't resolve. Guards against an
+        // over-eager rounding fix to `formatNumber`.
         let data = Value.array([.string("zero"), .string("one"), .string("two")])
         let scope = Scope(root: data)
-        let out = try AccessorOperators.opVar(args: .float(1.5), vars: scope)
-        XCTAssertEqual(out, .null)
-        XCTAssertEqual(logger.warnings.count, 1)
-        XCTAssertTrue(logger.warnings[0].contains("1.5"))
+        XCTAssertThrowsError(try AccessorOperators.opVar(args: .float(1.5), vars: scope)) { error in
+            XCTAssertEqual(error as? RulesEngine.EvaluationError, .unresolvedVariable(path: "1.5"))
+        }
     }
 }

--- a/Tests/UnitTests/RulesEngine/Helpers/PredicateConformanceFixture.swift
+++ b/Tests/UnitTests/RulesEngine/Helpers/PredicateConformanceFixture.swift
@@ -38,10 +38,14 @@ struct ExpectedError: Equatable, Decodable {
 
     let kind: String
     let `operator`: String?
+    /// Expected dot-path for `unresolvedVariable`. Optional: omit to assert
+    /// only that the variable failed to resolve.
+    let path: String?
 
     enum CodingKeys: String, CodingKey {
         case kind = "error"
         case `operator`
+        case path
     }
 }
 

--- a/Tests/UnitTests/RulesEngine/Helpers/PredicateConformanceFixture.swift
+++ b/Tests/UnitTests/RulesEngine/Helpers/PredicateConformanceFixture.swift
@@ -38,14 +38,14 @@ struct ExpectedError: Equatable, Decodable {
 
     let kind: String
     let `operator`: String?
-    /// Expected dot-path for `unresolvedVariable`. Optional: omit to assert
-    /// only that the variable failed to resolve.
-    let path: String?
+    /// Omit to assert only that the variable failed to resolve, whatever
+    /// path it was written as.
+    let unresolvedPath: String?
 
     enum CodingKeys: String, CodingKey {
         case kind = "error"
         case `operator`
-        case path
+        case unresolvedPath = "path"
     }
 }
 

--- a/Tests/UnitTests/RulesEngine/Helpers/PredicateConformanceRunner.swift
+++ b/Tests/UnitTests/RulesEngine/Helpers/PredicateConformanceRunner.swift
@@ -95,6 +95,14 @@ enum PredicateConformanceRunner {
                 return true
             }
 
+        case "unresolvedVariable":
+            if case .unresolvedVariable(let path) = error {
+                if let expectedPath = expected.path {
+                    return path == expectedPath
+                }
+                return true
+            }
+
         default:
             break
         }

--- a/Tests/UnitTests/RulesEngine/Helpers/PredicateConformanceRunner.swift
+++ b/Tests/UnitTests/RulesEngine/Helpers/PredicateConformanceRunner.swift
@@ -97,7 +97,7 @@ enum PredicateConformanceRunner {
 
         case "unresolvedVariable":
             if case .unresolvedVariable(let path) = error {
-                if let expectedPath = expected.path {
+                if let expectedPath = expected.unresolvedPath {
                     return path == expectedPath
                 }
                 return true

--- a/Tests/UnitTests/RulesEngine/PredicateFixtureTests.swift
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtureTests.swift
@@ -32,7 +32,7 @@ struct PredicateFixtureTests {
     /// fixtures are added or removed.
     @Test
     func fixtureCountMatchesExpected() {
-        let expectedCount = 446
+        let expectedCount = 447
         #expect(
             Self.fixtures.count == expectedCount,
             "Expected \(expectedCount) fixtures, loaded \(Self.fixtures.count)"

--- a/Tests/UnitTests/RulesEngine/PredicateFixtureTests.swift
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtureTests.swift
@@ -32,7 +32,7 @@ struct PredicateFixtureTests {
     /// fixtures are added or removed.
     @Test
     func fixtureCountMatchesExpected() {
-        let expectedCount = 411
+        let expectedCount = 428
         #expect(
             Self.fixtures.count == expectedCount,
             "Expected \(expectedCount) fixtures, loaded \(Self.fixtures.count)"

--- a/Tests/UnitTests/RulesEngine/PredicateFixtures/evaluator.json
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtures/evaluator.json
@@ -159,12 +159,11 @@
       "expected": false
     },
     {
-      "id": "evaluator_missing_variable_resolves_to_null_and_warns",
-      "description": "a missing var resolves to null, so {\"==\": [{\"var\": \"missing\"}, null]} is true and a warning is logged",
+      "id": "evaluator_missing_variable_surfaces_error_to_the_caller",
+      "description": "a missing var aborts the whole evaluation rather than resolving to null, so the caller gets to decide what an unanswerable rule means",
       "predicate": { "==": [{ "var": "missing" }, null] },
       "variables": {},
-      "expected": true,
-      "expectedWarnings": { "contains": ["missing"] }
+      "expected": { "error": "unresolvedVariable", "path": "missing" }
     },
     {
       "id": "evaluator_unsupported_operator_surfaces_error",

--- a/Tests/UnitTests/RulesEngine/PredicateFixtures/none.json
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtures/none.json
@@ -153,7 +153,7 @@
     },
     {
       "id": "none_map_filter_predicate_cannot_reach_parent_scope__none",
-      "description": "none/map/filter predicates cannot reach the parent scope; outer flag resolves to null inside the per-item evaluation",
+      "description": "none/map/filter predicates cannot reach the parent scope; the outer flag is unreachable per item and the lookup says so",
       "predicate": {
         "none": [
           [
@@ -173,11 +173,14 @@
       "variables": {
         "flag": true
       },
-      "expected": true
+      "expected": {
+        "error": "unresolvedVariable",
+        "path": "flag"
+      }
     },
     {
       "id": "none_map_filter_predicate_cannot_reach_parent_scope__map",
-      "description": "map predicate cannot reach the parent scope; flag resolves to null so each item yields false, giving [false,false] compared via string coercion",
+      "description": "map predicate cannot reach the parent scope; the unreachable flag aborts the map instead of mapping every item to a false derived from null",
       "predicate": {
         "==": [
           {
@@ -202,11 +205,14 @@
       "variables": {
         "flag": true
       },
-      "expected": true
+      "expected": {
+        "error": "unresolvedVariable",
+        "path": "flag"
+      }
     },
     {
       "id": "none_map_filter_predicate_cannot_reach_parent_scope__filter",
-      "description": "filter predicate cannot reach the parent scope; flag resolves to null so nothing is retained, giving [] compared via string coercion to the empty string",
+      "description": "filter predicate cannot reach the parent scope; the unreachable flag aborts the filter instead of silently retaining nothing",
       "predicate": {
         "==": [
           {
@@ -231,11 +237,14 @@
       "variables": {
         "flag": true
       },
-      "expected": true
+      "expected": {
+        "error": "unresolvedVariable",
+        "path": "flag"
+      }
     },
     {
       "id": "none_reads_named_property_on_object_items",
-      "description": "items are data objects supplied via var, so the per-item scope exposes their named keys. One item has active=true, so none short-circuits to false — proving the property is actually read (a non-reachable property would resolve to null and yield true).",
+      "description": "items are data objects supplied via var, so the per-item scope exposes their named keys. One item has active=true, so none short-circuits to false — proving the property is actually read (a non-reachable property would fail the lookup instead).",
       "predicate": {
         "none": [
           {

--- a/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_case.json
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_case.json
@@ -190,14 +190,30 @@
       }
     },
     {
-      "id": "lower_missing_variable_is_type_error",
-      "description": "Motivating case for throwing: a typo'd path resolves to null, and coercion would make {\"===\": [{\"rc.lower\": {\"var\": \"typo\"}}, \"null\"]} quietly true",
+      "id": "lower_missing_variable_fails_at_the_lookup",
+      "description": "A typo'd path is caught by var before rc.lower ever sees it, so the error names the unresolved path rather than blaming the operator for a null argument",
       "predicate": {
         "rc.lower": {
           "var": "missing"
         }
       },
       "variables": {},
+      "expected": {
+        "error": "unresolvedVariable",
+        "path": "missing"
+      }
+    },
+    {
+      "id": "lower_explicit_null_is_still_a_type_error",
+      "description": "A key that is present but null is a known value, not an unresolved one, so it reaches rc.lower and is refused there — coercing it would make it compare equal to the string \"null\"",
+      "predicate": {
+        "rc.lower": {
+          "var": "maybe"
+        }
+      },
+      "variables": {
+        "maybe": null
+      },
       "expected": {
         "error": "typeMismatch",
         "operator": "rc.lower"

--- a/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_length.json
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_length.json
@@ -178,14 +178,30 @@
       }
     },
     {
-      "id": "length_missing_variable_is_type_error",
-      "description": "var resolves a missing key to null; rc.length throws rather than silently returning 0",
+      "id": "length_missing_variable_fails_at_the_lookup",
+      "description": "the missing key is caught by var before rc.length ever sees it, so the error names the unresolved path rather than blaming the operator for a null argument",
       "predicate": {
         "rc.length": {
           "var": "missing"
         }
       },
       "variables": {},
+      "expected": {
+        "error": "unresolvedVariable",
+        "path": "missing"
+      }
+    },
+    {
+      "id": "length_explicit_null_is_still_a_type_error",
+      "description": "a key that is present but null is a known value, not an unresolved one, so it reaches rc.length and fails there instead",
+      "predicate": {
+        "rc.length": {
+          "var": "maybe"
+        }
+      },
+      "variables": {
+        "maybe": null
+      },
       "expected": {
         "error": "typeMismatch",
         "operator": "rc.length"

--- a/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_root_var.json
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_root_var.json
@@ -27,8 +27,8 @@
       "expectedWarnings": { "contains": [] }
     },
     {
-      "id": "rc_root_var_var_inside_some_would_miss_expired",
-      "description": "Same predicate with var instead of rc.rootVar: now resolves to null (0), so no subscription appears expired",
+      "id": "rc_root_var_var_inside_some_is_rejected_not_silently_wrong",
+      "description": "Same predicate written with var instead of rc.rootVar. The item scope has no now, and the old null-degrading lookup turned the comparison into expires < 0 and answered false for every subscription. The rule is now rejected outright, so the authoring mistake surfaces instead of shipping a wrong audience.",
       "predicate": {
         "some": [
           { "var": "subscriptions" },
@@ -42,8 +42,7 @@
           { "expires": 150 }
         ]
       },
-      "expected": false,
-      "expectedWarnings": { "contains": ["missing variable"] }
+      "expected": { "error": "unresolvedVariable", "path": "now" }
     },
     {
       "id": "rc_root_var_survives_nested_some",
@@ -171,11 +170,11 @@
       "expectedWarnings": { "contains": [] }
     },
     {
-      "id": "rc_root_var_missing_without_default_warns",
+      "id": "rc_root_var_missing_without_default_is_unresolved_variable_error",
+      "description": "rc.rootVar shares var's lookup, so an absent root key is unknown for it too",
       "predicate": { "===": [{ "rc.rootVar": "missing_key" }, null] },
       "variables": { "a": 1 },
-      "expected": true,
-      "expectedWarnings": { "contains": ["missing variable: missing_key"] }
+      "expected": { "error": "unresolvedVariable", "path": "missing_key" }
     },
     {
       "id": "rc_root_var_dot_path_with_numeric_array_index",

--- a/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_root_var.json
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_root_var.json
@@ -27,8 +27,8 @@
       "expectedWarnings": { "contains": [] }
     },
     {
-      "id": "rc_root_var_var_inside_some_is_rejected_not_silently_wrong",
-      "description": "Same predicate written with var instead of rc.rootVar. The item scope has no now, and the old null-degrading lookup turned the comparison into expires < 0 and answered false for every subscription. The rule is now rejected outright, so the authoring mistake surfaces instead of shipping a wrong audience.",
+      "id": "rc_root_var_var_inside_some_cannot_reach_now",
+      "description": "Same predicate written with var instead of rc.rootVar: the item scope holds only the subscription, so the outer now is unreachable and the lookup names it instead of quietly comparing every expires against null",
       "predicate": {
         "some": [
           { "var": "subscriptions" },

--- a/Tests/UnitTests/RulesEngine/PredicateFixtures/reduce.json
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtures/reduce.json
@@ -244,7 +244,7 @@
     },
     {
       "id": "reduce_predicate_cannot_reach_parent_scope",
-      "description": "a var lookup against a nonexistent key in the reduce scope resolves to null, not the parent's value; multiplier resolves to null so the accumulator becomes current each step, ending at 3",
+      "description": "the reduce scope holds only current and accumulator, so the outer multiplier is unreachable; the lookup now names it instead of quietly resolving to null and folding a wrong total",
       "predicate": {
         "===": [
           {
@@ -255,31 +255,35 @@
                 3
               ],
               {
-                "if": [
+                "+": [
                   {
-                    "==": [
+                    "var": "accumulator"
+                  },
+                  {
+                    "*": [
+                      {
+                        "var": "current"
+                      },
                       {
                         "var": "multiplier"
-                      },
-                      null
+                      }
                     ]
-                  },
-                  {
-                    "var": "current"
-                  },
-                  -999
+                  }
                 ]
               },
               0
             ]
           },
-          3
+          60
         ]
       },
       "variables": {
         "multiplier": 10
       },
-      "expected": true
+      "expected": {
+        "error": "unresolvedVariable",
+        "path": "multiplier"
+      }
     },
     {
       "id": "reduce_missing_initial_empty_source_is_null",

--- a/Tests/UnitTests/RulesEngine/PredicateFixtures/some.json
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtures/some.json
@@ -230,7 +230,7 @@
     },
     {
       "id": "some_predicate_cannot_reach_parent_scope",
-      "description": "inside the predicate only the current item is visible; outer x is unreachable so {\"var\": \"x\"} resolves to null and equality is false for every item",
+      "description": "inside the predicate only the current item is visible, so the outer x is unreachable; the error names the path rather than letting a null stand in for a value that does exist one scope up",
       "predicate": {
         "some": [
           [
@@ -250,7 +250,10 @@
       "variables": {
         "x": "outer"
       },
-      "expected": false
+      "expected": {
+        "error": "unresolvedVariable",
+        "path": "x"
+      }
     },
     {
       "id": "some_returns_true_when_one_object_in_array_matches",

--- a/Tests/UnitTests/RulesEngine/PredicateFixtures/unresolved_variable.json
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtures/unresolved_variable.json
@@ -1,0 +1,159 @@
+{
+  "fixtures": [
+    {
+      "id": "unresolved_numeric_comparison_is_rejected_instead_of_coercing_to_zero",
+      "description": "The motivating case. With a null-degrading lookup this becomes expires > 0, which is true for every subscription that ever existed, so an audience meant for active subscribers silently matches everyone.",
+      "predicate": {
+        ">": [{ "var": "expires" }, { "var": "now" }]
+      },
+      "variables": { "expires": 1000 },
+      "expected": { "error": "unresolvedVariable", "path": "now" }
+    },
+    {
+      "id": "unresolved_string_comparison_is_rejected_instead_of_coercing_to_empty",
+      "description": "The same hazard in string form: null stringifies to \"\", so a rule gating on an absent country would answer for a reason unrelated to where the user is",
+      "predicate": {
+        "==": [{ "var": "country" }, ""]
+      },
+      "variables": {},
+      "expected": { "error": "unresolvedVariable", "path": "country" }
+    },
+    {
+      "id": "unresolved_variable_reports_the_first_failing_path",
+      "description": "Evaluation stops at the first name it cannot resolve, so the error points at one concrete path rather than a set",
+      "predicate": {
+        "and": [{ "var": "first_missing" }, { "var": "second_missing" }]
+      },
+      "variables": {},
+      "expected": { "error": "unresolvedVariable", "path": "first_missing" }
+    },
+    {
+      "id": "present_but_null_value_is_known_and_does_not_raise",
+      "description": "An explicit null is an answer the scope actually gave, so it resolves normally; only an absent path is unknown",
+      "predicate": {
+        "===": [{ "var": "country" }, null]
+      },
+      "variables": { "country": null },
+      "expected": true
+    },
+    {
+      "id": "present_but_null_leaf_on_a_dot_path_is_known_and_does_not_raise",
+      "predicate": {
+        "===": [{ "var": "subscriber.country" }, null]
+      },
+      "variables": { "subscriber": { "country": null } },
+      "expected": true
+    },
+    {
+      "id": "default_marks_absence_as_expected_and_suppresses_the_error",
+      "description": "The spec's own escape hatch is how a rule opts into tolerating absence, which keeps the intent visible in the rule itself",
+      "predicate": {
+        "===": [{ "var": ["country", "unknown"] }, "unknown"]
+      },
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "undefined_default_suppresses_the_error_and_yields_null",
+      "description": "{\"var\": [path]} with an explicitly undefined default still counts as opting in, matching json-logic-js coercing that default to null",
+      "predicate": {
+        "===": [{ "var": ["country", null] }, null]
+      },
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "unevaluated_or_branch_never_raises",
+      "description": "or short-circuits on the first truthy operand, so a missing name in a branch that never runs cannot fail the rule",
+      "predicate": {
+        "or": [true, { "var": "never_read" }]
+      },
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "unevaluated_and_branch_never_raises",
+      "predicate": {
+        "==": [{ "and": [false, { "var": "never_read" }] }, false]
+      },
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "untaken_if_branch_never_raises",
+      "description": "Only the selected branch is evaluated, so a rule can guard a name it is not sure about",
+      "predicate": {
+        "===": [{ "if": [false, { "var": "never_read" }, "fallback"] }, "fallback"]
+      },
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "missing_operator_still_probes_absence_without_raising",
+      "description": "missing exists to ask whether a name is there, so it keeps reporting absence rather than raising on it",
+      "predicate": {
+        "==": [{ "missing": ["country"] }, "country"]
+      },
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "missing_some_still_probes_absence_without_raising",
+      "predicate": {
+        "==": [{ "missing_some": [1, ["a", "b"]] }, ""]
+      },
+      "variables": { "a": 1 },
+      "expected": true
+    },
+    {
+      "id": "missing_guard_lets_a_rule_branch_on_presence",
+      "description": "The full authoring pattern for a genuinely optional dimension: probe with missing, then read it only on the branch where it exists",
+      "predicate": {
+        "if": [
+          { "missing": ["country"] },
+          false,
+          { "==": [{ "var": "country" }, "ES"] }
+        ]
+      },
+      "variables": {},
+      "expected": false
+    },
+    {
+      "id": "unresolved_mid_path_break_reports_the_full_path",
+      "description": "The walk fails partway through, and the error names the path as written rather than the segment that broke",
+      "predicate": {
+        "===": [{ "var": "subscriber.address.city" }, null]
+      },
+      "variables": { "subscriber": { "address": {} } },
+      "expected": { "error": "unresolvedVariable", "path": "subscriber.address.city" }
+    },
+    {
+      "id": "unresolved_variable_inside_iteration_aborts_the_whole_rule",
+      "description": "An item that lacks the field the predicate reads makes that item unanswerable, and one unanswerable item makes the some unanswerable too",
+      "predicate": {
+        "some": [
+          { "var": "subscriptions" },
+          { "==": [{ "var": "tier" }, "gold"] }
+        ]
+      },
+      "variables": {
+        "subscriptions": [{ "tier": "silver" }, { "plan": "basic" }]
+      },
+      "expected": { "error": "unresolvedVariable", "path": "tier" }
+    },
+    {
+      "id": "iteration_over_heterogeneous_items_opts_in_with_a_default",
+      "description": "Same shape as above, written the way a rule should be when items legitimately vary",
+      "predicate": {
+        "some": [
+          { "var": "subscriptions" },
+          { "==": [{ "var": ["tier", "none"] }, "gold"] }
+        ]
+      },
+      "variables": {
+        "subscriptions": [{ "tier": "silver" }, { "plan": "basic" }]
+      },
+      "expected": false
+    }
+  ]
+}

--- a/Tests/UnitTests/RulesEngine/PredicateFixtures/var.json
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtures/var.json
@@ -20,18 +20,18 @@
       "expected": true
     },
     {
-      "id": "var_missing_key_returns_null_and_warns",
+      "id": "var_missing_key_without_default_is_unresolved_variable_error",
+      "description": "an absent key with no default is unknown rather than null, so the engine raises unresolvedVariable instead of handing back a value that would coerce to 0 or \"\"",
       "predicate": { "===": [{ "var": "missing_key" }, null] },
       "variables": { "a": 1 },
-      "expected": true,
-      "expectedWarnings": { "contains": ["missing_key"] }
+      "expected": { "error": "unresolvedVariable", "path": "missing_key" }
     },
     {
-      "id": "var_missing_dot_path_returns_null_and_warns",
+      "id": "var_missing_dot_path_without_default_is_unresolved_variable_error",
+      "description": "the error carries the full dot-path that failed, not just its first segment",
       "predicate": { "===": [{ "var": "a.c" }, null] },
       "variables": { "a": { "b": 1 } },
-      "expected": true,
-      "expectedWarnings": { "contains": ["a.c"] }
+      "expected": { "error": "unresolvedVariable", "path": "a.c" }
     },
     {
       "id": "var_missing_with_default_returns_default_and_does_not_warn",
@@ -45,16 +45,14 @@
       "description": "1e19 exceeds Int64.max; the path formatter must round-trip safely so the lookup just misses instead of trapping",
       "predicate": { "===": [{ "var": 1e19 }, null] },
       "variables": {},
-      "expected": true,
-      "expectedWarnings": { "contains": ["missing variable"] }
+      "expected": { "error": "unresolvedVariable", "path": "1e+19" }
     },
     {
       "id": "var_does_not_apply_flat_key_fallback",
       "description": "the literal key \"a.b\" exists flat, but the spec-strict lookup walks \"a\" then \"b\" and finds nothing",
       "predicate": { "===": [{ "var": "a.b" }, null] },
       "variables": { "a.b": 42 },
-      "expected": true,
-      "expectedWarnings": { "contains": ["missing variable"] }
+      "expected": { "error": "unresolvedVariable", "path": "a.b" }
     },
     {
       "id": "var_extra_args_are_ignored_with_warning",
@@ -120,11 +118,10 @@
     },
     {
       "id": "var_object_path_stringifies_and_misses",
-      "description": "object paths stringify to \"[object Object]\" and never match a real key, so var returns null and warns",
+      "description": "object paths stringify to \"[object Object]\" and never match a real key, so the lookup misses and the stringified path is what the error reports",
       "predicate": { "===": [{ "var": [{ "foo": 1, "bar": 2 }] }, null] },
       "variables": { "x": 1 },
-      "expected": true,
-      "expectedWarnings": { "contains": ["missing variable"] }
+      "expected": { "error": "unresolvedVariable", "path": "[object Object]" }
     },
     {
       "id": "var_splits_dot_paths_double_dot",

--- a/Tests/UnitTests/RulesEngine/PredicateFixtures/var.json
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtures/var.json
@@ -42,10 +42,10 @@
     },
     {
       "id": "var_oversized_float_path_does_not_crash",
-      "description": "1e19 exceeds Int64.max; the path formatter must round-trip safely so the lookup just misses instead of trapping",
+      "description": "1e19 exceeds Int64.max; the path formatter must round-trip safely so the lookup just misses instead of trapping. The rendered path is left unpinned because the platforms format this magnitude differently.",
       "predicate": { "===": [{ "var": 1e19 }, null] },
       "variables": {},
-      "expected": { "error": "unresolvedVariable", "path": "1e+19" }
+      "expected": { "error": "unresolvedVariable" }
     },
     {
       "id": "var_does_not_apply_flat_key_fallback",


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-android` and hybrids

Android port: RevenueCat/purchases-android#4043 (predicate fixtures are byte-identical between the two).

### Motivation

A `var` lookup that found nothing returned `null`, per the JSON Logic spec. That null coerces to `0` in a numeric comparison and `""` in a string one, so a rule reading a dimension this SDK version never supplied still produces an answer, often the wrong one. A missing `now` turns `{">": [expires, now]}` into `expires > 0`, true for every subscription that ever existed.

### Description

An absent variable means "unknown", which is not the same answer as "no". The lookup now throws `unresolvedVariable(path:)` and the SDK decides what an unanswerable rule means — `LocalRulesEvaluator` already tells an error apart from a non-match, keeps walking later rules, and throws only if none matched.

- Rules that tolerate absence opt in via the spec's own `{"var": ["path", default]}`. A key present but holding `null` is a known value and still resolves; `missing`/`missing_some` still probe absence.
- This diverges from `json-logic-js`, so the same rule that errors here answers `false` on web. Worth confirming khepri emits defaults wherever absence is legitimate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes targeting/audience evaluation so missing dimensions fail closed instead of coercing to null. Served rules without defaults can now surface as unanswerable rather than matching or missing, which is safer but a visible behavior change vs json-logic-js.
> 
> **Overview**
> `var` / `rc.rootVar` no longer treat a missing path as `null`. An absent key with no default throws `EvaluationError.unresolvedVariable(path:)`, so a rule cannot silently become `expires > 0` or invert under `!` because JSON Logic coerced `null` to `0` / `""`.
> 
> Explicit `null` in the scope is still a known value. Rules that tolerate absence must opt in with `{"var": ["path", default]}`. `missing` / `missing_some` still probe absence without throwing.
> 
> Callers already distinguish evaluation errors from non-matches: local rules skip an unanswerable predicate and keep walking; checkpoint audiences report `configurationUnavailable` instead of `noMatch` (and no longer match everyone when a missing dimension is negated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1973779e7476dbebb0ba8f6cb2a850b66f4c406e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->