### PR TITLE
feat(Checkpoints): refine public API

### DIFF
--- a/Examples/CheckpointTester/CheckpointTester/Sources/CheckpointDemoModel.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/CheckpointDemoModel.swift
@@ -81,7 +81,7 @@ final class CheckpointDemoModel: ObservableObject {
         case let received as CheckpointReceivedOfferingResult:
             return "Received offering · \(received.checkpoint.identifier) · \(received.offering.identifier)"
         case let noAction as CheckpointNoActionResult:
-            return "No action · \(noAction.checkpoint.identifier) · \(noAction.reason.value)"
+            return "No action · \(noAction.checkpoint.identifier) · \(noAction.reason)"
         default:
             return "Unknown checkpoint result · \(result.checkpoint.identifier)"
         }

--- a/Examples/CheckpointTester/CheckpointTester/Sources/GlobalCheckpointAnalyticsTracker.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/GlobalCheckpointAnalyticsTracker.swift
@@ -63,7 +63,7 @@ final class GlobalCheckpointAnalyticsTracker: ObservableObject, CheckpointListen
         case let received as CheckpointReceivedOfferingResult:
             return "Received offering · \(received.checkpoint.identifier) · \(received.offering.identifier)"
         case let noAction as CheckpointNoActionResult:
-            return "No action · \(noAction.checkpoint.identifier) · \(noAction.reason.value)"
+            return "No action · \(noAction.checkpoint.identifier) · \(noAction.reason)"
         default:
             return "Unknown result · \(result.checkpoint.identifier)"
         }

--- a/Examples/CheckpointTester/CheckpointTester/Sources/GlobalCheckpointAnalyticsTracker.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/GlobalCheckpointAnalyticsTracker.swift
@@ -33,13 +33,13 @@ final class GlobalCheckpointAnalyticsTracker: ObservableObject, CheckpointListen
     // These callbacks demonstrate an app-wide analytics integration using CheckpointListener.
     func onCheckpointHit(_ checkpoint: CheckpointInfo) {
         self.track(
-            "Hit · \(checkpoint.identifier) · customVariables=\(checkpoint.params.customVariables)"
+            "Hit · \(checkpoint.identifier) · customVariables=\(checkpoint.customVariables)"
         )
     }
 
     func onCheckpointCompleted(_ checkpoint: CheckpointInfo, result: CheckpointResult) {
         self.track(
-            "Completed · \(Self.describe(result)) · customVariables=\(checkpoint.params.customVariables)"
+            "Completed · \(Self.describe(result)) · customVariables=\(checkpoint.customVariables)"
         )
     }
 

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/EntitlementGateUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/EntitlementGateUseCaseView.swift
@@ -106,7 +106,7 @@ struct EntitlementGateUseCaseView: View {
         case let received as CheckpointReceivedOfferingResult:
             self.status = "Received offering '\(received.offering.identifier)'. The app owns what happens next."
         case let noAction as CheckpointNoActionResult:
-            self.status = "No paywall shown (\(noAction.reason.value)). Content remains locked."
+            self.status = "No paywall shown (\(noAction.reason)). Content remains locked."
         default:
             self.status = "Unknown checkpoint result. Content remains locked."
         }

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/HardPaywallUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/HardPaywallUseCaseView.swift
@@ -97,7 +97,7 @@ struct HardPaywallUseCaseView: View {
         case let received as CheckpointReceivedOfferingResult:
             self.status = "Received offering '\(received.offering.identifier)'. The app owns what happens next."
         case let noAction as CheckpointNoActionResult:
-            self.status = "No paywall shown (\(noAction.reason.value)). Content remains locked."
+            self.status = "No paywall shown (\(noAction.reason)). Content remains locked."
         default:
             self.status = "Unknown checkpoint result. Content remains locked."
         }

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/OnboardingUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/OnboardingUseCaseView.swift
@@ -131,7 +131,7 @@ struct OnboardingUseCaseView: View {
         case let received as CheckpointReceivedOfferingResult:
             return "Received offering '\(received.offering.identifier)'."
         case let noAction as CheckpointNoActionResult:
-            return "No paywall shown (\(noAction.reason.value))."
+            return "No paywall shown (\(noAction.reason))."
         default:
             return "Unknown checkpoint result."
         }

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/SoftPaywallUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/SoftPaywallUseCaseView.swift
@@ -88,7 +88,7 @@ struct SoftPaywallUseCaseView: View {
         case let received as CheckpointReceivedOfferingResult:
             self.status = "Received offering '\(received.offering.identifier)'. The app owns what happens next."
         case let noAction as CheckpointNoActionResult:
-            self.status = "No paywall shown (\(noAction.reason.value)). Content remains available."
+            self.status = "No paywall shown (\(noAction.reason)). Content remains available."
         default:
             self.status = "Unknown checkpoint result. Content remains available."
         }

