### PR TITLE
fix(paywalls): add user context to custom web checkout URLs

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -3248,6 +3248,7 @@
 		FACD00032F61A1230073D2DE /* ViewModelFactoryBadgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelFactoryBadgeTests.swift; sourceTree = "<group>"; };
 		FACD00072F61A1230073D2DE /* PackageComponentViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageComponentViewTests.swift; sourceTree = "<group>"; };
 		FACD00092F61A1230073D2DE /* PackageValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageValidatorTests.swift; sourceTree = "<group>"; };
+		DB04A6C4304033760087EFC5 /* PurchaseButtonComponentViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseButtonComponentViewModelTests.swift; sourceTree = "<group>"; };
 		FACD000B2F61A1230073D2DE /* PackageVisibilityPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageVisibilityPreview.swift; sourceTree = "<group>"; };
 		FACE0000000000000000A002 /* BackendRemoteConfigLaneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendRemoteConfigLaneTests.swift; sourceTree = "<group>"; };
 		FACE0000000000000000F001 /* PaywallViewControllerExitOfferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallViewControllerExitOfferTests.swift; sourceTree = "<group>"; };
@@ -3485,6 +3486,7 @@
 				FACD00072F61A1230073D2DE /* PackageComponentViewTests.swift */,
 				0DD50FFC7C0F48B6A0FDE360 /* PaywallPromoOfferCacheTests.swift */,
 				FACD00092F61A1230073D2DE /* PackageValidatorTests.swift */,
+				DB04A6C4304033760087EFC5 /* PurchaseButtonComponentViewModelTests.swift */,
 				FD4253DD2F1DBD7E0073D2DE /* FileImageLoaderTests.swift */,
 				57BFCD0F2EEB1234009E5844 /* TabsPackageSelectionResolverTests.swift */,
 				57BFCD0A2EEB0E56009E5844 /* TabsPackageInheritanceTests.swift */,

