### PR TITLE
Allow workflow previews to simulate promo offer eligibility

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -166,6 +166,7 @@ public struct PaywallView: View {
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         displayCloseButton: Bool = false,
         introEligibility: TrialOrIntroEligibilityChecker? = nil,
+        simulatePromoEligible: Bool = false,
         performPurchase: PerformPurchase? = nil,
         performRestore: PerformRestore? = nil
     ) {
@@ -177,7 +178,8 @@ public struct PaywallView: View {
             fonts: fonts,
             displayCloseButton: displayCloseButton,
             introEligibility: introEligibility,
-            purchaseHandler: purchaseHandler
+            purchaseHandler: purchaseHandler,
+            promoOfferCache: simulatePromoEligible ? PaywallPromoOfferCache(simulateEligible: true) : nil
         )
         configuration.injectedWorkflowContext = workflowContext
 


### PR DESCRIPTION
`PaywallView(offering:)` takes `simulatePromoEligible` and seeds a simulated `PaywallPromoOfferCache`, so a companion app can preview `promo_offer` rules against mock products. The `workflowContext:` initializer had no equivalent, so `configuration.promoOfferCache` stayed nil and `WorkflowPaywallView` fell back to a real-eligibility cache, which can never resolve for mock products. `promo_offer` overrides were therefore permanently false in a workflow preview.

Mirrors the offering initializer. Preview/companion-app surface only (`@_spi(Internal)`), no effect on production paywalls.

Unblocks the app side in revenuecat-mobile-ios, which cannot pass the toggle through without this parameter.

Verified by building the RevenueCat companion app against a local checkout carrying this parameter plus the app-side plumbing, then rendering a workflow preview: `12 months DEFAULT` before, `12 months PROMO - 30,00 EUR` after.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: this PR
- Branch: `facu/workflow-preview-simulate-promo-eligible`
- Author / human owner: facumenzella
- Agent(s): Claude Code (Opus 5, 1M context)
- Session source: current conversation
- Generated: 2026-08-27
- Context document version: 1

## Goal

Let the RevenueCat companion app's workflow preview honour the "Include a promotional offer" toggle, which currently has no effect on that screen.

## Initial Prompt

Follow-on from investigating a customer ticket where a paywall's promotional-offer rule never applied in the companion app's preview. The primary cause is fixed separately; this addresses the workflow-preview path found during that investigation.

## Important Follow-up Prompts

- "ok open a draft with the RC Mobile part too" scoped this PR: the app plumbing needs an SDK parameter, so the SDK half was split out here.

## Agent Contribution

- Traced that `WorkflowPaywallView` falls back to `PaywallPromoOfferCache(subscriptionHistoryTracker:)` when the injected cache is nil, confirmed with instrumented logs (`PaywallsV2View.init received promoOfferCache=NIL`, `seeded=[] simulate=false`).
- Added the parameter mirroring the offering initializer.
- Verified end to end in the companion app against a local checkout.

## Human Decisions

- Requested the app-side change, which required splitting this SDK parameter out rather than folding it into the unrelated production fix.

## Key Implementation Decisions

- Decision: add `simulatePromoEligible: Bool = false` to the `workflowContext:` initializer and build the cache exactly as the offering initializer does.
  - Rationale: smallest change, no new surface, keeps the two initializers symmetrical.
  - Rejected: exposing `PaywallPromoOfferCache` so callers inject their own. Would make an internal type public for no gain.
- Decision: keep this separate from the `promoEligibilityPackageInfos` production fix.
  - Rationale: different concerns and blast radius. That one is a shipped production bug; this is a preview-only API addition.

## Files / Symbols Touched

- `RevenueCatUI/PaywallView.swift`
  - Why: the workflow initializer never set `promoOfferCache`.
  - Symbols: `PaywallView.init(workflowContext:fonts:displayCloseButton:introEligibility:simulatePromoEligible:performPurchase:performRestore:)`
  - Review relevance: confirm the default `false` keeps every existing caller behaviourally identical.

## Dependencies / Config / Migrations

- None. Additive parameter with a default, so no call sites break.

## Validation

- Commands run:
  - `xcodebuild -project RevenueCat.xcodeproj -scheme RevenueCat -destination "platform=iOS Simulator,name=iPhone 16" build` in the companion app against a local checkout with this parameter: BUILD SUCCEEDED.
- Manual verification:
  - Workflow preview of a copied customer paywall on iPhone 16 simulator: `12 months DEFAULT - $59.99` before, `12 months PROMO - 30,00 EUR` after. The promo toggle was read from the app's real app-group value, not forced.
- CI:
  - Not captured at time of writing.

## Validation Gaps

- No unit test. The change is a parameter pass-through into a SwiftUI view's private configuration, with no observable surface to assert against from a test; `PaywallViewConfiguration` and `PaywallPromoOfferCache` are both internal. Covered by the manual app verification above.
- Not exercised on tvOS, where workflow paywall UI does not exist.

## Review Focus

- Is `@_spi(Internal)` the right visibility, matching the offering initializer?
- Should the workflow path instead inherit a cache from an enclosing `PaywallView` rather than building its own?

## Risks / Reviewer Notes

- Risk: low. Additive parameter defaulting to `false`; existing behaviour is unchanged unless a caller opts in.
- Note: a simulated cache fabricates sentinel-signed offers. `purchasableOffer(for:)` already returns nil in simulate mode, so these cannot reach StoreKit.

</details>