--- a/RevenueCatUI/Checkpoints/CheckpointPaywallResult.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointPaywallResult.swift
@@ -51,7 +51,7 @@ public final class CheckpointPaywallPresentedResult: CheckpointResult {
 /// ```swift
 /// switch result.paywallOutcome {
 /// case let outcome as CheckpointPaywallPurchasedOutcome:
-///     handlePurchase(outcome.customerInfo)
+///     handlePurchase(outcome.transaction, outcome.customerInfo)
 /// case let outcome as CheckpointPaywallRestoredOutcome:
 ///     handleRestore(outcome.customerInfo)
 /// case is CheckpointPaywallDismissedOutcome:
@@ -106,10 +106,14 @@ public final class CheckpointPaywallDismissedOutcome: CheckpointPaywallOutcome {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public final class CheckpointPaywallPurchasedOutcome: CheckpointPaywallOutcome {
 
+    /// The transaction completed by the purchase, if available.
+    public let transaction: StoreTransaction?
+
     /// Customer information after the completed purchase.
     public let customerInfo: CustomerInfo
 
-    init(customerInfo: CustomerInfo) {
+    init(transaction: StoreTransaction?, customerInfo: CustomerInfo) {
+        self.transaction = transaction
         self.customerInfo = customerInfo
         super.init()
     }
@@ -117,10 +121,14 @@ public final class CheckpointPaywallPurchasedOutcome: CheckpointPaywallOutcome {
     public override var description: String { return "Purchased" }
 
     override func isEqual(to other: CheckpointPaywallOutcome) -> Bool {
-        return (other as? CheckpointPaywallPurchasedOutcome)?.customerInfo.isEqual(self.customerInfo) == true
+        guard let other = other as? CheckpointPaywallPurchasedOutcome else { return false }
+        return self.transaction == other.transaction && self.customerInfo.isEqual(other.customerInfo)
     }
 
-    public override func hash(into hasher: inout Hasher) { hasher.combine(self.customerInfo.hash) }
+    public override func hash(into hasher: inout Hasher) {
+        hasher.combine(self.transaction)
+        hasher.combine(self.customerInfo.hash)
+    }
 
 }
 

--- a/RevenueCatUI/Checkpoints/CheckpointPaywallResult.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointPaywallResult.swift
@@ -44,7 +44,25 @@ public final class CheckpointPaywallPresentedResult: CheckpointResult {
 
 }
 
-/// Base class for the terminal result of a checkpoint-presented paywall.
+/// Base class for the terminal outcome of a checkpoint-presented paywall.
+///
+/// Inspect the concrete outcome type to determine how the paywall finished:
+///
+/// ```swift
+/// switch result.paywallOutcome {
+/// case let outcome as CheckpointPaywallPurchasedOutcome:
+///     handlePurchase(outcome.customerInfo)
+/// case let outcome as CheckpointPaywallRestoredOutcome:
+///     handleRestore(outcome.customerInfo)
+/// case is CheckpointPaywallDismissedOutcome:
+///     handleDismissal()
+/// case let outcome as CheckpointPaywallErrorOutcome:
+///     handleError(outcome.error)
+/// default:
+///     // Handle outcome types added in future SDK versions.
+///     break
+/// }
+/// ```
 @_spi(CheckpointsInternal)
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public class CheckpointPaywallOutcome: Equatable, Hashable, CustomStringConvertible {

--- a/RevenueCatUI/Checkpoints/CheckpointWorkflowPresenter.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointWorkflowPresenter.swift
@@ -149,10 +149,16 @@ extension CheckpointWorkflowPresenter {
     #if compiler(>=5.9)
     nonisolated func paywallViewController(
         _ controller: PaywallViewController,
-        didFinishPurchasingWith customerInfo: CustomerInfo
+        didFinishPurchasingWith customerInfo: CustomerInfo,
+        transaction: StoreTransaction?
     ) {
         MainActor.assumeIsolated {
-            self.stage(outcome: CheckpointPaywallPurchasedOutcome(customerInfo: customerInfo))
+            self.stage(
+                outcome: CheckpointPaywallPurchasedOutcome(
+                    transaction: transaction,
+                    customerInfo: customerInfo
+                )
+            )
         }
     }
 
@@ -200,9 +206,15 @@ extension CheckpointWorkflowPresenter {
     #else
     func paywallViewController(
         _ controller: PaywallViewController,
-        didFinishPurchasingWith customerInfo: CustomerInfo
+        didFinishPurchasingWith customerInfo: CustomerInfo,
+        transaction: StoreTransaction?
     ) {
-        self.stage(outcome: CheckpointPaywallPurchasedOutcome(customerInfo: customerInfo))
+        self.stage(
+            outcome: CheckpointPaywallPurchasedOutcome(
+                transaction: transaction,
+                customerInfo: customerInfo
+            )
+        )
     }
 
     func paywallViewController(

--- a/RevenueCatUI/Checkpoints/Checkpoints.swift
+++ b/RevenueCatUI/Checkpoints/Checkpoints.swift
@@ -114,10 +114,8 @@ public final class CheckpointNoActionReason: Equatable, Hashable, CustomStringCo
     public static let holdout = CheckpointNoActionReason(value: "HOLDOUT")
     /// The customer reached the configured frequency cap.
     public static let frequencyCapped = CheckpointNoActionReason(value: "FREQUENCY_CAPPED")
-    /// Checkpoint configuration could not be loaded.
+    /// The checkpoint could not be evaluated because required configuration or resources were unavailable.
     public static let configurationUnavailable = CheckpointNoActionReason(value: "CONFIGURATION_UNAVAILABLE")
-    /// Checkpoints are disabled.
-    public static let disabled = CheckpointNoActionReason(value: "DISABLED")
     /// The checkpoint identifier is not configured.
     public static let unknownCheckpoint = CheckpointNoActionReason(value: "UNKNOWN_CHECKPOINT")
     /// The checkpoint identifier is invalid.

--- a/RevenueCatUI/Checkpoints/Checkpoints.swift
+++ b/RevenueCatUI/Checkpoints/Checkpoints.swift
@@ -69,8 +69,12 @@ public final class CheckpointInfo: Equatable, Hashable, CustomStringConvertible,
     /// The identifier of the checkpoint that was hit.
     public let identifier: String
 
-    /// The parameters supplied when the checkpoint was hit.
-    public let params: CheckpointParams
+    /// The custom variables supplied when the checkpoint was hit.
+    public var customVariables: [String: CustomVariableValue] {
+        return self.params.customVariables
+    }
+
+    private let params: CheckpointParams
 
     /// Creates checkpoint information for an identifier and its parameters.
     public init(identifier: String, params: CheckpointParams) {
@@ -80,18 +84,18 @@ public final class CheckpointInfo: Equatable, Hashable, CustomStringConvertible,
 
     /// Returns whether two checkpoint information values are equal.
     public static func == (lhs: CheckpointInfo, rhs: CheckpointInfo) -> Bool {
-        return lhs.identifier == rhs.identifier && lhs.params == rhs.params
+        return lhs.identifier == rhs.identifier && lhs.customVariables == rhs.customVariables
     }
 
     /// Hashes the checkpoint information.
     public func hash(into hasher: inout Hasher) {
         hasher.combine(self.identifier)
-        hasher.combine(self.params)
+        hasher.combine(self.customVariables)
     }
 
     /// A debug description of the checkpoint information.
     public var description: String {
-        return "CheckpointInfo(identifier='\(self.identifier)', params=\(self.params))"
+        return "CheckpointInfo(identifier='\(self.identifier)', customVariables=\(self.customVariables))"
     }
 
 }

--- a/RevenueCatUI/Checkpoints/Checkpoints.swift
+++ b/RevenueCatUI/Checkpoints/Checkpoints.swift
@@ -136,7 +136,25 @@ public final class CheckpointNoActionReason: Equatable, Hashable, CustomStringCo
 
 }
 
-/// Base class for the result of hitting a checkpoint.
+/// Base class for the result of evaluating a checkpoint.
+///
+/// Inspect the concrete result type to determine what happened:
+///
+/// ```swift
+/// let result = try await Purchases.shared.checkpoint("onboarding_complete")
+///
+/// switch result {
+/// case let result as CheckpointPaywallPresentedResult:
+///     handlePaywallOutcome(result.paywallOutcome)
+/// case let result as CheckpointReceivedOfferingResult:
+///     showOffering(result.offering)
+/// case let result as CheckpointNoActionResult:
+///     handleNoAction(result.reason)
+/// default:
+///     // Handle result types added in future SDK versions.
+///     break
+/// }
+/// ```
 @_spi(CheckpointsInternal)
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public class CheckpointResult: Equatable, Hashable, CustomStringConvertible {
@@ -230,13 +248,21 @@ public final class CheckpointReceivedOfferingResult: CheckpointResult {
 }
 
 /// Global listener for checkpoint activity. All methods are called on the main thread.
+///
+/// ``CheckpointListener/onCheckpointHit(_:)`` is called before evaluation starts. After evaluation and any
+/// presented UI finish, ``CheckpointListener/onCheckpointCompleted(_:result:)`` is called before the per-call
+/// checkpoint API delivers its result.
 @_spi(CheckpointsInternal)
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public protocol CheckpointListener: AnyObject {
 
-    /// A checkpoint was hit, before evaluation.
+    /// A checkpoint was hit and evaluation is about to start.
+    ///
+    /// This does not indicate that a targeting rule matched or that UI will be presented.
     func onCheckpointHit(_ checkpoint: CheckpointInfo)
-    /// The checkpoint completed and its result was returned.
+    /// Checkpoint evaluation and any presented UI finished.
+    ///
+    /// This is called before the per-call checkpoint API delivers its result.
     func onCheckpointCompleted(_ checkpoint: CheckpointInfo, result: CheckpointResult)
 
 }

--- a/RevenueCatUI/Checkpoints/Checkpoints.swift
+++ b/RevenueCatUI/Checkpoints/Checkpoints.swift
@@ -105,8 +105,7 @@ public final class CheckpointInfo: Equatable, Hashable, CustomStringConvertible,
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public final class CheckpointNoActionReason: Equatable, Hashable, CustomStringConvertible, @unchecked Sendable {
 
-    /// The value identifying the reason.
-    public let value: String
+    let value: String
 
     /// No targeting rule matched.
     public static let noMatch = CheckpointNoActionReason(value: "NO_MATCH")

--- a/RevenueCatUI/Checkpoints/CheckpointsManager.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointsManager.swift
@@ -130,7 +130,7 @@ private extension CheckpointResolutionReason {
         case .configurationUnavailable:
             return .configurationUnavailable
         case .disabled:
-            return .disabled
+            return .configurationUnavailable
         case .unknownCheckpoint:
             return .unknownCheckpoint
         }

--- a/RevenueCatUI/Checkpoints/ObjCCheckpointTypes.swift
+++ b/RevenueCatUI/Checkpoints/ObjCCheckpointTypes.swift
@@ -222,9 +222,13 @@ public final class ObjCCheckpointPaywallDismissedOutcome: ObjCCheckpointPaywallO
 public final class ObjCCheckpointPaywallPurchasedOutcome: ObjCCheckpointPaywallOutcome {
 
     init(_ value: CheckpointPaywallPurchasedOutcome) {
+        self.transaction = value.transaction
         self.customerInfo = value.customerInfo
         super.init()
     }
+
+    /// The transaction completed by the purchase, if available.
+    @objc public let transaction: StoreTransaction?
 
     /// Customer information after the completed purchase.
     @objc public let customerInfo: CustomerInfo

--- a/RevenueCatUI/Checkpoints/ObjCCheckpointTypes.swift
+++ b/RevenueCatUI/Checkpoints/ObjCCheckpointTypes.swift
@@ -81,15 +81,15 @@ public final class ObjCCheckpointInfo: NSObject {
 
     init(_ value: CheckpointInfo) {
         self.identifier = value.identifier
-        self.params = ObjCCheckpointParams(value.params)
+        self.customVariables = value.customVariables.mapValues { $0.foundationValue } as NSDictionary
         super.init()
     }
 
     /// The identifier of the checkpoint that was hit.
     @objc public let identifier: String
 
-    /// The parameters supplied when the checkpoint was hit.
-    @objc public let params: ObjCCheckpointParams
+    /// The custom variables supplied when the checkpoint was hit.
+    @objc public let customVariables: NSDictionary
 
 }
 

--- a/RevenueCatUI/Checkpoints/Purchases+Checkpoints.swift
+++ b/RevenueCatUI/Checkpoints/Purchases+Checkpoints.swift
@@ -60,6 +60,7 @@ public extension Purchases {
     ///   - params: Optional per-call parameters.
     /// - Returns: The result for this checkpoint.
     /// - Throws: An error if checkpoint evaluation or presentation fails.
+    @discardableResult
     func checkpoint(
         _ identifier: String,
         params: CheckpointParams = .init()

--- a/RevenueCatUI/Checkpoints/Purchases+Checkpoints.swift
+++ b/RevenueCatUI/Checkpoints/Purchases+Checkpoints.swift
@@ -27,15 +27,16 @@ public extension Purchases {
         set { self.checkpointsManager.listener = newValue }
     }
 
-    /// Registers that a checkpoint was hit.
+    /// Evaluates a checkpoint and calls `completion` with its result.
     ///
-    /// Depending on the configured targeting rules, this may auto-present an experience or do nothing.
-    /// The call resolves when the experience finishes.
+    /// Depending on the configured targeting rules, this may automatically present an experience or return a
+    /// ``CheckpointNoActionResult`` without presenting UI. If an experience is presented, `completion` is called
+    /// after the experience finishes.
     /// - Parameters:
     ///   - identifier: The checkpoint identifier configured in the RevenueCat dashboard. It must start with a letter,
     ///     contain only ASCII letters, numbers, underscores, and hyphens, and be no more than 255 characters.
     ///   - params: Optional per-call parameters.
-    ///   - completion: Called with the result, or an error if the checkpoint could not be handled.
+    ///   - completion: Called with the checkpoint result, or with an error if evaluation or presentation fails.
     func checkpoint(
         _ identifier: String,
         params: CheckpointParams = .init(),
@@ -48,16 +49,17 @@ public extension Purchases {
         )
     }
 
-    /// Registers that a checkpoint was hit.
+    /// Evaluates a checkpoint and returns its result.
     ///
-    /// Depending on the configured targeting rules, this may auto-present an experience or do nothing.
-    /// The call resolves when the experience finishes.
+    /// Depending on the configured targeting rules, this may automatically present an experience or return a
+    /// ``CheckpointNoActionResult`` without presenting UI. If an experience is presented, this method returns
+    /// after the experience finishes.
     /// - Parameters:
     ///   - identifier: The checkpoint identifier configured in the RevenueCat dashboard. It must start with a letter,
     ///     contain only ASCII letters, numbers, underscores, and hyphens, and be no more than 255 characters.
     ///   - params: Optional per-call parameters.
     /// - Returns: The result for this checkpoint.
-    /// - Throws: An error if the checkpoint could not be handled.
+    /// - Throws: An error if checkpoint evaluation or presentation fails.
     func checkpoint(
         _ identifier: String,
         params: CheckpointParams = .init()

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCCheckpointAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCCheckpointAPI.m
@@ -39,6 +39,8 @@
         if ([result isKindOfClass:RCCheckpointPaywallPresentedResult.class]) {
             RCCheckpointPaywallOutcome *outcome = ((RCCheckpointPaywallPresentedResult *)result).paywallOutcome;
             if ([outcome isKindOfClass:RCCheckpointPaywallPurchasedOutcome.class]) {
+                RCStoreTransaction * __unused transaction =
+                    ((RCCheckpointPaywallPurchasedOutcome *)outcome).transaction;
                 RCCustomerInfo * __unused customerInfo =
                     ((RCCheckpointPaywallPurchasedOutcome *)outcome).customerInfo;
             } else if ([outcome isKindOfClass:RCCheckpointPaywallRestoredOutcome.class]) {

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCCheckpointAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCCheckpointAPI.m
@@ -34,7 +34,7 @@
                               completion:^(RCCheckpointResult * _Nullable result, NSError * _Nullable error) {
         RCCheckpointInfo *checkpoint = result.checkpoint;
         NSString * __unused identifier = checkpoint.identifier;
-        RCCheckpointParams * __unused resultParams = checkpoint.params;
+        NSDictionary * __unused resultCustomVariables = checkpoint.customVariables;
 
         if ([result isKindOfClass:RCCheckpointPaywallPresentedResult.class]) {
             RCCheckpointPaywallOutcome *outcome = ((RCCheckpointPaywallPresentedResult *)result).paywallOutcome;

--- a/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
+++ b/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
@@ -85,7 +85,6 @@ func checkCheckpointAPI(_ purchases: Purchases) {
     let _: CheckpointNoActionReason = .holdout
     let _: CheckpointNoActionReason = .frequencyCapped
     let _: CheckpointNoActionReason = .configurationUnavailable
-    let _: CheckpointNoActionReason = .disabled
     let _: CheckpointNoActionReason = .unknownCheckpoint
     let _: CheckpointNoActionReason = .invalidCheckpointIdentifier
 }

--- a/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
+++ b/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
@@ -19,7 +19,7 @@ private final class CheckpointListenerAPITester: CheckpointListener {
 
     func onCheckpointHit(_ checkpoint: CheckpointInfo) {
         let _: String = checkpoint.identifier
-        let _: CheckpointParams = checkpoint.params
+        let _: [String: CustomVariableValue] = checkpoint.customVariables
     }
 
     func onCheckpointCompleted(_ checkpoint: CheckpointInfo, result: CheckpointResult) {

--- a/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
+++ b/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
@@ -44,6 +44,7 @@ private final class CheckpointListenerAPITester: CheckpointListener {
             let _: Offering = receivedOffering.offering
         } else if let noAction = result as? CheckpointNoActionResult {
             let _: CheckpointNoActionReason = noAction.reason
+            let _: String = noAction.reason.description
         }
     }
 

--- a/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
+++ b/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
@@ -29,6 +29,7 @@ private final class CheckpointListenerAPITester: CheckpointListener {
             let outcome: CheckpointPaywallOutcome = presented.paywallOutcome
 
             if let purchased = outcome as? CheckpointPaywallPurchasedOutcome {
+                let _: StoreTransaction? = purchased.transaction
                 let _: CustomerInfo = purchased.customerInfo
             } else if let restored = outcome as? CheckpointPaywallRestoredOutcome {
                 let _: CustomerInfo = restored.customerInfo

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointWorkflowPresenterTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointWorkflowPresenterTests.swift
@@ -46,6 +46,35 @@ final class CheckpointWorkflowPresenterTests: TestCase {
         XCTAssertNil(store.call)
     }
 
+    func testPurchaseCallbackPreservesTransaction() throws {
+        let store = CheckpointCallStore()
+        let delegate = MockCheckpointPresenterDelegate()
+        let presentation = Self.presentation()
+        let presenter = CheckpointWorkflowPresenter(callStore: store) { _ in true }
+        let transaction = StoreTransaction(MockStoreTransaction())
+
+        try presenter.present(presentation: presentation, delegate: delegate)
+        presenter.paywallViewController(
+            PaywallViewController(offering: presentation.workflow.offering),
+            didFinishPurchasingWith: TestData.customerInfo,
+            transaction: transaction
+        )
+
+        guard let stagedOutcome = store.call?.stagedOutcome as? CheckpointPaywallPurchasedOutcome else {
+            return XCTFail("Expected a purchased outcome")
+        }
+        XCTAssertEqual(stagedOutcome.transaction, transaction)
+        XCTAssertEqual(stagedOutcome.customerInfo, TestData.customerInfo)
+
+        presenter.presentationDidDismiss()
+
+        guard let reportedOutcome = delegate.outcome as? CheckpointPaywallPurchasedOutcome else {
+            return XCTFail("Expected a purchased outcome")
+        }
+        XCTAssertEqual(reportedOutcome.transaction, transaction)
+        XCTAssertEqual(reportedOutcome.customerInfo, TestData.customerInfo)
+    }
+
     func testCallStoreDefaultsToDismissedAndRemovesCall() {
         let store = CheckpointCallStore()
         let delegate = MockCheckpointPresenterDelegate()

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
@@ -128,7 +128,7 @@ final class CheckpointsManagerTests: TestCase {
         }
         XCTAssertEqual(noAction.reason, .unknownCheckpoint)
         XCTAssertEqual(noAction.checkpoint.identifier, "unknown_checkpoint")
-        XCTAssertEqual(noAction.checkpoint.params.customVariables["name"], "Rick")
+        XCTAssertEqual(noAction.checkpoint.customVariables["name"], "Rick")
         XCTAssertEqual(
             listener.events,
             [.hit("unknown_checkpoint"), .completed("unknown_checkpoint")]

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
@@ -250,7 +250,7 @@ final class CheckpointsManagerTests: TestCase {
             guard case let .success(noAction as CheckpointNoActionResult) = result else {
                 return XCTFail("Expected a no-action result")
             }
-            XCTAssertEqual(noAction.reason, .disabled)
+            XCTAssertEqual(noAction.reason, .configurationUnavailable)
             completion.fulfill()
         }
 


### PR DESCRIPTION
## Description
Implements some of the API design improvements we've discovered and discussed during the API bash. More fundamental changes will be proposed in follow up PRs.

## Changes
- Improved doc comments 
- Removed the `.disabled` case from `noActionReason`, since it's not really actionable from the developer's side. Instead `.configurationUnavailable` will be returend, and it's docs have been improved and broadened
- Added the `transaction: StoreTransaction?` parameter to the `CheckpointPaywallPurchasedOutcome`, since similar APIs like `Purchases.shared.purchase()`, `.onPurchaseCompleted` and `PayallViewController` also support these. 
- No longer exposing `CheckpointParams` on the `CheckpointInfo`, instead we're now just exposing the relevant properties, which is only `customVariables` for now. We'll most likely rethink `CheckpointParams` in a future PR in any case.
- Removed the `value: String` property from `CheckpointNoActionReason`, since it shouldn't be used for pattern matching etc. Instead it can be compared against the static types directly in Swift. Logging support is kept as well as the string value for the Objc typed wrapped.
- The async checkpoint API now is annotated with `@discardableResult`, for cases where the result won't be used

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public SPI and Obj‑C checkpoint types change (params, no-action reasons, disabled mapping), which can break early adopters; purchase outcome now carries transaction data on the paywall path.
> 
> **Overview**
> Refines the **Checkpoints** SPI so integrators work with a narrower, more consistent surface and richer purchase results.
> 
> **`CheckpointInfo`** no longer exposes **`CheckpointParams`**; callers read **`customVariables`** directly (Swift and Obj‑C **`ObjCCheckpointInfo`** mirror this). **`CheckpointNoActionReason`** drops the public **`.value`** string and the **`.disabled`** case—apps compare static reasons (or **`description`** for logging); internal **`.disabled`** resolution now surfaces as **`.configurationUnavailable`**, with broadened docs for that case.
> 
> **`CheckpointPaywallPurchasedOutcome`** (and Obj‑C wrapper) now include optional **`StoreTransaction?`**, wired from **`PaywallViewController`** through **`CheckpointWorkflowPresenter`**. **`@discardableResult`** is added to the async **`Purchases.checkpoint`** API, with expanded doc comments on checkpoint results, paywall outcomes, and **`CheckpointListener`** timing.
> 
> CheckpointTester examples, API testers, and unit tests (including transaction preservation) are updated for the new shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1374d3ec809771f4d14c0c1e5ab58fac02c76622. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->