### PR TITLE
Name dropping build metadata unvalidated as a semver concession

### DIFF
--- a/Sources/RulesEngine/CustomOperators/SemverOperator.swift
+++ b/Sources/RulesEngine/CustomOperators/SemverOperator.swift
@@ -48,9 +48,10 @@ extension RulesEngine {
 /// identifiers (empty for a release version). Build metadata is dropped, since
 /// semver §10 excludes it from precedence.
 ///
-/// Two deliberate concessions to real-world version strings: a missing minor or
-/// patch is `0` (`"2.1"` ≡ `"2.1.0"`), and leading zeros are accepted
-/// (`"1.02.0"` ≡ `"1.2.0"`) even though the spec forbids them.
+/// Three deliberate concessions to real-world version strings: a missing minor
+/// or patch is `0` (`"2.1"` ≡ `"2.1.0"`), leading zeros are accepted
+/// (`"1.02.0"` ≡ `"1.2.0"`) even though the spec forbids them, and build
+/// metadata is dropped without being validated.
 private struct SemanticVersion {
 
     private static let coreComponents = 3

--- a/Tests/UnitTests/RulesEngine/PredicateFixtureTests.swift
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtureTests.swift
@@ -32,7 +32,7 @@ struct PredicateFixtureTests {
     /// fixtures are added or removed.
     @Test
     func fixtureCountMatchesExpected() {
-        let expectedCount = 518
+        let expectedCount = 519
         #expect(
             Self.fixtures.count == expectedCount,
             "Expected \(expectedCount) fixtures, loaded \(Self.fixtures.count)"

--- a/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_semver.json
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_semver.json
@@ -138,6 +138,13 @@
       "expected": true
     },
     {
+      "id": "semver_build_metadata_is_dropped_unvalidated",
+      "description": "Everything from the first + on is discarded without being checked, so a malformed tail still compares on its core",
+      "predicate": {"===": [{"rc.semverCompare": ["1.0.0++not a valid identifier", "1.0.0"]}, 0]},
+      "variables": {},
+      "expected": true
+    },
+    {
       "id": "semver_non_string_left_is_type_error",
       "description": "A bare number is not a version; 1 is not \"1.0.0\"",
       "predicate": {"rc.semverCompare": [1, "1.0.0"]},


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

Raised reviewing the Android port, RevenueCat/purchases-android#4077: `rc.semverCompare` discards everything from the first `+` on without checking it, so `"1.0.0++junk"` compares as `"1.0.0"`. That is intended, but it sat outside the documented list of concessions and read as an oversight.

### Description

The doc now counts it as the third concession, alongside partial versions and leading zeros, and a fixture pins it.

Behavior is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and test-only change; `rc.semverCompare` runtime behavior is unchanged.
> 
> **Overview**
> **Documents and tests an existing `rc.semverCompare` behavior**—no parsing or comparison logic changes.
> 
> The `SemanticVersion` doc comment now lists a **third real-world concession**: everything from the first `+` is stripped for precedence **without validating** build metadata (e.g. `"1.0.0++not a valid identifier"` still compares as `"1.0.0"`). That matches the existing `prefix { $0 != "+" }` parsing, which was already implied by §10 but easy to read as an oversight when porting.
> 
> A predicate fixture **`semver_build_metadata_is_dropped_unvalidated`** pins that case, and the fixture suite count is bumped **518 → 519**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13caee562a871ca2bee883cb8e021935eaeeef6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->