### PR TITLE
Fix workflows ignoring `zero_decimal_place_countries`

### DIFF
--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowScreenMapper.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowScreenMapper.swift
@@ -29,6 +29,7 @@ enum WorkflowScreenMapper {
             componentsLocalizations: screen.componentsLocalizations,
             revision: screen.revision,
             defaultLocaleIdentifier: screen.defaultLocale,
+            zeroDecimalPlaceCountries: screen.zeroDecimalPlaceCountries,
             exitOffers: screen.exitOffers,
             automaticallyScaleFontSize: screen.automaticallyScaleFontSize,
             stateDeclarations: screen.stateDeclarations

--- a/Sources/Networking/Responses/WorkflowsResponse.swift
+++ b/Sources/Networking/Responses/WorkflowsResponse.swift
@@ -149,6 +149,12 @@ import Foundation
     // swiftlint:disable:next identifier_name
     var _stateDeclarations: [String: PaywallComponent.StateDeclaration]?
     public var stateDeclarations: [String: PaywallComponent.StateDeclaration]? { _stateDeclarations }
+    /// Keyed by store in the payload (`{ "apple": [...] }`), like the offering paywall's own field.
+    @IgnoreDecodeErrors<PaywallData.ZeroDecimalPlaceCountries?>
+    // swiftlint:disable:next identifier_name
+    var _zeroDecimalPlaceCountries: PaywallData.ZeroDecimalPlaceCountries?
+    /// The storefront country codes that should display whole number prices without decimal places.
+    public var zeroDecimalPlaceCountries: [String] { _zeroDecimalPlaceCountries?.apple ?? [] }
 
     // `config` carries backend screen config the renderer doesn't read and is typed with the
     // internal `AnyDecodable`, so it's defaulted rather than exposed.
@@ -163,7 +169,8 @@ import Foundation
         offeringIdentifier: String?,
         exitOffers: ExitOffers? = nil,
         automaticallyScaleFontSize: Bool = true,
-        stateDeclarations: [String: PaywallComponent.StateDeclaration]? = nil
+        stateDeclarations: [String: PaywallComponent.StateDeclaration]? = nil,
+        zeroDecimalPlaceCountries: [String] = []
     ) {
         self.name = name
         self.templateName = templateName
@@ -177,6 +184,10 @@ import Foundation
         self.exitOffers = exitOffers
         self._automaticallyScaleFontSize = automaticallyScaleFontSize
         self._stateDeclarations = stateDeclarations
+        // Kept `nil` when empty so a screen built here matches one decoded without the key.
+        self._zeroDecimalPlaceCountries = zeroDecimalPlaceCountries.isEmpty
+            ? nil
+            : .init(apple: zeroDecimalPlaceCountries)
     }
 
 }
@@ -306,6 +317,8 @@ extension WorkflowScreen: Codable, Equatable, Sendable {
         case _automaticallyScaleFontSize = "automaticallyScaleFontSize"
         // swiftlint:disable:next identifier_name
         case _stateDeclarations = "stateDeclarations"
+        // swiftlint:disable:next identifier_name
+        case _zeroDecimalPlaceCountries = "zeroDecimalPlaceCountries"
     }
 
 }

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowScreenMapperTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowScreenMapperTests.swift
@@ -129,6 +129,28 @@ final class WorkflowScreenMapperTests: TestCase {
         expect(declaration.defaultValue) == .string("monthly")
     }
 
