### PR TITLE
Add unwrapped rc.length fixture case

### DIFF
--- a/Tests/UnitTests/RulesEngine/PredicateFixtureTests.swift
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtureTests.swift
@@ -32,7 +32,7 @@ struct PredicateFixtureTests {
     /// fixtures are added or removed.
     @Test
     func fixtureCountMatchesExpected() {
-        let expectedCount = 429
+        let expectedCount = 430
         #expect(
             Self.fixtures.count == expectedCount,
             "Expected \(expectedCount) fixtures, loaded \(Self.fixtures.count)"

--- a/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_length.json
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_length.json
@@ -57,6 +57,18 @@
       "expected": true
     },
     {
+      "id": "length_unwrapped_empty_array_is_type_error",
+      "description": "An unwrapped empty array is an empty argument list, not a literal array operand",
+      "predicate": {
+        "rc.length": []
+      },
+      "variables": {},
+      "expected": {
+        "error": "typeMismatch",
+        "operator": "rc.length"
+      }
+    },
+    {
       "id": "length_array_counts_top_level_elements",
       "predicate": {
         "===": [


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for purchases-android and hybrids

### Motivation
Keep the iOS and Android rc_length.json predicate fixtures bytewise identical after RevenueCat/purchases-android#4050 added coverage for the unwrapped empty-array form.

### Description
Verified the fixture files are bytewise identical with SHA-256 327b27a7ed02f0da4b8163cadd3e2a0f7212f4547c6e47498537713275055189.

Testing: focused UnitTests/PredicateFixtureTests through the Tuist workspace, plus SwiftLint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture addition; no production logic changes.
> 
> **Overview**
> Adds a predicate fixture so `{"rc.length": []}` is treated as an empty argument list (type mismatch), not a literal empty array. Aligns iOS `rc_length.json` with the Android suite.
> 
> Bumps the pinned fixture count in `PredicateFixtureTests` from 446 to 447.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 748de754cb81466e1409c9ab20642791931549cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->