### PR TITLE
feat(Checkpoints): refine result and listener APIs

### DIFF
--- a/Examples/CheckpointTester/CheckpointTester/Sources/CheckpointDemoModel.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/CheckpointDemoModel.swift
@@ -89,15 +89,15 @@ final class CheckpointDemoModel: ObservableObject {
 
     private static func describe(_ result: CheckpointPaywallOutcome) -> String {
         switch result {
-        case is CheckpointPaywallDismissedOutcome:
+        case is CheckpointPaywallOutcome.Dismissed:
             return "Dismissed"
-        case is CheckpointPaywallWebCheckoutOpenedOutcome:
+        case is CheckpointPaywallOutcome.WebCheckoutOpened:
             return "Web checkout opened"
-        case is CheckpointPaywallPurchasedOutcome:
+        case is CheckpointPaywallOutcome.Purchased:
             return "Purchased"
-        case is CheckpointPaywallRestoredOutcome:
+        case is CheckpointPaywallOutcome.Restored:
             return "Restored"
-        case let error as CheckpointPaywallErrorOutcome:
+        case let error as CheckpointPaywallOutcome.Error:
             return "Error · \(error.error.localizedDescription)"
         default:
             return "Unknown paywall outcome"

--- a/Examples/CheckpointTester/CheckpointTester/Sources/CheckpointDemoModel.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/CheckpointDemoModel.swift
@@ -29,10 +29,10 @@ final class CheckpointDemoModel: ObservableObject {
 
     private var pendingOutcomeAlerts: [OutcomeAlert] = []
 
-    func showOutcome(_ result: CheckpointResult) {
+    func showOutcome(_ result: CheckpointResult, checkpointIdentifier: String) {
         self.showOutcomeAlert(
             title: "Checkpoint result",
-            message: Self.describe(result)
+            message: Self.describe(result, checkpointIdentifier: checkpointIdentifier)
         )
     }
 
@@ -73,17 +73,17 @@ final class CheckpointDemoModel: ObservableObject {
         self.outcomeAlert = self.pendingOutcomeAlerts.removeFirst()
     }
 
-    private static func describe(_ result: CheckpointResult) -> String {
+    private static func describe(_ result: CheckpointResult, checkpointIdentifier: String) -> String {
         switch result {
         case let presented as CheckpointPaywallPresentedResult:
-            return "Paywall presented · \(presented.checkpoint.identifier)\n\n" +
+            return "Paywall presented · \(checkpointIdentifier)\n\n" +
                 "Paywall outcome: \(Self.describe(presented.paywallOutcome))"
         case let received as CheckpointReceivedOfferingResult:
-            return "Received offering · \(received.checkpoint.identifier) · \(received.offering.identifier)"
+            return "Received offering · \(checkpointIdentifier) · \(received.offering.identifier)"
         case let noAction as CheckpointNoActionResult:
-            return "No action · \(noAction.checkpoint.identifier) · \(noAction.reason)"
+            return "No action · \(checkpointIdentifier) · \(noAction.reason)"
         default:
-            return "Unknown checkpoint result · \(result.checkpoint.identifier)"
+            return "Unknown checkpoint result · \(checkpointIdentifier)"
         }
     }
 

--- a/Examples/CheckpointTester/CheckpointTester/Sources/CheckpointDemoModel.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/CheckpointDemoModel.swift
@@ -91,6 +91,8 @@ final class CheckpointDemoModel: ObservableObject {
         switch result {
         case is CheckpointPaywallDismissedOutcome:
             return "Dismissed"
+        case is CheckpointPaywallWebCheckoutOpenedOutcome:
+            return "Web checkout opened"
         case is CheckpointPaywallPurchasedOutcome:
             return "Purchased"
         case is CheckpointPaywallRestoredOutcome:

--- a/Examples/CheckpointTester/CheckpointTester/Sources/ContentView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/ContentView.swift
@@ -133,7 +133,10 @@ struct ContentView: View {
                                     "this-checkpoint-does-not-exist",
                                     customVariables: self.customVariables.checkpointCustomVariables
                                 )
-                                self.model.showOutcome(result)
+                                self.model.showOutcome(
+                                    result,
+                                    checkpointIdentifier: "this-checkpoint-does-not-exist"
+                                )
                             } catch {
                                 self.model.showError(error)
                             }
@@ -151,7 +154,7 @@ struct ContentView: View {
                                     "error_checkpoint",
                                     customVariables: self.customVariables.checkpointCustomVariables
                                 )
-                                self.model.showOutcome(result)
+                                self.model.showOutcome(result, checkpointIdentifier: "error_checkpoint")
                             } catch {
                                 self.model.showError(error)
                             }

--- a/Examples/CheckpointTester/CheckpointTester/Sources/GlobalCheckpointAnalyticsTracker.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/GlobalCheckpointAnalyticsTracker.swift
@@ -31,15 +31,16 @@ final class GlobalCheckpointAnalyticsTracker: ObservableObject, CheckpointListen
     // MARK: - New checkpoint public API implementation
 
     // These callbacks demonstrate an app-wide analytics integration using CheckpointListener.
-    func onCheckpointHit(_ checkpoint: CheckpointInfo) {
+    func onCheckpointHit(_ context: CheckpointHitContext) {
         self.track(
-            "Hit · \(checkpoint.identifier) · customVariables=\(checkpoint.customVariables)"
+            "Hit · \(context.identifier) · customVariables=\(context.customVariables)"
         )
     }
 
-    func onCheckpointCompleted(_ checkpoint: CheckpointInfo, result: CheckpointResult) {
+    func onCheckpointCompleted(_ context: CheckpointCompletedContext) {
         self.track(
-            "Completed · \(Self.describe(result)) · customVariables=\(checkpoint.customVariables)"
+            "Completed · \(context.identifier) · \(Self.describe(context.result)) · " +
+                "customVariables=\(context.customVariables)"
         )
     }
 
@@ -58,14 +59,13 @@ final class GlobalCheckpointAnalyticsTracker: ObservableObject, CheckpointListen
     private static func describe(_ result: CheckpointResult) -> String {
         switch result {
         case let presented as CheckpointPaywallPresentedResult:
-            return "Paywall presented · \(presented.checkpoint.identifier) · " +
-                Self.describe(presented.paywallOutcome)
+            return "Paywall presented · \(Self.describe(presented.paywallOutcome))"
         case let received as CheckpointReceivedOfferingResult:
-            return "Received offering · \(received.checkpoint.identifier) · \(received.offering.identifier)"
+            return "Received offering · \(received.offering.identifier)"
         case let noAction as CheckpointNoActionResult:
-            return "No action · \(noAction.checkpoint.identifier) · \(noAction.reason)"
+            return "No action · \(noAction.reason)"
         default:
-            return "Unknown result · \(result.checkpoint.identifier)"
+            return "Unknown result"
         }
     }
 

--- a/Examples/CheckpointTester/CheckpointTester/Sources/GlobalCheckpointAnalyticsTracker.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/GlobalCheckpointAnalyticsTracker.swift
@@ -73,6 +73,8 @@ final class GlobalCheckpointAnalyticsTracker: ObservableObject, CheckpointListen
         switch result {
         case is CheckpointPaywallDismissedOutcome:
             return "Dismissed"
+        case is CheckpointPaywallWebCheckoutOpenedOutcome:
+            return "Web checkout opened"
         case is CheckpointPaywallPurchasedOutcome:
             return "Purchased"
         case is CheckpointPaywallRestoredOutcome:

--- a/Examples/CheckpointTester/CheckpointTester/Sources/GlobalCheckpointAnalyticsTracker.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/GlobalCheckpointAnalyticsTracker.swift
@@ -71,15 +71,15 @@ final class GlobalCheckpointAnalyticsTracker: ObservableObject, CheckpointListen
 
     private static func describe(_ result: CheckpointPaywallOutcome) -> String {
         switch result {
-        case is CheckpointPaywallDismissedOutcome:
+        case is CheckpointPaywallOutcome.Dismissed:
             return "Dismissed"
-        case is CheckpointPaywallWebCheckoutOpenedOutcome:
+        case is CheckpointPaywallOutcome.WebCheckoutOpened:
             return "Web checkout opened"
-        case is CheckpointPaywallPurchasedOutcome:
+        case is CheckpointPaywallOutcome.Purchased:
             return "Purchased"
-        case is CheckpointPaywallRestoredOutcome:
+        case is CheckpointPaywallOutcome.Restored:
             return "Restored"
-        case let error as CheckpointPaywallErrorOutcome:
+        case let error as CheckpointPaywallOutcome.Error:
             return "Error · \(error.error.localizedDescription)"
         default:
             return "Unknown paywall outcome"

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/CustomCheckpointUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/CustomCheckpointUseCaseView.swift
@@ -60,7 +60,7 @@ struct CustomCheckpointUseCaseView: View {
                 self.trimmedIdentifier,
                 customVariables: self.customVariables.checkpointCustomVariables
             )
-            self.model.showOutcome(result)
+            self.model.showOutcome(result, checkpointIdentifier: self.trimmedIdentifier)
         } catch {
             self.model.showError(error)
         }

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/EntitlementGateUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/EntitlementGateUseCaseView.swift
@@ -121,6 +121,8 @@ struct EntitlementGateUseCaseView: View {
             self.updateAccess(with: restored.customerInfo, action: "Restore completed")
         case is CheckpointPaywallDismissedOutcome:
             self.status = "Paywall dismissed. Content remains locked."
+        case is CheckpointPaywallWebCheckoutOpenedOutcome:
+            self.status = "Web checkout opened. Refresh access after completing the purchase."
         case let failed as CheckpointPaywallErrorOutcome:
             self.status = "Paywall failed: \(failed.error.localizedDescription)"
         default:

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/EntitlementGateUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/EntitlementGateUseCaseView.swift
@@ -115,15 +115,15 @@ struct EntitlementGateUseCaseView: View {
     @MainActor
     private func handle(_ outcome: CheckpointPaywallOutcome) {
         switch outcome {
-        case let purchased as CheckpointPaywallPurchasedOutcome:
+        case let purchased as CheckpointPaywallOutcome.Purchased:
             self.updateAccess(with: purchased.customerInfo, action: "Purchase completed")
-        case let restored as CheckpointPaywallRestoredOutcome:
+        case let restored as CheckpointPaywallOutcome.Restored:
             self.updateAccess(with: restored.customerInfo, action: "Restore completed")
-        case is CheckpointPaywallDismissedOutcome:
+        case is CheckpointPaywallOutcome.Dismissed:
             self.status = "Paywall dismissed. Content remains locked."
-        case is CheckpointPaywallWebCheckoutOpenedOutcome:
+        case is CheckpointPaywallOutcome.WebCheckoutOpened:
             self.status = "Web checkout opened. Refresh access after completing the purchase."
-        case let failed as CheckpointPaywallErrorOutcome:
+        case let failed as CheckpointPaywallOutcome.Error:
             self.status = "Paywall failed: \(failed.error.localizedDescription)"
         default:
             self.status = "Unknown paywall outcome. Content remains locked."

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/HardPaywallUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/HardPaywallUseCaseView.swift
@@ -106,17 +106,17 @@ struct HardPaywallUseCaseView: View {
     @MainActor
     private func handle(_ outcome: CheckpointPaywallOutcome) {
         switch outcome {
-        case is CheckpointPaywallPurchasedOutcome:
+        case is CheckpointPaywallOutcome.Purchased:
             self.hasAccess = true
             self.status = "Purchase completed. Access granted."
-        case is CheckpointPaywallRestoredOutcome:
+        case is CheckpointPaywallOutcome.Restored:
             self.hasAccess = true
             self.status = "Restore completed. Access granted."
-        case is CheckpointPaywallDismissedOutcome:
+        case is CheckpointPaywallOutcome.Dismissed:
             self.status = "Paywall dismissed. Content remains locked."
-        case is CheckpointPaywallWebCheckoutOpenedOutcome:
+        case is CheckpointPaywallOutcome.WebCheckoutOpened:
             self.status = "Web checkout opened. Complete the purchase to unlock content."
-        case let failed as CheckpointPaywallErrorOutcome:
+        case let failed as CheckpointPaywallOutcome.Error:
             self.status = "Paywall failed: \(failed.error.localizedDescription)"
         default:
             self.status = "Unknown paywall outcome. Content remains locked."

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/HardPaywallUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/HardPaywallUseCaseView.swift
@@ -114,6 +114,8 @@ struct HardPaywallUseCaseView: View {
             self.status = "Restore completed. Access granted."
         case is CheckpointPaywallDismissedOutcome:
             self.status = "Paywall dismissed. Content remains locked."
+        case is CheckpointPaywallWebCheckoutOpenedOutcome:
+            self.status = "Web checkout opened. Complete the purchase to unlock content."
         case let failed as CheckpointPaywallErrorOutcome:
             self.status = "Paywall failed: \(failed.error.localizedDescription)"
         default:

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/OnboardingUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/OnboardingUseCaseView.swift
@@ -145,6 +145,8 @@ struct OnboardingUseCaseView: View {
             return "Restored during onboarding."
         case is CheckpointPaywallDismissedOutcome:
             return "Paywall dismissed."
+        case is CheckpointPaywallWebCheckoutOpenedOutcome:
+            return "Web checkout opened."
         case let failed as CheckpointPaywallErrorOutcome:
             return "Paywall failed: \(failed.error.localizedDescription)"
         default:

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/OnboardingUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/OnboardingUseCaseView.swift
@@ -139,15 +139,15 @@ struct OnboardingUseCaseView: View {
 
     private static func describe(_ outcome: CheckpointPaywallOutcome) -> String {
         switch outcome {
-        case is CheckpointPaywallPurchasedOutcome:
+        case is CheckpointPaywallOutcome.Purchased:
             return "Purchased during onboarding."
-        case is CheckpointPaywallRestoredOutcome:
+        case is CheckpointPaywallOutcome.Restored:
             return "Restored during onboarding."
-        case is CheckpointPaywallDismissedOutcome:
+        case is CheckpointPaywallOutcome.Dismissed:
             return "Paywall dismissed."
-        case is CheckpointPaywallWebCheckoutOpenedOutcome:
+        case is CheckpointPaywallOutcome.WebCheckoutOpened:
             return "Web checkout opened."
-        case let failed as CheckpointPaywallErrorOutcome:
+        case let failed as CheckpointPaywallOutcome.Error:
             return "Paywall failed: \(failed.error.localizedDescription)"
         default:
             return "Unknown paywall outcome."

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/SoftPaywallUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/SoftPaywallUseCaseView.swift
@@ -97,15 +97,15 @@ struct SoftPaywallUseCaseView: View {
     @MainActor
     private func handle(_ outcome: CheckpointPaywallOutcome) {
         switch outcome {
-        case let purchased as CheckpointPaywallPurchasedOutcome:
+        case let purchased as CheckpointPaywallOutcome.Purchased:
             self.updateSubscriptionStatus(with: purchased.customerInfo, action: "Purchased")
-        case let restored as CheckpointPaywallRestoredOutcome:
+        case let restored as CheckpointPaywallOutcome.Restored:
             self.updateSubscriptionStatus(with: restored.customerInfo, action: "Restored")
-        case is CheckpointPaywallDismissedOutcome:
+        case is CheckpointPaywallOutcome.Dismissed:
             self.status = "Paywall dismissed. Content remains available."
-        case is CheckpointPaywallWebCheckoutOpenedOutcome:
+        case is CheckpointPaywallOutcome.WebCheckoutOpened:
             self.status = "Web checkout opened. Content remains available."
-        case let failed as CheckpointPaywallErrorOutcome:
+        case let failed as CheckpointPaywallOutcome.Error:
             self.status = "Paywall failed: \(failed.error.localizedDescription)"
         default:
             self.status = "Unknown paywall outcome. Content remains available."

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/SoftPaywallUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/SoftPaywallUseCaseView.swift
@@ -103,6 +103,8 @@ struct SoftPaywallUseCaseView: View {
             self.updateSubscriptionStatus(with: restored.customerInfo, action: "Restored")
         case is CheckpointPaywallDismissedOutcome:
             self.status = "Paywall dismissed. Content remains available."
+        case is CheckpointPaywallWebCheckoutOpenedOutcome:
+            self.status = "Web checkout opened. Content remains available."
         case let failed as CheckpointPaywallErrorOutcome:
             self.status = "Paywall failed: \(failed.error.localizedDescription)"
         default:

--- a/RevenueCatUI/Checkpoints/CheckpointCallStore.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointCallStore.swift
@@ -28,7 +28,7 @@ final class CheckpointCallStore {
         init(
             presentation: CheckpointPresentation,
             delegate: CheckpointPresentationDelegate,
-            stagedOutcome: CheckpointPaywallOutcome = CheckpointPaywallDismissedOutcome.shared
+            stagedOutcome: CheckpointPaywallOutcome = CheckpointPaywallOutcome.Dismissed.shared
         ) {
             self.presentation = presentation
             self.delegate = delegate

--- a/RevenueCatUI/Checkpoints/CheckpointResults.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointResults.swift
@@ -201,7 +201,7 @@ public class CheckpointPaywallOutcome: Equatable, Hashable, CustomStringConverti
 
 }
 
-/// The customer dismissed the paywall.
+/// The customer dismissed the paywall without a purchase, restore, or error.
 @_spi(CheckpointsInternal)
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public final class CheckpointPaywallDismissedOutcome: CheckpointPaywallOutcome {
@@ -214,7 +214,9 @@ public final class CheckpointPaywallDismissedOutcome: CheckpointPaywallOutcome {
 
 }
 
-/// The customer opened a web checkout from the paywall.
+/// The customer opened a web checkout from the paywall to pay externally.
+///
+/// There is no in-app completion signal for the external payment.
 @_spi(CheckpointsInternal)
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 // swiftlint:disable:next type_name
@@ -282,7 +284,8 @@ public final class CheckpointPaywallRestoredOutcome: CheckpointPaywallOutcome {
 
 }
 
-/// The paywall ended with an error.
+/// A purchase or restore failed with an error. Cancellations are reported as
+/// ``CheckpointPaywallDismissedOutcome`` instead.
 @_spi(CheckpointsInternal)
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public final class CheckpointPaywallErrorOutcome: CheckpointPaywallOutcome {

--- a/RevenueCatUI/Checkpoints/CheckpointResults.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointResults.swift
@@ -152,15 +152,15 @@ public final class CheckpointPaywallPresentedResult: CheckpointResult {
 ///
 /// ```swift
 /// switch result.paywallOutcome {
-/// case let outcome as CheckpointPaywallPurchasedOutcome:
+/// case let outcome as CheckpointPaywallOutcome.Purchased:
 ///     handlePurchase(outcome.transaction, outcome.customerInfo)
-/// case let outcome as CheckpointPaywallRestoredOutcome:
+/// case let outcome as CheckpointPaywallOutcome.Restored:
 ///     handleRestore(outcome.customerInfo)
-/// case is CheckpointPaywallDismissedOutcome:
+/// case is CheckpointPaywallOutcome.Dismissed:
 ///     handleDismissal()
-/// case is CheckpointPaywallWebCheckoutOpenedOutcome:
+/// case is CheckpointPaywallOutcome.WebCheckoutOpened:
 ///     handleWebCheckoutOpened()
-/// case let outcome as CheckpointPaywallErrorOutcome:
+/// case let outcome as CheckpointPaywallOutcome.Error:
 ///     handleError(outcome.error)
 /// default:
 ///     // Handle outcome types added in future SDK versions.
@@ -190,111 +190,100 @@ public class CheckpointPaywallOutcome: Equatable, Hashable, CustomStringConverti
         hasher.combine(ObjectIdentifier(type(of: self)))
     }
 
-}
+    /// The customer dismissed the paywall without a purchase, restore, or error.
+    public final class Dismissed: CheckpointPaywallOutcome {
 
-/// The customer dismissed the paywall without a purchase, restore, or error.
-@_spi(CheckpointsInternal)
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-public final class CheckpointPaywallDismissedOutcome: CheckpointPaywallOutcome {
+        static let shared = Dismissed()
 
-    static let shared = CheckpointPaywallDismissedOutcome()
+        private override init() { super.init() }
 
-    private override init() { super.init() }
+        public override var description: String { return "Dismissed" }
 
-    public override var description: String { return "Dismissed" }
-
-}
-
-/// The customer opened a web checkout from the paywall to pay externally.
-///
-/// There is no in-app completion signal for the external payment.
-@_spi(CheckpointsInternal)
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-// swiftlint:disable:next type_name
-public final class CheckpointPaywallWebCheckoutOpenedOutcome: CheckpointPaywallOutcome {
-
-    static let shared = CheckpointPaywallWebCheckoutOpenedOutcome()
-
-    private override init() { super.init() }
-
-    public override var description: String { return "WebCheckoutOpened" }
-
-}
-
-/// The customer completed a purchase.
-@_spi(CheckpointsInternal)
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-public final class CheckpointPaywallPurchasedOutcome: CheckpointPaywallOutcome {
-
-    /// The transaction completed by the purchase, if available.
-    public let transaction: StoreTransaction?
-
-    /// Customer information after the completed purchase.
-    public let customerInfo: CustomerInfo
-
-    init(transaction: StoreTransaction?, customerInfo: CustomerInfo) {
-        self.transaction = transaction
-        self.customerInfo = customerInfo
-        super.init()
     }
 
-    public override var description: String { return "Purchased" }
+    /// The customer opened a web checkout from the paywall to pay externally.
+    ///
+    /// There is no in-app completion signal for the external payment.
+    public final class WebCheckoutOpened: CheckpointPaywallOutcome {
 
-    override func isEqual(to other: CheckpointPaywallOutcome) -> Bool {
-        guard let other = other as? CheckpointPaywallPurchasedOutcome else { return false }
-        return self.transaction == other.transaction && self.customerInfo.isEqual(other.customerInfo)
+        static let shared = WebCheckoutOpened()
+
+        private override init() { super.init() }
+
+        public override var description: String { return "WebCheckoutOpened" }
+
     }
 
-    public override func hash(into hasher: inout Hasher) {
-        hasher.combine(self.transaction)
-        hasher.combine(self.customerInfo.hash)
+    /// The customer completed a purchase.
+    public final class Purchased: CheckpointPaywallOutcome {
+
+        /// The transaction completed by the purchase, if available.
+        public let transaction: StoreTransaction?
+
+        /// Customer information after the completed purchase.
+        public let customerInfo: CustomerInfo
+
+        init(transaction: StoreTransaction?, customerInfo: CustomerInfo) {
+            self.transaction = transaction
+            self.customerInfo = customerInfo
+            super.init()
+        }
+
+        public override var description: String { return "Purchased" }
+
+        override func isEqual(to other: CheckpointPaywallOutcome) -> Bool {
+            guard let other = other as? Purchased else { return false }
+            return self.transaction == other.transaction && self.customerInfo.isEqual(other.customerInfo)
+        }
+
+        public override func hash(into hasher: inout Hasher) {
+            hasher.combine(self.transaction)
+            hasher.combine(self.customerInfo.hash)
+        }
+
     }
 
-}
+    /// The customer restored purchases.
+    public final class Restored: CheckpointPaywallOutcome {
 
-/// The customer restored purchases.
-@_spi(CheckpointsInternal)
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-public final class CheckpointPaywallRestoredOutcome: CheckpointPaywallOutcome {
+        /// Customer information after restoring purchases.
+        public let customerInfo: CustomerInfo
 
-    /// Customer information after restoring purchases.
-    public let customerInfo: CustomerInfo
+        init(customerInfo: CustomerInfo) {
+            self.customerInfo = customerInfo
+            super.init()
+        }
 
-    init(customerInfo: CustomerInfo) {
-        self.customerInfo = customerInfo
-        super.init()
+        public override var description: String { return "Restored" }
+
+        override func isEqual(to other: CheckpointPaywallOutcome) -> Bool {
+            return (other as? Restored)?.customerInfo.isEqual(self.customerInfo) == true
+        }
+
+        public override func hash(into hasher: inout Hasher) { hasher.combine(self.customerInfo.hash) }
+
     }
 
-    public override var description: String { return "Restored" }
+    /// A purchase or restore failed with an error. Cancellations are reported as
+    /// ``Dismissed`` instead.
+    public final class Error: CheckpointPaywallOutcome {
 
-    override func isEqual(to other: CheckpointPaywallOutcome) -> Bool {
-        return (other as? CheckpointPaywallRestoredOutcome)?.customerInfo.isEqual(self.customerInfo) == true
+        /// The error that ended the checkpoint experience.
+        public let error: PublicError
+
+        init(error: PublicError) {
+            self.error = error
+            super.init()
+        }
+
+        public override var description: String { return "Error(error=\(self.error))" }
+
+        override func isEqual(to other: CheckpointPaywallOutcome) -> Bool {
+            return (other as? Error)?.error.isEqual(self.error) == true
+        }
+
+        public override func hash(into hasher: inout Hasher) { hasher.combine(self.error.hash) }
+
     }
-
-    public override func hash(into hasher: inout Hasher) { hasher.combine(self.customerInfo.hash) }
-
-}
-
-/// A purchase or restore failed with an error. Cancellations are reported as
-/// ``CheckpointPaywallDismissedOutcome`` instead.
-@_spi(CheckpointsInternal)
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-public final class CheckpointPaywallErrorOutcome: CheckpointPaywallOutcome {
-
-    /// The error that ended the checkpoint experience.
-    public let error: PublicError
-
-    init(error: PublicError) {
-        self.error = error
-        super.init()
-    }
-
-    public override var description: String { return "Error(error=\(self.error))" }
-
-    override func isEqual(to other: CheckpointPaywallOutcome) -> Bool {
-        return (other as? CheckpointPaywallErrorOutcome)?.error.isEqual(self.error) == true
-    }
-
-    public override func hash(into hasher: inout Hasher) { hasher.combine(self.error.hash) }
 
 }

--- a/RevenueCatUI/Checkpoints/CheckpointResults.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointResults.swift
@@ -38,16 +38,11 @@ import Foundation
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public class CheckpointResult: Equatable, Hashable, CustomStringConvertible {
 
-    /// Information about the checkpoint that produced this result.
-    public let checkpoint: CheckpointInfo
-
-    init(checkpoint: CheckpointInfo) {
-        self.checkpoint = checkpoint
-    }
+    init() {}
 
     /// A debug description of the checkpoint result.
     public var description: String {
-        return "CheckpointResult(checkpoint=\(self.checkpoint))"
+        return "CheckpointResult"
     }
 
     /// Returns whether two checkpoint results are equal.
@@ -56,13 +51,12 @@ public class CheckpointResult: Equatable, Hashable, CustomStringConvertible {
     }
 
     func isEqual(to other: CheckpointResult) -> Bool {
-        return type(of: self) == type(of: other) && self.checkpoint == other.checkpoint
+        return type(of: self) == type(of: other)
     }
 
     /// Hashes the checkpoint result.
     public func hash(into hasher: inout Hasher) {
         hasher.combine(ObjectIdentifier(type(of: self)))
-        hasher.combine(self.checkpoint)
     }
 
 }
@@ -75,22 +69,21 @@ public final class CheckpointNoActionResult: CheckpointResult {
     /// The reason no experience was served.
     public let reason: CheckpointNoActionReason
 
-    init(checkpoint: CheckpointInfo, reason: CheckpointNoActionReason) {
+    init(reason: CheckpointNoActionReason) {
         self.reason = reason
-        super.init(checkpoint: checkpoint)
+        super.init()
     }
 
     public override var description: String {
-        return "NoAction(checkpoint=\(self.checkpoint), reason=\(self.reason))"
+        return "NoAction(reason=\(self.reason))"
     }
 
     override func isEqual(to other: CheckpointResult) -> Bool {
         guard let other = other as? CheckpointNoActionResult else { return false }
-        return self.checkpoint == other.checkpoint && self.reason == other.reason
+        return self.reason == other.reason
     }
 
     public override func hash(into hasher: inout Hasher) {
-        hasher.combine(self.checkpoint)
         hasher.combine(self.reason)
     }
 
@@ -105,22 +98,21 @@ public final class CheckpointReceivedOfferingResult: CheckpointResult {
     /// The offering the checkpoint selected.
     public let offering: Offering
 
-    init(checkpoint: CheckpointInfo, offering: Offering) {
+    init(offering: Offering) {
         self.offering = offering
-        super.init(checkpoint: checkpoint)
+        super.init()
     }
 
     public override var description: String {
-        return "ReceivedOffering(checkpoint=\(self.checkpoint), offering=\(self.offering.identifier))"
+        return "ReceivedOffering(offering=\(self.offering.identifier))"
     }
 
     override func isEqual(to other: CheckpointResult) -> Bool {
         guard let other = other as? CheckpointReceivedOfferingResult else { return false }
-        return self.checkpoint == other.checkpoint && self.offering == other.offering
+        return self.offering == other.offering
     }
 
     public override func hash(into hasher: inout Hasher) {
-        hasher.combine(self.checkpoint)
         hasher.combine(self.offering)
     }
 
@@ -134,22 +126,21 @@ public final class CheckpointPaywallPresentedResult: CheckpointResult {
     /// The terminal outcome of the presented paywall.
     public let paywallOutcome: CheckpointPaywallOutcome
 
-    init(checkpoint: CheckpointInfo, paywallOutcome: CheckpointPaywallOutcome) {
+    init(paywallOutcome: CheckpointPaywallOutcome) {
         self.paywallOutcome = paywallOutcome
-        super.init(checkpoint: checkpoint)
+        super.init()
     }
 
     public override var description: String {
-        return "PaywallPresented(checkpoint=\(self.checkpoint), paywallOutcome=\(self.paywallOutcome))"
+        return "PaywallPresented(paywallOutcome=\(self.paywallOutcome))"
     }
 
     override func isEqual(to other: CheckpointResult) -> Bool {
         guard let other = other as? CheckpointPaywallPresentedResult else { return false }
-        return self.checkpoint == other.checkpoint && self.paywallOutcome == other.paywallOutcome
+        return self.paywallOutcome == other.paywallOutcome
     }
 
     public override func hash(into hasher: inout Hasher) {
-        hasher.combine(self.checkpoint)
         hasher.combine(self.paywallOutcome)
     }
 

--- a/RevenueCatUI/Checkpoints/CheckpointResults.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointResults.swift
@@ -36,27 +36,13 @@ import Foundation
 /// ```
 @_spi(CheckpointsInternal)
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-public class CheckpointResult: Equatable, Hashable, CustomStringConvertible {
+public class CheckpointResult: CustomStringConvertible {
 
     init() {}
 
     /// A debug description of the checkpoint result.
     public var description: String {
         return "CheckpointResult"
-    }
-
-    /// Returns whether two checkpoint results are equal.
-    public static func == (lhs: CheckpointResult, rhs: CheckpointResult) -> Bool {
-        return lhs.isEqual(to: rhs)
-    }
-
-    func isEqual(to other: CheckpointResult) -> Bool {
-        return type(of: self) == type(of: other)
-    }
-
-    /// Hashes the checkpoint result.
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(ObjectIdentifier(type(of: self)))
     }
 
 }
@@ -76,15 +62,6 @@ public final class CheckpointNoActionResult: CheckpointResult {
 
     public override var description: String {
         return "NoAction(reason=\(self.reason))"
-    }
-
-    override func isEqual(to other: CheckpointResult) -> Bool {
-        guard let other = other as? CheckpointNoActionResult else { return false }
-        return self.reason == other.reason
-    }
-
-    public override func hash(into hasher: inout Hasher) {
-        hasher.combine(self.reason)
     }
 
 }
@@ -107,15 +84,6 @@ public final class CheckpointReceivedOfferingResult: CheckpointResult {
         return "ReceivedOffering(offering=\(self.offering.identifier))"
     }
 
-    override func isEqual(to other: CheckpointResult) -> Bool {
-        guard let other = other as? CheckpointReceivedOfferingResult else { return false }
-        return self.offering == other.offering
-    }
-
-    public override func hash(into hasher: inout Hasher) {
-        hasher.combine(self.offering)
-    }
-
 }
 
 /// A checkpoint-triggered paywall was presented and finished.
@@ -133,15 +101,6 @@ public final class CheckpointPaywallPresentedResult: CheckpointResult {
 
     public override var description: String {
         return "PaywallPresented(paywallOutcome=\(self.paywallOutcome))"
-    }
-
-    override func isEqual(to other: CheckpointResult) -> Bool {
-        guard let other = other as? CheckpointPaywallPresentedResult else { return false }
-        return self.paywallOutcome == other.paywallOutcome
-    }
-
-    public override func hash(into hasher: inout Hasher) {
-        hasher.combine(self.paywallOutcome)
     }
 
 }
@@ -169,26 +128,12 @@ public final class CheckpointPaywallPresentedResult: CheckpointResult {
 /// ```
 @_spi(CheckpointsInternal)
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-public class CheckpointPaywallOutcome: Equatable, Hashable, CustomStringConvertible {
+public class CheckpointPaywallOutcome: CustomStringConvertible {
 
     fileprivate init() {}
 
     /// A debug description of the paywall outcome.
     public var description: String { return "CheckpointPaywallOutcome" }
-
-    /// Returns whether two paywall outcomes are equal.
-    public static func == (lhs: CheckpointPaywallOutcome, rhs: CheckpointPaywallOutcome) -> Bool {
-        return lhs.isEqual(to: rhs)
-    }
-
-    func isEqual(to other: CheckpointPaywallOutcome) -> Bool {
-        return type(of: self) == type(of: other)
-    }
-
-    /// Hashes the paywall outcome.
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(ObjectIdentifier(type(of: self)))
-    }
 
     /// The customer dismissed the paywall without a purchase, restore, or error.
     public final class Dismissed: CheckpointPaywallOutcome {
@@ -231,16 +176,6 @@ public class CheckpointPaywallOutcome: Equatable, Hashable, CustomStringConverti
 
         public override var description: String { return "Purchased" }
 
-        override func isEqual(to other: CheckpointPaywallOutcome) -> Bool {
-            guard let other = other as? Purchased else { return false }
-            return self.transaction == other.transaction && self.customerInfo.isEqual(other.customerInfo)
-        }
-
-        public override func hash(into hasher: inout Hasher) {
-            hasher.combine(self.transaction)
-            hasher.combine(self.customerInfo.hash)
-        }
-
     }
 
     /// The customer restored purchases.
@@ -255,12 +190,6 @@ public class CheckpointPaywallOutcome: Equatable, Hashable, CustomStringConverti
         }
 
         public override var description: String { return "Restored" }
-
-        override func isEqual(to other: CheckpointPaywallOutcome) -> Bool {
-            return (other as? Restored)?.customerInfo.isEqual(self.customerInfo) == true
-        }
-
-        public override func hash(into hasher: inout Hasher) { hasher.combine(self.customerInfo.hash) }
 
     }
 
@@ -277,12 +206,6 @@ public class CheckpointPaywallOutcome: Equatable, Hashable, CustomStringConverti
         }
 
         public override var description: String { return "Error(error=\(self.error))" }
-
-        override func isEqual(to other: CheckpointPaywallOutcome) -> Bool {
-            return (other as? Error)?.error.isEqual(self.error) == true
-        }
-
-        public override func hash(into hasher: inout Hasher) { hasher.combine(self.error.hash) }
 
     }
 

--- a/RevenueCatUI/Checkpoints/CheckpointResults.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointResults.swift
@@ -167,6 +167,8 @@ public final class CheckpointPaywallPresentedResult: CheckpointResult {
 ///     handleRestore(outcome.customerInfo)
 /// case is CheckpointPaywallDismissedOutcome:
 ///     handleDismissal()
+/// case is CheckpointPaywallWebCheckoutOpenedOutcome:
+///     handleWebCheckoutOpened()
 /// case let outcome as CheckpointPaywallErrorOutcome:
 ///     handleError(outcome.error)
 /// default:
@@ -209,6 +211,20 @@ public final class CheckpointPaywallDismissedOutcome: CheckpointPaywallOutcome {
     private override init() { super.init() }
 
     public override var description: String { return "Dismissed" }
+
+}
+
+/// The customer opened a web checkout from the paywall.
+@_spi(CheckpointsInternal)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+// swiftlint:disable:next type_name
+public final class CheckpointPaywallWebCheckoutOpenedOutcome: CheckpointPaywallOutcome {
+
+    static let shared = CheckpointPaywallWebCheckoutOpenedOutcome()
+
+    private override init() { super.init() }
+
+    public override var description: String { return "WebCheckoutOpened" }
 
 }
 

--- a/RevenueCatUI/Checkpoints/CheckpointWorkflowPresenter.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointWorkflowPresenter.swift
@@ -189,6 +189,12 @@ extension CheckpointWorkflowPresenter {
         }
     }
 
+    nonisolated func paywallViewControllerDidOpenWebCheckout(_ controller: PaywallViewController) {
+        MainActor.assumeIsolated {
+            self.stage(outcome: CheckpointPaywallWebCheckoutOpenedOutcome.shared)
+        }
+    }
+
     nonisolated func paywallViewControllerWasDismissed(_ controller: PaywallViewController) {
         MainActor.assumeIsolated {
             self.presentationDidDismiss()
@@ -236,6 +242,10 @@ extension CheckpointWorkflowPresenter {
         didFailRestoringWith error: NSError
     ) {
         self.stage(outcome: CheckpointPaywallErrorOutcome(error: error))
+    }
+
+    func paywallViewControllerDidOpenWebCheckout(_ controller: PaywallViewController) {
+        self.stage(outcome: CheckpointPaywallWebCheckoutOpenedOutcome.shared)
     }
 
     func paywallViewControllerWasDismissed(_ controller: PaywallViewController) {

--- a/RevenueCatUI/Checkpoints/CheckpointWorkflowPresenter.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointWorkflowPresenter.swift
@@ -154,7 +154,7 @@ extension CheckpointWorkflowPresenter {
     ) {
         MainActor.assumeIsolated {
             self.stage(
-                outcome: CheckpointPaywallPurchasedOutcome(
+                outcome: CheckpointPaywallOutcome.Purchased(
                     transaction: transaction,
                     customerInfo: customerInfo
                 )
@@ -167,7 +167,7 @@ extension CheckpointWorkflowPresenter {
         didFinishRestoringWith customerInfo: CustomerInfo
     ) {
         MainActor.assumeIsolated {
-            self.stage(outcome: CheckpointPaywallRestoredOutcome(customerInfo: customerInfo))
+            self.stage(outcome: CheckpointPaywallOutcome.Restored(customerInfo: customerInfo))
         }
     }
 
@@ -176,7 +176,7 @@ extension CheckpointWorkflowPresenter {
         didFailPurchasingWith error: NSError
     ) {
         MainActor.assumeIsolated {
-            self.stage(outcome: CheckpointPaywallErrorOutcome(error: error))
+            self.stage(outcome: CheckpointPaywallOutcome.Error(error: error))
         }
     }
 
@@ -185,13 +185,13 @@ extension CheckpointWorkflowPresenter {
         didFailRestoringWith error: NSError
     ) {
         MainActor.assumeIsolated {
-            self.stage(outcome: CheckpointPaywallErrorOutcome(error: error))
+            self.stage(outcome: CheckpointPaywallOutcome.Error(error: error))
         }
     }
 
     nonisolated func paywallViewControllerDidOpenWebCheckout(_ controller: PaywallViewController) {
         MainActor.assumeIsolated {
-            self.stage(outcome: CheckpointPaywallWebCheckoutOpenedOutcome.shared)
+            self.stage(outcome: CheckpointPaywallOutcome.WebCheckoutOpened.shared)
         }
     }
 
@@ -216,7 +216,7 @@ extension CheckpointWorkflowPresenter {
         transaction: StoreTransaction?
     ) {
         self.stage(
-            outcome: CheckpointPaywallPurchasedOutcome(
+            outcome: CheckpointPaywallOutcome.Purchased(
                 transaction: transaction,
                 customerInfo: customerInfo
             )
@@ -227,25 +227,25 @@ extension CheckpointWorkflowPresenter {
         _ controller: PaywallViewController,
         didFinishRestoringWith customerInfo: CustomerInfo
     ) {
-        self.stage(outcome: CheckpointPaywallRestoredOutcome(customerInfo: customerInfo))
+        self.stage(outcome: CheckpointPaywallOutcome.Restored(customerInfo: customerInfo))
     }
 
     func paywallViewController(
         _ controller: PaywallViewController,
         didFailPurchasingWith error: NSError
     ) {
-        self.stage(outcome: CheckpointPaywallErrorOutcome(error: error))
+        self.stage(outcome: CheckpointPaywallOutcome.Error(error: error))
     }
 
     func paywallViewController(
         _ controller: PaywallViewController,
         didFailRestoringWith error: NSError
     ) {
-        self.stage(outcome: CheckpointPaywallErrorOutcome(error: error))
+        self.stage(outcome: CheckpointPaywallOutcome.Error(error: error))
     }
 
     func paywallViewControllerDidOpenWebCheckout(_ controller: PaywallViewController) {
-        self.stage(outcome: CheckpointPaywallWebCheckoutOpenedOutcome.shared)
+        self.stage(outcome: CheckpointPaywallOutcome.WebCheckoutOpened.shared)
     }
 
     func paywallViewControllerWasDismissed(_ controller: PaywallViewController) {

--- a/RevenueCatUI/Checkpoints/Checkpoints.swift
+++ b/RevenueCatUI/Checkpoints/Checkpoints.swift
@@ -42,10 +42,10 @@ final class CheckpointCallParams: @unchecked Sendable {
 
 }
 
-/// Information about a checkpoint that was hit.
+/// Context shared by checkpoint listener events.
 @_spi(CheckpointsInternal)
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-public final class CheckpointInfo: Equatable, Hashable, CustomStringConvertible, @unchecked Sendable {
+public class CheckpointContext: Equatable, Hashable, CustomStringConvertible, @unchecked Sendable {
 
     /// The identifier of the checkpoint that was hit.
     public let identifier: String
@@ -58,20 +58,74 @@ public final class CheckpointInfo: Equatable, Hashable, CustomStringConvertible,
         self.customVariables = params.customVariables
     }
 
-    /// Returns whether two checkpoint information values are equal.
-    public static func == (lhs: CheckpointInfo, rhs: CheckpointInfo) -> Bool {
-        return lhs.identifier == rhs.identifier && lhs.customVariables == rhs.customVariables
+    /// Returns whether two checkpoint contexts are equal.
+    public static func == (lhs: CheckpointContext, rhs: CheckpointContext) -> Bool {
+        return lhs.isEqual(to: rhs)
+    }
+
+    func isEqual(to other: CheckpointContext) -> Bool {
+        return type(of: self) == type(of: other) &&
+            self.identifier == other.identifier &&
+            self.customVariables == other.customVariables
     }
 
     /// Hashes the checkpoint information.
     public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(type(of: self)))
         hasher.combine(self.identifier)
         hasher.combine(self.customVariables)
     }
 
-    /// A debug description of the checkpoint information.
+    /// A debug description of the checkpoint context.
     public var description: String {
-        return "CheckpointInfo(identifier='\(self.identifier)', customVariables=\(self.customVariables))"
+        return "CheckpointContext(identifier='\(self.identifier)', customVariables=\(self.customVariables))"
+    }
+
+}
+
+/// Context delivered when a checkpoint is hit, before evaluation starts.
+@_spi(CheckpointsInternal)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public final class CheckpointHitContext: CheckpointContext, @unchecked Sendable {
+
+    override init(identifier: String, params: CheckpointCallParams) {
+        super.init(identifier: identifier, params: params)
+    }
+
+    public override var description: String {
+        return "CheckpointHitContext(identifier='\(self.identifier)', customVariables=\(self.customVariables))"
+    }
+
+}
+
+/// Context delivered when a checkpoint completes.
+@_spi(CheckpointsInternal)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public final class CheckpointCompletedContext: CheckpointContext, @unchecked Sendable {
+
+    /// What the checkpoint resolved to.
+    public let result: CheckpointResult
+
+    init(identifier: String, params: CheckpointCallParams, result: CheckpointResult) {
+        self.result = result
+        super.init(identifier: identifier, params: params)
+    }
+
+    override func isEqual(to other: CheckpointContext) -> Bool {
+        guard let other = other as? CheckpointCompletedContext else { return false }
+        return self.identifier == other.identifier &&
+            self.customVariables == other.customVariables &&
+            self.result == other.result
+    }
+
+    public override func hash(into hasher: inout Hasher) {
+        super.hash(into: &hasher)
+        hasher.combine(self.result)
+    }
+
+    public override var description: String {
+        return "CheckpointCompletedContext(identifier='\(self.identifier)', " +
+            "customVariables=\(self.customVariables), result=\(self.result))"
     }
 
 }
@@ -116,7 +170,7 @@ public final class CheckpointNoActionReason: Equatable, Hashable, CustomStringCo
 /// Global listener for checkpoint activity. All methods are called on the main thread.
 ///
 /// ``CheckpointListener/onCheckpointHit(_:)`` is called before evaluation starts. After evaluation and any
-/// presented UI finish, ``CheckpointListener/onCheckpointCompleted(_:result:)`` is called before the per-call
+/// presented UI finish, ``CheckpointListener/onCheckpointCompleted(_:)`` is called before the per-call
 /// checkpoint API delivers its result.
 @_spi(CheckpointsInternal)
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
@@ -125,11 +179,11 @@ public protocol CheckpointListener: AnyObject {
     /// A checkpoint was hit and evaluation is about to start.
     ///
     /// This does not indicate that a targeting rule matched or that UI will be presented.
-    func onCheckpointHit(_ checkpoint: CheckpointInfo)
+    func onCheckpointHit(_ context: CheckpointHitContext)
     /// Checkpoint evaluation and any presented UI finished.
     ///
     /// This is called before the per-call checkpoint API delivers its result.
-    func onCheckpointCompleted(_ checkpoint: CheckpointInfo, result: CheckpointResult)
+    func onCheckpointCompleted(_ context: CheckpointCompletedContext)
 
 }
 
@@ -138,8 +192,8 @@ public protocol CheckpointListener: AnyObject {
 public extension CheckpointListener {
 
     /// Default no-op implementation.
-    func onCheckpointHit(_ checkpoint: CheckpointInfo) {}
+    func onCheckpointHit(_ context: CheckpointHitContext) {}
     /// Default no-op implementation.
-    func onCheckpointCompleted(_ checkpoint: CheckpointInfo, result: CheckpointResult) {}
+    func onCheckpointCompleted(_ context: CheckpointCompletedContext) {}
 
 }

--- a/RevenueCatUI/Checkpoints/Checkpoints.swift
+++ b/RevenueCatUI/Checkpoints/Checkpoints.swift
@@ -45,7 +45,7 @@ final class CheckpointCallParams: @unchecked Sendable {
 /// Context shared by checkpoint listener events.
 @_spi(CheckpointsInternal)
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-public class CheckpointContext: Equatable, Hashable, CustomStringConvertible, @unchecked Sendable {
+public class CheckpointContext: CustomStringConvertible, @unchecked Sendable {
 
     /// The identifier of the checkpoint that was hit.
     public let identifier: String
@@ -56,24 +56,6 @@ public class CheckpointContext: Equatable, Hashable, CustomStringConvertible, @u
     init(identifier: String, params: CheckpointCallParams) {
         self.identifier = identifier
         self.customVariables = params.customVariables
-    }
-
-    /// Returns whether two checkpoint contexts are equal.
-    public static func == (lhs: CheckpointContext, rhs: CheckpointContext) -> Bool {
-        return lhs.isEqual(to: rhs)
-    }
-
-    func isEqual(to other: CheckpointContext) -> Bool {
-        return type(of: self) == type(of: other) &&
-            self.identifier == other.identifier &&
-            self.customVariables == other.customVariables
-    }
-
-    /// Hashes the checkpoint information.
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(ObjectIdentifier(type(of: self)))
-        hasher.combine(self.identifier)
-        hasher.combine(self.customVariables)
     }
 
     /// A debug description of the checkpoint context.
@@ -109,18 +91,6 @@ public final class CheckpointCompletedContext: CheckpointContext, @unchecked Sen
     init(identifier: String, params: CheckpointCallParams, result: CheckpointResult) {
         self.result = result
         super.init(identifier: identifier, params: params)
-    }
-
-    override func isEqual(to other: CheckpointContext) -> Bool {
-        guard let other = other as? CheckpointCompletedContext else { return false }
-        return self.identifier == other.identifier &&
-            self.customVariables == other.customVariables &&
-            self.result == other.result
-    }
-
-    public override func hash(into hasher: inout Hasher) {
-        super.hash(into: &hasher)
-        hasher.combine(self.result)
     }
 
     public override var description: String {

--- a/RevenueCatUI/Checkpoints/Checkpoints.swift
+++ b/RevenueCatUI/Checkpoints/Checkpoints.swift
@@ -83,7 +83,7 @@ public final class CheckpointNoActionReason: Equatable, Hashable, CustomStringCo
 
     let value: String
 
-    /// No targeting rule matched.
+    /// The checkpoint is configured, but no targeting rule matched.
     public static let noMatch = CheckpointNoActionReason(value: "NO_MATCH")
     /// The customer was assigned to a holdout.
     public static let holdout = CheckpointNoActionReason(value: "HOLDOUT")
@@ -91,7 +91,7 @@ public final class CheckpointNoActionReason: Equatable, Hashable, CustomStringCo
     public static let frequencyCapped = CheckpointNoActionReason(value: "FREQUENCY_CAPPED")
     /// The checkpoint could not be evaluated because required configuration or resources were unavailable.
     public static let configurationUnavailable = CheckpointNoActionReason(value: "CONFIGURATION_UNAVAILABLE")
-    /// The checkpoint identifier is not configured.
+    /// The checkpoint identifier is not configured in the RevenueCat dashboard.
     public static let unknownCheckpoint = CheckpointNoActionReason(value: "UNKNOWN_CHECKPOINT")
     /// The checkpoint identifier is invalid.
     public static let invalidCheckpointIdentifier = CheckpointNoActionReason(value: "INVALID_CHECKPOINT_IDENTIFIER")

--- a/RevenueCatUI/Checkpoints/CheckpointsManager.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointsManager.swift
@@ -76,16 +76,14 @@ final class CheckpointsManager {
         identifier: String,
         params: CheckpointCallParams
     ) async throws -> CheckpointResult {
-        let checkpoint = CheckpointInfo(identifier: identifier, params: params)
-        self.listener?.onCheckpointHit(checkpoint)
+        self.listener?.onCheckpointHit(CheckpointHitContext(identifier: identifier, params: params))
 
         guard CheckpointIdentifierValidator.isValid(identifier) else {
             Logger.error(CheckpointIdentifierValidator.invalidIdentifierLogMessage(identifier))
-            let result = CheckpointNoActionResult(
-                checkpoint: checkpoint,
-                reason: .invalidCheckpointIdentifier
+            let result = CheckpointNoActionResult(reason: .invalidCheckpointIdentifier)
+            self.listener?.onCheckpointCompleted(
+                CheckpointCompletedContext(identifier: identifier, params: params, result: result)
             )
-            self.listener?.onCheckpointCompleted(checkpoint, result: result)
             return result
         }
 
@@ -97,24 +95,17 @@ final class CheckpointsManager {
                 customVariables: params.customVariables
             )
             let outcome = try await self.executor.execute(presentation)
-            result = CheckpointPaywallPresentedResult(
-                checkpoint: checkpoint,
-                paywallOutcome: outcome
-            )
+            result = CheckpointPaywallPresentedResult(paywallOutcome: outcome)
         case let .matchedOffering(offering):
             // Data-only, so this never claims the presentation slot the executor owns.
-            result = CheckpointReceivedOfferingResult(
-                checkpoint: checkpoint,
-                offering: offering
-            )
+            result = CheckpointReceivedOfferingResult(offering: offering)
         case let .noAction(reason):
-            result = CheckpointNoActionResult(
-                checkpoint: checkpoint,
-                reason: reason.noActionReason
-            )
+            result = CheckpointNoActionResult(reason: reason.noActionReason)
         }
 
-        self.listener?.onCheckpointCompleted(checkpoint, result: result)
+        self.listener?.onCheckpointCompleted(
+            CheckpointCompletedContext(identifier: identifier, params: params, result: result)
+        )
         return result
     }
 

--- a/RevenueCatUI/Checkpoints/CheckpointsManager.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointsManager.swift
@@ -120,8 +120,6 @@ private extension CheckpointResolutionReason {
             return .noMatch
         case .configurationUnavailable:
             return .configurationUnavailable
-        case .disabled:
-            return .configurationUnavailable
         case .unknownCheckpoint:
             return .unknownCheckpoint
         }

--- a/RevenueCatUI/Checkpoints/Purchases+Checkpoints.swift
+++ b/RevenueCatUI/Checkpoints/Purchases+Checkpoints.swift
@@ -22,6 +22,8 @@ import Foundation
 public extension Purchases {
 
     /// Global listener for checkpoint activity.
+    ///
+    /// The listener is held by this ``Purchases`` instance and is cleared when the SDK is reconfigured.
     var checkpointListener: CheckpointListener? {
         get { return self.checkpointsManager.listener }
         set { self.checkpointsManager.listener = newValue }

--- a/Sources/Checkpoints/CheckpointWorkflowResolver.swift
+++ b/Sources/Checkpoints/CheckpointWorkflowResolver.swift
@@ -34,8 +34,6 @@ import Foundation
     case noMatch
     /// Checkpoint configuration could not be loaded.
     case configurationUnavailable
-    /// Checkpoints are disabled.
-    case disabled
     /// The checkpoint identifier is not configured.
     case unknownCheckpoint
 
@@ -72,7 +70,7 @@ protocol CheckpointWorkflowResolver: AnyObject {
 final class DisabledCheckpointWorkflowResolver: CheckpointWorkflowResolver {
 
     func resolve(identifier: String, params: CheckpointParams) async throws -> CheckpointResolution {
-        return .noAction(.disabled)
+        return .noAction(.configurationUnavailable)
     }
 
 }
@@ -136,7 +134,7 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
         } catch let error as CancellationError {
             throw error
         } catch CheckpointRulesProviderError.remoteConfigDisabled {
-            return .noAction(.disabled)
+            return .noAction(.configurationUnavailable)
         } catch {
             return .noAction(.configurationUnavailable)
         }

--- a/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
+++ b/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
@@ -35,6 +35,8 @@ private final class CheckpointListenerAPITester: CheckpointListener {
                 let _: CustomerInfo = restored.customerInfo
             } else if let failed = outcome as? CheckpointPaywallErrorOutcome {
                 let _: PublicError = failed.error
+            } else if outcome is CheckpointPaywallWebCheckoutOpenedOutcome {
+                let _: String = outcome.description
             } else {
                 let _: Bool = outcome is CheckpointPaywallDismissedOutcome
             }

--- a/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
+++ b/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
@@ -32,17 +32,17 @@ private final class CheckpointListenerAPITester: CheckpointListener {
         if let presented = result as? CheckpointPaywallPresentedResult {
             let outcome: CheckpointPaywallOutcome = presented.paywallOutcome
 
-            if let purchased = outcome as? CheckpointPaywallPurchasedOutcome {
+            if let purchased = outcome as? CheckpointPaywallOutcome.Purchased {
                 let _: StoreTransaction? = purchased.transaction
                 let _: CustomerInfo = purchased.customerInfo
-            } else if let restored = outcome as? CheckpointPaywallRestoredOutcome {
+            } else if let restored = outcome as? CheckpointPaywallOutcome.Restored {
                 let _: CustomerInfo = restored.customerInfo
-            } else if let failed = outcome as? CheckpointPaywallErrorOutcome {
+            } else if let failed = outcome as? CheckpointPaywallOutcome.Error {
                 let _: PublicError = failed.error
-            } else if outcome is CheckpointPaywallWebCheckoutOpenedOutcome {
+            } else if outcome is CheckpointPaywallOutcome.WebCheckoutOpened {
                 let _: String = outcome.description
             } else {
-                let _: Bool = outcome is CheckpointPaywallDismissedOutcome
+                let _: Bool = outcome is CheckpointPaywallOutcome.Dismissed
             }
 
             let _: String = outcome.description

--- a/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
+++ b/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
@@ -17,13 +17,17 @@ import RevenueCat
 
 private final class CheckpointListenerAPITester: CheckpointListener {
 
-    func onCheckpointHit(_ checkpoint: CheckpointInfo) {
-        let _: String = checkpoint.identifier
-        let _: [String: CustomVariableValue] = checkpoint.customVariables
+    func onCheckpointHit(_ context: CheckpointHitContext) {
+        let _: CheckpointContext = context
+        let _: String = context.identifier
+        let _: [String: CustomVariableValue] = context.customVariables
     }
 
-    func onCheckpointCompleted(_ checkpoint: CheckpointInfo, result: CheckpointResult) {
-        let _: CheckpointInfo = result.checkpoint
+    func onCheckpointCompleted(_ context: CheckpointCompletedContext) {
+        let _: CheckpointContext = context
+        let _: String = context.identifier
+        let _: [String: CustomVariableValue] = context.customVariables
+        let result: CheckpointResult = context.result
 
         if let presented = result as? CheckpointPaywallPresentedResult {
             let outcome: CheckpointPaywallOutcome = presented.paywallOutcome

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointWorkflowPresenterTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointWorkflowPresenterTests.swift
@@ -95,6 +95,30 @@ final class CheckpointWorkflowPresenterTests: TestCase {
         XCTAssertNil(store.call)
     }
 
+    func testPurchaseOutcomeReplacesEarlierWebCheckoutOutcome() throws {
+        let store = CheckpointCallStore()
+        let delegate = MockCheckpointPresenterDelegate()
+        let presentation = Self.presentation()
+        let presenter = CheckpointWorkflowPresenter(callStore: store) { _ in true }
+        let controller = PaywallViewController(offering: presentation.workflow.offering)
+        let transaction = StoreTransaction(MockStoreTransaction())
+
+        try presenter.present(presentation: presentation, delegate: delegate)
+        presenter.paywallViewControllerDidOpenWebCheckout(controller)
+        presenter.paywallViewController(
+            controller,
+            didFinishPurchasingWith: TestData.customerInfo,
+            transaction: transaction
+        )
+        presenter.presentationDidDismiss()
+
+        guard let outcome = delegate.outcome as? CheckpointPaywallPurchasedOutcome else {
+            return XCTFail("Expected the later purchase outcome")
+        }
+        XCTAssertEqual(outcome.transaction, transaction)
+        XCTAssertEqual(outcome.customerInfo, TestData.customerInfo)
+    }
+
     func testCallStoreDefaultsToDismissedAndRemovesCall() {
         let store = CheckpointCallStore()
         let delegate = MockCheckpointPresenterDelegate()

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointWorkflowPresenterTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointWorkflowPresenterTests.swift
@@ -75,6 +75,26 @@ final class CheckpointWorkflowPresenterTests: TestCase {
         XCTAssertEqual(reportedOutcome.customerInfo, TestData.customerInfo)
     }
 
+    func testWebCheckoutCallbackStagesOutcomeUntilPresentationFinishesDismissing() throws {
+        let store = CheckpointCallStore()
+        let delegate = MockCheckpointPresenterDelegate()
+        let presentation = Self.presentation()
+        let presenter = CheckpointWorkflowPresenter(callStore: store) { _ in true }
+
+        try presenter.present(presentation: presentation, delegate: delegate)
+        presenter.paywallViewControllerDidOpenWebCheckout(
+            PaywallViewController(offering: presentation.workflow.offering)
+        )
+
+        XCTAssertTrue(store.call?.stagedOutcome is CheckpointPaywallWebCheckoutOpenedOutcome)
+        XCTAssertNil(delegate.outcome)
+
+        presenter.presentationDidDismiss()
+
+        XCTAssertTrue(delegate.outcome is CheckpointPaywallWebCheckoutOpenedOutcome)
+        XCTAssertNil(store.call)
+    }
+
     func testCallStoreDefaultsToDismissedAndRemovesCall() {
         let store = CheckpointCallStore()
         let delegate = MockCheckpointPresenterDelegate()

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointWorkflowPresenterTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointWorkflowPresenterTests.swift
@@ -30,7 +30,7 @@ final class CheckpointWorkflowPresenterTests: TestCase {
         let error = NSError(domain: "test", code: 1)
 
         try presenter.present(presentation: Self.presentation(), delegate: delegate)
-        presenter.stage(outcome: CheckpointPaywallErrorOutcome(error: error))
+        presenter.stage(outcome: CheckpointPaywallOutcome.Error(error: error))
 
         XCTAssertEqual(delegate.finishCount, 0)
         XCTAssertNotNil(store.call)
@@ -39,7 +39,7 @@ final class CheckpointWorkflowPresenterTests: TestCase {
         presenter.presentationDidDismiss()
 
         XCTAssertEqual(delegate.finishCount, 1)
-        guard let errorOutcome = delegate.outcome as? CheckpointPaywallErrorOutcome else {
+        guard let errorOutcome = delegate.outcome as? CheckpointPaywallOutcome.Error else {
             return XCTFail("Expected an error outcome")
         }
         XCTAssertEqual(errorOutcome.error, error)
@@ -60,7 +60,7 @@ final class CheckpointWorkflowPresenterTests: TestCase {
             transaction: transaction
         )
 
-        guard let stagedOutcome = store.call?.stagedOutcome as? CheckpointPaywallPurchasedOutcome else {
+        guard let stagedOutcome = store.call?.stagedOutcome as? CheckpointPaywallOutcome.Purchased else {
             return XCTFail("Expected a purchased outcome")
         }
         XCTAssertEqual(stagedOutcome.transaction, transaction)
@@ -68,7 +68,7 @@ final class CheckpointWorkflowPresenterTests: TestCase {
 
         presenter.presentationDidDismiss()
 
-        guard let reportedOutcome = delegate.outcome as? CheckpointPaywallPurchasedOutcome else {
+        guard let reportedOutcome = delegate.outcome as? CheckpointPaywallOutcome.Purchased else {
             return XCTFail("Expected a purchased outcome")
         }
         XCTAssertEqual(reportedOutcome.transaction, transaction)
@@ -86,12 +86,12 @@ final class CheckpointWorkflowPresenterTests: TestCase {
             PaywallViewController(offering: presentation.workflow.offering)
         )
 
-        XCTAssertTrue(store.call?.stagedOutcome is CheckpointPaywallWebCheckoutOpenedOutcome)
+        XCTAssertTrue(store.call?.stagedOutcome is CheckpointPaywallOutcome.WebCheckoutOpened)
         XCTAssertNil(delegate.outcome)
 
         presenter.presentationDidDismiss()
 
-        XCTAssertTrue(delegate.outcome is CheckpointPaywallWebCheckoutOpenedOutcome)
+        XCTAssertTrue(delegate.outcome is CheckpointPaywallOutcome.WebCheckoutOpened)
         XCTAssertNil(store.call)
     }
 
@@ -112,7 +112,7 @@ final class CheckpointWorkflowPresenterTests: TestCase {
         )
         presenter.presentationDidDismiss()
 
-        guard let outcome = delegate.outcome as? CheckpointPaywallPurchasedOutcome else {
+        guard let outcome = delegate.outcome as? CheckpointPaywallOutcome.Purchased else {
             return XCTFail("Expected the later purchase outcome")
         }
         XCTAssertEqual(outcome.transaction, transaction)
@@ -126,7 +126,7 @@ final class CheckpointWorkflowPresenterTests: TestCase {
 
         let call = store.remove()
 
-        guard call?.stagedOutcome is CheckpointPaywallDismissedOutcome else {
+        guard call?.stagedOutcome is CheckpointPaywallOutcome.Dismissed else {
             return XCTFail("Expected a dismissed outcome")
         }
         XCTAssertTrue(call?.delegate === delegate)

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
@@ -190,7 +190,7 @@ final class CheckpointsManagerTests: TestCase {
 
     func testCompletionAPIForwardsResult() {
         let completion = self.expectation(description: "Checkpoint completes")
-        let manager = CheckpointsManager { _, _ in .noAction(.disabled) }
+        let manager = CheckpointsManager { _, _ in .noAction(.configurationUnavailable) }
 
         manager.checkpoint(identifier: "disabled", params: .init()) { result in
             guard case let .success(noAction as CheckpointNoActionResult) = result else {

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
@@ -73,12 +73,13 @@ final class CheckpointsManagerTests: TestCase {
             return XCTFail("Expected a no-action result")
         }
         XCTAssertEqual(noAction.reason, .unknownCheckpoint)
-        XCTAssertEqual(noAction.checkpoint.identifier, "unknown_checkpoint")
-        XCTAssertEqual(noAction.checkpoint.customVariables["name"], "Rick")
         XCTAssertEqual(
             listener.events,
             [.hit("unknown_checkpoint"), .completed("unknown_checkpoint")]
         )
+        XCTAssertEqual(listener.hitContexts.first?.customVariables["name"], "Rick")
+        XCTAssertEqual(listener.completedContexts.first?.customVariables["name"], "Rick")
+        XCTAssertEqual(listener.completedContexts.first?.result, noAction)
     }
 
     func testInvalidCustomVariableKeysDoNotReachResolution() async throws {
@@ -145,7 +146,6 @@ final class CheckpointsManagerTests: TestCase {
             return XCTFail("Expected a received-offering result")
         }
         XCTAssertEqual(received.offering.identifier, "offering-id")
-        XCTAssertEqual(received.checkpoint.identifier, "onboarding")
         // Data-only, so it never claims the executor's one-presentation-at-a-time slot.
         XCTAssertTrue(executor.presentations.isEmpty)
         XCTAssertEqual(listener.events, [.hit("onboarding"), .completed("onboarding")])
@@ -235,7 +235,6 @@ final class CheckpointsManagerTests: TestCase {
         }
 
         XCTAssertEqual(noActionResult.reason, .invalidCheckpointIdentifier)
-        XCTAssertEqual(noActionResult.checkpoint.identifier, invalidIdentifier)
         XCTAssertEqual(resolutionCount, 0)
         XCTAssertEqual(listener.events, [.hit(invalidIdentifier), .completed(invalidIdentifier)])
         self.logger.verifyMessageWasLogged(
@@ -266,20 +265,33 @@ final class CheckpointsManagerTests: TestCase {
     }
 
     func testUIOwnedReferenceModelsPreserveValueEqualityAndHashing() {
-        let firstInfo = CheckpointInfo(
+        let firstHitContext = CheckpointHitContext(
             identifier: "test",
             params: CheckpointCallParams(customVariables: ["name": "Rick"])
         )
-        let secondInfo = CheckpointInfo(
+        let secondHitContext = CheckpointHitContext(
             identifier: "test",
             params: CheckpointCallParams(customVariables: ["name": "Rick"])
         )
-        let firstResult = CheckpointNoActionResult(checkpoint: firstInfo, reason: .noMatch)
-        let secondResult = CheckpointNoActionResult(checkpoint: secondInfo, reason: .noMatch)
+        let firstResult = CheckpointNoActionResult(reason: .noMatch)
+        let secondResult = CheckpointNoActionResult(reason: .noMatch)
+        let firstCompletedContext = CheckpointCompletedContext(
+            identifier: "test",
+            params: CheckpointCallParams(customVariables: ["name": "Rick"]),
+            result: firstResult
+        )
+        let secondCompletedContext = CheckpointCompletedContext(
+            identifier: "test",
+            params: CheckpointCallParams(customVariables: ["name": "Rick"]),
+            result: secondResult
+        )
 
-        XCTAssertEqual(firstInfo, secondInfo)
+        XCTAssertEqual(firstHitContext, secondHitContext)
+        XCTAssertEqual(firstCompletedContext, secondCompletedContext)
+        XCTAssertNotEqual(firstHitContext, firstCompletedContext)
         XCTAssertEqual(firstResult, secondResult)
-        XCTAssertEqual(Set([firstInfo, secondInfo]).count, 1)
+        XCTAssertEqual(Set([firstHitContext, secondHitContext]).count, 1)
+        XCTAssertEqual(Set([firstCompletedContext, secondCompletedContext]).count, 1)
         XCTAssertEqual(Set([firstResult, secondResult]).count, 1)
     }
 
@@ -600,13 +612,17 @@ private final class ListenerRecorder: CheckpointListener {
     }
 
     private(set) var events: [Event] = []
+    private(set) var hitContexts: [CheckpointHitContext] = []
+    private(set) var completedContexts: [CheckpointCompletedContext] = []
 
-    func onCheckpointHit(_ checkpoint: CheckpointInfo) {
-        self.events.append(.hit(checkpoint.identifier))
+    func onCheckpointHit(_ context: CheckpointHitContext) {
+        self.hitContexts.append(context)
+        self.events.append(.hit(context.identifier))
     }
 
-    func onCheckpointCompleted(_ checkpoint: CheckpointInfo, result: CheckpointResult) {
-        self.events.append(.completed(checkpoint.identifier))
+    func onCheckpointCompleted(_ context: CheckpointCompletedContext) {
+        self.completedContexts.append(context)
+        self.events.append(.completed(context.identifier))
     }
 
 }

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
@@ -79,7 +79,10 @@ final class CheckpointsManagerTests: TestCase {
         )
         XCTAssertEqual(listener.hitContexts.first?.customVariables["name"], "Rick")
         XCTAssertEqual(listener.completedContexts.first?.customVariables["name"], "Rick")
-        XCTAssertEqual(listener.completedContexts.first?.result, noAction)
+        XCTAssertEqual(
+            (listener.completedContexts.first?.result as? CheckpointNoActionResult)?.reason,
+            noAction.reason
+        )
     }
 
     func testInvalidCustomVariableKeysDoNotReachResolution() async throws {
@@ -262,37 +265,6 @@ final class CheckpointsManagerTests: TestCase {
         }
 
         self.waitForExpectations(timeout: 1)
-    }
-
-    func testUIOwnedReferenceModelsPreserveValueEqualityAndHashing() {
-        let firstHitContext = CheckpointHitContext(
-            identifier: "test",
-            params: CheckpointCallParams(customVariables: ["name": "Rick"])
-        )
-        let secondHitContext = CheckpointHitContext(
-            identifier: "test",
-            params: CheckpointCallParams(customVariables: ["name": "Rick"])
-        )
-        let firstResult = CheckpointNoActionResult(reason: .noMatch)
-        let secondResult = CheckpointNoActionResult(reason: .noMatch)
-        let firstCompletedContext = CheckpointCompletedContext(
-            identifier: "test",
-            params: CheckpointCallParams(customVariables: ["name": "Rick"]),
-            result: firstResult
-        )
-        let secondCompletedContext = CheckpointCompletedContext(
-            identifier: "test",
-            params: CheckpointCallParams(customVariables: ["name": "Rick"]),
-            result: secondResult
-        )
-
-        XCTAssertEqual(firstHitContext, secondHitContext)
-        XCTAssertEqual(firstCompletedContext, secondCompletedContext)
-        XCTAssertNotEqual(firstHitContext, firstCompletedContext)
-        XCTAssertEqual(firstResult, secondResult)
-        XCTAssertEqual(Set([firstHitContext, secondHitContext]).count, 1)
-        XCTAssertEqual(Set([firstCompletedContext, secondCompletedContext]).count, 1)
-        XCTAssertEqual(Set([firstResult, secondResult]).count, 1)
     }
 
     private static func offering() -> Offering {

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
@@ -102,7 +102,7 @@ final class CheckpointsManagerTests: TestCase {
 
     func testResolvedWorkflowProducesPaywallResult() async throws {
         let executor = MockCheckpointWorkflowExecutor()
-        executor.outcome = CheckpointPaywallDismissedOutcome.shared
+        executor.outcome = CheckpointPaywallOutcome.Dismissed.shared
         let manager = CheckpointsManager(
             resolveCheckpoint: { _, _ in .matchedWorkflow(Self.workflow()) },
             executor: executor
@@ -122,7 +122,7 @@ final class CheckpointsManagerTests: TestCase {
         guard let presented = result as? CheckpointPaywallPresentedResult else {
             return XCTFail("Expected a presented-paywall result")
         }
-        XCTAssertTrue(presented.paywallOutcome is CheckpointPaywallDismissedOutcome)
+        XCTAssertTrue(presented.paywallOutcome is CheckpointPaywallOutcome.Dismissed)
         XCTAssertEqual(executor.presentations.map(\.workflow.workflow.id), ["workflow-id"])
         XCTAssertEqual(executor.presentations.first?.customVariables, [
             "name": "Rick",
@@ -336,7 +336,7 @@ final class CheckpointWorkflowExecutorTests: TestCase {
         let presenter = MockCheckpointPresenter()
         presenter.onPresent = { presentation in
             presentation.delegate.checkpointPresentationFinished(
-                outcome: CheckpointPaywallDismissedOutcome.shared
+                outcome: CheckpointPaywallOutcome.Dismissed.shared
             )
         }
         let executor = CheckpointWorkflowExecutor { presenter }
@@ -365,7 +365,7 @@ final class CheckpointWorkflowExecutorTests: TestCase {
         presenter.presentationError = nil
         presenter.onPresent = { presentation in
             presentation.delegate.checkpointPresentationFinished(
-                outcome: CheckpointPaywallDismissedOutcome.shared
+                outcome: CheckpointPaywallOutcome.Dismissed.shared
             )
         }
         _ = try await executor.execute(Self.presentation())
@@ -393,7 +393,7 @@ final class CheckpointWorkflowExecutorTests: TestCase {
 
         let presentation = try XCTUnwrap(presenter.presentations.first)
         presentation.delegate.checkpointPresentationFinished(
-            outcome: CheckpointPaywallDismissedOutcome.shared
+            outcome: CheckpointPaywallOutcome.Dismissed.shared
         )
         _ = try await firstExecution.value
     }
@@ -402,7 +402,7 @@ final class CheckpointWorkflowExecutorTests: TestCase {
         let presenter = MockCheckpointPresenter()
         presenter.onPresent = { presentation in
             presentation.delegate.checkpointPresentationFinished(
-                outcome: CheckpointPaywallDismissedOutcome.shared
+                outcome: CheckpointPaywallOutcome.Dismissed.shared
             )
         }
         let executor = CheckpointWorkflowExecutor { presenter }
@@ -431,7 +431,7 @@ final class CheckpointWorkflowExecutorTests: TestCase {
 
         presenter.onPresent = { presentation in
             presentation.delegate.checkpointPresentationFinished(
-                outcome: CheckpointPaywallDismissedOutcome.shared
+                outcome: CheckpointPaywallOutcome.Dismissed.shared
             )
         }
         _ = try await executor.execute(Self.presentation())
@@ -476,7 +476,7 @@ final class CheckpointWorkflowExecutorTests: TestCase {
     func testCompletedOutcomeWinsBeforeScheduledCancellationRuns() async throws {
         let presenter = MockCheckpointPresenter()
         let expectedError = NSError(domain: "test", code: 42)
-        let expectedOutcome = CheckpointPaywallErrorOutcome(error: expectedError)
+        let expectedOutcome = CheckpointPaywallOutcome.Error(error: expectedError)
         var execution: Task<CheckpointPaywallOutcome, Error>?
         presenter.onPresent = { presentation in
             execution?.cancel()
@@ -489,7 +489,7 @@ final class CheckpointWorkflowExecutorTests: TestCase {
         execution = Task { try await executor.execute(Self.presentation()) }
         let outcome = try await XCTUnwrap(execution).value
 
-        guard let errorOutcome = outcome as? CheckpointPaywallErrorOutcome else {
+        guard let errorOutcome = outcome as? CheckpointPaywallOutcome.Error else {
             return XCTFail("Expected the completed presentation outcome")
         }
         XCTAssertEqual(errorOutcome.error, expectedError)
@@ -501,7 +501,7 @@ final class CheckpointWorkflowExecutorTests: TestCase {
         let executor = CheckpointWorkflowExecutor { presenter }
 
         executor.checkpointPresentationFinished(
-            outcome: CheckpointPaywallDismissedOutcome.shared
+            outcome: CheckpointPaywallOutcome.Dismissed.shared
         )
 
         XCTAssertTrue(presenter.presentations.isEmpty)
@@ -544,7 +544,7 @@ final class CheckpointWorkflowExecutorTests: TestCase {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private final class MockCheckpointWorkflowExecutor: CheckpointExecutor {
 
-    var outcome: CheckpointPaywallOutcome = CheckpointPaywallDismissedOutcome.shared
+    var outcome: CheckpointPaywallOutcome = CheckpointPaywallOutcome.Dismissed.shared
     var error: Error?
     private(set) var presentations: [CheckpointPresentation] = []
 

--- a/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
@@ -70,19 +70,19 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
     }
     #endif
 
-    func testDisabledResolverResolvesDisabled() async throws {
+    func testDisabledResolverResolvesConfigurationUnavailable() async throws {
         let resolver = DisabledCheckpointWorkflowResolver()
 
         let resolution = try await resolver.resolve(identifier: self.checkpointIdentifier, params: self.params)
 
-        XCTAssertEqual(Self.noActionReason(resolution), .disabled)
+        XCTAssertEqual(Self.noActionReason(resolution), .configurationUnavailable)
     }
 
-    func testRemoteConfigDisabledResolvesDisabled() async throws {
+    func testRemoteConfigDisabledResolvesConfigurationUnavailable() async throws {
         self.checkpointsProvider.result = .failure(.remoteConfigDisabled)
 
         let resolution = try await self.resolve()
-        XCTAssertEqual(Self.noActionReason(resolution), .disabled)
+        XCTAssertEqual(Self.noActionReason(resolution), .configurationUnavailable)
     }
 
     func testUnconfiguredCheckpointResolvesUnknownCheckpoint() async throws {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesCheckpointEventsTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesCheckpointEventsTests.swift
@@ -44,7 +44,7 @@ class PurchasesCheckpointEventsTests: BasePurchasesTests {
             params: .init()
         )
 
-        guard case .noAction(.disabled) = resolution else {
+        guard case .noAction(.configurationUnavailable) = resolution else {
             fail("Expected resolution to report no action, got \(resolution)")
             return
         }


### PR DESCRIPTION
## Description
Refines the result and listener APIs and increases cross platform consistency with Android. 

## Changes
- Adds CheckpointPaywallWebCheckoutOpenedOutcome for paywalls that open external web checkout
- Replaces `CheckpointInfo` listener argument with listener specific arguments such as `CheckpointHitContext` and `CheckpointCompletedContext`, sharing the same `CheckpointContext` super class with common properties like `identifier` and `customVariables` passed at the call-site.
- Aligns listener outcome documentation with Android
- Removes the internal `.disabled` reason in favor of the `.configurationUnavailable` one

Android reference: [RevenueCat/purchases-android#4108](https://github.com/RevenueCat/purchases-android/pull/4108)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking SPI changes to listener signatures, result shape, and paywall outcome type names affect integrators on CheckpointsInternal; purchase/paywall completion paths are touched but covered by new presenter tests.
> 
> **Overview**
> Refines the Checkpoints **SPI surface** for closer alignment with Android: listener callbacks and result types carry less duplicated metadata, paywall outcomes are namespaced, and external web checkout is a first-class terminal outcome.
> 
> **Listener API:** `CheckpointInfo` is replaced by `CheckpointHitContext` and `CheckpointCompletedContext` (shared `CheckpointContext` with `identifier` and `customVariables`). `onCheckpointCompleted` now takes a single context that includes `result` instead of separate checkpoint + result parameters.
> 
> **Result types:** `CheckpointResult` and subclasses no longer embed `checkpoint` / `CheckpointInfo`, and **Equatable/Hashable** are dropped from results and paywall outcomes. Paywall terminal types move from standalone classes (`CheckpointPaywallPurchasedOutcome`, etc.) to **nested types** on `CheckpointPaywallOutcome` (`Purchased`, `Restored`, `Dismissed`, `Error`). **`WebCheckoutOpened`** is added and wired from `paywallViewControllerDidOpenWebCheckout` in `CheckpointWorkflowPresenter` (staged like other outcomes; a later purchase can replace it).
> 
> **Resolution:** Internal `CheckpointResolutionReason.disabled` is removed; disabled remote config and the disabled resolver now map to **`configurationUnavailable`** in public no-action reasons. Docs note `checkpointListener` is cleared on SDK reconfigure.
> 
> CheckpointTester and tests are updated to pass checkpoint identifiers at the call site for display/analytics and to handle the new outcome and listener shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0e1cceaa5a9f32bb6aeba5a24dac15e85ddc34d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->