+    func testPassesThroughZeroDecimalPlaceCountries() throws {
+        let screen = try Self.makeScreen(
+            zeroDecimalPlaceCountriesJSON: """
+            { "apple": ["TWN", "MEX"], "google": ["TW", "MX"] }
+            """
+        )
+        let uiConfig = try Self.makeUIConfig()
+
+        let result = WorkflowScreenMapper.toPaywallComponents(screen: screen, uiConfig: uiConfig)
+
+        expect(result.data.zeroDecimalPlaceCountries) == ["TWN", "MEX"]
+    }
+
+    func testZeroDecimalPlaceCountriesIsEmptyWhenAbsent() throws {
+        let screen = try Self.makeScreen()
+        let uiConfig = try Self.makeUIConfig()
+
+        let result = WorkflowScreenMapper.toPaywallComponents(screen: screen, uiConfig: uiConfig)
+
+        expect(result.data.zeroDecimalPlaceCountries).to(beEmpty())
+    }
+
     func testStateDeclarationsAreNilWhenScreenDeclaresNone() throws {
         let screen = try Self.makeScreen()
         let uiConfig = try Self.makeUIConfig()
@@ -151,7 +173,8 @@ private extension WorkflowScreenMapperTests {
         defaultLocale: String = "en_US",
         automaticallyScaleFontSize: Bool? = nil,
         exitOfferOfferingId: String? = nil,
-        stateDeclarationsJSON: String? = nil
+        stateDeclarationsJSON: String? = nil,
+        zeroDecimalPlaceCountriesJSON: String? = nil
     ) throws -> RevenueCat.WorkflowScreen {
         var automaticallyScaleFontSizeFragment = ""
         if let automaticallyScaleFontSize {
@@ -163,6 +186,12 @@ private extension WorkflowScreenMapperTests {
         if let stateDeclarationsJSON {
             stateDeclarationsFragment = """
             , "state_declarations": \(stateDeclarationsJSON)
+            """
+        }
+        var zeroDecimalFragment = ""
+        if let zeroDecimalPlaceCountriesJSON {
+            zeroDecimalFragment = """
+            , "zero_decimal_place_countries": \(zeroDecimalPlaceCountriesJSON)
             """
         }
         var exitOffersJSON = ""
@@ -204,7 +233,7 @@ private extension WorkflowScreenMapperTests {
                         }
                     }
                 }
-            }\(automaticallyScaleFontSizeFragment)\(exitOffersJSON)\(stateDeclarationsFragment)
+            }\(automaticallyScaleFontSizeFragment)\(exitOffersJSON)\(stateDeclarationsFragment)\(zeroDecimalFragment)
         }
         """
         let data = try XCTUnwrap(json.data(using: .utf8))

--- a/Tests/RevenueCatUITests/Purchasing/WorkflowPreviewTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/WorkflowPreviewTests.swift
@@ -32,6 +32,18 @@ final class WorkflowPreviewTests: TestCase {
         expect(context.workflow.id) == "wf_test"
     }
 
+    func testInitialOfferingCarriesTheScreenZeroDecimalPlaceCountries() throws {
+        let baseOffering = Self.makeOffering(identifier: "offering_a")
+        let workflow = try Self.makeWorkflow(
+            screenOfferingIdentifier: "offering_a",
+            zeroDecimalPlaceCountries: ["TWN", "MEX"]
+        )
+
+        let context = try WorkflowPreview.makeContext(workflow: workflow, offerings: [baseOffering])
+
+        expect(context.initialOffering.internalPaywallComponents?.data.zeroDecimalPlaceCountries) == ["TWN", "MEX"]
+    }
+
     func testMakeContextPropagatesPresentedOfferingContext() throws {
         let baseOffering = Self.makeOffering(identifier: "offering_a")
         let workflow = try Self.makeWorkflow(screenOfferingIdentifier: "offering_a")
@@ -91,7 +103,10 @@ private extension WorkflowPreviewTests {
 
     /// Builds a single-screen workflow using the `@_spi(Internal)` initializers (C-1), sourcing the
     /// `componentsConfig` sub-object from JSON since hand-building it is impractical.
-    static func makeWorkflow(screenOfferingIdentifier: String) throws -> PublishedWorkflow {
+    static func makeWorkflow(
+        screenOfferingIdentifier: String,
+        zeroDecimalPlaceCountries: [String] = []
+    ) throws -> PublishedWorkflow {
         let screen = WorkflowScreen(
             name: nil,
             templateName: "tmpl",
@@ -99,7 +114,8 @@ private extension WorkflowPreviewTests {
             componentsConfig: try Self.makeComponentsConfig(),
             componentsLocalizations: [:],
             defaultLocale: "en_US",
-            offeringIdentifier: screenOfferingIdentifier
+            offeringIdentifier: screenOfferingIdentifier,
+            zeroDecimalPlaceCountries: zeroDecimalPlaceCountries
         )
         let step = WorkflowStep(id: "step_1", type: "screen", screenId: "screen_1")
 

--- a/Tests/UnitTests/Networking/Workflows/WorkflowResponseTests.swift
+++ b/Tests/UnitTests/Networking/Workflows/WorkflowResponseTests.swift
@@ -253,6 +253,44 @@ class WorkflowResponseTests: TestCase {
         expect(screen.automaticallyScaleFontSize) == false
     }
 
+    func testDecodeWorkflowScreenZeroDecimalPlaceCountries() throws {
+        let screen = try Self.decodeWorkflowScreen(
+            zeroDecimalPlaceCountriesJSON: """
+            { "apple": ["TWN", "MEX"], "google": ["TW", "MX"] }
+            """
+        )
+
+        expect(screen.zeroDecimalPlaceCountries) == ["TWN", "MEX"]
+    }
+
+    func testDecodeWorkflowScreenZeroDecimalPlaceCountriesDefaultsToEmpty() throws {
+        let screen = try Self.decodeWorkflowScreen()
+
+        expect(screen.zeroDecimalPlaceCountries).to(beEmpty())
+    }
+
+    func testDecodeWorkflowScreenZeroDecimalPlaceCountriesIgnoresMalformedValue() throws {
+        let screen = try Self.decodeWorkflowScreen(zeroDecimalPlaceCountriesJSON: "\"TWN\"")
+
+        expect(screen.zeroDecimalPlaceCountries).to(beEmpty())
+    }
+
+    func testWorkflowScreenInitializerAcceptsZeroDecimalPlaceCountries() throws {
+        let decodedScreen = try Self.decodeWorkflowScreen()
+        let screen = WorkflowScreen(
+            name: decodedScreen.name,
+            templateName: decodedScreen.templateName,
+            assetBaseURL: decodedScreen.assetBaseURL,
+            componentsConfig: decodedScreen.componentsConfig,
+            componentsLocalizations: decodedScreen.componentsLocalizations,
+            defaultLocale: decodedScreen.defaultLocale,
+            offeringIdentifier: decodedScreen.offeringIdentifier,
+            zeroDecimalPlaceCountries: ["TWN"]
+        )
+
+        expect(screen.zeroDecimalPlaceCountries) == ["TWN"]
+    }
+
     func testDecodeWorkflowScreenWithExitOffers() throws {
         let json = """
         {
@@ -463,11 +501,20 @@ class WorkflowResponseTests: TestCase {
 
 private extension WorkflowResponseTests {
 
-    static func decodeWorkflowScreen(automaticallyScaleFontSize: Bool? = nil) throws -> WorkflowScreen {
+    static func decodeWorkflowScreen(
+        automaticallyScaleFontSize: Bool? = nil,
+        zeroDecimalPlaceCountriesJSON: String? = nil
+    ) throws -> WorkflowScreen {
         var automaticallyScaleFontSizeFragment = ""
         if let automaticallyScaleFontSize {
             automaticallyScaleFontSizeFragment = """
             , "automatically_scale_font_size": \(automaticallyScaleFontSize)
+            """
+        }
+        var zeroDecimalFragment = ""
+        if let zeroDecimalPlaceCountriesJSON {
+            zeroDecimalFragment = """
+            , "zero_decimal_place_countries": \(zeroDecimalPlaceCountriesJSON)
             """
         }
         let json = """
@@ -487,7 +534,7 @@ private extension WorkflowResponseTests {
               },
               "background": { "type": "color", "value": { "light": { "type": "hex", "value": "#FFFFFF" } } }
             }
-          }\(automaticallyScaleFontSizeFragment)
+          }\(automaticallyScaleFontSizeFragment)\(zeroDecimalFragment)
         }
         """.data(using: .utf8)!
 


### PR DESCRIPTION
SDK side of https://github.com/RevenueCat/khepri/pull/24207. Workflow paywalls always got an empty `zeroDecimalPlaceCountries`, so they showed decimal prices in TWN/KAZ/MEX/PHL/THA/IND.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow decoding/mapping fix with tests; malformed payloads are ignored and only Apple storefront codes are used, matching existing paywall behavior.
> 
> **Overview**
> Workflow paywalls now honor `zero_decimal_place_countries` from the backend instead of always rendering decimal prices in storefronts like TWN/MEX.
> 
> `WorkflowScreen` decodes the nested `{ "apple": [...] }` payload (same shape as offering paywalls), ignores malformed values, and `WorkflowScreenMapper` copies the Apple country list onto `PaywallComponentsData`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c360d28a0c6f448460ea545d24196731bdd6756. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->