### PR TITLE
Announce public API changes from main only

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2556,8 +2556,7 @@ platform :ios do
 
     # Informational: a GitHub or Slack outage must not decide whether the gate fails.
     begin
-      # Every change reaches main exactly once, so announcing only there keeps the feed to one
-      # post per change rather than one per PR run.
+      # Announcing only from main keeps the feed to one post per change.
       announcement = if on_main
                        notify_api_changes_on_slack(
                          reports_by_target: reports_by_target,
@@ -2586,8 +2585,7 @@ platform :ios do
     end
 
     if ApiDiffHelper.gate_blocked?(all_breaks, labels)
-      # main has no PR to carry the label and the PR run already gated the change, so failing here
-      # would only redden main for something that was already approved.
+      # main has no PR to read the label from, and the PR run already gated the change.
       if on_main
         UI.important("Breaking public API changes on main, already gated on the PR run")
       else
@@ -2659,7 +2657,7 @@ platform :ios do
     bot_token = ENV["SLACK_ACCESS_TOKEN_CIRCLE_CI_NOTIFY_ORB_IOS"]
     channel = ENV["SLACK_CHANNEL_SDK_NEW_API"]
 
-    source = api_gate_pr_link
+    source = api_gate_commit_link
     modules = ApiDiffHelper.changed_modules(options[:reports_by_target])
 
     summary = ApiDiffHelper.slack_summary(
@@ -2716,12 +2714,12 @@ platform :ios do
     comment ? comment["body"].to_s : ""
   end
 
-  private_lane :api_gate_pr_link do
-    # A main run has no PR context, so the squash merge subject is the only link left.
-    pr_number = detect_pr_number || ApiDiffHelper.pr_number_from_subject(sh("git", "log", "-1", "--format=%s", log: false))
-    next "" if pr_number.nil?
+  # The commit page carries the PR link, and its sha is what tells a rerun it already announced.
+  private_lane :api_gate_commit_link do
+    sha = sh("git", "rev-parse", "HEAD", log: false).strip
+    next "" if sha.empty?
 
-    "<https://github.com/RevenueCat/#{REPO_NAME}/pull/#{pr_number}|##{pr_number}>"
+    "<https://github.com/RevenueCat/#{REPO_NAME}/commit/#{sha}|#{sha[0, 7]}>"
   end
 
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2501,17 +2501,19 @@ platform :ios do
     end
 
 
-    # Regenerated baselines make the freshness diff empty, so the gate needs the merge base.
+    # Regenerated baselines make the freshness diff empty, so the gate needs an earlier base.
     runner = ->(*command) { sh(*command, log: false) }
-    merge_base = ApiDiffHelper.resolve_merge_base(runner: runner)
-    UI.message("Comparing against the merge base #{merge_base}")
+    branch = ApiDiffHelper.current_branch(runner: runner)
+    on_main = ApiDiffHelper.main_branch?(branch)
+    comparison_base = ApiDiffHelper.resolve_comparison_base(runner: runner, branch: branch)
+    UI.message("Comparing #{branch} against #{comparison_base}")
 
     breaks_by_scheme = {}
     reports_by_target = {}
 
     schemes.each do |scheme|
-      base_dir = File.join(ApiDiffHelper::MERGE_BASE_SWIFTINTERFACE_DIR, scheme)
-      ApiDiffHelper.extract_baselines_at(merge_base, base_dir, scheme, runner: runner)
+      base_dir = File.join(ApiDiffHelper::BASE_SWIFTINTERFACE_DIR, scheme)
+      ApiDiffHelper.extract_baselines_at(comparison_base, base_dir, scheme, runner: runner)
       prefix = ApiDiffHelper.api_file_prefix(scheme)
       scheme_breaks = []
 
@@ -2554,11 +2556,17 @@ platform :ios do
 
     # Informational: a GitHub or Slack outage must not decide whether the gate fails.
     begin
-      announcement = notify_api_changes_on_slack(
-        reports_by_target: reports_by_target,
-        breaks: all_breaks,
-        labels: labels
-      )
+      # Every change reaches main exactly once, so announcing only there keeps the feed to one
+      # post per change rather than one per PR run.
+      announcement = if on_main
+                       notify_api_changes_on_slack(
+                         reports_by_target: reports_by_target,
+                         breaks: all_breaks,
+                         labels: labels
+                       )
+                     else
+                       { fingerprint: nil, notice: nil }
+                     end
       schemes.each do |scheme|
         upsert_api_diff_comment(
           scheme: scheme,
@@ -2578,7 +2586,13 @@ platform :ios do
     end
 
     if ApiDiffHelper.gate_blocked?(all_breaks, labels)
-      UI.user_error!("Breaking public API changes detected. Add #{ApiDiffHelper::BREAKING_CHANGE_LABEL} if intentional.")
+      # main has no PR to carry the label and the PR run already gated the change, so failing here
+      # would only redden main for something that was already approved.
+      if on_main
+        UI.important("Breaking public API changes on main, already gated on the PR run")
+      else
+        UI.user_error!("Breaking public API changes detected. Add #{ApiDiffHelper::BREAKING_CHANGE_LABEL} if intentional.")
+      end
     end
   end
 
@@ -2703,7 +2717,8 @@ platform :ios do
   end
 
   private_lane :api_gate_pr_link do
-    pr_number = detect_pr_number
+    # A main run has no PR context, so the squash merge subject is the only link left.
+    pr_number = detect_pr_number || ApiDiffHelper.pr_number_from_subject(sh("git", "log", "-1", "--format=%s", log: false))
     next "" if pr_number.nil?
 
     "<https://github.com/RevenueCat/#{REPO_NAME}/pull/#{pr_number}|##{pr_number}>"

--- a/fastlane/api_diff_helper.rb
+++ b/fastlane/api_diff_helper.rb
@@ -312,8 +312,7 @@ module ApiDiffHelper
     runner.call("git", "rev-parse", "--abbrev-ref", "HEAD").to_s.strip
   end
 
-  # On main the merge base is HEAD itself, which compares the commit against itself and reports
-  # nothing. main is where merges land, so HEAD^ is the API the merge replaced.
+  # On main the merge base is HEAD, so HEAD^ is what the merge replaced.
   def resolve_comparison_base(runner:, branch:)
     return resolve_previous_commit(runner: runner) if main_branch?(branch)
 
@@ -333,14 +332,6 @@ module ApiDiffHelper
     raise "Could not resolve the commit before HEAD" if sha.empty?
 
     sha
-  end
-
-  MERGED_PR_SUBJECT = /\(#(\d+)\)\s*\z/.freeze
-
-  # A main run has no PR context, but the squash merge keeps the number in its subject.
-  def pr_number_from_subject(subject)
-    match = MERGED_PR_SUBJECT.match(subject.to_s.strip)
-    match && match[1]
   end
 
   def extract_baselines_at(sha, destination_dir, scheme, runner:)
@@ -779,11 +770,11 @@ module ApiDiffHelper
   def slack_summary(breaks, labels, source:, new_declarations: [], modules: [], modifications: [])
     changed = unbroken_modifications(modifications, breaks)
     headline = if breaks.any?
-                 gate_blocked?(breaks, labels) ? ":warning: *Breaking public API changes*" : ":warning: *Breaking public API changes* (allowed by label)"
+                 gate_blocked?(breaks, labels) ? ":warning: *Breaking public API landed on main*" : ":warning: *Breaking public API landed on main* (allowed by label)"
                elsif new_declarations.any?
-                 ":sparkles: *New public API*"
+                 ":sparkles: *New public API landed on main*"
                else
-                 ":pencil2: *Public API changed*"
+                 ":pencil2: *Public API changed on main*"
                end
     headline = [headline, announcement_identity(modules)].join(" · ")
 

--- a/fastlane/api_diff_helper.rb
+++ b/fastlane/api_diff_helper.rb
@@ -297,7 +297,28 @@ module ApiDiffHelper
     !output.to_s.include?(NO_CHANGES_MARKER)
   end
 
-  MERGE_BASE_SWIFTINTERFACE_DIR = "/tmp/merge-base-swiftinterface".freeze
+  BASE_SWIFTINTERFACE_DIR = "/tmp/comparison-base-swiftinterface".freeze
+
+  MAIN_BRANCH = "main".freeze
+
+  def main_branch?(branch)
+    branch.to_s.strip == MAIN_BRANCH
+  end
+
+  def current_branch(runner:)
+    branch = ENV["CIRCLE_BRANCH"].to_s.strip
+    return branch unless branch.empty?
+
+    runner.call("git", "rev-parse", "--abbrev-ref", "HEAD").to_s.strip
+  end
+
+  # On main the merge base is HEAD itself, which compares the commit against itself and reports
+  # nothing. main is where merges land, so HEAD^ is the API the merge replaced.
+  def resolve_comparison_base(runner:, branch:)
+    return resolve_previous_commit(runner: runner) if main_branch?(branch)
+
+    resolve_merge_base(runner: runner)
+  end
 
   # The PR's own baselines match the generated files once regenerated, erasing the evidence.
   def resolve_merge_base(runner:)
@@ -305,6 +326,21 @@ module ApiDiffHelper
     raise "Could not resolve the merge base with origin/main" if sha.empty?
 
     sha
+  end
+
+  def resolve_previous_commit(runner:)
+    sha = runner.call("git", "rev-parse", "HEAD^").to_s.strip
+    raise "Could not resolve the commit before HEAD" if sha.empty?
+
+    sha
+  end
+
+  MERGED_PR_SUBJECT = /\(#(\d+)\)\s*\z/.freeze
+
+  # A main run has no PR context, but the squash merge keeps the number in its subject.
+  def pr_number_from_subject(subject)
+    match = MERGED_PR_SUBJECT.match(subject.to_s.strip)
+    match && match[1]
   end
 
   def extract_baselines_at(sha, destination_dir, scheme, runner:)

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -455,12 +455,6 @@ class ApiDiffHelperTest < Minitest::Test
     assert_match(/before HEAD/, error.message)
   end
 
-  def test_pr_number_comes_from_the_squash_merge_subject
-    assert_equal "7489", ApiDiffHelper.pr_number_from_subject("Remove unused background.jpg asset (#7489)")
-    assert_nil ApiDiffHelper.pr_number_from_subject("Fix issue #7489 in the parser")
-    assert_nil ApiDiffHelper.pr_number_from_subject("")
-  end
-
   def test_extract_baselines_writes_one_file_per_platform
     Dir.mktmpdir do |dir|
       runner = ->(*command) { "public func fromMergeBase()\n// #{command.last}\n" }
@@ -1385,7 +1379,7 @@ class ApiDiffHelperTest < Minitest::Test
 
     message = ApiDiffHelper.slack_summary(breaks, [], source: "<url|#42> Some PR", new_declarations: ["public func a()"])
 
-    assert message.start_with?(":warning: *Breaking public API changes*")
+    assert message.start_with?(":warning: *Breaking public API landed on main*")
     assert_includes message, "<url|#42> Some PR"
     assert_includes message, "1 potential break"
   end
@@ -1393,7 +1387,7 @@ class ApiDiffHelperTest < Minitest::Test
   def test_slack_summary_leads_with_new_api_when_nothing_breaks
     message = ApiDiffHelper.slack_summary([], [], source: "<url|#42> Some PR", new_declarations: ["public func a()", "public var b: Swift.Int"])
 
-    assert message.start_with?(":sparkles: *New public API*")
+    assert message.start_with?(":sparkles: *New public API landed on main*")
     assert_includes message, "2 new declarations"
   end
 
@@ -1741,7 +1735,7 @@ class ApiDiffHelperTest < Minitest::Test
 
     message = ApiDiffHelper.slack_summary([], [], source: "<url|#7439>", modules: ["RevenueCat"], modifications: modifications)
 
-    assert message.start_with?(":pencil2: *Public API changed* · iOS :ios: · `RevenueCat`")
+    assert message.start_with?(":pencil2: *Public API changed on main* · iOS :ios: · `RevenueCat`")
     assert_includes message, "1 modification"
     assert_includes message, "~ added @available(*, deprecated…): "
     assert_includes message, "purchaseDate(forEntitlement"
@@ -1778,7 +1772,7 @@ class ApiDiffHelperTest < Minitest::Test
       [], [], source: "", new_declarations: ["public func a()"], modules: ["RevenueCat"], modifications: modifications
     )
 
-    assert message.start_with?(":sparkles: *New public API*")
+    assert message.start_with?(":sparkles: *New public API landed on main*")
     assert_includes message, "1 new declaration, 1 modification"
     assert_includes message, "+ public func a()"
     assert_includes message, "~ added @available"
@@ -1787,7 +1781,7 @@ class ApiDiffHelperTest < Minitest::Test
   def test_slack_summary_labels_the_platform_and_modules
     message = ApiDiffHelper.slack_summary([], [], source: "<url|#42>", new_declarations: ["public func a()"], modules: ["RevenueCatUI"])
 
-    assert message.start_with?(":sparkles: *New public API* · iOS :ios: · `RevenueCatUI`")
+    assert message.start_with?(":sparkles: *New public API landed on main* · iOS :ios: · `RevenueCatUI`")
   end
 
   def test_changed_modules_names_only_the_schemes_that_changed
@@ -1886,6 +1880,18 @@ class ApiDiffHelperTest < Minitest::Test
                     "the comment must be written after the announcement it records"
   end
 
+
+  # A rerun of the same main job must not post twice, and last_announcement bails on an empty
+  # source, so the commit link is what keeps the suppression alive.
+  def test_the_announcement_source_is_the_commit
+    lane = File.read(File.expand_path("Fastfile", __dir__))
+    link = lane[/private_lane :api_gate_commit_link do.*?\n  end\n/m]
+
+    refute_nil link, "the api_gate_commit_link lane moved; update this test"
+    assert_match(%r{/commit/}, link, "the message links the commit, not the PR")
+    assert_match(/next "" if sha\.empty\?/, link)
+    refute_match(/detect_pr_number/, lane[/source = api_gate_commit_link/] || "x")
+  end
 
   # The feed was noisy because every PR run posted. Only main does now, so each change lands once.
   def test_slack_is_announced_only_on_main

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -409,6 +409,58 @@ class ApiDiffHelperTest < Minitest::Test
     assert_match(/merge base/, error.message)
   end
 
+  def test_current_branch_prefers_the_ci_variable
+    with_circle_branch("main") do
+      assert_equal "main", ApiDiffHelper.current_branch(runner: ->(*_c) { "detached\n" })
+    end
+  end
+
+  def test_current_branch_falls_back_to_git
+    with_circle_branch(nil) do
+      runner = ->(*command) { command == ["git", "rev-parse", "--abbrev-ref", "HEAD"] ? "my-branch\n" : "" }
+
+      assert_equal "my-branch", ApiDiffHelper.current_branch(runner: runner)
+    end
+  end
+
+  # On main the merge base is HEAD, so reusing it would compare the commit against itself.
+  def test_comparison_base_on_main_is_the_previous_commit
+    runner = lambda do |*command|
+      case command
+      when ["git", "rev-parse", "HEAD^"] then "prevsha\n"
+      when ["git", "merge-base", "origin/main", "HEAD"] then "headsha\n"
+      end
+    end
+
+    assert_equal "prevsha", ApiDiffHelper.resolve_comparison_base(runner: runner, branch: "main")
+  end
+
+  def test_comparison_base_off_main_stays_the_merge_base
+    runner = lambda do |*command|
+      case command
+      when ["git", "rev-parse", "HEAD^"] then "prevsha\n"
+      when ["git", "merge-base", "origin/main", "HEAD"] then "forksha\n"
+      end
+    end
+
+    ["my-branch", "release/5.86.0", "gh-readonly-queue/main/pr-1-abc"].each do |branch|
+      assert_equal "forksha", ApiDiffHelper.resolve_comparison_base(runner: runner, branch: branch)
+    end
+  end
+
+  # A root commit would otherwise diff the whole API in as new.
+  def test_previous_commit_raises_when_empty
+    error = assert_raises(RuntimeError) { ApiDiffHelper.resolve_previous_commit(runner: ->(*_c) { "\n" }) }
+
+    assert_match(/before HEAD/, error.message)
+  end
+
+  def test_pr_number_comes_from_the_squash_merge_subject
+    assert_equal "7489", ApiDiffHelper.pr_number_from_subject("Remove unused background.jpg asset (#7489)")
+    assert_nil ApiDiffHelper.pr_number_from_subject("Fix issue #7489 in the parser")
+    assert_nil ApiDiffHelper.pr_number_from_subject("")
+  end
+
   def test_extract_baselines_writes_one_file_per_platform
     Dir.mktmpdir do |dir|
       runner = ->(*command) { "public func fromMergeBase()\n// #{command.last}\n" }
@@ -1835,7 +1887,38 @@ class ApiDiffHelperTest < Minitest::Test
   end
 
 
+  # The feed was noisy because every PR run posted. Only main does now, so each change lands once.
+  def test_slack_is_announced_only_on_main
+    lane = File.read(File.expand_path("Fastfile", __dir__))
+    announce = lane[/announcement = if on_main.*?\n                     end\n/m]
+
+    refute_nil announce, "the Slack announcement is no longer gated on main; update this test"
+    assert_match(/notify_api_changes_on_slack/, announce)
+    assert_match(/\{ fingerprint: nil, notice: nil \}/, announce,
+                 "a PR run still needs an announcement shape for the comment")
+  end
+
+  # main carries no PR to hold the label, so the gate there would fail changes the PR approved.
+  def test_the_breaking_change_gate_cannot_redden_main
+    lane = File.read(File.expand_path("Fastfile", __dir__))
+    gate = lane[/if ApiDiffHelper\.gate_blocked\?.*?\n    end\n/m]
+
+    refute_nil gate, "the gate section of check_api_changes moved; update this test"
+    assert_match(/if on_main/, gate, "main must not fail the gate")
+    assert_operator gate.index("if on_main"), :<, gate.index("UI.user_error!"),
+                    "the main branch of the gate must come before the failure"
+  end
+
+
   # --- Attribute additions: allowlist, not denylist ---
+
+  def with_circle_branch(value)
+    previous = ENV["CIRCLE_BRANCH"]
+    ENV["CIRCLE_BRANCH"] = value
+    yield
+  ensure
+    ENV["CIRCLE_BRANCH"] = previous
+  end
 
   def modification_adding(attribute)
     "// From\npublic func f()\n\n// To\npublic func f()\n\n/**\nChanges:\n- Added attribute `#{attribute}`\n*/"


### PR DESCRIPTION
### Motivation

`#feed-sdk-new-api` is noisy: every PR run gets posted so a single change shows up in the feed once per push. Posting from main instead means each change lands there once, when it's actually about to get shipped.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: #7500
- Branch: `facu/api-diff-slack-main-only`
- Author / human owner: facumenzella
- Agent(s): Claude Code, Opus 5 (1M context)
- Session source: current conversation
- Generated: 2026-08-25
- Context document version: 2

## Goal

Stop `#feed-sdk-new-api` from being spammed by per-PR-run announcements, without weakening the PR-time public API checks.

## Initial Prompt

"we're posting api changes on #feed-sdk-new-api but it's noisy. Can you make this only run on main? Whenever something gets merged"

(The session opened with a separate question about whether the API check should be skipped when a PR is behind its base branch. Answer: no, the gate is already merge-base anchored, so staleness cannot produce false positives. No change came out of that thread.)

## Important Follow-up Prompts

- "Can you make it run on main, comparing the current commit with the previous commit files?" — confirmed `HEAD^` as the base on main.
- "don't run it on PRs anymore, just on main", then "i don't want to drop the whole check. i just want to drop the slack message on PRs, only on main" — scoped the change to the Slack post. The whole `check-api-changes` job stays on PRs.
- "pr_labels_for_api_gate still should work on PRs" / "pr:breaking-api for example should still be a thing on prs" — confirmed the gate is untouched on PR runs; only the main branch of it logs instead of failing.
- "we don't need the merged PR number anymore… we just post a message saying new api just landed on main", then "and a link to the commit" — replaced the PR link with a commit link and reworded the headline.
- Feedback that the comment above `resolve_comparison_base` was too verbose; the comments added in this branch were trimmed to one line each.

## Agent Contribution

- Traced the existing wiring: `check-api-changes-*` already runs in both the PR workflow and `release-or-main` (`.circleci/default_config.yml:2309`, `:2757`), so no CircleCI change was needed.
- Identified that gating Slack on main alone would have silenced the feed entirely, because the merge base on main is HEAD.
- Identified that `last_announcement` bails on an empty `source`, so dropping the link outright would have silently disabled duplicate suppression.
- Implemented the branch-aware base, the main-only announcement, the main-side gate exemption and the commit link.
- Wrote 8 tests, captured RED against the pre-change implementation before GREEN.

## Human Decisions

- Decision: keep the full `check-api-changes` job on PRs. The agent offered dropping it entirely as an option; rejected.
- Decision: base the main-side comparison on the previous commit.
- Decision: the Slack message links the commit, not the PR. The commit page already carries the PR link.
- Decision: the message should say the change landed on main.

## Key Implementation Decisions

- Decision: `HEAD^` as the comparison base on main, merge base everywhere else.
  - Rationale: the merge base on main is HEAD, so the diff would always be empty.
  - Rejected: comparing against `origin/main`'s tip on PRs. That is what the merge base already avoids, and it would reintroduce false positives on stale branches.
- Decision: skip the breaking-change gate on main only.
  - Rationale: `pr_labels_for_api_gate` returns `[]` without PR context, so once main had a real diff, every intentional `pr:breaking-api` change would have turned main red. PR runs are unchanged and still fail.
  - Rejected: reading the label off the merged PR on main. More moving parts for a gate the PR run already enforced.
- Decision: `source` is the commit link.
  - Rationale: it satisfies the "link the commit" ask and keeps duplicate suppression alive, since `last_announcement` returns nil on an empty source. The sha is a better dedup key than the PR link, it is unique per merge.
  - Rejected: parsing the PR number out of the squash merge subject (implemented first, then removed), and dropping the source entirely.

## Files / Symbols Touched

- `fastlane/api_diff_helper.rb`
  - Why: branch-aware base resolution and the reworded headline.
  - Symbols: `resolve_comparison_base`, `resolve_previous_commit`, `current_branch`, `main_branch?`, `slack_summary`, `BASE_SWIFTINTERFACE_DIR` (renamed from `MERGE_BASE_SWIFTINTERFACE_DIR`)
  - Review relevance: whether `HEAD^` is the right base on main, and whether `CIRCLE_BRANCH` is reliable there.
- `fastlane/Fastfile`
  - Why: gate the announcement and the failure on `on_main`, link the commit.
  - Symbols: `check_api_changes`, `api_gate_commit_link` (replaces `api_gate_pr_link`)
  - Review relevance: the `announcement = if on_main` branch returns `{ fingerprint: nil, notice: nil }` so the PR comment keeps its shape.
- `fastlane/api_diff_helper_test.rb`
  - Why: cover the new behavior.
  - Symbols: `test_comparison_base_on_main_is_the_previous_commit`, `test_comparison_base_off_main_stays_the_merge_base`, `test_slack_is_announced_only_on_main`, `test_the_breaking_change_gate_cannot_redden_main`, `test_the_announcement_source_is_the_commit`, and 3 others.

## Dependencies / Config / Migrations

- None. No CircleCI config change, the job already runs on main.

## Validation

- Commands run:
  - `ruby fastlane/api_diff_helper_test.rb` against the pre-change implementation: 146 runs, 3 failures, 5 errors (RED)
  - `ruby fastlane/api_diff_helper_test.rb` after: 146 runs, 497 assertions, 0 failures, 0 errors (GREEN)
  - `ruby -c fastlane/Fastfile`, `ruby -c fastlane/api_diff_helper.rb`: Syntax OK
- Manual verification:
  - Rendered a sample `slack_summary` locally to check the message shape.
  - main is linear squash merges, confirmed on the last 8 commits of `origin/main`.
  - No shallow-clone config in `.circleci/default_config.yml`, so `HEAD^` resolves under `checkout`.
- CI:
  - `Not captured` at time of writing.

## Validation Gaps

- The lane cannot run outside fastlane, so the main-only announcement, the commit link and the gate exemption are pinned by structural tests that read the `Fastfile`, not by executing it. First real proof is the first main run after merge.
- Never exercised against a real main build. If `CIRCLE_BRANCH` is not `main` there, the feed goes silent rather than noisy, which fails safe but silently.

## Review Focus

- Is `CIRCLE_BRANCH` reliably `main` on `release-or-main` runs? The whole change hangs on it.
- The invariant behind `HEAD^`: does anything merge to main without the swiftinterface baselines regenerated? If so the main-side diff attributes the drift to the wrong commit.
- `release/*` also runs `release-or-main` and now announces nothing. Intended?
- Is dropping the gate's failure on main acceptable, or should main still fail loudly?

## Risks / Reviewer Notes

- Risk: a commit lands on main with stale `api/*.swiftinterface`, so `HEAD^` vs `HEAD` misattributes the drift.
  - Evidence: the first half of `check_api_changes` fails any PR whose committed baselines don't match its build, so this requires the check to be bypassed.
  - Mitigation: none added, the existing PR-time freshness check is the guardrail.
- Risk: the feed goes quiet and nobody notices.
  - Evidence: no alerting on absence of posts.
  - Mitigation: `Not run`. Worth a manual check on the first merge after this lands.

## Non-goals / Out of Scope

- Removing `check-api-changes` from PR runs. Explicitly rejected by the author.
- Any change to the merge-base behavior, the inline PR comment, or the `pr:breaking-api` gate on PRs.
- `api_slack_unreachable_notice` / `slack_credentials_reachable?` / `SLACK_UNREACHABLE_NOTICE` are now near-dead, they only render in a PR comment and PRs no longer announce. Left in place to keep the diff tight, flagged as a follow-up.

## Omitted Context

- Raw transcript, unrelated exploration, sensitive details, repetitive attempts, and chain-of-thought-style content were omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior depends on `CIRCLE_BRANCH` being `main` on post-merge CI and on `HEAD^` being the right baseline for squash merges; mis-detection silences Slack or misattributes API drift without failing main on intentional breaks.
> 
> **Overview**
> **#feed-sdk-new-api** posts only when `check_api_changes` runs on **main**, so each merge gets one Slack message instead of one per PR push. PR runs still diff baselines, update GitHub comments, and enforce **`pr:breaking-api`**; they skip Slack and return a stub announcement shape for the comment flow.
> 
> On **main**, the public-API gate compares **`HEAD` vs `HEAD^`** (merge base would be empty). Off main it still uses the merge base with **`origin/main`**. Slack copy says changes **landed on main**, and the link is the **commit** (not the PR) for dedup on reruns. **Breaking-change failures are downgraded to a log on main** because there is no PR label context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 023e05b186d1d058baa294da0d67193924953e0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->