### PR TITLE
Let fixtures assert error message substrings

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		E5F60718293A4B5C03D0102 /* LengthOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F60718293A4B5C03D0101 /* LengthOperator.swift */; };
 		F60718293A4B5C03D01F2 /* SemverOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60718293A4B5C03D01F1 /* SemverOperator.swift */; };
 		F60718293A4B5C03D02A2 /* SplitOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60718293A4B5C03D02A1 /* SplitOperator.swift */; };
+		F60718293A4B5C03D03A2 /* SortByOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60718293A4B5C03D03A1 /* SortByOperator.swift */; };
 		B2C3D4E5F60718293A4B5C02 /* RootVarOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F60718293A4B5C01 /* RootVarOperator.swift */; };
 		0F4E490A741F00F18C4985D8 /* WebViewSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CC1CD0385BF18D1392EB43 /* WebViewSession.swift */; };
 		116EA498A344F7446083E8C5 /* EqualityOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41EEB3B4E7701F8CC8B811A9 /* EqualityOperators.swift */; };
@@ -3073,6 +3074,7 @@
 		E5F60718293A4B5C03D0101 /* LengthOperator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LengthOperator.swift; sourceTree = "<group>"; };
 		F60718293A4B5C03D01F1 /* SemverOperator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SemverOperator.swift; sourceTree = "<group>"; };
 		F60718293A4B5C03D02A1 /* SplitOperator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SplitOperator.swift; sourceTree = "<group>"; };
+		F60718293A4B5C03D03A1 /* SortByOperator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SortByOperator.swift; sourceTree = "<group>"; };
 		B2C3D4E5F60718293A4B5C01 /* RootVarOperator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RootVarOperator.swift; sourceTree = "<group>"; };
 		AC01FEB700000000000000B5 /* WebViewComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewComponentTests.swift; sourceTree = "<group>"; };
 		AC06C294F30E7D8000000002 /* SelectedPackageId.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedPackageId.swift; sourceTree = "<group>"; };
@@ -6672,6 +6674,7 @@
 				E5F60718293A4B5C03D0101 /* LengthOperator.swift */,
 				F60718293A4B5C03D01F1 /* SemverOperator.swift */,
 				F60718293A4B5C03D02A1 /* SplitOperator.swift */,
+				F60718293A4B5C03D03A1 /* SortByOperator.swift */,
 				B2C3D4E5F60718293A4B5C01 /* RootVarOperator.swift */,
 			);
 			name = CustomOperators;
@@ -8113,6 +8116,7 @@
 				E5F60718293A4B5C03D0102 /* LengthOperator.swift in Sources */,
 				F60718293A4B5C03D01F2 /* SemverOperator.swift in Sources */,
 				F60718293A4B5C03D02A2 /* SplitOperator.swift in Sources */,
+				F60718293A4B5C03D03A2 /* SortByOperator.swift in Sources */,
 				B2C3D4E5F60718293A4B5C02 /* RootVarOperator.swift in Sources */,
 				55DACDF3302BC30A005EE017 /* IAMCallbacks.swift in Sources */,
 				1701E7CE20E0879817B3F61B /* RulesEngineLogger.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		F60718293A4B5C03D01F2 /* SemverOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60718293A4B5C03D01F1 /* SemverOperator.swift */; };
 		F60718293A4B5C03D02A2 /* SplitOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60718293A4B5C03D02A1 /* SplitOperator.swift */; };
 		F60718293A4B5C03D03A2 /* SortByOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60718293A4B5C03D03A1 /* SortByOperator.swift */; };
+		F60718293A4B5C03D04A2 /* SliceOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60718293A4B5C03D04A1 /* SliceOperator.swift */; };
 		B2C3D4E5F60718293A4B5C02 /* RootVarOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F60718293A4B5C01 /* RootVarOperator.swift */; };
 		0F4E490A741F00F18C4985D8 /* WebViewSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CC1CD0385BF18D1392EB43 /* WebViewSession.swift */; };
 		116EA498A344F7446083E8C5 /* EqualityOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41EEB3B4E7701F8CC8B811A9 /* EqualityOperators.swift */; };
@@ -3075,6 +3076,7 @@
 		F60718293A4B5C03D01F1 /* SemverOperator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SemverOperator.swift; sourceTree = "<group>"; };
 		F60718293A4B5C03D02A1 /* SplitOperator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SplitOperator.swift; sourceTree = "<group>"; };
 		F60718293A4B5C03D03A1 /* SortByOperator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SortByOperator.swift; sourceTree = "<group>"; };
+		F60718293A4B5C03D04A1 /* SliceOperator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SliceOperator.swift; sourceTree = "<group>"; };
 		B2C3D4E5F60718293A4B5C01 /* RootVarOperator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RootVarOperator.swift; sourceTree = "<group>"; };
 		AC01FEB700000000000000B5 /* WebViewComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewComponentTests.swift; sourceTree = "<group>"; };
 		AC06C294F30E7D8000000002 /* SelectedPackageId.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedPackageId.swift; sourceTree = "<group>"; };
@@ -6675,6 +6677,7 @@
 				F60718293A4B5C03D01F1 /* SemverOperator.swift */,
 				F60718293A4B5C03D02A1 /* SplitOperator.swift */,
 				F60718293A4B5C03D03A1 /* SortByOperator.swift */,
+				F60718293A4B5C03D04A1 /* SliceOperator.swift */,
 				B2C3D4E5F60718293A4B5C01 /* RootVarOperator.swift */,
 			);
 			name = CustomOperators;
@@ -8117,6 +8120,7 @@
 				F60718293A4B5C03D01F2 /* SemverOperator.swift in Sources */,
 				F60718293A4B5C03D02A2 /* SplitOperator.swift in Sources */,
 				F60718293A4B5C03D03A2 /* SortByOperator.swift in Sources */,
+				F60718293A4B5C03D04A2 /* SliceOperator.swift in Sources */,
 				B2C3D4E5F60718293A4B5C02 /* RootVarOperator.swift in Sources */,
 				55DACDF3302BC30A005EE017 /* IAMCallbacks.swift in Sources */,
 				1701E7CE20E0879817B3F61B /* RulesEngineLogger.swift in Sources */,

