### PR TITLE
Chore(Paywalls): Create Web View Context - #7530

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -80,7 +80,7 @@
 		F60718293A4B5C03D02A2 /* SplitOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60718293A4B5C03D02A1 /* SplitOperator.swift */; };
 		B2C3D4E5F60718293A4B5C02 /* RootVarOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F60718293A4B5C01 /* RootVarOperator.swift */; };
 		0F4E490A741F00F18C4985D8 /* WebViewSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CC1CD0385BF18D1392EB43 /* WebViewSession.swift */; };
-		A0F100000000000000000002 /* PaywallWebViewContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F100000000000000000001 /* PaywallWebViewContext.swift */; };
+		A0F100000000000000000002 /* PaywallWebViewStaticContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F100000000000000000001 /* PaywallWebViewStaticContext.swift */; };
 		116EA498A344F7446083E8C5 /* EqualityOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41EEB3B4E7701F8CC8B811A9 /* EqualityOperators.swift */; };
 		11CC2EA83C56933E40D8E5D8 /* WebViewEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89DD761C9E00E61032AAEB44 /* WebViewEnvelope.swift */; };
 		150BEBF14F59182317CDA8DA /* WorkflowContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = F598F832810DB534092FBED3 /* WorkflowContext.swift */; };
@@ -3007,7 +3007,7 @@
 		9D09F3CA2E3A859A0002840E /* sr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sr; path = sr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9D09F3CB2E3A859A0002840F /* sr_Latn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sr_Latn; path = sr_Latn.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9D09F3CC2E3A859A00028410 /* sl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sl; path = sl.lproj/Localizable.strings; sourceTree = "<group>"; };
-		A0F100000000000000000001 /* PaywallWebViewContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallWebViewContext.swift; sourceTree = "<group>"; };
+		A0F100000000000000000001 /* PaywallWebViewStaticContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallWebViewStaticContext.swift; sourceTree = "<group>"; };
 		A0F100000000000000000003 /* PaywallWebViewContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallWebViewContextTests.swift; sourceTree = "<group>"; };
 		9D0C57ECDF0E7F1A5B4418FF /* PaywallWebViewValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallWebViewValue.swift; sourceTree = "<group>"; };
 		9E7AD021B4580265DFDF6A02 /* WebViewNavigationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewNavigationPolicyTests.swift; sourceTree = "<group>"; };
@@ -3756,7 +3756,7 @@
 			isa = PBXGroup;
 			children = (
 				28661C6CE3F64078A0138080 /* WebViewOriginPolicy.swift */,
-				A0F100000000000000000001 /* PaywallWebViewContext.swift */,
+				A0F100000000000000000001 /* PaywallWebViewStaticContext.swift */,
 				9D0C57ECDF0E7F1A5B4418FF /* PaywallWebViewValue.swift */,
 				89DD761C9E00E61032AAEB44 /* WebViewEnvelope.swift */,
 				72CC1CD0385BF18D1392EB43 /* WebViewSession.swift */,
@@ -8809,7 +8809,7 @@
 				887A60D02C1D037000E1A461 /* View+PurchaseRestoreCompleted.swift in Sources */,
 				03C72F8D2D3311E300297FEC /* DisplayableColor.swift in Sources */,
 				887A60CD2C1D037000E1A461 /* PaywallView.swift in Sources */,
-				A0F100000000000000000002 /* PaywallWebViewContext.swift in Sources */,
+				A0F100000000000000000002 /* PaywallWebViewStaticContext.swift in Sources */,
 				887A60C12C1D037000E1A461 /* DebugErrorView.swift in Sources */,
 				887A607C2C1D037000E1A461 /* ColorInformation+MultiScheme.swift in Sources */,
 				839F343B2E3BC5C8006355B0 /* PlatformBezierPath.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		F60718293A4B5C03D02A2 /* SplitOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60718293A4B5C03D02A1 /* SplitOperator.swift */; };
 		B2C3D4E5F60718293A4B5C02 /* RootVarOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F60718293A4B5C01 /* RootVarOperator.swift */; };
 		0F4E490A741F00F18C4985D8 /* WebViewSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CC1CD0385BF18D1392EB43 /* WebViewSession.swift */; };
+		A0F100000000000000000002 /* PaywallWebViewContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F100000000000000000001 /* PaywallWebViewContext.swift */; };
 		116EA498A344F7446083E8C5 /* EqualityOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41EEB3B4E7701F8CC8B811A9 /* EqualityOperators.swift */; };
 		11CC2EA83C56933E40D8E5D8 /* WebViewEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89DD761C9E00E61032AAEB44 /* WebViewEnvelope.swift */; };
 		150BEBF14F59182317CDA8DA /* WorkflowContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = F598F832810DB534092FBED3 /* WorkflowContext.swift */; };
@@ -3006,6 +3007,8 @@
 		9D09F3CA2E3A859A0002840E /* sr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sr; path = sr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9D09F3CB2E3A859A0002840F /* sr_Latn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sr_Latn; path = sr_Latn.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9D09F3CC2E3A859A00028410 /* sl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sl; path = sl.lproj/Localizable.strings; sourceTree = "<group>"; };
+		A0F100000000000000000001 /* PaywallWebViewContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallWebViewContext.swift; sourceTree = "<group>"; };
+		A0F100000000000000000003 /* PaywallWebViewContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallWebViewContextTests.swift; sourceTree = "<group>"; };
 		9D0C57ECDF0E7F1A5B4418FF /* PaywallWebViewValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallWebViewValue.swift; sourceTree = "<group>"; };
 		9E7AD021B4580265DFDF6A02 /* WebViewNavigationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewNavigationPolicyTests.swift; sourceTree = "<group>"; };
 		9F2A6D48C1B34E7295D8F0A3 /* BrowserNavigateToTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserNavigateToTests.swift; sourceTree = "<group>"; };
@@ -3476,6 +3479,7 @@
 				C3E609D42BFA15783D609EB2 /* WebViewInstanceTests.swift */,
 				9E7AD021B4580265DFDF6A02 /* WebViewNavigationPolicyTests.swift */,
 				AAB0C0DE00000000000A0601 /* WebViewOriginTests.swift */,
+				A0F100000000000000000003 /* PaywallWebViewContextTests.swift */,
 				686562C08D953A27986DB276 /* PaywallWebViewValueTests.swift */,
 				C1B939C7DAAFEA1DE2DE2674 /* WebViewEnvelopeTests.swift */,
 				F75819E258F47D1DB058500D /* WebViewSessionTests.swift */,
