### PR TITLE
Expose OIDC and Firebase identities

### DIFF
--- a/Sources/Identity/Identity.swift
+++ b/Sources/Identity/Identity.swift
@@ -25,6 +25,18 @@ public final class Identity: NSObject {
         Identity(token: .signInWithApple(identityToken))
     }
 
+    /// An OIDC identity
+    @objc(identityWithOIDCToken:)
+    public static func oidc(_ identityToken: Data) -> Identity {
+        Identity(token: .oidc(identityToken))
+    }
+
+    /// A Firebase identity
+    @objc(identityWithFirebaseToken:)
+    public static func firebase(_ identityToken: Data) -> Identity {
+        Identity(token: .firebase(identityToken))
+    }
+
     internal let authToken: IdentityAuthToken
 
     /// Retrieve the source service of this identity
@@ -57,7 +69,7 @@ public final class IdentitySource: NSObject, CaseIterable {
     @objc public static let google = IdentitySource("google")
 
     /// The identity is a Sign In With Apple identity
-    @objc public static let signInWithApple = IdentitySource("signInWithApple")
+    @objc public static let signInWithApple = IdentitySource("apple")
 
     /// The identity is from Facebook
     @objc public static let facebook = IdentitySource("facebook")

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCAuthenticationAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCAuthenticationAPI.m
@@ -27,12 +27,15 @@
     RCIdentity *siwa = [RCIdentity identityWithSignInWithAppleToken:[NSData data]];
     RCIdentitySource *__unused source = siwa.identitySource;
 
+    RCIdentity *__unused oidc = [RCIdentity identityWithOIDCToken:[NSData data]];
+    RCIdentity *__unused firebase = [RCIdentity identityWithFirebaseToken:[NSData data]];
+
     RCIdentitySource *__unused anonymousSource = [RCIdentitySource anonymous];
     RCIdentitySource *__unused appleSource = [RCIdentitySource signInWithApple];
     RCIdentitySource *__unused googleSource = [RCIdentitySource google];
-    RCIdentitySource *__unused firebase = [RCIdentitySource firebase];
-    RCIdentitySource *__unused facebook = [RCIdentitySource facebook];
-    RCIdentitySource *__unused oidc = [RCIdentitySource oidc];
+    RCIdentitySource *__unused firebaseSource = [RCIdentitySource firebase];
+    RCIdentitySource *__unused facebookSource = [RCIdentitySource facebook];
+    RCIdentitySource *__unused oidcSource = [RCIdentitySource oidc];
 }
 
 - (void)authenticatorDidEncounterError:(NSError *)error { }

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/AuthenticationAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/AuthenticationAPI.swift
@@ -27,6 +27,9 @@ func checkAuthenticationAPI() {
     let siwa: Identity = Identity.signInWithApple(Data())
     let _: IdentitySource = siwa.identitySource
 
+    let _: Identity = Identity.oidc(Data())
+    let _: Identity = Identity.firebase(Data())
+
     let _: IdentitySource = IdentitySource.anonymous
     let _: IdentitySource = IdentitySource.signInWithApple
     let _: IdentitySource = IdentitySource.google

--- a/Tests/UnitTests/Identity/IdentityTests.swift
+++ b/Tests/UnitTests/Identity/IdentityTests.swift
@@ -48,12 +48,56 @@ class IdentityTests: TestCase {
         expect(identity1.authToken.cacheIdentifier) == identity2.authToken.cacheIdentifier
     }
 
+    func testOIDCFactoryCreatesIdentityWithOIDCSource() {
+        let token = "identity-token".asData
+        let identity = Identity.oidc(token)
+
+        expect(identity.identitySource) === IdentitySource.oidc
+    }
+
+    func testOIDCFactoryCreatesDistinctIdentitiesForDifferentTokens() {
+        let identity1 = Identity.oidc("token-1".asData)
+        let identity2 = Identity.oidc("token-2".asData)
+
+        expect(identity1.authToken.cacheIdentifier) != identity2.authToken.cacheIdentifier
+    }
+
+    func testOIDCFactoryCreatesEqualCacheIdentifierForSameToken() {
+        let token = "identity-token".asData
+        let identity1 = Identity.oidc(token)
+        let identity2 = Identity.oidc(token)
+
+        expect(identity1.authToken.cacheIdentifier) == identity2.authToken.cacheIdentifier
+    }
+
+    func testFirebaseFactoryCreatesIdentityWithFirebaseSource() {
+        let token = "identity-token".asData
+        let identity = Identity.firebase(token)
+
+        expect(identity.identitySource) === IdentitySource.firebase
+    }
+
+    func testFirebaseFactoryCreatesDistinctIdentitiesForDifferentTokens() {
+        let identity1 = Identity.firebase("token-1".asData)
+        let identity2 = Identity.firebase("token-2".asData)
+
+        expect(identity1.authToken.cacheIdentifier) != identity2.authToken.cacheIdentifier
+    }
+
+    func testFirebaseFactoryCreatesEqualCacheIdentifierForSameToken() {
+        let token = "identity-token".asData
+        let identity1 = Identity.firebase(token)
+        let identity2 = Identity.firebase(token)
+
+        expect(identity1.authToken.cacheIdentifier) == identity2.authToken.cacheIdentifier
+    }
+
     // MARK: - IdentitySource
 
     func testIdentitySourceAllCasesContainsEverySource() {
         let rawValues = Set(IdentitySource.allCases.map { $0.rawValue })
 
-        expect(rawValues) == Set(["anonymous", "oidc", "google", "signInWithApple", "facebook", "firebase"])
+        expect(rawValues) == Set(["anonymous", "oidc", "google", "apple", "facebook", "firebase"])
     }
 
     func testIdentitySourceDescriptionMatchesRawValue() {


### PR DESCRIPTION
Expose OIDC and Firebase as possible authentication identities.

(Also updates a constant to match what the server's actually sending)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication identity construction and changes the Sign in with Apple source raw string, which could break code or persisted data that still expects `"signInWithApple"`.
> 
> **Overview**
> Adds public **`Identity.oidc(_:)`** and **`Identity.firebase(_:)`** factories (with matching ObjC **`identityWithOIDCToken:`** / **`identityWithFirebaseToken:`** APIs) so apps can build identities from OIDC and Firebase ID tokens the same way as Sign in with Apple.
> 
> **`IdentitySource.signInWithApple`**’s server-facing raw value changes from **`"signInWithApple"`** to **`"apple"`** so client parsing matches what the backend sends. API testers and unit tests cover the new factories and the updated source string set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bd1034c8cbf259d27c50e0b297c4a44728eefcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->