### PR TITLE
test(customer-center): pin what Change Plans offers with no configuration

### DIFF
--- a/Tests/RevenueCatUITests/CustomerCenter/ChangePlansEmptyConfigTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/ChangePlansEmptyConfigTests.swift
@@ -1,0 +1,133 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ChangePlansEmptyConfigTests.swift
+//
+//  Created by Facundo Menzella on 20/8/26.
+
+import Nimble
+@_spi(Internal) @testable import RevenueCat
+@_spi(Internal) @testable import RevenueCatUI
+import StoreKit
+import XCTest
+
+#if os(iOS)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@MainActor
+final class ChangePlansEmptyConfigTests: TestCase {
+
+    // A subscription group holding exactly two products. The dashboard treats a group
+    // that size as non-configurable, so it never writes a `change_plans` entry and the
+    // served config carries `[]`.
+    private static let groupID = "pro_group"
+    private static let monthlyID = "com.revenuecat.monthly"
+    private static let yearlyID = "com.revenuecat.yearly"
+
+    func testEmptyChangePlansConfigLeavesNothingToOffer() async throws {
+        let viewModel = await Self.viewModel(changePlans: [])
+
+        // Nothing in the served config matches the subscribed product's group, so the
+        // SDK has no product list to hand to StoreKit.
+        expect(viewModel.purchaseInformation?.changePlan).to(beNil())
+        expect(viewModel.changePlanProductIDs) == []
+
+        // `ChangePlansSheetViewModifier` gates on `productIDs.count >= 2`, so with an
+        // empty list it renders `SubscriptionStoreView(groupID:)` instead, showing the
+        // entire App Store subscription group rather than the configured products.
+        expect(viewModel.changePlanProductIDs.count >= 2).to(beFalse())
+    }
+
+    func testConfiguredTwoProductGroupOffersBothProducts() async throws {
+        // The response a dashboard that stopped skipping two-product groups would send.
+        let changePlan = CustomerCenterConfigData.ChangePlan(
+            groupId: Self.groupID,
+            groupName: "Pro",
+            products: [
+                .init(productId: Self.monthlyID, selected: true),
+                .init(productId: Self.yearlyID, selected: true)
+            ]
+        )
+
+        let viewModel = await Self.viewModel(changePlans: [changePlan])
+
+        expect(viewModel.purchaseInformation?.changePlan).toNot(beNil())
+        expect(viewModel.changePlanProductIDs) == [Self.monthlyID, Self.yearlyID]
+
+        // Two ids clear the gate, so the sheet lists exactly these products.
+        expect(viewModel.changePlanProductIDs.count >= 2).to(beTrue())
+    }
+
+    private static func viewModel(
+        changePlans: [CustomerCenterConfigData.ChangePlan]
+    ) async -> BaseManageSubscriptionViewModel {
+        let product = TestStoreProduct(
+            localizedTitle: "Monthly Pro",
+            price: 9.99,
+            currencyCode: "USD",
+            localizedPriceString: "$9.99",
+            productIdentifier: monthlyID,
+            productType: .autoRenewableSubscription,
+            localizedDescription: "Pro",
+            subscriptionGroupIdentifier: groupID,
+            subscriptionPeriod: .init(value: 1, unit: .month),
+            locale: Locale(identifier: "en_US")
+        ).toStoreProduct()
+
+        let transaction = MockTransaction(
+            productIdentifier: monthlyID,
+            store: .appStore,
+            type: .subscription(
+                isActive: true,
+                willRenew: true,
+                expiresDate: Date().addingTimeInterval(60 * 60 * 24),
+                isTrial: false,
+                ownershipType: .purchased
+            ),
+            isCancelled: false,
+            managementURL: URL(string: "https://www.revenuecat.com")!,
+            price: .init(currency: "USD", amount: 9.99),
+            displayName: "Monthly Pro",
+            periodType: .normal,
+            purchaseDate: Date(),
+            unsubscribeDetectedAt: nil,
+            billingIssuesDetectedAt: nil,
+            gracePeriodExpiresDate: nil,
+            refundedAtDate: nil,
+            storeIdentifier: nil,
+            identifier: nil,
+            originalPurchaseDate: nil,
+            isSandbox: false,
+            isSubscription: true
+        )
+
+        let purchasesProvider = MockCustomerCenterPurchases(products: [product])
+
+        let purchaseInformation = await PurchaseInformation.from(
+            transaction: transaction,
+            customerInfo: CustomerInfoFixtures.customerInfoWithAppleSubscriptions,
+            purchasesProvider: purchasesProvider,
+            changePlans: changePlans,
+            customerCenterStoreKitUtilities: MockCustomerCenterStoreKitUtilities(),
+            localization: CustomerCenterConfigData.mock(lastPublishedAppVersion: nil).localization
+        )
+
+        return BaseManageSubscriptionViewModel(
+            screen: .init(type: .management, title: "Manage", subtitle: nil, paths: [], offering: nil),
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchaseInformation: purchaseInformation,
+            purchasesProvider: purchasesProvider
+        )
+    }
+}
+
+#endif


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
A support report traced back to `ChangePlansSheetViewModifier`'s `productIDs.count >= 2` gate, which
had no test coverage at all, nor did `changePlanProductIDs`. Change Plans is iOS only, so nothing
else covers this behavior.

