### PR TITLE
Cache web purchase redemption CustomerInfo for the initiating App User ID

### DIFF
--- a/Sources/WebPurchaseRedemption/WebPurchaseRedemptionHelper.swift
+++ b/Sources/WebPurchaseRedemption/WebPurchaseRedemptionHelper.swift
@@ -35,14 +35,15 @@ actor WebPurchaseRedemptionHelper: WebPurchaseRedemptionHelperType {
 
     func handleRedeemWebPurchase(redemptionToken: String) async -> WebPurchaseRedemptionResult {
         Logger.verbose(Strings.webRedemption.redeeming_web_purchase)
+        let appUserID = self.identityManager.currentAppUserID
         return await withCheckedContinuation { continuation in
-            self.backend.redeemWebPurchaseAPI.postRedeemWebPurchase(appUserID: identityManager.currentAppUserID,
+            self.backend.redeemWebPurchaseAPI.postRedeemWebPurchase(appUserID: appUserID,
                                                                     redemptionToken: redemptionToken) { result in
                 switch result {
                 case let .success(customerInfo):
                     Logger.debug(Strings.webRedemption.redeemed_web_purchase)
                     self.customerInfoManager.cache(customerInfo: customerInfo,
-                                                   appUserID: self.identityManager.currentAppUserID)
+                                                   appUserID: appUserID)
                     continuation.resume(returning: .success(customerInfo))
                 case let .failure(error):
                     Logger.error(Strings.webRedemption.error_redeeming_web_purchase(error))

--- a/Tests/UnitTests/DeepLink/WebPurchaseRedemptionHelperTests.swift
+++ b/Tests/UnitTests/DeepLink/WebPurchaseRedemptionHelperTests.swift
@@ -73,6 +73,19 @@ class WebPurchaseRedemptionHelperTests: TestCase {
         expect(receivedCustomerInfo) == expectedCustomerInfo
     }
 
+    func testHandleRedeemWebPurchaseCachesCustomerInfoForUserThatStartedRequest() async throws {
+        let expectedCustomerInfo = CustomerInfo(testData: BaseBackendLoginTests.validCustomerResponse)!
+        self.redeemWebPurchaseAPI.stubbedPostRedeemWebPurchaseResult = .success(expectedCustomerInfo)
+        self.redeemWebPurchaseAPI.postRedeemWebPurchaseCallback = {
+            self.identityManager.mockAppUserID = "new-user-id"
+        }
+
+        _ = await self.helper.handleRedeemWebPurchase(redemptionToken: "test-redemption-token")
+
+        expect(self.redeemWebPurchaseAPI.invokedPostRedeemWebPurchaseParameters?.appUserId) == "test-user-id"
+        expect(self.customerInfoManager.invokedCacheCustomerInfoParameters?.appUserID) == "test-user-id"
+    }
+
     func testHandleRedeemWebPurchaseInvalidToken() async throws {
         self.redeemWebPurchaseAPI.stubbedPostRedeemWebPurchaseResult = .failure(.invalidWebRedemptionToken)
 

--- a/Tests/UnitTests/Mocks/MockRedeemWebPurchaseAPI.swift
+++ b/Tests/UnitTests/Mocks/MockRedeemWebPurchaseAPI.swift
@@ -25,6 +25,7 @@ class MockRedeemWebPurchaseAPI: RedeemWebPurchaseAPI {
     var invokedPostRedeemWebPurchaseParameters: (appUserId: String, redemptionToken: String)?
 
     var stubbedPostRedeemWebPurchaseResult: Result<CustomerInfo, BackendError>?
+    var postRedeemWebPurchaseCallback: (() -> Void)?
 
     override func postRedeemWebPurchase(appUserID: String,
                                         redemptionToken: String,
@@ -33,6 +34,7 @@ class MockRedeemWebPurchaseAPI: RedeemWebPurchaseAPI {
         self.invokedPostRedeemWebPurchaseCount += 1
         self.invokedPostRedeemWebPurchaseParameters = (appUserID, redemptionToken)
 
+        self.postRedeemWebPurchaseCallback?()
         completion(self.stubbedPostRedeemWebPurchaseResult ?? .failure(.missingAppUserID()))
     }
 


### PR DESCRIPTION
## Description

After making the API request to POST redeem web purchase, and receiving the response with the updated `CustomerInfo`, we reached back into the identityManager to get the current appUserID in order to cache the updated `CustomerInfo` for this app user ID. However theoretically the user ID could have changed between initiating the request and receiving the response. Possibly saving the updated `CustomerInfo` of user A under the cache key for user `B`, resulting in `CustomerInfo` data being shared between app user IDs

## Changes

We're now capturing the initiating `appUserID` and reusing that value when storing the `CustomerInfo` in the cache. Ensuring that it's saved for the app user that originally initiated the request.

Equivalent Android PR: https://github.com/RevenueCat/purchases-android/pull/4114

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CustomerInfo cache keys for web redemption; the change corrects cross-user cache corruption if identity switches during the network call.
> 
> **Overview**
> Fixes a race where **web purchase redemption** could cache updated `CustomerInfo` under the wrong app user if `identityManager.currentAppUserID` changed between starting the redeem request and handling the response.
> 
> `handleRedeemWebPurchase` now **snapshots** `appUserID` once before the async `postRedeemWebPurchase` call and uses that same value for the API request and `customerInfoManager.cache`, instead of reading the current ID again on success.
> 
> Tests add a mock callback that changes the identity mid-request and assert both the POST and cache still use **test-user-id**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54949af5643e3012af218fc4e690cca78bebddde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->