### PR TITLE
Add rc.split custom operator

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		A1B2C3D4E5F60718293A4B5E /* CustomOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B5D /* CustomOperators.swift */; };
 		D4E5F60718293A4B5C03D02 /* CaseOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E5F60718293A4B5C03D01 /* CaseOperators.swift */; };
 		E5F60718293A4B5C03D0102 /* LengthOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F60718293A4B5C03D0101 /* LengthOperator.swift */; };
+		F60718293A4B5C03D02A2 /* SplitOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60718293A4B5C03D02A1 /* SplitOperator.swift */; };
 		B2C3D4E5F60718293A4B5C02 /* RootVarOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F60718293A4B5C01 /* RootVarOperator.swift */; };
 		0F4E490A741F00F18C4985D8 /* WebViewSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CC1CD0385BF18D1392EB43 /* WebViewSession.swift */; };
 		116EA498A344F7446083E8C5 /* EqualityOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41EEB3B4E7701F8CC8B811A9 /* EqualityOperators.swift */; };
@@ -3002,6 +3003,7 @@
 		A1B2C3D4E5F60718293A4B5D /* CustomOperators.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomOperators.swift; sourceTree = "<group>"; };
 		D4E5F60718293A4B5C03D01 /* CaseOperators.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CaseOperators.swift; sourceTree = "<group>"; };
 		E5F60718293A4B5C03D0101 /* LengthOperator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LengthOperator.swift; sourceTree = "<group>"; };
+		F60718293A4B5C03D02A1 /* SplitOperator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SplitOperator.swift; sourceTree = "<group>"; };
 		B2C3D4E5F60718293A4B5C01 /* RootVarOperator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RootVarOperator.swift; sourceTree = "<group>"; };
 		AC01FEB700000000000000B5 /* WebViewComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewComponentTests.swift; sourceTree = "<group>"; };
 		AC06C294F30E7D8000000002 /* SelectedPackageId.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedPackageId.swift; sourceTree = "<group>"; };
@@ -6547,6 +6549,7 @@
 				A1B2C3D4E5F60718293A4B5D /* CustomOperators.swift */,
 				D4E5F60718293A4B5C03D01 /* CaseOperators.swift */,
 				E5F60718293A4B5C03D0101 /* LengthOperator.swift */,
+				F60718293A4B5C03D02A1 /* SplitOperator.swift */,
 				B2C3D4E5F60718293A4B5C01 /* RootVarOperator.swift */,
 			);
 			name = CustomOperators;
@@ -7962,6 +7965,7 @@
 				A1B2C3D4E5F60718293A4B5E /* CustomOperators.swift in Sources */,
 				D4E5F60718293A4B5C03D02 /* CaseOperators.swift in Sources */,
 				E5F60718293A4B5C03D0102 /* LengthOperator.swift in Sources */,
+				F60718293A4B5C03D02A2 /* SplitOperator.swift in Sources */,
 				B2C3D4E5F60718293A4B5C02 /* RootVarOperator.swift in Sources */,
 				1701E7CE20E0879817B3F61B /* RulesEngineLogger.swift in Sources */,
 				A91C0A012FEA000000000001 /* RulesEngineLoggerBridge.swift in Sources */,

--- a/Sources/RulesEngine/CustomOperators/CustomOperators.swift
+++ b/Sources/RulesEngine/CustomOperators/CustomOperators.swift
@@ -31,6 +31,9 @@ extension RulesEngine {
             case "rc.rootVar":
                 return try RootVarOperator.opRootVar(args: args, vars: vars)
 
+            case "rc.split":
+                return try SplitOperator.opSplit(args: args, vars: vars)
+
             default:
                 throw EvaluationError.unsupportedOperator(name: operatorName)
             }

