### PR TITLE
feat(checkpoints): add subscriber attribute editor to CheckpointTester

### DIFF
--- a/Examples/CheckpointTester/CheckpointTester/Sources/ContentView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/ContentView.swift
@@ -22,6 +22,7 @@ struct ContentView: View {
     @ObservedObject var model: CheckpointDemoModel
     @ObservedObject var analyticsTracker: GlobalCheckpointAnalyticsTracker
     @StateObject private var customVariables = CustomVariables()
+    @State private var isSubscriberAttributeEditorPresented = false
 
     var body: some View {
         TabView {
@@ -39,6 +40,10 @@ struct ContentView: View {
                 .tabItem {
                     Label("Listener", systemImage: "waveform.path.ecg")
                 }
+        }
+        .sheet(isPresented: self.$isSubscriberAttributeEditorPresented) {
+            SubscriberAttributeEditor()
+                .presentationDetents([.medium])
         }
         .alert(
             isPresented: Binding(
@@ -156,6 +161,7 @@ struct ContentView: View {
 
             }
             .navigationTitle("Checkpoint Tester")
+            .subscriberAttributeToolbar(isPresented: self.$isSubscriberAttributeEditorPresented)
         }
     }
 
@@ -187,6 +193,7 @@ struct ContentView: View {
                 }
             }
             .navigationTitle("Custom variables")
+            .subscriberAttributeToolbar(isPresented: self.$isSubscriberAttributeEditorPresented)
         }
     }
 
@@ -219,6 +226,23 @@ struct ContentView: View {
                 }
             }
             .navigationTitle("Global Listener")
+            .subscriberAttributeToolbar(isPresented: self.$isSubscriberAttributeEditorPresented)
+        }
+    }
+
+}
+
+private extension View {
+
+    func subscriberAttributeToolbar(isPresented: Binding<Bool>) -> some View {
+        self.toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    isPresented.wrappedValue = true
+                } label: {
+                    Label("Set subscriber attribute", systemImage: "person.crop.circle.badge.plus")
+                }
+            }
         }
     }
 

--- a/Examples/CheckpointTester/CheckpointTester/Sources/SubscriberAttributeEditor.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/SubscriberAttributeEditor.swift
@@ -41,12 +41,6 @@ struct SubscriberAttributeEditor: View {
             .navigationTitle("Subscriber attribute")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") {
-                        self.dismiss()
-                    }
-                }
-
                 ToolbarItemGroup(placement: .confirmationAction) {
                     Button("Unset", role: .destructive) {
                         self.updateAttribute(value: "")

--- a/Examples/CheckpointTester/CheckpointTester/Sources/SubscriberAttributeEditor.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/SubscriberAttributeEditor.swift
@@ -1,0 +1,78 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SubscriberAttributeEditor.swift
+//
+//  Created by Rick van der Linden.
+//
+
+import RevenueCat
+import SwiftUI
+
+struct SubscriberAttributeEditor: View {
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var key = ""
+    @State private var value = ""
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField("Attribute key", text: self.$key)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                    TextField("Attribute value", text: self.$value)
+                        .textInputAutocapitalization(.never)
+                } footer: {
+                    Text(
+                        "Subscriber attributes are part of checkpoint rule evaluation. " +
+                        "Changing one here can change which rule matches on the next checkpoint."
+                    )
+                }
+            }
+            .navigationTitle("Subscriber attribute")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        self.dismiss()
+                    }
+                }
+
+                ToolbarItemGroup(placement: .confirmationAction) {
+                    Button("Unset", role: .destructive) {
+                        self.updateAttribute(value: "")
+                    }
+                    .disabled(!self.hasKey)
+
+                    Button("Set") {
+                        self.updateAttribute(value: self.value)
+                    }
+                    .disabled(!self.hasKey)
+                }
+            }
+        }
+    }
+
+    private var trimmedKey: String {
+        return self.key.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var hasKey: Bool {
+        return !self.trimmedKey.isEmpty
+    }
+
+    private func updateAttribute(value: String) {
+        Purchases.shared.attribution.setAttributes([self.trimmedKey: value])
+        self.dismiss()
+    }
+
+}

--- a/Examples/CheckpointTester/README.md
+++ b/Examples/CheckpointTester/README.md
@@ -10,7 +10,12 @@ The app demonstrates how application behavior can respond to checkpoint results:
 - completing an onboarding flow regardless of the checkpoint result;
 - skipping a checkpoint when `CustomerInfo` already contains an active entitlement;
 - exercising deterministic no-action and error results;
+- setting or unsetting subscriber attributes used by checkpoint rules;
 - editing custom checkpoint properties and displaying a live analytics event log.
+
+Use the person button in any tab's navigation bar to set or unset one subscriber attribute. The attributes are
+part of the checkpoint rule evaluation scope, so this can change which rule matches without rebuilding the app.
+Unsetting passes an empty string, which is how the iOS SDK deletes an attribute.
 
 The generated app shares PaywallsTester's bundle identifier and `Products.storekit` configuration so it can use
 the same local in-app purchase products and RevenueCat project.


### PR DESCRIPTION
## Description
Allows setting and unsetting subscriber attributes from the CheckpointTester app, allowing them to be tested in Checkpoint rule evaluation.

<img width="402" height="874" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-24 at 17 03 20" src="https://github.com/user-attachments/assets/6ec2c2ec-c92e-45d9-927d-e4daf1534551" />

Android counterpart: https://github.com/RevenueCat/purchases-android/pull/4046

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app UI only; uses the existing public attribution API and does not change SDK or production behavior.
> 
> **Overview**
> Adds a way to set or unset a subscriber attribute from CheckpointTester so checkpoint rules that depend on attributes can be exercised without rebuilding.
> 
> A person-button in every tab opens a medium sheet to enter a key/value. **Set** writes via `Purchases.shared.attribution.setAttributes`; **Unset** sends an empty string (SDK delete). README documents the flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f40f931484bd95399d786eca3c9084eee7ed7f7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->