### PR TITLE
fix(paywalls): drop bidirectional marks from the currency symbol

### DIFF
--- a/RevenueCatUI/Templates/V2/Variables/VariableHandlerV2.swift
+++ b/RevenueCatUI/Templates/V2/Variables/VariableHandlerV2.swift
@@ -566,12 +566,8 @@ extension VariablesV2 {
 
         // The displayed token can be the ISO code rather than a symbol (e.g. "24,99 USD"),
         // so fall back to the currency's narrow symbol, which is never a code.
-        //
-        // Right-to-left locales wrap the price in bidirectional marks, so the token can arrive as
-        // `<LRM>RUB`. Compare without them, or the code goes unrecognized and renders as-is.
         if let displayedToken, let currencyCode = product.currencyCode,
-           displayedToken.trimmingCharacters(in: .currencyTokenPadding)
-            .caseInsensitiveCompare(currencyCode) == .orderedSame {
+           displayedToken.caseInsensitiveCompare(currencyCode) == .orderedSame {
             return self.narrowCurrencySymbol(currencyCode: currencyCode,
                                              locale: product.priceFormatter?.locale) ?? displayedToken
         }
@@ -588,8 +584,7 @@ extension VariablesV2 {
                 .presentation(.narrow)
                 .locale(locale ?? .autoupdatingCurrent)
             )
-            .currencySymbolFromPriceString?
-            .trimmingCharacters(in: .currencyTokenPadding)
+            .currencySymbolFromPriceString
     }
 
     func productPrice(package: Package, showZeroDecimalPlacePrices: Bool) -> String {
@@ -1153,7 +1148,7 @@ private extension String {
         }
 
         let symbol = "\(self[..<firstDigit])\(self[self.index(after: lastDigit)...])"
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: .currencyTokenPadding)
 
         return symbol.isEmpty ? nil : symbol
     }

--- a/Tests/RevenueCatUITests/PaywallsV2/VariableHandlerV2Tests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/VariableHandlerV2Tests.swift
@@ -346,6 +346,74 @@ class VariableHandlerV2Test: TestCase {
         expect(perYear).to(equal("$24.99"))
     }
 
+    /// A right-to-left locale wraps the price in bidirectional marks even when the currency has a
+    /// real symbol, so the token comes back padded with a mark and a space rather than as `US$`.
+    /// This is what `ar_SO` actually returns for a USD product.
+    func testProductCurrencySymbolStripsPaddingFromASymbolToken() {
+        let package = Self.package(
+            currencyCode: "USD",
+            localizedPriceString: "\u{200E}\u{0662}\u{0664}\u{066B}\u{0669}\u{0669}\u{00A0}US$",
+            identifier: "com.revenuecat.product.currency_symbol_rtl_symbol",
+            locale: "ar_SO"
+        )
+
+        let result = variableHandler.processVariables(
+            in: "{{ product.currency_symbol }}",
+            with: package,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+
+        expect(result).to(equal("US$"))
+    }
+
+    /// Hebrew puts a mark on both sides of the symbol.
+    func testProductCurrencySymbolStripsPaddingAroundASymbolToken() {
+        let package = Self.package(
+            currencyCode: "USD",
+            localizedPriceString: "\u{200E}24.99\u{00A0}\u{200E}$",
+            identifier: "com.revenuecat.product.currency_symbol_rtl_wrapped",
+            locale: "he_IL"
+        )
+
+        let result = variableHandler.processVariables(
+            in: "{{ product.currency_symbol }}",
+            with: package,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+
+        expect(result).to(equal("$"))
+    }
+
+    private static func package(
+        currencyCode: String,
+        localizedPriceString: String,
+        identifier: String,
+        locale: String
+    ) -> Package {
+        return Package(
+            identifier: PackageType.annual.identifier,
+            packageType: .annual,
+            storeProduct: TestStoreProduct(
+                localizedTitle: "Yearly",
+                price: 24.99,
+                currencyCode: currencyCode,
+                localizedPriceString: localizedPriceString,
+                productIdentifier: identifier,
+                productType: .autoRenewableSubscription,
+                localizedDescription: "PRO yearly",
+                subscriptionGroupIdentifier: "group",
+                subscriptionPeriod: .init(value: 1, unit: .year),
+                locale: Locale(identifier: locale)
+            ).toStoreProduct(),
+            offeringIdentifier: "offering",
+            webCheckoutUrl: nil
+        )
+    }
+
     /// Right-to-left locales wrap the displayed price in bidirectional marks, so the extracted
     /// token arrives as `<LRM>RUB` rather than `RUB`. The ISO code has to be recognized through
     /// them, otherwise the variable renders the code.


### PR DESCRIPTION
Stacked on #7509.

### Motivation

`product.currency_symbol` renders a non-breaking space and an invisible mark in front of the symbol. 

A paywall writing `{{ product.currency_symbol }}0.00` gets a stray gap since 5.70.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized paywall display fix in currency parsing only; behavior change is stripping invisible RTL padding from symbols, with targeted tests and no payment or auth impact.
> 
> **Overview**
> Fixes **`{{ product.currency_symbol }}`** in RTL locales (e.g. `ar_SO`, `he_IL`) returning invisible left-to-right marks, non-breaking spaces, or other padding ahead of or around the symbol—so templates like `{{ product.currency_symbol }}0.00` no longer get stray gaps.
> 
> **`currencySymbolFromPriceString`** now trims with **`.currencyTokenPadding`** (whitespace/newlines plus control characters, including bidi marks) instead of only `.whitespacesAndNewlines`. Padding is removed once at extraction, so **`productCurrencySymbol`** and **`narrowCurrencySymbol`** no longer duplicate that trimming or special-case ISO-code comparison for marks.
> 
> Adds unit tests for RTL-shaped price strings (`ar_SO` → `US$`, `he_IL` → `$`) and a shared test **`package`** helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4de30f14cfe33310168ea5c21447fab864fedeec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->