### PR TITLE
Bump sdks-common-config to 4.6.1 to cache the mise toolchain

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1,6 +1,6 @@
 orbs:
   macos: circleci/macos@2.5.1
-  revenuecat: revenuecat/sdks-common-config@4.5.1
+  revenuecat: revenuecat/sdks-common-config@4.6.0
   # Disabled until compatible with M1: codecov: codecov/codecov@3.3.0
   # codecov: codecov/codecov@3.3.0
 

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1,8 +1,6 @@
 orbs:
   macos: circleci/macos@2.5.1
-  # TEMP: dev orb from https://github.com/RevenueCat/sdks-circleci-orb/pull/88
-  # Revert to a released version before merging.
-  revenuecat: revenuecat/sdks-common-config@dev:dcbe778a5b52fbfcaa4f23ceca86c52fc263c88b
+  revenuecat: revenuecat/sdks-common-config@4.6.1
   # Disabled until compatible with M1: codecov: codecov/codecov@3.3.0
   # codecov: codecov/codecov@3.3.0
 

--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1,6 +1,8 @@
 orbs:
   macos: circleci/macos@2.5.1
-  revenuecat: revenuecat/sdks-common-config@4.6.0
+  # TEMP: dev orb from https://github.com/RevenueCat/sdks-circleci-orb/pull/88
+  # Revert to a released version before merging.
+  revenuecat: revenuecat/sdks-common-config@dev:dcbe778a5b52fbfcaa4f23ceca86c52fc263c88b
   # Disabled until compatible with M1: codecov: codecov/codecov@3.3.0
   # codecov: codecov/codecov@3.3.0
 


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

Every job spends ~100s in `Install mise tools`, across 13 call sites. Orb 4.6.0 caches `~/.local/share/mise` (RevenueCat/sdks-circleci-orb#86); we pin 4.5.1, which predates it, so nothing was ever cached.

### Description

- 4.6.0 alone is not enough: its cache key omits the OS version, and this fleet spans macOS 13.2, 15.3 and 26.3, so a toolchain restored across versions aborted in `bundle install`. 4.6.1 (RevenueCat/sdks-circleci-orb#88) keys on it.
- Those ~100s are a source build, not a download: no `jdx/ruby` prebuilt exists for Ruby 3.2.0, and that pin is deliberate, so cold caches still pay it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only orb pin; no product or security logic. Cache-key behavior could affect job install times if the orb cache is wrong, but 4.6.1 is meant to avoid cross-OS restores.
> 
> **Overview**
> Pins the CircleCI `revenuecat/sdks-common-config` orb from `4.5.1` to `4.6.1` so `install-mise-tools` can cache `~/.local/share/mise` with an OS-version-aware cache key.
> 
> That should cut the repeated ~100s mise install on jobs that already share a toolchain, without restoring a cache built on a different macOS version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b398c0d1e31fb659d95dc8ffd9604cb66b31c61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->