### PR TITLE
Remove already-subscribed logic from paywalls

### DIFF
--- a/RevenueCatUI/Data/PaywallViewConfiguration.swift
+++ b/RevenueCatUI/Data/PaywallViewConfiguration.swift
@@ -14,7 +14,6 @@ import Foundation
 struct PaywallViewConfiguration {
 
     var content: Content
-    var customerInfo: CustomerInfo?
     var mode: PaywallViewMode
     var fonts: PaywallFontProvider
 
@@ -34,7 +33,6 @@ struct PaywallViewConfiguration {
 
     init(
         content: Content,
-        customerInfo: CustomerInfo? = nil,
         mode: PaywallViewMode = .default,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         displayCloseButton: Bool = false,
@@ -43,7 +41,6 @@ struct PaywallViewConfiguration {
         promoOfferCache: PaywallPromoOfferCache? = nil
     ) {
         self.content = content
-        self.customerInfo = customerInfo
         self.mode = mode
         self.fonts = fonts
         self.displayCloseButton = displayCloseButton
@@ -77,7 +74,6 @@ extension PaywallViewConfiguration {
 
     init(
         offering: Offering? = nil,
-        customerInfo: CustomerInfo? = nil,
         mode: PaywallViewMode = .default,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         displayCloseButton: Bool = false,
@@ -89,7 +85,6 @@ extension PaywallViewConfiguration {
 
         self.init(
             content: .optionalOffering(offering),
-            customerInfo: customerInfo,
             mode: mode,
             fonts: fonts,
             displayCloseButton: displayCloseButton,

--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -22,7 +22,6 @@ enum Strings {
     case found_multiple_packages_of_same_identifier(String)
     case unrecognized_variable_name(variableName: String)
 
-    case product_already_subscribed
     case purchase_failed(Error)
 
     case determining_whether_to_display_paywall
@@ -155,9 +154,6 @@ extension Strings: CustomStringConvertible {
         case let .unrecognized_variable_name(variableName):
             return "Found an unrecognized variable '\(variableName)'. It will be replaced with an empty string.\n" +
             "See the docs for more information: https://www.revenuecat.com/docs/paywalls#variables"
-
-        case .product_already_subscribed:
-            return "User is already subscribed to this product. Ignoring."
 
         case .determining_whether_to_display_paywall:
             return "Determining whether to display paywall"

--- a/RevenueCatUI/Data/TemplateViewConfiguration.swift
+++ b/RevenueCatUI/Data/TemplateViewConfiguration.swift
@@ -50,7 +50,6 @@ extension TemplateViewConfiguration {
 
         let content: RevenueCat.Package
         let localization: ProcessedLocalizedConfiguration
-        let currentlySubscribed: Bool
         let discountRelativeToMostExpensivePerMonth: Double?
 
     }
@@ -156,7 +155,6 @@ extension TemplateViewConfiguration.PackageConfiguration {
     // swiftlint:disable:next function_parameter_count
     static func create(
         with packages: [RevenueCat.Package],
-        activelySubscribedProductIdentifiers: Set<String>,
         filter: [String],
         default: String?,
         localization: PaywallData.LocalizedConfiguration?,
@@ -189,7 +187,6 @@ extension TemplateViewConfiguration.PackageConfiguration {
 
         return try Self.create(
             with: packages,
-            activelySubscribedProductIdentifiers: activelySubscribedProductIdentifiers,
             parameters: parameters,
             locale: locale,
             showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
@@ -201,7 +198,6 @@ extension TemplateViewConfiguration.PackageConfiguration {
     // swiftlint:disable:next function_body_length
     private static func create(
         with packages: [RevenueCat.Package],
-        activelySubscribedProductIdentifiers: Set<String>,
         parameters: Parameters,
         locale: Locale,
         showZeroDecimalPlacePrices: Bool
@@ -211,7 +207,6 @@ extension TemplateViewConfiguration.PackageConfiguration {
             let filteredPackages = Self.processPackages(
                 from: packages,
                 filter: filter,
-                activelySubscribedProductIdentifiers: activelySubscribedProductIdentifiers,
                 localization: localization,
                 locale: locale,
                 showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
@@ -247,7 +242,6 @@ extension TemplateViewConfiguration.PackageConfiguration {
                 let filteredPackages = Self.processPackages(
                     from: packages,
                     filter: tier.packages,
-                    activelySubscribedProductIdentifiers: activelySubscribedProductIdentifiers,
                     localization: localization,
                     locale: locale,
                     showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
@@ -291,11 +285,9 @@ extension TemplateViewConfiguration.PackageConfiguration {
         }
     }
 
-    // swiftlint:disable:next function_parameter_count
     private static func processPackages(
         from packages: [RevenueCat.Package],
         filter: [String],
-        activelySubscribedProductIdentifiers: Set<String>,
         localization: PaywallData.LocalizedConfiguration,
         locale: Locale,
         showZeroDecimalPlacePrices: Bool
@@ -317,9 +309,6 @@ extension TemplateViewConfiguration.PackageConfiguration {
                         context: .init(discountRelativeToMostExpensivePerMonth: discount,
                                        showZeroDecimalPlacePrices: showZeroDecimalPlacePrices),
                         locale: locale
-                    ),
-                    currentlySubscribed: activelySubscribedProductIdentifiers.contains(
-                        package.storeProduct.productIdentifier
                     ),
                     discountRelativeToMostExpensivePerMonth: discount
                 )

--- a/RevenueCatUI/Helpers/PreviewHelpers.swift
+++ b/RevenueCatUI/Helpers/PreviewHelpers.swift
@@ -61,7 +61,6 @@ struct PreviewableTemplate<T: TemplateViewType>: View {
 
     init(
         offering: Offering,
-        activelySubscribedProductIdentifiers: Set<String> = [],
         mode: PaywallViewMode = .default,
         presentInSheet: Bool = false,
         creator: @escaping Creator
@@ -71,7 +70,6 @@ struct PreviewableTemplate<T: TemplateViewType>: View {
 
         self.configuration = paywall.configuration(
             for: offering,
-            activelySubscribedProductIdentifiers: activelySubscribedProductIdentifiers,
             template: template,
             mode: mode,
             fonts: DefaultPaywallFontProvider(),

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -50,8 +50,6 @@ public struct PaywallView: View {
     private var workflowContext: WorkflowContext?
 
     @State
-    private var customerInfo: CustomerInfo?
-    @State
     private var error: NSError?
 
     private var promoOfferCache: PaywallPromoOfferCache?
@@ -138,10 +136,6 @@ public struct PaywallView: View {
     // swiftlint:disable:next missing_docs
     @_spi(Internal) public init(
         offering: Offering,
-        // Supplying this skips the `Purchases.shared.customerInfo()` fetch, whose failure would
-        // otherwise render the default paywall. Lets a host render a paywall with no configured
-        // project, which is how the fixture app in `Projects/PaywallFixtures` works.
-        customerInfo: CustomerInfo? = nil,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         displayCloseButton: Bool = false,
         introEligibility: TrialOrIntroEligibilityChecker? = nil,
@@ -154,7 +148,6 @@ public struct PaywallView: View {
         self.init(
             configuration: .init(
                 offering: offering,
-                customerInfo: customerInfo,
                 fonts: fonts,
                 displayCloseButton: displayCloseButton,
                 introEligibility: introEligibility,
@@ -212,9 +205,6 @@ public struct PaywallView: View {
         self._workflowContext = .init(initialValue: initialPaywallViewData?.workflowContext)
         self._offering = .init(
             initialValue: initialPaywallViewData?.offering
-        )
-        self._customerInfo = .init(
-            initialValue: configuration.customerInfo ?? Self.loadCachedCustomerInfoIfPossible()
         )
 
         self.contentToDisplay = configuration.content
@@ -277,10 +267,9 @@ public struct PaywallView: View {
             if let error = self.initializationError {
                 DebugErrorView(error.localizedDescription, releaseBehavior: .fatalError)
             } else if self.introEligibility.isConfigured, self.purchaseHandler.isConfigured {
-                if let offering = self.offering, let customerInfo = self.customerInfo {
+                if let offering = self.offering {
                     self.paywallView(for: offering,
                                      workflowContext: self.workflowContext,
-                                     activelySubscribedProductIdentifiers: customerInfo.activeSubscriptions,
                                      fonts: self.fonts,
                                      checker: self.introEligibility,
                                      purchaseHandler: self.purchaseHandler)
@@ -302,15 +291,9 @@ public struct PaywallView: View {
                                     throw PaywallError.purchasesNotConfigured
                                 }
 
-                                if self.offering == nil {
-                                    let paywallData = try await self.loadPaywallData()
-                                    self.offering = paywallData.offering
-                                    self.workflowContext = paywallData.workflowContext
-                                }
-
-                                if self.customerInfo == nil {
-                                    self.customerInfo = try await Purchases.shared.customerInfo()
-                                }
+                                let paywallData = try await self.loadPaywallData()
+                                self.offering = paywallData.offering
+                                self.workflowContext = paywallData.workflowContext
                             } catch let error as NSError {
                                 self.error = error
                             }
@@ -339,11 +322,10 @@ public struct PaywallView: View {
 //    }
 
     @ViewBuilder
-    // swiftlint:disable:next function_body_length function_parameter_count
+    // swiftlint:disable:next function_body_length
     private func paywallView(
         for offering: Offering,
         workflowContext: WorkflowContext?,
-        activelySubscribedProductIdentifiers: Set<String>,
         fonts: PaywallFontProvider,
         checker: TrialOrIntroEligibilityChecker,
         purchaseHandler: PurchaseHandler
@@ -368,7 +350,6 @@ public struct PaywallView: View {
             case .footer, .condensedFooter:
                 LoadedOfferingPaywallView(
                     offering: offering,
-                    activelySubscribedProductIdentifiers: activelySubscribedProductIdentifiers,
                     paywall: paywall,
                     template: PaywallData.defaultTemplate,
                     mode: self.mode,
@@ -418,7 +399,6 @@ public struct PaywallView: View {
 
             LoadedOfferingPaywallView(
                 offering: offering,
-                activelySubscribedProductIdentifiers: activelySubscribedProductIdentifiers,
                 paywall: paywall,
                 template: template,
                 mode: self.mode,
@@ -442,14 +422,6 @@ public struct PaywallView: View {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(tvOS, unavailable)
 private extension PaywallView {
-
-    static func loadCachedCustomerInfoIfPossible() -> CustomerInfo? {
-        if Purchases.isConfigured {
-            return Purchases.shared.cachedCustomerInfo
-        } else {
-            return nil
-        }
-    }
 
     func loadPaywallData() async throws -> PurchaseHandler.ResolvedPaywallViewData {
         return try await self.purchaseHandler.resolvePaywallViewData(for: self.contentToDisplay)
@@ -478,7 +450,6 @@ private extension PaywallView {
 struct LoadedOfferingPaywallView: View {
 
     private let offering: Offering
-    private let activelySubscribedProductIdentifiers: Set<String>
     private let paywall: PaywallData
     private let template: PaywallTemplate
     private let mode: PaywallViewMode
@@ -511,7 +482,6 @@ struct LoadedOfferingPaywallView: View {
 
     init(
         offering: Offering,
-        activelySubscribedProductIdentifiers: Set<String>,
         paywall: PaywallData,
         template: PaywallTemplate,
         mode: PaywallViewMode,
@@ -524,7 +494,6 @@ struct LoadedOfferingPaywallView: View {
         error: Offering.PaywallValidationError? = nil
     ) {
         self.offering = offering
-        self.activelySubscribedProductIdentifiers = activelySubscribedProductIdentifiers
         self.paywall = paywall
         self.template = template
         self.mode = mode
@@ -590,7 +559,6 @@ struct LoadedOfferingPaywallView: View {
     private var content: some View {
         let configuration = self.paywall.configuration(
             for: self.offering,
-            activelySubscribedProductIdentifiers: self.activelySubscribedProductIdentifiers,
             template: self.template,
             mode: self.mode,
             fonts: self.fonts,
@@ -768,7 +736,6 @@ struct PaywallView_Previews: PreviewProvider {
                 PaywallView(
                     configuration: .init(
                         offering: offering,
-                        customerInfo: TestData.customerInfo,
                         mode: mode,
                         introEligibility: PreviewHelpers.introEligibilityChecker,
                         purchaseHandler: PreviewHelpers.purchaseHandler
@@ -822,7 +789,6 @@ struct PaywallLocalizationPreviews: PreviewProvider {
         PaywallView(
             configuration: .init(
                 offering: offering,
-                customerInfo: TestData.customerInfo,
                 mode: .fullScreen,
                 introEligibility: PreviewHelpers.introEligibilityChecker,
                 purchaseHandler: .mock(preferredLocaleOverride: locale)

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -93,7 +93,6 @@ extension PaywallData {
     // swiftlint:disable:next function_parameter_count
     func configuration(
         for offering: Offering,
-        activelySubscribedProductIdentifiers: Set<String>,
         template: PaywallTemplate,
         mode: PaywallViewMode,
         fonts: PaywallFontProvider,
@@ -104,7 +103,6 @@ extension PaywallData {
             TemplateViewConfiguration(
                 mode: mode,
                 packages: try .create(with: offering.availablePackages,
-                                      activelySubscribedProductIdentifiers: activelySubscribedProductIdentifiers,
                                       filter: self.config.packages,
                                       default: self.config.defaultPackage,
                                       localization: self.localizedConfiguration,

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -587,8 +587,8 @@ private struct PresentingPaywallModifier: ViewModifier {
             switch presentationMode {
             case .sheet:
                 content
-                    .sheet(item: self.$data, onDismiss: self.handleMainPaywallDismiss) { data in
-                        self.paywallView(data)
+                    .sheet(item: self.$data, onDismiss: self.handleMainPaywallDismiss) { _ in
+                        self.paywallView()
                         // The default height given to sheets on Mac Catalyst is too small, and looks terrible.
                         // So we need to give it a more reasonable default size. This is the height of an
                         // iPhone 6/7/8 screen. This aligns with our documentation that we will show a paywall
@@ -602,8 +602,8 @@ private struct PresentingPaywallModifier: ViewModifier {
             #if !os(macOS)
             case .fullScreen:
                 content
-                    .fullScreenCover(item: self.$data, onDismiss: self.handleMainPaywallDismiss) { data in
-                        self.paywallView(data)
+                    .fullScreenCover(item: self.$data, onDismiss: self.handleMainPaywallDismiss) { _ in
+                        self.paywallView()
                     }
             #endif
             }
@@ -653,11 +653,10 @@ private struct PresentingPaywallModifier: ViewModifier {
         }
     }
 
-    private func paywallView(_ data: Data) -> some View {
+    private func paywallView() -> some View {
         PaywallView(
             configuration: .init(
                 content: self.content,
-                customerInfo: data.customerInfo,
                 fonts: self.fontProvider,
                 displayCloseButton: true,
                 introEligibility: self.introEligibility,

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -490,11 +490,6 @@ private struct PresentingPaywallModifier: ViewModifier {
     @Environment(\.scenePhase) var scenePhase
     @Environment(\.customPaywallVariables) private var customPaywallVariables
 
-    private struct Data: Identifiable {
-        var customerInfo: CustomerInfo
-        var id: String { self.customerInfo.originalAppUserId }
-    }
-
     var shouldDisplay: @Sendable (CustomerInfo) -> Bool
     var presentationMode: PaywallPresentationMode
     var purchaseStarted: PurchaseOfPackageStartedHandler?
@@ -571,7 +566,7 @@ private struct PresentingPaywallModifier: ViewModifier {
     private var promoOfferCacheOwner: PromoOfferCacheOwner
 
     @State
-    private var data: Data?
+    private var isPresented = false
 
     /// Owns the exit-offer lifecycle (sourcing + presentation state + transitions).
     @StateObject
@@ -587,7 +582,7 @@ private struct PresentingPaywallModifier: ViewModifier {
             switch presentationMode {
             case .sheet:
                 content
-                    .sheet(item: self.$data, onDismiss: self.handleMainPaywallDismiss) { _ in
+                    .sheet(isPresented: self.$isPresented, onDismiss: self.handleMainPaywallDismiss) {
                         self.paywallView()
                         // The default height given to sheets on Mac Catalyst is too small, and looks terrible.
                         // So we need to give it a more reasonable default size. This is the height of an
@@ -602,7 +597,8 @@ private struct PresentingPaywallModifier: ViewModifier {
             #if !os(macOS)
             case .fullScreen:
                 content
-                    .fullScreenCover(item: self.$data, onDismiss: self.handleMainPaywallDismiss) { _ in
+                    .fullScreenCover(isPresented: self.$isPresented,
+                                     onDismiss: self.handleMainPaywallDismiss) {
                         self.paywallView()
                     }
             #endif
@@ -646,10 +642,10 @@ private struct PresentingPaywallModifier: ViewModifier {
         if self.shouldDisplay(info) {
             Logger.debug(Strings.displaying_paywall)
 
-            self.data = .init(customerInfo: info)
+            self.isPresented = true
         } else {
             Logger.debug(Strings.not_displaying_paywall)
-            self.data = nil
+            self.isPresented = false
         }
     }
 
@@ -706,7 +702,7 @@ private struct PresentingPaywallModifier: ViewModifier {
     private func close() {
         Logger.debug(Strings.dismissing_paywall)
 
-        self.data = nil
+        self.isPresented = false
     }
 
     private func resetWorkflowCompletedInSession() {

--- a/RevenueCatUI/View+PresentPaywallFooter.swift
+++ b/RevenueCatUI/View+PresentPaywallFooter.swift
@@ -143,7 +143,6 @@ extension View {
                                                       performRestore: myAppPurchaseLogic?.performRestore)
         return self.originalTemplatePaywallFooter(
             offering: nil,
-            customerInfo: nil,
             condensed: condensed,
             fonts: fonts,
             introEligibility: nil,
@@ -190,7 +189,6 @@ extension View {
         let purchaseHandler = PurchaseHandler.default()
         return self.originalTemplatePaywallFooter(
             offering: offering,
-            customerInfo: nil,
             condensed: condensed,
             fonts: fonts,
             introEligibility: nil,
@@ -283,7 +281,6 @@ extension View {
                                                       performRestore: myAppPurchaseLogic?.performRestore)
         return self.originalTemplatePaywallFooter(
             offering: offering,
-            customerInfo: nil,
             condensed: condensed,
             fonts: fonts,
             introEligibility: nil,
@@ -301,7 +298,6 @@ extension View {
     @available(macOS, unavailable, message: "Legacy paywalls are unavailable in macOS")
     func originalTemplatePaywallFooter(
         offering: Offering?,
-        customerInfo: CustomerInfo?,
         condensed: Bool = false,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         introEligibility: TrialOrIntroEligibilityChecker? = nil,
@@ -319,7 +315,6 @@ extension View {
                 PresentingPaywallFooterModifier(
                     configuration: .init(
                         content: .optionalOffering(offering),
-                        customerInfo: customerInfo,
                         mode: condensed ? .condensedFooter : .footer,
                         fonts: fonts,
                         displayCloseButton: false,

--- a/RevenueCatUI/Views/LoadingPaywallView.swift
+++ b/RevenueCatUI/Views/LoadingPaywallView.swift
@@ -38,7 +38,6 @@ struct LoadingPaywallView: View {
                 availablePackages: Self.packages,
                 webCheckoutUrl: nil
             ),
-            activelySubscribedProductIdentifiers: [],
             paywall: Self.defaultPaywall,
             template: Self.template,
             mode: self.mode,

--- a/RevenueCatUI/Views/PurchaseButton.swift
+++ b/RevenueCatUI/Views/PurchaseButton.swift
@@ -86,10 +86,6 @@ struct PurchaseButton: View {
             guard !self.purchaseHandler.actionInProgress else {
                 return
             }
-            guard !self.selectedPackage.currentlySubscribed else {
-                Logger.warning(Strings.product_already_subscribed)
-                return
-            }
 
             let selectedContent = self.selectedPackage.content
             self.componentInteractionLogger(.paywallPurchaseButtonAction(
@@ -251,7 +247,6 @@ struct PurchaseButton_Previews: PreviewProvider {
                 context: .init(discountRelativeToMostExpensivePerMonth: nil),
                 locale: .current
             ),
-            currentlySubscribed: false,
             discountRelativeToMostExpensivePerMonth: nil
         )
         private static let packages: TemplateViewConfiguration.PackageConfiguration = .single(Self.package)

--- a/Tests/RevenueCatUITests/BaseSnapshotTest.swift
+++ b/Tests/RevenueCatUITests/BaseSnapshotTest.swift
@@ -74,7 +74,6 @@ class BaseSnapshotTest: TestCase {
         return PaywallView(
             configuration: .init(
                 offering: offering,
-                customerInfo: TestData.customerInfo,
                 mode: mode,
                 fonts: fonts,
                 introEligibility: introEligibility,

--- a/Tests/RevenueCatUITests/Data/TemplateViewConfigurationTests.swift
+++ b/Tests/RevenueCatUITests/Data/TemplateViewConfigurationTests.swift
@@ -28,7 +28,6 @@ class TemplateViewConfigurationCreationTests: BaseTemplateViewConfigurationTests
         expect {
             try Config.create(
                 with: [],
-                activelySubscribedProductIdentifiers: [],
                 filter: [PackageType.monthly.identifier],
                 default: nil,
                 localization: TestData.paywallWithIntroOffer.localizedConfiguration,
@@ -43,7 +42,6 @@ class TemplateViewConfigurationCreationTests: BaseTemplateViewConfigurationTests
         expect {
             try Config.create(
                 with: [TestData.monthlyPackage],
-                activelySubscribedProductIdentifiers: [],
                 filter: [],
                 default: nil,
                 localization: TestData.paywallWithIntroOffer.localizedConfiguration,
@@ -58,7 +56,6 @@ class TemplateViewConfigurationCreationTests: BaseTemplateViewConfigurationTests
         expect {
             try Config.create(
                 with: [TestData.monthlyPackage],
-                activelySubscribedProductIdentifiers: [],
                 filter: [PackageType.monthly.identifier],
                 default: nil,
                 localization: nil,
@@ -72,7 +69,6 @@ class TemplateViewConfigurationCreationTests: BaseTemplateViewConfigurationTests
     func testCreateSinglePackage() throws {
         let result = try Config.create(
             with: [TestData.monthlyPackage],
-            activelySubscribedProductIdentifiers: [],
             filter: [PackageType.monthly.identifier],
             default: nil,
             localization: Self.localization,
@@ -84,31 +80,6 @@ class TemplateViewConfigurationCreationTests: BaseTemplateViewConfigurationTests
         switch result {
         case let .single(package):
             expect(package.content) === TestData.monthlyPackage
-            expect(package.currentlySubscribed) == false
-            expect(package.discountRelativeToMostExpensivePerMonth).to(beNil())
-            Self.verifyLocalizationWasProcessed(package.localization, for: TestData.monthlyPackage)
-        case .multiple, .multiTier:
-            fail("Invalid result: \(result)")
-        }
-    }
-
-    func testCreateSingleSubscribedPackage() throws {
-        let result = try Config.create(
-            with: [TestData.monthlyPackage],
-            activelySubscribedProductIdentifiers: [TestData.monthlyPackage.storeProduct.productIdentifier,
-                                                  "Anotoher product"],
-            filter: [PackageType.monthly.identifier],
-            default: nil,
-            localization: Self.localization,
-            localizationByTier: [:],
-            tiers: [],
-            setting: .single
-        )
-
-        switch result {
-        case let .single(package):
-            expect(package.content) === TestData.monthlyPackage
-            expect(package.currentlySubscribed) == true
             expect(package.discountRelativeToMostExpensivePerMonth).to(beNil())
             Self.verifyLocalizationWasProcessed(package.localization, for: TestData.monthlyPackage)
         case .multiple, .multiTier:
@@ -119,7 +90,6 @@ class TemplateViewConfigurationCreationTests: BaseTemplateViewConfigurationTests
     func testCreateOnlyLifetime() throws {
         let result = try Config.create(
             with: [TestData.lifetimePackage],
-            activelySubscribedProductIdentifiers: [],
             filter: [PackageType.lifetime.identifier],
             default: nil,
             localization: Self.localization,
@@ -131,7 +101,6 @@ class TemplateViewConfigurationCreationTests: BaseTemplateViewConfigurationTests
         switch result {
         case let .single(package):
             expect(package.content) === TestData.lifetimePackage
-            expect(package.currentlySubscribed) == false
             expect(package.discountRelativeToMostExpensivePerMonth).to(beNil())
             Self.verifyLocalizationWasProcessed(package.localization, for: TestData.lifetimePackage)
         case .multiple, .multiTier:
@@ -146,10 +115,6 @@ class TemplateViewConfigurationCreationTests: BaseTemplateViewConfigurationTests
                    TestData.weeklyPackage,
                    TestData.lifetimePackage,
                    Self.consumable],
-            activelySubscribedProductIdentifiers: [
-                TestData.monthlyPackage.storeProduct.productIdentifier,
-                TestData.lifetimePackage.storeProduct.productIdentifier
-            ],
             filter: [PackageType.annual.identifier,
                      PackageType.monthly.identifier,
                      PackageType.lifetime.identifier,
@@ -174,25 +139,21 @@ class TemplateViewConfigurationCreationTests: BaseTemplateViewConfigurationTests
 
             let annual = packages[0]
             expect(annual.content) === TestData.annualPackage
-            expect(annual.currentlySubscribed) == false
             expect(annual.discountRelativeToMostExpensivePerMonth)
                 .to(beCloseTo(0.36, within: 0.01))
             Self.verifyLocalizationWasProcessed(annual.localization, for: TestData.annualPackage)
 
             let monthly = packages[1]
             expect(monthly.content) === TestData.monthlyPackage
-            expect(monthly.currentlySubscribed) == true
             expect(monthly.discountRelativeToMostExpensivePerMonth).to(beNil())
             Self.verifyLocalizationWasProcessed(monthly.localization, for: TestData.monthlyPackage)
 
             let lifetime = packages[2]
             expect(lifetime.content) === TestData.lifetimePackage
-            expect(lifetime.currentlySubscribed) == true
             Self.verifyLocalizationWasProcessed(lifetime.localization, for: TestData.lifetimePackage)
 
             let consumable = packages[3]
             expect(consumable.content) === Self.consumable
-            expect(consumable.currentlySubscribed) == false
             Self.verifyLocalizationWasProcessed(consumable.localization, for: Self.consumable)
         }
     }
@@ -201,7 +162,6 @@ class TemplateViewConfigurationCreationTests: BaseTemplateViewConfigurationTests
         expect {
             try Config.create(
                 with: [TestData.monthlyPackage],
-                activelySubscribedProductIdentifiers: [],
                 filter: [],
                 default: nil,
                 localization: nil,
@@ -222,7 +182,6 @@ class TemplateViewConfigurationCreationTests: BaseTemplateViewConfigurationTests
                     TestData.weeklyPackage,
                     TestData.lifetimePackage
                 ],
-                activelySubscribedProductIdentifiers: [],
                 filter: [PackageType.annual.identifier],
                 default: nil,
                 localization: nil,
@@ -257,7 +216,6 @@ class TemplateViewConfigurationCreationTests: BaseTemplateViewConfigurationTests
 
         let result = try Config.create(
             with: [TestData.monthlyPackage],
-            activelySubscribedProductIdentifiers: [],
             filter: [],
             default: nil,
             localization: nil,
@@ -285,7 +243,6 @@ class TemplateViewConfigurationCreationTests: BaseTemplateViewConfigurationTests
             expect(tierData.first.content) === TestData.monthlyPackage
 
             let package = tierData.first
-            expect(package.currentlySubscribed) == false
             expect(package.discountRelativeToMostExpensivePerMonth).to(beNil())
             Self.verifyLocalizationWasProcessed(package.localization, for: TestData.monthlyPackage)
 
@@ -304,7 +261,6 @@ class TemplateViewConfigurationCreationTests: BaseTemplateViewConfigurationTests
         expect {
             try Config.create(
                 with: [TestData.monthlyPackage],
-                activelySubscribedProductIdentifiers: [],
                 filter: [],
                 default: nil,
                 localization: nil,
@@ -346,10 +302,6 @@ class TemplateViewConfigurationCreationTests: BaseTemplateViewConfigurationTests
                 TestData.weeklyPackage,
                 TestData.lifetimePackage
             ],
-            activelySubscribedProductIdentifiers: [
-                TestData.annualProduct.productIdentifier,
-                TestData.lifetimeProduct.productIdentifier
-            ],
             filter: [],
             default: nil,
             localization: nil,
@@ -375,14 +327,12 @@ class TemplateViewConfigurationCreationTests: BaseTemplateViewConfigurationTests
 
                 let monthly = firstTier.all[0]
                 expect(monthly.content) === TestData.monthlyPackage
-                expect(monthly.currentlySubscribed) == false
                 expect(monthly.discountRelativeToMostExpensivePerMonth).to(beNil())
                 expect(monthly.localization.tierName).to(beNil())
                 Self.verifyLocalizationWasProcessed(monthly.localization, for: TestData.monthlyPackage)
 
                 let annual = firstTier.all[1]
                 expect(annual.content) === TestData.annualPackage
-                expect(annual.currentlySubscribed) == true
                 expect(annual.discountRelativeToMostExpensivePerMonth)
                     .to(beCloseTo(0.36, within: 0.01))
                 expect(annual.localization.tierName).to(beNil())
@@ -394,14 +344,12 @@ class TemplateViewConfigurationCreationTests: BaseTemplateViewConfigurationTests
 
                 let weekly = secondTier.all[0]
                 expect(weekly.content) === TestData.weeklyPackage
-                expect(weekly.currentlySubscribed) == false
                 expect(weekly.discountRelativeToMostExpensivePerMonth).to(beNil())
                 expect(weekly.localization.tierName) == "Premium"
                 Self.verifyLocalizationWasProcessed(weekly.localization, for: TestData.weeklyPackage)
 
                 let lifetime = secondTier.all[1]
                 expect(lifetime.content) === TestData.lifetimePackage
-                expect(lifetime.currentlySubscribed) == true
                 expect(lifetime.discountRelativeToMostExpensivePerMonth).to(beNil())
                 expect(lifetime.localization.tierName) == "Premium"
                 Self.verifyLocalizationWasProcessed(lifetime.localization, for: TestData.lifetimePackage)
@@ -428,7 +376,6 @@ class TemplateViewConfigurationCreationTests: BaseTemplateViewConfigurationTests
                 TestData.monthlyPackage,
                 TestData.annualPackage
             ],
-            activelySubscribedProductIdentifiers: [],
             filter: [],
             default: nil,
             localization: nil,
@@ -452,7 +399,6 @@ class TemplateViewConfigurationCreationTests: BaseTemplateViewConfigurationTests
             expect(all[firstTier]?.first.content) == TestData.monthlyPackage
 
             let package = try XCTUnwrap(all[firstTier]?.first)
-            expect(package.currentlySubscribed) == false
             expect(package.discountRelativeToMostExpensivePerMonth).to(beNil())
             Self.verifyLocalizationWasProcessed(package.localization, for: TestData.monthlyPackage)
 
@@ -581,7 +527,6 @@ class TemplateViewConfigurationBaseExtensionTests: BaseTemplateViewConfiguration
 
         self.singlePackageConfiguration = try Config.create(
             with: [Self.package1],
-            activelySubscribedProductIdentifiers: [],
             filter: [Self.package1.packageType.identifier],
             default: nil,
             localization: Self.localization,
@@ -591,7 +536,6 @@ class TemplateViewConfigurationBaseExtensionTests: BaseTemplateViewConfiguration
         )
         self.multiPackageConfigurationSameText = try Config.create(
             with: Self.allPackages,
-            activelySubscribedProductIdentifiers: [],
             filter: Self.allPackages.map(\.packageType.identifier),
             default: nil,
             localization: .init(
@@ -610,7 +554,6 @@ class TemplateViewConfigurationBaseExtensionTests: BaseTemplateViewConfiguration
         )
         self.multiPackageConfigurationDifferentText = try Config.create(
             with: Self.allPackages,
-            activelySubscribedProductIdentifiers: [],
             filter: Self.allPackages.map(\.packageType.identifier),
             default: nil,
             localization: Self.localization,
@@ -620,7 +563,6 @@ class TemplateViewConfigurationBaseExtensionTests: BaseTemplateViewConfiguration
         )
         self.multiPackageConfigurationNoOfferDetails = try Config.create(
             with: Self.allPackages,
-            activelySubscribedProductIdentifiers: [],
             filter: Self.allPackages.map(\.packageType.identifier),
             default: nil,
             localization: .init(
@@ -638,7 +580,6 @@ class TemplateViewConfigurationBaseExtensionTests: BaseTemplateViewConfiguration
 
         self.multiTierConfigurationSameText = try Config.create(
             with: Self.allPackages,
-            activelySubscribedProductIdentifiers: [],
             filter: [],
             default: nil,
             localization: nil,
@@ -669,7 +610,6 @@ class TemplateViewConfigurationBaseExtensionTests: BaseTemplateViewConfiguration
         )
         self.multiTierConfigurationDifferentText = try Config.create(
             with: Self.allPackages,
-            activelySubscribedProductIdentifiers: [],
             filter: [],
             default: nil,
             localization: nil,
@@ -682,7 +622,6 @@ class TemplateViewConfigurationBaseExtensionTests: BaseTemplateViewConfiguration
         )
         self.multiTierConfigurationNoOfferDetails = try Config.create(
             with: Self.allPackages,
-            activelySubscribedProductIdentifiers: [],
             filter: [],
             default: nil,
             localization: nil,

--- a/Tests/RevenueCatUITests/PaywallFooterTests.swift
+++ b/Tests/RevenueCatUITests/PaywallFooterTests.swift
@@ -35,7 +35,6 @@ class PaywallFooterTests: TestCase {
         _ = try Text("")
             .originalTemplatePaywallFooter(
                 offering: Self.offering,
-                customerInfo: TestData.customerInfo,
                 introEligibility: .producing(eligibility: .eligible),
                 purchaseHandler: Self.purchaseHandler,
                 purchaseStarted: { package in packageBeingPurchased = package }
@@ -55,7 +54,6 @@ class PaywallFooterTests: TestCase {
         _ = try Text("")
             .originalTemplatePaywallFooter(
                 offering: Self.offering,
-                customerInfo: TestData.customerInfo,
                 introEligibility: .producing(eligibility: .eligible),
                 purchaseHandler: Self.purchaseHandler,
                 purchaseCompleted: { customerInfo = $0 }
@@ -75,7 +73,6 @@ class PaywallFooterTests: TestCase {
         _ = try Text("")
             .originalTemplatePaywallFooter(
                 offering: Self.offering,
-                customerInfo: TestData.customerInfo,
                 introEligibility: .producing(eligibility: .eligible),
                 purchaseHandler: Self.failingHandler,
                 purchaseFailure: { error = $0 }
@@ -95,7 +92,6 @@ class PaywallFooterTests: TestCase {
         _ = try Text("")
             .originalTemplatePaywallFooter(
                 offering: Self.offering,
-                customerInfo: TestData.customerInfo,
                 introEligibility: .producing(eligibility: .eligible),
                 purchaseHandler: Self.purchaseHandler,
                 restoreStarted: { started = true }
@@ -115,7 +111,6 @@ class PaywallFooterTests: TestCase {
         _ = try Text("")
             .originalTemplatePaywallFooter(
                 offering: Self.offering,
-                customerInfo: TestData.customerInfo,
                 introEligibility: .producing(eligibility: .eligible),
                 purchaseHandler: Self.purchaseHandler,
                 restoreCompleted: { customerInfo = $0 }
@@ -137,7 +132,6 @@ class PaywallFooterTests: TestCase {
         _ = try Text("")
             .originalTemplatePaywallFooter(
                 offering: Self.offering,
-                customerInfo: TestData.customerInfo,
                 introEligibility: .producing(eligibility: .eligible),
                 purchaseHandler: Self.failingHandler,
                 restoreFailure: { error = $0 }
@@ -164,7 +158,6 @@ class PaywallFooterTests: TestCase {
         _ = try Text("")
             .originalTemplatePaywallFooter(
                 offering: Self.offering,
-                customerInfo: TestData.customerInfo,
                 introEligibility: .producing(eligibility: .eligible),
                 purchaseHandler: handler
             )
@@ -188,7 +181,6 @@ class PaywallFooterTests: TestCase {
         _ = try Text("")
             .originalTemplatePaywallFooter(
                 offering: Self.offering,
-                customerInfo: TestData.customerInfo,
                 introEligibility: .producing(eligibility: .eligible),
                 purchaseHandler: handler
             )

--- a/Tests/RevenueCatUITests/PaywallViewEventsTests.swift
+++ b/Tests/RevenueCatUITests/PaywallViewEventsTests.swift
@@ -220,7 +220,6 @@ private extension BasePaywallViewEventsTests {
         PaywallView(
             configuration: .init(
                 offering: Self.offering.withLocalImages,
-                customerInfo: TestData.customerInfo,
                 mode: self.mode,
                 introEligibility: .producing(eligibility: .eligible),
                 purchaseHandler: self.handler

--- a/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
+++ b/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
@@ -29,7 +29,6 @@ class PurchaseCompletedHandlerTests: TestCase {
 
         _ = try PaywallView(
             offering: Self.offering.withLocalImages,
-            customerInfo: TestData.customerInfo,
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: Self.purchaseHandler
         )
@@ -57,7 +56,6 @@ class PurchaseCompletedHandlerTests: TestCase {
 
         _ = try PaywallView(
             offering: Self.offering.withLocalImages,
-            customerInfo: TestData.customerInfo,
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: handler
         )
@@ -80,7 +78,6 @@ class PurchaseCompletedHandlerTests: TestCase {
 
         _ = try PaywallView(
             offering: Self.offering.withLocalImages,
-            customerInfo: TestData.customerInfo,
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: Self.purchaseHandler
         )
@@ -101,7 +98,6 @@ class PurchaseCompletedHandlerTests: TestCase {
 
         _ = try PaywallView(
             offering: Self.offering.withLocalImages,
-            customerInfo: TestData.customerInfo,
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: Self.purchaseHandler
         )
@@ -127,7 +123,6 @@ class PurchaseCompletedHandlerTests: TestCase {
 
         _ = try PaywallView(
             offering: Self.offering.withLocalImages,
-            customerInfo: TestData.customerInfo,
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: handler
         )
@@ -151,7 +146,6 @@ class PurchaseCompletedHandlerTests: TestCase {
 
         let dispose = try PaywallView(
             offering: Self.offering.withLocalImages,
-            customerInfo: TestData.customerInfo,
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: handler
         )
@@ -183,7 +177,6 @@ class PurchaseCompletedHandlerTests: TestCase {
 
         _ = try PaywallView(
             offering: Self.offering.withLocalImages,
-            customerInfo: TestData.customerInfo,
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: Self.purchaseHandler
         )
@@ -206,7 +199,6 @@ class PurchaseCompletedHandlerTests: TestCase {
 
         _ = try PaywallView(
             offering: Self.offering.withLocalImages,
-            customerInfo: TestData.customerInfo,
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: Self.failingHandler
         )
@@ -227,7 +219,6 @@ class PurchaseCompletedHandlerTests: TestCase {
 
         _ = try PaywallView(
             offering: Self.offering.withLocalImages,
-            customerInfo: TestData.customerInfo,
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: Self.purchaseHandler
         )
@@ -248,7 +239,6 @@ class PurchaseCompletedHandlerTests: TestCase {
 
         _ = try PaywallView(
             offering: Self.offering.withLocalImages,
-            customerInfo: TestData.customerInfo,
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: Self.purchaseHandler
         )
@@ -271,7 +261,6 @@ class PurchaseCompletedHandlerTests: TestCase {
 
         _ = try PaywallView(
             offering: Self.offering.withLocalImages,
-            customerInfo: TestData.customerInfo,
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: Self.failingHandler
         )
@@ -293,7 +282,6 @@ class PurchaseCompletedHandlerTests: TestCase {
 
         let dispose = try PaywallView(
             offering: Self.offering.withLocalImages,
-            customerInfo: TestData.customerInfo,
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: handler
         )
@@ -327,14 +315,12 @@ private extension PaywallView {
 
     init(
         offering: Offering,
-        customerInfo: CustomerInfo,
         introEligibility: TrialOrIntroEligibilityChecker,
         purchaseHandler: PurchaseHandler
     ) {
         self.init(
             configuration: .init(
                 offering: offering,
-                customerInfo: customerInfo,
                 introEligibility: introEligibility,
                 purchaseHandler: purchaseHandler
             )

--- a/Tests/RevenueCatUITests/Templates/ExternalPurchaseAndRestoreTests.swift
+++ b/Tests/RevenueCatUITests/Templates/ExternalPurchaseAndRestoreTests.swift
@@ -45,7 +45,6 @@ class ZZExternalPurchaseAndRestoreTests: TestCase {
 
         _ = try PaywallView(
             offering: Self.offering.withLocalImages,
-            customerInfo: TestData.customerInfo,
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: purchasHandler
         )
@@ -95,7 +94,6 @@ class ZZExternalPurchaseAndRestoreTests: TestCase {
 
         _ = try PaywallView(
             offering: Self.offering.withLocalImages,
-            customerInfo: TestData.customerInfo,
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: purchasHandler
         )
@@ -145,7 +143,6 @@ class ZZExternalPurchaseAndRestoreTests: TestCase {
 
         _ = try PaywallView(
             offering: Self.offering.withLocalImages,
-            customerInfo: TestData.customerInfo,
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: purchasHandler
         )
@@ -195,7 +192,6 @@ class ZZExternalPurchaseAndRestoreTests: TestCase {
 
         _ = try PaywallView(
             offering: Self.offering.withLocalImages,
-            customerInfo: TestData.customerInfo,
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: purchasHandler
         )
@@ -225,7 +221,6 @@ class ZZExternalPurchaseAndRestoreTests: TestCase {
 
         _ = try PaywallView(
             offering: Self.offering.withLocalImages,
-            customerInfo: TestData.customerInfo,
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: purchasHandler
         )
@@ -274,7 +269,6 @@ class ZZExternalPurchaseAndRestoreTests: TestCase {
 
         _ = try PaywallView(
             offering: Self.offering.withLocalImages,
-            customerInfo: TestData.customerInfo,
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: purchasHandler
         )
@@ -374,14 +368,12 @@ private extension PaywallView {
 
     init(
         offering: Offering,
-        customerInfo: CustomerInfo,
         introEligibility: TrialOrIntroEligibilityChecker,
         purchaseHandler: PurchaseHandler
     ) {
         self.init(
             configuration: .init(
                 offering: offering,
-                customerInfo: customerInfo,
                 introEligibility: introEligibility,
                 purchaseHandler: purchaseHandler
             )

--- a/Tests/RevenueCatUITests/Templates/OtherPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/Templates/OtherPaywallViewTests.swift
@@ -5,16 +5,9 @@
 //  Created by Nacho Soto on 7/20/23.
 //
 
-import Nimble
-@_spi(Internal) import RevenueCat
 @_spi(Internal) @testable import RevenueCatUI
-import SnapshotTesting
 import SwiftUI
 import XCTest
-
-#if canImport(UIKit)
-import UIKit
-#endif
 
 #if !os(watchOS) && !os(macOS)
 
@@ -36,136 +29,6 @@ class OtherPaywallViewTests: BaseSnapshotTest {
             .recordSnapshot(size: Self.footerSize)
     }
 
-    #if !os(tvOS)
-    func testFullScreenV2CanRenderWithoutCustomerInfo() throws {
-        let title = "V2 paywall content"
-        let offering = try Self.v2Offering(title: title)
-        let view = PaywallView(
-            configuration: .init(
-                offering: offering,
-                mode: .fullScreen,
-                introEligibility: .producing(eligibility: .eligible),
-                purchaseHandler: .mock()
-            )
-        )
-
-        let (window, hostedView) = Self.host(view, size: Self.fullScreenSize)
-        defer { window.isHidden = true }
-
-        expect(hostedView.containsText(title)).toEventually(beTrue())
-    }
-
-    func testFullScreenV1CanRenderWithoutCustomerInfo() {
-        let view = PaywallView(
-            configuration: .init(
-                offering: TestData.offeringWithIntroOffer,
-                mode: .fullScreen,
-                introEligibility: .producing(eligibility: .eligible),
-                purchaseHandler: .mock()
-            )
-        )
-
-        let (window, hostedView) = Self.host(view, size: Self.fullScreenSize)
-        defer { window.isHidden = true }
-
-        expect(hostedView.containsText(matching: "curiosity")).toEventually(beTrue())
-    }
-
-    func testFooterCanRenderWithoutCustomerInfo() {
-        let view = PaywallView(
-            configuration: .init(
-                offering: TestData.offeringWithIntroOffer,
-                mode: .footer,
-                introEligibility: .producing(eligibility: .eligible),
-                purchaseHandler: .mock()
-            )
-        )
-
-        let (window, hostedView) = Self.host(view, size: Self.footerSize)
-        defer { window.isHidden = true }
-
-        expect(hostedView.containsText(matching: "Purchase")).toEventually(beTrue())
-    }
-    #endif
-
 }
-
-#if !os(tvOS)
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-private extension OtherPaywallViewTests {
-
-    static func v2Offering(title: String) throws -> Offering {
-        let data = PaywallComponentsData(
-            templateName: "test",
-            assetBaseURL: try XCTUnwrap(URL(string: "https://assets.revenuecat.com")),
-            componentsConfig: .init(
-                base: .init(
-                    stack: .init(components: [
-                        .text(.init(text: "title", color: .init(light: .hex("#000000"))))
-                    ]),
-                    stickyFooter: nil,
-                    background: .color(.init(light: .hex("#FFFFFF")))
-                )
-            ),
-            componentsLocalizations: [
-                "en_US": ["title": .string(title)]
-            ],
-            revision: 1,
-            defaultLocaleIdentifier: "en_US"
-        )
-
-        return Offering(
-            identifier: "v2-offering",
-            serverDescription: "V2 offering",
-            paywallComponents: .init(uiConfig: PreviewUIConfig.make(), data: data),
-            availablePackages: [],
-            webCheckoutUrl: nil
-        )
-    }
-
-    static func host<Content: View>(
-        _ view: Content,
-        size: CGSize
-    ) -> (UIWindow, UIView) {
-        let controller = UIHostingController(rootView: view)
-        let window = UIWindow(frame: CGRect(origin: .zero, size: size))
-        window.rootViewController = controller
-        window.makeKeyAndVisible()
-        controller.view.layoutIfNeeded()
-
-        return (window, controller.view)
-    }
-
-}
-
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-private extension UIView {
-
-    func containsText(_ text: String) -> Bool {
-        return self.containsText(matching: text, exact: true)
-    }
-
-    func containsText(matching text: String) -> Bool {
-        return self.containsText(matching: text, exact: false)
-    }
-
-    private func containsText(matching text: String, exact: Bool) -> Bool {
-        if let label = self as? UILabel, let labelText = label.text {
-            if exact ? labelText == text : labelText.contains(text) {
-                return true
-            }
-        }
-
-        if let accessibilityLabel = self.accessibilityLabel {
-            if exact ? accessibilityLabel == text : accessibilityLabel.contains(text) {
-                return true
-            }
-        }
-
-        return self.subviews.contains { $0.containsText(matching: text, exact: exact) }
-    }
-
-}
-#endif
 
 #endif

--- a/Tests/RevenueCatUITests/Templates/OtherPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/Templates/OtherPaywallViewTests.swift
@@ -5,9 +5,10 @@
 //  Created by Nacho Soto on 7/20/23.
 //
 
-@_spi(Internal) @testable import RevenueCatUI
-import SwiftUI
-import XCTest
+import Nimble
+import RevenueCat
+@testable import RevenueCatUI
+import SnapshotTesting
 
 #if !os(watchOS) && !os(macOS)
 

--- a/Tests/RevenueCatUITests/Templates/OtherPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/Templates/OtherPaywallViewTests.swift
@@ -30,6 +30,136 @@ class OtherPaywallViewTests: BaseSnapshotTest {
             .recordSnapshot(size: Self.footerSize)
     }
 
+    #if !os(tvOS)
+    func testFullScreenV2CanRenderWithoutCustomerInfo() throws {
+        let title = "V2 paywall content"
+        let offering = try Self.v2Offering(title: title)
+        let view = PaywallView(
+            configuration: .init(
+                offering: offering,
+                mode: .fullScreen,
+                introEligibility: .producing(eligibility: .eligible),
+                purchaseHandler: .mock()
+            )
+        )
+
+        let (window, hostedView) = Self.host(view, size: Self.fullScreenSize)
+        defer { window.isHidden = true }
+
+        expect(hostedView.containsText(title)).toEventually(beTrue())
+    }
+
+    func testFullScreenV1CanRenderWithoutCustomerInfo() {
+        let view = PaywallView(
+            configuration: .init(
+                offering: TestData.offeringWithIntroOffer,
+                mode: .fullScreen,
+                introEligibility: .producing(eligibility: .eligible),
+                purchaseHandler: .mock()
+            )
+        )
+
+        let (window, hostedView) = Self.host(view, size: Self.fullScreenSize)
+        defer { window.isHidden = true }
+
+        expect(hostedView.containsText(matching: "curiosity")).toEventually(beTrue())
+    }
+
+    func testFooterCanRenderWithoutCustomerInfo() {
+        let view = PaywallView(
+            configuration: .init(
+                offering: TestData.offeringWithIntroOffer,
+                mode: .footer,
+                introEligibility: .producing(eligibility: .eligible),
+                purchaseHandler: .mock()
+            )
+        )
+
+        let (window, hostedView) = Self.host(view, size: Self.footerSize)
+        defer { window.isHidden = true }
+
+        expect(hostedView.containsText(matching: "Purchase")).toEventually(beTrue())
+    }
+    #endif
+
 }
+
+#if !os(tvOS)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension OtherPaywallViewTests {
+
+    static func v2Offering(title: String) throws -> Offering {
+        let data = PaywallComponentsData(
+            templateName: "test",
+            assetBaseURL: try XCTUnwrap(URL(string: "https://assets.revenuecat.com")),
+            componentsConfig: .init(
+                base: .init(
+                    stack: .init(components: [
+                        .text(.init(text: "title", color: .init(light: .hex("#000000"))))
+                    ]),
+                    stickyFooter: nil,
+                    background: .color(.init(light: .hex("#FFFFFF")))
+                )
+            ),
+            componentsLocalizations: [
+                "en_US": ["title": .string(title)]
+            ],
+            revision: 1,
+            defaultLocaleIdentifier: "en_US"
+        )
+
+        return Offering(
+            identifier: "v2-offering",
+            serverDescription: "V2 offering",
+            paywallComponents: .init(uiConfig: PreviewUIConfig.make(), data: data),
+            availablePackages: [],
+            webCheckoutUrl: nil
+        )
+    }
+
+    static func host<Content: View>(
+        _ view: Content,
+        size: CGSize
+    ) -> (UIWindow, UIView) {
+        let controller = UIHostingController(rootView: view)
+        let window = UIWindow(frame: CGRect(origin: .zero, size: size))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        controller.view.layoutIfNeeded()
+
+        return (window, controller.view)
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension UIView {
+
+    func containsText(_ text: String) -> Bool {
+        return self.containsText(matching: text, exact: true)
+    }
+
+    func containsText(matching text: String) -> Bool {
+        return self.containsText(matching: text, exact: false)
+    }
+
+    private func containsText(matching text: String, exact: Bool) -> Bool {
+        if let label = self as? UILabel, let labelText = label.text {
+            if exact ? labelText == text : labelText.contains(text) {
+                return true
+            }
+        }
+
+        if let accessibilityLabel = self.accessibilityLabel {
+            if exact ? accessibilityLabel == text : accessibilityLabel.contains(text) {
+                return true
+            }
+        }
+
+        return self.subviews.contains { $0.containsText(matching: text, exact: exact) }
+    }
+
+}
+#endif
 
 #endif

--- a/Tests/RevenueCatUITests/Templates/OtherPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/Templates/OtherPaywallViewTests.swift
@@ -6,9 +6,15 @@
 //
 
 import Nimble
-import RevenueCat
-@testable import RevenueCatUI
+@_spi(Internal) import RevenueCat
+@_spi(Internal) @testable import RevenueCatUI
 import SnapshotTesting
+import SwiftUI
+import XCTest
+
+#if canImport(UIKit)
+import UIKit
+#endif
 
 #if !os(watchOS) && !os(macOS)
 

--- a/Tests/TestingApps/PaywallFixtures/FixtureRootView.swift
+++ b/Tests/TestingApps/PaywallFixtures/FixtureRootView.swift
@@ -45,24 +45,15 @@ struct FixturePaywallView: View {
 
     let fixture: PaywallFixture
 
-    /// Eligibility is stubbed, customer info is supplied rather than fetched, and purchases are
-    /// no-ops, so nothing here reaches StoreKit or the network and the accessibility tree depends
-    /// only on the fixture.
+    /// Eligibility is stubbed and purchases are no-ops, so nothing here reaches StoreKit or the
+    /// network and the accessibility tree depends only on the fixture.
     private static let eligibility = TrialOrIntroEligibilityChecker { packages in
         Dictionary(uniqueKeysWithValues: packages.map { ($0, IntroEligibilityStatus.eligible) })
     }
 
-    private static let customerInfo = CustomerInfo(
-        entitlements: .init(),
-        requestDate: Date(timeIntervalSince1970: 0),
-        firstSeen: Date(timeIntervalSince1970: 0),
-        originalAppUserId: "fixtures"
-    )
-
     var body: some View {
         PaywallView(
             offering: self.fixture.offering,
-            customerInfo: Self.customerInfo,
             introEligibility: Self.eligibility,
             performPurchase: { _ in (userCancelled: true, error: nil) },
             performRestore: { (success: false, error: nil) }

--- a/Tests/TestingApps/PaywallValidationTester/PaywallValidationTesterView.swift
+++ b/Tests/TestingApps/PaywallValidationTester/PaywallValidationTesterView.swift
@@ -28,7 +28,6 @@ struct PaywallValidationTesterView: View {
                             PaywallView(
                                 configuration: .init(
                                     offering: offering,
-                                    customerInfo: TestData.customerInfo,
                                     mode: .default,
                                     fonts: DefaultPaywallFontProvider(),
                                     introEligibility: .producing(eligibility: .eligible),

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/SamplePaywalls.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/SamplePaywalls.swift
@@ -78,8 +78,6 @@ final class SamplePaywallLoader {
         )
     }
 
-    let customerInfo = TestData.customerInfo
-
     private func paywall(for template: PaywallTemplate) -> PaywallData {
         switch template {
         case .template1:

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/CustomPaywall.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/CustomPaywall.swift
@@ -19,7 +19,6 @@ import SwiftUI
 struct CustomPaywall: View {
 
     var offering: Offering?
-    var customerInfo: CustomerInfo?
     var condensed: Bool
     var introEligibility: TrialOrIntroEligibilityChecker?
     var purchaseHandler: PurchaseHandler?
@@ -35,7 +34,6 @@ struct CustomPaywall: View {
         CustomPaywallContent(selectedTierName: self.currentTierName)
             .originalTemplatePaywallFooter(
                 offering: self.offering,
-                customerInfo: self.customerInfo,
                 condensed: self.condensed,
                 fonts: DefaultPaywallFontProvider(),
                 introEligibility: self.introEligibility ?? .default(),
@@ -55,7 +53,6 @@ struct CustomPaywall_Previews: PreviewProvider {
         ForEach(Self.condensedOptions, id: \.self) { mode in
             CustomPaywall(
                 offering: TestData.offeringWithMultiPackagePaywall,
-                customerInfo: TestData.customerInfo,
                 condensed: mode,
                 introEligibility: .producing(eligibility: .eligible),
                 purchaseHandler: .mock()
@@ -66,7 +63,6 @@ struct CustomPaywall_Previews: PreviewProvider {
         ForEach(Self.condensedOptions, id: \.self) { mode in
             CustomPaywall(
                 offering: TestData.offeringWithMultiPackageHorizontalPaywall,
-                customerInfo: TestData.customerInfo,
                 condensed: mode,
                 introEligibility: .producing(eligibility: .eligible),
                 purchaseHandler: .mock()
@@ -77,7 +73,6 @@ struct CustomPaywall_Previews: PreviewProvider {
         ForEach(Self.condensedOptions, id: \.self) { mode in
             CustomPaywall(
                 offering: TestData.offeringWithTemplate5Paywall,
-                customerInfo: TestData.customerInfo,
                 condensed: mode,
                 introEligibility: .producing(eligibility: .eligible),
                 purchaseHandler: .mock()

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/PaywallPresenter.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/PaywallPresenter.swift
@@ -65,14 +65,12 @@ struct PaywallPresenter: View {
         case .footer:
             CustomPaywallContent()
                 .originalTemplatePaywallFooter(offering: self.offering,
-                                               customerInfo: nil,
                                                introEligibility: introEligibilityChecker,
                                                purchaseHandler: .default())
 
         case .condensedFooter:
             CustomPaywallContent()
                 .originalTemplatePaywallFooter(offering: self.offering,
-                                               customerInfo: nil,
                                                condensed: true,
                                                introEligibility: introEligibilityChecker,
                                                purchaseHandler: .default())

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
@@ -48,7 +48,6 @@ struct SamplePaywallsList: View {
             case .fullScreen, .sheet:
                 PaywallView(configuration: .init(
                     offering: Self.loader.offering(for: template),
-                    customerInfo: Self.loader.customerInfo,
                     displayCloseButton: Self.displayCloseButton,
                     introEligibility: Self.introEligibility
                 ))
@@ -67,7 +66,6 @@ struct SamplePaywallsList: View {
             #if !os(watchOS) && !os(macOS)
             case .footer, .condensedFooter:
                 CustomPaywall(offering: Self.loader.offering(for: template),
-                              customerInfo: Self.loader.customerInfo,
                               condensed: mode == .condensedFooter,
                               introEligibility: Self.introEligibility)
             #endif
@@ -77,7 +75,6 @@ struct SamplePaywallsList: View {
             PaywallView(
                 configuration: .init(
                     offering: Self.loader.offering(for: template),
-                    customerInfo: Self.loader.customerInfo,
                     fonts: Self.customFontProvider,
                     displayCloseButton: Self.displayCloseButton,
                     introEligibility: Self.introEligibility
@@ -86,15 +83,13 @@ struct SamplePaywallsList: View {
 
         #if os(iOS)
         case let .customPaywall(mode):
-            CustomPaywall(customerInfo: Self.loader.customerInfo,
-                          condensed: mode == .condensedFooter)
+            CustomPaywall(condensed: mode == .condensedFooter)
         #endif
 
         case .missingPaywall:
             PaywallView(
                 configuration: .init(
                     offering: Self.loader.offeringWithDefaultPaywall(),
-                    customerInfo: Self.loader.customerInfo,
                     introEligibility: Self.introEligibility
                 )
             )
@@ -103,7 +98,6 @@ struct SamplePaywallsList: View {
             PaywallView(
                 configuration: .init(
                     offering: Self.loader.offeringWithUnrecognizedPaywall(),
-                    customerInfo: Self.loader.customerInfo,
                     introEligibility: Self.introEligibility
                 )
             )
@@ -111,7 +105,6 @@ struct SamplePaywallsList: View {
         case .componentPaywall(let data):
             PaywallView(configuration: .init(
                 offering: Self.loader.offering(with: data),
-                customerInfo: Self.loader.customerInfo,
                 displayCloseButton: Self.displayCloseButton,
                 introEligibility: Self.introEligibility
             ))


### PR DESCRIPTION
### Motivation

Paywalls blocked first paint on a `CustomerInfo` fetch (several seconds on cold start) purely to know which products the user already owns. https://github.com/RevenueCat/purchases-android/pull/2492 dropped that dependency; this brings iOS in line.

### Description

Removes the subscribed-product list from paywall state entirely, so V1, V2 and footers all render as soon as the offering is available.

Already-subscribed products are now handled by StoreKit itself, which surfaces its own “You’re currently subscribed to this” alert.

Behavior change is limited to V1: the purchase button no longer silently no-ops on an already-owned product, so purchase callbacks now fire where they previously didn't. V2 already behaved this way before this PR.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Intentional V1 behavior change on purchase for owned products plus removal of a gate that previously blocked paywall UI on failed `customerInfo` fetches; purchase and presentation paths should be regression-tested.
> 
> **Overview**
> **Paywalls no longer wait on `CustomerInfo` before rendering.** `PaywallViewConfiguration`, footers, and `presentIfNeeded` drop `customerInfo` / active-subscription sets; loading only resolves offering (and workflow) data, so V1, V2, and footers can appear as soon as the offering is available instead of after a cold-start customer fetch.
> 
> **Template and purchase behavior is simplified.** `TemplateViewConfiguration.Package` loses `currentlySubscribed`, package building no longer takes `activelySubscribedProductIdentifiers`, and `PurchaseButton` no longer short-circuits with the removed `product_already_subscribed` warning—**V1 purchase taps on an already-owned product now run the purchase path** (and callbacks can fire) instead of silently no-oping, matching V2.
> 
> **Presentation plumbing:** conditional paywall presentation uses a boolean `isPresented` flag rather than a sheet item keyed by `CustomerInfo`. Tests, previews, and sample apps are updated to stop injecting `customerInfo`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b8f36fc2cadb113272021ec72dca74be6fb284d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
