### PR TITLE
ci: delete the per-PR machinery and the dedup the main-only API feed made dead

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2554,17 +2554,10 @@ platform :ios do
 
     ApiDiffHelper.print_breaking_summary(all_breaks, labels)
 
-    # Informational: a GitHub or Slack outage must not decide whether the gate fails.
-    begin
-      # main carries no pull request to comment on, and announcing only from there keeps the
-      # feed to one post per change.
-      if on_main
-        notify_api_changes_on_slack(
-          reports_by_target: reports_by_target,
-          breaks: all_breaks,
-          labels: labels
-        )
-      else
+    # main carries no pull request to comment on.
+    # Informational: a GitHub outage must not decide whether the gate fails.
+    unless on_main
+      begin
         schemes.each do |scheme|
           upsert_api_diff_comment(
             scheme: scheme,
@@ -2573,9 +2566,9 @@ platform :ios do
             labels: labels
           )
         end
+      rescue StandardError => e
+        UI.important("Could not publish the API diff report: #{e.message}")
       end
-    rescue StandardError => e
-      UI.important("Could not publish the API diff report: #{e.message}")
     end
 
     if failed_platforms.any?
@@ -2588,6 +2581,20 @@ platform :ios do
         UI.important("Breaking public API changes on main, already gated on the PR run")
       else
         UI.user_error!("Breaking public API changes detected. Add #{ApiDiffHelper::BREAKING_CHANGE_LABEL} if intentional.")
+      end
+    end
+
+    # Last, and only from main: nothing below can fail the job, so a rerun cannot post twice, and
+    # a run whose baselines did not match never announces a surface it could not validate.
+    if on_main
+      begin
+        notify_api_changes_on_slack(
+          reports_by_target: reports_by_target,
+          breaks: all_breaks,
+          labels: labels
+        )
+      rescue StandardError => e
+        UI.important("Could not announce the API change: #{e.message}")
       end
     end
   end
@@ -2669,16 +2676,6 @@ platform :ios do
       next
     end
 
-    state, history_error = ApiDiffHelper.announcement_state(
-      summary, bot_token: bot_token, channel: channel, source: source
-    )
-    if state == :same
-      UI.message("This API change is already in the SDK API feed, not posting it again")
-      next
-    end
-
-    UI.important("Could not read the SDK API feed, so this change may be announced twice: #{history_error}") if history_error
-
     begin
       ApiDiffHelper.post_slack_message(request)
       UI.success("Posted the API change summary to Slack")
@@ -2687,7 +2684,7 @@ platform :ios do
     end
   end
 
-  # The commit page carries the PR link, and its sha is what tells a rerun it already announced.
+  # The commit page carries the PR link, so the message needs only the commit.
   private_lane :api_gate_commit_link do
     sha = sh("git", "rev-parse", "HEAD", log: false).strip
     next "" if sha.empty?

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2556,25 +2556,23 @@ platform :ios do
 
     # Informational: a GitHub or Slack outage must not decide whether the gate fails.
     begin
-      # Announcing only from main keeps the feed to one post per change.
-      announcement = if on_main
-                       notify_api_changes_on_slack(
-                         reports_by_target: reports_by_target,
-                         breaks: all_breaks,
-                         labels: labels
-                       )
-                     else
-                       { fingerprint: nil, notice: nil }
-                     end
-      schemes.each do |scheme|
-        upsert_api_diff_comment(
-          scheme: scheme,
-          reports_by_target: reports_by_target.select { |target, _r| target.start_with?("#{scheme} ") },
-          breaks: breaks_by_scheme.fetch(scheme, []),
-          labels: labels,
-          notice: announcement[:notice],
-          announced_fingerprint: announcement[:fingerprint]
+      # main carries no pull request to comment on, and announcing only from there keeps the
+      # feed to one post per change.
+      if on_main
+        notify_api_changes_on_slack(
+          reports_by_target: reports_by_target,
+          breaks: all_breaks,
+          labels: labels
         )
+      else
+        schemes.each do |scheme|
+          upsert_api_diff_comment(
+            scheme: scheme,
+            reports_by_target: reports_by_target.select { |target, _r| target.start_with?("#{scheme} ") },
+            breaks: breaks_by_scheme.fetch(scheme, []),
+            labels: labels
+          )
+        end
       end
     rescue StandardError => e
       UI.important("Could not publish the API diff report: #{e.message}")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2662,20 +2662,15 @@ platform :ios do
       modules: modules,
       modifications: ApiDiffHelper.modified_declarations(options[:reports_by_target])
     )
-    request = ApiDiffHelper.slack_post_request(
-      summary,
-      webhook_url: ENV["SLACK_URL_SDK_NEW_API"],
-      bot_token: bot_token,
-      channel: channel
-    )
+    request = ApiDiffHelper.slack_post_request(summary, bot_token: bot_token, channel: channel)
 
     if request.nil?
-      UI.important("No Slack credential reachable. Expected SLACK_ACCESS_TOKEN_CIRCLE_CI_NOTIFY_ORB_IOS from the slack-secrets context plus SLACK_CHANNEL_SDK_NEW_API, or SLACK_URL_SDK_NEW_API. Skipping.")
+      UI.important("No Slack credential reachable. Expected SLACK_ACCESS_TOKEN_CIRCLE_CI_NOTIFY_ORB_IOS from the slack-secrets context plus SLACK_CHANNEL_SDK_NEW_API. Skipping.")
       next
     end
 
     state, history_error = ApiDiffHelper.announcement_state(
-      summary, bot_token: bot_token, channel: channel, source: source, modules: modules
+      summary, bot_token: bot_token, channel: channel, source: source
     )
     if state == :same
       UI.message("This API change is already in the SDK API feed, not posting it again")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2609,12 +2609,9 @@ platform :ios do
       next
     end
 
-    announced_fingerprint = options[:announced_fingerprint] ||
-                            ApiDiffHelper.announced_fingerprint_in(existing&.dig("body"), options[:scheme])
-
     section = ApiDiffHelper.api_diff_comment_section(
       options[:scheme], options[:reports_by_target], options[:breaks], options[:labels],
-      notice: options[:notice], announced_fingerprint: announced_fingerprint
+      notice: options[:notice]
     )
 
     if existing
@@ -2642,14 +2639,14 @@ platform :ios do
     end
   end
 
-  # Returns { fingerprint:, notice: }; the notice ends up in the PR comment.
+  # Returns { notice: }.
   private_lane :notify_api_changes_on_slack do |options|
     breaks = options[:breaks]
     changed_targets = options[:reports_by_target].select { |_t, r| ApiDiffHelper.api_changes_reported?(r) }
 
     if breaks.empty? && changed_targets.empty?
       UI.message("No public API changes, nothing to post to Slack")