@@ -3752,6 +3756,7 @@
 			isa = PBXGroup;
 			children = (
 				28661C6CE3F64078A0138080 /* WebViewOriginPolicy.swift */,
+				A0F100000000000000000001 /* PaywallWebViewContext.swift */,
 				9D0C57ECDF0E7F1A5B4418FF /* PaywallWebViewValue.swift */,
 				89DD761C9E00E61032AAEB44 /* WebViewEnvelope.swift */,
 				72CC1CD0385BF18D1392EB43 /* WebViewSession.swift */,
@@ -8804,6 +8809,7 @@
 				887A60D02C1D037000E1A461 /* View+PurchaseRestoreCompleted.swift in Sources */,
 				03C72F8D2D3311E300297FEC /* DisplayableColor.swift in Sources */,
 				887A60CD2C1D037000E1A461 /* PaywallView.swift in Sources */,
+				A0F100000000000000000002 /* PaywallWebViewContext.swift in Sources */,
 				887A60C12C1D037000E1A461 /* DebugErrorView.swift in Sources */,
 				887A607C2C1D037000E1A461 /* ColorInformation+MultiScheme.swift in Sources */,
 				839F343B2E3BC5C8006355B0 /* PlatformBezierPath.swift in Sources */,

--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -119,6 +119,7 @@ enum Strings {
     case paywall_web_view_load_failed(String)
     case paywall_web_view_http_error(statusCode: Int)
     case web_view_data_store_removal_failed(UUID, Error)
+    case web_view_context_encoding_failed(Error)
 
     // Exit Offers
     case errorFetchingOfferings(Error)
@@ -442,6 +443,8 @@ extension Strings: CustomStringConvertible {
             "its offerings-provided paywall."
         case .purchases_did_configure:
             return "Purchases notified purchases-ui of configuration"
+        case .web_view_context_encoding_failed(let error):
+            return "Encoding web view context failed with error: \(error)"
         }
     }
 

--- a/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewStaticContext.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewStaticContext.swift
@@ -136,10 +136,6 @@ struct PaywallWebViewStaticContext {
     private static let storeTypes: [Store: String] = [
         .appStore: "app_store",
         .macAppStore: "mac_app_store",
-        .stripe: "stripe",
-        .rcBilling: "rc_billing",
-        .external: "external",
-        .paddle: "paddle",
         .testStore: "test_store"
     ]
 

--- a/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewStaticContext.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewStaticContext.swift
@@ -70,7 +70,7 @@ struct PaywallWebViewStaticContext {
             packages: .array(self.packages.map(self.packageValue)),
             package: package.map(self.packageValue) ?? .null,
             selectedPackage: selectedPackage.map(self.packageValue) ?? .null,
-            workflow: self.workflow.map(Self.workflowValue) ?? .null,
+            workflow: self.workflow.map(Self.workflowValue),
             localeIdentifier: locale.identifier,
             isDarkMode: isDarkMode
         )
@@ -78,27 +78,34 @@ struct PaywallWebViewStaticContext {
 
     private func packageValue(_ package: Package) -> PaywallWebViewValue {
         let product = package.storeProduct
-        let period = product.subscriptionPeriod.map(Self.isoPeriod)
+        let period = product.subscriptionPeriod.flatMap(Self.isoPeriod)
+        var store: [String: PaywallWebViewValue] = [
+            "store_type": .string(self.store)
+        ]
+        if let storefrontCountryCode = self.storefrontCountryCode {
+            store["country"] = .string(storefrontCountryCode)
+        }
+
+        var productValue: [String: PaywallWebViewValue] = [
+            "identifier": .string(product.productIdentifier),
+            "store": .object(store),
+            "display_name": .string(product.localizedTitle),
+            "is_subscription": .bool(product.productCategory == .subscription),
+            "is_family_shareable": .bool(product.isFamilyShareable),
+            "is_auto_renewing": .bool(product.subscriptionPeriod != nil), // accounts for both sk1 and sk2
+            "price": .object([
+                "amount": .number(Self.doubleValue(product.price)),
+                "currency": product.currencyCode.map(PaywallWebViewValue.string) ?? .null
+            ])
+        ]
+        if let period {
+            productValue["period"] = .string(period)
+        }
 
         return .object([
             "identifier": .string(package.identifier),
             "products": .array([
-                .object([
-                    "identifier": .string(product.productIdentifier),
-                    "store": .object([
-                        "store_type": .string(self.store),
-                        "country": self.storefrontCountryCode.map(PaywallWebViewValue.string) ?? .null
-                    ]),
-                    "display_name": .string(product.localizedTitle),
-                    "is_subscription": .bool(product.productCategory == .subscription),
-                    "period": period.map(PaywallWebViewValue.string) ?? .null,
-                    "is_family_shareable": .bool(product.isFamilyShareable),
-                    "is_auto_renewing": .bool(product.subscriptionPeriod != nil), // accounts for both sk1 and sk2
-                    "price": .object([
-                        "amount": .number(Self.doubleValue(product.price)),
-                        "currency": product.currencyCode.map(PaywallWebViewValue.string) ?? .null
-                    ])
-                ])
+                .object(productValue)
             ])
         ])
     }
@@ -110,7 +117,7 @@ struct PaywallWebViewStaticContext {
             "step_type": workflow.stepType.map(PaywallWebViewValue.string) ?? .null,
             "screen_type": workflow.screenType.map {
                 .array($0.map(PaywallWebViewValue.string))
-            } ?? .null
+            } ?? .array([])
         ])
     }
 
@@ -129,14 +136,14 @@ struct PaywallWebViewStaticContext {
         return Double(decimalNumber.stringValue) ?? decimalNumber.doubleValue
     }
 
