### PR TITLE
Fix Test run for watch and tvos

### DIFF
--- a/Tests/UnitTests/Paywalls/WebBundleURLBatcherTests.swift
+++ b/Tests/UnitTests/Paywalls/WebBundleURLBatcherTests.swift
@@ -775,6 +775,9 @@ private extension WebBundleURLBatcherTests {
         initialStepId: String,
         singleStepFallbackId: String? = nil
     ) throws -> PublishedWorkflow {
+        #if os(watchOS) || os(tvOS) || !canImport(WebKit)
+        throw XCTSkip("Web view components are not supported on this platform")
+        #else
         let fallback = singleStepFallbackId.map { ", \"single_step_fallback_id\": \"\($0)\"" } ?? ""
         let json = """
         {
@@ -787,6 +790,7 @@ private extension WebBundleURLBatcherTests {
         """
         let data = try XCTUnwrap(json.data(using: .utf8))
         return try JSONDecoder.default.decode(PublishedWorkflow.self, from: data)
+        #endif
     }
 
     static func screenJSON(name: String, url: String) -> String {


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->
<!-- AI agents: fill in this template, and also follow the "Pull Requests" section in AGENTS.md. -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only compile/runtime skip; no production code or behavior changes.
> 
> **Overview**
> Skips `PublishedWorkflow` JSON decoding in `WebBundleURLBatcherTests` on watchOS, tvOS, and other platforms without WebKit.
> 
> `workflowFromJSON` now throws `XCTSkip` on those platforms so web-view-backed unit tests do not fail when the component type is unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fd728106b61d39a876e69c87b24b2fdf48f97af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->