### PR TITLE
refactor(Checkpoints): remove CheckpointParams from the public API

### DIFF
--- a/Examples/CheckpointTester/CheckpointTester/Sources/ContentView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/ContentView.swift
@@ -131,7 +131,7 @@ struct ContentView: View {
                             do {
                                 let result = try await Purchases.shared.checkpoint(
                                     "this-checkpoint-does-not-exist",
-                                    params: self.customVariables.checkpointParams
+                                    customVariables: self.customVariables.checkpointCustomVariables
                                 )
                                 self.model.showOutcome(result)
                             } catch {
@@ -149,7 +149,7 @@ struct ContentView: View {
                             do {
                                 let result = try await Purchases.shared.checkpoint(
                                     "error_checkpoint",
-                                    params: self.customVariables.checkpointParams
+                                    customVariables: self.customVariables.checkpointCustomVariables
                                 )
                                 self.model.showOutcome(result)
                             } catch {

--- a/Examples/CheckpointTester/CheckpointTester/Sources/CustomVariables.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/CustomVariables.swift
@@ -22,7 +22,7 @@ final class CustomVariables: ObservableObject {
         CustomVariable(name: "source", value: "CheckpointTester"),
     ]
 
-    var checkpointParams: CheckpointParams {
+    var checkpointCustomVariables: [String: CustomVariableValue] {
         var customVariables: [String: CustomVariableValue] = [:]
 
         for variable in self.variables {
@@ -32,7 +32,7 @@ final class CustomVariables: ObservableObject {
             }
         }
 
-        return CheckpointParams(customVariables: customVariables)
+        return customVariables
     }
 
 }

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/CustomCheckpointUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/CustomCheckpointUseCaseView.swift
@@ -42,7 +42,7 @@ struct CustomCheckpointUseCaseView: View {
                 }
                 .disabled(self.trimmedIdentifier.isEmpty || self.isRunning)
             } footer: {
-                Text("The current custom variables are passed as checkpoint parameters.")
+                Text("The current custom variables are passed to the checkpoint.")
             }
         }
         .navigationTitle("Custom checkpoint")
@@ -58,7 +58,7 @@ struct CustomCheckpointUseCaseView: View {
         do {
             let result = try await Purchases.shared.checkpoint(
                 self.trimmedIdentifier,
-                params: self.customVariables.checkpointParams
+                customVariables: self.customVariables.checkpointCustomVariables
             )
             self.model.showOutcome(result)
         } catch {

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/EntitlementGateUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/EntitlementGateUseCaseView.swift
@@ -90,7 +90,7 @@ struct EntitlementGateUseCaseView: View {
 
             let result = try await Purchases.shared.checkpoint(
                 "entitlement_gate",
-                params: self.entitlementCheckpointParams
+                customVariables: self.entitlementCheckpointCustomVariables
             )
             self.handle(result)
         } catch {
@@ -136,10 +136,10 @@ struct EntitlementGateUseCaseView: View {
             : "\(action), but no active entitlement was found."
     }
 
-    private var entitlementCheckpointParams: CheckpointParams {
-        var customVariables = self.customVariables.checkpointParams.customVariables
+    private var entitlementCheckpointCustomVariables: [String: CustomVariableValue] {
+        var customVariables = self.customVariables.checkpointCustomVariables
         customVariables["gate"] = .string("entitlement")
-        return CheckpointParams(customVariables: customVariables)
+        return customVariables
     }
 
     private static func activeEntitlementIdentifiers(from customerInfo: CustomerInfo) -> [String] {

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/HardPaywallUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/HardPaywallUseCaseView.swift
@@ -81,7 +81,7 @@ struct HardPaywallUseCaseView: View {
         do {
             let result = try await Purchases.shared.checkpoint(
                 "hard_paywall",
-                params: self.paramsForNextAttempt()
+                customVariables: self.customVariablesForNextAttempt()
             )
             self.handle(result)
         } catch {
@@ -122,12 +122,12 @@ struct HardPaywallUseCaseView: View {
     }
 
     @MainActor
-    private func paramsForNextAttempt() -> CheckpointParams {
+    private func customVariablesForNextAttempt() -> [String: CustomVariableValue] {
         self.attempts += 1
-        var customVariables = self.customVariables.checkpointParams.customVariables
+        var customVariables = self.customVariables.checkpointCustomVariables
         customVariables["gate"] = .string("hard")
         customVariables["attempt"] = .number(Double(self.attempts))
-        return CheckpointParams(customVariables: customVariables)
+        return customVariables
     }
 
 }

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/OnboardingUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/OnboardingUseCaseView.swift
@@ -113,7 +113,7 @@ struct OnboardingUseCaseView: View {
         do {
             let result = try await Purchases.shared.checkpoint(
                 "onboarding_complete",
-                params: self.personalizationCheckpointParams
+                customVariables: self.personalizationCheckpointCustomVariables
             )
             self.checkpointResult = Self.describe(result)
         } catch {
@@ -152,10 +152,10 @@ struct OnboardingUseCaseView: View {
         }
     }
 
-    private var personalizationCheckpointParams: CheckpointParams {
-        var customVariables = self.customVariables.checkpointParams.customVariables
+    private var personalizationCheckpointCustomVariables: [String: CustomVariableValue] {
+        var customVariables = self.customVariables.checkpointCustomVariables
         customVariables["step"] = .string("personalize")
-        return CheckpointParams(customVariables: customVariables)
+        return customVariables
     }
 
 }

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/SoftPaywallUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/SoftPaywallUseCaseView.swift
@@ -72,7 +72,7 @@ struct SoftPaywallUseCaseView: View {
         do {
             let result = try await Purchases.shared.checkpoint(
                 "soft_paywall",
-                params: self.customVariables.checkpointParams
+                customVariables: self.customVariables.checkpointCustomVariables
             )
             self.handle(result)
         } catch {

--- a/RevenueCatUI/Checkpoints/Checkpoints.swift
+++ b/RevenueCatUI/Checkpoints/Checkpoints.swift
@@ -27,32 +27,13 @@ extension CustomVariableValue {
 
 }
 
-/// Per-call parameters for a checkpoint.
-@_spi(CheckpointsInternal)
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-public final class CheckpointParams: Equatable, Hashable, CustomStringConvertible, @unchecked Sendable {
+final class CheckpointCallParams: @unchecked Sendable {
 
-    /// Custom variables usable in checkpoint targeting rules and feature events.
-    public let customVariables: [String: CustomVariableValue]
+    let customVariables: [String: CustomVariableValue]
 
-    /// Creates checkpoint parameters with the supplied custom variables.
-    public init(customVariables: [String: CustomVariableValue] = [:]) {
+    init(customVariables: [String: CustomVariableValue] = [:]) {
         self.customVariables = RevenueCat.CustomVariableKeyValidator.validateAndFilter(customVariables)
-    }
-
-    /// Returns whether two parameter collections contain the same custom variables.
-    public static func == (lhs: CheckpointParams, rhs: CheckpointParams) -> Bool {
-        return lhs.customVariables == rhs.customVariables
-    }
-
-    /// Hashes the checkpoint parameters.
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(self.customVariables)
-    }
-
-    /// A debug description of the checkpoint parameters.
-    public var description: String {
-        return "CheckpointParams(customVariables=\(self.customVariables))"
     }
 
     var coreParams: RevenueCat.CheckpointParams {
@@ -70,16 +51,11 @@ public final class CheckpointInfo: Equatable, Hashable, CustomStringConvertible,
     public let identifier: String
 
     /// The custom variables supplied when the checkpoint was hit.
-    public var customVariables: [String: CustomVariableValue] {
-        return self.params.customVariables
-    }
+    public let customVariables: [String: CustomVariableValue]
 
-    private let params: CheckpointParams
-
-    /// Creates checkpoint information for an identifier and its parameters.
-    public init(identifier: String, params: CheckpointParams) {
+    init(identifier: String, params: CheckpointCallParams) {
         self.identifier = identifier
-        self.params = params
+        self.customVariables = params.customVariables
     }
 
     /// Returns whether two checkpoint information values are equal.

--- a/RevenueCatUI/Checkpoints/CheckpointsManager.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointsManager.swift
@@ -34,16 +34,16 @@ final class CheckpointsManager {
 
     private let listenerLock = NSLock()
     private var storedListener: CheckpointListener?
-    private let resolveCheckpoint: (String, CheckpointParams) async throws -> CheckpointResolution
+    private let resolveCheckpoint: (String, CheckpointCallParams) async throws -> CheckpointResolution
     @MainActor private lazy var executor: CheckpointExecutor = CheckpointWorkflowExecutor()
 
-    init(resolveCheckpoint: @escaping (String, CheckpointParams) async throws -> CheckpointResolution) {
+    init(resolveCheckpoint: @escaping (String, CheckpointCallParams) async throws -> CheckpointResolution) {
         self.resolveCheckpoint = resolveCheckpoint
     }
 
     @MainActor
     init(
-        resolveCheckpoint: @escaping (String, CheckpointParams) async throws -> CheckpointResolution,
+        resolveCheckpoint: @escaping (String, CheckpointCallParams) async throws -> CheckpointResolution,
         executor: CheckpointExecutor
     ) {
         self.resolveCheckpoint = resolveCheckpoint
@@ -52,7 +52,7 @@ final class CheckpointsManager {
 
     func checkpoint(
         identifier: String,
-        params: CheckpointParams,
+        params: CheckpointCallParams,
         completion: @escaping (Result<CheckpointResult, PublicError>) -> Void
     ) {
         Task { @MainActor in
@@ -74,7 +74,7 @@ final class CheckpointsManager {
     @MainActor
     func checkpoint(
         identifier: String,
-        params: CheckpointParams
+        params: CheckpointCallParams
     ) async throws -> CheckpointResult {
         let checkpoint = CheckpointInfo(identifier: identifier, params: params)
         self.listener?.onCheckpointHit(checkpoint)

--- a/RevenueCatUI/Checkpoints/ObjCCheckpointTypes.swift
+++ b/RevenueCatUI/Checkpoints/ObjCCheckpointTypes.swift
@@ -34,19 +34,12 @@ private enum CheckpointStrings: LogMessage {
 }
 #endif
 
-/// Objective-C-compatible checkpoint parameters.
-@_spi(CheckpointsInternal)
 @available(iOS 15.0, *)
-@objc(RCCheckpointParams)
-public final class ObjCCheckpointParams: NSObject {
+extension CheckpointCallParams {
 
-    let value: CheckpointParams
-
-    /// Creates checkpoint parameters from Objective-C Foundation primitive values. Unsupported values are dropped.
-    @objc(initWithCustomVariables:)
-    public init(customVariables: NSDictionary) {
+    convenience init(objectiveCCustomVariables: NSDictionary?) {
         var values: [String: CustomVariableValue] = [:]
-        for (rawKey, rawValue) in customVariables {
+        for (rawKey, rawValue) in objectiveCCustomVariables ?? [:] {
             guard let key = rawKey as? String,
                   let value = CustomVariableValue(foundationValue: rawValue) else {
                 #if DEBUG
@@ -56,19 +49,7 @@ public final class ObjCCheckpointParams: NSObject {
             }
             values[key] = value
         }
-        self.value = CheckpointParams(customVariables: values)
-        super.init()
-    }
-
-    init(_ value: CheckpointParams) {
-        self.value = value
-        super.init()
-    }
-
-    /// The custom variables as Objective-C Foundation primitive values.
-    @objc(customVariables)
-    public var customVariables: NSDictionary {
-        return self.value.customVariables.mapValues { $0.foundationValue } as NSDictionary
+        self.init(customVariables: values)
     }
 
 }

--- a/RevenueCatUI/Checkpoints/Purchases+Checkpoints.swift
+++ b/RevenueCatUI/Checkpoints/Purchases+Checkpoints.swift
@@ -35,16 +35,16 @@ public extension Purchases {
     /// - Parameters:
     ///   - identifier: The checkpoint identifier configured in the RevenueCat dashboard. It must start with a letter,
     ///     contain only ASCII letters, numbers, underscores, and hyphens, and be no more than 255 characters.
-    ///   - params: Optional per-call parameters.
+    ///   - customVariables: Values usable in checkpoint targeting rules, feature events, and the presented paywall.
     ///   - completion: Called with the checkpoint result, or with an error if evaluation or presentation fails.
     func checkpoint(
         _ identifier: String,
-        params: CheckpointParams = .init(),
+        customVariables: [String: CustomVariableValue] = [:],
         completion: @escaping (Result<CheckpointResult, PublicError>) -> Void
     ) {
         self.checkpointsManager.checkpoint(
             identifier: identifier,
-            params: params,
+            params: .init(customVariables: customVariables),
             completion: completion
         )
     }
@@ -57,17 +57,17 @@ public extension Purchases {
     /// - Parameters:
     ///   - identifier: The checkpoint identifier configured in the RevenueCat dashboard. It must start with a letter,
     ///     contain only ASCII letters, numbers, underscores, and hyphens, and be no more than 255 characters.
-    ///   - params: Optional per-call parameters.
+    ///   - customVariables: Values usable in checkpoint targeting rules, feature events, and the presented paywall.
     /// - Returns: The result for this checkpoint.
     /// - Throws: An error if checkpoint evaluation or presentation fails.
     @discardableResult
     func checkpoint(
         _ identifier: String,
-        params: CheckpointParams = .init()
+        customVariables: [String: CustomVariableValue] = [:]
     ) async throws -> CheckpointResult {
         return try await self.checkpointsManager.checkpoint(
             identifier: identifier,
-            params: params
+            params: .init(customVariables: customVariables)
         )
     }
 
@@ -80,15 +80,17 @@ public extension Purchases {
 public extension Purchases {
 
     /// Objective-C-compatible checkpoint API. The identifier must start with a letter and contain only ASCII letters,
-    /// numbers, underscores, and hyphens, and be no more than 255 characters.
+    /// numbers, underscores, and hyphens, and be no more than 255 characters. Custom variables may contain Foundation
+    /// string, number, and Boolean values; unsupported entries are dropped.
     @_disfavoredOverload
-    @objc(checkpointWithIdentifier:params:completion:)
+    @objc(checkpointWithIdentifier:customVariables:completion:)
     func checkpoint(
         _ identifier: String,
-        objcParams: ObjCCheckpointParams?,
+        objcCustomVariables: NSDictionary?,
         completion: @escaping (ObjCCheckpointResult?, PublicError?) -> Void
     ) {
-        self.checkpoint(identifier, params: objcParams?.value ?? .init()) { result in
+        let params = CheckpointCallParams(objectiveCCustomVariables: objcCustomVariables)
+        self.checkpointsManager.checkpoint(identifier: identifier, params: params) { result in
             switch result {
             case let .success(result):
                 completion(ObjCCheckpointResult.wrapping(result), nil)

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCCheckpointAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCCheckpointAPI.m
@@ -23,14 +23,11 @@
 
 + (void)checkAPI {
     RCPurchases *purchases = RCPurchases.sharedPurchases;
-    RCCheckpointParams *params = [[RCCheckpointParams alloc] initWithCustomVariables:@{
-        @"name": @"Rick",
-        @"subscriber": @YES,
-    }];
-    NSDictionary * __unused customVariables = params.customVariables;
-
     [purchases checkpointWithIdentifier:@"test_checkpoint"
-                                  params:params
+                         customVariables:@{
+                             @"name": @"Rick",
+                             @"subscriber": @YES,
+                         }
                               completion:^(RCCheckpointResult * _Nullable result, NSError * _Nullable error) {
         RCCheckpointInfo *checkpoint = result.checkpoint;
         NSString * __unused identifier = checkpoint.identifier;
@@ -61,7 +58,7 @@
     }];
 
     [purchases checkpointWithIdentifier:@"test_checkpoint"
-                                  params:nil
+                         customVariables:nil
                               completion:^(RCCheckpointResult * _Nullable result, NSError * _Nullable error) {}];
 }
 

--- a/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
+++ b/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
@@ -56,30 +56,31 @@ func checkCheckpointAPI(_ purchases: Purchases) {
     purchases.checkpointListener = CheckpointListenerAPITester()
     let _: CheckpointListener? = purchases.checkpointListener
 
-    let literalParams = CheckpointParams(customVariables: [
+    let literalCustomVariables: [String: CustomVariableValue] = [
         "name": "Rick",
         "points": 120,
         "score": 4.5,
         "subscriber": true
-    ])
-    let explicitParams = CheckpointParams(customVariables: [
+    ]
+    let explicitCustomVariables: [String: CustomVariableValue] = [
         "name": .string("Rick"),
         "points": .number(120),
         "score": .number(4.5),
         "subscriber": .bool(true)
-    ])
-    let _: [String: CustomVariableValue] = literalParams.customVariables
-    let _: [String: CustomVariableValue] = explicitParams.customVariables
+    ]
 
     purchases.checkpoint(
         "test_checkpoint",
-        params: literalParams
+        customVariables: literalCustomVariables
     ) { (_: Result<CheckpointResult, PublicError>) in }
 
     purchases.checkpoint("test_checkpoint") { (_: Result<CheckpointResult, PublicError>) in }
 
     Task {
-        let _: CheckpointResult = try await purchases.checkpoint("test_checkpoint")
+        let _: CheckpointResult = try await purchases.checkpoint(
+            "test_checkpoint",
+            customVariables: explicitCustomVariables
+        )
     }
 
     let _: CheckpointNoActionReason = .noMatch

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
@@ -22,8 +22,8 @@ final class CheckpointsManagerTests: TestCase {
 
     #if ENABLE_CHECKPOINTS_OBJC
 
-    func testObjectiveCParamsConvertAndRoundTripSupportedFoundationValues() throws {
-        let params = ObjCCheckpointParams(customVariables: [
+    func testObjectiveCCustomVariablesConvertSupportedFoundationValues() throws {
+        let params = CheckpointCallParams(objectiveCCustomVariables: [
             "string": "value",
             "integer": NSNumber(value: Int64(42)),
             "double": NSNumber(value: 4.5),
@@ -31,7 +31,7 @@ final class CheckpointsManagerTests: TestCase {
             "false": NSNumber(value: false)
         ])
 
-        XCTAssertEqual(params.value.customVariables, [
+        XCTAssertEqual(params.customVariables, [
             "string": .string("value"),
             "integer": .number(42),
             "double": .number(4.5),
@@ -39,12 +39,10 @@ final class CheckpointsManagerTests: TestCase {
             "false": .bool(false)
         ])
 
-        let roundTrip = ObjCCheckpointParams(customVariables: params.customVariables)
-        XCTAssertEqual(roundTrip.value, params.value)
     }
 
-    func testObjectiveCParamsDropUnsupportedValuesAndNonStringKeys() {
-        let params = ObjCCheckpointParams(customVariables: [
+    func testObjectiveCCustomVariablesDropUnsupportedValuesAndNonStringKeys() {
+        let params = CheckpointCallParams(objectiveCCustomVariables: [
             "valid": "value",
             "invalid-key": "value",
             "null": NSNull(),
@@ -53,7 +51,7 @@ final class CheckpointsManagerTests: TestCase {
             NSNumber(value: 1): "invalid key"
         ])
 
-        XCTAssertEqual(params.value.customVariables, ["valid": .string("value")])
+        XCTAssertEqual(params.customVariables, ["valid": .string("value")])
     }
 
     func testObjectiveCResultWrapsInvalidIdentifierNoActionResult() throws {
@@ -74,8 +72,8 @@ final class CheckpointsManagerTests: TestCase {
 
     #endif
 
-    func testCheckpointParamsConvertCustomVariableValuesForCoreResolution() {
-        let params = RevenueCatUI.CheckpointParams(customVariables: [
+    func testCheckpointCallParamsConvertCustomVariableValuesForCoreResolution() {
+        let params = CheckpointCallParams(customVariables: [
             "string": "value",
             "integer": 42,
             "double": 4.5,
@@ -92,8 +90,8 @@ final class CheckpointsManagerTests: TestCase {
         XCTAssertEqual(params.coreParams.customVariables, expected)
     }
 
-    func testCheckpointParamsDropInvalidCustomVariableKeys() {
-        let params = RevenueCatUI.CheckpointParams(customVariables: [
+    func testCheckpointCallParamsDropInvalidCustomVariableKeys() {
+        let params = CheckpointCallParams(customVariables: [
             "valid_key": "value",
             "invalid-key": "value",
             "1valid": "value",
@@ -120,7 +118,7 @@ final class CheckpointsManagerTests: TestCase {
 
         let result = try await manager.checkpoint(
             identifier: "unknown_checkpoint",
-            params: CheckpointParams(customVariables: ["name": "Rick"])
+            params: CheckpointCallParams(customVariables: ["name": "Rick"])
         )
 
         guard let noAction = result as? CheckpointNoActionResult else {
@@ -136,7 +134,7 @@ final class CheckpointsManagerTests: TestCase {
     }
 
     func testInvalidCustomVariableKeysDoNotReachResolution() async throws {
-        var resolvedParams: RevenueCatUI.CheckpointParams?
+        var resolvedParams: CheckpointCallParams?
         let manager = CheckpointsManager { _, params in
             resolvedParams = params
             return .noAction(.noMatch)
@@ -144,7 +142,7 @@ final class CheckpointsManagerTests: TestCase {
 
         _ = try await manager.checkpoint(
             identifier: "test",
-            params: CheckpointParams(customVariables: [
+            params: CheckpointCallParams(customVariables: [
                 "valid_key": "value",
                 "invalid-key": "value"
             ])
@@ -322,11 +320,11 @@ final class CheckpointsManagerTests: TestCase {
     func testUIOwnedReferenceModelsPreserveValueEqualityAndHashing() {
         let firstInfo = CheckpointInfo(
             identifier: "test",
-            params: CheckpointParams(customVariables: ["name": "Rick"])
+            params: CheckpointCallParams(customVariables: ["name": "Rick"])
         )
         let secondInfo = CheckpointInfo(
             identifier: "test",
-            params: CheckpointParams(customVariables: ["name": "Rick"])
+            params: CheckpointCallParams(customVariables: ["name": "Rick"])
         )
         let firstResult = CheckpointNoActionResult(checkpoint: firstInfo, reason: .noMatch)
         let secondResult = CheckpointNoActionResult(checkpoint: secondInfo, reason: .noMatch)


### PR DESCRIPTION
## Description
As we discussed during the API bash, the need for having the `CheckpointParams` object is not as strong as it is for Android. Therefore I think we can safely remove this type from the public API, and instead just introduce new (optional) parameters. We should, however introduce overloads in case any of these changes would introduce breaking changes. But we should be able to do that in any case.

## Changes
Removes the `CheckpointParams` type from the public API, directly taking its values instead (currently just `customVariables`). The `CheckpointParams` type is still kept internally though, as it will allow for having multiple overloads call the same single internal API, passing along all parameters at once.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking public API change for Swift and Objective-C checkpoint callers, though checkpoint behavior and custom-variable validation should stay the same.
> 
> **Overview**
> Removes the public **`CheckpointParams`** wrapper and passes **`customVariables`** directly into **`Purchases.checkpoint`**. Swift async/completion overloads now take an optional `[String: CustomVariableValue]` (default `[:]`); callers no longer construct a params object.
> 
> **Objective-C** drops **`RCCheckpointParams`** in favor of **`checkpointWithIdentifier:customVariables:completion:`**, passing an **`NSDictionary`** of Foundation primitives (same validation/dropping behavior as before). **`CheckpointInfo`** exposes **`customVariables`** on the result instead of going through params.
> 
> Internally, per-call state moves to **`CheckpointCallParams`** (still validated and mapped to core **`RevenueCat.CheckpointParams`**). CheckpointTester, API testers, and manager tests are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fc1bbee7f393f98b97df37e541b9321099d6346. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->