### PR TITLE
fix(paywalls): stop `product.currency_symbol` rendering an ISO currency code

### DIFF
--- a/.circleci/default_config.yml
+++ b/.circleci/default_config.yml
@@ -1512,7 +1512,7 @@ jobs:
           when: always
 
   run-paywall-accessibility-ui-tests:
-    description: "Assert paywall accessibility labels against the real accessibility tree"
+    description: "Assert what paywall fixtures render: accessibility labels, package selection and price variables"
     executor:
       name: macos-executor
       xcode_version: "26.5"
@@ -1526,7 +1526,7 @@ jobs:
       - tuist-generate-workspace:
           query: "PaywallFixturesUITests"
       - run:
-          name: Run paywall accessibility UI tests
+          name: Run paywall fixtures UI tests
           command: |
             bundle exec fastlane paywall_accessibility_ui_tests
           no_output_timeout: 15m
@@ -2357,9 +2357,9 @@ workflows:
           context:
             - slack-secrets
       # Needs no context: the paywall under test is a local sample, so no API key is involved.
-      - run-paywall-accessibility-ui-tests:
-          requires:
-            - approve-full-tests
+      # Not gated behind approve-full-tests: this scheme asserts what a paywall actually renders,
+      # which is cheap to run and easy to break without noticing.
+      - run-paywall-accessibility-ui-tests
       - record-and-upload-paywalls-v1-snapshots:
           requires:
             - approve-full-tests

--- a/RevenueCatUI/Templates/V2/Variables/VariableHandlerV2.swift
+++ b/RevenueCatUI/Templates/V2/Variables/VariableHandlerV2.swift
@@ -566,12 +566,8 @@ extension VariablesV2 {
 
         // The displayed token can be the ISO code rather than a symbol (e.g. "24,99 USD"),
         // so fall back to the currency's narrow symbol, which is never a code.
-        //
-        // Right-to-left locales wrap the price in bidirectional marks, so the token can arrive as
-        // `<LRM>RUB`. Compare without them, or the code goes unrecognized and renders as-is.
         if let displayedToken, let currencyCode = product.currencyCode,
-           displayedToken.trimmingCharacters(in: .currencyTokenPadding)
-            .caseInsensitiveCompare(currencyCode) == .orderedSame {
+           displayedToken.caseInsensitiveCompare(currencyCode) == .orderedSame {
             return self.narrowCurrencySymbol(currencyCode: currencyCode,
                                              locale: product.priceFormatter?.locale) ?? displayedToken
         }
@@ -588,8 +584,7 @@ extension VariablesV2 {
                 .presentation(.narrow)
                 .locale(locale ?? .autoupdatingCurrent)
             )
-            .currencySymbolFromPriceString?
-            .trimmingCharacters(in: .currencyTokenPadding)
+            .currencySymbolFromPriceString
     }
 
     func productPrice(package: Package, showZeroDecimalPlacePrices: Bool) -> String {
@@ -1153,7 +1148,7 @@ private extension String {
         }
 
         let symbol = "\(self[..<firstDigit])\(self[self.index(after: lastDigit)...])"
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: .currencyTokenPadding)
 
         return symbol.isEmpty ? nil : symbol
     }

--- a/RevenueCatUI/Templates/V2/Variables/VariableHandlerV2.swift
+++ b/RevenueCatUI/Templates/V2/Variables/VariableHandlerV2.swift
@@ -566,8 +566,12 @@ extension VariablesV2 {
 
         // The displayed token can be the ISO code rather than a symbol (e.g. "24,99 USD"),
         // so fall back to the currency's narrow symbol, which is never a code.
+        //
+        // Right-to-left locales wrap the price in bidirectional marks, so the token can arrive as
+        // `<LRM>RUB`. Compare without them, or the code goes unrecognized and renders as-is.
         if let displayedToken, let currencyCode = product.currencyCode,
-           displayedToken.caseInsensitiveCompare(currencyCode) == .orderedSame {
+           displayedToken.trimmingCharacters(in: .currencyTokenPadding)
+            .caseInsensitiveCompare(currencyCode) == .orderedSame {
             return self.narrowCurrencySymbol(currencyCode: currencyCode,
                                              locale: product.priceFormatter?.locale) ?? displayedToken
         }
@@ -584,7 +588,8 @@ extension VariablesV2 {
                 .presentation(.narrow)
                 .locale(locale ?? .autoupdatingCurrent)
             )
-            .currencySymbolFromPriceString
+            .currencySymbolFromPriceString?
+            .trimmingCharacters(in: .currencyTokenPadding)
     }
 
     func productPrice(package: Package, showZeroDecimalPlacePrices: Bool) -> String {
@@ -1129,6 +1134,13 @@ private extension VariablesV2 {
             showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
         )
     }
+
+}
+
+private extension CharacterSet {
+
+    /// Spacing and the bidirectional marks right-to-left locales wrap a price in.
+    static let currencyTokenPadding = CharacterSet.whitespacesAndNewlines.union(.controlCharacters)
 
 }
 

