### PR TITLE
Fall back to "en" when a workflow screen omits `default_locale`

### DIFF
--- a/Sources/Misc/Codable/DefaultDecodable.swift
+++ b/Sources/Misc/Codable/DefaultDecodable.swift
@@ -198,7 +198,7 @@ enum DefaultDecodable {
         enum EmptyString: DefaultValueProvider {
             static var defaultValue: String { "" }
         }
-        
+
         enum EnglishLocale: DefaultValueProvider {
             static var defaultValue: String { "en" }
         }

--- a/Sources/Misc/Codable/DefaultDecodable.swift
+++ b/Sources/Misc/Codable/DefaultDecodable.swift
@@ -198,6 +198,10 @@ enum DefaultDecodable {
         enum EmptyString: DefaultValueProvider {
             static var defaultValue: String { "" }
         }
+        
+        enum EnglishLocale: DefaultValueProvider {
+            static var defaultValue: String { "en" }
+        }
 
         enum Zero: DefaultValueProvider {
             static var defaultValue: Int { 0 }
@@ -244,6 +248,7 @@ extension DefaultDecodable {
     typealias True = DefaultValue<Sources.True>
     typealias False = DefaultValue<Sources.False>
     typealias EmptyString = DefaultValue<Sources.EmptyString>
+    typealias EnglishLocale = DefaultValue<Sources.EnglishLocale>
     typealias EmptyArray<T: List> = DefaultValue<Sources.EmptyArray<T>>
     typealias EmptyDictionary<T: Map> = DefaultValue<Sources.EmptyDictionary<T>>
     typealias Now = DefaultValue<Sources.Now>

--- a/Sources/Misc/Codable/DefaultDecodable.swift
+++ b/Sources/Misc/Codable/DefaultDecodable.swift
@@ -199,10 +199,6 @@ enum DefaultDecodable {
             static var defaultValue: String { "" }
         }
 
-        enum EnglishLocale: DefaultValueProvider {
-            static var defaultValue: String { "en" }
-        }
-
         enum Zero: DefaultValueProvider {
             static var defaultValue: Int { 0 }
         }
@@ -248,7 +244,6 @@ extension DefaultDecodable {
     typealias True = DefaultValue<Sources.True>
     typealias False = DefaultValue<Sources.False>
     typealias EmptyString = DefaultValue<Sources.EmptyString>
-    typealias EnglishLocale = DefaultValue<Sources.EnglishLocale>
     typealias EmptyArray<T: List> = DefaultValue<Sources.EmptyArray<T>>
     typealias EmptyDictionary<T: Map> = DefaultValue<Sources.EmptyDictionary<T>>
     typealias Now = DefaultValue<Sources.Now>

--- a/Sources/Networking/Responses/WorkflowsResponse.swift
+++ b/Sources/Networking/Responses/WorkflowsResponse.swift
@@ -134,7 +134,8 @@ import Foundation
     public let assetBaseURL: URL
     public let componentsConfig: PaywallComponentsData.ComponentsConfig
     public let componentsLocalizations: [PaywallComponent.LocaleID: PaywallComponent.LocalizationDictionary]
-    public let defaultLocale: PaywallComponent.LocaleID
+    var _defaultLocale: PaywallComponent.LocaleID
+    public var defaultLocale: PaywallComponent.LocaleID { _defaultLocale }
     @DefaultDecodable.EmptyDictionary
     var config: [String: AnyDecodable]
     public let offeringIdentifier: String?
@@ -178,7 +179,7 @@ import Foundation
         self.assetBaseURL = assetBaseURL
         self.componentsConfig = componentsConfig
         self.componentsLocalizations = componentsLocalizations
-        self.defaultLocale = defaultLocale
+        self._defaultLocale = defaultLocale
         self.config = [:]
         self.offeringIdentifier = offeringIdentifier
         self.exitOffers = exitOffers
@@ -309,7 +310,8 @@ extension WorkflowScreen: Codable, Equatable, Sendable {
         case assetBaseURL = "assetBaseUrl"
         case componentsConfig
         case componentsLocalizations
-        case defaultLocale
+        // swiftlint:disable:next identifier_name
+        case _defaultLocale = "defaultLocale"
         case config
         case offeringIdentifier
         case exitOffers

--- a/Sources/Networking/Responses/WorkflowsResponse.swift
+++ b/Sources/Networking/Responses/WorkflowsResponse.swift
@@ -134,6 +134,7 @@ import Foundation
     public let assetBaseURL: URL
     public let componentsConfig: PaywallComponentsData.ComponentsConfig
     public let componentsLocalizations: [PaywallComponent.LocaleID: PaywallComponent.LocalizationDictionary]
+    // swiftlint:disable:next identifier_name
     var _defaultLocale: PaywallComponent.LocaleID
     public var defaultLocale: PaywallComponent.LocaleID { _defaultLocale }
     @DefaultDecodable.EmptyDictionary

--- a/Sources/Networking/Responses/WorkflowsResponse.swift
+++ b/Sources/Networking/Responses/WorkflowsResponse.swift
@@ -134,7 +134,7 @@ import Foundation
     public let assetBaseURL: URL
     public let componentsConfig: PaywallComponentsData.ComponentsConfig
     public let componentsLocalizations: [PaywallComponent.LocaleID: PaywallComponent.LocalizationDictionary]
-    @DefaultDecodable.EnglishLocale
+    @DefaultValue<PaywallComponent.DefaultLocaleFallback>
     // swiftlint:disable:next identifier_name
     var _defaultLocale: PaywallComponent.LocaleID
     public var defaultLocale: PaywallComponent.LocaleID { _defaultLocale }

--- a/Sources/Networking/Responses/WorkflowsResponse.swift
+++ b/Sources/Networking/Responses/WorkflowsResponse.swift
@@ -134,6 +134,7 @@ import Foundation
     public let assetBaseURL: URL
     public let componentsConfig: PaywallComponentsData.ComponentsConfig
     public let componentsLocalizations: [PaywallComponent.LocaleID: PaywallComponent.LocalizationDictionary]
+    @DefaultDecodable.EnglishLocale
     // swiftlint:disable:next identifier_name
     var _defaultLocale: PaywallComponent.LocaleID
     public var defaultLocale: PaywallComponent.LocaleID { _defaultLocale }

--- a/Sources/Paywalls/Components/Common/PaywallComponentBase.swift
+++ b/Sources/Paywalls/Components/Common/PaywallComponentBase.swift
@@ -71,7 +71,7 @@ import Foundation
 }
 
 extension PaywallComponent {
-    
+
     enum DefaultLocaleFallback: DefaultValueProvider {
 
         static let defaultValue: PaywallComponent.LocaleID = "en"

--- a/Sources/Paywalls/Components/Common/PaywallComponentBase.swift
+++ b/Sources/Paywalls/Components/Common/PaywallComponentBase.swift
@@ -70,6 +70,16 @@ import Foundation
     typealias ColorHex = String
 }
 
+extension PaywallComponent {
+    
+    enum DefaultLocaleFallback: DefaultValueProvider {
+
+        static let defaultValue: PaywallComponent.LocaleID = "en"
+
+    }
+
+}
+
 @_spi(Internal) extension PaywallComponent {
 
     enum CodingKeys: String, CodingKey {

--- a/Tests/UnitTests/Networking/Responses/PublishedWorkflowCodableTests.swift
+++ b/Tests/UnitTests/Networking/Responses/PublishedWorkflowCodableTests.swift
@@ -114,4 +114,43 @@ class PublishedWorkflowCodableTests: TestCase {
         expect(decoded.metadata?["source"]) == .string("cdn")
     }
 
+    func testDecodingScreenWithNullDefaultLocaleDoesNotFailWholeWorkflow() throws {
+        let json = """
+        {
+          "id": "wf-1",
+          "display_name": "Test",
+          "initial_step_id": "step-1",
+          "steps": {},
+          "screens": {
+            "pwa-1": {
+              "template_name": "tmpl",
+              "asset_base_url": "https://assets.revenuecat.com",
+              "default_locale": null,
+              "components_localizations": {},
+              "components_config": {
+                "base": {
+                  "stack": {
+                    "type": "stack", "components": [],
+                    "dimension": { "type": "vertical", "alignment": "center", "distribution": "center" },
+                    "size": { "width": { "type": "fill" }, "height": { "type": "fill" } },
+                    "padding": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 },
+                    "margin": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 }
+                  },
+                  "background": {
+                    "type": "color", "value": { "light": { "type": "hex", "value": "#FFFFFF" } }
+                  }
+                }
+              }
+            }
+          }
+        }
+        """
+        let decoded = try JSONDecoder.default.decode(
+            PublishedWorkflow.self,
+            jsonData: try XCTUnwrap(json.data(using: .utf8))
+        )
+
+        expect(decoded.screens["pwa-1"]?.defaultLocale) == "en"
+    }
+
 }

--- a/Tests/UnitTests/Networking/Workflows/WorkflowResponseTests.swift
+++ b/Tests/UnitTests/Networking/Workflows/WorkflowResponseTests.swift
@@ -497,14 +497,55 @@ class WorkflowResponseTests: TestCase {
         expect(step.metadata).to(beNil())
     }
 
+    // MARK: - default_locale
+
+    func testDecodeWorkflowScreenDefaultLocalePreservesValue() throws {
+        let screen = try Self.decodeWorkflowScreen(defaultLocaleJSON: "\"es_ES\"")
+
+        expect(screen.defaultLocale) == "es_ES"
+    }
+
+    func testDecodeWorkflowScreenDefaultLocaleDefaultsToEnglishWhenNull() throws {
+        let screen = try Self.decodeWorkflowScreen(defaultLocaleJSON: "null")
+
+        expect(screen.defaultLocale) == "en"
+    }
+
+    func testDecodeWorkflowScreenDefaultLocaleDefaultsToEnglishWhenMissing() throws {
+        let screen = try Self.decodeWorkflowScreen(defaultLocaleJSON: nil)
+
+        expect(screen.defaultLocale) == "en"
+    }
+
+    func testWorkflowAndOfferingsPathsAgreeOnDefaultLocale() throws {
+        for localeJSON in ["\"es_ES\"", "null", nil] {
+            let screen = try Self.decodeWorkflowScreen(defaultLocaleJSON: localeJSON)
+            let componentsData = try Self.decodePaywallComponentsData(defaultLocaleJSON: localeJSON)
+
+            expect(screen.defaultLocale).to(
+                equal(componentsData.defaultLocale),
+                description: "default_locale diverged for payload \(localeJSON ?? "<omitted>")"
+            )
+        }
+    }
+
 }
 
 private extension WorkflowResponseTests {
 
+    /// - Parameter defaultLocaleJSON: the raw JSON value for `default_locale`, or `nil` to omit the key
+    /// entirely. The backend sends `null` here for template-derived screens.
     static func decodeWorkflowScreen(
+        defaultLocaleJSON: String? = "\"en_US\"",
         automaticallyScaleFontSize: Bool? = nil,
         zeroDecimalPlaceCountriesJSON: String? = nil
     ) throws -> WorkflowScreen {
+        var defaultLocaleFragment = ""
+        if let defaultLocaleJSON {
+            defaultLocaleFragment = """
+            "default_locale": \(defaultLocaleJSON),
+            """
+        }
         var automaticallyScaleFontSizeFragment = ""
         if let automaticallyScaleFontSize {
             automaticallyScaleFontSizeFragment = """
@@ -521,7 +562,7 @@ private extension WorkflowResponseTests {
         {
           "template_name": "tmpl",
           "asset_base_url": "https://assets.revenuecat.com",
-          "default_locale": "en_US",
+          \(defaultLocaleFragment)
           "components_localizations": {},
           "components_config": {
             "base": {
@@ -539,6 +580,37 @@ private extension WorkflowResponseTests {
         """.data(using: .utf8)!
 
         return try JSONDecoder.default.decode(WorkflowScreen.self, from: json)
+    }
+
+    static func decodePaywallComponentsData(defaultLocaleJSON: String?) throws -> PaywallComponentsData {
+        var defaultLocaleFragment = ""
+        if let defaultLocaleJSON {
+            defaultLocaleFragment = """
+            "default_locale": \(defaultLocaleJSON),
+            """
+        }
+        let json = """
+        {
+          "template_name": "tmpl",
+          "asset_base_url": "https://assets.revenuecat.com",
+          \(defaultLocaleFragment)
+          "components_localizations": {},
+          "components_config": {
+            "base": {
+              "stack": {
+                "type": "stack", "components": [],
+                "dimension": { "type": "vertical", "alignment": "center", "distribution": "center" },
+                "size": { "width": { "type": "fill" }, "height": { "type": "fill" } },
+                "padding": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 },
+                "margin": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 }
+              },
+              "background": { "type": "color", "value": { "light": { "type": "hex", "value": "#FFFFFF" } } }
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        return try JSONDecoder.default.decode(PaywallComponentsData.self, from: json)
     }
 
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->
<!-- AI agents: fill in this template, and also follow the "Pull Requests" section in AGENTS.md. -->

### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

`WorkflowScreen.defaultLocale` was hard-required, while the same field on the offerings path falls back to `"en"`. The backend sends `default_locale: null` for template-derived screens, so any such paywall resolved through the workflow CDN failed to decode entirely and fell back to the default paywall.
Context: https://revenuecat.slack.com/archives/C093NCRHZ0T/p1787752483767479

### Description

Both decoders converge on the same `PaywallComponentsData` via `WorkflowScreenMapper`, so the divergence in strictness was unintentional. This wraps the field in `@DefaultDecodable.EnglishLocale` to match `PaywallComponentsData.init(from:)`. The public `defaultLocale` remains a non-optional `LocaleID` and no API change.

Verified against the affected payload shape: a `WorkflowScreen` with `default_locale: null` previously threw
`DecodingError.valueNotFound … Path: defaultLocale`, matching the error in customer logs, and now decodes to `"en"`. The offerings path is unchanged for present/null/omitted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow JSON decoding change with no public API surface change; reduces decode failures rather than altering runtime paywall logic.
> 
> **Overview**
> **Workflow CDN paywalls no longer fail to decode** when the backend sends `default_locale: null` (common for template-derived screens). `WorkflowScreen` now decodes `default_locale` through `@DefaultValue<PaywallComponent.DefaultLocaleFallback>`, backing storage `_defaultLocale`, with **`"en"`** when the value is null or absent—matching the offerings path’s behavior in `PaywallComponentsData`.
> 
> The public **`defaultLocale`** property stays a non-optional `LocaleID`; only decoding and the memberwise initializer wiring changed. Tests cover null, missing, and explicit locales on both `WorkflowScreen` and `PublishedWorkflow`, and assert workflow vs offerings decoding agree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecc6f46ad10e8ac2f4a45af962ec6f6a26757fdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->