### PR TITLE
fix(customer center): show the most recent one-time purchases

### DIFF
--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -266,7 +266,8 @@ private extension CustomerCenterViewModel {
 
     func loadNonSubscriptionsSection(customerInfo: CustomerInfo, configuration: CustomerCenterConfigData) async {
         var activeNonSubscriptionPurchases: [PurchaseInformation] = []
-        for subscription in customerInfo.nonSubscriptions {
+        // customerInfo returns these oldest first, and the management screen only shows the first few
+        for subscription in customerInfo.nonSubscriptions.sorted(by: { $0.purchaseDate > $1.purchaseDate }) {
 
             let purchaseInfo: PurchaseInformation = await .from(
                 transaction: subscription,
@@ -278,9 +279,7 @@ private extension CustomerCenterViewModel {
             )
             activeNonSubscriptionPurchases.append(purchaseInfo)
         }
-        // customerInfo returns these oldest first, and the management screen only shows the first few
         self.nonSubscriptionsSection = activeNonSubscriptionPurchases
-            .sorted { $0.latestPurchaseDate > $1.latestPurchaseDate }
     }
 
     func loadMostRecentExpiredTransaction(customerInfo: CustomerInfo, configuration: CustomerCenterConfigData) async {

--- a/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift
@@ -278,7 +278,9 @@ private extension CustomerCenterViewModel {
             )
             activeNonSubscriptionPurchases.append(purchaseInfo)
         }
+        // customerInfo returns these oldest first, and the management screen only shows the first few
         self.nonSubscriptionsSection = activeNonSubscriptionPurchases
+            .sorted { $0.latestPurchaseDate > $1.latestPurchaseDate }
     }
 
     func loadMostRecentExpiredTransaction(customerInfo: CustomerInfo, configuration: CustomerCenterConfigData) async {

--- a/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
@@ -744,6 +744,47 @@ final class CustomerCenterViewModelTests: TestCase {
         ]
     }
 
+    func testNonSubscriptionsSection_ordersByPurchaseDate_whenAnEntitlementWasGrantedLater() async throws {
+        let customerInfo = CustomerInfoFixtures.customerInfo(
+            subscriptions: [],
+            entitlements: [
+                // Granted after the purchase, so the entitlement date is newer than the transaction's
+                CustomerInfoFixtures.Entitlement(
+                    entitlementId: "day_pass",
+                    productId: "com.revenuecat.older",
+                    purchaseDate: "2026-06-01T00:00:00Z"
+                )
+            ],
+            nonSubscriptions: [
+                CustomerInfoFixtures.NonSubscriptionTransaction(
+                    productId: "com.revenuecat.older",
+                    id: "1",
+                    store: "app_store",
+                    purchaseDate: "2024-01-01T00:00:00Z"
+                ),
+                CustomerInfoFixtures.NonSubscriptionTransaction(
+                    productId: "com.revenuecat.newer",
+                    id: "2",
+                    store: "app_store",
+                    purchaseDate: "2025-01-01T00:00:00Z"
+                )
+            ]
+        )
+
+        let viewModel = CustomerCenterViewModel(
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchasesProvider: MockCustomerCenterPurchases(customerInfo: customerInfo)
+        )
+
+        await viewModel.loadScreen()
+
+        expect(viewModel.state) == .success
+        expect(viewModel.nonSubscriptionsSection.map(\.productIdentifier)) == [
+            "com.revenuecat.newer",
+            "com.revenuecat.older"
+        ]
+    }
+
     func testShouldShowEarliestExpiration_whenUserHasTwoActiveSubscriptionsTwoEntitlements() async throws {
         // Arrange
         let yearlyProduct = (

--- a/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift
@@ -703,6 +703,47 @@ final class CustomerCenterViewModelTests: TestCase {
         expect(purchaseInformation.productIdentifier) == productIdLifetime
     }
 
+    func testNonSubscriptionsSection_ordersMostRecentPurchaseFirst() async throws {
+        let customerInfo = CustomerInfoFixtures.customerInfo(
+            subscriptions: [],
+            entitlements: [],
+            nonSubscriptions: [
+                CustomerInfoFixtures.NonSubscriptionTransaction(
+                    productId: "com.revenuecat.oldest",
+                    id: "1",
+                    store: "app_store",
+                    purchaseDate: "2024-01-01T00:00:00Z"
+                ),
+                CustomerInfoFixtures.NonSubscriptionTransaction(
+                    productId: "com.revenuecat.middle",
+                    id: "2",
+                    store: "app_store",
+                    purchaseDate: "2025-01-01T00:00:00Z"
+                ),
+                CustomerInfoFixtures.NonSubscriptionTransaction(
+                    productId: "com.revenuecat.newest",
+                    id: "3",
+                    store: "app_store",
+                    purchaseDate: "2026-01-01T00:00:00Z"
+                )
+            ]
+        )
+
+        let viewModel = CustomerCenterViewModel(
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchasesProvider: MockCustomerCenterPurchases(customerInfo: customerInfo)
+        )
+
+        await viewModel.loadScreen()
+
+        expect(viewModel.state) == .success
+        expect(viewModel.nonSubscriptionsSection.map(\.productIdentifier)) == [
+            "com.revenuecat.newest",
+            "com.revenuecat.middle",
+            "com.revenuecat.oldest"
+        ]
+    }
+
     func testShouldShowEarliestExpiration_whenUserHasTwoActiveSubscriptionsTwoEntitlements() async throws {
         // Arrange
         let yearlyProduct = (


### PR DESCRIPTION
### Motivation

They grant day/week passes as non-renewing purchases and the Customer Center management screen kept showing them old passes instead of the ones the customer just bought.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: this PR
- Branch: `facu/fix-non-subscriptions-recent-first`
- Author / human owner: facumenzella
- Agent(s): Claude Code (Opus 5, 1M context)
- Session source: current conversation
- Generated: 2026-08-27
- Context document version: 1

## Goal

Fix the Customer Center management screen showing the oldest one-time purchases instead of the most recent ones.

## Initial Prompt

Explain how purchase history works in Customer Center on iOS, and what is actually hidden when purchase history is disabled (verbatim opener: "How does purchase work in iOS? When its hidden, what do we hide?", corrected to purchase history in the following message). The investigation was to answer a Slack thread about Natlink's feedback; the bug fix came out of it.

## Important Follow-up Prompts

- "what tweak, or workaround can we offer?" which turned the read-only investigation into looking for actionable levers, and surfaced the ordering defect.
- "the sort order is actually a bug, let's fix it" which authorized the code change.

## Agent Contribution

- Traced the purchase-history entry point gating (`displayPurchaseHistoryLink` AND `shouldShowSeeAllPurchasesButton`) and confirmed nothing gates `PurchaseHistoryView` itself.
- Found the ordering defect by following `customerInfo.nonSubscriptions` back to `TransactionsFactory.nonSubscriptionTransactions`, which sorts ascending by `purchaseDate`, and forward to the `.prefix(2)` in `RelevantPurchasesListView`.
- Wrote the characterization test first, watched it fail, then applied the fix.
- On a second pass, found that sorting the mapped `PurchaseInformation` was insufficient because `latestPurchaseDate` falls back to the entitlement's date, and hardened the fix to sort the transactions instead.
- Drafted the Slack replies for the thread (posted by the human).

## Human Decisions

- Decided the sort order was a bug rather than intended behavior.
- Scope kept to the fix; Slack replies reviewed and posted manually.

## Key Implementation Decisions

- Decision: sort `customerInfo.nonSubscriptions` by `purchaseDate` descending before mapping them, in `CustomerCenterViewModel.loadNonSubscriptionsSection`.
  - Rationale: fixes the root cause once, so the `prefix(2)` truncation, the section order, and `singlePurchaseView`'s `.first` fallback all pick the most recent purchases. Sorting the transactions also sidesteps `PurchaseInformation.latestPurchaseDate`, which is the entitlement's date whenever an entitlement matches the product.
  - Rejected: `suffix(2)` in `RelevantPurchasesListView`, which fixes the truncation but leaves the section and the `.first` fallback wrong.
  - Rejected: sorting the mapped `PurchaseInformation` by `latestPurchaseDate`, which was the first attempt here and is proven wrong by `testNonSubscriptionsSection_ordersByPurchaseDate_whenAnEntitlementWasGrantedLater`.
- Decision: leave `PurchaseHistoryViewModel` sorting ascending.
  - Rationale: that screen lists every purchase, so chronological order hides nothing. Flagged as an optional follow-up.

## Files / Symbols Touched

- `RevenueCatUI/CustomerCenter/ViewModels/CustomerCenterViewModel.swift`
  - Why: the ordering fix
  - Symbols: `loadNonSubscriptionsSection`
  - Review relevance: confirm newest-first is what we want for the section itself, not only for choosing which 2 survive the truncation
- `Tests/RevenueCatUITests/CustomerCenter/CustomerCenterViewModelTests.swift`
  - Why: characterization test
  - Symbols: `testNonSubscriptionsSection_ordersMostRecentPurchaseFirst`, `testNonSubscriptionsSection_ordersByPurchaseDate_whenAnEntitlementWasGrantedLater`
  - Review relevance: the first covers plain ordering across 2024/2025/2026; the second pins the entitlement-date substitution, which is Natlink's shape (entitlements granted over one-time purchases)

## Dependencies / Config / Migrations

- None captured.

## Validation

- Commands run:
  - `xcodebuild test -workspace RevenueCat-Tuist.xcworkspace -scheme RevenueCatUITests -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' -only-testing:'RevenueCatUITests/CustomerCenterViewModelTests/testNonSubscriptionsSection_ordersMostRecentPurchaseFirst'`: RED before the fix, `expected to equal <[com.revenuecat.newest, com.revenuecat.middle, com.revenuecat.oldest]>, got <[com.revenuecat.oldest, com.revenuecat.middle, com.revenuecat.newest]>`
  - `xcodebuild test ... -only-testing:'RevenueCatUITests/CustomerCenterViewModelTests/testNonSubscriptionsSection_ordersByPurchaseDate_whenAnEntitlementWasGrantedLater'`: RED against the first version of the fix, `expected to equal <[com.revenuecat.newer, com.revenuecat.older]>, got <[com.revenuecat.older, com.revenuecat.newer]>`
  - `xcodebuild test ... -only-testing:` the six Customer Center suites (`CustomerCenterViewModelTests`, `BaseManageSubscriptionViewModelTests`, `SubscriptionDetailViewModelTests`, `PurchaseInformationTests`, `PurchaseCardViewBadgeTests`, `VirtualCurrencyBalancesScreenViewModelTests`): 138 tests, 0 failures after the final fix
  - `swiftlint lint --quiet <the two changed files>`: no violations
- Manual verification:
  - Not run, no device or simulator walkthrough of the screen.
- CI:
  - Not captured at the time of writing.

## Validation Gaps

- No snapshot test covers the management screen with more than two non-subscription purchases, so the ordering is only asserted at the view-model level.
- The full `RevenueCatUITests` target was not run locally, only the Customer Center suites.

## Review Focus

- Is newest-first the order we want for the non-subscriptions section itself, or only for choosing which 2 survive the `prefix`?
- Repeat purchases of the same product all match the same entitlement, so they carry the same `latestPurchaseDate`. Sorting the transactions keeps their relative order deterministic, but is `purchaseDate` the date we want to rank by, or `originalPurchaseDate`?
- `singlePurchaseView` picks `nonSubscriptionsSection.first` when there are no subscriptions; it now resolves to the most recent purchase. Intended?
- Should purchase history also list newest first, for consistency?

## Risks / Reviewer Notes

- Risk: the section order is user-visible, so anyone relying on the old chronological order sees a change.
  - Evidence: the old order was the two oldest of N, which is what the customer report is about.
  - Mitigation: none needed, the previous behavior is the bug.

## Non-goals / Out of Scope

- Raising or removing the cap of 2 non-subscriptions on the management screen.
- Anything about promotional-entitlement cards or granting entitlements a display name, which was the other half of the Slack thread.

## Omitted Context

- Raw transcript, unrelated exploration, sensitive details, repetitive attempts, and chain-of-thought-style content were omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized display-order change in Customer Center for non-subscription purchases; no auth, billing, or persistence changes.
> 
> **Overview**
> **Customer Center** now lists one-time (non-subscription) purchases **newest first** when building `nonSubscriptionsSection`, instead of using `customerInfo.nonSubscriptions` in its default oldest-first order.
> 
> In `loadNonSubscriptionsSection`, transactions are sorted by **`purchaseDate` descending** before mapping to `PurchaseInformation`. That matters because the management UI only surfaces the first couple of entries (`prefix(2)`), so the old order surfaced stale day/week passes instead of the latest buy. Sorting raw transactions avoids ranking by **`PurchaseInformation.latestPurchaseDate`**, which can follow a **later entitlement grant** and mis-order purchases.
> 
> Two view-model tests lock in newest-first ordering and the entitlement-date edge case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac4ce1228da26427a0326e564729a55568bd7ab2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->