### PR TITLE
Surface attribute sync errors when fetching offerings

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1218,7 +1218,34 @@ public extension Purchases {
             return
         }
 
-        self.syncSubscriberAttributes(completion: {
+        let firstBlockingError: Atomic<PublicError?> = nil
+        /// Whether an attribute sync error should prevent offerings from being fetched.
+        let shouldBlockOfferingsFetch: @Sendable (PublicError) -> Bool = { error in
+            guard
+                error.userInfo[NSError.UserInfoKey.backendErrorCode as String] as? Int
+                    == BackendErrorCode.invalidSubscriberAttributes.rawValue,
+                let attributeErrors = error.subscriberAttributesErrors,
+                !attributeErrors.isEmpty
+            else {
+                return true
+            }
+
+            return attributeErrors.keys.contains { !$0.hasPrefix("$") }
+        }
+
+        self.syncSubscriberAttributes(syncedAttribute: { error in
+            // Reserved-only 7263 errors are non-blocking because those attributes cannot always be updated.
+            if let error, shouldBlockOfferingsFetch(error) {
+                firstBlockingError.modify {
+                    $0 = $0 ?? error
+                }
+            }
+        }, completion: {
+            if let error = firstBlockingError.value {
+                completion(nil, error)
+                return
+            }
+
             self.systemInfo.isApplicationBackgrounded { isAppBackgrounded in
                 self.remoteConfigManager.refreshRemoteConfig(
                     fetchContext: .read,

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1230,8 +1230,9 @@ public extension Purchases {
                 return true
             }
 
-            // Only `$`-prefixed errors are non-blocking: they identify reserved attributes, some of which cannot be
-            // overwritten. Non-`$` keys are custom attributes, so a failure means their intended values were not synced.
+            // Only `$`-prefixed errors are non-blocking: they identify reserved attributes,
+            // some of which cannot be overwritten. Non-`$` keys are custom attributes,
+            // so a failure means their intended values were not synced.
             return attributeErrors.keys.contains { !$0.hasPrefix("$") }
         }
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1219,7 +1219,7 @@ public extension Purchases {
         }
 
         let firstBlockingError: Atomic<PublicError?> = nil
-        /// Whether an attribute sync error should prevent offerings from being fetched.
+        /// Returns whether an attribute sync error should prevent offerings from being fetched.
         let shouldBlockOfferingsFetch: @Sendable (PublicError) -> Bool = { error in
             guard
                 error.userInfo[NSError.UserInfoKey.backendErrorCode as String] as? Int
@@ -1230,11 +1230,13 @@ public extension Purchases {
                 return true
             }
 
+            // Only `$`-prefixed errors are non-blocking: they identify reserved attributes, some of which cannot be
+            // overwritten. Non-`$` keys are custom attributes, so a failure means their intended values were not synced.
             return attributeErrors.keys.contains { !$0.hasPrefix("$") }
         }
 
         self.syncSubscriberAttributes(syncedAttribute: { error in
-            // Reserved-only 7263 errors are non-blocking because those attributes cannot always be updated.
+            // Reserved-only errors are non-blocking because those attributes cannot always be updated.
             if let error, shouldBlockOfferingsFetch(error) {
                 firstBlockingError.modify {
                     $0 = $0 ?? error
@@ -1242,7 +1244,9 @@ public extension Purchases {
             }
         }, completion: {
             if let error = firstBlockingError.value {
-                completion(nil, error)
+                self.operationDispatcher.dispatchOnMainActor {
+                    completion(nil, error)
+                }
                 return
             }
 

--- a/Tests/UnitTests/Mocks/MockSubscriberAttributesManager.swift
+++ b/Tests/UnitTests/Mocks/MockSubscriberAttributesManager.swift
@@ -425,6 +425,7 @@ class MockSubscriberAttributesManager: SubscriberAttributesManager {
     var invokedSyncAttributesForAllUsersCount = 0
     var invokedSyncAttributesForAllUsersParameters: (currentAppUserID: String?, Void)?
     var invokedSyncAttributesForAllUsersParametersList = [(currentAppUserID: String?, Void)]()
+    var stubbedSyncAttributesForAllUsersError: PurchasesError?
 
     override func syncAttributesForAllUsers(
         currentAppUserID: String,
@@ -435,6 +436,7 @@ class MockSubscriberAttributesManager: SubscriberAttributesManager {
         invokedSyncAttributesForAllUsersCount += 1
         invokedSyncAttributesForAllUsersParameters = (currentAppUserID, ())
         invokedSyncAttributesForAllUsersParametersList.append((currentAppUserID, ()))
+        syncedAttribute?(stubbedSyncAttributesForAllUsersError)
         completion?()
 
         return -1

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncAttributesAndOfferingsIfNeededTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncAttributesAndOfferingsIfNeededTests.swift
@@ -80,6 +80,21 @@ class PurchasesSyncAttributesAndOfferingsTests: BasePurchasesTests {
         expect(self.mockOfferingsManager.invokedOfferingsCount) == 0
     }
 
+    func testAttributeSyncErrorCompletionIsCalledOnMainThread() {
+        self.setupPurchases()
+        self.subscriberAttributesManager.stubbedSyncAttributesForAllUsersError = ErrorUtils.networkError()
+
+        let completionCalled = self.expectation(description: "Completion called")
+        DispatchQueue.global().async {
+            self.purchases.syncAttributesAndOfferingsIfNeeded { _, _ in
+                expect(Thread.isMainThread).to(beTrue())
+                completionCalled.fulfill()
+            }
+        }
+
+        self.wait(for: [completionCalled], timeout: 1)
+    }
+
     func testAttributeSyncErrorIsThrownWithoutFetchingOfferingsAsync() async {
         self.setupPurchases()
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncAttributesAndOfferingsIfNeededTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncAttributesAndOfferingsIfNeededTests.swift
@@ -54,6 +54,123 @@ class PurchasesSyncAttributesAndOfferingsTests: BasePurchasesTests {
         expect(self.mockOfferingsManager.invokedOfferingsCount) == 1
     }
 
+    func testAttributeSyncErrorIsReturnedWithoutFetchingOfferings() throws {
+        self.setupPurchases()
+
+        let expectedError = ErrorUtils.networkError()
+        self.subscriberAttributesManager.stubbedSyncAttributesForAllUsersError = expectedError
+        self.mockOfferingsManager.stubbedOfferingsCompletionResult = .success(
+            try XCTUnwrap(self.offeringsFactory.createOfferings(from: [:],
+                                                                contents: .mockContents,
+                                                                loadedFromDiskCache: false))
+        )
+
+        var receivedOfferings: Offerings?
+        var receivedError: PublicError?
+        waitUntil { completed in
+            self.purchases.syncAttributesAndOfferingsIfNeeded { offerings, error in
+                receivedOfferings = offerings
+                receivedError = error
+                completed()
+            }
+        }
+
+        expect(receivedOfferings).to(beNil())
+        expect(receivedError).to(matchError(expectedError))
+        expect(self.mockOfferingsManager.invokedOfferingsCount) == 0
+    }
+
+    func testAttributeSyncErrorIsThrownWithoutFetchingOfferingsAsync() async {
+        self.setupPurchases()
+
+        let expectedError = ErrorUtils.networkError()
+        self.subscriberAttributesManager.stubbedSyncAttributesForAllUsersError = expectedError
+
+        do {
+            _ = try await self.purchases.syncAttributesAndOfferingsIfNeeded()
+            fail("Expected attribute sync error")
+        } catch {
+            expect(error).to(matchError(expectedError))
+        }
+
+        expect(self.mockOfferingsManager.invokedOfferingsCount) == 0
+    }
+
+    func testReservedAttributeSyncErrorDoesNotPreventFetchingOfferings() throws {
+        self.setupPurchases()
+        self.subscriberAttributesManager.stubbedSyncAttributesForAllUsersError = self.attributeError(
+            code: .invalidSubscriberAttributes,
+            attributeErrors: ["$idfv": "IDFV cannot be modified."]
+        )
+        try self.stubOfferings()
+
+        let result = self.syncAttributesAndOfferings()
+
+        expect(result.offerings).toNot(beNil())
+        expect(result.error).to(beNil())
+        expect(self.mockOfferingsManager.invokedOfferingsCount) == 1
+    }
+
+    func testCustomAttributeSyncErrorIsReturnedWithoutFetchingOfferings() {
+        self.setupPurchases()
+        let expectedError = self.attributeError(
+            code: .invalidSubscriberAttributes,
+            attributeErrors: ["favorite_color": "Value is too long."]
+        )
+        self.subscriberAttributesManager.stubbedSyncAttributesForAllUsersError = expectedError
+
+        let result = self.syncAttributesAndOfferings()
+
+        expect(result.offerings).to(beNil())
+        expect(result.error).to(matchError(expectedError.asPublicError))
+        expect(self.mockOfferingsManager.invokedOfferingsCount) == 0
+    }
+
+    func testMixedReservedAndCustomAttributeSyncErrorIsReturnedWithoutFetchingOfferings() {
+        self.setupPurchases()
+        let expectedError = self.attributeError(
+            code: .invalidSubscriberAttributes,
+            attributeErrors: [
+                "$idfv": "IDFV cannot be modified.",
+                "favorite_color": "Value is too long."
+            ]
+        )
+        self.subscriberAttributesManager.stubbedSyncAttributesForAllUsersError = expectedError
+
+        let result = self.syncAttributesAndOfferings()
+
+        expect(result.offerings).to(beNil())
+        expect(result.error).to(matchError(expectedError.asPublicError))
+        expect(self.mockOfferingsManager.invokedOfferingsCount) == 0
+    }
+
+    func testReservedAttributeSyncErrorWithoutAttributeDetailsIsReturnedWithoutFetchingOfferings() {
+        self.setupPurchases()
+        let expectedError = self.attributeError(code: .invalidSubscriberAttributes, attributeErrors: [:])
+        self.subscriberAttributesManager.stubbedSyncAttributesForAllUsersError = expectedError
+
+        let result = self.syncAttributesAndOfferings()
+
+        expect(result.offerings).to(beNil())
+        expect(result.error).to(matchError(expectedError.asPublicError))
+        expect(self.mockOfferingsManager.invokedOfferingsCount) == 0
+    }
+
+    func testInvalidAttributeBodyErrorForReservedAttributeIsReturnedWithoutFetchingOfferings() {
+        self.setupPurchases()
+        let expectedError = self.attributeError(
+            code: .invalidSubscriberAttributesBody,
+            attributeErrors: ["$idfv": "IDFV cannot be modified."]
+        )
+        self.subscriberAttributesManager.stubbedSyncAttributesForAllUsersError = expectedError
+
+        let result = self.syncAttributesAndOfferings()
+
+        expect(result.offerings).to(beNil())
+        expect(result.error).to(matchError(expectedError.asPublicError))
+        expect(self.mockOfferingsManager.invokedOfferingsCount) == 0
+    }
+
     func testRefreshesRemoteConfig() throws {
         self.systemInfo.stubbedRemoteConfigEnabled = true
         self.setupPurchases()
@@ -106,5 +223,30 @@ class PurchasesSyncAttributesAndOfferingsTests: BasePurchasesTests {
                                                                 contents: .mockContents,
                                                                 loadedFromDiskCache: false))
         )
+    }
+
+    private func syncAttributesAndOfferings() -> (offerings: Offerings?, error: PublicError?) {
+        var result: (offerings: Offerings?, error: PublicError?) = (nil, nil)
+
+        waitUntil { completed in
+            self.purchases.syncAttributesAndOfferingsIfNeeded { offerings, error in
+                result = (offerings, error)
+                completed()
+            }
+        }
+
+        return result
+    }
+
+    private func attributeError(
+        code: BackendErrorCode,
+        attributeErrors: [String: String]
+    ) -> PurchasesError {
+        return ErrorResponse(
+            code: code,
+            originalCode: code.rawValue,
+            message: "Invalid attributes",
+            attributeErrors: attributeErrors
+        ).asBackendError(with: .invalidRequest)
     }
 }


### PR DESCRIPTION
## Description
Currently `syncAttributesAndOfferingsIfNeeded()` does not actually return an error if attribute syncing fails. Which is unexpected if you're trying to sync attributes that are expected to influence the offerings returned. 

This PR fixes this by returning the error returned from syncing attributes, before attempting to refresh the offerings. Ensuring that the error is surfaced correctly.

## Changes
We will now treat any error received during attribute syncing as fatal, thus returning and not continuing with fetching offerings, with one exception.

(Some) reserved attributes can only be set once, and any subsequent sync of an updated value will result in an error. Therefore we will treat these as non fatal, so if a sync results in errors only from reserved attributes, we'll still consider it a success and continue. This of course does not apply if any other errors are also encountered.

Android counterpart: RevenueCat/purchases-android#4129

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public behavior of a common identity/offerings API—apps may now see errors and miss offerings where sync previously succeeded silently—but scope is limited to attribute-sync failure handling with a deliberate reserved-attribute carve-out.
> 
> **Overview**
> **`syncAttributesAndOfferingsIfNeeded`** now fails fast when subscriber attribute sync hits a **blocking** error: it returns `(nil, error)` on the main thread and **does not** fetch offerings. Blocking errors include network failures, non-attribute backend errors, custom (non-`$`) attribute validation failures, mixed reserved+custom failures, and `invalidSubscriberAttributes` responses with no per-key details.
> 
> The exception is **`invalidSubscriberAttributes`** where **every** failing key is a reserved **`$…`** attribute (e.g. `$idfv`): those sync failures are treated as non-blocking and offerings are still loaded after remote config refresh, matching the idea that some reserved values cannot be overwritten.
> 
> Tests and **`MockSubscriberAttributesManager`** were extended to simulate per-sync errors via **`syncedAttribute`** and cover blocking vs non-blocking cases for completion, async, and main-thread delivery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83f4bd4c5e8f03206f2182435113bf52609447a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->