### PR TITLE
Fix(CI): Skip tests on unsupported os versions

### DIFF
--- a/Tests/RevenueCatUITests/Cache/WebBundlePrewarmerIntegrationTests.swift
+++ b/Tests/RevenueCatUITests/Cache/WebBundlePrewarmerIntegrationTests.swift
@@ -25,7 +25,8 @@ final class WebBundlePrewarmerIntegrationTests: TestCase {
 
     private static let completionLimit: TimeInterval = 10
 
-    func testProductionPrewarmerLoadsAboutBlank() async {
+    func testProductionPrewarmerLoadsAboutBlank() async throws {
+        try AvailabilityChecks.iOS17APIAvailableOrSkipTest()
         let prewarmer = WebBundlePrewarmer()
         let start = Date()
 
@@ -37,7 +38,8 @@ final class WebBundlePrewarmerIntegrationTests: TestCase {
         XCTAssertEqual(self.loadLogCount, 1, self.loadLogDescription)
     }
 
-    func testProductionPrewarmerLoadsABatchOfLocalPages() async {
+    func testProductionPrewarmerLoadsABatchOfLocalPages() async throws {
+        try AvailabilityChecks.iOS17APIAvailableOrSkipTest()
         let prewarmer = WebBundlePrewarmer(maxConcurrentLoads: 3)
         let start = Date()
 


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->
<!-- AI agents: fill in this template, and also follow the "Pull Requests" section in AGENTS.md. -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

Fix CI on main

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only availability skip; no production or security-sensitive code changes.
> 
> **Overview**
> Makes `WebBundlePrewarmer` integration tests skip on runtimes below iOS 17 / macOS 14 instead of failing CI.
> 
> Both tests now `throw` and call `AvailabilityChecks.iOS17APIAvailableOrSkipTest()`, matching the existing pattern used with `@available` APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c23048ba55384bf95c1be47dfc0040487c7b6e5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->