### PR TITLE
feat(checkpoints): add transformations remote config provider

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1554,6 +1554,7 @@
 		A7D100000000000000000002 /* AudiencesConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D100000000000000000001 /* AudiencesConfigProvider.swift */; };
 		A7D200000000000000000002 /* Audience.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D200000000000000000001 /* Audience.swift */; };
 		A7D200000000000000000004 /* AudienceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D200000000000000000003 /* AudienceTests.swift */; };
+		A7D300000000000000000002 /* TransformationsConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D300000000000000000001 /* TransformationsConfigProvider.swift */; };
 		FEDA000000000000000000E1 /* MockRemoteConfigSourceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA000000000000000000E0 /* MockRemoteConfigSourceProvider.swift */; };
 		FEDA000000000000000000E2 /* MockRemoteConfigSourceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA000000000000000000E0 /* MockRemoteConfigSourceProvider.swift */; };
 		FEDA0000000000000000F0A2 /* GetRemoteConfigFallbackOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA0000000000000000F0A1 /* GetRemoteConfigFallbackOperation.swift */; };
@@ -3339,6 +3340,7 @@
 		A7D100000000000000000001 /* AudiencesConfigProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiencesConfigProvider.swift; sourceTree = "<group>"; };
 		A7D200000000000000000001 /* Audience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Audience.swift; sourceTree = "<group>"; };
 		A7D200000000000000000003 /* AudienceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudienceTests.swift; sourceTree = "<group>"; };
+		A7D300000000000000000001 /* TransformationsConfigProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransformationsConfigProvider.swift; sourceTree = "<group>"; };
 		FEDA000000000000000000E0 /* MockRemoteConfigSourceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRemoteConfigSourceProvider.swift; sourceTree = "<group>"; };
 		FEDA0000000000000000F0A1 /* GetRemoteConfigFallbackOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetRemoteConfigFallbackOperation.swift; sourceTree = "<group>"; };
 		FFB683A085B695768EAB9AA5 /* WorkflowsConfigProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowsConfigProviderTests.swift; sourceTree = "<group>"; };
@@ -5036,6 +5038,7 @@
 				FEDA000000000000000000C4 /* CheckpointsConfigProvider.swift */,
 				A7D200000000000000000001 /* Audience.swift */,
 				A7D100000000000000000001 /* AudiencesConfigProvider.swift */,
+				A7D300000000000000000001 /* TransformationsConfigProvider.swift */,
 				A1B2C3D42FE7000000000001 /* RemoteConfigTopic.swift */,
 				A1B2C3D42FE1000000000011 /* RemoteConfigSignatureContextProvider.swift */,
 			);
@@ -7731,6 +7734,7 @@
 				FEDA000000000000000000D4 /* CheckpointsConfigProvider.swift in Sources */,
 				A7D200000000000000000002 /* Audience.swift in Sources */,
 				A7D100000000000000000002 /* AudiencesConfigProvider.swift in Sources */,
+				A7D300000000000000000002 /* TransformationsConfigProvider.swift in Sources */,
 				A1B2C3D42FE2000000000006 /* RemoteConfigStrings.swift in Sources */,
 				A1B2C3D42FE7000000000002 /* RemoteConfigTopic.swift in Sources */,
 				A1B2C3D42FE1000000000010 /* RemoteConfigSignatureContextProvider.swift in Sources */,

