### PR TITLE
chore: don't run danger on main

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -2546,7 +2546,10 @@ workflows:
             pattern: "^generated_(snapshots|swiftinterface)/main-.*"
             value: << pipeline.git.branch >>
     jobs:
-      - danger
+      - danger:
+          filters:
+            branches:
+              ignore: main
 
   weekly-run-workflow:
     when:


### PR DESCRIPTION
Danger runs on every push to `main`, but there's no PR there for it to comment on.

Added a branch filter to the danger job so it skips `main`. `cordova-plugin-purchases` already did this, this brings the rest of the SDK repos in line. Release and snapshot branches are unchanged.

### Verification
- [x] `circleci config validate .circleci/default_config.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only branch filter on the Danger job; no application or release behavior changes.
> 
> **Overview**
> **CircleCI** no longer runs the **Danger** job when pipelines are triggered from **`main`**, by adding `filters.branches.ignore: main` on the `danger` job inside the existing `danger` workflow.
> 
> Danger is meant to comment on pull requests; direct pushes to `main` have no PR target, so this avoids pointless runs and aligns with the pattern used in other RevenueCat SDK repos. Other branches covered by that workflow (including release and generated snapshot branches) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da6f1810724ed00e0fe97c541a3ecd38a2effdf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->