-    private static func isoPeriod(_ period: SubscriptionPeriod) -> String {
+    private static func isoPeriod(_ period: SubscriptionPeriod) -> String? {
         let unit: String
         switch period.unit {
         case .day: unit = "D"
         case .week: unit = "W"
         case .month: unit = "M"
         case .year: unit = "Y"
-        @unknown default: unit = ""
+        @unknown default: return nil
         }
         return "P\(period.value)\(unit)"
     }
@@ -153,21 +160,20 @@ struct PaywallWebViewContext: Equatable {
     let packages: PaywallWebViewValue
     let package: PaywallWebViewValue
     let selectedPackage: PaywallWebViewValue
-    let workflow: PaywallWebViewValue
+    let workflow: PaywallWebViewValue?
     let localeIdentifier: String
     let isDarkMode: Bool
 
     func payload(updatedAt date: Date) -> [String: PaywallWebViewValue] {
         let updatedAtMilliseconds = floor(date.timeIntervalSince1970 * 1_000)
 
-        return [
+        var payload: [String: PaywallWebViewValue] = [
             "custom": self.custom,
             "inputs": self.inputs,
             "offering": self.offering,
             "packages": self.packages,
             "package": self.package,
             "selected_package": self.selectedPackage,
-            "workflow": self.workflow,
             "device_meta": .object([
                 "is_preview": .bool(false),
                 "locale": .string(self.localeIdentifier),
@@ -175,6 +181,10 @@ struct PaywallWebViewContext: Equatable {
                 "updated_at": .number(updatedAtMilliseconds)
             ])
         ]
+        if let workflow = self.workflow {
+            payload["workflow"] = workflow
+        }
+        return payload
     }
 
     func payloadJSON(updatedAt date: Date = .now, encoder: JSONEncoder = .init()) -> String? {

--- a/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewStaticContext.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewStaticContext.swift
@@ -28,6 +28,9 @@ struct PaywallWebViewStaticContext {
     let workflow: Workflow?
     let storefrontCountryCode: String?
 
+    // inputs are not yet supported. However the contract requires this data.
+    let inputs: [String: String] = [:]
+
     init(
         offering: Offering,
         packages: [Package],
@@ -56,6 +59,7 @@ struct PaywallWebViewStaticContext {
 
         return .init(
             custom: .object(customVariables.mapValues(Self.webValue)),
+            inputs: .object(self.inputs.mapValues(PaywallWebViewValue.string)),
             offering: .object([
                 "identifier": .string(self.offeringIdentifier),
                 "display_name": .string(self.offeringDisplayName)
@@ -141,6 +145,7 @@ struct PaywallWebViewStaticContext {
 struct PaywallWebViewContext: Equatable {
 
     let custom: PaywallWebViewValue
+    let inputs: PaywallWebViewValue
     let offering: PaywallWebViewValue
     let packages: PaywallWebViewValue
     let package: PaywallWebViewValue
@@ -154,6 +159,7 @@ struct PaywallWebViewContext: Equatable {
 
         return [
             "custom": self.custom,
+            "inputs": self.inputs,
             "offering": self.offering,
             "packages": self.packages,
             "package": self.package,

--- a/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewStaticContext.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewStaticContext.swift
@@ -1,0 +1,188 @@
+//
+//  PaywallWebViewStaticContext.swift
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Created by Jacob Zivan Rakidzich on 8/28/26.
+//
+
+import Foundation
+@_spi(Internal) import RevenueCat
+import SwiftUI
+
+#if !os(tvOS) // For Paywalls V2
+
+/// Page-level inputs that are shared by every web view in a rendered paywall.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct PaywallWebViewStaticContext {
+
+    struct Workflow {
+        let id: String
+        let stepID: String
+        let stepType: String?
+        let screenType: [String]?
+    }
+
+    let offeringIdentifier: String
+    let offeringDisplayName: String
+    let packages: [Package]
+    let workflow: Workflow?
+    let storefrontCountryCode: String?
+
+    init(
+        offering: Offering,
+        packages: [Package],
+        workflow: Workflow?,
+        storefrontCountryCode: String?
+    ) {
+        var identifiers = Set<String>()
+
+        self.offeringIdentifier = offering.identifier
+        self.offeringDisplayName = offering.serverDescription
+        self.packages = packages.filter { identifiers.insert($0.identifier).inserted }
+        self.workflow = workflow
+        self.storefrontCountryCode = storefrontCountryCode
+    }
+
+    func snapshot(
+        package: Package?,
+        selectedPackageID: String?,
+        customVariables: [String: CustomVariableValue],
+        locale: Locale,
+        isDarkMode: Bool
+    ) -> PaywallWebViewContext {
+        let selectedPackage = selectedPackageID.flatMap { identifier in
+            self.packages.first { $0.identifier == identifier }
+        }
+
+        return .init(
+            custom: .object(customVariables.mapValues(Self.webValue)),
+            offering: .object([
+                "identifier": .string(self.offeringIdentifier),
+                "display_name": .string(self.offeringDisplayName)
+            ]),
+            packages: .array(self.packages.map(self.packageValue)),
+            package: package.map(self.packageValue) ?? .null,
+            selectedPackage: selectedPackage.map(self.packageValue) ?? .null,
+            workflow: self.workflow.map(Self.workflowValue) ?? .null,
+            localeIdentifier: locale.identifier,
+            isDarkMode: isDarkMode
+        )
+    }
+
+    private func packageValue(_ package: Package) -> PaywallWebViewValue {
+        let product = package.storeProduct
+        let period = product.subscriptionPeriod.map(Self.isoPeriod)
+
+        return .object([
+            "identifier": .string(package.identifier),
+            "products": .array([
+                .object([
+                    "identifier": .string(product.productIdentifier),
+                    "store": .object([
+                        "store_type": .string("app_store"),
+                        "country": self.storefrontCountryCode.map(PaywallWebViewValue.string) ?? .null
+                    ]),
+                    "display_name": .string(product.localizedTitle),
+                    "is_subscription": .bool(product.productCategory == .subscription),
+                    "period": period.map(PaywallWebViewValue.string) ?? .null,
+                    "is_family_shareable": .bool(product.isFamilyShareable),
+                    "is_auto_renewing": .bool(product.productType == .autoRenewableSubscription),
+                    "price": .object([
+                        "amount": .number(Self.doubleValue(product.price)),
+                        "currency": product.currencyCode.map(PaywallWebViewValue.string) ?? .null
+                    ])
+                ])
+            ])
+        ])
+    }
+
+    private static func workflowValue(_ workflow: Workflow) -> PaywallWebViewValue {
+        return .object([
+            "workflow_id": .string(workflow.id),
+            "step_id": .string(workflow.stepID),
+            "step_type": workflow.stepType.map(PaywallWebViewValue.string) ?? .null,
+            "screen_type": workflow.screenType.map {
+                .array($0.map(PaywallWebViewValue.string))
+            } ?? .null
+        ])
+    }
+
+    private static func webValue(_ value: CustomVariableValue) -> PaywallWebViewValue {
+        return value.map(
+            string: PaywallWebViewValue.string,
+            number: PaywallWebViewValue.number,
+            boolean: PaywallWebViewValue.bool
+        )
+    }
+
+    private static func doubleValue(_ value: Decimal) -> Double {
+        // Converting through the decimal string avoids visible JSON artifacts such as
+        // `53.989999999999995`. The result remains a `Double` because JavaScript uses `Number`.
+        let decimalNumber = NSDecimalNumber(decimal: value)
+        return Double(decimalNumber.stringValue) ?? decimalNumber.doubleValue
+    }
+
+    private static func isoPeriod(_ period: SubscriptionPeriod) -> String {
+        let unit: String
+        switch period.unit {
+        case .day: unit = "D"
+        case .week: unit = "W"
+        case .month: unit = "M"
+        case .year: unit = "Y"
+        @unknown default: unit = ""
+        }
+        return "P\(period.value)\(unit)"
+    }
+
+}
+
+/// Semantic context delivered to a web view. `updated_at` is added only when the packet is sent.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct PaywallWebViewContext: Equatable {
+
+    let custom: PaywallWebViewValue
+    let offering: PaywallWebViewValue
+    let packages: PaywallWebViewValue
+    let package: PaywallWebViewValue
+    let selectedPackage: PaywallWebViewValue
+    let workflow: PaywallWebViewValue
+    let localeIdentifier: String
+    let isDarkMode: Bool
+
+    func payload(updatedAt date: Date) -> [String: PaywallWebViewValue] {
+        let updatedAtMilliseconds = floor(date.timeIntervalSince1970 * 1_000)
+
+        return [
+            "custom": self.custom,
+            "offering": self.offering,
+            "packages": self.packages,
+            "package": self.package,
+            "selected_package": self.selectedPackage,
+            "workflow": self.workflow,
+            "device_meta": .object([
+                "is_preview": .bool(false),
+                "locale": .string(self.localeIdentifier),
+                "dark_mode": .bool(self.isDarkMode),
+                "updated_at": .number(updatedAtMilliseconds)
+            ])
+        ]
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private struct PaywallWebViewStaticContextKey: EnvironmentKey {
+    static let defaultValue: PaywallWebViewStaticContext? = nil
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension EnvironmentValues {
+
+    var paywallWebViewStaticContext: PaywallWebViewStaticContext? {
+        get { self[PaywallWebViewStaticContextKey.self] }
+        set { self[PaywallWebViewStaticContextKey.self] = newValue }
+    }
+
+}
+
+#endif

--- a/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewStaticContext.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewStaticContext.swift
@@ -174,6 +174,16 @@ struct PaywallWebViewContext: Equatable {
         ]
     }
 
+    func payloadJSON(updatedAt date: Date = .now, encoder: JSONEncoder = .init()) -> String? {
+        do {
+            let data = try encoder.encode(payload(updatedAt: date))
+            return String(data: data, encoding: .utf8)
+        } catch {
+            Logger.debug(Strings.web_view_context_encoding_failed(error))
+            return nil
+        }
+    }
+
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewStaticContext.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewStaticContext.swift
@@ -86,6 +86,13 @@ struct PaywallWebViewStaticContext {
             store["country"] = .string(storefrontCountryCode)
         }
 
+        var price: [String: PaywallWebViewValue] = [
+            "amount": .number(Self.doubleValue(product.price))
+        ]
+        if let currencyCode = product.currencyCode {
+            price["currency"] = .string(currencyCode)
+        }
+
         var productValue: [String: PaywallWebViewValue] = [
             "identifier": .string(product.productIdentifier),
             "store": .object(store),
@@ -93,10 +100,7 @@ struct PaywallWebViewStaticContext {
             "is_subscription": .bool(product.productCategory == .subscription),
             "is_family_shareable": .bool(product.isFamilyShareable),
             "is_auto_renewing": .bool(product.subscriptionPeriod != nil), // accounts for both sk1 and sk2
-            "price": .object([
-                "amount": .number(Self.doubleValue(product.price)),
-                "currency": product.currencyCode.map(PaywallWebViewValue.string) ?? .null
-            ])
+            "price": .object(price)
         ]
         if let period {
             productValue["period"] = .string(period)

--- a/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewStaticContext.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewStaticContext.swift
@@ -90,7 +90,7 @@ struct PaywallWebViewStaticContext {
                     "is_subscription": .bool(product.productCategory == .subscription),
                     "period": period.map(PaywallWebViewValue.string) ?? .null,
                     "is_family_shareable": .bool(product.isFamilyShareable),
-                    "is_auto_renewing": .bool(product.subscriptionPeriod != nil),
+                    "is_auto_renewing": .bool(product.subscriptionPeriod != nil), // accounts for both sk1 and sk2
                     "price": .object([
                         "amount": .number(Self.doubleValue(product.price)),
                         "currency": product.currencyCode.map(PaywallWebViewValue.string) ?? .null

--- a/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewStaticContext.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewStaticContext.swift
@@ -26,7 +26,7 @@ struct PaywallWebViewStaticContext {
     let offeringDisplayName: String
     let packages: [Package]
     let workflow: Workflow?
-    let store: Store
+    let store: String
     let storefrontCountryCode: String?
 
     // inputs are not yet supported. However the contract requires this data.
@@ -36,7 +36,7 @@ struct PaywallWebViewStaticContext {
         offering: Offering,
         packages: [Package],
         workflow: Workflow?,
-        store: Store,
+        store: String,
         storefrontCountryCode: String?
     ) {
         var identifiers = Set<String>()
@@ -86,7 +86,7 @@ struct PaywallWebViewStaticContext {
                 .object([
                     "identifier": .string(product.productIdentifier),
                     "store": .object([
-                        "store_type": .string(Self.storeType(self.store)),
+                        "store_type": .string(self.store),
                         "country": self.storefrontCountryCode.map(PaywallWebViewValue.string) ?? .null
                     ]),
                     "display_name": .string(product.localizedTitle),
@@ -128,16 +128,6 @@ struct PaywallWebViewStaticContext {
         let decimalNumber = NSDecimalNumber(decimal: value)
         return Double(decimalNumber.stringValue) ?? decimalNumber.doubleValue
     }
-
-    private static func storeType(_ store: Store) -> String {
-        return self.storeTypes[store] ?? "unknown"
-    }
-
-    private static let storeTypes: [Store: String] = [
-        .appStore: "app_store",
-        .macAppStore: "mac_app_store",
-        .testStore: "test_store"
-    ]
 
     private static func isoPeriod(_ period: SubscriptionPeriod) -> String {
         let unit: String

--- a/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewStaticContext.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewStaticContext.swift
@@ -90,7 +90,7 @@ struct PaywallWebViewStaticContext {
                     "is_subscription": .bool(product.productCategory == .subscription),
                     "period": period.map(PaywallWebViewValue.string) ?? .null,
                     "is_family_shareable": .bool(product.isFamilyShareable),
-                    "is_auto_renewing": .bool(product.productType == .autoRenewableSubscription),
+                    "is_auto_renewing": .bool(product.subscriptionPeriod != nil),
                     "price": .object([
                         "amount": .number(Self.doubleValue(product.price)),
                         "currency": product.currencyCode.map(PaywallWebViewValue.string) ?? .null

--- a/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewStaticContext.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewStaticContext.swift
@@ -26,6 +26,7 @@ struct PaywallWebViewStaticContext {
     let offeringDisplayName: String
     let packages: [Package]
     let workflow: Workflow?
+    let store: Store
     let storefrontCountryCode: String?
 
     // inputs are not yet supported. However the contract requires this data.
@@ -35,6 +36,7 @@ struct PaywallWebViewStaticContext {
         offering: Offering,
         packages: [Package],
         workflow: Workflow?,
+        store: Store,
         storefrontCountryCode: String?
     ) {
         var identifiers = Set<String>()
@@ -43,6 +45,7 @@ struct PaywallWebViewStaticContext {
         self.offeringDisplayName = offering.serverDescription
         self.packages = packages.filter { identifiers.insert($0.identifier).inserted }
         self.workflow = workflow
+        self.store = store
         self.storefrontCountryCode = storefrontCountryCode
     }
 
@@ -83,7 +86,7 @@ struct PaywallWebViewStaticContext {
                 .object([
                     "identifier": .string(product.productIdentifier),
                     "store": .object([
-                        "store_type": .string("app_store"),
+                        "store_type": .string(Self.storeType(self.store)),
                         "country": self.storefrontCountryCode.map(PaywallWebViewValue.string) ?? .null
                     ]),
                     "display_name": .string(product.localizedTitle),
@@ -125,6 +128,20 @@ struct PaywallWebViewStaticContext {
         let decimalNumber = NSDecimalNumber(decimal: value)
         return Double(decimalNumber.stringValue) ?? decimalNumber.doubleValue
     }
+
+    private static func storeType(_ store: Store) -> String {
+        return self.storeTypes[store] ?? "unknown"
+    }
+
+    private static let storeTypes: [Store: String] = [
+        .appStore: "app_store",
+        .macAppStore: "mac_app_store",
+        .stripe: "stripe",
+        .rcBilling: "rc_billing",
+        .external: "external",
+        .paddle: "paddle",
+        .testStore: "test_store"
+    ]
 
     private static func isoPeriod(_ period: SubscriptionPeriod) -> String {
         let unit: String

--- a/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewStaticContext.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/PaywallWebViewStaticContext.swift
@@ -71,7 +71,7 @@ struct PaywallWebViewStaticContext {
             package: package.map(self.packageValue) ?? .null,
             selectedPackage: selectedPackage.map(self.packageValue) ?? .null,
             workflow: self.workflow.map(Self.workflowValue),
-            localeIdentifier: locale.identifier,
+            localeIdentifier: Self.bcp47Identifier(for: locale),
             isDarkMode: isDarkMode
         )
     }
@@ -134,6 +134,14 @@ struct PaywallWebViewStaticContext {
         // `53.989999999999995`. The result remains a `Double` because JavaScript uses `Number`.
         let decimalNumber = NSDecimalNumber(decimal: value)
         return Double(decimalNumber.stringValue) ?? decimalNumber.doubleValue
+    }
+
+    private static func bcp47Identifier(for locale: Locale) -> String {
+        if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+            return Locale.identifier(.bcp47, from: locale.identifier)
+        } else {
+            return Locale.canonicalLanguageIdentifier(from: locale.identifier)
+        }
     }
 
     private static func isoPeriod(_ period: SubscriptionPeriod) -> String? {

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewContextTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewContextTests.swift
@@ -118,11 +118,13 @@ final class PaywallWebViewContextTests: TestCase {
         let productValue = try self.productValue(
             productType: .nonConsumable,
             subscriptionPeriod: nil,
-            storefrontCountryCode: nil
+            storefrontCountryCode: nil,
+            currencyCode: nil
         )
 
         XCTAssertNil(productValue["period"])
         XCTAssertNil(productValue["store"]?.objectValue?["country"])
+        XCTAssertNil(productValue["price"]?.objectValue?["currency"])
     }
 
     func testSnapshotUsesEmptyScreenTypeWhenUnavailable() throws {
@@ -294,13 +296,15 @@ final class PaywallWebViewContextTests: TestCase {
         productType: StoreProduct.ProductType,
         subscriptionPeriod: SubscriptionPeriod?,
         store: String = "app_store",
-        storefrontCountryCode: String? = "USA"
+        storefrontCountryCode: String? = "USA",
+        currencyCode: String? = "USD"
     ) throws -> [String: PaywallWebViewValue] {
         let context = self.context(
             productType: productType,
             subscriptionPeriod: subscriptionPeriod,
             store: store,
-            storefrontCountryCode: storefrontCountryCode
+            storefrontCountryCode: storefrontCountryCode,
+            currencyCode: currencyCode
         )
         return try XCTUnwrap(
             context.packages.arrayValue?.first?
@@ -315,12 +319,13 @@ final class PaywallWebViewContextTests: TestCase {
         workflow: PaywallWebViewStaticContext.Workflow? = nil,
         store: String = "app_store",
         storefrontCountryCode: String? = "USA",
+        currencyCode: String? = "USD",
         locale: Locale = Locale(identifier: "en_US")
     ) -> PaywallWebViewContext {
-        let product = TestStoreProduct(
+        var product = TestStoreProduct(
             localizedTitle: "Test",
             price: 1.99,
-            currencyCode: "USD",
+            currencyCode: currencyCode ?? "",
             localizedPriceString: "$1.99",
             productIdentifier: "com.revenuecat.test",
             productType: productType,
@@ -328,6 +333,7 @@ final class PaywallWebViewContextTests: TestCase {
             subscriptionPeriod: subscriptionPeriod,
             locale: Locale(identifier: "en_US")
         )
+        product.currencyCode = currencyCode
         let package = Package(
             identifier: "$rc_custom",
             packageType: .custom,

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewContextTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewContextTests.swift
@@ -140,6 +140,17 @@ final class PaywallWebViewContextTests: TestCase {
         XCTAssertEqual(context.workflow?.objectValue?["screen_type"], .array([]))
     }
 
+    func testSnapshotUsesBCP47LocaleIdentifier() {
+        let context = self.context(
+            productType: .nonConsumable,
+            subscriptionPeriod: nil,
+            locale: Locale(identifier: "sr_Latn_RS")
+        )
+
+        let locale = context.payload(updatedAt: .now)["device_meta"]?.objectValue?["locale"]
+        XCTAssertEqual(locale?.stringValue, "sr-Latn-RS")
+    }
+
     private static let expectedPayload = """
     {
       "custom" : {
@@ -150,7 +161,7 @@ final class PaywallWebViewContextTests: TestCase {
       "device_meta" : {
         "dark_mode" : true,
         "is_preview" : false,
-        "locale" : "en_US",
+        "locale" : "en-US",
         "updated_at" : 1787000000000
       },
       "inputs" : {
@@ -303,7 +314,8 @@ final class PaywallWebViewContextTests: TestCase {
         subscriptionPeriod: SubscriptionPeriod?,
         workflow: PaywallWebViewStaticContext.Workflow? = nil,
         store: String = "app_store",
-        storefrontCountryCode: String? = "USA"
+        storefrontCountryCode: String? = "USA",
+        locale: Locale = Locale(identifier: "en_US")
     ) -> PaywallWebViewContext {
         let product = TestStoreProduct(
             localizedTitle: "Test",
@@ -339,7 +351,7 @@ final class PaywallWebViewContextTests: TestCase {
             package: package,
             selectedPackageID: nil,
             customVariables: [:],
-            locale: Locale(identifier: "en_US"),
+            locale: locale,
             isDarkMode: false
         )
         return context

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewContextTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewContextTests.swift
@@ -104,6 +104,42 @@ final class PaywallWebViewContextTests: TestCase {
         XCTAssertEqual(productValue["store"]?.objectValue?["store_type"]?.stringValue, "test_store")
     }
 
+    func testSnapshotOmitsUnavailableWorkflow() throws {
+        let context = self.context(
+            productType: .nonConsumable,
+            subscriptionPeriod: nil,
+            workflow: nil
+        )
+
+        XCTAssertNil(context.payload(updatedAt: .now)["workflow"])
+    }
+
+    func testSnapshotOmitsUnavailableProductValues() throws {
+        let productValue = try self.productValue(
+            productType: .nonConsumable,
+            subscriptionPeriod: nil,
+            storefrontCountryCode: nil
+        )
+
+        XCTAssertNil(productValue["period"])
+        XCTAssertNil(productValue["store"]?.objectValue?["country"])
+    }
+
+    func testSnapshotUsesEmptyScreenTypeWhenUnavailable() throws {
+        let context = self.context(
+            productType: .nonConsumable,
+            subscriptionPeriod: nil,
+            workflow: .init(
+                id: "wf_123",
+                stepID: "step_paywall",
+                stepType: "screen",
+                screenType: nil
+            )
+        )
+
+        XCTAssertEqual(context.workflow?.objectValue?["screen_type"], .array([]))
+    }
+
     private static let expectedPayload = """
     {
       "custom" : {
@@ -246,8 +282,29 @@ final class PaywallWebViewContextTests: TestCase {
     private func productValue(
         productType: StoreProduct.ProductType,
         subscriptionPeriod: SubscriptionPeriod?,
-        store: String = "app_store"
+        store: String = "app_store",
+        storefrontCountryCode: String? = "USA"
     ) throws -> [String: PaywallWebViewValue] {
+        let context = self.context(
+            productType: productType,
+            subscriptionPeriod: subscriptionPeriod,
+            store: store,
+            storefrontCountryCode: storefrontCountryCode
+        )
+        return try XCTUnwrap(
+            context.packages.arrayValue?.first?
+                .objectValue?["products"]?.arrayValue?.first?
+                .objectValue
+        )
+    }
+
+    private func context(
+        productType: StoreProduct.ProductType,
+        subscriptionPeriod: SubscriptionPeriod?,
+        workflow: PaywallWebViewStaticContext.Workflow? = nil,
+        store: String = "app_store",
+        storefrontCountryCode: String? = "USA"
+    ) -> PaywallWebViewContext {
         let product = TestStoreProduct(
             localizedTitle: "Test",
             price: 1.99,
@@ -275,9 +332,9 @@ final class PaywallWebViewContextTests: TestCase {
         let context = PaywallWebViewStaticContext(
             offering: offering,
             packages: [package],
-            workflow: nil,
+            workflow: workflow,
             store: store,
-            storefrontCountryCode: "USA"
+            storefrontCountryCode: storefrontCountryCode
         ).snapshot(
             package: package,
             selectedPackageID: nil,
@@ -285,11 +342,7 @@ final class PaywallWebViewContextTests: TestCase {
             locale: Locale(identifier: "en_US"),
             isDarkMode: false
         )
-        return try XCTUnwrap(
-            context.packages.arrayValue?.first?
-                .objectValue?["products"]?.arrayValue?.first?
-                .objectValue
-        )
+        return context
     }
 
 }

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewContextTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewContextTests.swift
@@ -1,0 +1,182 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+
+@_spi(Internal) @testable import RevenueCat
+@testable import RevenueCatUI
+import XCTest
+
+#if !os(tvOS)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+final class PaywallWebViewContextTests: TestCase {
+
+    func testSnapshotJSONMatchesExpectedPayload() throws {
+        let monthly = Self.package(from: TestData.monthlyPackage)
+        let annual = Self.package(from: TestData.annualPackage)
+        let offering = Offering(
+            identifier: "default",
+            serverDescription: "Default",
+            availablePackages: [monthly, annual],
+            webCheckoutUrl: nil
+        )
+        let staticContext = PaywallWebViewStaticContext(
+            offering: offering,
+            packages: [monthly, annual, annual],
+            workflow: .init(
+                id: "wf_123",
+                stepID: "step_paywall",
+                stepType: "screen",
+                screenType: ["paywall"]
+            ),
+            storefrontCountryCode: "USA"
+        )
+
+        let context = staticContext.snapshot(
+            package: annual,
+            selectedPackageID: monthly.identifier,
+            customVariables: [
+                "first_name": .string("Alex"),
+                "streak_days": .number(12),
+                "is_premium": .bool(true)
+            ],
+            locale: Locale(identifier: "en_US"),
+            isDarkMode: true
+        )
+        let payload = context.payload(updatedAt: Date(timeIntervalSince1970: 1_787_000_000))
+
+        let actualData = try JSONEncoder().encode(payload)
+        let actualJSON = try JSONDecoder().decode(PaywallWebViewValue.self, from: actualData)
+        let expectedJSON = try JSONDecoder().decode(
+            PaywallWebViewValue.self,
+            from: Data(Self.expectedPayload.utf8)
+        )
+
+        XCTAssertEqual(actualJSON, expectedJSON)
+    }
+
+    private static let expectedPayload = """
+    {
+      "custom": {
+        "first_name": "Alex",
+        "streak_days": 12,
+        "is_premium": true
+      },
+      "offering": {
+        "identifier": "default",
+        "display_name": "Default"
+      },
+      "packages": [
+        {
+          "identifier": "$rc_monthly",
+          "products": [
+            {
+              "identifier": "com.revenuecat.product_2",
+              "store": {
+                "store_type": "app_store",
+                "country": "USA"
+              },
+              "display_name": "Monthly",
+              "is_subscription": true,
+              "period": "P1M",
+              "is_family_shareable": false,
+              "is_auto_renewing": true,
+              "price": {
+                "amount": 6.99,
+                "currency": "USD"
+              }
+            }
+          ]
+        },
+        {
+          "identifier": "$rc_annual",
+          "products": [
+            {
+              "identifier": "com.revenuecat.product_3",
+              "store": {
+                "store_type": "app_store",
+                "country": "USA"
+              },
+              "display_name": "Annual",
+              "is_subscription": true,
+              "period": "P1Y",
+              "is_family_shareable": false,
+              "is_auto_renewing": true,
+              "price": {
+                "amount": 53.99,
+                "currency": "USD"
+              }
+            }
+          ]
+        }
+      ],
+      "package": {
+        "identifier": "$rc_annual",
+        "products": [
+          {
+            "identifier": "com.revenuecat.product_3",
+            "store": {
+              "store_type": "app_store",
+              "country": "USA"
+            },
+            "display_name": "Annual",
+            "is_subscription": true,
+            "period": "P1Y",
+            "is_family_shareable": false,
+            "is_auto_renewing": true,
+            "price": {
+              "amount": 53.99,
+              "currency": "USD"
+            }
+          }
+        ]
+      },
+      "selected_package": {
+        "identifier": "$rc_monthly",
+        "products": [
+          {
+            "identifier": "com.revenuecat.product_2",
+            "store": {
+              "store_type": "app_store",
+              "country": "USA"
+            },
+            "display_name": "Monthly",
+            "is_subscription": true,
+            "period": "P1M",
+            "is_family_shareable": false,
+            "is_auto_renewing": true,
+            "price": {
+              "amount": 6.99,
+              "currency": "USD"
+            }
+          }
+        ]
+      },
+      "workflow": {
+        "workflow_id": "wf_123",
+        "step_id": "step_paywall",
+        "step_type": "screen",
+        "screen_type": ["paywall"]
+      },
+      "device_meta": {
+        "is_preview": false,
+        "locale": "en_US",
+        "dark_mode": true,
+        "updated_at": 1787000000000
+      }
+    }
+    """
+
+    private static func package(from package: Package) -> Package {
+        return .init(
+            identifier: package.identifier,
+            packageType: package.packageType,
+            storeProduct: package.storeProduct,
+            offeringIdentifier: package.offeringIdentifier,
+            webCheckoutUrl: package.webCheckoutUrl
+        )
+    }
+
+}
+
+#endif

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewContextTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewContextTests.swift
@@ -29,7 +29,7 @@ final class PaywallWebViewContextTests: TestCase {
                 stepType: "screen",
                 screenType: ["paywall"]
             ),
-            store: .appStore,
+            store: "app_store",
             storefrontCountryCode: "USA"
         )
 
@@ -98,7 +98,7 @@ final class PaywallWebViewContextTests: TestCase {
         let productValue = try self.productValue(
             productType: .nonConsumable,
             subscriptionPeriod: nil,
-            store: .testStore
+            store: "test_store"
         )
 
         XCTAssertEqual(productValue["store"]?.objectValue?["store_type"]?.stringValue, "test_store")
@@ -246,7 +246,7 @@ final class PaywallWebViewContextTests: TestCase {
     private func productValue(
         productType: StoreProduct.ProductType,
         subscriptionPeriod: SubscriptionPeriod?,
-        store: Store = .appStore
+        store: String = "app_store"
     ) throws -> [String: PaywallWebViewValue] {
         let product = TestStoreProduct(
             localizedTitle: "Test",

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewContextTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewContextTests.swift
@@ -54,7 +54,23 @@ final class PaywallWebViewContextTests: TestCase {
             )
         )
 
-        XCTAssertEqual(actualPayload, Self.expectedPayload)
+
+    func testSubscriptionPeriodDeterminesAutoRenewalWhenProductTypeIsUnavailable() throws {
+        let isAutoRenewing = try self.autoRenewingValue(
+            productType: .nonConsumable,
+            subscriptionPeriod: .init(value: 1, unit: .month)
+        )
+
+        XCTAssertTrue(isAutoRenewing)
+    }
+
+    func testNonRenewingSubscriptionIsNotAutoRenewing() throws {
+        let isAutoRenewing = try self.autoRenewingValue(
+            productType: .nonRenewableSubscription,
+            subscriptionPeriod: nil
+        )
+
+        XCTAssertFalse(isAutoRenewing)
     }
 
     private static let expectedPayload = """
@@ -182,6 +198,55 @@ final class PaywallWebViewContextTests: TestCase {
             offeringIdentifier: package.offeringIdentifier,
             webCheckoutUrl: package.webCheckoutUrl
         )
+    }
+
+    private func autoRenewingValue(
+        productType: StoreProduct.ProductType,
+        subscriptionPeriod: SubscriptionPeriod?
+    ) throws -> Bool {
+        let product = TestStoreProduct(
+            localizedTitle: "Test",
+            price: 1.99,
+            currencyCode: "USD",
+            localizedPriceString: "$1.99",
+            productIdentifier: "com.revenuecat.test",
+            productType: productType,
+            localizedDescription: "Test product",
+            subscriptionPeriod: subscriptionPeriod,
+            locale: Locale(identifier: "en_US")
+        )
+        let package = Package(
+            identifier: "$rc_custom",
+            packageType: .custom,
+            storeProduct: product.toStoreProduct(),
+            offeringIdentifier: "default",
+            webCheckoutUrl: nil
+        )
+        let offering = Offering(
+            identifier: "default",
+            serverDescription: "Default",
+            availablePackages: [package],
+            webCheckoutUrl: nil
+        )
+        let context = PaywallWebViewStaticContext(
+            offering: offering,
+            packages: [package],
+            workflow: nil,
+            storefrontCountryCode: "USA"
+        ).snapshot(
+            package: package,
+            selectedPackageID: nil,
+            customVariables: [:],
+            locale: Locale(identifier: "en_US"),
+            isDarkMode: false
+        )
+        let productValue = try XCTUnwrap(
+            context.packages.arrayValue?.first?
+                .objectValue?["products"]?.arrayValue?.first?
+                .objectValue
+        )
+
+        return try XCTUnwrap(productValue["is_auto_renewing"]?.boolValue)
     }
 
 }

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewContextTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewContextTests.swift
@@ -45,124 +45,124 @@ final class PaywallWebViewContextTests: TestCase {
         )
         let payload = context.payload(updatedAt: Date(timeIntervalSince1970: 1_787_000_000))
 
-        let actualData = try JSONEncoder().encode(payload)
-        let actualJSON = try JSONDecoder().decode(PaywallWebViewValue.self, from: actualData)
-        let expectedJSON = try JSONDecoder().decode(
-            PaywallWebViewValue.self,
-            from: Data(Self.expectedPayload.utf8)
-        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
 
-        XCTAssertEqual(actualJSON, expectedJSON)
+        let actualPayload = try XCTUnwrap(String(data: encoder.encode(payload), encoding: .utf8))
+
+        XCTAssertEqual(actualPayload, Self.expectedPayload)
     }
 
     private static let expectedPayload = """
     {
-      "custom": {
-        "first_name": "Alex",
-        "streak_days": 12,
-        "is_premium": true
+      "custom" : {
+        "first_name" : "Alex",
+        "is_premium" : true,
+        "streak_days" : 12
       },
-      "offering": {
-        "identifier": "default",
-        "display_name": "Default"
+      "device_meta" : {
+        "dark_mode" : true,
+        "is_preview" : false,
+        "locale" : "en_US",
+        "updated_at" : 1787000000000
       },
-      "packages": [
+      "offering" : {
+        "display_name" : "Default",
+        "identifier" : "default"
+      },
+      "package" : {
+        "identifier" : "$rc_annual",
+        "products" : [
+          {
+            "display_name" : "Annual",
+            "identifier" : "com.revenuecat.product_3",
+            "is_auto_renewing" : true,
+            "is_family_shareable" : false,
+            "is_subscription" : true,
+            "period" : "P1Y",
+            "price" : {
+              "amount" : 53.99,
+              "currency" : "USD"
+            },
+            "store" : {
+              "country" : "USA",
+              "store_type" : "app_store"
+            }
+          }
+        ]
+      },
+      "packages" : [
         {
-          "identifier": "$rc_monthly",
-          "products": [
+          "identifier" : "$rc_monthly",
+          "products" : [
             {
-              "identifier": "com.revenuecat.product_2",
-              "store": {
-                "store_type": "app_store",
-                "country": "USA"
+              "display_name" : "Monthly",
+              "identifier" : "com.revenuecat.product_2",
+              "is_auto_renewing" : true,
+              "is_family_shareable" : false,
+              "is_subscription" : true,
+              "period" : "P1M",
+              "price" : {
+                "amount" : 6.99,
+                "currency" : "USD"
               },
-              "display_name": "Monthly",
-              "is_subscription": true,
-              "period": "P1M",
-              "is_family_shareable": false,
-              "is_auto_renewing": true,
-              "price": {
-                "amount": 6.99,
-                "currency": "USD"
+              "store" : {
+                "country" : "USA",
+                "store_type" : "app_store"
               }
             }
           ]
         },
         {
-          "identifier": "$rc_annual",
-          "products": [
+          "identifier" : "$rc_annual",
+          "products" : [
             {
-              "identifier": "com.revenuecat.product_3",
-              "store": {
-                "store_type": "app_store",
-                "country": "USA"
+              "display_name" : "Annual",
+              "identifier" : "com.revenuecat.product_3",
+              "is_auto_renewing" : true,
+              "is_family_shareable" : false,
+              "is_subscription" : true,
+              "period" : "P1Y",
+              "price" : {
+                "amount" : 53.99,
+                "currency" : "USD"
               },
-              "display_name": "Annual",
-              "is_subscription": true,
-              "period": "P1Y",
-              "is_family_shareable": false,
-              "is_auto_renewing": true,
-              "price": {
-                "amount": 53.99,
-                "currency": "USD"
+              "store" : {
+                "country" : "USA",
+                "store_type" : "app_store"
               }
             }
           ]
         }
       ],
-      "package": {
-        "identifier": "$rc_annual",
-        "products": [
+      "selected_package" : {
+        "identifier" : "$rc_monthly",
+        "products" : [
           {
-            "identifier": "com.revenuecat.product_3",
-            "store": {
-              "store_type": "app_store",
-              "country": "USA"
+            "display_name" : "Monthly",
+            "identifier" : "com.revenuecat.product_2",
+            "is_auto_renewing" : true,
+            "is_family_shareable" : false,
+            "is_subscription" : true,
+            "period" : "P1M",
+            "price" : {
+              "amount" : 6.99,
+              "currency" : "USD"
             },
-            "display_name": "Annual",
-            "is_subscription": true,
-            "period": "P1Y",
-            "is_family_shareable": false,
-            "is_auto_renewing": true,
-            "price": {
-              "amount": 53.99,
-              "currency": "USD"
+            "store" : {
+              "country" : "USA",
+              "store_type" : "app_store"
             }
           }
         ]
       },
-      "selected_package": {
-        "identifier": "$rc_monthly",
-        "products": [
-          {
-            "identifier": "com.revenuecat.product_2",
-            "store": {
-              "store_type": "app_store",
-              "country": "USA"
-            },
-            "display_name": "Monthly",
-            "is_subscription": true,
-            "period": "P1M",
-            "is_family_shareable": false,
-            "is_auto_renewing": true,
-            "price": {
-              "amount": 6.99,
-              "currency": "USD"
-            }
-          }
-        ]
-      },
-      "workflow": {
-        "workflow_id": "wf_123",
-        "step_id": "step_paywall",
-        "step_type": "screen",
-        "screen_type": ["paywall"]
-      },
-      "device_meta": {
-        "is_preview": false,
-        "locale": "en_US",
-        "dark_mode": true,
-        "updated_at": 1787000000000
+      "workflow" : {
+        "screen_type" : [
+          "paywall"
+        ],
+        "step_id" : "step_paywall",
+        "step_type" : "screen",
+        "workflow_id" : "wf_123"
       }
     }
     """

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewContextTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewContextTests.swift
@@ -63,7 +63,7 @@ final class PaywallWebViewContextTests: TestCase {
         }
 
         let decoder = JSONDecoder()
-        let subjectResult = try decoder.decode(
+        let actualResult = try decoder.decode(
             PaywallWebViewValue.self,
             from: Data(actualPayload.utf8)
         )

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewContextTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewContextTests.swift
@@ -43,12 +43,16 @@ final class PaywallWebViewContextTests: TestCase {
             locale: Locale(identifier: "en_US"),
             isDarkMode: true
         )
-        let payload = context.payload(updatedAt: Date(timeIntervalSince1970: 1_787_000_000))
 
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
 
-        let actualPayload = try XCTUnwrap(String(data: encoder.encode(payload), encoding: .utf8))
+        let actualPayload = try XCTUnwrap(
+            context.payloadJSON(
+                updatedAt: Date(timeIntervalSince1970: 1_787_000_000),
+                encoder: encoder
+            )
+        )
 
         XCTAssertEqual(actualPayload, Self.expectedPayload)
     }

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewContextTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewContextTests.swift
@@ -66,6 +66,9 @@ final class PaywallWebViewContextTests: TestCase {
         "locale" : "en_US",
         "updated_at" : 1787000000000
       },
+      "inputs" : {
+
+      },
       "offering" : {
         "display_name" : "Default",
         "identifier" : "default"

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewContextTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewContextTests.swift
@@ -29,6 +29,7 @@ final class PaywallWebViewContextTests: TestCase {
                 stepType: "screen",
                 screenType: ["paywall"]
             ),
+            store: .appStore,
             storefrontCountryCode: "USA"
         )
 
@@ -91,6 +92,16 @@ final class PaywallWebViewContextTests: TestCase {
         )
 
         XCTAssertFalse(isAutoRenewing)
+    }
+
+    func testSnapshotUsesConfiguredTestStore() throws {
+        let productValue = try self.productValue(
+            productType: .nonConsumable,
+            subscriptionPeriod: nil,
+            store: .testStore
+        )
+
+        XCTAssertEqual(productValue["store"]?.objectValue?["store_type"]?.stringValue, "test_store")
     }
 
     private static let expectedPayload = """
@@ -224,6 +235,19 @@ final class PaywallWebViewContextTests: TestCase {
         productType: StoreProduct.ProductType,
         subscriptionPeriod: SubscriptionPeriod?
     ) throws -> Bool {
+        let productValue = try self.productValue(
+            productType: productType,
+            subscriptionPeriod: subscriptionPeriod
+        )
+
+        return try XCTUnwrap(productValue["is_auto_renewing"]?.boolValue)
+    }
+
+    private func productValue(
+        productType: StoreProduct.ProductType,
+        subscriptionPeriod: SubscriptionPeriod?,
+        store: Store = .appStore
+    ) throws -> [String: PaywallWebViewValue] {
         let product = TestStoreProduct(
             localizedTitle: "Test",
             price: 1.99,
@@ -252,6 +276,7 @@ final class PaywallWebViewContextTests: TestCase {
             offering: offering,
             packages: [package],
             workflow: nil,
+            store: store,
             storefrontCountryCode: "USA"
         ).snapshot(
             package: package,
@@ -260,13 +285,11 @@ final class PaywallWebViewContextTests: TestCase {
             locale: Locale(identifier: "en_US"),
             isDarkMode: false
         )
-        let productValue = try XCTUnwrap(
+        return try XCTUnwrap(
             context.packages.arrayValue?.first?
                 .objectValue?["products"]?.arrayValue?.first?
                 .objectValue
         )
-
-        return try XCTUnwrap(productValue["is_auto_renewing"]?.boolValue)
     }
 
 }

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewContextTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewContextTests.swift
@@ -54,6 +54,11 @@ final class PaywallWebViewContextTests: TestCase {
             )
         )
 
+        XCTAssertEqual(
+            actualPayload.trimmingWhitespacesAndNewLines,
+            Self.expectedPayload.trimmingWhitespacesAndNewLines
+        )
+    }
 
     func testSubscriptionPeriodDeterminesAutoRenewalWhenProductTypeIsUnavailable() throws {
         let isAutoRenewing = try self.autoRenewingValue(

--- a/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewContextTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PaywallWebViewContextTests.swift
@@ -54,10 +54,25 @@ final class PaywallWebViewContextTests: TestCase {
             )
         )
 
-        XCTAssertEqual(
-            actualPayload.trimmingWhitespacesAndNewLines,
-            Self.expectedPayload.trimmingWhitespacesAndNewLines
+        if #available(iOS 17, macOS 14, watchOS 10, *) {
+            // compare actual JSON strings -> more stable floating point from these os versions
+            // and onward. In practice this isn't truly necessary because of how we send the data
+            // over the bridge and how it handles the javascript Number type. But, this assertion
+            // is more explicit and easier for a human to reason about
+            XCTAssertEqual(actualPayload, Self.expectedPayload)
+        }
+
+        let decoder = JSONDecoder()
+        let subjectResult = try decoder.decode(
+            PaywallWebViewValue.self,
+            from: Data(actualPayload.utf8)
         )
+        let expectedResult = try decoder.decode(
+            PaywallWebViewValue.self,
+            from: Data(Self.expectedPayload.utf8)
+        )
+
+        XCTAssertEqual(actualResult, expectedResult)
     }
 
     func testSubscriptionPeriodDeterminesAutoRenewalWhenProductTypeIsUnavailable() throws {


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->
<!-- AI agents: fill in this template, and also follow the "Pull Requests" section in AGENTS.md. -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->
We need to send certain data across the webview bridge so the webviews can use custom variables and details about products
[linear issue PWENG-228](https://linear.app/revenuecat/issue/PWENG-228/ios-create-context-json-object)
### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
Creates the context JSON object

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive modeling and tests with no bridge or purchase-path integration yet; incorrect product JSON would matter once wired but is covered by contract tests.
> 
> **Overview**
> Adds **Paywalls V2 web view context** so native paywalls can build a structured JSON payload for the JavaScript bridge (custom variables, offering/packages, workflow metadata, and device state).
> 
> `PaywallWebViewStaticContext` holds page-level data (offering, deduplicated packages, store/country, optional workflow) and `snapshot(...)` merges per-render inputs (component package, selected package, custom variables, locale, dark mode) into `PaywallWebViewContext`. The context exposes `payload` / `payloadJSON` with fields such as `selected_package`, `device_meta` (`locale`, `dark_mode`, `updated_at`), and optional `workflow`; encoding failures log via new `web_view_context_encoding_failed`. A SwiftUI `EnvironmentValues.paywallWebViewStaticContext` hook is included for downstream wiring.
> 
> Unit tests lock the full JSON contract and edge cases (auto-renew inference, omitted optional fields, BCP47 locale, empty workflow `screen_type`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83854c42f4bd1081d0332dbd9af52baa9e71212c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->