### Description
Two cases pin what Change Plans offers for a subscription group holding exactly two products. The
dashboard treats a group that size as non-configurable and never writes a `change_plans` entry for
it, so the served config carries `[]`.

With no entry the SDK resolves no change plan, hands StoreKit no product ids, and the sheet falls
through to `SubscriptionStoreView(groupID:)`, which shows the entire App Store subscription group
rather than the developer's products. With the group configured, both ids come through and the sheet
lists exactly those two.

Characterization only, no production code touched. The second case is the one that shows a config fix
would work; the first is the behavior a fix would change.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: RevenueCat/purchases-ios (branch `facu/change-plans-empty-config-gate`)
- Author / human owner: facumenzella
- Agent: Claude Code (Claude Opus 5, 1M context)
- Generated: 2026-08-20

## Goal

Establish, with tests rather than reasoning, what the Change Plans sheet offers when the served
Customer Center config contains no `change_plans` entry for the subscribed product's group.

## What was verified

- `PurchaseInformation+Creation.swift:36-39` resolves `changePlan` to nil when `changePlans` is
  empty, so `changePlanProductIDs` (`BaseManageSubscriptionViewModel.swift:270-273`) is `[]`.
- `CustomerCenterPurchasesType.swift:154-166` then takes the `SubscriptionStoreView(groupID:)`
  branch. Zero ids and one id land on the same branch.
- Confirmed on a simulator as well as in tests: with an empty config the sheet listed every product
  in the App Store subscription group; with the two products configured it listed exactly those two.
- `grep` for `changePlanProductIDs`, `ChangePlansSheet`, `validAmountOfProducts` across `Tests/`
  returned nothing before this change.

## Decisions

- Kept this PR characterization-only. The behavior change belongs on the config side, not in the SDK,
  because the SDK has no product list to fall back to when the config is empty.
- Did not extract the gate into a testable value in this PR, which is what coverage of the branch
  itself would need. Noted as a follow-up rather than bundled here.
- Customer identifiers from the originating report are deliberately absent; the fixtures use generic
  ids.

## Not captured / not done

- No test covers which `SubscriptionStoreView` initializer runs, only the inputs to the gate.
- Whether the config side should stop skipping two-product groups, or the backend should synthesize
  an explicit entry, is undecided.

## Verification

- `xcodebuild test -only-testing:RevenueCatUITests/ChangePlansEmptyConfigTests` on an iPhone 16 Pro
  (iOS 18.4): Executed 2 tests, 0 failures.
- `swiftlint` on the added file: clean.

</details>
