### PR TITLE
Fix: Flaky web view cache test

### DIFF
--- a/Tests/RevenueCatUITests/Cache/WebBundleCacheCoordinatorTests.swift
+++ b/Tests/RevenueCatUITests/Cache/WebBundleCacheCoordinatorTests.swift
@@ -187,10 +187,8 @@ final class WebBundleCacheCoordinatorTests: TestCase {
 
         await self.fulfillment(of: [loaded], timeout: 1)
         let invocations = await recorder.invocations
-        XCTAssertEqual(
-            invocations,
-            urls.map { .init(url: $0.url, storeID: identifier) }
-        )
+        XCTAssertEqual(Set(invocations.map(\.url)), Set(urls.map(\.url)))
+        XCTAssertEqual(invocations.map(\.storeID), Array(repeating: identifier, count: urls.count))
         withExtendedLifetime(coordinator) {}
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->
<!-- AI agents: fill in this template, and also follow the "Pull Requests" section in AGENTS.md. -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

Integration between warmer and coordinator failed due to ordering on asynchronous work

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

used a set to ensure that order doesn't matter in the test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only assertion change; no production or security impact.
> 
> **Overview**
> Fixes a flaky `WebBundleCacheCoordinator` test by no longer asserting prewarm invocations in a fixed order.
> 
> `testReceivedAssetURLsPrewarmsUsingTheCurrentIdentifier` now compares URLs as a set and only checks that every invocation used the current store identifier, matching async prewarm completion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 714a3b1b691a184aae7e48752450499f9435fcdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->