-      next({ fingerprint: nil, notice: nil })
+      next({ notice: nil })
     end
 
     bot_token = ENV["SLACK_ACCESS_TOKEN_CIRCLE_CI_NOTIFY_ORB_IOS"]
@@ -2666,8 +2663,6 @@ platform :ios do
       modules: modules,
       modifications: ApiDiffHelper.modified_declarations(options[:reports_by_target])
     )
-    fingerprint = ApiDiffHelper.announcement_fingerprint(summary)
-
     request = ApiDiffHelper.slack_post_request(
       summary,
       webhook_url: ENV["SLACK_URL_SDK_NEW_API"],
@@ -2677,15 +2672,15 @@ platform :ios do
 
     if request.nil?
       UI.important("No Slack credential reachable. Expected SLACK_ACCESS_TOKEN_CIRCLE_CI_NOTIFY_ORB_IOS from the slack-secrets context plus SLACK_CHANNEL_SDK_NEW_API, or SLACK_URL_SDK_NEW_API. Skipping.")
-      next({ fingerprint: nil, notice: ApiDiffHelper::SLACK_UNREACHABLE_NOTICE })
+      next({ notice: ApiDiffHelper::SLACK_UNREACHABLE_NOTICE })
     end
 
     state, history_error = ApiDiffHelper.announcement_state(
       summary, bot_token: bot_token, channel: channel, source: source, modules: modules
     )
-    if ApiDiffHelper.already_announced?(state, fingerprint) { api_diff_comment_body_on_pr }
+    if state == :same
       UI.message("This API change is already in the SDK API feed, not posting it again")
-      next({ fingerprint: fingerprint, notice: nil })
+      next({ notice: nil })
     end
 
     notice = "Could not read the SDK API feed, so this change may be announced twice: #{history_error}." if history_error
@@ -2693,23 +2688,11 @@ platform :ios do
     begin
       ApiDiffHelper.post_slack_message(request)
       UI.success("Posted the API change summary to Slack")
-      { fingerprint: fingerprint, notice: notice }
+      { notice: notice }
     rescue StandardError => e
       UI.important("Could not announce the API change: #{e.message}")
-      { fingerprint: nil, notice: "This change was not announced in the SDK API feed: #{e.message}." }
+      { notice: "This change was not announced in the SDK API feed: #{e.message}." }
     end
-  end
-
-  private_lane :api_diff_comment_body_on_pr do
-    pr_number = detect_pr_number
-    token = ENV["DANGER_GITHUB_API_TOKEN"]
-    next "" if pr_number.nil? || token.nil? || token.empty?
-
-    comment = find_pr_comment(
-      "RevenueCat/#{REPO_NAME}", pr_number, token, ApiDiffHelper::API_DIFF_COMMENT_MARKER
-    )
-
-    comment ? comment["body"].to_s : ""
   end
 
   # The commit page carries the PR link, and its sha is what tells a rerun it already announced.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2610,8 +2610,7 @@ platform :ios do
     end
 
     section = ApiDiffHelper.api_diff_comment_section(
-      options[:scheme], options[:reports_by_target], options[:breaks], options[:labels],
-      notice: options[:notice]
+      options[:scheme], options[:reports_by_target], options[:breaks], options[:labels]
     )
 
     if existing
@@ -2639,14 +2638,14 @@ platform :ios do
     end
   end
 
-  # Returns { notice: }.
+  # main has no PR comment to carry a warning, so every outcome is reported in the job log.
   private_lane :notify_api_changes_on_slack do |options|
     breaks = options[:breaks]
     changed_targets = options[:reports_by_target].select { |_t, r| ApiDiffHelper.api_changes_reported?(r) }
 
     if breaks.empty? && changed_targets.empty?
       UI.message("No public API changes, nothing to post to Slack")
-      next({ notice: nil })
+      next
     end
 
     bot_token = ENV["SLACK_ACCESS_TOKEN_CIRCLE_CI_NOTIFY_ORB_IOS"]
@@ -2672,7 +2671,7 @@ platform :ios do
 
     if request.nil?
       UI.important("No Slack credential reachable. Expected SLACK_ACCESS_TOKEN_CIRCLE_CI_NOTIFY_ORB_IOS from the slack-secrets context plus SLACK_CHANNEL_SDK_NEW_API, or SLACK_URL_SDK_NEW_API. Skipping.")
-      next({ notice: ApiDiffHelper::SLACK_UNREACHABLE_NOTICE })
+      next
     end
 
     state, history_error = ApiDiffHelper.announcement_state(
@@ -2680,18 +2679,16 @@ platform :ios do
     )
     if state == :same
       UI.message("This API change is already in the SDK API feed, not posting it again")
-      next({ notice: nil })
+      next
     end
 
-    notice = "Could not read the SDK API feed, so this change may be announced twice: #{history_error}." if history_error
+    UI.important("Could not read the SDK API feed, so this change may be announced twice: #{history_error}") if history_error
 
     begin
       ApiDiffHelper.post_slack_message(request)
       UI.success("Posted the API change summary to Slack")
-      { notice: notice }
     rescue StandardError => e
-      UI.important("Could not announce the API change: #{e.message}")
-      { notice: "This change was not announced in the SDK API feed: #{e.message}." }
+      UI.important("The public API changed, but it was not announced in the SDK API feed: #{e.message}")
     end
   end
 

--- a/fastlane/api_diff_helper.rb
+++ b/fastlane/api_diff_helper.rb
@@ -582,46 +582,16 @@ module ApiDiffHelper
     end
   end
 
-  def announced_marker(fingerprint)
-    "<!-- api-diff-announced:#{fingerprint} -->"
-  end
-
-  def announcement_fingerprint(message)
-    Digest::SHA256.hexdigest(message.to_s)[0, 12]
-  end
-
-  ANNOUNCED_MARKER_PATTERN = /<!-- api-diff-announced:([0-9a-f]+) -->/.freeze
-
-  # The marker records the last summary that reached the channel, which a run with nothing to
-  # announce, or one whose post failed, did not change.
-  def announced_fingerprint_in(comment_body, module_name)
-    open_tag = Regexp.escape(api_diff_section_open(module_name))
-    close_tag = Regexp.escape(api_diff_section_close(module_name))
-    section = comment_body.to_s[/#{open_tag}.*?#{close_tag}/m]
-
-    section && ANNOUNCED_MARKER_PATTERN.match(section)&.captures&.first
-  end
-
-  # The comment body is only read for :unknown, so the caller passes a block that fetches it.
-  def already_announced?(state, fingerprint)
-    return true if state == :same
-    return false unless state == :unknown
-
-    yield.to_s.include?(announced_marker(fingerprint))
-  end
-
   def comment_needed?(reports_by_target, breaks, existing_body, module_name)
     return true if breaks.any? || changed_modules(reports_by_target).any?
 
     existing_body.to_s.include?(api_diff_section_open(module_name))
   end
 
-  def api_diff_comment_section(module_name, reports_by_target, breaks, labels, notice: nil, announced_fingerprint: nil)
+  def api_diff_comment_section(module_name, reports_by_target, breaks, labels, notice: nil)
     inner = api_diff_comment_body(reports_by_target, breaks, labels, heading: "### #{module_name}", notice: notice)
-    parts = [api_diff_section_open(module_name), inner]
-    parts << announced_marker(announced_fingerprint) if announced_fingerprint
 
-    (parts << api_diff_section_close(module_name)).join("\n")
+    [api_diff_section_open(module_name), inner, api_diff_section_close(module_name)].join("\n")
   end
 
   def api_diff_comment_body(reports_by_target, breaks, labels, heading: nil, notice: nil)

--- a/fastlane/api_diff_helper.rb
+++ b/fastlane/api_diff_helper.rb
@@ -769,56 +769,6 @@ module ApiDiffHelper
     }
   end
 
-  SLACK_HISTORY_LIMIT = 100
-
-  # conversations.history takes a channel ID, never a `#name`.
-  CHANNEL_ID = /\A[CGD][A-Z0-9]+\z/.freeze
-
-  def slack_history_request(channel, bot_token:, limit: SLACK_HISTORY_LIMIT)
-    {
-      url: "https://slack.com/api/conversations.history?channel=#{channel}&limit=#{limit}",
-      headers: { "Authorization" => "Bearer #{bot_token}" }
-    }
-  end
-
-  def recent_slack_messages(request, getter: nil)
-    getter ||= ->(url, headers) { Net::HTTP.get_response(URI.parse(url), headers) }
-
-    response = getter.call(request[:url], request[:headers])
-    raise "Slack returned #{response.code}: #{response.body}" unless (200..299).cover?(response.code.to_i)
-
-    parsed = JSON.parse(response.body.to_s)
-    raise "Slack rejected conversations.history: #{parsed['error']}" unless parsed["ok"]
-
-    parsed["messages"].to_a.map { |message| message["text"].to_s }
-  end
-
-  # conversations.history answers newest first, so the first match is the channel's last word. One
-  # run posts once for every module, and the source is a commit sha, so it identifies the message.
-  def last_announcement(texts, source)
-    return nil if source.to_s.empty?
-
-    texts.find { |text| text.include?(source) }
-  end
-
-  # conversations.history needs an ID rather than a name.
-  # Returns [:same | :different | :unknown, why_unknown].
-  def announcement_state(message, bot_token:, channel:, source:, getter: nil)
-    return [:unknown, "no bot token, so the SDK API feed cannot be read"] if bot_token.to_s.empty?
-
-    unless CHANNEL_ID.match?(channel.to_s)
-      return [:unknown, "#{channel} is a channel name, and conversations.history needs the channel ID"]
-    end
-
-    request = slack_history_request(channel, bot_token: bot_token)
-    last = last_announcement(recent_slack_messages(request, getter: getter), source)
-    return [:unknown, nil] if last.nil?
-
-    [last == message ? :same : :different, nil]
-  rescue StandardError => e
-    [:unknown, e.message]
-  end
-
   # `poster` exists so the tests can exercise the response handling without a network.
   def post_slack_message(request, poster: nil)
     poster ||= ->(url, body, headers) { Net::HTTP.post(URI.parse(url), body, headers) }

--- a/fastlane/api_diff_helper.rb
+++ b/fastlane/api_diff_helper.rb
@@ -757,8 +757,6 @@ module ApiDiffHelper
   end
 
 
-  # A bot token only, no webhook: conversations.history is what suppresses a rerun, and a webhook
-  # cannot read the channel.
   def slack_post_request(message, bot_token:, channel:)
     return nil if bot_token.to_s.empty? || channel.to_s.empty?
 

--- a/fastlane/api_diff_helper.rb
+++ b/fastlane/api_diff_helper.rb
@@ -759,15 +759,9 @@ module ApiDiffHelper
   end
 
 
-  def slack_post_request(message, webhook_url: nil, bot_token: nil, channel: nil)
-    unless webhook_url.to_s.empty?
-      return {
-        url: webhook_url,
-        headers: { "Content-Type" => "application/json" },
-        body: { text: message }
-      }
-    end
-
+  # A bot token only, no webhook: conversations.history is what suppresses a rerun, and a webhook
+  # cannot read the channel.
+  def slack_post_request(message, bot_token:, channel:)
     return nil if bot_token.to_s.empty? || channel.to_s.empty?
 
     {
@@ -801,19 +795,17 @@ module ApiDiffHelper
     parsed["messages"].to_a.map { |message| message["text"].to_s }
   end
 
-  # conversations.history answers newest first, so the first match is the channel's last word. The
-  # trailing backtick in the identity keeps `RevenueCat` from matching `RevenueCatUI`.
-  def last_announcement(texts, source, modules)
+  # conversations.history answers newest first, so the first match is the channel's last word. One
+  # run posts once for every module, and the source is a commit sha, so it identifies the message.
+  def last_announcement(texts, source)
     return nil if source.to_s.empty?
 
-    identity = announcement_identity(modules)
-
-    texts.find { |text| text.include?(source) && text.include?(identity) }
+    texts.find { |text| text.include?(source) }
   end
 
-  # A webhook cannot read the channel, and conversations.history needs an ID rather than a name.
+  # conversations.history needs an ID rather than a name.
   # Returns [:same | :different | :unknown, why_unknown].
-  def announcement_state(message, bot_token:, channel:, source:, modules:, getter: nil)
+  def announcement_state(message, bot_token:, channel:, source:, getter: nil)
     return [:unknown, "no bot token, so the SDK API feed cannot be read"] if bot_token.to_s.empty?
 
     unless CHANNEL_ID.match?(channel.to_s)
@@ -821,7 +813,7 @@ module ApiDiffHelper
     end
 
     request = slack_history_request(channel, bot_token: bot_token)
-    last = last_announcement(recent_slack_messages(request, getter: getter), source, modules)
+    last = last_announcement(recent_slack_messages(request, getter: getter), source)
     return [:unknown, nil] if last.nil?
 
     [last == message ? :same : :different, nil]
@@ -836,7 +828,7 @@ module ApiDiffHelper
     response = poster.call(request[:url], request[:body].to_json, request[:headers])
     raise "Slack returned #{response.code}: #{response.body}" unless (200..299).cover?(response.code.to_i)
 
-    # chat.postMessage answers 200 with ok:false, and a webhook answers with the bare string "ok".
+    # chat.postMessage answers 200 with ok:false.
     parsed = begin
       JSON.parse(response.body.to_s)
     rescue JSON::ParserError

--- a/fastlane/api_diff_helper.rb
+++ b/fastlane/api_diff_helper.rb
@@ -1,7 +1,6 @@
 # Helper module for API diff functionality
 # Used by generate_swiftinterface and check_api_changes lanes
 
-require 'digest'
 require 'fileutils'
 require 'json'
 require 'net/http'
@@ -685,7 +684,6 @@ module ApiDiffHelper
 
   SDK_PLATFORM_LABEL = "iOS :ios:".freeze
 
-  # last_announcement matches on this, so the headline and the dedup key cannot drift apart.
   def announcement_identity(modules)
     [SDK_PLATFORM_LABEL, *modules.map { |name| "`#{name}`" }].join(" · ")
   end

--- a/fastlane/api_diff_helper.rb
+++ b/fastlane/api_diff_helper.rb
@@ -588,19 +588,14 @@ module ApiDiffHelper
     existing_body.to_s.include?(api_diff_section_open(module_name))
   end
 
-  def api_diff_comment_section(module_name, reports_by_target, breaks, labels, notice: nil)
-    inner = api_diff_comment_body(reports_by_target, breaks, labels, heading: "### #{module_name}", notice: notice)
+  def api_diff_comment_section(module_name, reports_by_target, breaks, labels)
+    inner = api_diff_comment_body(reports_by_target, breaks, labels, heading: "### #{module_name}")
 
     [api_diff_section_open(module_name), inner, api_diff_section_close(module_name)].join("\n")
   end
 
-  def api_diff_comment_body(reports_by_target, breaks, labels, heading: nil, notice: nil)
+  def api_diff_comment_body(reports_by_target, breaks, labels, heading: nil)
     lines = heading ? [heading] : [API_DIFF_COMMENT_MARKER, "## Public API changes"]
-
-    unless notice.to_s.empty?
-      lines << ""
-      lines << ":warning: #{notice}"
-    end
 
     if breaks.any?
       lines << ""
@@ -763,8 +758,6 @@ module ApiDiffHelper
     lines.join("\n")
   end
 
-
-  SLACK_UNREACHABLE_NOTICE = "No Slack credentials were reachable, so this change was not announced in the SDK API feed.".freeze
 
   def slack_post_request(message, webhook_url: nil, bot_token: nil, channel: nil)
     unless webhook_url.to_s.empty?

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -1871,13 +1871,20 @@ class ApiDiffHelperTest < Minitest::Test
     assert_match(/ApiDiffHelper\.post_slack_message/, slack_lane)
   end
 
-  def test_the_announcement_happens_before_the_comment_is_written
+  # main has no pull request to comment on, and a PR run does not announce, so the two are
+  # exclusive. Nothing carries state from the announcement into the comment any more.
+  def test_main_announces_and_a_pull_request_comments
     lane = File.read(File.expand_path("Fastfile", __dir__))
     publishing = lane[/# Informational: a GitHub or Slack outage.*?rescue StandardError/m]
 
     refute_nil publishing, "the publishing section of check_api_changes moved; update this test"
-    assert_operator publishing.index("upsert_api_diff_comment"), :>, publishing.index("notify_api_changes_on_slack"),
-                    "the comment must be written after the announcement it records"
+    announcing, commenting = publishing.split("else", 2)
+
+    assert_match(/if on_main/, announcing)
+    assert_match(/notify_api_changes_on_slack/, announcing)
+    refute_match(/upsert_api_diff_comment/, announcing, "main has no pull request to comment on")
+    assert_match(/upsert_api_diff_comment/, commenting)
+    refute_match(/notify_api_changes_on_slack/, commenting, "a PR run must not reach the feed")
   end
 
 
@@ -1896,12 +1903,10 @@ class ApiDiffHelperTest < Minitest::Test
   # The feed was noisy because every PR run posted. Only main does now, so each change lands once.
   def test_slack_is_announced_only_on_main
     lane = File.read(File.expand_path("Fastfile", __dir__))
-    announce = lane[/announcement = if on_main.*?\n                     end\n/m]
+    slack_call = lane[/^\s*(if on_main\n)?\s*notify_api_changes_on_slack\(/]
 
-    refute_nil announce, "the Slack announcement is no longer gated on main; update this test"
-    assert_match(/notify_api_changes_on_slack/, announce)
-    assert_match(/\{ fingerprint: nil, notice: nil \}/, announce,
-                 "a PR run still needs an announcement shape for the comment")
+    refute_nil slack_call, "the notify_api_changes_on_slack call moved; update this test"
+    assert_match(/if on_main/, slack_call, "the announcement is no longer gated on main")
   end
 
   # main carries no PR to hold the label, so the gate there would fail changes the PR approved.

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -1656,20 +1656,6 @@ class ApiDiffHelperTest < Minitest::Test
     assert_includes message, "apiDiffDemoPing"
   end
 
-  def test_comment_body_carries_the_slack_notice
-    body = ApiDiffHelper.api_diff_comment_body(
-      { "RevenueCat iOS" => SINGLE_ADDITION_OUTPUT }, [], [], notice: ApiDiffHelper::SLACK_UNREACHABLE_NOTICE
-    )
-
-    assert_includes body, ":warning: #{ApiDiffHelper::SLACK_UNREACHABLE_NOTICE}"
-  end
-
-  def test_comment_body_omits_the_notice_when_slack_is_reachable
-    body = ApiDiffHelper.api_diff_comment_body({ "RevenueCat iOS" => SINGLE_ADDITION_OUTPUT }, [], [])
-
-    refute_includes body, ":warning: No Slack credentials"
-  end
-
   # A PR whose only interface delta is an added attribute reached the feed as a headline and a link,
   # with the headline claiming new API. See purchases-ios#7439.
   def test_slack_summary_reports_an_attribute_only_modification
@@ -1840,6 +1826,19 @@ class ApiDiffHelperTest < Minitest::Test
     assert_match(%r{/commit/}, link, "the message links the commit, not the PR")
     assert_match(/next "" if sha\.empty\?/, link)
     refute_match(/detect_pr_number/, lane[/source = api_gate_commit_link/] || "x")
+  end
+
+  # A silent feed is the failure nobody notices, and main has no PR comment left to warn in, so
+  # the job log is the only place an unreachable credential or a failed post can surface.
+  def test_every_announcement_failure_reaches_the_job_log
+    lane = File.read(File.expand_path("Fastfile", __dir__))
+    slack_lane = lane[/private_lane :notify_api_changes_on_slack do.*?\n  end\n/m]
+
+    refute_nil slack_lane, "the notify_api_changes_on_slack lane moved; update this test"
+    assert_match(/UI\.important\("No Slack credential reachable/, slack_lane)
+    assert_match(/UI\.important\("Could not read the SDK API feed/, slack_lane)
+    assert_match(/UI\.important\("The public API changed, but it was not announced/, slack_lane)
+    refute_match(/notice/, slack_lane, "the notice went to a PR comment that main does not have")
   end
 
   # The feed was noisy because every PR run posted. Only main does now, so each change lands once.

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -1392,17 +1392,14 @@ class ApiDiffHelperTest < Minitest::Test
   end
 
 
-  def test_slack_request_supports_webhook_or_bot_token
-    webhook = ApiDiffHelper.slack_post_request("hi", webhook_url: "https://hooks.example/abc")
-    assert_equal "https://hooks.example/abc", webhook[:url]
-    assert_equal({ text: "hi" }, webhook[:body])
-
+  # A webhook cannot read conversations.history, so accepting one would silently disable dedup.
+  def test_slack_request_needs_a_bot_token_and_a_channel
     bot = ApiDiffHelper.slack_post_request("hi", bot_token: "xoxb-t", channel: "C1")
     assert_equal "https://slack.com/api/chat.postMessage", bot[:url]
     assert_equal "Bearer xoxb-t", bot[:headers]["Authorization"]
 
-    assert_nil ApiDiffHelper.slack_post_request("hi"), "no credential means no request"
-    assert_nil ApiDiffHelper.slack_post_request("hi", bot_token: "xoxb-t"), "a bot token with no channel has nowhere to post"
+    assert_nil ApiDiffHelper.slack_post_request("hi", bot_token: "", channel: "C1"), "no token means no request"
+    assert_nil ApiDiffHelper.slack_post_request("hi", bot_token: "xoxb-t", channel: ""), "a bot token with no channel has nowhere to post"
   end
 
 
@@ -1442,8 +1439,8 @@ class ApiDiffHelperTest < Minitest::Test
     assert_match(/channel_not_found/, error.message)
   end
 
-  # Incoming webhooks answer with the bare string "ok", which is not JSON.
-  def test_post_slack_message_accepts_a_non_json_webhook_body
+  # A 2xx that does not parse must not read as a rejection: only an explicit ok:false is one.
+  def test_post_slack_message_accepts_a_non_json_body
     poster = ->(_url, _body, _headers) { SlackResponse.new("200", "ok") }
 
     ApiDiffHelper.post_slack_message(slack_request, poster: poster)
@@ -1475,17 +1472,19 @@ class ApiDiffHelperTest < Minitest::Test
     assert_match(/missing_scope/, error.message)
   end
 
-  def announcement(declaration, source: "<url|#7355>", modules: ["RevenueCat"])
+  COMMIT_LINK = "<https://github.com/RevenueCat/purchases-ios/commit/abc1234|abc1234>".freeze
+
+  def announcement(declaration, source: COMMIT_LINK, modules: ["RevenueCat"])
     ApiDiffHelper.slack_summary([], [], source: source, new_declarations: [declaration], modules: modules)
   end
 
-  def state_for(message, texts, source: "<url|#7355>", modules: ["RevenueCat"])
+  def state_for(message, texts, source: COMMIT_LINK)
     ApiDiffHelper.announcement_state(
-      message, bot_token: "xoxb-1", channel: "C1", source: source, modules: modules, getter: history_getter(texts)
+      message, bot_token: "xoxb-1", channel: "C1", source: source, getter: history_getter(texts)
     )
   end
 
-  def test_announcement_state_recognises_the_last_word_on_this_pull_request
+  def test_announcement_state_recognises_the_last_word_on_this_commit
     summary = announcement("public func a()")
 
     state, unusable = state_for(summary, [summary, announcement("public func older()")])
@@ -1494,28 +1493,19 @@ class ApiDiffHelperTest < Minitest::Test
     assert_nil unusable
   end
 
-  def test_announcement_state_is_different_when_the_pull_request_moved_on_and_back
+  def test_announcement_state_is_different_when_the_same_commit_says_something_else
     summary = announcement("public func a()")
 
-    state, _unusable = state_for(summary, [announcement("public func b()"), summary])
+    state, _unusable = state_for(summary, [announcement("public func b()")])
 
     assert_equal :different, state
   end
 
-  def test_announcement_state_ignores_another_modules_announcement
-    summary = announcement("public func a()")
-    other_module = announcement("public func a()", modules: ["RevenueCatUI"])
-
-    state, unusable = state_for(summary, [other_module])
-
-    assert_equal :unknown, state
-    assert_nil unusable
-  end
-
-  def test_announcement_state_ignores_another_pull_requests_announcement
+  # The commit link is the whole dedup key, so a different commit must never read as a duplicate.
+  def test_announcement_state_ignores_another_commits_announcement
     summary = announcement("public func a()")
 
-    state, _unusable = state_for(summary, [announcement("public func a()", source: "<url|#7354>")])
+    state, _unusable = state_for(summary, [announcement("public func a()", source: "<url|deadbee>")])
 
     assert_equal :unknown, state
   end
@@ -1523,7 +1513,7 @@ class ApiDiffHelperTest < Minitest::Test
   # chat.postMessage takes a `#name`, conversations.history does not.
   def test_announcement_state_needs_the_channel_id
     state, unusable = ApiDiffHelper.announcement_state(
-      "summary", bot_token: "xoxb-1", channel: "#feed", source: "<url|#1>", modules: ["RevenueCat"],
+      "summary", bot_token: "xoxb-1", channel: "#feed", source: COMMIT_LINK,
       getter: ->(*) { raise "must not read" }
     )
 
@@ -1533,7 +1523,7 @@ class ApiDiffHelperTest < Minitest::Test
 
   def test_announcement_state_reports_a_missing_token
     state, unusable = ApiDiffHelper.announcement_state(
-      "summary", bot_token: "", channel: "C1", source: "<url|#1>", modules: ["RevenueCat"]
+      "summary", bot_token: "", channel: "C1", source: COMMIT_LINK
     )
 
     assert_equal :unknown, state
@@ -1542,7 +1532,7 @@ class ApiDiffHelperTest < Minitest::Test
 
   def test_announcement_state_reports_a_failed_read
     state, unusable = ApiDiffHelper.announcement_state(
-      "summary", bot_token: "xoxb-1", channel: "C1", source: "<url|#1>", modules: ["RevenueCat"],
+      "summary", bot_token: "xoxb-1", channel: "C1", source: COMMIT_LINK,
       getter: ->(*) { raise "slack is down" }
     )
 
@@ -1789,7 +1779,7 @@ class ApiDiffHelperTest < Minitest::Test
 
 
   # The lane used to hand-roll the post. Keeping it in the helper is what puts the response
-  # handling (non-2xx, ok:false, non-JSON webhook body) under test at all.
+  # handling (non-2xx, ok:false, non-JSON body) under test at all.
   def test_the_slack_post_lives_in_the_helper_not_in_the_lane
     lane = File.read(File.expand_path("Fastfile", __dir__))
     slack_lane = lane[/private_lane :notify_api_changes_on_slack do.*?\n  end\n/m]

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -1392,7 +1392,6 @@ class ApiDiffHelperTest < Minitest::Test
   end
 
 
-  # A webhook cannot read conversations.history, so accepting one would silently disable dedup.
   def test_slack_request_needs_a_bot_token_and_a_channel
     bot = ApiDiffHelper.slack_post_request("hi", bot_token: "xoxb-t", channel: "C1")
     assert_equal "https://slack.com/api/chat.postMessage", bot[:url]

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -1550,15 +1550,6 @@ class ApiDiffHelperTest < Minitest::Test
     assert_equal "slack is down", unusable
   end
 
-  def test_announcement_fingerprint_moves_with_the_summary
-    first = ApiDiffHelper.slack_summary([], [], source: "<url|#1>", new_declarations: ["public func a()"])
-    same = ApiDiffHelper.slack_summary([], [], source: "<url|#1>", new_declarations: ["public func a()"])
-    other = ApiDiffHelper.slack_summary([], [], source: "<url|#1>", new_declarations: ["public func b()"])
-
-    assert_equal ApiDiffHelper.announcement_fingerprint(first), ApiDiffHelper.announcement_fingerprint(same)
-    refute_equal ApiDiffHelper.announcement_fingerprint(first), ApiDiffHelper.announcement_fingerprint(other)
-  end
-
   def test_no_comment_for_a_pull_request_that_never_touched_the_public_api
     refute ApiDiffHelper.comment_needed?({ "RevenueCat iOS" => NO_CHANGES_OUTPUT }, [], nil, "RevenueCat")
     refute ApiDiffHelper.comment_needed?({}, [], "<!-- api-diff-report -->", "RevenueCat")
@@ -1578,62 +1569,13 @@ class ApiDiffHelperTest < Minitest::Test
     assert ApiDiffHelper.comment_needed?({}, [{ reason: :removed, owner: nil, declaration: "public func a()" }], nil, "RevenueCat")
   end
 
-  def test_announced_fingerprint_survives_a_run_with_nothing_to_announce
-    announced = ApiDiffHelper.merge_api_diff_comment(
-      nil, "RevenueCat",
-      ApiDiffHelper.api_diff_comment_section("RevenueCat", {}, [], [], announced_fingerprint: "abc123abc123")
-    )
-
-    assert_equal "abc123abc123", ApiDiffHelper.announced_fingerprint_in(announced, "RevenueCat")
-    assert_nil ApiDiffHelper.announced_fingerprint_in(announced, "RevenueCatUI")
-    assert_nil ApiDiffHelper.announced_fingerprint_in(nil, "RevenueCat")
-  end
-
-  # Another module's marker must not be mistaken for this module's.
-  def test_announced_fingerprint_is_read_from_this_modules_section
-    body = [
-      ApiDiffHelper.api_diff_comment_section("RevenueCat", {}, [], []),
-      ApiDiffHelper.api_diff_comment_section("RevenueCatUI", {}, [], [], announced_fingerprint: "def456def456")
-    ].join("\n")
-
-    assert_nil ApiDiffHelper.announced_fingerprint_in(body, "RevenueCat")
-    assert_equal "def456def456", ApiDiffHelper.announced_fingerprint_in(body, "RevenueCatUI")
-  end
-
-  def test_already_announced_reads_the_comment_only_when_the_channel_said_nothing
-    body = "## Public API changes\n#{ApiDiffHelper.announced_marker('abc123abc123')}\n"
-
-    assert ApiDiffHelper.already_announced?(:same, "def456def456") { raise "must not read" }
-    refute ApiDiffHelper.already_announced?(:different, "abc123abc123") { raise "must not read" }
-    assert ApiDiffHelper.already_announced?(:unknown, "abc123abc123") { body }
-    refute ApiDiffHelper.already_announced?(:unknown, "def456def456") { body }
-    refute ApiDiffHelper.already_announced?(:unknown, "abc123abc123") { nil }
-  end
-
-  def test_comment_section_carries_the_announced_fingerprint
+  def test_comment_section_is_closed_after_its_body
     section = ApiDiffHelper.api_diff_comment_section(
-      "RevenueCat", { "RevenueCat iOS" => SINGLE_ADDITION_OUTPUT }, [], [], announced_fingerprint: "abc123abc123"
+      "RevenueCat", { "RevenueCat iOS" => SINGLE_ADDITION_OUTPUT }, [], []
     )
 
-    assert_includes section, ApiDiffHelper.announced_marker("abc123abc123")
+    assert section.start_with?(ApiDiffHelper.api_diff_section_open("RevenueCat"))
     assert section.rstrip.end_with?(ApiDiffHelper.api_diff_section_close("RevenueCat"))
-  end
-
-  def test_comment_section_omits_the_marker_when_nothing_was_announced
-    section = ApiDiffHelper.api_diff_comment_section("RevenueCat", { "RevenueCat iOS" => SINGLE_ADDITION_OUTPUT }, [], [])
-
-    refute_includes section, "api-diff-announced"
-  end
-
-  def test_merging_a_section_replaces_a_stale_fingerprint
-    announced = ApiDiffHelper.api_diff_comment_section("RevenueCat", {}, [], [], announced_fingerprint: "aaaaaaaaaaaa")
-    body = ApiDiffHelper.merge_api_diff_comment(nil, "RevenueCat", announced)
-    reannounced = ApiDiffHelper.api_diff_comment_section("RevenueCat", {}, [], [], announced_fingerprint: "bbbbbbbbbbbb")
-
-    merged = ApiDiffHelper.merge_api_diff_comment(body, "RevenueCat", reannounced)
-
-    assert_includes merged, ApiDiffHelper.announced_marker("bbbbbbbbbbbb")
-    refute_includes merged, ApiDiffHelper.announced_marker("aaaaaaaaaaaa")
   end
 
 

--- a/fastlane/api_diff_helper_test.rb
+++ b/fastlane/api_diff_helper_test.rb
@@ -1447,98 +1447,7 @@ class ApiDiffHelperTest < Minitest::Test
   end
 
 
-  # --- Announcing a change once ---
-
-  def history_getter(texts)
-    lambda do |_url, _headers|
-      SlackResponse.new("200", { ok: true, messages: texts.map { |text| { "text" => text } } }.to_json)
-    end
-  end
-
-  def test_slack_history_request_reads_the_channel_with_the_bot_token
-    request = ApiDiffHelper.slack_history_request("C1", bot_token: "xoxb-1")
-
-    assert_includes request[:url], "https://slack.com/api/conversations.history?channel=C1"
-    assert_equal "Bearer xoxb-1", request[:headers]["Authorization"]
-    assert_equal ["new", "old"], ApiDiffHelper.recent_slack_messages(request, getter: history_getter(["new", "old"]))
-  end
-
-  def test_recent_slack_messages_raises_when_the_token_cannot_read_the_channel
-    getter = ->(_url, _headers) { SlackResponse.new("200", '{"ok":false,"error":"missing_scope"}') }
-
-    error = assert_raises(RuntimeError) do
-      ApiDiffHelper.recent_slack_messages(ApiDiffHelper.slack_history_request("C1", bot_token: "xoxb-1"), getter: getter)
-    end
-    assert_match(/missing_scope/, error.message)
-  end
-
-  COMMIT_LINK = "<https://github.com/RevenueCat/purchases-ios/commit/abc1234|abc1234>".freeze
-
-  def announcement(declaration, source: COMMIT_LINK, modules: ["RevenueCat"])
-    ApiDiffHelper.slack_summary([], [], source: source, new_declarations: [declaration], modules: modules)
-  end
-
-  def state_for(message, texts, source: COMMIT_LINK)
-    ApiDiffHelper.announcement_state(
-      message, bot_token: "xoxb-1", channel: "C1", source: source, getter: history_getter(texts)
-    )
-  end
-
-  def test_announcement_state_recognises_the_last_word_on_this_commit
-    summary = announcement("public func a()")
-
-    state, unusable = state_for(summary, [summary, announcement("public func older()")])
-
-    assert_equal :same, state
-    assert_nil unusable
-  end
-
-  def test_announcement_state_is_different_when_the_same_commit_says_something_else
-    summary = announcement("public func a()")
-
-    state, _unusable = state_for(summary, [announcement("public func b()")])
-
-    assert_equal :different, state
-  end
-
-  # The commit link is the whole dedup key, so a different commit must never read as a duplicate.
-  def test_announcement_state_ignores_another_commits_announcement
-    summary = announcement("public func a()")
-
-    state, _unusable = state_for(summary, [announcement("public func a()", source: "<url|deadbee>")])
-
-    assert_equal :unknown, state
-  end
-
-  # chat.postMessage takes a `#name`, conversations.history does not.
-  def test_announcement_state_needs_the_channel_id
-    state, unusable = ApiDiffHelper.announcement_state(
-      "summary", bot_token: "xoxb-1", channel: "#feed", source: COMMIT_LINK,
-      getter: ->(*) { raise "must not read" }
-    )
-
-    assert_equal :unknown, state
-    assert_match(/channel ID/, unusable)
-  end
-
-  def test_announcement_state_reports_a_missing_token
-    state, unusable = ApiDiffHelper.announcement_state(
-      "summary", bot_token: "", channel: "C1", source: COMMIT_LINK
-    )
-
-    assert_equal :unknown, state
-    assert_match(/cannot be read/, unusable)
-  end
-
-  def test_announcement_state_reports_a_failed_read
-    state, unusable = ApiDiffHelper.announcement_state(
-      "summary", bot_token: "xoxb-1", channel: "C1", source: COMMIT_LINK,
-      getter: ->(*) { raise "slack is down" }
-    )
-
-    assert_equal :unknown, state
-    assert_equal "slack is down", unusable
-  end
+  # --- The PR comment ---
 
   def test_no_comment_for_a_pull_request_that_never_touched_the_public_api
     refute ApiDiffHelper.comment_needed?({ "RevenueCat iOS" => NO_CHANGES_OUTPUT }, [], nil, "RevenueCat")
@@ -1791,23 +1700,48 @@ class ApiDiffHelperTest < Minitest::Test
 
   # main has no pull request to comment on, and a PR run does not announce, so the two are
   # exclusive. Nothing carries state from the announcement into the comment any more.
+  def check_api_changes_lane
+    fastfile = File.read(File.expand_path("Fastfile", __dir__))
+    lane = fastfile[/lane :check_api_changes do.*?\n  end\n/m]
+
+    refute_nil lane, "the check_api_changes lane moved; update these tests"
+    lane
+  end
+
   def test_main_announces_and_a_pull_request_comments
-    lane = File.read(File.expand_path("Fastfile", __dir__))
-    publishing = lane[/# Informational: a GitHub or Slack outage.*?rescue StandardError/m]
+    lane = check_api_changes_lane
 
-    refute_nil publishing, "the publishing section of check_api_changes moved; update this test"
-    announcing, commenting = publishing.split("else", 2)
+    assert_match(/unless on_main\n\s*begin\n\s*schemes\.each/, lane,
+                 "the comment is written on a PR only; main has no pull request")
+    assert_match(/if on_main\n\s*begin\n\s*notify_api_changes_on_slack/, lane,
+                 "the feed is announced from main only")
+  end
 
-    assert_match(/if on_main/, announcing)
-    assert_match(/notify_api_changes_on_slack/, announcing)
-    refute_match(/upsert_api_diff_comment/, announcing, "main has no pull request to comment on")
-    assert_match(/upsert_api_diff_comment/, commenting)
-    refute_match(/notify_api_changes_on_slack/, commenting, "a PR run must not reach the feed")
+  # There is no dedup left, so the only thing keeping a rerun from posting twice is that a run
+  # which is going to fail never posts at all. Announcing has to stay last in the lane.
+  def test_nothing_can_fail_the_job_after_the_announcement
+    lane = check_api_changes_lane
+
+    announcement = lane.index("notify_api_changes_on_slack")
+    refute_nil announcement, "the announcement moved; update this test"
+
+    # There are two `failed_platforms.any?` blocks: the build summary and the failure. Anchor on
+    # the one that raises, which is the whole point of the ordering.
+    baseline_failure = lane.index(/if failed_platforms\.any\?\n\s*UI\.user_error!/)
+    refute_nil baseline_failure, "the baseline freshness failure moved; update this test"
+
+    assert_operator announcement, :>, baseline_failure,
+                    "a run whose baselines did not match must not announce"
+    assert_operator announcement, :>, lane.index("ApiDiffHelper.gate_blocked?"),
+                    "the gate must be decided before anything reaches the feed"
+    refute_match(/UI\.user_error!/, lane[announcement..],
+                 "nothing may fail the job after the post, or a rerun would post twice"
+    )
   end
 
 
-  # A rerun of the same main job must not post twice, and last_announcement bails on an empty
-  # source, so the commit link is what keeps the suppression alive.
+  # The feed's only pointer back at the change, so it links the commit rather than a PR that
+  # main runs do not have.
   def test_the_announcement_source_is_the_commit
     lane = File.read(File.expand_path("Fastfile", __dir__))
     link = lane[/private_lane :api_gate_commit_link do.*?\n  end\n/m]
@@ -1826,18 +1760,8 @@ class ApiDiffHelperTest < Minitest::Test
 
     refute_nil slack_lane, "the notify_api_changes_on_slack lane moved; update this test"
     assert_match(/UI\.important\("No Slack credential reachable/, slack_lane)
-    assert_match(/UI\.important\("Could not read the SDK API feed/, slack_lane)
     assert_match(/UI\.important\("The public API changed, but it was not announced/, slack_lane)
     refute_match(/notice/, slack_lane, "the notice went to a PR comment that main does not have")
-  end
-
-  # The feed was noisy because every PR run posted. Only main does now, so each change lands once.
-  def test_slack_is_announced_only_on_main
-    lane = File.read(File.expand_path("Fastfile", __dir__))
-    slack_call = lane[/^\s*(if on_main\n)?\s*notify_api_changes_on_slack\(/]
-
-    refute_nil slack_call, "the notify_api_changes_on_slack call moved; update this test"
-    assert_match(/if on_main/, slack_call, "the announcement is no longer gated on main")
   end
 
   # main carries no PR to hold the label, so the gate there would fail changes the PR approved.


### PR DESCRIPTION
- Deletes the per-PR announcement machinery that #7500 made unreachable: the `<!-- api-diff-announced:<hash> -->` fingerprint fallback and the "Slack unreachable" notice both lived in a PR comment, and announcing now happens only on `main`, where `detect_pr_number` returns nil.
- `check_api_changes` now announces on `main` or comments on a PR, never both, so the `{ fingerprint: nil, notice: nil }` stub is gone.
- Drops dedup entirely, along with the `SLACK_URL_SDK_NEW_API` webhook branch that nothing ever set. 
- Announcing moves to the end of the lane instead. A run that fails on stale baselines no longer posts, so the rerun that mattered has nothing to duplicate.
- Android counterpart: https://github.com/RevenueCat/purchases-android/pull/4101

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

<details><summary>Agent description</summary>

### Motivation

`#feed-sdk-new-api` was noisy, so #7500 moved announcing from every PR CI run to `main` only, keyed on the commit sha. That PR was scoped tight on purpose and flagged the leftovers as a follow-up. This is the follow-up.

The dedup added in #7431 was built for the per-PR world. Its fallback store and its user-facing warning both live in a **PR comment**. Announcing only happens on `main`, where there is no PR, so that half of the design became unreachable.

### Description

- `fastlane/Fastfile`: the publishing section becomes `if on_main` announce / `else` comment. Deletes the `api_diff_comment_body_on_pr` lane whole; `notify_api_changes_on_slack` stops returning a hash and reports every outcome with `UI.important` / `UI.success`.
- `fastlane/api_diff_helper.rb`: deletes `announced_marker`, `announcement_fingerprint`, `ANNOUNCED_MARKER_PATTERN`, `announced_fingerprint_in`, `already_announced?`, `SLACK_UNREACHABLE_NOTICE`, the `notice:` params on the comment builders, the webhook branch of `slack_post_request`, and the whole history path: `slack_history_request`, `recent_slack_messages`, `last_announcement`, `announcement_state`, `CHANNEL_ID`, `SLACK_HISTORY_LIMIT`. The `digest` require goes with the fingerprint.
- Keeps `API_DIFF_COMMENT_MARKER` and `merge_api_diff_comment`: different marker, still live on PR runs.

**Not visible in the diff:** one webhook pipeline runs per main commit, on both platforms. The daily `api`-triggered pipeline lands on an already-built commit (`caa1fc5` here) but does not run `check-api-changes`, and CircleCI's rerun-from-failed skips jobs that already succeeded, which is visible on pipelines 42823 and 42809 where the workflow failed while `check-api-changes` passed. So nothing fires the announcement twice on its own.

The other load-bearing fact is `detect_pr_number` (`fastlane/Fastfile:734`), which reads `CIRCLE_PULL_REQUEST` or a `gh-readonly-queue/...` branch name. On a `main` push neither exists, so every PR-comment-backed path was dead rather than merely unused.

**Worth noting separately:** `SLACK_URL_SDK_NEW_API` appeared twice in the whole `RevenueCat` org, both in this `Fastfile`, referenced by no config. Whether a context defines it is unverified, since context values are not API-readable. Either way the branch was a footgun, not a fallback: a webhook cannot read the channel.

Dropping dedup also drops two operational requirements that were invisible when violated. It needed `channels:history` on the token and a channel **ID** in `SLACK_CHANNEL_SDK_NEW_API`, not `#feed-sdk-new-api`; with either wrong, `announcement_state` returned `:unknown` and posted anyway.

### Regression gates

The structural tests that regex the `Fastfile` are the real gates:
- `test_nothing_can_fail_the_job_after_the_announcement` is the important one, since it is now the only thing standing between a rerun and a double post. It asserts the announcement sits after the baseline-freshness failure and the gate, with no `UI.user_error!` after it. Verified by moving the announcement back and watching it fail.
- `test_main_announces_and_a_pull_request_comments` pins the either/or.
- `test_every_announcement_failure_reaches_the_job_log` pins the log lines that replace the notice, so the observability cannot be dropped silently later.

**Limitations:**
- The lane cannot run outside fastlane, so the ordering, the either/or and the log lines are pinned by tests that read the `Fastfile`, not by executing it. First real proof is the first merge to `main` after this lands: one message in the feed with the commit link, none on the PR run.
- Rerunning a fully green main workflow will now post a second message. That is the one case dedup covered and this does not, and it costs a duplicate line in a feed.
- `release/*` still announces nothing, unchanged from #7500.

**Rejected:**
- Keeping dedup as rerun insurance. It is ~50 lines and two silent operational dependencies to make a manual rerun idempotent, and reordering covers the rerun that can actually happen without asking anything of the token.
- Deleting the non-JSON body tolerance in `post_slack_message` along with the webhook. An unparseable 2xx would then be reported as a failed post, which is a behavior change beyond removing the webhook. Only the test name and comment changed.
- Dropping `slack-secrets-ios` from the PR-run `check-api-changes` job. PR runs no longer post, so it is a candidate, but `generate-swiftinterface` also attaches it without touching the feed and context variable names are not readable, so this needs `circleci context show` first.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI behavior changes: duplicate Slack posts are possible on a full green main workflow rerun, and announcement failures are log-only with no PR comment fallback on main.
> 
> **Overview**
> **`check_api_changes`** now treats **main** and **PR** runs as mutually exclusive: PR jobs only upsert GitHub API-diff comments; **Slack announcements run only on `main`**, moved to the **end** of the lane so baseline failures and the breaking-change gate complete before anything posts.
> 
> Removes the leftover per-PR announcement plumbing—`api-diff-announced` fingerprints, Slack “notice” lines in comments, `api_diff_comment_body_on_pr`, and the hash return from `notify_api_changes_on_slack`—in favor of **`UI.important` / `UI.success`** in CI logs on main.
> 
> **`ApiDiffHelper`** drops Slack dedup (`conversations.history`, `announcement_state`, `already_announced?`), the **`SLACK_URL_SDK_NEW_API` webhook** path, and comment `notice` / `announced_fingerprint` parameters; **`slack_post_request`** requires bot token + channel only. Tests are trimmed and new **Fastfile structure tests** lock main-vs-PR behavior and “announce last” ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bce3ef69861fc0ecd6c07925c797b84e589ab524. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->