### PR TITLE
Expose access token via AuthenticationDelegate

### DIFF
--- a/Sources/Authentication/Authentication.swift
+++ b/Sources/Authentication/Authentication.swift
@@ -70,7 +70,7 @@ public final class Authentication: NSObject {
     /// - Warning: The delegate is not retained, so your app must retain a reference
     /// to the delegate to prevent it from being unintentionally deallocated.
     @objc public weak var delegate: AuthenticationDelegate?
-    
+
     /// The access token for the currently authenticated user, if one exists.
     @objc public var currentAccessToken: String? { tokenManager.currentAccessToken }
 
@@ -293,6 +293,7 @@ public final class Authentication: NSObject {
     }
 
     internal func reportAuthenticationResult(_ result: Result<String?, PublicError>) {
+        guard tokenManager.enabled else { return }
         guard let delegate else { return }
 
         switch result {

--- a/Sources/Authentication/Authentication.swift
+++ b/Sources/Authentication/Authentication.swift
@@ -293,11 +293,11 @@ public final class Authentication: NSObject {
     }
 
     internal func reportAuthenticationResult(_ result: Result<String?, PublicError>) {
-        guard tokenManager.enabled else { return }
         guard let delegate else { return }
 
         switch result {
         case .success(let newAccessToken):
+            guard tokenManager.enabled else { return }
             if let impl = delegate.authenticatorDidUpdateAccessToken {
                 self.operationDispatcher.dispatchOnMainThread {
                     impl(newAccessToken)

--- a/Sources/Authentication/Authentication.swift
+++ b/Sources/Authentication/Authentication.swift
@@ -27,7 +27,7 @@ public protocol AuthenticationDelegate: NSObjectProtocol {
     /// This method is *not* invoked when ``Authentication.logIn(using:)`` or
     /// ``Authentication.logOut()`` fail, as both of those methods report any failures directly.
     ///
-    /// When this method is implemented, all access tokens conveyed via ``authenticatorDidUpdateAccessToken(_:)``
+    /// When this method is invoked, all access tokens previously sent to ``authenticatorDidUpdateAccessToken(_:)``
     /// should be assumed to be invalid.
     ///
     /// - Parameter error: The ``PublicError`` indicating why authentication has failed

--- a/Sources/Authentication/Authentication.swift
+++ b/Sources/Authentication/Authentication.swift
@@ -27,8 +27,18 @@ public protocol AuthenticationDelegate: NSObjectProtocol {
     /// This method is *not* invoked when ``Authentication.logIn(using:)`` or
     /// ``Authentication.logOut()`` fail, as both of those methods report any failures directly.
     ///
+    /// When this method is implemented, all access tokens conveyed via ``authenticatorDidUpdateAccessToken(_:)``
+    /// should be assumed to be invalid.
+    ///
     /// - Parameter error: The ``PublicError`` indicating why authentication has failed
     func authenticatorDidEncounterError(_ error: PublicError)
+    
+    /// The SDK has updated the current user's access token
+    ///
+    /// This token can be used to communicate directly with the RevenueCat backend on behalf of the current user.
+    ///
+    /// - Parameter newAccessToken: The new access token, or `nil` if authentication failed.
+    @objc optional func authenticatorDidUpdateAccessToken(_ newAccessToken: String?)
 }
 
 internal protocol InternalAuthenticatorDelegate: AnyObject {
@@ -77,8 +87,8 @@ public final class Authentication: NSObject {
         self.internalDelegate = internalDelegate
         super.init()
 
-        tokenManager.reportError = { [weak self] in
-            self?.reportAuthenticationError($0)
+        tokenManager.reportTokenUpdate = { [weak self] in
+            self?.reportAuthenticationResult($0)
         }
     }
 
@@ -211,7 +221,7 @@ public final class Authentication: NSObject {
             self.operationDispatcher.dispatchOnMainThread {
                 completion?(nil, error.asPublicError)
             }
-            if userInitiated == false { self.reportAuthenticationError(error.asPublicError) }
+            if userInitiated == false { self.reportAuthenticationResult(.failure(error.asPublicError)) }
             return
         }
 
@@ -230,7 +240,7 @@ public final class Authentication: NSObject {
                 self.internalDelegate?.authenticatorDidLogIn(info: result.info)
             case .failure(let error):
                 if userInitiated == false {
-                    self.reportAuthenticationError(error.asPublicError)
+                    self.reportAuthenticationResult(.failure(error.asPublicError))
                 }
             }
 
@@ -244,7 +254,7 @@ public final class Authentication: NSObject {
             self.operationDispatcher.dispatchOnMainThread {
                 completion?(nil, error)
             }
-            if userInitiated == false { self.reportAuthenticationError(error) }
+            if userInitiated == false { self.reportAuthenticationResult(.failure(error)) }
             return
         }
 
@@ -259,7 +269,7 @@ public final class Authentication: NSObject {
                     }
                 }
                 if userInitiated == false {
-                    self.reportAuthenticationError(error.asPublicError)
+                    self.reportAuthenticationResult(.failure(error.asPublicError))
                 }
             } else {
                 self.operationDispatcher.dispatchOnMainThread {
@@ -279,14 +289,24 @@ public final class Authentication: NSObject {
         }
     }
 
-    internal func reportAuthenticationError(_ error: PublicError) {
+    internal func reportAuthenticationResult(_ result: Result<String, PublicError>) {
         guard let delegate else { return }
 
-        // if we currently have user initiated requests going, then skip reporting this error via the delegate
-        if self.ongoingUserInitiatedRequestCount.value > 0 { return }
+        switch result {
+        case .success(let newAccessToken):
+            if let impl = delegate.authenticatorDidUpdateAccessToken {
+                self.operationDispatcher.dispatchOnMainThread {
+                    impl(newAccessToken)
+                }
+            }
 
-        self.operationDispatcher.dispatchOnMainThread {
-            delegate.authenticatorDidEncounterError(error)
+        case .failure(let error):
+            // if we currently have user initiated requests going, then skip reporting this error via the delegate
+            if self.ongoingUserInitiatedRequestCount.value > 0 { return }
+
+            self.operationDispatcher.dispatchOnMainThread {
+                delegate.authenticatorDidEncounterError(error)
+            }
         }
     }
 

--- a/Sources/Authentication/Authentication.swift
+++ b/Sources/Authentication/Authentication.swift
@@ -32,7 +32,7 @@ public protocol AuthenticationDelegate: NSObjectProtocol {
     ///
     /// - Parameter error: The ``PublicError`` indicating why authentication has failed
     func authenticatorDidEncounterError(_ error: PublicError)
-    
+
     /// The SDK has updated the current user's access token
     ///
     /// This token can be used to communicate directly with the RevenueCat backend on behalf of the current user.

--- a/Sources/Authentication/Authentication.swift
+++ b/Sources/Authentication/Authentication.swift
@@ -70,6 +70,9 @@ public final class Authentication: NSObject {
     /// - Warning: The delegate is not retained, so your app must retain a reference
     /// to the delegate to prevent it from being unintentionally deallocated.
     @objc public weak var delegate: AuthenticationDelegate?
+    
+    /// The access token for the currently authenticated user, if one exists.
+    @objc public var currentAccessToken: String? { tokenManager.currentAccessToken }
 
     private let ongoingUserInitiatedRequestCount = Atomic(0)
 
@@ -289,7 +292,7 @@ public final class Authentication: NSObject {
         }
     }
 
-    internal func reportAuthenticationResult(_ result: Result<String, PublicError>) {
+    internal func reportAuthenticationResult(_ result: Result<String?, PublicError>) {
         guard let delegate else { return }
 
         switch result {

--- a/Sources/Networking/HTTPClient/TokenManager.swift
+++ b/Sources/Networking/HTTPClient/TokenManager.swift
@@ -42,7 +42,7 @@ class TokenManager {
         self.storage = storage
     }
 
-    var reportTokenUpdate: ((Result<String, PublicError>) -> Void)?
+    var reportTokenUpdate: ((Result<String?, PublicError>) -> Void)?
 
     var hasCurrentAccessToken: Bool { currentAccessToken != nil }
 
@@ -107,15 +107,19 @@ class TokenManager {
     }
 
     func saveTokens(refreshToken: String?, accessToken: String, idToken: String?, for userID: String) {
+        guard enabled == true else { return }
         storage.setString(refreshToken, for: .refresh(userID))
         storage.setString(accessToken, for: .access(userID))
         storage.setString(idToken, for: .id(userID))
+        reportTokenUpdate?(.success(accessToken))
     }
 
     func deleteTokens(for userID: String) {
+        guard enabled == true else { return }
         storage.setString(nil, for: .refresh(userID))
         storage.setString(nil, for: .access(userID))
         storage.setString(nil, for: .id(userID))
+        reportTokenUpdate?(.success(nil))
     }
 
     func deleteAccessToken(for userID: String) {
@@ -182,7 +186,7 @@ class TokenManager {
 
         // make sure this response is a successful one
         let didHandle: Bool
-        let reportedResult: Result<String, PublicError>
+        let reportedResult: Result<String?, PublicError>
         switch result {
         case .success(let response):
             if response.httpStatusCode == .success {

--- a/Sources/Networking/HTTPClient/TokenManager.swift
+++ b/Sources/Networking/HTTPClient/TokenManager.swift
@@ -107,7 +107,6 @@ class TokenManager {
     }
 
     func saveTokens(refreshToken: String?, accessToken: String, idToken: String?, for userID: String) {
-        guard enabled == true else { return }
         storage.setString(refreshToken, for: .refresh(userID))
         storage.setString(accessToken, for: .access(userID))
         storage.setString(idToken, for: .id(userID))
@@ -115,7 +114,6 @@ class TokenManager {
     }
 
     func deleteTokens(for userID: String) {
-        guard enabled == true else { return }
         storage.setString(nil, for: .refresh(userID))
         storage.setString(nil, for: .access(userID))
         storage.setString(nil, for: .id(userID))

--- a/Sources/Networking/HTTPClient/TokenManager.swift
+++ b/Sources/Networking/HTTPClient/TokenManager.swift
@@ -42,7 +42,7 @@ class TokenManager {
         self.storage = storage
     }
 
-    var reportError: ((PublicError) -> Void)?
+    var reportTokenUpdate: ((Result<String, PublicError>) -> Void)?
 
     var hasCurrentAccessToken: Bool { currentAccessToken != nil }
 
@@ -182,7 +182,7 @@ class TokenManager {
 
         // make sure this response is a successful one
         let didHandle: Bool
-        let reportedError: PublicError?
+        let reportedResult: Result<String, PublicError>
         switch result {
         case .success(let response):
             if response.httpStatusCode == .success {
@@ -192,15 +192,15 @@ class TokenManager {
                 self.currentAccessToken = tokens.accessToken
                 self.currentIDToken = tokens.idToken
 
-                reportedError = nil
+                reportedResult = .success(tokens.accessToken)
                 didHandle = true
             } else {
                 // a non-successful response that somehow didn't get turned into an actual error
-                reportedError = ErrorUtils.unknownError().asPublicError
+                reportedResult = .failure(ErrorUtils.unknownError().asPublicError)
                 didHandle = false
             }
         case .failure(let error):
-            reportedError = error.asPublicError
+            reportedResult = .failure(error.asPublicError)
             didHandle = false
         }
 
@@ -211,9 +211,7 @@ class TokenManager {
         }
 
         defer {
-            if let reportedError, let reportError {
-                reportError(reportedError)
-            }
+            reportTokenUpdate?(reportedResult)
         }
 
         handlers.forEach { $0(didHandle) }

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCAuthenticationAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCAuthenticationAPI.m
@@ -37,4 +37,6 @@
 
 - (void)authenticatorDidEncounterError:(NSError *)error { }
 
+- (void)authenticatorDidUpdateAccessToken:(NSString *)newAccessToken { }
+
 @end

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCAuthenticationAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCAuthenticationAPI.m
@@ -24,6 +24,8 @@
     [auth identifyCurrentUserAsID:@"" completion:^(RCCustomerInfo *i, BOOL created, NSError *error) { }];
     [auth logOutWithCompletion:^(RCCustomerInfo *i, NSError *error) { }];
 
+    NSString *__unused token = auth.currentAccessToken;
+
     RCIdentity *siwa = [RCIdentity identityWithSignInWithAppleToken:[NSData data]];
     RCIdentitySource *__unused source = siwa.identitySource;
 

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/AuthenticationAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/AuthenticationAPI.swift
@@ -44,4 +44,5 @@ func checkAuthenticationAPI() {
 
 class AuthDelegate: NSObject, AuthenticationDelegate {
     func authenticatorDidEncounterError(_ error: PublicError) { }
+    func authenticatorDidUpdateAccessToken(_ newAccessToken: String?) { }
 }

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/AuthenticationAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/AuthenticationAPI.swift
@@ -24,6 +24,8 @@ func checkAuthenticationAPI() {
 
     }
 
+    let _: String? = auth.currentAccessToken
+
     let siwa: Identity = Identity.signInWithApple(Data())
     let _: IdentitySource = siwa.identitySource
 

--- a/Tests/UnitTests/Authentication/AuthenticationTests.swift
+++ b/Tests/UnitTests/Authentication/AuthenticationTests.swift
@@ -411,7 +411,7 @@ class AuthenticationTests: TestCase {
     }
 
     func testReportAuthenticationResultNotifiesTheDelegateOfANewAccessTokenOnTheMainThread() {
-        let authentication = self.makeAuthentication()
+        let authentication = self.makeAuthentication(tokenManagerEnabled: true)
 
         authentication.reportAuthenticationResult(.success("new-access-token"))
 
@@ -426,7 +426,7 @@ class AuthenticationTests: TestCase {
         // `authenticatorDidUpdateAccessToken` is an `@objc optional` requirement, so delegates written
         // before it existed (or that simply don't care about it) won't implement it. Reporting a new
         // access token to one of those delegates should be a silent no-op rather than a crash.
-        let authentication = self.makeAuthentication()
+        let authentication = self.makeAuthentication(tokenManagerEnabled: true)
         let minimalDelegate = MinimalAuthenticationDelegate()
         authentication.delegate = minimalDelegate
 

--- a/Tests/UnitTests/Authentication/AuthenticationTests.swift
+++ b/Tests/UnitTests/Authentication/AuthenticationTests.swift
@@ -28,7 +28,7 @@ class AuthenticationTests: TestCase {
     private var secureItemStorage: MockSecureItemStorage!
     private var tokenManager: TokenManager!
     // `Authentication` only holds a *weak* reference to itself inside the closure it hands to
-    // `tokenManager.reportError`, so tests that don't otherwise keep the `Authentication` returned by
+    // `tokenManager.reportTokenUpdate`, so tests that don't otherwise keep the `Authentication` returned by
     // `makeAuthentication()` alive would see it deallocated immediately, silently turning that closure
     // into a no-op. Stashing it here keeps it alive for the lifetime of the test regardless of whether
     // the caller captures the return value.
@@ -377,26 +377,63 @@ class AuthenticationTests: TestCase {
         }
     }
 
-    // MARK: - reportAuthenticationError(_:)
+    // MARK: - reportAuthenticationResult(_:)
 
-    func testReportAuthenticationErrorDoesNothingWhenNoDelegateIsSet() {
+    func testReportAuthenticationResultDoesNothingForAFailureWhenNoDelegateIsSet() {
         let authentication = self.makeAuthentication()
         authentication.delegate = nil
 
-        authentication.reportAuthenticationError(NSError(domain: "AuthenticationTests", code: 1))
+        authentication.reportAuthenticationResult(.failure(NSError(domain: "AuthenticationTests", code: 1)))
 
         expect(self.operationDispatcher.invokedDispatchOnMainThread) == false
         expect(self.authenticationDelegate.invokedAuthenticatorDidEncounterError) == false
     }
 
-    func testReportAuthenticationErrorNotifiesTheDelegateOnTheMainThread() {
+    func testReportAuthenticationResultNotifiesTheDelegateOfAFailureOnTheMainThread() {
         let authentication = self.makeAuthentication()
         let error = NSError(domain: "AuthenticationTests", code: 1)
 
-        authentication.reportAuthenticationError(error)
+        authentication.reportAuthenticationResult(.failure(error))
 
         expect(self.operationDispatcher.invokedDispatchOnMainThread) == true
         expect(self.authenticationDelegate.invokedAuthenticatorDidEncounterErrorParametersList) == [error]
+        // a failure is never accompanied by a new access token
+        expect(self.authenticationDelegate.invokedAuthenticatorDidUpdateAccessToken) == false
+    }
+
+    func testReportAuthenticationResultDoesNothingForANewAccessTokenWhenNoDelegateIsSet() {
+        let authentication = self.makeAuthentication()
+        authentication.delegate = nil
+
+        authentication.reportAuthenticationResult(.success("new-access-token"))
+
+        expect(self.operationDispatcher.invokedDispatchOnMainThread) == false
+    }
+
+    func testReportAuthenticationResultNotifiesTheDelegateOfANewAccessTokenOnTheMainThread() {
+        let authentication = self.makeAuthentication()
+
+        authentication.reportAuthenticationResult(.success("new-access-token"))
+
+        expect(self.operationDispatcher.invokedDispatchOnMainThread) == true
+        expect(self.authenticationDelegate.invokedAuthenticatorDidUpdateAccessTokenParametersList) ==
+            ["new-access-token"]
+        // a new access token is never accompanied by an authentication error
+        expect(self.authenticationDelegate.invokedAuthenticatorDidEncounterError) == false
+    }
+
+    func testReportAuthenticationResultDoesNotCrashWhenTheDelegateDoesNotImplementAccessTokenUpdates() {
+        // `authenticatorDidUpdateAccessToken` is an `@objc optional` requirement, so delegates written
+        // before it existed (or that simply don't care about it) won't implement it. Reporting a new
+        // access token to one of those delegates should be a silent no-op rather than a crash.
+        let authentication = self.makeAuthentication()
+        let minimalDelegate = MinimalAuthenticationDelegate()
+        authentication.delegate = minimalDelegate
+
+        authentication.reportAuthenticationResult(.success("new-access-token"))
+
+        expect(self.operationDispatcher.invokedDispatchOnMainThread) == false
+        expect(minimalDelegate.invokedAuthenticatorDidEncounterError) == false
     }
 
     // MARK: - logInIfNeeded(completion:)
@@ -441,12 +478,12 @@ class AuthenticationTests: TestCase {
         )
     }
 
-    // MARK: - Token refresh failure reporting
+    // MARK: - Token refresh reporting
 
-    /// These tests exercise the wiring set up in `Authentication.init`, where `tokenManager.reportError`
-    /// is connected to `reportAuthenticationError(_:)`. This is how failures to refresh an expired access
-    /// token (which happen deep inside `HTTPClient`, well outside of any explicit, user-initiated call)
-    /// make their way to the `AuthenticationDelegate`.
+    /// These tests exercise the wiring set up in `Authentication.init`, where `tokenManager.reportTokenUpdate`
+    /// is connected to `reportAuthenticationResult(_:)`. This is how both a failed and a successful attempt
+    /// to refresh the session's access token (which happens deep inside `HTTPClient`, well outside of any
+    /// explicit, user-initiated call) makes its way to the `AuthenticationDelegate`.
     func testAuthenticationDelegateIsInvokedWhenTokenRefreshFails() {
         _ = self.makeAuthentication(tokenManagerEnabled: true)
         let networkError = NetworkError.networkError(NSError(domain: "AuthenticationTests", code: 401))
@@ -459,26 +496,21 @@ class AuthenticationTests: TestCase {
         expect(self.authenticationDelegate.invokedAuthenticatorDidEncounterErrorParametersList.last).to(
             matchError(networkError.asPublicError)
         )
+        // a failed refresh never has a new access token to report
+        expect(self.authenticationDelegate.invokedAuthenticatorDidUpdateAccessToken) == false
     }
 
-    func testAuthenticationDelegateIsNotInvokedWhenTokenRefreshSucceeds() {
+    func testAuthenticationDelegateReceivesTheNewAccessTokenWhenTokenRefreshSucceeds() {
         _ = self.makeAuthentication(tokenManagerEnabled: true)
-        let response = VerifiedHTTPResponse<TokenResponse>(
-            httpStatusCode: .success,
-            responseHeaders: [:],
-            body: TokenResponse(accessToken: "new-access-token",
-                                idToken: "new-id-token",
-                                refreshToken: "new-refresh-token",
-                                scope: "openid",
-                                expiresIn: 3600),
-            verificationResult: .notRequested,
-            isLoadShedderResponse: false,
-            isFallbackUrlResponse: false
-        )
+        let response = Self.makeTokenRefreshResponse(accessToken: "new-access-token")
 
         let didHandle = self.tokenManager.handleTokenRefreshResponse(.success(response))
 
         expect(didHandle) == true
+        expect(self.operationDispatcher.invokedDispatchOnMainThread) == true
+        expect(self.authenticationDelegate.invokedAuthenticatorDidUpdateAccessTokenParametersList) ==
+            ["new-access-token"]
+        // a successful refresh never reports an authentication error
         expect(self.authenticationDelegate.invokedAuthenticatorDidEncounterError) == false
     }
 
@@ -490,6 +522,27 @@ class AuthenticationTests: TestCase {
         _ = self.tokenManager.handleTokenRefreshResponse(.failure(networkError))
 
         expect(self.authenticationDelegate.invokedAuthenticatorDidEncounterError) == false
+    }
+
+    func testAuthenticationDelegateIsNotInvokedForANewAccessTokenWhenNoDelegateIsSet() {
+        let authentication = self.makeAuthentication(tokenManagerEnabled: true)
+        authentication.delegate = nil
+
+        _ = self.tokenManager.handleTokenRefreshResponse(.success(Self.makeTokenRefreshResponse()))
+
+        expect(self.authenticationDelegate.invokedAuthenticatorDidUpdateAccessToken) == false
+    }
+
+}
+
+/// A minimal stand-in for a delegate implementation that predates (or simply doesn't implement)
+/// the optional `authenticatorDidUpdateAccessToken(_:)` requirement.
+private final class MinimalAuthenticationDelegate: NSObject, AuthenticationDelegate {
+
+    private(set) var invokedAuthenticatorDidEncounterError = false
+
+    func authenticatorDidEncounterError(_ error: PublicError) {
+        self.invokedAuthenticatorDidEncounterError = true
     }
 
 }
@@ -507,6 +560,23 @@ private extension AuthenticationTests {
                 "original_application_version": NSNull()
             ] as [String: Any]
         ]
+    }
+
+    static func makeTokenRefreshResponse(
+        accessToken: String = "new-access-token"
+    ) -> VerifiedHTTPResponse<TokenResponse> {
+        return VerifiedHTTPResponse<TokenResponse>(
+            httpStatusCode: .success,
+            responseHeaders: [:],
+            body: TokenResponse(accessToken: accessToken,
+                                idToken: "new-id-token",
+                                refreshToken: "new-refresh-token",
+                                scope: "openid",
+                                expiresIn: 3600),
+            verificationResult: .notRequested,
+            isLoadShedderResponse: false,
+            isFallbackUrlResponse: false
+        )
     }
 
 }

--- a/Tests/UnitTests/Mocks/MockAuthenticationDelegate.swift
+++ b/Tests/UnitTests/Mocks/MockAuthenticationDelegate.swift
@@ -27,4 +27,14 @@ final class MockAuthenticationDelegate: NSObject, AuthenticationDelegate {
         self.invokedAuthenticatorDidEncounterErrorParametersList.append(error)
     }
 
+    private(set) var invokedAuthenticatorDidUpdateAccessToken = false
+    private(set) var invokedAuthenticatorDidUpdateAccessTokenCount = 0
+    private(set) var invokedAuthenticatorDidUpdateAccessTokenParametersList: [String?] = []
+
+    func authenticatorDidUpdateAccessToken(_ newAccessToken: String?) {
+        self.invokedAuthenticatorDidUpdateAccessToken = true
+        self.invokedAuthenticatorDidUpdateAccessTokenCount += 1
+        self.invokedAuthenticatorDidUpdateAccessTokenParametersList.append(newAccessToken)
+    }
+
 }

--- a/Tests/UnitTests/Networking/TokenManagerTests.swift
+++ b/Tests/UnitTests/Networking/TokenManagerTests.swift
@@ -269,7 +269,7 @@ class TokenManagerTests: TestCase {
     func testReportTokenUpdateCanBeSetAndIsInvokedWithAFailure() {
         let manager = TokenManager(enabled: true, storage: self.storage)
         let expectedError = NSError(domain: "TokenManagerTests", code: 1)
-        var receivedResult: Result<String, PublicError>?
+        var receivedResult: Result<String?, PublicError>?
 
         manager.reportTokenUpdate = { result in
             receivedResult = result
@@ -285,7 +285,7 @@ class TokenManagerTests: TestCase {
 
     func testReportTokenUpdateCanBeSetAndIsInvokedWithANewAccessToken() {
         let manager = TokenManager(enabled: true, storage: self.storage)
-        var receivedResult: Result<String, PublicError>?
+        var receivedResult: Result<String?, PublicError>?
 
         manager.reportTokenUpdate = { result in
             receivedResult = result
@@ -575,7 +575,7 @@ class TokenManagerTests: TestCase {
     func testHandleTokenRefreshResponseReturnsFalseAndDoesNothingWhenDisabled() {
         let manager = TokenManager(enabled: false, storage: self.storage)
         manager.currentUserProvider = self.userProvider
-        var reportedResult: Result<String, PublicError>?
+        var reportedResult: Result<String?, PublicError>?
         manager.reportTokenUpdate = { reportedResult = $0 }
 
         let didHandle = manager.handleTokenRefreshResponse(.failure(Self.makeNetworkError()))
@@ -587,7 +587,7 @@ class TokenManagerTests: TestCase {
     func testHandleTokenRefreshResponseSavesTokensAndReturnsTrueOnSuccess() {
         let manager = TokenManager(enabled: true, storage: self.storage)
         manager.currentUserProvider = self.userProvider
-        var reportedResult: Result<String, PublicError>?
+        var reportedResult: Result<String?, PublicError>?
         manager.reportTokenUpdate = { reportedResult = $0 }
 
         let didHandle = manager.handleTokenRefreshResponse(.success(Self.makeTokenResponse(
@@ -613,7 +613,7 @@ class TokenManagerTests: TestCase {
         let manager = TokenManager(enabled: true, storage: self.storage)
         manager.currentUserProvider = self.userProvider
         manager.currentAccessToken = "old-access"
-        var reportedResult: Result<String, PublicError>?
+        var reportedResult: Result<String?, PublicError>?
         manager.reportTokenUpdate = { reportedResult = $0 }
         let networkError = Self.makeNetworkError()
 
@@ -633,7 +633,7 @@ class TokenManagerTests: TestCase {
     func testHandleTokenRefreshResponseReportsAnErrorWhenTheResponseIsNotSuccessful() {
         let manager = TokenManager(enabled: true, storage: self.storage)
         manager.currentUserProvider = self.userProvider
-        var reportedResult: Result<String, PublicError>?
+        var reportedResult: Result<String?, PublicError>?
         manager.reportTokenUpdate = { reportedResult = $0 }
         let response = VerifiedHTTPResponse<TokenResponse>(
             httpStatusCode: .unauthorized,

--- a/Tests/UnitTests/Networking/TokenManagerTests.swift
+++ b/Tests/UnitTests/Networking/TokenManagerTests.swift
@@ -258,25 +258,45 @@ class TokenManagerTests: TestCase {
         expect(manager.currentIDToken) == "id"
     }
 
-    // MARK: - reportError
+    // MARK: - reportTokenUpdate
 
-    func testReportErrorIsNilByDefault() {
+    func testReportTokenUpdateIsNilByDefault() {
         let manager = TokenManager(enabled: true, storage: self.storage)
 
-        expect(manager.reportError).to(beNil())
+        expect(manager.reportTokenUpdate).to(beNil())
     }
 
-    func testReportErrorCanBeSetAndIsInvokedWhenCalled() {
+    func testReportTokenUpdateCanBeSetAndIsInvokedWithAFailure() {
         let manager = TokenManager(enabled: true, storage: self.storage)
         let expectedError = NSError(domain: "TokenManagerTests", code: 1)
-        var receivedError: PublicError?
+        var receivedResult: Result<String, PublicError>?
 
-        manager.reportError = { error in
-            receivedError = error
+        manager.reportTokenUpdate = { result in
+            receivedResult = result
         }
-        manager.reportError?(expectedError)
+        manager.reportTokenUpdate?(.failure(expectedError))
 
-        expect(receivedError) == expectedError
+        guard case let .failure(error) = receivedResult else {
+            fail("Expected .failure, got \(String(describing: receivedResult))")
+            return
+        }
+        expect(error) == expectedError
+    }
+
+    func testReportTokenUpdateCanBeSetAndIsInvokedWithANewAccessToken() {
+        let manager = TokenManager(enabled: true, storage: self.storage)
+        var receivedResult: Result<String, PublicError>?
+
+        manager.reportTokenUpdate = { result in
+            receivedResult = result
+        }
+        manager.reportTokenUpdate?(.success("new-access-token"))
+
+        guard case let .success(accessToken) = receivedResult else {
+            fail("Expected .success, got \(String(describing: receivedResult))")
+            return
+        }
+        expect(accessToken) == "new-access-token"
     }
 
     // MARK: - currentIdentitySources
@@ -555,20 +575,20 @@ class TokenManagerTests: TestCase {
     func testHandleTokenRefreshResponseReturnsFalseAndDoesNothingWhenDisabled() {
         let manager = TokenManager(enabled: false, storage: self.storage)
         manager.currentUserProvider = self.userProvider
-        var reportedError: PublicError?
-        manager.reportError = { reportedError = $0 }
+        var reportedResult: Result<String, PublicError>?
+        manager.reportTokenUpdate = { reportedResult = $0 }
 
         let didHandle = manager.handleTokenRefreshResponse(.failure(Self.makeNetworkError()))
 
         expect(didHandle) == false
-        expect(reportedError).to(beNil())
+        expect(reportedResult).to(beNil())
     }
 
     func testHandleTokenRefreshResponseSavesTokensAndReturnsTrueOnSuccess() {
         let manager = TokenManager(enabled: true, storage: self.storage)
         manager.currentUserProvider = self.userProvider
-        var reportedError: PublicError?
-        manager.reportError = { reportedError = $0 }
+        var reportedResult: Result<String, PublicError>?
+        manager.reportTokenUpdate = { reportedResult = $0 }
 
         let didHandle = manager.handleTokenRefreshResponse(.success(Self.makeTokenResponse(
             accessToken: "new-access",
@@ -577,33 +597,44 @@ class TokenManagerTests: TestCase {
         )))
 
         expect(didHandle) == true
-        expect(reportedError).to(beNil())
         expect(manager.currentAccessToken) == "new-access"
         expect(manager.currentIDToken) == "new-id"
         expect(manager.currentRefreshToken) == "new-refresh"
+
+        // a successful refresh reports the new access token via `reportTokenUpdate`
+        guard case let .success(reportedAccessToken) = reportedResult else {
+            fail("Expected .success, got \(String(describing: reportedResult))")
+            return
+        }
+        expect(reportedAccessToken) == "new-access"
     }
 
     func testHandleTokenRefreshResponseReportsTheErrorAndReturnsFalseOnFailure() {
         let manager = TokenManager(enabled: true, storage: self.storage)
         manager.currentUserProvider = self.userProvider
         manager.currentAccessToken = "old-access"
-        var reportedError: PublicError?
-        manager.reportError = { reportedError = $0 }
+        var reportedResult: Result<String, PublicError>?
+        manager.reportTokenUpdate = { reportedResult = $0 }
         let networkError = Self.makeNetworkError()
 
         let didHandle = manager.handleTokenRefreshResponse(.failure(networkError))
 
         expect(didHandle) == false
-        expect(reportedError).to(matchError(networkError.asPublicError))
         // a failed refresh should not clear out whatever access token was already stored
         expect(manager.currentAccessToken) == "old-access"
+
+        guard case let .failure(reportedError) = reportedResult else {
+            fail("Expected .failure, got \(String(describing: reportedResult))")
+            return
+        }
+        expect(reportedError).to(matchError(networkError.asPublicError))
     }
 
     func testHandleTokenRefreshResponseReportsAnErrorWhenTheResponseIsNotSuccessful() {
         let manager = TokenManager(enabled: true, storage: self.storage)
         manager.currentUserProvider = self.userProvider
-        var reportedError: PublicError?
-        manager.reportError = { reportedError = $0 }
+        var reportedResult: Result<String, PublicError>?
+        manager.reportTokenUpdate = { reportedResult = $0 }
         let response = VerifiedHTTPResponse<TokenResponse>(
             httpStatusCode: .unauthorized,
             responseHeaders: [:],
@@ -620,7 +651,10 @@ class TokenManagerTests: TestCase {
         let didHandle = manager.handleTokenRefreshResponse(.success(response))
 
         expect(didHandle) == false
-        expect(reportedError).toNot(beNil())
+        guard case .failure = reportedResult else {
+            fail("Expected .failure, got \(String(describing: reportedResult))")
+            return
+        }
     }
 
     func testHandleTokenRefreshResponseNotifiesDuplicateRequestHandlersOnFailure() {


### PR DESCRIPTION
This adds an optional `AuthenticationDelegate` method so that developers who are interested in using the RC access token can retrieve it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API now surfaces bearer access tokens and pushes them through delegate callbacks; mishandling or logging tokens increases exposure, though the optional delegate preserves compatibility.
> 
> **Overview**
> Adds **`Authentication.currentAccessToken`** and an optional **`authenticatorDidUpdateAccessToken(_:)`** delegate callback so apps can read the IAM access token for direct RevenueCat API calls. Docs note that **`authenticatorDidEncounterError`** means prior tokens from the update callback should be treated as invalid.
> 
> **`TokenManager`** replaces error-only **`reportError`** with **`reportTokenUpdate`**, emitting **`.success`** when tokens are saved, cleared on logout (**`nil`**), or refreshed, and **`.failure`** on refresh/auth failures. **`Authentication`** routes those results through **`reportAuthenticationResult`**, dispatching token updates on the main thread when IAM is enabled and the delegate implements the optional method (backward compatible for older delegates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12b7804bf3683ac20ec0b4dcdb61b347e695924b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->