--- a/Sources/RulesEngine/CustomOperators/SplitOperator.swift
+++ b/Sources/RulesEngine/CustomOperators/SplitOperator.swift
@@ -1,0 +1,59 @@
+//
+//  SplitOperator.swift
+//
+//  Created by Antonio Pallares.
+//
+
+import Foundation
+
+extension RulesEngine {
+
+    /// `rc.split` — splits a string into an array of fields.
+    enum SplitOperator {
+
+        /// `{"rc.split": [input, separator]}` — every field, including empty
+        /// ones, as strings. Numeric-looking fields are not coerced, so
+        /// `"1,2"` splits into `["1", "2"]`.
+        ///
+        /// A `var` path cannot index the result of an expression, so a field is
+        /// read by wrapping the array in a one-element list and letting an
+        /// iteration operator rebind the scope to it:
+        ///
+        /// ```json
+        /// {"some": [[{"rc.split": [{"var": "locale"}, "-"]}],
+        ///           {"===": [{"var": "0"}, "es"]}]}
+        /// ```
+        ///
+        /// The array is also usable directly by `in` and by the iteration
+        /// operators, which is enough for most membership and any/all tests.
+        ///
+        /// Both operands must be strings and the separator must be non-empty,
+        /// otherwise `EvaluationError.typeMismatch`. An empty separator would
+        /// mean "split into characters", which the engine deliberately does not
+        /// offer; arity is exact for the same reason as `rc.semverCompare`.
+        static func opSplit(args: Value, vars: Scope) throws -> Value {
+            let evaluated = try Operators.evalArgs(args, vars: vars)
+
+            guard evaluated.count == 2 else {
+                throw EvaluationError.typeMismatch(
+                    message: "operator 'rc.split' expects 2 arguments, got \(evaluated.count)"
+                )
+            }
+
+            guard case .string(let input) = evaluated[0] else {
+                throw EvaluationError.typeMismatch(
+                    message: "operator 'rc.split' expected a string to split, got \(evaluated[0])"
+                )
+            }
+
+            guard case .string(let separator) = evaluated[1], !separator.isEmpty else {
+                throw EvaluationError.typeMismatch(
+                    message: "operator 'rc.split' expected a non-empty string separator, "
+                        + "got \(evaluated[1])"
+                )
+            }
+
+            return .array(input.components(separatedBy: separator).map(Value.string))
+        }
+    }
+}