--- a/Sources/Networking/RemoteConfigTopic.swift
+++ b/Sources/Networking/RemoteConfigTopic.swift
@@ -18,6 +18,7 @@ enum RemoteConfigTopic: String {
     case sources
     case checkpointRules = "checkpoint_rules"
     case audiences
+    case transformations
 
     var wireName: String {
         return self.rawValue

--- a/Sources/Networking/TransformationsConfigProvider.swift
+++ b/Sources/Networking/TransformationsConfigProvider.swift
@@ -1,0 +1,83 @@
+//
+//  TransformationsConfigProvider.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+
+struct Transformation: Equatable, Sendable {
+
+    let identifier: String
+    /// The JSON Logic rule, kept as a JSON string because that is what `RulesEngine.transform` takes.
+    let rule: String
+
+}
+
+protocol TransformationsConfigProviderType {
+
+    func getTransformation(_ identifier: String) async -> Transformation?
+
+}
+
+/// The topic-specific front door for transformations, reading through `RemoteConfigManager`'s
+/// `transformations` topic.
+final class TransformationsConfigProvider: TransformationsConfigProviderType {
+
+    private let manager: RemoteConfigManagerType
+
+    init(manager: RemoteConfigManagerType) {
+        self.manager = manager
+    }
+
+    /// Reads a transformation from inline topic metadata. A malformed transformation is dropped independently,
+    /// so it does not prevent other transformations from being read.
+    func getTransformation(_ identifier: String) async -> Transformation? {
+        guard let content = await self.manager.topic(.transformations)?[identifier]?.content,
+              !content.isEmpty else {
+            return nil
+        }
+
+        do {
+            let data = try JSONSerialization.data(withJSONObject: content.mapValues(\.asAny))
+            let payload = try JSONDecoder.default.decode(TransformationPayload.self, from: data)
+
+            return Transformation(identifier: identifier, rule: payload.rule)
+        } catch {
+            Logger.error(Strings.codable.decoding_error(error, Transformation.self))
+            return nil
+        }
+    }
+
+}
+
+extension TransformationsConfigProvider: @unchecked Sendable {}
+
+private struct TransformationPayload: Decodable {
+
+    let rule: String
+
+    private enum CodingKeys: String, CodingKey {
+        case rule
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let rule = try container.decode([String: AnyDecodable].self, forKey: .rule)
+
+        guard let data = try? JSONSerialization.data(
+            withJSONObject: rule.mapValues(\.asAny),
+            options: [.sortedKeys]
+        ), let serialized = String(bytes: data, encoding: .utf8) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .rule,
+                in: container,
+                debugDescription: "'rule' could not be re-serialized for the rules engine"
+            )
+        }
+
+        self.rule = serialized
+    }
+
+}

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
@@ -215,6 +215,128 @@ final class RemoteConfigIntegrationTests: TestCase {
         expect(audience).to(beNil())
     }
 