--- a/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
@@ -135,7 +135,6 @@ struct PurchaseButtonComponentView: View {
     private func purchaseInWeb() async throws {
         self.logIfInPreview(package: self.packageContext.package)
 
-        // Resolved at tap time so a login or logout since the paywall loaded is reflected in the URL.
         guard let launchWebCheckout = self.viewModel.urlForWebCheckout(
             packageContext: self.packageContext,
             appUserID: Purchases.isConfigured ? Purchases.shared.appUserID : "",

--- a/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
@@ -135,7 +135,12 @@ struct PurchaseButtonComponentView: View {
     private func purchaseInWeb() async throws {
         self.logIfInPreview(package: self.packageContext.package)
 
-        guard let launchWebCheckout = self.viewModel.urlForWebCheckout(packageContext: packageContext) else {
+        // Resolved at tap time so a login or logout since the paywall loaded is reflected in the URL.
+        guard let launchWebCheckout = self.viewModel.urlForWebCheckout(
+            packageContext: self.packageContext,
+            appUserID: Purchases.isConfigured ? Purchases.shared.appUserID : "",
+            isSandbox: Purchases.isConfigured ? Purchases.shared.isSandbox : false
+        ) else {
             Logger.error(Strings.no_web_checkout_url_found)
             return
         }

--- a/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentViewModel.swift
@@ -114,21 +114,21 @@ class PurchaseButtonComponentViewModel {
         appUserID: String,
         isSandbox: Bool
     ) -> URL {
-        var queryItems: [(name: String, value: String)] = [(Self.sourceParam, Self.sourceValue)]
+        var queryItems = [URLQueryItem(name: Self.sourceParam, value: Self.sourceValue)]
 
         if let appUserIDParam = configuration.appUserIDParam {
-            queryItems.append((appUserIDParam, appUserID))
+            queryItems.append(.init(name: appUserIDParam, value: appUserID))
         }
 
         if let envParam = configuration.envParam {
-            queryItems.append((envParam, isSandbox ? Self.sandboxEnvValue : Self.productionEnvValue))
+            queryItems.append(.init(name: envParam, value: isSandbox ? Self.sandboxEnvValue : Self.productionEnvValue))
         }
 
         if let packageParam = configuration.packageParam, let package {
-            queryItems.append((packageParam, package.identifier))
+            queryItems.append(.init(name: packageParam, value: package.identifier))
         }
 
-        return url.upserting(queryItems: queryItems)
+        return url.upserting(queryItems)
     }
 
     private static let sourceParam = "rc_source"
@@ -140,31 +140,36 @@ class PurchaseButtonComponentViewModel {
 
 private extension URL {
 
-    /// Adds each item, replacing any same-named item already in the URL and leaving everything else —
-    /// unrelated query parameters and the fragment — byte-for-byte intact.
-    func upserting(queryItems newItems: [(name: String, value: String)]) -> URL {
+    /// Replaces any same-named item, leaving other query items and the fragment byte-for-byte intact.
+    func upserting(_ newItems: [URLQueryItem]) -> URL {
         guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
             return self
         }
 
         let replacedNames = Set(newItems.map(\.name))
-        var items = components.percentEncodedQueryItems ?? []
-        items.removeAll { replacedNames.contains($0.name.removingPercentEncoding ?? $0.name) }
-        items.append(contentsOf: newItems.map {
-            URLQueryItem(name: $0.name.percentEncodedForQuery, value: $0.value.percentEncodedForQuery)
-        })
-        components.percentEncodedQueryItems = items
+        let kept = (components.percentEncodedQueryItems ?? []).filter {
+            !replacedNames.contains($0.name.removingPercentEncoding ?? $0.name)
+        }
+
+        components.percentEncodedQueryItems = kept + newItems.map(\.percentEncoded)
 
         return components.url ?? self
     }
 
 }
 
+private extension URLQueryItem {
+
+    /// Stricter than `urlQueryAllowed`, which leaves `+` intact for servers to read as a space.
+    var percentEncoded: URLQueryItem {
+        return .init(name: self.name.encodedForQuery, value: self.value?.encodedForQuery)
+    }
+
+}
+
 private extension String {
 
-    /// `urlQueryAllowed` permits characters that are legal in a query string but ambiguous inside a
-    /// single parameter — most notably `+`, which many servers read as a space.
-    var percentEncodedForQuery: String {
+    var encodedForQuery: String {
         return self.addingPercentEncoding(withAllowedCharacters: Self.queryParameterAllowed) ?? self
     }
 

--- a/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentViewModel.swift
@@ -64,7 +64,11 @@ class PurchaseButtonComponentViewModel {
 
     typealias LaunchWebCheckout = (url: URL, method: PaywallComponent.ButtonComponent.URLMethod, autoDismiss: Bool)
 
-    func urlForWebCheckout(packageContext: PackageContext?) -> LaunchWebCheckout? {
+    func urlForWebCheckout(
+        packageContext: PackageContext?,
+        appUserID: String,
+        isSandbox: Bool
+    ) -> LaunchWebCheckout? {
         guard let method = self.method else {
             return nil
         }
@@ -85,37 +89,90 @@ class PurchaseButtonComponentViewModel {
                 return nil
             }
         case .customWebCheckout(let customWebCheckout):
-            if let customUrl = self.customWebCheckoutUrl {
-                if let package = packageContext?.package,
-                   let packageParam = customWebCheckout.customUrl.packageParam {
-                    let url = customUrl.appending(name: packageParam, value: package.identifier)
-                    return (url,
-                            customWebCheckout.openMethod ?? .externalBrowser,
-                            customWebCheckout.autoDismiss ?? true)
-                } else {
-                    return (customUrl,
-                            customWebCheckout.openMethod ?? .externalBrowser,
-                            customWebCheckout.autoDismiss ?? true)
-                }
-            } else {
+            guard let customUrl = self.customWebCheckoutUrl else {
                 return nil
             }
+
+            let url = Self.resolvedCustomWebCheckoutUrl(
+                customUrl,
+                configuration: customWebCheckout.customUrl,
+                package: packageContext?.package,
+                appUserID: appUserID,
+                isSandbox: isSandbox
+            )
+
+            return (url,
+                    customWebCheckout.openMethod ?? .externalBrowser,
+                    customWebCheckout.autoDismiss ?? true)
         }
     }
+
+    private static func resolvedCustomWebCheckoutUrl(
+        _ url: URL,
+        configuration: PaywallComponent.PurchaseButtonComponent.CustomWebCheckout.CustomURL,
+        package: Package?,
+        appUserID: String,
+        isSandbox: Bool
+    ) -> URL {
+        var queryItems: [(name: String, value: String)] = [(Self.sourceParam, Self.sourceValue)]
+
+        if let appUserIDParam = configuration.appUserIDParam {
+            queryItems.append((appUserIDParam, appUserID))
+        }
+
+        if let envParam = configuration.envParam {
+            queryItems.append((envParam, isSandbox ? Self.sandboxEnvValue : Self.productionEnvValue))
+        }
+
+        if let packageParam = configuration.packageParam, let package {
+            queryItems.append((packageParam, package.identifier))
+        }
+
+        return url.upserting(queryItems: queryItems)
+    }
+
+    private static let sourceParam = "rc_source"
+    private static let sourceValue = "app"
+    private static let sandboxEnvValue = "sandbox"
+    private static let productionEnvValue = "production"
 
 }
 
 private extension URL {
 
-    func appending(name: String, value: String?) -> URL {
-        var components = URLComponents(url: self, resolvingAgainstBaseURL: false)
+    /// Adds each item, replacing any same-named item already in the URL and leaving everything else —
+    /// unrelated query parameters and the fragment — byte-for-byte intact.
+    func upserting(queryItems newItems: [(name: String, value: String)]) -> URL {
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
+            return self
+        }
 
-        var queryItems = components?.queryItems ?? []
-        queryItems.append(URLQueryItem(name: name, value: value))
-        components?.queryItems = queryItems
+        let replacedNames = Set(newItems.map(\.name))
+        var items = components.percentEncodedQueryItems ?? []
+        items.removeAll { replacedNames.contains($0.name.removingPercentEncoding ?? $0.name) }
+        items.append(contentsOf: newItems.map {
+            URLQueryItem(name: $0.name.percentEncodedForQuery, value: $0.value.percentEncodedForQuery)
+        })
+        components.percentEncodedQueryItems = items
 
-        return components?.url ?? self
+        return components.url ?? self
     }
+
+}
+
+private extension String {
+
+    /// `urlQueryAllowed` permits characters that are legal in a query string but ambiguous inside a
+    /// single parameter — most notably `+`, which many servers read as a space.
+    var percentEncodedForQuery: String {
+        return self.addingPercentEncoding(withAllowedCharacters: Self.queryParameterAllowed) ?? self
+    }
+
+    private static let queryParameterAllowed: CharacterSet = {
+        var allowed = CharacterSet.urlQueryAllowed
+        allowed.remove(charactersIn: "+&=?#")
+        return allowed
+    }()
 
 }
 

--- a/Sources/Paywalls/Components/PaywallPurchaseButtonComponent.swift
+++ b/Sources/Paywalls/Components/PaywallPurchaseButtonComponent.swift
@@ -117,15 +117,28 @@ import Foundation
 
                 public let url: LocalizationKey
                 public let packageParam: String?
+                public let appUserIDParam: String?
+                public let envParam: String?
 
-                public init(url: PaywallComponent.LocalizationKey, packageParam: String? = nil) {
+                public init(
+                    url: PaywallComponent.LocalizationKey,
+                    packageParam: String? = nil,
+                    appUserIDParam: String? = nil,
+                    envParam: String? = nil
+                ) {
                     self.url = url
                     self.packageParam = packageParam
+                    self.appUserIDParam = appUserIDParam
+                    self.envParam = envParam
                 }
 
+                // `JSONDecoder.default` converts snake case before matching these keys, so they hold the
+                // already-converted form of `url_lid` and `app_user_id_param`.
                 private enum CodingKeys: String, CodingKey {
                     case url = "urlLid"
                     case packageParam
+                    case appUserIDParam = "appUserIdParam"
+                    case envParam
                 }
 
             }

--- a/Sources/Paywalls/Components/PaywallPurchaseButtonComponent.swift
+++ b/Sources/Paywalls/Components/PaywallPurchaseButtonComponent.swift
@@ -132,8 +132,7 @@ import Foundation
                     self.envParam = envParam
                 }
 
-                // `JSONDecoder.default` converts snake case before matching these keys, so they hold the
-                // already-converted form of `url_lid` and `app_user_id_param`.
+                // Keys are matched after `JSONDecoder.default` has already converted from snake case.
                 private enum CodingKeys: String, CodingKey {
                     case url = "urlLid"
                     case packageParam

--- a/Tests/RevenueCatUITests/PaywallsV2/PurchaseButtonComponentViewModelTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PurchaseButtonComponentViewModelTests.swift
@@ -1,0 +1,339 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PurchaseButtonComponentViewModelTests.swift
+
+import Nimble
+@_spi(Internal) @testable import RevenueCat
+@testable import RevenueCatUI
+import XCTest
+
+#if !os(tvOS) // For Paywalls V2
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+final class PurchaseButtonComponentViewModelTests: TestCase {
+
+    private static let urlLid = "url_lid"
+
+    // MARK: - Environment
+
+    func testCustomWebCheckoutUsesProductionEnvironment() throws {
+        let viewModel = try self.makeViewModel(
+            url: "https://example.com/checkout",
+            envParam: "rc_env"
+        )
+
+        let launch = try XCTUnwrap(viewModel.urlForWebCheckout(
+            packageContext: nil,
+            appUserID: "user_1",
+            isSandbox: false
+        ))
+
+        expect(self.queryItems(in: launch.url)["rc_env"]) == "production"
+    }
+
+    func testCustomWebCheckoutUsesSandboxEnvironment() throws {
+        let viewModel = try self.makeViewModel(
+            url: "https://example.com/checkout",
+            envParam: "rc_env"
+        )
+
+        let launch = try XCTUnwrap(viewModel.urlForWebCheckout(
+            packageContext: nil,
+            appUserID: "user_1",
+            isSandbox: true
+        ))
+
+        expect(self.queryItems(in: launch.url)["rc_env"]) == "sandbox"
+    }
+
+    // MARK: - Parameter names
+
+    func testCustomWebCheckoutAddsAllConfiguredParameters() throws {
+        let viewModel = try self.makeViewModel(
+            url: "https://example.com/checkout",
+            packageParam: "my_package",
+            appUserIDParam: "my_user",
+            envParam: "my_env"
+        )
+
+        let launch = try XCTUnwrap(viewModel.urlForWebCheckout(
+            packageContext: Self.packageContext(identifier: "monthly"),
+            appUserID: "user_1",
+            isSandbox: false
+        ))
+
+        expect(self.queryItems(in: launch.url)) == [
+            "rc_source": "app",
+            "my_user": "user_1",
+            "my_env": "production",
+            "my_package": "monthly"
+        ]
+    }
+
+    func testCustomWebCheckoutWithNoConfiguredParametersOnlyAddsSource() throws {
+        let viewModel = try self.makeViewModel(url: "https://example.com/checkout")
+
+        let launch = try XCTUnwrap(viewModel.urlForWebCheckout(
+            packageContext: Self.packageContext(identifier: "monthly"),
+            appUserID: "user_1",
+            isSandbox: true
+        ))
+
+        expect(self.queryItems(in: launch.url)) == ["rc_source": "app"]
+    }
+
+    func testCustomWebCheckoutWithoutSelectedPackageOmitsPackageParameter() throws {
+        let viewModel = try self.makeViewModel(
+            url: "https://example.com/checkout",
+            packageParam: "my_package",
+            appUserIDParam: "my_user",
+            envParam: "my_env"
+        )
+
+        let launch = try XCTUnwrap(viewModel.urlForWebCheckout(
+            packageContext: PackageContext(package: nil, variableContext: .init(packages: [])),
+            appUserID: "user_1",
+            isSandbox: false
+        ))
+
+        expect(self.queryItems(in: launch.url)) == [
+            "rc_source": "app",
+            "my_user": "user_1",
+            "my_env": "production"
+        ]
+    }
+
+    // MARK: - Encoding
+
+    func testCustomWebCheckoutPercentEncodesValues() throws {
+        let viewModel = try self.makeViewModel(
+            url: "https://example.com/checkout",
+            packageParam: "my package",
+            appUserIDParam: "my_user",
+            envParam: "my_env"
+        )
+
+        let launch = try XCTUnwrap(viewModel.urlForWebCheckout(
+            packageContext: Self.packageContext(identifier: "monthly&plan"),
+            appUserID: "user+one@example.com",
+            isSandbox: false
+        ))
+
+        let query = try XCTUnwrap(URLComponents(url: launch.url, resolvingAgainstBaseURL: false)?.percentEncodedQuery)
+        expect(query).to(contain("my_user=user%2Bone@example.com"))
+        expect(query).to(contain("my%20package=monthly%26plan"))
+
+        expect(self.queryItems(in: launch.url)) == [
+            "rc_source": "app",
+            "my_user": "user+one@example.com",
+            "my_env": "production",
+            "my package": "monthly&plan"
+        ]
+    }
+
+    // MARK: - Existing URL contents
+
+    func testCustomWebCheckoutPreservesExistingQueryItemsAndFragment() throws {
+        let viewModel = try self.makeViewModel(
+            url: "https://example.com/checkout?campaign=summer&utm_source=email#section",
+            appUserIDParam: "my_user"
+        )
+
+        let launch = try XCTUnwrap(viewModel.urlForWebCheckout(
+            packageContext: nil,
+            appUserID: "user_1",
+            isSandbox: false
+        ))
+
+        let components = try XCTUnwrap(URLComponents(url: launch.url, resolvingAgainstBaseURL: false))
+        expect(components.fragment) == "section"
+        expect(self.queryItems(in: launch.url)) == [
+            "campaign": "summer",
+            "utm_source": "email",
+            "rc_source": "app",
+            "my_user": "user_1"
+        ]
+    }
+
+    func testCustomWebCheckoutReplacesExistingParametersWithTheSameName() throws {
+        let viewModel = try self.makeViewModel(
+            url: "https://example.com/checkout?rc_source=web&my_user=stale&keep=me",
+            appUserIDParam: "my_user"
+        )
+
+        let launch = try XCTUnwrap(viewModel.urlForWebCheckout(
+            packageContext: nil,
+            appUserID: "user_1",
+            isSandbox: false
+        ))
+
+        expect(self.queryItems(in: launch.url)) == [
+            "keep": "me",
+            "rc_source": "app",
+            "my_user": "user_1"
+        ]
+    }
+
+    func testCustomWebCheckoutIsStableAcrossCalls() throws {
+        let viewModel = try self.makeViewModel(
+            url: "https://example.com/checkout",
+            packageParam: "my_package",
+            appUserIDParam: "my_user",
+            envParam: "my_env"
+        )
+        let packageContext = Self.packageContext(identifier: "monthly")
+
+        let first = try XCTUnwrap(viewModel.urlForWebCheckout(
+            packageContext: packageContext,
+            appUserID: "user_1",
+            isSandbox: false
+        ))
+        let second = try XCTUnwrap(viewModel.urlForWebCheckout(
+            packageContext: packageContext,
+            appUserID: "user_1",
+            isSandbox: false
+        ))
+
+        expect(first.url) == second.url
+    }
+
+    func testCustomWebCheckoutWithMissingLocalizedUrlThrows() throws {
+        expect {
+            try self.makeViewModel(url: nil)
+        }.to(throwError())
+    }
+
+    // MARK: - RC Billing methods
+
+    func testWebCheckoutUrlIsUnchanged() throws {
+        let checkoutUrl = try XCTUnwrap(URL(string: "https://pay.rev.cat/checkout?foo=bar"))
+        let viewModel = try self.makeViewModel(
+            method: .webCheckout(.init()),
+            webCheckoutUrl: checkoutUrl
+        )
+
+        let launch = try XCTUnwrap(viewModel.urlForWebCheckout(
+            packageContext: nil,
+            appUserID: "user_1",
+            isSandbox: true
+        ))
+
+        expect(launch.url) == checkoutUrl
+    }
+
+    func testWebProductSelectionUrlIsUnchanged() throws {
+        let checkoutUrl = try XCTUnwrap(URL(string: "https://pay.rev.cat/checkout?foo=bar"))
+        let viewModel = try self.makeViewModel(
+            method: .webProductSelection(.init()),
+            webCheckoutUrl: checkoutUrl
+        )
+
+        let launch = try XCTUnwrap(viewModel.urlForWebCheckout(
+            packageContext: nil,
+            appUserID: "user_1",
+            isSandbox: true
+        ))
+
+        expect(launch.url) == checkoutUrl
+    }
+
+    // MARK: - Helpers
+
+    private func queryItems(in url: URL) -> [String: String] {
+        let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        return items.reduce(into: [:]) { result, item in
+            result[item.name] = item.value
+        }
+    }
+
+    private func makeViewModel(
+        url: String?,
+        packageParam: String? = nil,
+        appUserIDParam: String? = nil,
+        envParam: String? = nil
+    ) throws -> PurchaseButtonComponentViewModel {
+        return try self.makeViewModel(
+            method: .customWebCheckout(
+                .init(
+                    customUrl: .init(
+                        url: Self.urlLid,
+                        packageParam: packageParam,
+                        appUserIDParam: appUserIDParam,
+                        envParam: envParam
+                    )
+                )
+            ),
+            localizedUrl: url
+        )
+    }
+
+    private func makeViewModel(
+        method: PaywallComponent.PurchaseButtonComponent.Method,
+        localizedUrl: String? = nil,
+        webCheckoutUrl: URL? = nil
+    ) throws -> PurchaseButtonComponentViewModel {
+        let component = PaywallComponent.PurchaseButtonComponent(
+            stack: .init(components: []),
+            action: nil,
+            method: method,
+            name: nil
+        )
+        let uiConfigProvider = UIConfigProvider(uiConfig: PreviewUIConfig.make())
+        let stackViewModel = StackComponentViewModel(
+            component: component.stack,
+            viewModels: [],
+            badgeViewModels: [],
+            uiConfigProvider: uiConfigProvider
+        )
+
+        return try PurchaseButtonComponentViewModel(
+            localizationProvider: .init(
+                locale: .current,
+                localizedStrings: localizedUrl.map { [Self.urlLid: .string($0)] } ?? [:]
+            ),
+            component: component,
+            offering: .init(
+                identifier: "test",
+                serverDescription: "",
+                metadata: [:],
+                availablePackages: [],
+                webCheckoutUrl: webCheckoutUrl
+            ),
+            stackViewModel: stackViewModel
+        )
+    }
+
+    private static func packageContext(identifier: String) -> PackageContext {
+        let product = TestStoreProduct(
+            localizedTitle: "PRO",
+            price: 3.99,
+            currencyCode: "USD",
+            localizedPriceString: "$3.99",
+            productIdentifier: "com.revenuecat.monthly",
+            productType: .autoRenewableSubscription,
+            localizedDescription: "Monthly subscription",
+            subscriptionGroupIdentifier: "group",
+            subscriptionPeriod: .init(value: 1, unit: .month),
+            locale: Locale(identifier: "en_US")
+        )
+        let package = Package(
+            identifier: identifier,
+            packageType: .monthly,
+            storeProduct: product.toStoreProduct(),
+            offeringIdentifier: "default",
+            webCheckoutUrl: nil
+        )
+
+        return PackageContext(package: package, variableContext: .init(packages: [package]))
+    }
+
+}
+
+#endif

--- a/Tests/UnitTests/Paywalls/Components/PurchaseButtonComponentTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/PurchaseButtonComponentTests.swift
@@ -277,7 +277,9 @@ class PurchaseButtonComponentCodableTests: TestCase {
                 "type": "custom_web_checkout",
                 "custom_url": {
                     "url_lid": "123",
-                    "package_param": "rc_package"
+                    "package_param": "rc_package",
+                    "app_user_id_param": "rc_app_user_id",
+                    "env_param": "rc_env"
                 },
                 "auto_dismiss": false,
                 "open_method": "in_app_browser"
@@ -298,7 +300,12 @@ class PurchaseButtonComponentCodableTests: TestCase {
             action: nil,
             method: .customWebCheckout(
                 .init(
-                    customUrl: .init(url: "123", packageParam: "rc_package"),
+                    customUrl: .init(
+                        url: "123",
+                        packageParam: "rc_package",
+                        appUserIDParam: "rc_app_user_id",
+                        envParam: "rc_env"
+                    ),
                     autoDismiss: false,
                     openMethod: .inAppBrowser
                 )
@@ -307,6 +314,62 @@ class PurchaseButtonComponentCodableTests: TestCase {
         )
 
         XCTAssertEqual(decodedPurchaseButton, purchaseButtonComponent)
+    }
+
+    func testMethodCustomWebCheckoutWithNullParamsDecoding() throws {
+        let jsonString = """
+        {
+            "type": "purchase_button",
+            "method": {
+                "type": "custom_web_checkout",
+                "custom_url": {
+                    "url_lid": "123",
+                    "package_param": null,
+                    "app_user_id_param": null,
+                    "env_param": null
+                }
+            },
+            "stack": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedPurchaseButton = try JSONDecoder.default.decode(PaywallComponent.PurchaseButtonComponent.self,
+                                                                   from: jsonData)
+
+        guard case let .customWebCheckout(customWebCheckout)? = decodedPurchaseButton.method else {
+            return XCTFail("Expected a custom web checkout method")
+        }
+
+        XCTAssertNil(customWebCheckout.customUrl.packageParam)
+        XCTAssertNil(customWebCheckout.customUrl.appUserIDParam)
+        XCTAssertNil(customWebCheckout.customUrl.envParam)
+    }
+
+    func testMethodCustomWebCheckoutWithMissingParamsDecoding() throws {
+        let jsonString = """
+        {
+            "type": "purchase_button",
+            "method": {
+                "type": "custom_web_checkout",
+                "custom_url": {
+                    "url_lid": "123"
+                }
+            },
+            "stack": \(jsonStringDefaultStack)
+        }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+        let decodedPurchaseButton = try JSONDecoder.default.decode(PaywallComponent.PurchaseButtonComponent.self,
+                                                                   from: jsonData)
+
+        guard case let .customWebCheckout(customWebCheckout)? = decodedPurchaseButton.method else {
+            return XCTFail("Expected a custom web checkout method")
+        }
+
+        XCTAssertEqual(customWebCheckout.customUrl.url, "123")
+        XCTAssertNil(customWebCheckout.customUrl.packageParam)
+        XCTAssertNil(customWebCheckout.customUrl.appUserIDParam)
+        XCTAssertNil(customWebCheckout.customUrl.envParam)
     }
 
     // MARK: - Method.description


### PR DESCRIPTION
Custom web checkout URLs are now served from a static CDN blob, so the per-user query parameters the backend used to append are missing. This restores them by resolving the values in the SDK instead.

https://github.com/RevenueCat/purchases-android/pull/4107


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how checkout URLs are built and embeds app user ID in query strings for custom web checkout; purchase-adjacent but narrowly scoped and heavily tested.
> 
> **Overview**
> **Custom web checkout** links now get per-user query parameters on the client, matching what used to be added server-side before paywall JSON moved to static CDN blobs.
> 
> `PurchaseButtonComponentViewModel.urlForWebCheckout` takes `appUserID` and `isSandbox` (from `Purchases.shared` in the view). For **custom web checkout**, it always adds `rc_source=app` and, when configured in paywall JSON, optional params for app user ID, `sandbox`/`production` env, and selected package identifier. URL assembly uses **upsert** semantics so existing query keys and fragments stay intact while same-named params are replaced, with stricter percent-encoding for values.
> 
> The paywall model gains optional `appUserIDParam` and `envParam` on `CustomWebCheckout.CustomURL` (decoded from `app_user_id_param` / `env_param`). **RC Billing** `web_checkout` and `web_product_selection` URLs are unchanged. Coverage adds `PurchaseButtonComponentViewModelTests` plus codable tests for the new fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79fb2f37cf11cc2511d6e8692df71b777b6f2ad3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->