--- a/Tests/UnitTests/RulesEngine/PredicateFixtureTests.swift
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtureTests.swift
@@ -32,7 +32,7 @@ struct PredicateFixtureTests {
     /// fixtures are added or removed.
     @Test
     func fixtureCountMatchesExpected() {
-        let expectedCount = 429
+        let expectedCount = 446
         #expect(
             Self.fixtures.count == expectedCount,
             "Expected \(expectedCount) fixtures, loaded \(Self.fixtures.count)"

--- a/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_split.json
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_split.json
@@ -1,0 +1,123 @@
+{
+  "fixtures": [
+    {
+      "id": "split_splits_on_single_character_separator",
+      "predicate": {"===": [{"rc.length": {"rc.split": ["a,b,c", ","]}}, 3]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "split_keeps_empty_field_between_separators",
+      "description": "Empty fields are preserved, so a field count matches the separator count plus one",
+      "predicate": {"===": [{"rc.length": {"rc.split": ["a,,b", ","]}}, 3]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "split_keeps_leading_and_trailing_empty_fields",
+      "predicate": {"===": [{"rc.length": {"rc.split": [",a,", ","]}}, 3]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "split_empty_input_yields_one_empty_field",
+      "description": "An empty input is one empty field, not zero fields",
+      "predicate": {"===": [{"rc.length": {"rc.split": ["", ","]}}, 1]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "split_multi_character_separator",
+      "predicate": {"===": [{"rc.length": {"rc.split": ["a::b::c", "::"]}}, 3]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "split_separator_not_found_returns_whole_input",
+      "predicate": {"some": [[{"rc.split": ["abc", ","]}], {"===": [{"var": "0"}, "abc"]}]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "split_positional_access_via_iteration",
+      "description": "Motivating case: a var path cannot index an expression, so the array is wrapped in a one-element list and an iteration operator rebinds the scope to it",
+      "predicate": {
+        "some": [
+          [{"rc.split": [{"var": "locale"}, "-"]}],
+          {"and": [{"===": [{"var": "0"}, "es"]}, {"===": [{"var": "1"}, "419"]}]}
+        ]
+      },
+      "variables": {"locale": "es-419"},
+      "expected": true
+    },
+    {
+      "id": "split_fields_iterate_directly",
+      "description": "The result is a real array, so iteration operators consume it without the wrapping idiom",
+      "predicate": {"some": [{"rc.split": ["1,2,30", ","]}, {"===": [{"var": ""}, "30"]}]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "split_fields_are_strings_not_numbers",
+      "description": "Fields are never coerced: strict equality against the number 1 does not match \"1\"",
+      "predicate": {"some": [{"rc.split": ["1,2", ","]}, {"===": [{"var": ""}, 1]}]},
+      "variables": {},
+      "expected": false
+    },
+    {
+      "id": "split_result_supports_in_operator",
+      "description": "Membership needs no indexing at all",
+      "predicate": {"in": ["pro", {"rc.split": ["free,pro,plus", ","]}]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "split_preserves_multi_scalar_characters",
+      "description": "Splitting works on characters, so a multi-scalar grapheme survives intact",
+      "predicate": {"some": [[{"rc.split": ["a,👍", ","]}], {"===": [{"var": "1"}, "👍"]}]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "split_non_string_input_is_type_error",
+      "predicate": {"rc.split": [1, ","]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.split"}
+    },
+    {
+      "id": "split_non_string_separator_is_type_error",
+      "description": "Both operands are validated, not just the first",
+      "predicate": {"rc.split": ["a,b", 1]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.split"}
+    },
+    {
+      "id": "split_empty_separator_is_type_error",
+      "description": "JS would split into characters here; the engine rejects it instead, as rc.entries does for strings",
+      "predicate": {"rc.split": ["abc", ""]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.split"}
+    },
+    {
+      "id": "split_missing_variable_is_type_error",
+      "description": "A missing variable would otherwise split into a single empty field and match loosely",
+      "predicate": {"rc.split": [{"var": "missing"}, ","]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.split"}
+    },
+    {
+      "id": "split_missing_operand_is_type_error",
+      "description": "No implicit separator: a one-sided call is a lowering bug",
+      "predicate": {"rc.split": ["a,b"]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.split"}
+    },
+    {
+      "id": "split_extra_operand_is_type_error",
+      "description": "Unlike the unary custom operators, which ignore extra arguments, arity is exact here",
+      "predicate": {"rc.split": ["a,b", ",", ","]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.split"}
+    }
+  ]
+}


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

Rules need to target parts of composite strings: locale subtags, product-id namespaces, version components.

### Description

`{"rc.split": [input, separator]}` returns every field, including empty ones, always as strings.

I had previously held this operator back believing its array result was unusable, since a `var` path cannot index the result of an expression. It can, by wrapping the array in a one-element list so an iteration operator rebinds the scope to it:

```json
{"some": [[{"rc.split": [{"var": "locale"}, "-"]}], {"===": [{"var": "0"}, "es"]}]}
```

`in` and the iteration operators consume the array directly, which covers most membership and any/all tests.

An empty separator throws `typeMismatch` instead of splitting into characters, matching the decision made for `rc.entries` on string input.

Fixture coverage was checked by mutation: dropping empty fields, coercing numeric fields, truncating a multi-character separator and loosening either operand are each caught.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new rules-engine operator that changes how targeting predicates can match string data. Behavior is additive and tightly validated, but incorrect split semantics would affect live rule evaluation.
> 
> **Overview**
> Adds the `rc.split` JSON Logic operator so rules can break composite strings (locale subtags, product IDs, versions) into string fields.
> 
> `{"rc.split": [input, separator]}` returns every field, including empties, with no numeric coercion. Both operands must be strings, the separator must be non-empty, and arity is exact; otherwise it throws `typeMismatch`. Results work with `in` and iteration operators; positional access uses the documented wrap-in-list idiom.
> 
> Covered by 17 new predicate fixtures (suite count 429 → 446).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fec0990c8fcea83e4d947ed12f835b5f2888895. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->