+    func testTransformationsTopicWireNameMatchesBackend() {
+        expect(RemoteConfigTopic.transformations.wireName) == "transformations"
+    }
+
+    func testTransformationsProviderDecodesInlineMetadata() async throws {
+        let container = try Self.containerData(topics: .init(entries: [
+            RemoteConfigTopic.transformations.wireName: [
+                "active_entitlement": .init(content: [
+                    "created_via": "dashboard",
+                    "rule": .object([
+                        "values": .array([.bool(true), .int(1), .double(1.5), .null, .string("value")]),
+                        "missing_some": .array([
+                            .int(1),
+                            .array([.string("customer.custom_value")])
+                        ])
+                    ])
+                ])
+            ]
+        ]))
+
+        await self.refresh(with: container)
+
+        let transformation = await TransformationsConfigProvider(manager: self.manager)
+            .getTransformation("active_entitlement")
+
+        expect(transformation) == Transformation(
+            identifier: "active_entitlement",
+            rule: #"{"missing_some":[1,["customer.custom_value"]],"values":[true,1,1.5,null,"value"]}"#
+        )
+    }
+
+    func testTransformationsProviderReturnsNilForMissingEntries() async throws {
+        let container = try Self.containerData(topics: .init(entries: [
+            RemoteConfigTopic.transformations.wireName: [
+                "empty": .init(),
+                "missing_rule": .init(content: ["created_via": "dashboard"])
+            ]
+        ]))
+
+        await self.refresh(with: container)
+
+        let provider = TransformationsConfigProvider(manager: self.manager)
+        let unknown = await provider.getTransformation("unknown")
+        let empty = await provider.getTransformation("empty")
+        let missingRule = await provider.getTransformation("missing_rule")
+
+        expect(unknown).to(beNil())
+        expect(empty).to(beNil())
+        expect(missingRule).to(beNil())
+    }
+
+    func testTransformationsProviderReturnsNilWhenTopicIsAbsent() async throws {
+        let container = try Self.containerData(topics: .init())
+
+        await self.refresh(with: container)
+
+        let transformation = await TransformationsConfigProvider(manager: self.manager)
+            .getTransformation("active_entitlement")
+
+        expect(transformation).to(beNil())
+    }
+
+    func testTransformationsProviderRejectsNonObjectRules() async throws {
+        let invalidRules: [String: AnyDecodable] = [
+            "array": .array([]),
+            "boolean": .bool(true),
+            "number": .int(1),
+            "null": .null,
+            "string": .string("rule")
+        ]
+        let items = invalidRules.mapValues { RemoteConfiguration.ConfigItem(content: ["rule": $0]) }
+        let container = try Self.containerData(topics: .init(entries: [
+            RemoteConfigTopic.transformations.wireName: items
+        ]))
+
+        await self.refresh(with: container)
+
+        let provider = TransformationsConfigProvider(manager: self.manager)
+        for identifier in invalidRules.keys {
+            let transformation = await provider.getTransformation(identifier)
+            expect(transformation).to(beNil())
+        }
+    }
+
+    func testTransformationsProviderReturnsNilForBlobOnlyItem() async throws {
+        let payload = #"{ "rule": { "var": "" } }"#.asData
+        let ref = RCContainerTestData.blobRef(for: payload)
+        let container = try Self.containerData(
+            topics: .init(entries: [
+                RemoteConfigTopic.transformations.wireName: [
+                    "active_entitlement": .init(blobRef: ref, prefetch: true)
+                ]
+            ]),
+            contentElements: [(payload, .none)]
+        )
+
+        await self.refresh(with: container)
+
+        let transformation = await TransformationsConfigProvider(manager: self.manager)
+            .getTransformation("active_entitlement")
+
+        expect(transformation).to(beNil())
+    }
+
+    func testTransformationsProviderIsolatesMalformedItems() async throws {
+        let container = try Self.containerData(topics: .init(entries: [
+            RemoteConfigTopic.transformations.wireName: [
+                "invalid": .init(content: ["rule": []]),
+                "valid": .init(content: ["rule": ["var": "customer"]])
+            ]
+        ]))
+
+        await self.refresh(with: container)
+
+        let provider = TransformationsConfigProvider(manager: self.manager)
+        let invalid = await provider.getTransformation("invalid")
+        let valid = await provider.getTransformation("valid")
+
+        expect(invalid).to(beNil())
+        expect(valid) == Transformation(identifier: "valid", rule: #"{"var":"customer"}"#)
+    }
+
     func testUncompressedConfigAndInlineBlobCanBeReadThroughFacade() async throws {
         let blob = #"{"workflow":"inline"}"#.asData
         let ref = RCContainerTestData.blobRef(for: blob)


### PR DESCRIPTION
## Description
Adds the `transformations` config provider, which reads the variable transformation rules that will be used in audience rules (actual implementation will be done in a follow up PR)

## Open questions
- [ ]  Naming, currently it is `TransformationsConfigProvider` and the topic is called `transformations`. We could make this a bit more explicit regarding the rules engine, but I think will quickly become a bit too verbose. Something like `RuleTransformationsConfigProvider` could work though. Happy to hear some thoughts on this as well.
- [ ] I think having this as a separate topic makes sense since they could be used for other rule evaluations that won't necessarily be audiences down the road, although I currently don't have an example case for this just yet.
- [ ] I've currently implemented the transformation rules themselves directly in the topic. Having them be published as (inlined) blobs would probably help with reducing the response size and allows for some more aggressive caching. However I expect these blobs to be relatively small strings, so I'm not sure if having the extra disk IO is worth it. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only remote config plumbing with defensive decoding; no production behavior changes until a follow-up integrates transformations into rule evaluation.
> 
> **Overview**
> Adds a **`transformations`** remote config topic and **`TransformationsConfigProvider`**, which loads JSON Logic transformation rules by identifier from **inline topic metadata** (same general shape as **`AudiencesConfigProvider`**). Each entry decodes to a **`Transformation`** whose **`rule`** is re-serialized to a JSON string for the rules engine; bad entries return **`nil`** without affecting siblings.
> 
> **Blob-only** transformation items are intentionally **not** supported yet (tests expect **`nil`**). Integration tests cover wire name, decoding, missing/invalid payloads, and malformed-item isolation. **No callers** wire this into audience evaluation in this PR—that is planned separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee16c345f7567ee8b0fa0ad66a130f31c7937b32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->