### PR TITLE
feat: Expose displayName and originalPurchaseDate on NonSubscriptionTransaction

### DIFF
--- a/Sources/Purchasing/NonSubscriptionTransaction.swift
+++ b/Sources/Purchasing/NonSubscriptionTransaction.swift
@@ -28,6 +28,10 @@ public final class NonSubscriptionTransaction: NSObject {
     /// The date that App Store charged the user’s account.
     @objc public let purchaseDate: Date
 
+    /// The date this purchase was first made, which for a repeatable purchase is not
+    /// ``purchaseDate``. `nil` when the store never reported one.
+    @objc public let originalPurchaseDate: Date?
+
     /// The unique identifier for the transaction created by RevenueCat.
     @objc public let transactionIdentifier: String
 
@@ -43,6 +47,9 @@ public final class NonSubscriptionTransaction: NSObject {
     /// Whether or not the purchase was made in sandbox mode.
     @objc public let isSandbox: Bool
 
+    /// The display name of the product as configured in the RevenueCat dashboard.
+    @objc public let displayName: String?
+
     init?(with transaction: CustomerInfoResponse.Transaction, productID: String) {
         guard let transactionIdentifier = transaction.transactionIdentifier,
               let storeTransactionIdentifier = transaction.storeTransactionIdentifier else {
@@ -54,6 +61,8 @@ public final class NonSubscriptionTransaction: NSObject {
         self.transactionIdentifier = transactionIdentifier
         self.storeTransactionIdentifier = storeTransactionIdentifier
         self.purchaseDate = transaction.purchaseDate
+        self.originalPurchaseDate = transaction.originalPurchaseDate
+        self.displayName = transaction.displayName
         self.productIdentifier = productID
         self.store = transaction.store
         self.price = transaction.price.map { ProductPaidPrice(currency: $0.currency, amount: $0.amount) }
@@ -65,6 +74,8 @@ public final class NonSubscriptionTransaction: NSObject {
         <\(String(describing: NonSubscriptionTransaction.self)):
             productIdentifier=\(self.productIdentifier)
             purchaseDate=\(self.purchaseDate)
+            originalPurchaseDate=\(String(describing: self.originalPurchaseDate))
+            displayName=\(self.displayName ?? "null")
             transactionIdentifier=\(self.transactionIdentifier)
             storeTransactionIdentifier=\(self.storeTransactionIdentifier)
         >

--- a/Sources/Purchasing/NonSubscriptionTransaction.swift
+++ b/Sources/Purchasing/NonSubscriptionTransaction.swift
@@ -28,8 +28,8 @@ public final class NonSubscriptionTransaction: NSObject {
     /// The date that App Store charged the user’s account.
     @objc public let purchaseDate: Date
 
-    /// The date this purchase was first made, which for a repeatable purchase is not
-    /// ``purchaseDate``. `nil` when the store never reported one.
+    /// Date of the original store transaction. Earlier than ``purchaseDate`` on a restore.
+    /// `nil` when the store never reported one.
     @objc public let originalPurchaseDate: Date?
 
     /// The unique identifier for the transaction created by RevenueCat.

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCNonSubscriptionTransactionAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCNonSubscriptionTransactionAPI.m
@@ -18,6 +18,8 @@
     NSDate *pd __unused = transaction.purchaseDate;
     NSString *tid __unused = transaction.transactionIdentifier;
     NSString *stid __unused = transaction.storeTransactionIdentifier;
+    NSDate *opd __unused = transaction.originalPurchaseDate;
+    NSString *dn __unused = transaction.displayName;
 }
 
 @end

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/NonSubscriptionTransactionAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/NonSubscriptionTransactionAPI.swift
@@ -13,9 +13,11 @@ private var transaction: NonSubscriptionTransaction!
 func checkNonSubscriptionTransactionAPI() {
     let _: String = transaction.productIdentifier
     let _: Date = transaction.purchaseDate
+    let _: Date? = transaction.originalPurchaseDate
     let _: String = transaction.transactionIdentifier
     let _: String = transaction.storeTransactionIdentifier
     let _: Store = transaction.store
     let _: ProductPaidPrice? = transaction.price
     let _: Bool = transaction.isSandbox
+    let _: String? = transaction.displayName
 }

--- a/Tests/UnitTests/Purchasing/TransactionsFactoryTests.swift
+++ b/Tests/UnitTests/Purchasing/TransactionsFactoryTests.swift
@@ -37,6 +37,48 @@ class TransactionsFactoryTests: TestCase {
 
     }
 
+    func testNonSubscriptionsCarryTheDisplayNameAndOriginalPurchaseDate() throws {
+        let transactions = try TransactionsFactory.nonSubscriptionTransactions(
+            withSubscriptionsData: [
+                "100_coins": [
+                    [
+                        "id": "72c26cc69c",
+                        "store_transaction_id": "1",
+                        "is_sandbox": false,
+                        "original_purchase_date": "1990-08-30T02:40:36Z",
+                        "purchase_date": "2019-07-11T18:36:20Z",
+                        "display_name": "100 Coins",
+                        "store": "app_store"
+                    ]
+                ]
+            ]
+        )
+
+        let transaction = try XCTUnwrap(transactions.first)
+        expect(transaction.displayName) == "100 Coins"
+        expect(transaction.originalPurchaseDate) == ISO8601DateFormatter().date(from: "1990-08-30T02:40:36Z")
+    }
+
+    func testNonSubscriptionsOmitADisplayNameAndOriginalPurchaseDateTheStoreDidNotSend() throws {
+        let transactions = try TransactionsFactory.nonSubscriptionTransactions(
+            withSubscriptionsData: [
+                "100_coins": [
+                    [
+                        "id": "72c26cc69c",
+                        "store_transaction_id": "1",
+                        "is_sandbox": false,
+                        "purchase_date": "2019-07-11T18:36:20Z",
+                        "store": "app_store"
+                    ]
+                ]
+            ]
+        )
+
+        let transaction = try XCTUnwrap(transactions.first)
+        expect(transaction.displayName).to(beNil())
+        expect(transaction.originalPurchaseDate).to(beNil())
+    }
+
     func testNonSubscriptionsIsEmptyIfThereAreNoNonSubscriptions() {
         let list = TransactionsFactory.nonSubscriptionTransactions(withSubscriptionsData: [:])
         expect(list).to(beEmpty())

--- a/api/revenuecat-api-ios-simulator.swiftinterface
+++ b/api/revenuecat-api-ios-simulator.swiftinterface
@@ -1826,11 +1826,13 @@ extension RevenueCat.IntroEligibility : Swift.Sendable {
 @_hasMissingDesignatedInitializers @objc(RCNonSubscriptionTransaction) final public class NonSubscriptionTransaction : ObjectiveC.NSObject {
   @objc final public let productIdentifier: Swift.String
   @objc final public let purchaseDate: Foundation.Date
+  @objc final public let originalPurchaseDate: Foundation.Date?
   @objc final public let transactionIdentifier: Swift.String
   @objc final public let storeTransactionIdentifier: Swift.String
   @objc final public let store: RevenueCat.Store
   @objc final public let price: RevenueCat.ProductPaidPrice?
   @objc final public let isSandbox: Swift.Bool
+  @objc final public let displayName: Swift.String?
   @objc override final public var description: Swift.String {
     @objc get
   }

--- a/api/revenuecat-api-ios.swiftinterface
+++ b/api/revenuecat-api-ios.swiftinterface
@@ -1826,11 +1826,13 @@ extension RevenueCat.IntroEligibility : Swift.Sendable {
 @_hasMissingDesignatedInitializers @objc(RCNonSubscriptionTransaction) final public class NonSubscriptionTransaction : ObjectiveC.NSObject {
   @objc final public let productIdentifier: Swift.String
   @objc final public let purchaseDate: Foundation.Date
+  @objc final public let originalPurchaseDate: Foundation.Date?
   @objc final public let transactionIdentifier: Swift.String
   @objc final public let storeTransactionIdentifier: Swift.String
   @objc final public let store: RevenueCat.Store
   @objc final public let price: RevenueCat.ProductPaidPrice?
   @objc final public let isSandbox: Swift.Bool
+  @objc final public let displayName: Swift.String?
   @objc override final public var description: Swift.String {
     @objc get
   }

--- a/api/revenuecat-api-macos.swiftinterface
+++ b/api/revenuecat-api-macos.swiftinterface
@@ -1793,11 +1793,13 @@ extension RevenueCat.IntroEligibility : Swift.Sendable {
 @_hasMissingDesignatedInitializers @objc(RCNonSubscriptionTransaction) final public class NonSubscriptionTransaction : ObjectiveC.NSObject {
   @objc final public let productIdentifier: Swift.String
   @objc final public let purchaseDate: Foundation.Date
+  @objc final public let originalPurchaseDate: Foundation.Date?
   @objc final public let transactionIdentifier: Swift.String
   @objc final public let storeTransactionIdentifier: Swift.String
   @objc final public let store: RevenueCat.Store
   @objc final public let price: RevenueCat.ProductPaidPrice?
   @objc final public let isSandbox: Swift.Bool
+  @objc final public let displayName: Swift.String?
   @objc override final public var description: Swift.String {
     @objc get
   }

--- a/api/revenuecat-api-tvos-simulator.swiftinterface
+++ b/api/revenuecat-api-tvos-simulator.swiftinterface
@@ -1793,11 +1793,13 @@ extension RevenueCat.IntroEligibility : Swift.Sendable {
 @_hasMissingDesignatedInitializers @objc(RCNonSubscriptionTransaction) final public class NonSubscriptionTransaction : ObjectiveC.NSObject {
   @objc final public let productIdentifier: Swift.String
   @objc final public let purchaseDate: Foundation.Date
+  @objc final public let originalPurchaseDate: Foundation.Date?
   @objc final public let transactionIdentifier: Swift.String
   @objc final public let storeTransactionIdentifier: Swift.String
   @objc final public let store: RevenueCat.Store
   @objc final public let price: RevenueCat.ProductPaidPrice?
   @objc final public let isSandbox: Swift.Bool
+  @objc final public let displayName: Swift.String?
   @objc override final public var description: Swift.String {
     @objc get
   }

--- a/api/revenuecat-api-tvos.swiftinterface
+++ b/api/revenuecat-api-tvos.swiftinterface
@@ -1793,11 +1793,13 @@ extension RevenueCat.IntroEligibility : Swift.Sendable {
 @_hasMissingDesignatedInitializers @objc(RCNonSubscriptionTransaction) final public class NonSubscriptionTransaction : ObjectiveC.NSObject {
   @objc final public let productIdentifier: Swift.String
   @objc final public let purchaseDate: Foundation.Date
+  @objc final public let originalPurchaseDate: Foundation.Date?
   @objc final public let transactionIdentifier: Swift.String
   @objc final public let storeTransactionIdentifier: Swift.String
   @objc final public let store: RevenueCat.Store
   @objc final public let price: RevenueCat.ProductPaidPrice?
   @objc final public let isSandbox: Swift.Bool
+  @objc final public let displayName: Swift.String?
   @objc override final public var description: Swift.String {
     @objc get
   }

--- a/api/revenuecat-api-visionos-simulator.swiftinterface
+++ b/api/revenuecat-api-visionos-simulator.swiftinterface
@@ -1826,11 +1826,13 @@ extension RevenueCat.IntroEligibility : Swift.Sendable {
 @_hasMissingDesignatedInitializers @objc(RCNonSubscriptionTransaction) final public class NonSubscriptionTransaction : ObjectiveC.NSObject {
   @objc final public let productIdentifier: Swift.String
   @objc final public let purchaseDate: Foundation.Date
+  @objc final public let originalPurchaseDate: Foundation.Date?
   @objc final public let transactionIdentifier: Swift.String
   @objc final public let storeTransactionIdentifier: Swift.String
   @objc final public let store: RevenueCat.Store
   @objc final public let price: RevenueCat.ProductPaidPrice?
   @objc final public let isSandbox: Swift.Bool
+  @objc final public let displayName: Swift.String?
   @objc override final public var description: Swift.String {
     @objc get
   }

--- a/api/revenuecat-api-visionos.swiftinterface
+++ b/api/revenuecat-api-visionos.swiftinterface
@@ -1826,11 +1826,13 @@ extension RevenueCat.IntroEligibility : Swift.Sendable {
 @_hasMissingDesignatedInitializers @objc(RCNonSubscriptionTransaction) final public class NonSubscriptionTransaction : ObjectiveC.NSObject {
   @objc final public let productIdentifier: Swift.String
   @objc final public let purchaseDate: Foundation.Date
+  @objc final public let originalPurchaseDate: Foundation.Date?
   @objc final public let transactionIdentifier: Swift.String
   @objc final public let storeTransactionIdentifier: Swift.String
   @objc final public let store: RevenueCat.Store
   @objc final public let price: RevenueCat.ProductPaidPrice?
   @objc final public let isSandbox: Swift.Bool
+  @objc final public let displayName: Swift.String?
   @objc override final public var description: Swift.String {
     @objc get
   }

--- a/api/revenuecat-api-watchos-simulator.swiftinterface
+++ b/api/revenuecat-api-watchos-simulator.swiftinterface
@@ -1794,11 +1794,13 @@ extension RevenueCat.IntroEligibility : Swift.Sendable {
 @_hasMissingDesignatedInitializers @objc(RCNonSubscriptionTransaction) final public class NonSubscriptionTransaction : ObjectiveC.NSObject {
   @objc final public let productIdentifier: Swift.String
   @objc final public let purchaseDate: Foundation.Date
+  @objc final public let originalPurchaseDate: Foundation.Date?
   @objc final public let transactionIdentifier: Swift.String
   @objc final public let storeTransactionIdentifier: Swift.String
   @objc final public let store: RevenueCat.Store
   @objc final public let price: RevenueCat.ProductPaidPrice?
   @objc final public let isSandbox: Swift.Bool
+  @objc final public let displayName: Swift.String?
   @objc override final public var description: Swift.String {
     @objc get
   }

--- a/api/revenuecat-api-watchos.swiftinterface
+++ b/api/revenuecat-api-watchos.swiftinterface
@@ -1794,11 +1794,13 @@ extension RevenueCat.IntroEligibility : Swift.Sendable {
 @_hasMissingDesignatedInitializers @objc(RCNonSubscriptionTransaction) final public class NonSubscriptionTransaction : ObjectiveC.NSObject {
   @objc final public let productIdentifier: Swift.String
   @objc final public let purchaseDate: Foundation.Date
+  @objc final public let originalPurchaseDate: Foundation.Date?
   @objc final public let transactionIdentifier: Swift.String
   @objc final public let storeTransactionIdentifier: Swift.String
   @objc final public let store: RevenueCat.Store
   @objc final public let price: RevenueCat.ProductPaidPrice?
   @objc final public let isSandbox: Swift.Bool
+  @objc final public let displayName: Swift.String?
   @objc override final public var description: Swift.String {
     @objc get
   }


### PR DESCRIPTION
### Motivation

`display_name` and `original_purchase_date` come in the customer info payload for one-time purchases but `NonSubscriptionTransaction` drops both so a consumable can't be described the way a subscription can. 

Android already exposes them. See https://github.com/RevenueCat/purchases-ios/pull/7461

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public API on a purchase model with optional fields only; no auth, persistence, or purchase-flow changes.
> 
> **Overview**
> Surfaces `displayName` and `originalPurchaseDate` on `NonSubscriptionTransaction` so one-time purchases can show the same dashboard name and original store date already present in the customer-info payload (and on subscriptions / Android).
> 
> Both properties are optional and stay `nil` when the backend omits them. Mapping is wired through the existing `CustomerInfoResponse.Transaction` fields, with Swift/ObjC API testers and unit tests covering present and missing values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 274ea8c62a106bdd5b47a773509b726af8b8ca10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->