### PR TITLE
Refresh two rules engine doc comments that outlived their examples

### DIFF
--- a/Sources/LocalRules/DimensionProvider.swift
+++ b/Sources/LocalRules/DimensionProvider.swift
@@ -50,7 +50,8 @@ enum DimensionValue: Equatable, Sendable {
     ///
     /// Records are only expressible inside a collection. Collection operators
     /// evaluate each record in its own scope, so a record must contain every
-    /// value needed to evaluate it.
+    /// value needed to evaluate it, unless the predicate reaches the snapshot
+    /// with `rc.rootVar`.
     case objectList([[String: DimensionValue]])
 }
 

--- a/Sources/RulesEngine/CustomOperators/LengthOperator.swift
+++ b/Sources/RulesEngine/CustomOperators/LengthOperator.swift
@@ -22,8 +22,8 @@ extension RulesEngine {
         /// - **Anything else**: throws `EvaluationError.typeMismatch`.
         ///
         /// Non-string/non-array inputs throw rather than defaulting to `0`.
-        /// A silent zero would make `{"==": [{"rc.length": {"var": "missing"}},
-        /// 0]}` quietly true when a key is absent.
+        /// A silent zero would make `{"==": [{"rc.length": {"var": "note"}},
+        /// 0]}` quietly true for a key that is present but holds `null`.
         ///
         /// Uses `Operators.firstArgEvaluated` spread semantics; extra arguments
         /// are silently ignored. Literal array operands must be wrapped


### PR DESCRIPTION
### Motivation

There were some doc comments still describing an absent variable as null.

### Description

- `rc.length` justifies throwing with `{"var": "missing"}`, which can no longer reach the operator since #7460 made the lookup raise first. Restated against a key that is present but holds `null`, matching what `rc.lower` already says.
- `DimensionValue.objectList` tells providers a record must carry everything a predicate about it needs, which predates `rc.rootVar` (#7432).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes with no runtime or API behavior impact.
> 
> **Overview**
> **Documentation-only** refresh for two rules-engine comments that no longer matched how lookups and collection scopes work.
> 
> `DimensionValue.objectList` now notes that each record does not need to carry every value when a predicate can read the evaluation snapshot via **`rc.rootVar`** (post-#7432).
> 
> The **`rc.length`** throw-vs-zero rationale swaps the example from a missing key (`{"var": "missing"}`) to a present key with **`null`**, since absent variables fail at lookup before the operator runs (#7460)—consistent with **`rc.lower`**’s wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78faa3b7b990a9b7546fcd83e0efbde7444449d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->