### PR TITLE
Remove `@objc` from the new `confirmIn` purchase params

### DIFF
--- a/Sources/Purchasing/Purchases/PurchaseParams.swift
+++ b/Sources/Purchasing/Purchases/PurchaseParams.swift
@@ -166,6 +166,11 @@ import AppKit
          *
          * Availability: iOS 17.0+, macCatalyst 17.0+, tvOS 17.0+, visionOS 1.0+
          */
+        // Note: This API is intentionally not marked as @objc, because it takes in a platform-specific
+        // parameter. If we mark this as @objc, then the auto-generated RevenueCat-Swift.h file will contain
+        // references to platform-specific APIs and will not be able to build on all platforms.
+        //
+        // In this case, UIScene is unavailable on native macOS.
         @available(iOS 17.0, macCatalyst 17.0, tvOS 17.0, visionOS 1.0, *)
         public func with(confirmInScene: UIScene) -> Self {
             self.storeKit2ConfirmInOptions = StoreKit2ConfirmInOptions(confirmInScene: confirmInScene)
@@ -182,6 +187,11 @@ import AppKit
          *
          * Availability: macOS 15.2+
          */
+        // Note: This API is intentionally not marked as @objc, because it takes in a platform-specific
+        // parameter. If we mark this as @objc, then the auto-generated RevenueCat-Swift.h file will contain
+        // references to platform-specific APIs and will not be able to build on all platforms.
+        //
+        // In this case, NSWindow is unavailable on iOS/visionOS/watchOS.
         @available(macOS 15.2, *)
         public func with(confirmInWindow: NSWindow) -> Self {
             self.storeKit2ConfirmInOptions = StoreKit2ConfirmInOptions(confirmInWindow: confirmInWindow)

--- a/Sources/Purchasing/Purchases/PurchaseParams.swift
+++ b/Sources/Purchasing/Purchases/PurchaseParams.swift
@@ -158,6 +158,11 @@ import AppKit
         #endif
 
         #if canImport(UIKit) && !os(watchOS)
+        // Note: This API is intentionally not marked as @objc, because it takes in a platform-specific
+        // parameter. If we mark this as @objc, then the auto-generated RevenueCat-Swift.h file will contain
+        // references to platform-specific APIs and will not be able to build on all platforms.
+        //
+        // In this case, UIScene is unavailable on native macOS.
         /**
          * Set `confirmInScene`.
          *
@@ -166,11 +171,6 @@ import AppKit
          *
          * Availability: iOS 17.0+, macCatalyst 17.0+, tvOS 17.0+, visionOS 1.0+
          */
-        // Note: This API is intentionally not marked as @objc, because it takes in a platform-specific
-        // parameter. If we mark this as @objc, then the auto-generated RevenueCat-Swift.h file will contain
-        // references to platform-specific APIs and will not be able to build on all platforms.
-        //
-        // In this case, UIScene is unavailable on native macOS.
         @available(iOS 17.0, macCatalyst 17.0, tvOS 17.0, visionOS 1.0, *)
         public func with(confirmInScene: UIScene) -> Self {
             self.storeKit2ConfirmInOptions = StoreKit2ConfirmInOptions(confirmInScene: confirmInScene)
@@ -179,6 +179,11 @@ import AppKit
         #endif
 
         #if canImport(AppKit) && !targetEnvironment(macCatalyst)
+        // Note: This API is intentionally not marked as @objc, because it takes in a platform-specific
+        // parameter. If we mark this as @objc, then the auto-generated RevenueCat-Swift.h file will contain
+        // references to platform-specific APIs and will not be able to build on all platforms.
+        //
+        // In this case, NSWindow is unavailable on iOS/visionOS/watchOS.
         /**
          * Set `confirmInWindow`.
          *
@@ -187,11 +192,6 @@ import AppKit
          *
          * Availability: macOS 15.2+
          */
-        // Note: This API is intentionally not marked as @objc, because it takes in a platform-specific
-        // parameter. If we mark this as @objc, then the auto-generated RevenueCat-Swift.h file will contain
-        // references to platform-specific APIs and will not be able to build on all platforms.
-        //
-        // In this case, NSWindow is unavailable on iOS/visionOS/watchOS.
         @available(macOS 15.2, *)
         public func with(confirmInWindow: NSWindow) -> Self {
             self.storeKit2ConfirmInOptions = StoreKit2ConfirmInOptions(confirmInWindow: confirmInWindow)

--- a/Sources/Purchasing/Purchases/PurchaseParams.swift
+++ b/Sources/Purchasing/Purchases/PurchaseParams.swift
@@ -167,7 +167,7 @@ import AppKit
          * Availability: iOS 17.0+, macCatalyst 17.0+, tvOS 17.0+, visionOS 1.0+
          */
         @available(iOS 17.0, macCatalyst 17.0, tvOS 17.0, visionOS 1.0, *)
-        @objc public func with(confirmInScene: UIScene) -> Self {
+        public func with(confirmInScene: UIScene) -> Self {
             self.storeKit2ConfirmInOptions = StoreKit2ConfirmInOptions(confirmInScene: confirmInScene)
             return self
         }
@@ -183,7 +183,7 @@ import AppKit
          * Availability: macOS 15.2+
          */
         @available(macOS 15.2, *)
-        @objc public func with(confirmInWindow: NSWindow) -> Self {
+        public func with(confirmInWindow: NSWindow) -> Self {
             self.storeKit2ConfirmInOptions = StoreKit2ConfirmInOptions(confirmInWindow: confirmInWindow)
             return self
         }

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCPurchasesAPI.m
@@ -191,24 +191,6 @@ NSURL *url;
         }];
     }
 
-    #if __has_include(<UIKit/UIKit.h>)
-    if (@available(iOS 17.0, iOSApplicationExtension 17.0, macCatalyst 17.0, tvOS 17.0, *)) {
-        UIScene *scene;
-        RCPurchaseParams *paramsWithUIScene = [[[[RCPurchaseParamsBuilder alloc] initWithProduct:storeProduct]
-                                                withConfirmInScene:scene]
-                                               build];
-    }
-    #endif
-
-    #if __has_include(<AppKit/AppKit.h>)
-    if (@available(macOS 15.2, *)) {
-        NSWindow *window;
-        RCPurchaseParams *paramsWithNSWindow = [[[[RCPurchaseParamsBuilder alloc] initWithProduct:storeProduct]
-                                                 withConfirmInWindow:window]
-                                               build];
-    }
-    #endif
-
     [p purchaseWithParams:productParams completion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *error, BOOL userCancelled) { }];
     [p purchaseWithParams:packageParams completion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *error, BOOL userCancelled) { }];
     #endif

--- a/api/revenuecat-api-ios-simulator.swiftinterface
+++ b/api/revenuecat-api-ios-simulator.swiftinterface
@@ -2066,7 +2066,7 @@ extension RevenueCat.Attribution : @unchecked Swift.Sendable {
     @objc public func with(promotionalOffer: RevenueCat.PromotionalOffer) -> Self
     @objc public func with(quantity: Swift.Int) -> Self
     @available(iOS 17.0, macCatalyst 17.0, tvOS 17.0, visionOS 1.0, *)
-    @objc public func with(confirmInScene: UIKit.UIScene) -> Self
+    public func with(confirmInScene: UIKit.UIScene) -> Self
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @objc public func with(winBackOffer: RevenueCat.WinBackOffer) -> Self
     @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)

--- a/api/revenuecat-api-ios.swiftinterface
+++ b/api/revenuecat-api-ios.swiftinterface
@@ -2066,7 +2066,7 @@ extension RevenueCat.Attribution : @unchecked Swift.Sendable {
     @objc public func with(promotionalOffer: RevenueCat.PromotionalOffer) -> Self
     @objc public func with(quantity: Swift.Int) -> Self
     @available(iOS 17.0, macCatalyst 17.0, tvOS 17.0, visionOS 1.0, *)
-    @objc public func with(confirmInScene: UIKit.UIScene) -> Self
+    public func with(confirmInScene: UIKit.UIScene) -> Self
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @objc public func with(winBackOffer: RevenueCat.WinBackOffer) -> Self
     @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)

--- a/api/revenuecat-api-macos.swiftinterface
+++ b/api/revenuecat-api-macos.swiftinterface
@@ -2033,7 +2033,7 @@ extension RevenueCat.Attribution : @unchecked Swift.Sendable {
     @objc public func with(promotionalOffer: RevenueCat.PromotionalOffer) -> Self
     @objc public func with(quantity: Swift.Int) -> Self
     @available(macOS 15.2, *)
-    @objc public func with(confirmInWindow: AppKit.NSWindow) -> Self
+    public func with(confirmInWindow: AppKit.NSWindow) -> Self
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @objc public func with(winBackOffer: RevenueCat.WinBackOffer) -> Self
     @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)

--- a/api/revenuecat-api-tvos-simulator.swiftinterface
+++ b/api/revenuecat-api-tvos-simulator.swiftinterface
@@ -2033,7 +2033,7 @@ extension RevenueCat.Attribution : @unchecked Swift.Sendable {
     @objc public func with(promotionalOffer: RevenueCat.PromotionalOffer) -> Self
     @objc public func with(quantity: Swift.Int) -> Self
     @available(iOS 17.0, macCatalyst 17.0, tvOS 17.0, visionOS 1.0, *)
-    @objc public func with(confirmInScene: UIKit.UIScene) -> Self
+    public func with(confirmInScene: UIKit.UIScene) -> Self
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @objc public func with(winBackOffer: RevenueCat.WinBackOffer) -> Self
     @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)

--- a/api/revenuecat-api-tvos.swiftinterface
+++ b/api/revenuecat-api-tvos.swiftinterface
@@ -2033,7 +2033,7 @@ extension RevenueCat.Attribution : @unchecked Swift.Sendable {
     @objc public func with(promotionalOffer: RevenueCat.PromotionalOffer) -> Self
     @objc public func with(quantity: Swift.Int) -> Self
     @available(iOS 17.0, macCatalyst 17.0, tvOS 17.0, visionOS 1.0, *)
-    @objc public func with(confirmInScene: UIKit.UIScene) -> Self
+    public func with(confirmInScene: UIKit.UIScene) -> Self
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @objc public func with(winBackOffer: RevenueCat.WinBackOffer) -> Self
     @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)

--- a/api/revenuecat-api-visionos-simulator.swiftinterface
+++ b/api/revenuecat-api-visionos-simulator.swiftinterface
@@ -2066,7 +2066,7 @@ extension RevenueCat.Attribution : @unchecked Swift.Sendable {
     @objc public func with(promotionalOffer: RevenueCat.PromotionalOffer) -> Self
     @objc public func with(quantity: Swift.Int) -> Self
     @available(iOS 17.0, macCatalyst 17.0, tvOS 17.0, visionOS 1.0, *)
-    @objc public func with(confirmInScene: UIKit.UIScene) -> Self
+    public func with(confirmInScene: UIKit.UIScene) -> Self
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @objc public func with(winBackOffer: RevenueCat.WinBackOffer) -> Self
     @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)

--- a/api/revenuecat-api-visionos.swiftinterface
+++ b/api/revenuecat-api-visionos.swiftinterface
@@ -2066,7 +2066,7 @@ extension RevenueCat.Attribution : @unchecked Swift.Sendable {
     @objc public func with(promotionalOffer: RevenueCat.PromotionalOffer) -> Self
     @objc public func with(quantity: Swift.Int) -> Self
     @available(iOS 17.0, macCatalyst 17.0, tvOS 17.0, visionOS 1.0, *)
-    @objc public func with(confirmInScene: UIKit.UIScene) -> Self
+    public func with(confirmInScene: UIKit.UIScene) -> Self
     @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     @objc public func with(winBackOffer: RevenueCat.WinBackOffer) -> Self
     @available(iOS 15.0, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4, *)


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

The SPM installation test fails on Mac Catalyst for the 5.86.0 release. #4779 added the first `@objc` API with a platform-specific parameter type, so the `RevenueCat-Swift.h` snapshot regenerated at release time now declares `withConfirmInWindow:(NSWindow *)` — unavailable on Mac Catalyst, which fails the bridging header PCH.

### Description

Both setters remain available from Swift. They have not shipped in any release, so no Objective-C API is lost.

Verified by regenerating the header with the release lane's `xcodebuild` invocation and compiling it for `arm64-apple-ios-macabi`: it fails with the current snapshot and is clean with this change.

The `release/5.86.0` branch needs its header regenerated once this lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Swift-only API change for methods that had not shipped in a release; fixes build compatibility without altering purchase runtime logic.
> 
> **Overview**
> Removes **`@objc`** from `PurchaseParams.Builder.with(confirmInScene:)` and `with(confirmInWindow:)` so those platform-specific types (`UIScene`, `NSWindow`) are not emitted into the auto-generated **`RevenueCat-Swift.h`**, which was breaking Mac Catalyst / cross-platform bridging header builds (e.g. SPM install tests on 5.86.0).
> 
> The setters stay available from **Swift** only; comments in `PurchaseParams.swift` document the intentional exclusion from the Obj-C surface. The Objective-C API tester drops coverage for the removed builder methods, and the checked **`api/*.swiftinterface`** snapshots match the new signatures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ed9d17435d1a8d05bac3485839176c5b0e07b68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->