### PR TITLE
fix: prevent Template 4 offer-name text from wrapping on visionOS

### DIFF
--- a/RevenueCatUI/Templates/Template4View.swift
+++ b/RevenueCatUI/Templates/Template4View.swift
@@ -373,11 +373,15 @@ private struct PackageButton: View {
                 Text(firstRow)
                     .frame(maxWidth: .infinity)
                     .font(self.font(for: .title).bold())
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.6)
             }
 
             Text(secondRow)
                 .frame(maxWidth: .infinity)
                 .font(self.font(for: .title3).weight(.regular))
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
         }
     }
 


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

Resolves #3696. On visionOS, Template 4's package button wraps a single-word offer/duration name (e.g. "Monthly") onto two lines instead of shrinking to fit, because the offer-name text lacked the scale-to-fit constraints already used elsewhere in the same view.

### Description

Adds `.lineLimit(1)` + `.minimumScaleFactor(0.6)` to the offer-name `Text` views in `offerText(firstRow:secondRow:)`, mirroring the identical pattern already applied to the price text (`0.7`) and badge text (`0.5`) in the same file.

**Testing:** I didn't have a macOS/Xcode environment available to run the existing `Template4ViewTests` snapshot suite or generate new snapshot references, so no test was added and this change has not been visually verified locally — leaving the unit-tests checkbox unchecked above. The diff is a minimal, mechanical application of an already-proven in-file pattern (same modifiers, applied twice already to sibling `Text` views in this file), but a maintainer visual check on a visionOS simulator before merge is recommended. Not requesting the `pr:fix` / `pr:RevenueCatUI` labels be applied automatically since I don't have write access to this repo — happy to have a maintainer add them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small SwiftUI layout tweak on paywall package labels; no logic, data, or security changes. Snapshot/visual verification on visionOS is still recommended.
> 
> **Overview**
> Stops Template 4 package offer names from wrapping on visionOS by shrinking to fit instead of breaking a single word (e.g. “Monthly”) onto two lines.
> 
> Applies `.lineLimit(1)` and `.minimumScaleFactor(0.6)` to both rows in `offerText(firstRow:secondRow:)`, matching the existing scale-to-fit pattern on price and badge text in the same view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b15afc24b69526df10b6794079f4e5cf4d9a8df1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->