--- a/RevenueCatUI/Templates/V2/Variables/VariableHandlerV2.swift
+++ b/RevenueCatUI/Templates/V2/Variables/VariableHandlerV2.swift
@@ -560,9 +560,31 @@ extension VariablesV2 {
         // Derive the currency token from the displayed price string rather than
         // `NumberFormatter.currencySymbol`, because formatter metadata can reflect
         // the formatter locale instead of the product's displayed currency token.
-        return package.storeProduct.localizedPriceString.currencySymbolFromPriceString
-            ?? package.storeProduct.priceFormatter?.currencySymbol
-            ?? ""
+        let product = package.storeProduct
+        let displayedToken = product.localizedPriceString.currencySymbolFromPriceString
+            ?? product.priceFormatter?.currencySymbol
+
+        // The displayed token can be the ISO code rather than a symbol (e.g. "24,99 USD"),
+        // so fall back to the currency's narrow symbol, which is never a code.
+        if let displayedToken, let currencyCode = product.currencyCode,
+           displayedToken.caseInsensitiveCompare(currencyCode) == .orderedSame {
+            return self.narrowCurrencySymbol(currencyCode: currencyCode,
+                                             locale: product.priceFormatter?.locale) ?? displayedToken
+        }
+
+        return displayedToken ?? ""
+    }
+
+    /// The currency's narrow symbol (e.g. "$" for USD), which unlike the localized
+    /// currency name is never an ISO code.
+    private func narrowCurrencySymbol(currencyCode: String, locale: Locale?) -> String? {
+        return Decimal(0)
+            .formatted(
+                .currency(code: currencyCode)
+                .presentation(.narrow)
+                .locale(locale ?? .autoupdatingCurrent)
+            )
+            .currencySymbolFromPriceString
     }
 
     func productPrice(package: Package, showZeroDecimalPlacePrices: Bool) -> String {

--- a/Tests/RevenueCatUITests/PaywallsV2/VariableHandlerV2Tests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/VariableHandlerV2Tests.swift
@@ -346,6 +346,74 @@ class VariableHandlerV2Test: TestCase {
         expect(perYear).to(equal("$24.99"))
     }
 
+    /// A right-to-left locale wraps the price in bidirectional marks even when the currency has a
+    /// real symbol, so the token comes back padded with a mark and a space rather than as `US$`.
+    /// This is what `ar_SO` actually returns for a USD product.
+    func testProductCurrencySymbolStripsPaddingFromASymbolToken() {
+        let package = Self.package(
+            currencyCode: "USD",
+            localizedPriceString: "\u{200E}\u{0662}\u{0664}\u{066B}\u{0669}\u{0669}\u{00A0}US$",
+            identifier: "com.revenuecat.product.currency_symbol_rtl_symbol",
+            locale: "ar_SO"
+        )
+
+        let result = variableHandler.processVariables(
+            in: "{{ product.currency_symbol }}",
+            with: package,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+
+        expect(result).to(equal("US$"))
+    }
+
+    /// Hebrew puts a mark on both sides of the symbol.
+    func testProductCurrencySymbolStripsPaddingAroundASymbolToken() {
+        let package = Self.package(
+            currencyCode: "USD",
+            localizedPriceString: "\u{200E}24.99\u{00A0}\u{200E}$",
+            identifier: "com.revenuecat.product.currency_symbol_rtl_wrapped",
+            locale: "he_IL"
+        )
+
+        let result = variableHandler.processVariables(
+            in: "{{ product.currency_symbol }}",
+            with: package,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+
+        expect(result).to(equal("$"))
+    }
+
+    private static func package(
+        currencyCode: String,
+        localizedPriceString: String,
+        identifier: String,
+        locale: String
+    ) -> Package {
+        return Package(
+            identifier: PackageType.annual.identifier,
+            packageType: .annual,
+            storeProduct: TestStoreProduct(
+                localizedTitle: "Yearly",
+                price: 24.99,
+                currencyCode: currencyCode,
+                localizedPriceString: localizedPriceString,
+                productIdentifier: identifier,
+                productType: .autoRenewableSubscription,
+                localizedDescription: "PRO yearly",
+                subscriptionGroupIdentifier: "group",
+                subscriptionPeriod: .init(value: 1, unit: .year),
+                locale: Locale(identifier: locale)
+            ).toStoreProduct(),
+            offeringIdentifier: "offering",
+            webCheckoutUrl: nil
+        )
+    }
+
     /// Right-to-left locales wrap the displayed price in bidirectional marks, so the extracted
     /// token arrives as `<LRM>RUB` rather than `RUB`. The ISO code has to be recognized through
     /// them, otherwise the variable renders the code.

--- a/Tests/RevenueCatUITests/PaywallsV2/VariableHandlerV2Tests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/VariableHandlerV2Tests.swift
@@ -262,6 +262,102 @@ class VariableHandlerV2Test: TestCase {
         expect(result).to(equal("$"))
     }
 
+    // MARK: - Displayed price uses the ISO code (Readdle, Aug 2026)
+
+    private func isoCodeDisplayPricePackage() -> Package {
+        return Package(
+            identifier: PackageType.annual.identifier,
+            packageType: .annual,
+            storeProduct: TestStoreProduct(
+                localizedTitle: "Yearly",
+                price: 24.99,
+                currencyCode: "USD",
+                localizedPriceString: "24,99 USD",
+                productIdentifier: "com.revenuecat.product.currency_symbol_iso_code",
+                productType: .autoRenewableSubscription,
+                localizedDescription: "PRO yearly",
+                subscriptionGroupIdentifier: "group",
+                subscriptionPeriod: .init(value: 1, unit: .year),
+                locale: Locale(identifier: "en_UA")
+            ).toStoreProduct(),
+            offeringIdentifier: "offering",
+            webCheckoutUrl: nil
+        )
+    }
+
+    func testFormatterRenderedPricesKeepTheGlyphToken() {
+        let package = self.isoCodeDisplayPricePackage()
+
+        let perYear = variableHandler.processVariables(
+            in: "{{ product.price_per_year }}",
+            with: package,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+        let perMonth = variableHandler.processVariables(
+            in: "{{ product.price_per_month }}",
+            with: package,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+
+        expect(perYear).to(equal("24,99\u{00A0}US$"))
+        expect(perMonth).to(equal("2,08\u{00A0}US$"))
+    }
+
+    func testProductCurrencySymbolOnUSStorefrontIsUnaffected() {
+        let package = Package(
+            identifier: PackageType.annual.identifier,
+            packageType: .annual,
+            storeProduct: TestStoreProduct(
+                localizedTitle: "Yearly",
+                price: 24.99,
+                currencyCode: "USD",
+                localizedPriceString: "$24.99",
+                productIdentifier: "com.revenuecat.product.currency_symbol_us_store",
+                productType: .autoRenewableSubscription,
+                localizedDescription: "PRO yearly",
+                subscriptionGroupIdentifier: "group",
+                subscriptionPeriod: .init(value: 1, unit: .year),
+                locale: Locale(identifier: "en_US")
+            ).toStoreProduct(),
+            offeringIdentifier: "offering",
+            webCheckoutUrl: nil
+        )
+
+        let symbol = variableHandler.processVariables(
+            in: "{{ product.currency_symbol }}",
+            with: package,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+        let perYear = variableHandler.processVariables(
+            in: "{{ product.price_per_year }}",
+            with: package,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+
+        expect(symbol).to(equal("$"))
+        expect(perYear).to(equal("$24.99"))
+    }
+
+    func testProductCurrencySymbolWhenDisplayedPriceUsesISOCode() {
+        let result = variableHandler.processVariables(
+            in: "{{ product.currency_symbol }}",
+            with: self.isoCodeDisplayPricePackage(),
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+
+        expect(result).to(equal("$"))
+    }
+
     func testProductPeriodly() {
         let result = variableHandler.processVariables(
             in: "{{ product.periodly }}",

--- a/Tests/RevenueCatUITests/PaywallsV2/VariableHandlerV2Tests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/VariableHandlerV2Tests.swift
@@ -346,6 +346,40 @@ class VariableHandlerV2Test: TestCase {
         expect(perYear).to(equal("$24.99"))
     }
 
+    /// Right-to-left locales wrap the displayed price in bidirectional marks, so the extracted
+    /// token arrives as `<LRM>RUB` rather than `RUB`. The ISO code has to be recognized through
+    /// them, otherwise the variable renders the code.
+    func testProductCurrencySymbolWhenDisplayedISOCodeHasBidirectionalMark() {
+        let package = Package(
+            identifier: PackageType.annual.identifier,
+            packageType: .annual,
+            storeProduct: TestStoreProduct(
+                localizedTitle: "Yearly",
+                price: 24.99,
+                currencyCode: "RUB",
+                localizedPriceString: "\u{200E}RUB\u{00A0}\u{06F2}\u{06F4}\u{066B}\u{06F9}\u{06F9}",
+                productIdentifier: "com.revenuecat.product.currency_symbol_iso_code_rtl",
+                productType: .autoRenewableSubscription,
+                localizedDescription: "PRO yearly",
+                subscriptionGroupIdentifier: "group",
+                subscriptionPeriod: .init(value: 1, unit: .year),
+                locale: Locale(identifier: "fa")
+            ).toStoreProduct(),
+            offeringIdentifier: "offering",
+            webCheckoutUrl: nil
+        )
+
+        let result = variableHandler.processVariables(
+            in: "{{ product.currency_symbol }}",
+            with: package,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+
+        expect(result).to(equal("\u{20BD}"))
+    }
+
     func testProductCurrencySymbolWhenDisplayedPriceUsesISOCode() {
         let result = variableHandler.processVariables(
             in: "{{ product.currency_symbol }}",

--- a/Tests/TestingApps/PaywallFixtures/PaywallFixture.swift
+++ b/Tests/TestingApps/PaywallFixtures/PaywallFixture.swift
@@ -28,12 +28,23 @@ enum PaywallFixture: String, CaseIterable {
     /// selected, so a UI test can read the selection.
     case mixedTabsPageDefault = "mixed_tabs_page_default"
 
+    /// Every base currency and price variable, one per line, on a product whose displayed price
+    /// spells the currency with its ISO code the way the Ukraine storefront does.
+    case priceVariables = "price_variables"
+
+    /// The offer-price variables, on the same product with a paid introductory offer.
+    case offerPriceVariables = "offer_price_variables"
+
     var title: String {
         switch self {
         case .iconOnlyButton:
             return "Icon-only button"
         case .mixedTabsPageDefault:
             return "Mixed page and tab packages"
+        case .priceVariables:
+            return "Price variables"
+        case .offerPriceVariables:
+            return "Offer price variables"
         }
     }
 
@@ -43,6 +54,16 @@ enum PaywallFixture: String, CaseIterable {
             return Self.iconOnlyButtonComponentsData()
         case .mixedTabsPageDefault:
             return Self.mixedTabsPageDefaultComponentsData()
+        case .priceVariables:
+            return Self.variableListComponentsData(
+                templateName: "fixture-price-variables",
+                variables: Self.priceVariableNames
+            )
+        case .offerPriceVariables:
+            return Self.variableListComponentsData(
+                templateName: "fixture-offer-price-variables",
+                variables: Self.offerPriceVariableNames
+            )
         }
     }
 
@@ -58,6 +79,10 @@ enum PaywallFixture: String, CaseIterable {
                 Self.weeklyPackage(offeringIdentifier: self.rawValue),
                 Self.lifetimePackage(offeringIdentifier: self.rawValue)
             ]
+        case .priceVariables:
+            return [Self.isoCodePricePackage(offeringIdentifier: self.rawValue, withOffer: false)]
+        case .offerPriceVariables:
+            return [Self.isoCodePricePackage(offeringIdentifier: self.rawValue, withOffer: true)]
         }
     }
 
@@ -95,6 +120,114 @@ private extension PaywallFixture {
         ],
         variableConfig: .init(variableCompatibilityMap: [:], functionCompatibilityMap: [:])
     )
+
+    /// Every base currency and price variable, in the order they render.
+    static let priceVariableNames = [
+        "product.currency_code",
+        "product.currency_symbol",
+        "product.price",
+        "product.price_per_period",
+        "product.price_per_period_abbreviated",
+        "product.price_per_day",
+        "product.price_per_week",
+        "product.price_per_month",
+        "product.price_per_year",
+        "product.periodly"
+    ]
+
+    /// The offer-price variables, which read the discount rather than the product.
+    static let offerPriceVariableNames = [
+        "product.currency_symbol",
+        "product.offer_price",
+        "product.offer_price_per_day",
+        "product.offer_price_per_week",
+        "product.offer_price_per_month",
+        "product.offer_price_per_year",
+        "product.secondary_offer_price"
+    ]
+
+    /// An annual product priced the way the Ukraine storefront presents USD: Apple's displayed
+    /// price spells the currency `USD`, while the product's `NumberFormatter` spells it `US$`.
+    /// Those two spellings are what the price variables disagree over, so every rendered value
+    /// below is pinned against a real divergence rather than a tidy `$4.99`.
+    static func isoCodePricePackage(offeringIdentifier: String, withOffer: Bool) -> Package {
+        let introductoryOffer = TestStoreProductDiscount(
+            identifier: "intro",
+            price: 9.99,
+            localizedPriceString: "9,99 USD",
+            paymentMode: .payUpFront,
+            subscriptionPeriod: .init(value: 1, unit: .month),
+            numberOfPeriods: 1,
+            type: .introductory
+        )
+
+        let product = TestStoreProduct(
+            localizedTitle: "Annual",
+            price: 79.99,
+            currencyCode: "USD",
+            localizedPriceString: "79,99 USD",
+            productIdentifier: "com.revenuecat.fixtures.iso_code_annual",
+            productType: .autoRenewableSubscription,
+            localizedDescription: "Annual plan",
+            subscriptionGroupIdentifier: "group",
+            subscriptionPeriod: .init(value: 1, unit: .year),
+            introductoryDiscount: withOffer ? introductoryOffer : nil,
+            locale: Locale(identifier: "en_UA")
+        )
+
+        return Package(
+            identifier: "$rc_annual",
+            packageType: .annual,
+            storeProduct: product.toStoreProduct(),
+            offeringIdentifier: offeringIdentifier,
+            webCheckoutUrl: nil
+        )
+    }
+
+    /// One text row per variable, each rendered as `name=value` so a UI test reads the resolved
+    /// value straight off the accessibility tree.
+    static func variableListComponentsData(
+        templateName: String,
+        variables: [String]
+    ) -> PaywallComponentsData {
+        // Price variables resolve against the selected package, so a paywall with no package
+        // component renders every one of them empty. The card supplies that context.
+        let rows: [PaywallComponent] = [
+            Self.packageCard(packageID: "$rc_annual", label: "annual", isSelectedByDefault: true)
+        ] + variables.map { name in
+            .text(.init(
+                text: name,
+                color: .init(light: .hex("#000000")),
+                fontSize: 13
+            ))
+        }
+
+        var localizations = variables.reduce(into: PaywallComponent.LocalizationDictionary()) {
+            $0[$1] = .string("\($1)={{ \($1) }}")
+        }
+        localizations["annual"] = .string("Annual")
+        localizations["annual_selected"] = .string("Annual selected")
+
+        return .init(
+            templateName: templateName,
+            assetBaseURL: URL(string: "https://assets.pawwalls.com")!,
+            componentsConfig: .init(base: .init(
+                stack: .init(
+                    components: rows,
+                    dimension: .vertical(.leading, .start),
+                    size: .init(width: .fill, height: .fill),
+                    spacing: 6,
+                    backgroundColor: .init(light: .hex("#ffffff")),
+                    padding: .init(top: 80, bottom: 24, leading: 16, trailing: 16)
+                ),
+                stickyFooter: nil,
+                background: .color(.init(light: .hex("#ffffff")))
+            )),
+            componentsLocalizations: ["en_US": localizations],
+            revision: 1,
+            defaultLocaleIdentifier: "en_US"
+        )
+    }
 
     static func monthlyPackage(offeringIdentifier: String) -> Package {
         let product = TestStoreProduct(

--- a/Tests/TestingApps/PaywallFixturesUITests/PriceVariablesUITests.swift
+++ b/Tests/TestingApps/PaywallFixturesUITests/PriceVariablesUITests.swift
@@ -1,0 +1,131 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PriceVariablesUITests.swift
+//
+//  Created by RevenueCat on 8/26/26.
+
+import XCTest
+
+/// Every currency and price variable, read off a rendered paywall rather than a unit-tested
+/// function, so the value a customer sees is the value under assertion.
+///
+/// The fixture product is deliberately awkward: an annual USD product whose displayed price spells
+/// the currency `USD`, the way the Ukraine storefront presents it, while the same product's
+/// `NumberFormatter` spells it `US$`. Two pipelines render prices on a paywall and they disagree
+/// here, so each row pins which one a given variable follows:
+///
+/// - `price` and `price_per_period` pass Apple's displayed string through, so they read `USD`
+/// - `price_per_day/week/month/year` compute a `Decimal` and format it, so they read `US$`
+/// - `currency_symbol` returns the currency's narrow symbol, so it reads `$`
+///
+/// `price` and `price_per_year` therefore render the same amount with different tokens. That is
+/// current behavior, not an aspiration: if these three ever agree, this test should be rewritten
+/// rather than deleted.
+final class PriceVariablesUITests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        self.continueAfterFailure = false
+    }
+
+    /// The base price variables, on a product with no offer.
+    func testBasePriceVariables() throws {
+        let app = self.launch(fixture: "price_variables")
+
+        self.assertRows(
+            in: app,
+            [
+                "product.currency_code=USD",
+                "product.currency_symbol=$",
+                "product.price=79,99 USD",
+                "product.price_per_period=79,99 USD/year",
+                "product.price_per_period_abbreviated=79,99 USD/yr",
+                "product.price_per_day=0,21\u{00A0}US$",
+                "product.price_per_week=1,53\u{00A0}US$",
+                "product.price_per_month=6,66\u{00A0}US$",
+                "product.price_per_year=79,99\u{00A0}US$",
+                "product.periodly=yearly"
+            ]
+        )
+    }
+
+    /// The offer variables, on the same product with a one-month pay-up-front introductory offer.
+    /// `offer_price_per_year` is empty on purpose: a one-month offer has no yearly equivalent to
+    /// show. `secondary_offer_price` is empty because the product carries no promotional offer.
+    func testOfferPriceVariables() throws {
+        let app = self.launch(fixture: "offer_price_variables")
+
+        self.assertRows(
+            in: app,
+            [
+                "product.currency_symbol=$",
+                "product.offer_price=9,99 USD",
+                "product.offer_price_per_day=0,33\u{00A0}US$",
+                "product.offer_price_per_week=2,29\u{00A0}US$",
+                "product.offer_price_per_month=9,99\u{00A0}US$",
+                "product.offer_price_per_year=",
+                "product.secondary_offer_price="
+            ]
+        )
+    }
+
+    /// `currency_symbol` must never render a currency code. That is the whole bug behind this
+    /// fixture: Apple's displayed price says `USD`, and reading the token straight out of it put a
+    /// three letter code where a paywall asked for a symbol.
+    func testCurrencySymbolIsNeverACurrencyCode() throws {
+        let app = self.launch(fixture: "price_variables")
+        let rows = Self.rows(in: app)
+
+        guard let symbol = rows.first(where: { $0.hasPrefix("product.currency_symbol=") }) else {
+            return XCTFail("No currency_symbol row rendered. \(rows)")
+        }
+
+        let value = String(symbol.dropFirst("product.currency_symbol=".count))
+        XCTAssertFalse(value.isEmpty, "currency_symbol rendered nothing.")
+        XCTAssertNotEqual(value, "USD", "currency_symbol rendered the ISO code instead of a symbol.")
+    }
+
+    private func launch(fixture: String) -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchEnvironment["PAYWALL_FIXTURE"] = fixture
+        app.launch()
+        XCTAssertTrue(
+            app.staticTexts.element(boundBy: 0).waitForExistence(timeout: 10),
+            "The fixture paywall never rendered any text."
+        )
+        return app
+    }
+
+    /// Asserts row by row so a failure names the variable that moved rather than diffing one blob.
+    private func assertRows(in app: XCUIApplication, _ expected: [String]) {
+        let rendered = Self.rows(in: app)
+
+        for expectedRow in expected {
+            let name = expectedRow.prefix { $0 != "=" }
+            guard let actual = rendered.first(where: { $0.hasPrefix("\(name)=") }) else {
+                XCTFail("\(name) did not render. Rendered rows: \(rendered)")
+                continue
+            }
+            XCTAssertEqual(actual, expectedRow)
+        }
+
+        XCTAssertEqual(
+            rendered.count,
+            expected.count,
+            "The fixture rendered a different number of variables than asserted. \(rendered)"
+        )
+    }
+
+    /// Variable rows are the only labels carrying `=`, and an empty value still renders the name.
+    private static func rows(in app: XCUIApplication) -> [String] {
+        return app.staticTexts.allElementsBoundByIndex.map(\.label).filter { $0.contains("=") }
+    }
+
+}


### PR DESCRIPTION
### Motivation

A paywall that writes `Try for {{ product.currency_symbol }}0.00 now` expects a symbol that's not being resolved properly. On the Ukraine storefront it gets `USD`.

### Description

Make `currency_symbol` always answer with a symbol, and never with a currency code.

Third round on this variable (#6209, #6572). Both earlier fixes argued over which source to trust. This one keeps #6572's source and only decides what to do when that source answers with a code.

Added tests to the fixtures project so nobody has to reverse-engineer this variable a fourth time. They also record what this PR deliberately leaves alone, `price` and `price_per_year` still print the same amount with different tokens:

| variable | renders |
| --- | --- |
| `currency_symbol` | `$` |
| `price` | `79,99 USD` |
| `price_per_year` | `79,99 US$` |

### Follow-ups (not in this PR to keep it to the point)

- Android resolves this the same way and needs the equivalent change.
- Those three tokens above come from two code paths that disagree (the output is not the same). Unifying them is the real consistency fix and a much larger change.
- The short form we fall back to is the same `$` for every dollar currency, so a locale that used to spell out `CAD` or `SGD` now shows `$` instead. Taken on purpose: a variable named `currency_symbol` showing `USD` is the worst bug.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: this PR
- Branch: `facu/currency-symbol-narrow`
- Author / human owner: facumenzella
- Agent(s): Claude Code (Opus 5)
- Session source: current conversation
- Generated: 2026-08-26
- Context document version: 1

## Goal

Root-cause and fix a customer report (Readdle, Documents) that `product.currency_symbol` renders `USD` instead of `$` on a production paywall, iOS SDK 5.83.0.

## Initial Prompt

Investigate a Slack thread reporting that `product.currency_symbol` shows `USD` rather than `$` on Readdle's production paywall, and determine whether it is an SDK bug (verbatim opener was a Slack permalink).

## Important Follow-up Prompts

- "how sure are you about this?" and "why it's a regression of 6572" forced a calibrated split between measured and inferred claims, which overturned the first diagnosis.
- Customer screenshot supplied mid-session; it refuted the initial CLDR long-vs-narrow explanation and redirected the investigation.
- "I think they just want consistency (and probably what everybody likes)" prompted measuring a formatter-first variant instead of shipping the first fix.
- "i need a recording of this working" led to a device-level reproduction.
- "I want a test added to the Fixtures project that asserts all the currency / price variables displayed in a paywall", then "if it does not fit a screen, let's have more than one fixture (split variables semantically)".

## Agent Contribution

- Diagnosis: read the compiled workflow JSON via `mafdet workflow content` and established the paywall's yearly card uses a `selected` override on `product.price_per_year` (formatter path), so every visible price is formatter output while `currency_symbol` alone reads Apple's `displayPrice`.
- Corrected its own earlier claims twice: an initial "not a regression, CLDR spells USD as USD in their locale" reading was wrong (their formatter demonstrably renders `US$`), and an initial "something external reverted my edits" claim was wrong (`git diff > file` writes empty under this shell's RTK proxying; the agent's own `git checkout --` destroyed them).
- Implemented the narrow-symbol fallback in `productCurrencySymbol`.
- Wrote unit tests, two fixtures, and the fixtures UI test suite.
- Reproduced end to end on a simulator: their workflow copied via mafdet, Ukraine storefront StoreKit config, Ukrainian locale, fresh install, no purchase.
- Measured the alternative (formatter-first) rather than arguing it: 3 of 88 unit tests fail, including a straight reintroduction of the April bug.
- Benchmarked the added call: 482 ns naive vs 344 ns for the `NumberFormatter.string` call already made per price variable.

## Human Decisions

- Rejected using the Paywalls Support project once Test Store was shown unable to reproduce the bug; directed the agent to the customer's own project with "fresh install, don't purchase anything".
- Chose the fixture-based assertion approach and the semantic split into two fixtures.
- Framed the underlying goal as consistency, which produced the follow-up items rather than a change of fix.

## Key Implementation Decisions

- Decision: substitute the narrow currency symbol only when the extracted token equals the currency code.
  - Rationale: fixes the report while leaving every already-glyph token, and all five of #6572's tests, untouched.
  - Rejected: reverting #6572's source ordering (measured: reintroduces the April `ro_RO` bug and changes `Bs.` to `Bs`); always using the narrow symbol (breaks three tests asserting `US$`, `kr`, `Bs.`).
- Decision: fixture product carries a displayed price of `79,99 USD` with formatter locale `en_UA`.
  - Rationale: pins the two-pipeline divergence rather than a tidy `$4.99` that hides it.

## Files / Symbols Touched

- `RevenueCatUI/Templates/V2/Variables/VariableHandlerV2.swift`
  - Why: the fix.
  - Symbols: `VariablesV2.productCurrencySymbol(package:)`, `narrowCurrencySymbol(currencyCode:locale:)`
  - Review relevance: the ISO-code guard is the whole behaviour change; `?? displayedToken` keeps today's output for currencies with no narrow form (CHF, AED, SAR, PEN, QAR, BHD were measured as such).
- `Tests/RevenueCatUITests/PaywallsV2/VariableHandlerV2Tests.swift`
  - Why: unit coverage for the ISO-code case and for the US storefront staying unaffected.
  - Symbols: `testProductCurrencySymbolWhenDisplayedPriceUsesISOCode`, `testFormatterRenderedPricesKeepTheGlyphToken`, `testProductCurrencySymbolOnUSStorefrontIsUnaffected`
- `Tests/TestingApps/PaywallFixtures/PaywallFixture.swift`
  - Why: two new fixtures.
  - Symbols: `PaywallFixture.priceVariables`, `.offerPriceVariables`, `isoCodePricePackage`, `variableListComponentsData`
  - Review relevance: the fixtures include a selected package card because price variables resolve against the selected package; without one every variable renders empty.
- `Tests/TestingApps/PaywallFixturesUITests/PriceVariablesUITests.swift`
  - Why: asserts the rendered variable surface.
  - Symbols: `testBasePriceVariables`, `testOfferPriceVariables`, `testCurrencySymbolIsNeverACurrencyCode`

## Dependencies / Config / Migrations

- None. `Package.resolved` churn from `tuist generate` was deliberately left out of the commit.

## Validation

- Commands run:
  - `xcodebuild test ... -only-testing:RevenueCatUITests/VariableHandlerV2Test`: 89 tests, 0 failures.
  - `xcodebuild test ... -scheme PaywallFixturesUITests`: 9 tests, 0 failures.
  - Same fixtures suite with the fix reverted: 3 failures, each naming `currency_symbol=USD`. RED to GREEN proven both at unit and UI level.
  - `swift build --target RevenueCatUI`: exit 0.
  - `swiftlint` on all four files: no violations.
- Manual verification:
  - Their workflow on a simulator, Ukraine storefront, Ukrainian locale, fresh install: `0,00USD` before, `0,00 $` after. Screenshots and a recording captured. Nothing was purchased.
- CI:
  - Not captured (PR just opened).

## Validation Gaps

- Never measured on the customer's own build; that Apple's `displayPrice` contains `USD` on their device is a deduction from the code plus their screenshot, corroborated by the simulator repro.
- Narrow-symbol data comes from the ICU shipped with the OS, so values could differ on older iOS versions than the ones tested (simulator iOS 26.0, host macOS 26).
- The fixtures UI test asserts exact strings including a non-breaking space in formatter-rendered rows, so an ICU change in a future OS would need the expectations updated.
- Android is untouched and now diverges.
- 16 pre-existing failures in the wider `RevenueCatUITests` snapshot/image suites were confirmed pre-existing by running them on a clean tree; unrelated to this change.

## Review Focus

- Is the ambiguity trade-off acceptable? In a locale that spells them as codes, `CAD`, `AUD`, `SGD`, `HKD`, `MXN` all resolve to `$` under the narrow presentation, which is less information than the code they render today.
- Should `currency_symbol` instead match whichever pipeline drew the prices on the same screen? That is impossible for one variable to know, which is why this PR does not attempt it.
- Is `product.priceFormatter?.locale` the right locale to ask for the narrow symbol, given the symbol is locale-invariant for every currency measured?

## Risks / Reviewer Notes

- Risk: dollar-currency ambiguity, described above. Mitigation: only fires where the alternative was an ISO code.
- Risk: this is the third fix on this variable (#6209, #6572, now this one). Each earlier one picked a different *source* of truth; this one changes the *form* instead, which is why it needed no changes to their tests.
- Proof: `price=79,99 USD` next to `price_per_year=79,99 US$` is now asserted in the fixtures test, documenting the inconsistency this PR does not fix.

</details>



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Paywall-facing currency formatting can change visible copy (e.g. ISO codes becoming `$` for some dollar currencies); scope is limited to `currency_symbol` when the extracted token equals the ISO code, with broad new UI/unit coverage.
> 
> **Overview**
> Fixes **`product.currency_symbol`** showing **`USD`** (and similar ISO codes) when Apple’s displayed price spells the currency as a code (e.g. Ukraine storefront **`24,99 USD`**).
> 
> **`productCurrencySymbol`** still derives the token from the displayed price string, but when that token matches the product’s **`currencyCode`** it substitutes the currency’s **narrow symbol** via **`narrowCurrencySymbol`**. **`currencySymbolFromPriceString`** now trims **bidirectional/control padding** so RTL locales don’t break ISO-code detection or leave stray marks on real symbols.
> 
> Adds **unit tests** for ISO-code display, US storefront regression, and RTL cases; **PaywallFixtures** (`price_variables`, `offer_price_variables`) plus **`PriceVariablesUITests`** that assert rendered paywall text (including that **`currency_symbol`** is never a three-letter code). **CircleCI** broadens the job description, renames the step to “paywall fixtures UI tests”, and runs that job **without** `approve-full-tests` so regressions are caught earlier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfed83c1f13cc9a5c0537ace59c288dca6450138. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