--- a/Sources/RulesEngine/CustomOperators/CustomOperators.swift
+++ b/Sources/RulesEngine/CustomOperators/CustomOperators.swift
@@ -14,8 +14,6 @@ extension RulesEngine {
     /// future standard JSON Logic operator.
     enum CustomOperators {
 
-        // A flat switch is the point of a dispatcher; it grows one case per
-        // operator, as `Operators.dispatch` does.
         // swiftlint:disable:next cyclomatic_complexity
         static func dispatch(
             op operatorName: String,

--- a/Sources/RulesEngine/CustomOperators/CustomOperators.swift
+++ b/Sources/RulesEngine/CustomOperators/CustomOperators.swift
@@ -14,6 +14,9 @@ extension RulesEngine {
     /// future standard JSON Logic operator.
     enum CustomOperators {
 
+        // A flat switch is the point of a dispatcher; it grows one case per
+        // operator, as `Operators.dispatch` does.
+        // swiftlint:disable:next cyclomatic_complexity
         static func dispatch(
             op operatorName: String,
             args: Value,

--- a/Sources/RulesEngine/CustomOperators/CustomOperators.swift
+++ b/Sources/RulesEngine/CustomOperators/CustomOperators.swift
@@ -39,6 +39,9 @@ extension RulesEngine {
             case "rc.semverCompare":
                 return try SemverOperator.opSemverCompare(args: args, vars: vars)
 
+            case "rc.sortBy":
+                return try SortByOperator.opSortBy(args: args, vars: vars)
+
             case "rc.split":
                 return try SplitOperator.opSplit(args: args, vars: vars)
 

--- a/Sources/RulesEngine/CustomOperators/CustomOperators.swift
+++ b/Sources/RulesEngine/CustomOperators/CustomOperators.swift
@@ -39,6 +39,9 @@ extension RulesEngine {
             case "rc.semverCompare":
                 return try SemverOperator.opSemverCompare(args: args, vars: vars)
 
+            case "rc.slice":
+                return try SliceOperator.opSlice(args: args, vars: vars)
+
             case "rc.sortBy":
                 return try SortByOperator.opSortBy(args: args, vars: vars)
 

--- a/Sources/RulesEngine/CustomOperators/SliceOperator.swift
+++ b/Sources/RulesEngine/CustomOperators/SliceOperator.swift
@@ -1,0 +1,74 @@
+//
+//  SliceOperator.swift
+//
+//  Created by Antonio Pallares.
+//
+
+import Foundation
+
+/// Name used in this operator's error messages.
+private let operatorName = "rc.slice"
+
+extension RulesEngine {
+
+    /// `rc.slice` — takes a run of elements out of an array.
+    enum SliceOperator {
+
+        /// `{"rc.slice": [array, start]}` or
+        /// `{"rc.slice": [array, start, length]}`.
+        ///
+        /// Start and length mean what they mean in `substr`, the string operator
+        /// already in the engine: a negative `start` counts from the end, a
+        /// negative `length` drops that many elements from the right, and both
+        /// clamp to the array instead of failing. Strings keep using `substr`.
+        ///
+        /// Indices must be whole numbers — `.float` is accepted because all
+        /// arithmetic returns it, so `length - 1` is an ordinary way to reach the
+        /// last element. A fractional or non-numeric index throws
+        /// `EvaluationError.typeMismatch`, as does a non-array operand.
+        static func opSlice(args: Value, vars: Scope) throws -> Value {
+            let evaluated = try Operators.evalArgs(args, vars: vars)
+
+            guard evaluated.count == 2 || evaluated.count == 3 else {
+                throw EvaluationError.typeMismatch(
+                    message: "operator '\(operatorName)' expects 2 or 3 arguments, "
+                        + "got \(evaluated.count)"
+                )
+            }
+
+            guard case .array(let items) = evaluated[0] else {
+                throw EvaluationError.typeMismatch(
+                    message: "operator '\(operatorName)' expected an array to slice, "
+                        + "got \(evaluated[0]); strings use 'substr'"
+                )
+            }
+
+            let start = try Self.index(evaluated[1], argument: "start")
+            let begin = start < 0 ? max(items.count + start, 0) : min(start, items.count)
+            let remaining = Array(items[begin...])
+
+            guard evaluated.count == 3 else { return .array(remaining) }
+
+            let length = try Self.index(evaluated[2], argument: "length")
+            let count = length < 0
+                ? max(remaining.count + length, 0)
+                : min(length, remaining.count)
+            return .array(Array(remaining[..<count]))
+        }
+
+        /// Reads a whole-number index, rejecting anything that is not one.
+        private static func index(_ value: Value, argument: String) throws -> Int {
+            switch value {
+            case .int(let number):
+                return Int(clamping: number)
+            case .float(let number) where number.truncatingRemainder(dividingBy: 1) == 0:
+                return Operators.clampedInt(number)
+            default:
+                throw EvaluationError.typeMismatch(
+                    message: "operator '\(operatorName)' expected a whole number "
+                        + "\(argument), got \(value)"
+                )
+            }
+        }
+    }
+}

--- a/Sources/RulesEngine/CustomOperators/SliceOperator.swift
+++ b/Sources/RulesEngine/CustomOperators/SliceOperator.swift
@@ -37,9 +37,13 @@ extension RulesEngine {
             }
 
             guard case .array(let items) = evaluated[0] else {
+                var hint = ""
+                if case .string = evaluated[0] {
+                    hint = "; strings use 'substr'"
+                }
                 throw EvaluationError.typeMismatch(
                     message: "operator '\(operatorName)' expected an array to slice, "
-                        + "got \(evaluated[0]); strings use 'substr'"
+                        + "got \(evaluated[0])\(hint)"
                 )
             }
 

--- a/Sources/RulesEngine/CustomOperators/SortByOperator.swift
+++ b/Sources/RulesEngine/CustomOperators/SortByOperator.swift
@@ -20,11 +20,11 @@ extension RulesEngine {
         /// `keyExpression` is evaluated once per item with the scope rebound to
         /// that item, the same way `map` evaluates its template.
         ///
-        /// Keys must be all strings or all numbers; anything else, including a
-        /// mix, throws `EvaluationError.typeMismatch`. Ordering values of
-        /// different types would need a total order the rule author never asked
-        /// for. Descending is not offered: reversing a sorted array is a
-        /// separate operator, not a mode of this one.
+        /// Keys must be all strings or all finite numbers; anything else,
+        /// including a mix, throws `EvaluationError.typeMismatch`. Ordering
+        /// values of different types would need a total order the rule author
+        /// never asked for. Descending is not offered: reversing a sorted array
+        /// is a separate operator, not a mode of this one.
         static func opSortBy(args: Value, vars: Scope) throws -> Value {
             let raw = Operators.argsAsList(args)
 
@@ -74,7 +74,17 @@ extension RulesEngine {
                 switch key {
                 case .string:
                     sawString = true
-                case .int, .float:
+                case .int:
+                    sawNumber = true
+                case .float(let number):
+                    // A NaN key compares false against everything, so every
+                    // pair would tie and the input would come back unsorted.
+                    guard number.isFinite else {
+                        throw EvaluationError.typeMismatch(
+                            message: "operator '\(operatorName)' expected a finite number key, "
+                                + "got \(key)"
+                        )
+                    }
                     sawNumber = true
                 default:
                     throw EvaluationError.typeMismatch(

--- a/Sources/RulesEngine/CustomOperators/SortByOperator.swift
+++ b/Sources/RulesEngine/CustomOperators/SortByOperator.swift
@@ -47,8 +47,7 @@ extension RulesEngine {
         }
 
         /// Sorts by `keys`, falling back to the input position so equal keys
-        /// keep their order. Swift does not guarantee `sorted(by:)` is stable,
-        /// and the two engines must agree on the output for every input.
+        /// keep their order. Swift does not guarantee `sorted(by:)` is stable.
         private static func sorted(_ items: [Value], by keys: [Value]) throws -> [Value] {
             let order = try Self.comparator(for: keys)
 

--- a/Sources/RulesEngine/CustomOperators/SortByOperator.swift
+++ b/Sources/RulesEngine/CustomOperators/SortByOperator.swift
@@ -102,7 +102,12 @@ extension RulesEngine {
                     guard case .string(let left) = left, case .string(let right) = right else {
                         return false
                     }
-                    return left < right
+                    // Swift orders by Unicode scalar and treats canonically
+                    // equivalent strings as equal; JS and Kotlin both order by
+                    // UTF-16 code unit. The two disagree once a scalar above
+                    // the surrogate range meets an astral one, so follow the
+                    // engines the rules are written against.
+                    return left.utf16.lexicographicallyPrecedes(right.utf16)
                 }
             }
             return { left, right in (left.asNumber ?? 0) < (right.asNumber ?? 0) }

--- a/Sources/RulesEngine/CustomOperators/SortByOperator.swift
+++ b/Sources/RulesEngine/CustomOperators/SortByOperator.swift
@@ -21,10 +21,8 @@ extension RulesEngine {
         /// that item, the same way `map` evaluates its template.
         ///
         /// Keys must be all strings or all finite numbers; anything else,
-        /// including a mix, throws `EvaluationError.typeMismatch`. Ordering
-        /// values of different types would need a total order the rule author
-        /// never asked for. There is no direction argument; a descending numeric
-        /// sort negates the key.
+        /// including a mix, throws `EvaluationError.typeMismatch`. There is no
+        /// direction argument.
         static func opSortBy(args: Value, vars: Scope) throws -> Value {
             let raw = Operators.argsAsList(args)
 

--- a/Sources/RulesEngine/CustomOperators/SortByOperator.swift
+++ b/Sources/RulesEngine/CustomOperators/SortByOperator.swift
@@ -1,0 +1,104 @@
+//
+//  SortByOperator.swift
+//
+//  Created by Antonio Pallares.
+//
+
+import Foundation
+
+/// Name used in this operator's error messages.
+private let operatorName = "rc.sortBy"
+
+extension RulesEngine {
+
+    /// `rc.sortBy` — orders an array by a key computed per item.
+    enum SortByOperator {
+
+        /// `{"rc.sortBy": [array, keyExpression]}` — the original items in
+        /// ascending key order, ties keeping their input order.
+        ///
+        /// `keyExpression` is evaluated once per item with the scope rebound to
+        /// that item, the same way `map` evaluates its template.
+        ///
+        /// Keys must be all strings or all numbers; anything else, including a
+        /// mix, throws `EvaluationError.typeMismatch`. Ordering values of
+        /// different types would need a total order the rule author never asked
+        /// for. Descending is not offered: reversing a sorted array is a
+        /// separate operator, not a mode of this one.
+        static func opSortBy(args: Value, vars: Scope) throws -> Value {
+            let raw = Operators.argsAsList(args)
+
+            guard raw.count == 2 else {
+                throw EvaluationError.typeMismatch(
+                    message: "operator '\(operatorName)' expects 2 arguments, got \(raw.count)"
+                )
+            }
+
+            let source = try Evaluator.evaluateValue(raw[0], vars: vars)
+            guard case .array(let items) = source else {
+                throw EvaluationError.typeMismatch(
+                    message: "operator '\(operatorName)' expected an array to sort, got \(source)"
+                )
+            }
+
+            let keys = try items.map { item in
+                try Evaluator.evaluateValue(raw[1], vars: vars.scoped(to: item))
+            }
+
+            return .array(try Self.sorted(items, by: keys))
+        }
+
+        /// Sorts by `keys`, falling back to the input position so equal keys
+        /// keep their order. Swift does not guarantee `sorted(by:)` is stable,
+        /// and the two engines must agree on the output for every input.
+        private static func sorted(_ items: [Value], by keys: [Value]) throws -> [Value] {
+            let order = try Self.comparator(for: keys)
+
+            return zip(keys.indices, zip(keys, items))
+                .sorted { left, right in
+                    let (leftIndex, (leftKey, _)) = left
+                    let (rightIndex, (rightKey, _)) = right
+                    if order(leftKey, rightKey) { return true }
+                    if order(rightKey, leftKey) { return false }
+                    return leftIndex < rightIndex
+                }
+                .map { _, pair in pair.1 }
+        }
+
+        /// Picks the ordering the whole key set supports, or throws.
+        private static func comparator(for keys: [Value]) throws -> (Value, Value) -> Bool {
+            var sawString = false
+            var sawNumber = false
+
+            for key in keys {
+                switch key {
+                case .string:
+                    sawString = true
+                case .int, .float:
+                    sawNumber = true
+                default:
+                    throw EvaluationError.typeMismatch(
+                        message: "operator '\(operatorName)' expected string or number keys, got \(key)"
+                    )
+                }
+            }
+
+            guard !(sawString && sawNumber) else {
+                throw EvaluationError.typeMismatch(
+                    message: "operator '\(operatorName)' expected keys of a single type, "
+                        + "got both strings and numbers"
+                )
+            }
+
+            if sawString {
+                return { left, right in
+                    guard case .string(let left) = left, case .string(let right) = right else {
+                        return false
+                    }
+                    return left < right
+                }
+            }
+            return { left, right in (left.asNumber ?? 0) < (right.asNumber ?? 0) }
+        }
+    }
+}

--- a/Sources/RulesEngine/CustomOperators/SortByOperator.swift
+++ b/Sources/RulesEngine/CustomOperators/SortByOperator.swift
@@ -11,7 +11,7 @@ private let operatorName = "rc.sortBy"
 
 extension RulesEngine {
 
-    /// `rc.sortBy` — orders an array by a key computed per item.
+    /// `rc.sortBy` — orders an array in ascending order by a key computed per item.
     enum SortByOperator {
 
         /// `{"rc.sortBy": [array, keyExpression]}` — the original items in
@@ -23,8 +23,8 @@ extension RulesEngine {
         /// Keys must be all strings or all finite numbers; anything else,
         /// including a mix, throws `EvaluationError.typeMismatch`. Ordering
         /// values of different types would need a total order the rule author
-        /// never asked for. Descending is not offered: reversing a sorted array
-        /// is a separate operator, not a mode of this one.
+        /// never asked for. There is no direction argument; a descending numeric
+        /// sort negates the key.
         static func opSortBy(args: Value, vars: Scope) throws -> Value {
             let raw = Operators.argsAsList(args)
 

--- a/Tests/UnitTests/RulesEngine/Helpers/PredicateConformanceFixture.swift
+++ b/Tests/UnitTests/RulesEngine/Helpers/PredicateConformanceFixture.swift
@@ -41,11 +41,19 @@ struct ExpectedError: Equatable, Decodable {
     /// Omit to assert only that the variable failed to resolve, whatever
     /// path it was written as.
     let unresolvedPath: String?
+    /// Substrings that must each appear in the error message. Keep these to
+    /// wording a rule author is meant to act on: how an engine renders the
+    /// offending value is not part of the contract.
+    let messageContains: [String]?
+    /// Substrings that must not appear in the error message.
+    let messageOmits: [String]?
 
     enum CodingKeys: String, CodingKey {
         case kind = "error"
         case `operator`
         case unresolvedPath = "path"
+        case messageContains
+        case messageOmits
     }
 }
 

--- a/Tests/UnitTests/RulesEngine/Helpers/PredicateConformanceRunner.swift
+++ b/Tests/UnitTests/RulesEngine/Helpers/PredicateConformanceRunner.swift
@@ -74,6 +74,7 @@ enum PredicateConformanceRunner {
                     )
                     return
                 }
+                assertMessage(error: error, expected: expectedError, fixtureID: fixture.id)
             } catch {
                 Issue.record(
                     "Fixture \(fixture.id) threw \(error), expected \(expectedError.kind)"
@@ -107,6 +108,29 @@ enum PredicateConformanceRunner {
             break
         }
         return false
+    }
+
+    private static func assertMessage(
+        error: RulesEngine.EvaluationError,
+        expected: ExpectedError,
+        fixtureID: String
+    ) {
+        let message = error.description
+
+        for substring in expected.messageContains ?? [] {
+            #expect(
+                message.contains(substring),
+                "Fixture \(fixtureID) expected a message containing \"\(substring)\", "
+                    + "got \"\(message)\""
+            )
+        }
+        for substring in expected.messageOmits ?? [] {
+            #expect(
+                !message.contains(substring),
+                "Fixture \(fixtureID) expected a message without \"\(substring)\", "
+                    + "got \"\(message)\""
+            )
+        }
     }
 
     private static func assertWarnings(

--- a/Tests/UnitTests/RulesEngine/PredicateFixtureTests.swift
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtureTests.swift
@@ -32,7 +32,7 @@ struct PredicateFixtureTests {
     /// fixtures are added or removed.
     @Test
     func fixtureCountMatchesExpected() {
-        let expectedCount = 537
+        let expectedCount = 559
         #expect(
             Self.fixtures.count == expectedCount,
             "Expected \(expectedCount) fixtures, loaded \(Self.fixtures.count)"

--- a/Tests/UnitTests/RulesEngine/PredicateFixtureTests.swift
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtureTests.swift
@@ -32,7 +32,7 @@ struct PredicateFixtureTests {
     /// fixtures are added or removed.
     @Test
     func fixtureCountMatchesExpected() {
-        let expectedCount = 518
+        let expectedCount = 537
         #expect(
             Self.fixtures.count == expectedCount,
             "Expected \(expectedCount) fixtures, loaded \(Self.fixtures.count)"

--- a/Tests/UnitTests/RulesEngine/PredicateFixtureTests.swift
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtureTests.swift
@@ -32,7 +32,7 @@ struct PredicateFixtureTests {
     /// fixtures are added or removed.
     @Test
     func fixtureCountMatchesExpected() {
-        let expectedCount = 562
+        let expectedCount = 563
         #expect(
             Self.fixtures.count == expectedCount,
             "Expected \(expectedCount) fixtures, loaded \(Self.fixtures.count)"

--- a/Tests/UnitTests/RulesEngine/PredicateFixtureTests.swift
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtureTests.swift
@@ -32,7 +32,7 @@ struct PredicateFixtureTests {
     /// fixtures are added or removed.
     @Test
     func fixtureCountMatchesExpected() {
-        let expectedCount = 537
+        let expectedCount = 539
         #expect(
             Self.fixtures.count == expectedCount,
             "Expected \(expectedCount) fixtures, loaded \(Self.fixtures.count)"

--- a/Tests/UnitTests/RulesEngine/PredicateFixtureTests.swift
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtureTests.swift
@@ -32,7 +32,7 @@ struct PredicateFixtureTests {
     /// fixtures are added or removed.
     @Test
     func fixtureCountMatchesExpected() {
-        let expectedCount = 563
+        let expectedCount = 575
         #expect(
             Self.fixtures.count == expectedCount,
             "Expected \(expectedCount) fixtures, loaded \(Self.fixtures.count)"

--- a/Tests/UnitTests/RulesEngine/PredicateFixtureTests.swift
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtureTests.swift
@@ -32,7 +32,7 @@ struct PredicateFixtureTests {
     /// fixtures are added or removed.
     @Test
     func fixtureCountMatchesExpected() {
-        let expectedCount = 575
+        let expectedCount = 574
         #expect(
             Self.fixtures.count == expectedCount,
             "Expected \(expectedCount) fixtures, loaded \(Self.fixtures.count)"

--- a/Tests/UnitTests/RulesEngine/PredicateFixtureTests.swift
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtureTests.swift
@@ -32,7 +32,7 @@ struct PredicateFixtureTests {
     /// fixtures are added or removed.
     @Test
     func fixtureCountMatchesExpected() {
-        let expectedCount = 540
+        let expectedCount = 544
         #expect(
             Self.fixtures.count == expectedCount,
             "Expected \(expectedCount) fixtures, loaded \(Self.fixtures.count)"

--- a/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_slice.json
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_slice.json
@@ -1,0 +1,146 @@
+{
+  "fixtures": [
+    {
+      "id": "slice_from_start_drops_the_leading_elements",
+      "predicate": {"some": [[{"rc.slice": [["a", "b", "c", "d"], 2]}], {"and": [{"===": [{"var": "0"}, "c"]}, {"===": [{"var": "1"}, "d"]}]}]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "slice_start_zero_keeps_everything",
+      "predicate": {"===": [{"rc.length": {"rc.slice": [["a", "b", "c"], 0]}}, 3]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "slice_with_length_takes_a_run",
+      "description": "The third argument is a count, matching substr rather than JS slice's end index",
+      "predicate": {"some": [[{"rc.slice": [["a", "b", "c", "d"], 1, 2]}], {"and": [{"===": [{"rc.length": {"var": ""}}, 2]}, {"===": [{"var": "0"}, "b"]}, {"===": [{"var": "1"}, "c"]}]}]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "slice_negative_start_counts_from_the_end",
+      "description": "The top-N case: the last two elements without knowing the length",
+      "predicate": {"some": [[{"rc.slice": [["a", "b", "c", "d"], -2]}], {"and": [{"===": [{"var": "0"}, "c"]}, {"===": [{"var": "1"}, "d"]}]}]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "slice_negative_length_drops_from_the_right",
+      "predicate": {"some": [[{"rc.slice": [["a", "b", "c", "d"], 1, -1]}], {"and": [{"===": [{"rc.length": {"var": ""}}, 2]}, {"===": [{"var": "0"}, "b"]}]}]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "slice_length_beyond_the_end_clamps",
+      "description": "Asking for more than exists is normal for a top-N rule, not an error",
+      "predicate": {"===": [{"rc.length": {"rc.slice": [["a", "b"], 0, 10]}}, 2]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "slice_start_beyond_the_end_is_empty",
+      "predicate": {"===": [{"rc.length": {"rc.slice": [["a", "b"], 5]}}, 0]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "slice_negative_start_beyond_the_length_clamps_to_zero",
+      "predicate": {"===": [{"rc.length": {"rc.slice": [["a", "b"], -10]}}, 2]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "slice_zero_length_is_empty",
+      "predicate": {"===": [{"rc.length": {"rc.slice": [["a", "b"], 0, 0]}}, 0]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "slice_empty_array_stays_empty",
+      "predicate": {"===": [{"rc.length": {"rc.slice": [[], 0, 3]}}, 0]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "slice_computed_index_from_arithmetic",
+      "description": "Arithmetic returns floats, so a whole-valued float must be a usable index",
+      "predicate": {"some": [[{"rc.slice": [{"var": "xs"}, {"-": [{"rc.length": {"var": "xs"}}, 1]}]}], {"===": [{"var": "0"}, "d"]}]},
+      "variables": {"xs": ["a", "b", "c", "d"]},
+      "expected": true
+    },
+    {
+      "id": "slice_preserves_element_types",
+      "description": "Elements come through untouched, unlike rc.split which always yields strings",
+      "predicate": {"some": [[{"rc.slice": [{"var": "xs"}, 1, 1]}], {"===": [{"var": "0"}, 2]}]},
+      "variables": {"xs": [1, 2, 3]},
+      "expected": true
+    },
+    {
+      "id": "slice_composes_with_sort_by_for_top_n",
+      "description": "The pairing this operator exists for: order, then keep the tail",
+      "predicate": {"some": [[{"rc.slice": [{"rc.sortBy": [{"var": "subs"}, {"var": "expires"}]}, -2]}], {"and": [{"===": [{"var": "0.id"}, "monthly"]}, {"===": [{"var": "1.id"}, "annual"]}]}]},
+      "variables": {"subs": [{"id": "monthly", "expires": "2026-03-09"}, {"id": "weekly", "expires": "2026-01-02"}, {"id": "annual", "expires": "2026-11-30"}]},
+      "expected": true
+    },
+    {
+      "id": "slice_result_works_with_in",
+      "predicate": {"in": ["b", {"rc.slice": [["a", "b", "c"], 1, 1]}]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "slice_non_array_source_is_a_type_error",
+      "description": "Strings keep using substr rather than being sliced here",
+      "predicate": {"rc.slice": ["abcd", 1]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.slice"}
+    },
+    {
+      "id": "slice_missing_start_is_a_type_error",
+      "description": "No implicit zero: an absent index is a lowering bug, not a whole-array copy",
+      "predicate": {"rc.slice": [["a", "b"]]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.slice"}
+    },
+    {
+      "id": "slice_fourth_argument_is_a_type_error",
+      "predicate": {"rc.slice": [["a", "b"], 0, 1, 2]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.slice"}
+    },
+    {
+      "id": "slice_fractional_start_is_a_type_error",
+      "description": "A fractional index means the arithmetic producing it was wrong; truncating would hide that",
+      "predicate": {"rc.slice": [["a", "b", "c"], 1.5]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.slice"}
+    },
+    {
+      "id": "slice_fractional_length_is_a_type_error",
+      "predicate": {"rc.slice": [["a", "b", "c"], 0, 1.5]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.slice"}
+    },
+    {
+      "id": "slice_string_start_is_a_type_error",
+      "description": "substr coerces a non-numeric start to 0; a custom operator refuses instead",
+      "predicate": {"rc.slice": [["a", "b"], "1"]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.slice"}
+    },
+    {
+      "id": "slice_null_start_is_a_type_error",
+      "predicate": {"rc.slice": [["a", "b"], null]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.slice"}
+    },
+    {
+      "id": "slice_missing_variable_fails_at_the_lookup",
+      "predicate": {"rc.slice": [{"var": "nope"}, 0]},
+      "variables": {},
+      "expected": {"error": "unresolvedVariable", "path": "nope"}
+    }
+  ]
+}

--- a/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_slice.json
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_slice.json
@@ -71,6 +71,25 @@
       "expected": true
     },
     {
+      "id": "slice_integral_float_start_is_accepted",
+      "description": "A literal whole-valued float is an index, not a fractional one",
+      "predicate": {"some": [[{"rc.slice": [["a", "b", "c", "d"], 2.0]}], {"and": [{"===": [{"var": "0"}, "c"]}, {"===": [{"var": "1"}, "d"]}]}]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "slice_negative_integral_float_start_is_accepted",
+      "predicate": {"some": [[{"rc.slice": [["a", "b", "c", "d"], -2.0]}], {"and": [{"===": [{"var": "0"}, "c"]}, {"===": [{"var": "1"}, "d"]}]}]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "slice_integral_float_length_is_accepted",
+      "predicate": {"some": [[{"rc.slice": [["a", "b", "c", "d"], 0, 2.0]}], {"and": [{"===": [{"rc.length": {"var": ""}}, 2]}, {"===": [{"var": "0"}, "a"]}]}]},
+      "variables": {},
+      "expected": true
+    },
+    {
       "id": "slice_preserves_element_types",
       "description": "Elements come through untouched, unlike rc.split which always yields strings",
       "predicate": {"some": [[{"rc.slice": [{"var": "xs"}, 1, 1]}], {"===": [{"var": "0"}, 2]}]},
@@ -101,6 +120,26 @@
       "id": "slice_object_source_is_a_type_error",
       "description": "A keyed object has no positions to slice; rc.entries is the way in",
       "predicate": {"rc.slice": [{"a": 1, "b": 2}, 1]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.slice"}
+    },
+    {
+      "id": "slice_number_source_is_a_type_error",
+      "description": "substr would stringify the number first; nothing here is sliceable",
+      "predicate": {"rc.slice": [12345, 1]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.slice"}
+    },
+    {
+      "id": "slice_bool_source_is_a_type_error",
+      "predicate": {"rc.slice": [true, 1]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.slice"}
+    },
+    {
+      "id": "slice_null_source_is_a_type_error",
+      "description": "A field that resolved to null is a broken rule, not an empty slice",
+      "predicate": {"rc.slice": [null, 1]},
       "variables": {},
       "expected": {"error": "typeMismatch", "operator": "rc.slice"}
     },
@@ -140,6 +179,46 @@
     {
       "id": "slice_null_start_is_a_type_error",
       "predicate": {"rc.slice": [["a", "b"], null]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.slice"}
+    },
+    {
+      "id": "slice_non_numeric_string_start_is_a_type_error",
+      "description": "substr sends a string with no number in it to 0; this refuses instead",
+      "predicate": {"rc.slice": [["a", "b"], "abc"]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.slice"}
+    },
+    {
+      "id": "slice_bool_start_is_a_type_error",
+      "description": "substr reads true as 1; a boolean index is a lowering bug here",
+      "predicate": {"rc.slice": [["a", "b"], true]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.slice"}
+    },
+    {
+      "id": "slice_negative_fractional_start_is_a_type_error",
+      "description": "substr truncates toward zero, so -1.5 would silently mean -1",
+      "predicate": {"rc.slice": [["a", "b", "c"], -1.5]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.slice"}
+    },
+    {
+      "id": "slice_numeric_string_length_is_a_type_error",
+      "description": "substr would read \"1\" as 1; the length argument is no laxer than the start",
+      "predicate": {"rc.slice": [["a", "b", "c"], 0, "1"]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.slice"}
+    },
+    {
+      "id": "slice_null_length_is_a_type_error",
+      "predicate": {"rc.slice": [["a", "b", "c"], 0, null]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.slice"}
+    },
+    {
+      "id": "slice_bool_length_is_a_type_error",
+      "predicate": {"rc.slice": [["a", "b", "c"], 0, true]},
       "variables": {},
       "expected": {"error": "typeMismatch", "operator": "rc.slice"}
     },

--- a/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_slice.json
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_slice.json
@@ -71,21 +71,15 @@
       "expected": true
     },
     {
-      "id": "slice_integral_float_start_is_accepted",
-      "description": "A literal whole-valued float is an index, not a fractional one",
-      "predicate": {"some": [[{"rc.slice": [["a", "b", "c", "d"], 2.0]}], {"and": [{"===": [{"var": "0"}, "c"]}, {"===": [{"var": "1"}, "d"]}]}]},
+      "id": "slice_negative_whole_float_start_is_accepted",
+      "description": "Arithmetic is what produces a float index; a literal -2.0 decodes as an int",
+      "predicate": {"some": [[{"rc.slice": [["a", "b", "c", "d"], {"-": [0, 2]}]}], {"and": [{"===": [{"var": "0"}, "c"]}, {"===": [{"var": "1"}, "d"]}]}]},
       "variables": {},
       "expected": true
     },
     {
-      "id": "slice_negative_integral_float_start_is_accepted",
-      "predicate": {"some": [[{"rc.slice": [["a", "b", "c", "d"], -2.0]}], {"and": [{"===": [{"var": "0"}, "c"]}, {"===": [{"var": "1"}, "d"]}]}]},
-      "variables": {},
-      "expected": true
-    },
-    {
-      "id": "slice_integral_float_length_is_accepted",
-      "predicate": {"some": [[{"rc.slice": [["a", "b", "c", "d"], 0, 2.0]}], {"and": [{"===": [{"rc.length": {"var": ""}}, 2]}, {"===": [{"var": "0"}, "a"]}]}]},
+      "id": "slice_whole_float_length_is_accepted",
+      "predicate": {"some": [[{"rc.slice": [["a", "b", "c", "d"], 0, {"+": [1, 1]}]}], {"and": [{"===": [{"rc.length": {"var": ""}}, 2]}, {"===": [{"var": "0"}, "a"]}]}]},
       "variables": {},
       "expected": true
     },

--- a/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_slice.json
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_slice.json
@@ -105,37 +105,57 @@
     },
     {
       "id": "slice_string_source_is_a_type_error",
-      "description": "Strings keep using substr rather than being sliced here",
+      "description": "Strings keep using substr rather than being sliced here, and the message says so",
       "predicate": {"rc.slice": ["abcd", 1]},
       "variables": {},
-      "expected": {"error": "typeMismatch", "operator": "rc.slice"}
+      "expected": {
+        "error": "typeMismatch",
+        "operator": "rc.slice",
+        "messageContains": ["strings use 'substr'"]
+      }
     },
     {
       "id": "slice_object_source_is_a_type_error",
       "description": "A keyed object has no positions to slice; rc.entries is the way in",
       "predicate": {"rc.slice": [{"a": 1, "b": 2}, 1]},
       "variables": {},
-      "expected": {"error": "typeMismatch", "operator": "rc.slice"}
+      "expected": {
+        "error": "typeMismatch",
+        "operator": "rc.slice",
+        "messageOmits": ["substr"]
+      }
     },
     {
       "id": "slice_number_source_is_a_type_error",
       "description": "substr would stringify the number first; nothing here is sliceable",
       "predicate": {"rc.slice": [12345, 1]},
       "variables": {},
-      "expected": {"error": "typeMismatch", "operator": "rc.slice"}
+      "expected": {
+        "error": "typeMismatch",
+        "operator": "rc.slice",
+        "messageOmits": ["substr"]
+      }
     },
     {
       "id": "slice_bool_source_is_a_type_error",
       "predicate": {"rc.slice": [true, 1]},
       "variables": {},
-      "expected": {"error": "typeMismatch", "operator": "rc.slice"}
+      "expected": {
+        "error": "typeMismatch",
+        "operator": "rc.slice",
+        "messageOmits": ["substr"]
+      }
     },
     {
       "id": "slice_null_source_is_a_type_error",
       "description": "A field that resolved to null is a broken rule, not an empty slice",
       "predicate": {"rc.slice": [null, 1]},
       "variables": {},
-      "expected": {"error": "typeMismatch", "operator": "rc.slice"}
+      "expected": {
+        "error": "typeMismatch",
+        "operator": "rc.slice",
+        "messageOmits": ["substr"]
+      }
     },
     {
       "id": "slice_missing_start_is_a_type_error",

--- a/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_slice.json
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_slice.json
@@ -91,9 +91,16 @@
       "expected": true
     },
     {
-      "id": "slice_non_array_source_is_a_type_error",
+      "id": "slice_string_source_is_a_type_error",
       "description": "Strings keep using substr rather than being sliced here",
       "predicate": {"rc.slice": ["abcd", 1]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.slice"}
+    },
+    {
+      "id": "slice_object_source_is_a_type_error",
+      "description": "A keyed object has no positions to slice; rc.entries is the way in",
+      "predicate": {"rc.slice": [{"a": 1, "b": 2}, 1]},
       "variables": {},
       "expected": {"error": "typeMismatch", "operator": "rc.slice"}
     },

--- a/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_sort_by.json
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_sort_by.json
@@ -9,7 +9,7 @@
     },
     {
       "id": "sort_by_string_keys_order_by_utf16_code_unit",
-      "description": "An astral key sorts before a BMP one above the surrogate range, as in JS and Kotlin; Swift's own < would reverse these",
+      "description": "String keys order as UTF-16 code units: an astral key starts with a leading surrogate, which sorts below any code unit above the surrogate range",
       "predicate": {"some": [[{"rc.sortBy": [{"var": "xs"}, {"var": ""}]}], {"and": [{"===": [{"var": "0"}, "\uD83D\uDE00"]}, {"===": [{"var": "1"}, "\uFF21"]}]}]},
       "variables": {"xs": ["\uFF21", "\uD83D\uDE00"]},
       "expected": true
@@ -22,14 +22,14 @@
     },
     {
       "id": "sort_by_ascii_sorts_before_an_astral_key",
-      "description": "Below the surrogate range the two orderings agree, so ASCII stays first",
+      "description": "Control case: an ASCII code unit sorts below a leading surrogate",
       "predicate": {"some": [[{"rc.sortBy": [{"var": "xs"}, {"var": ""}]}], {"and": [{"===": [{"var": "0"}, "Z"]}, {"===": [{"var": "1"}, "\uD83D\uDE00"]}, {"===": [{"var": "2"}, "\uFF21"]}]}]},
       "variables": {"xs": ["\uFF21", "\uD83D\uDE00", "Z"]},
       "expected": true
     },
     {
       "id": "sort_by_orders_canonically_equivalent_keys_by_code_unit",
-      "description": "Swift reads these two spellings of e-acute as equal, which would leave them in input order; === cannot tell them apart either, so assert on UTF-16 length",
+      "description": "The two spellings of e-acute are distinct keys, and the decomposed one starts with 'e' so it sorts first. UTF-16 length is what tells the two spellings apart",
       "predicate": {"some": [[{"rc.sortBy": [{"var": "xs"}, {"var": ""}]}], {"and": [{"===": [{"rc.length": {"var": "0"}}, 2]}, {"===": [{"rc.length": {"var": "1"}}, 1]}]}]},
       "variables": {"xs": ["\u00E9", "e\u0301"]},
       "expected": true

--- a/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_sort_by.json
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_sort_by.json
@@ -8,6 +8,33 @@
       "expected": true
     },
     {
+      "id": "sort_by_string_keys_order_by_utf16_code_unit",
+      "description": "An astral key sorts before a BMP one above the surrogate range, as in JS and Kotlin; Swift's own < would reverse these",
+      "predicate": {"some": [[{"rc.sortBy": [{"var": "xs"}, {"var": ""}]}], {"and": [{"===": [{"var": "0"}, "\uD83D\uDE00"]}, {"===": [{"var": "1"}, "\uFF21"]}]}]},
+      "variables": {"xs": ["\uFF21", "\uD83D\uDE00"]},
+      "expected": true
+    },
+    {
+      "id": "sort_by_utf16_order_holds_whatever_the_input_order",
+      "predicate": {"some": [[{"rc.sortBy": [{"var": "xs"}, {"var": ""}]}], {"and": [{"===": [{"var": "0"}, "\uD83D\uDE00"]}, {"===": [{"var": "1"}, "\uFF21"]}]}]},
+      "variables": {"xs": ["\uD83D\uDE00", "\uFF21"]},
+      "expected": true
+    },
+    {
+      "id": "sort_by_ascii_sorts_before_an_astral_key",
+      "description": "Below the surrogate range the two orderings agree, so ASCII stays first",
+      "predicate": {"some": [[{"rc.sortBy": [{"var": "xs"}, {"var": ""}]}], {"and": [{"===": [{"var": "0"}, "Z"]}, {"===": [{"var": "1"}, "\uD83D\uDE00"]}, {"===": [{"var": "2"}, "\uFF21"]}]}]},
+      "variables": {"xs": ["\uFF21", "\uD83D\uDE00", "Z"]},
+      "expected": true
+    },
+    {
+      "id": "sort_by_orders_canonically_equivalent_keys_by_code_unit",
+      "description": "Swift reads these two spellings of e-acute as equal, which would leave them in input order; === cannot tell them apart either, so assert on UTF-16 length",
+      "predicate": {"some": [[{"rc.sortBy": [{"var": "xs"}, {"var": ""}]}], {"and": [{"===": [{"rc.length": {"var": "0"}}, 2]}, {"===": [{"rc.length": {"var": "1"}}, 1]}]}]},
+      "variables": {"xs": ["\u00E9", "e\u0301"]},
+      "expected": true
+    },
+    {
       "id": "sort_by_returns_the_original_items_not_the_keys",
       "description": "Like filter, the retained values are the inputs; the key is only the ordering",
       "predicate": {"some": [[{"rc.sortBy": [{"var": "subs"}, {"var": "expires"}]}], {"===": [{"var": "0.id"}, "weekly"]}]},

--- a/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_sort_by.json
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_sort_by.json
@@ -1,0 +1,130 @@
+{
+  "fixtures": [
+    {
+      "id": "sort_by_ascending_string_keys",
+      "description": "The sorted array is read by rebinding scope to it, the same way rc.split results are read",
+      "predicate": {"some": [[{"rc.sortBy": [{"var": "subs"}, {"var": "expires"}]}], {"and": [{"===": [{"var": "0.id"}, "weekly"]}, {"===": [{"var": "1.id"}, "monthly"]}, {"===": [{"var": "2.id"}, "annual"]}]}]},
+      "variables": {"subs": [{"id": "monthly", "expires": "2026-03-09"}, {"id": "weekly", "expires": "2026-01-02"}, {"id": "annual", "expires": "2026-11-30"}]},
+      "expected": true
+    },
+    {
+      "id": "sort_by_returns_the_original_items_not_the_keys",
+      "description": "Like filter, the retained values are the inputs; the key is only the ordering",
+      "predicate": {"some": [[{"rc.sortBy": [{"var": "subs"}, {"var": "expires"}]}], {"===": [{"var": "0.id"}, "weekly"]}]},
+      "variables": {"subs": [{"id": "monthly", "expires": "2026-03-09"}, {"id": "weekly", "expires": "2026-01-02"}]},
+      "expected": true
+    },
+    {
+      "id": "sort_by_numeric_keys_compare_numerically",
+      "description": "The motivating case: lexicographic ordering would put 100 before 9",
+      "predicate": {"some": [[{"rc.sortBy": [[9, 10, 100], {"var": ""}]}], {"and": [{"===": [{"var": "0"}, 9]}, {"===": [{"var": "1"}, 10]}, {"===": [{"var": "2"}, 100]}]}]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "sort_by_mixes_ints_and_floats",
+      "predicate": {"some": [[{"rc.sortBy": [[3, -1, 2.5], {"var": ""}]}], {"and": [{"===": [{"var": "0"}, -1]}, {"===": [{"var": "1"}, 2.5]}, {"===": [{"var": "2"}, 3]}]}]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "sort_by_is_stable_for_equal_keys",
+      "description": "Ties keep input order, so the two engines agree on an output the key alone does not determine",
+      "predicate": {"some": [[{"rc.sortBy": [{"var": "xs"}, {"var": "k"}]}], {"and": [{"===": [{"var": "0.id"}, "third"]}, {"===": [{"var": "1.id"}, "first"]}, {"===": [{"var": "2.id"}, "second"]}]}]},
+      "variables": {"xs": [{"id": "first", "k": 1}, {"id": "second", "k": 1}, {"id": "third", "k": 0}]},
+      "expected": true
+    },
+    {
+      "id": "sort_by_keeps_every_duplicate",
+      "description": "Unlike sorting through rc.fromEntries, items sharing a key are not collapsed",
+      "predicate": {"===": [{"rc.length": {"rc.sortBy": [{"var": "xs"}, {"var": "k"}]}}, 3]},
+      "variables": {"xs": [{"k": 1}, {"k": 1}, {"k": 1}]},
+      "expected": true
+    },
+    {
+      "id": "sort_by_empty_array_is_empty",
+      "predicate": {"===": [{"rc.length": {"rc.sortBy": [[], {"var": ""}]}}, 0]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "sort_by_single_element",
+      "predicate": {"some": [[{"rc.sortBy": [[5], {"var": ""}]}], {"===": [{"var": "0"}, 5]}]},
+      "variables": {},
+      "expected": true
+    },
+    {
+      "id": "sort_by_key_expression_sees_the_item",
+      "description": "The key template is evaluated per item with scope rebound, as map does",
+      "predicate": {"some": [[{"rc.sortBy": [{"var": "xs"}, {"cat": [{"var": "a"}, {"var": "b"}]}]}], {"===": [{"var": "0.a"}, "x"]}]},
+      "variables": {"xs": [{"a": "y", "b": "1"}, {"a": "x", "b": "9"}]},
+      "expected": true
+    },
+    {
+      "id": "sort_by_key_expression_can_reach_the_root",
+      "description": "Scope is rebound to the item, so rc.rootVar is how the key reads top-level data",
+      "predicate": {"some": [[{"rc.sortBy": [{"var": "xs"}, {"-": [{"rc.rootVar": "base"}, {"var": "k"}]}]}], {"===": [{"var": "0.k"}, 3]}]},
+      "variables": {"base": 100, "xs": [{"k": 1}, {"k": 3}, {"k": 2}]},
+      "expected": true
+    },
+    {
+      "id": "sort_by_descending_is_expressed_by_negating_the_key",
+      "description": "No direction argument: a descending numeric sort negates the key instead",
+      "predicate": {"some": [[{"rc.sortBy": [{"var": "xs"}, {"-": [0, {"var": ""}]}]}], {"===": [{"var": "0"}, 3]}]},
+      "variables": {"xs": [1, 3, 2]},
+      "expected": true
+    },
+    {
+      "id": "sort_by_non_array_source_is_a_type_error",
+      "predicate": {"rc.sortBy": ["nope", {"var": ""}]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.sortBy"}
+    },
+    {
+      "id": "sort_by_missing_operand_is_a_type_error",
+      "description": "No implicit key expression: a one-sided call is a lowering bug",
+      "predicate": {"rc.sortBy": [[1, 2]]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.sortBy"}
+    },
+    {
+      "id": "sort_by_extra_operand_is_a_type_error",
+      "description": "Arity is exact so a third argument is not mistaken for a direction flag",
+      "predicate": {"rc.sortBy": [[1, 2], {"var": ""}, "desc"]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.sortBy"}
+    },
+    {
+      "id": "sort_by_null_key_is_a_type_error",
+      "predicate": {"rc.sortBy": [{"var": "xs"}, {"var": "k"}]},
+      "variables": {"xs": [{"k": null}]},
+      "expected": {"error": "typeMismatch", "operator": "rc.sortBy"}
+    },
+    {
+      "id": "sort_by_bool_key_is_a_type_error",
+      "predicate": {"rc.sortBy": [[true], {"var": ""}]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.sortBy"}
+    },
+    {
+      "id": "sort_by_object_key_is_a_type_error",
+      "predicate": {"rc.sortBy": [{"var": "xs"}, {"var": "k"}]},
+      "variables": {"xs": [{"k": {"a": 1}}]},
+      "expected": {"error": "typeMismatch", "operator": "rc.sortBy"}
+    },
+    {
+      "id": "sort_by_mixed_key_types_is_a_type_error",
+      "description": "Ordering a number against a string would need a total order the rule never asked for",
+      "predicate": {"rc.sortBy": [[1, "a"], {"var": ""}]},
+      "variables": {},
+      "expected": {"error": "typeMismatch", "operator": "rc.sortBy"}
+    },
+    {
+      "id": "sort_by_missing_key_fails_at_the_lookup",
+      "description": "An item without the key is caught by var before rc.sortBy compares anything",
+      "predicate": {"rc.sortBy": [{"var": "xs"}, {"var": "k"}]},
+      "variables": {"xs": [{"k": 1}, {"other": 2}]},
+      "expected": {"error": "unresolvedVariable", "path": "k"}
+    }
+  ]
+}

--- a/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_sort_by.json
+++ b/Tests/UnitTests/RulesEngine/PredicateFixtures/rc_sort_by.json
@@ -120,6 +120,20 @@
       "expected": {"error": "typeMismatch", "operator": "rc.sortBy"}
     },
     {
+      "id": "sort_by_nan_key_is_a_type_error",
+      "description": "Negating a string key is the natural way to attempt a descending sort by date; it yields NaN, which would tie with everything and hand back the input unsorted",
+      "predicate": {"rc.sortBy": [{"var": "subs"}, {"-": [0, {"var": "expires"}]}]},
+      "variables": {"subs": [{"expires": "2026-03-09"}, {"expires": "2026-01-02"}]},
+      "expected": {"error": "typeMismatch", "operator": "rc.sortBy"}
+    },
+    {
+      "id": "sort_by_infinite_key_is_a_type_error",
+      "description": "A non-finite key means the key arithmetic went wrong, so it is refused alongside NaN",
+      "predicate": {"rc.sortBy": [{"var": "xs"}, {"/": [{"var": "k"}, 0]}]},
+      "variables": {"xs": [{"k": 1}, {"k": 2}]},
+      "expected": {"error": "typeMismatch", "operator": "rc.sortBy"}
+    },
+    {
       "id": "sort_by_missing_key_fails_at_the_lookup",
       "description": "An item without the key is caught by var before rc.sortBy compares anything",
       "predicate": {"rc.sortBy": [{"var": "xs"}, {"var": "k"}]},


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Error fixtures could pin the error *kind* but not a word of the message, so guidance written for rule authors was untestable. `rc.slice` points a string operand at `substr`; nothing could assert that it appears, or that it stays out of the other type mismatches.

### Description
Adds optional `messageContains` / `messageOmits` substring assertions to an error fixture's `expected`, alongside the existing `error` and `operator` keys.

- Substrings only, never whole messages: how each engine renders the offending value is not part of the contract, so Android stays free to differ there while both must emit the shared hint.
- Applied to the five `rc.slice` source-type fixtures. Forcing the hint on always fails 4; removing it fails 1.
- Separate from #7505 because it changes `ExpectedError` and the runner, which every fixture file goes through.
