### PR TITLE
Feat(Paywalls): Web Views can observe paywall data

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1326,6 +1326,7 @@
 		B34605EB279A766C0031CA74 /* OperationQueue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34605EA279A766C0031CA74 /* OperationQueue+Extensions.swift */; };
 		B34D2AA0269606E400D88C3A /* IntroEligibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3DF6A4F269524080030D57C /* IntroEligibility.swift */; };
 		B34D2AA626976FC700D88C3A /* ErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34D2AA526976FC700D88C3A /* ErrorCode.swift */; };
+		757E74012F5E00000066DCDC /* ConfiguredStoreEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 757E74002F5E00000066DCDC /* ConfiguredStoreEnvironment.swift */; };
 		B35042C426CDB79A00905B95 /* Purchases.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35042C326CDB79A00905B95 /* Purchases.swift */; };
 		B35042C626CDD3B100905B95 /* PurchasesDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35042C526CDD3B100905B95 /* PurchasesDelegate.swift */; };
 		B359DDF027EAA2B4003ABA54 /* MockDateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351B516F26D44E8D00BD2BD7 /* MockDateProvider.swift */; };
@@ -3112,6 +3113,7 @@
 		B34605D0279A6E600031CA74 /* CustomerAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomerAPI.swift; sourceTree = "<group>"; };
 		B34605EA279A766C0031CA74 /* OperationQueue+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OperationQueue+Extensions.swift"; sourceTree = "<group>"; };
 		B34D2AA526976FC700D88C3A /* ErrorCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorCode.swift; sourceTree = "<group>"; };
+		757E74002F5E00000066DCDC /* ConfiguredStoreEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfiguredStoreEnvironment.swift; sourceTree = "<group>"; };
 		B35042C326CDB79A00905B95 /* Purchases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Purchases.swift; sourceTree = "<group>"; };
 		B35042C526CDD3B100905B95 /* PurchasesDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesDelegate.swift; sourceTree = "<group>"; };
 		B35F9E0826B4BEED00095C3F /* String+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
@@ -6806,6 +6808,7 @@
 			isa = PBXGroup;
 			children = (
 				B3843BCA285149A0009F4854 /* Attribution.swift */,
+				757E74002F5E00000066DCDC /* ConfiguredStoreEnvironment.swift */,
 				887E7B582C13CD2C002977DE /* PurchasesAreCompletedBy.swift */,
 				4D2C7D0A2CC40A35002562BC /* PurchaseParams.swift */,
 				57FD7B1428DA4037009CA4E4 /* PurchasesType.swift */,
@@ -7854,6 +7857,7 @@
 				2C2AEB3B2CA7209F00A50F38 /* PaywallPackageComponent.swift in Sources */,
 				16BCA36C2E4D9B5700B39E7F /* SimpleNetworkServiceType.swift in Sources */,
 				57EAE52D274468900060EB74 /* RawDataContainer.swift in Sources */,
+				757E74012F5E00000066DCDC /* ConfiguredStoreEnvironment.swift in Sources */,
 				B35042C426CDB79A00905B95 /* Purchases.swift in Sources */,
 				16BCA3682E4D9B0C00B39E7F /* FileRepository.swift in Sources */,
 				2D1015DE275A57FC0086173F /* SubscriptionPeriod.swift in Sources */,

--- a/RevenueCatUI/Purchasing/MockPurchases.swift
+++ b/RevenueCatUI/Purchasing/MockPurchases.swift
@@ -35,8 +35,10 @@ final class MockPurchases: PaywallPurchasesType, @unchecked Sendable {
     var isUIPreviewMode = false
     var remoteConfigEnabled = false
 
-    var storeFrontCountryCode: String? { nil }
-    var configuredStoreEnvironment: String { "test_store" }
+    let configuredStoreEnvironment = ConfiguredStoreEnvironment(
+        apiKey: "test_",
+        storeFrontCountryCode: nil
+    )
 
     var purchasesAreCompletedBy: PurchasesAreCompletedBy {
         get { return _purchasesAreCompletedBy }

--- a/RevenueCatUI/Purchasing/MockPurchases.swift
+++ b/RevenueCatUI/Purchasing/MockPurchases.swift
@@ -36,6 +36,7 @@ final class MockPurchases: PaywallPurchasesType, @unchecked Sendable {
     var remoteConfigEnabled = false
 
     var storeFrontCountryCode: String? { nil }
+    var configuredStoreEnvironment: String { "test_store" }
 
     var purchasesAreCompletedBy: PurchasesAreCompletedBy {
         get { return _purchasesAreCompletedBy }

--- a/RevenueCatUI/Purchasing/MockPurchases.swift
+++ b/RevenueCatUI/Purchasing/MockPurchases.swift
@@ -35,6 +35,8 @@ final class MockPurchases: PaywallPurchasesType, @unchecked Sendable {
     var isUIPreviewMode = false
     var remoteConfigEnabled = false
 
+    var storeFrontCountryCode: String? { nil }
+
     var purchasesAreCompletedBy: PurchasesAreCompletedBy {
         get { return _purchasesAreCompletedBy }
         set { _ = newValue }

--- a/RevenueCatUI/Purchasing/PaywallPurchasesType.swift
+++ b/RevenueCatUI/Purchasing/PaywallPurchasesType.swift
@@ -35,14 +35,12 @@ protocol PaywallPurchasesType: Sendable {
     /// Returns a tracker of user's subscription history
     var subscriptionHistoryTracker: SubscriptionHistoryTracker { get }
 
-    var configuredStoreEnvironment: String { get }
-
     @Sendable
     func offerings() async throws -> Offerings
 
     var cachedOfferings: Offerings? { get }
 
-    var storeFrontCountryCode: String? { get }
+    var configuredStoreEnvironment: ConfiguredStoreEnvironment { get }
 
 #if !os(tvOS)
     @Sendable

--- a/RevenueCatUI/Purchasing/PaywallPurchasesType.swift
+++ b/RevenueCatUI/Purchasing/PaywallPurchasesType.swift
@@ -35,6 +35,8 @@ protocol PaywallPurchasesType: Sendable {
     /// Returns a tracker of user's subscription history
     var subscriptionHistoryTracker: SubscriptionHistoryTracker { get }
 
+    var configuredStoreEnvironment: String { get }
+
     @Sendable
     func offerings() async throws -> Offerings
 

--- a/RevenueCatUI/Purchasing/PaywallPurchasesType.swift
+++ b/RevenueCatUI/Purchasing/PaywallPurchasesType.swift
@@ -40,6 +40,8 @@ protocol PaywallPurchasesType: Sendable {
 
     var cachedOfferings: Offerings? { get }
 
+    var storeFrontCountryCode: String? { get }
+
 #if !os(tvOS)
     @Sendable
     func workflow(forOfferingIdentifier offeringID: String) async throws -> WorkflowDataResult

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -1166,9 +1166,10 @@ private final class NotConfiguredPurchases: PaywallPurchasesType {
 
     var cachedOfferings: Offerings? { nil }
 
-    var storeFrontCountryCode: String? { nil }
-
-    var configuredStoreEnvironment: String { "test_store" }
+    let configuredStoreEnvironment = ConfiguredStoreEnvironment(
+        apiKey: "test_",
+        storeFrontCountryCode: nil
+    )
 
 #if !os(tvOS)
     func workflow(forOfferingIdentifier offeringID: String) async throws -> WorkflowDataResult {

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -88,6 +88,10 @@ final class PurchaseHandler: ObservableObject {
         return purchases.storeFrontCountryCode
     }
 
+    var configuredStoreEnvironment: String {
+        return purchases.configuredStoreEnvironment
+    }
+
     /// The result of a purchase completed in the current session.
     /// This is reset when a new paywall session starts, allowing us to track
     /// whether a purchase happened during this specific paywall presentation.

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -84,11 +84,7 @@ final class PurchaseHandler: ObservableObject {
         return actionTypeInProgress != nil
     }
 
-    var storeFrontCountryCode: String? {
-        return purchases.storeFrontCountryCode
-    }
-
-    var configuredStoreEnvironment: String {
+    var configuredStoreEnvironment: ConfiguredStoreEnvironment {
         return purchases.configuredStoreEnvironment
     }
 

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -84,6 +84,10 @@ final class PurchaseHandler: ObservableObject {
         return actionTypeInProgress != nil
     }
 
+    var storeFrontCountryCode: String? {
+        return purchases.storeFrontCountryCode
+    }
+
     /// The result of a purchase completed in the current session.
     /// This is reset when a new paywall session starts, allowing us to track
     /// whether a purchase happened during this specific paywall presentation.
@@ -1161,6 +1165,8 @@ private final class NotConfiguredPurchases: PaywallPurchasesType {
     func offerings() async throws -> Offerings { throw ErrorCode.configurationError }
 
     var cachedOfferings: Offerings? { nil }
+
+    var storeFrontCountryCode: String? { nil }
 
 #if !os(tvOS)
     func workflow(forOfferingIdentifier offeringID: String) async throws -> WorkflowDataResult {

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -1172,6 +1172,8 @@ private final class NotConfiguredPurchases: PaywallPurchasesType {
 
     var storeFrontCountryCode: String? { nil }
 
+    var configuredStoreEnvironment: String { "test_store" }
+
 #if !os(tvOS)
     func workflow(forOfferingIdentifier offeringID: String) async throws -> WorkflowDataResult {
         throw ErrorCode.configurationError

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
@@ -32,8 +32,17 @@ struct WebViewComponentView: View {
     @Environment(\.customPaywallVariables)
     private var customVariables
 
+    @Environment(\.locale)
+    private var locale
+
+    @Environment(\.colorScheme)
+    private var colorScheme
+
     @Environment(\.selectedPackageId)
     private var selectedPackageId
+
+    @Environment(\.paywallWebViewStaticContext)
+    private var webViewStaticContext
 
     @Environment(\.paywallStateValues)
     private var paywallStateValues
@@ -57,6 +66,16 @@ struct WebViewComponentView: View {
         )
     }
 
+    private var webViewContext: PaywallWebViewContext? {
+        return self.webViewStaticContext?.snapshot(
+            package: self.packageContext.package,
+            selectedPackageID: self.selectedPackageId,
+            customVariables: self.viewModel.resolvedCustomVariables(overridingWith: self.customVariables),
+            locale: self.locale,
+            isDarkMode: self.colorScheme == .dark
+        )
+    }
+
     var body: some View {
         #if os(watchOS) || !canImport(WebKit)
         EmptyView()
@@ -65,7 +84,9 @@ struct WebViewComponentView: View {
         // Gating here (rather than deep in the session) keeps the whole web view unrendered when it
         // can't work — no usable origin, or an empty component id the bridge would only reject on —
         // instead of mounting an inert bridge. See `WebViewComponentStyle.isRenderable`.
-        if style.isRenderable, let url = style.url, let instance = self.viewModel.webViewInstance() {
+        if style.isRenderable,
+           let url = style.url,
+           let instance = self.viewModel.webViewInstance(context: self.webViewContext) {
             HostedWebViewComponentView(
                 size: style.size,
                 url: url,

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentViewModel.swift
@@ -43,9 +43,10 @@ final class WebViewComponentViewModel: Hashable {
     /// The live web view for this component, created on first use. `nil` when the component has no
     /// resolvable origin to gate the bridge against.
     @MainActor
-    func webViewInstance() -> WebViewInstance? {
+    func webViewInstance(context: PaywallWebViewContext? = nil) -> WebViewInstance? {
         if let storedWebViewInstance = self.storedWebViewInstance {
             guard storedWebViewInstance.isUnusable else {
+                storedWebViewInstance.session.updateContext(context)
                 return storedWebViewInstance
             }
 
@@ -63,10 +64,19 @@ final class WebViewComponentViewModel: Hashable {
             fitsWidth: self.component.size.width.isFit,
             fitsHeight: self.component.size.height.isFit
         )
+        webViewInstance.session.updateContext(context)
         self.storedWebViewInstance = webViewInstance
         return webViewInstance
     }
     #endif
+
+    func resolvedCustomVariables(
+        overridingWith customVariables: [String: CustomVariableValue]
+    ) -> [String: CustomVariableValue] {
+        return self.uiConfigProvider.defaultCustomVariables.merging(customVariables) { _, supplied in
+            supplied
+        }
+    }
 
     /// Resolves the component's rendered properties for the current presentation context, applying any
     /// matching overrides on top of the base component values.

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewEnvelope.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewEnvelope.swift
@@ -18,6 +18,7 @@ enum WebViewEnvelope {
 
     static let messageTypeResize = "resize"
     static let messageTypeFit = "fit"
+    static let messageTypeContextUpdate = "context"
 
     static let maxResizePoints: CGFloat = 10_000
     static let resizeThreshold: CGFloat = 1

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewEnvelope.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewEnvelope.swift
@@ -19,6 +19,7 @@ enum WebViewEnvelope {
     static let messageTypeResize = "resize"
     static let messageTypeFit = "fit"
     static let messageTypeContextUpdate = "context"
+    static let messageTypeContext = "context"
 
     static let maxResizePoints: CGFloat = 10_000
     static let resizeThreshold: CGFloat = 1

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewEnvelope.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewEnvelope.swift
@@ -18,7 +18,6 @@ enum WebViewEnvelope {
 
     static let messageTypeResize = "resize"
     static let messageTypeFit = "fit"
-    static let messageTypeContextUpdate = "context"
     static let messageTypeContext = "context"
 
     static let maxResizePoints: CGFloat = 10_000

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewSession.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewSession.swift
@@ -68,7 +68,7 @@ final class WebViewSession: NSObject, ObservableObject, WKScriptMessageHandler {
             .init(
                 kind: .message,
                 componentID: self.componentID,
-                type: WebViewEnvelope.messageTypeContextUpdate,
+                type: WebViewEnvelope.messageTypeContext,
                 payload: context.payload(updatedAt: self.dateProvider())
             ),
             allowBeforeNavigation: false
@@ -173,7 +173,7 @@ final class WebViewSession: NSObject, ObservableObject, WKScriptMessageHandler {
             .init(
                 kind: .`init`,
                 componentID: self.componentID,
-                payload: self.context?.payload(updatedAt: self.dateProvider())
+                payload: self.initPayload()
             ),
             allowBeforeNavigation: true
         ) else {
@@ -181,6 +181,17 @@ final class WebViewSession: NSObject, ObservableObject, WKScriptMessageHandler {
         }
         self.channelOpen = true
         self.sendFitMessageIfNeeded()
+    }
+
+    /// `init.payload` is `{ context: <snapshot> }` so the handshake can grow later.
+    /// Subsequent `context` messages send the snapshot as the payload itself.
+    private func initPayload() -> [String: PaywallWebViewValue]? {
+        guard let context = self.context else {
+            return nil
+        }
+        return [
+            WebViewEnvelope.messageTypeContext: .object(context.payload(updatedAt: self.dateProvider()))
+        ]
     }
 
     private func handleResize(_ payload: [String: PaywallWebViewValue]?) {

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewSession.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewSession.swift
@@ -27,6 +27,7 @@ final class WebViewSession: NSObject, ObservableObject, WKScriptMessageHandler {
     var currentURL: () -> URL?
 
     let fitAxes: (width: Bool, height: Bool)
+    private let dateProvider: () -> Date
 
     /// The single protocol version this SDK build implements. Deliberately not the schema's
     /// `protocol_version`: the host must never accept a handshake for a version it cannot service,
@@ -35,19 +36,43 @@ final class WebViewSession: NSObject, ObservableObject, WKScriptMessageHandler {
 
     private var lastAppliedWidth: CGFloat?
     private var lastAppliedHeight: CGFloat?
+    private var context: PaywallWebViewContext?
 
     init(
         componentID: String,
         expectedOrigin: WebViewOrigin,
         fitAxes: (width: Bool, height: Bool),
         evaluateJavaScript: @escaping (String) -> Bool,
-        currentURL: @escaping () -> URL?
+        currentURL: @escaping () -> URL?,
+        dateProvider: @escaping () -> Date = Date.init
     ) {
         self.componentID = componentID
         self.expectedOrigin = expectedOrigin
         self.fitAxes = fitAxes
         self.evaluateJavaScript = evaluateJavaScript
         self.currentURL = currentURL
+        self.dateProvider = dateProvider
+    }
+
+    func updateContext(_ context: PaywallWebViewContext?) {
+        guard context != self.context else {
+            return
+        }
+
+        self.context = context
+        guard self.channelOpen, let context else {
+            return
+        }
+
+        self.send(
+            .init(
+                kind: .message,
+                componentID: self.componentID,
+                type: WebViewEnvelope.messageTypeContextUpdate,
+                payload: context.payload(updatedAt: self.dateProvider())
+            ),
+            allowBeforeNavigation: false
+        )
     }
 
     /// Resets handshake and resize thresholds for a new main-frame document.
@@ -144,7 +169,14 @@ final class WebViewSession: NSObject, ObservableObject, WKScriptMessageHandler {
         // `connect` retry instead of stranding the bridge half-open (native "open", page never got
         // `init`). `allowBeforeNavigation: true` because the top-level `url` may not be populated
         // this early; the `connect` was already origin-gated and later sends still check it.
-        guard self.send(.init(kind: .`init`, componentID: self.componentID), allowBeforeNavigation: true) else {
+        guard self.send(
+            .init(
+                kind: .`init`,
+                componentID: self.componentID,
+                payload: self.context?.payload(updatedAt: self.dateProvider())
+            ),
+            allowBeforeNavigation: true
+        ) else {
             return
         }
         self.channelOpen = true

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -284,6 +284,7 @@ struct PaywallsV2View: View {
             offering: self.offering,
             packages: self.workflowPackages ?? paywallState.packages,
             workflow: workflow,
+            store: self.purchaseHandler.configuredStoreEnvironment,
             storefrontCountryCode: self.purchaseHandler.storeFrontCountryCode
         )
         return LoadedPaywallsV2View(

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -102,6 +102,7 @@ struct PaywallsV2View: View {
     /// `workflowScreenType`, which gates whether events fire.
     private let workflowId: String?
     private let stepId: String?
+    private let workflowStepType: String?
     private let traceId: String?
     /// Whether this workflow step is the workflow's `singleStepFallbackId`. Only consulted for untagged
     /// steps (`nil` `screen_type`), where it restores the structural rule of reporting on the fallback
@@ -145,6 +146,7 @@ struct PaywallsV2View: View {
         workflowScreenType: [String]? = nil,
         workflowId: String? = nil,
         stepId: String? = nil,
+        workflowStepType: String? = nil,
         traceId: String? = nil,
         isWorkflowSingleStepFallback: Bool = false
     ) {
@@ -169,6 +171,7 @@ struct PaywallsV2View: View {
         self.workflowScreenType = workflowScreenType
         self.workflowId = workflowId
         self.stepId = stepId
+        self.workflowStepType = workflowStepType
         self.traceId = traceId
         self.isWorkflowSingleStepFallback = isWorkflowSingleStepFallback
         self._paywallPromoOfferCache = .init(wrappedValue: promoOfferCache ?? PaywallPromoOfferCache(
@@ -266,6 +269,24 @@ struct PaywallsV2View: View {
 
     private func loadedPaywallView(paywallState: PaywallState) -> some View {
         let contentLocale = paywallState.rootViewModel.localizationProvider.locale
+        let workflow: PaywallWebViewStaticContext.Workflow? = {
+            guard let workflowId = self.workflowId, let stepId = self.stepId else {
+                return nil
+            }
+            return .init(
+                id: workflowId,
+                stepID: stepId,
+                stepType: self.workflowStepType,
+                screenType: self.workflowScreenType
+            )
+        }()
+        let webViewContext = PaywallWebViewStaticContext(
+            offering: self.offering,
+            packages: self.workflowPackages ?? paywallState.packages,
+            workflow: workflow,
+            isPreview: self.purchaseHandler.isUIPreviewMode,
+            storefrontCountryCode: self.purchaseHandler.storefrontCountryCode
+        )
         return LoadedPaywallsV2View(
             introOfferEligibilityContext: introOfferEligibilityContext,
             paywallState: paywallState,
@@ -287,6 +308,7 @@ struct PaywallsV2View: View {
         .environment(\.locale, contentLocale)
         .environment(\.layoutDirection, contentLocale.swiftUILayoutDirection)
         .environment(\.screenCondition, ScreenCondition.from(self.horizontalSizeClass))
+        .environment(\.paywallWebViewStaticContext, webViewContext)
         .environment(\.urlOpenedNotifier, URLOpenedNotifier { [purchaseHandler] url in
             purchaseHandler.signalURLOpened(url)
         })

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -284,7 +284,6 @@ struct PaywallsV2View: View {
             offering: self.offering,
             packages: self.workflowPackages ?? paywallState.packages,
             workflow: workflow,
-            isPreview: self.purchaseHandler.isUIPreviewMode,
             storefrontCountryCode: self.purchaseHandler.storefrontCountryCode
         )
         return LoadedPaywallsV2View(

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -284,8 +284,8 @@ struct PaywallsV2View: View {
             offering: self.offering,
             packages: self.workflowPackages ?? paywallState.packages,
             workflow: workflow,
-            store: self.purchaseHandler.configuredStoreEnvironment,
-            storefrontCountryCode: self.purchaseHandler.storeFrontCountryCode
+            store: self.purchaseHandler.configuredStoreEnvironment.entitlementProviderName(),
+            storefrontCountryCode: self.purchaseHandler.configuredStoreEnvironment.storeFrontCountryCode
         )
         return LoadedPaywallsV2View(
             introOfferEligibilityContext: introOfferEligibilityContext,

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -284,7 +284,7 @@ struct PaywallsV2View: View {
             offering: self.offering,
             packages: self.workflowPackages ?? paywallState.packages,
             workflow: workflow,
-            storefrontCountryCode: self.purchaseHandler.storefrontCountryCode
+            storefrontCountryCode: self.purchaseHandler.storeFrontCountryCode
         )
         return LoadedPaywallsV2View(
             introOfferEligibilityContext: introOfferEligibilityContext,

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -524,6 +524,7 @@ struct WorkflowPaywallView: View {
             // Workflow purchase attribution, orthogonal to the screen_type gate.
             workflowId: self.context.workflow.id,
             stepId: page.stepId,
+            workflowStepType: page.stepType,
             traceId: self.stepEventCoordinator.traceId,
             isWorkflowSingleStepFallback: page.isSingleStepFallback
         )
@@ -784,6 +785,7 @@ struct WorkflowPaywallView: View {
         return .init(
             stepId: stepId,
             content: .init(paywallComponents: paywallComponents, offering: offering),
+            stepType: step.type,
             screenType: step.stepScreenType,
             isSingleStepFallback: stepId == context.workflow.singleStepFallbackId,
             headerComponent: screen.componentsConfig.base.header,
@@ -886,6 +888,7 @@ private struct RenderedPage: Identifiable {
     let id = UUID()
     let stepId: String
     let content: CurrentStepContent
+    let stepType: String
     /// The step's `screen_type` classification (`nil` when the backend did not tag it). Drives whether
     /// this page reports paywall events. See `PaywallsV2View.shouldTrackPaywallEvents`.
     let screenType: [String]?

--- a/RevenueCatUI/Views/LoadingPaywallView.swift
+++ b/RevenueCatUI/Views/LoadingPaywallView.swift
@@ -161,6 +161,11 @@ private final class LoadingPaywallPurchases: PaywallPurchasesType {
 
     var cachedOfferings: Offerings? { nil }
 
+    let configuredStoreEnvironment = ConfiguredStoreEnvironment(
+        apiKey: "test_",
+        storeFrontCountryCode: nil
+    )
+
 #if !os(tvOS)
     func workflow(forOfferingIdentifier offeringID: String) async throws -> WorkflowDataResult {
         throw ErrorCode.configurationError

--- a/Sources/Networking/Responses/WorkflowsResponse.swift
+++ b/Sources/Networking/Responses/WorkflowsResponse.swift
@@ -72,7 +72,7 @@ import Foundation
 @_spi(Internal) public struct WorkflowStep {
 
     public let id: String
-    @_spi(Internal) let type: String
+    @_spi(Internal) public let type: String
     public let screenId: String?
     @DefaultDecodable.EmptyDictionary
     var paramValues: [String: AnyDecodable]

--- a/Sources/Networking/Responses/WorkflowsResponse.swift
+++ b/Sources/Networking/Responses/WorkflowsResponse.swift
@@ -72,7 +72,7 @@ import Foundation
 @_spi(Internal) public struct WorkflowStep {
 
     public let id: String
-    let type: String
+    @_spi(Internal) let type: String
     public let screenId: String?
     @DefaultDecodable.EmptyDictionary
     var paramValues: [String: AnyDecodable]

--- a/Sources/Purchasing/Purchases/ConfiguredStoreEnvironment.swift
+++ b/Sources/Purchasing/Purchases/ConfiguredStoreEnvironment.swift
@@ -37,6 +37,8 @@ import Foundation
             return "app_store"
         } else if self.apiKey.starts(with: "test_") {
             return "test_store"
+        } else if !self.apiKey.contains("_") {
+            return "app_store"
         }
         return "unknown"
     }

--- a/Sources/Purchasing/Purchases/ConfiguredStoreEnvironment.swift
+++ b/Sources/Purchasing/Purchases/ConfiguredStoreEnvironment.swift
@@ -7,10 +7,11 @@
 
 import Foundation
 
+/// Describes the underlying store used to make purchases with the RenvenueCat SDK
 @objc(RCConfiguredStoreEnvironment)
 @_spi(Internal) public final class ConfiguredStoreEnvironment: NSObject, @unchecked Sendable {
     private let apiKey: String
-    private let fixedStoreFrontCountryCode: () -> String?
+    private let _storeFrontCountryCode: () -> String?
 
     convenience init(systemInfo: SystemInfo) {
         self.init(apiKey: systemInfo.apiKey, storeFrontCountryCode: systemInfo.storefront?.countryCode)
@@ -18,13 +19,15 @@ import Foundation
 
     @_spi(Internal) public init(apiKey: String, storeFrontCountryCode: @autoclosure @escaping () -> String?) {
         self.apiKey = apiKey
-        self.fixedStoreFrontCountryCode = storeFrontCountryCode
+        self._storeFrontCountryCode = storeFrontCountryCode
     }
 
+    /// The Apple app store country identifier. i.e. "USA"
     @_spi(Internal) public var storeFrontCountryCode: String? {
-        return self.fixedStoreFrontCountryCode()
+        return self._storeFrontCountryCode()
     }
 
+    /// Get the the RevenueCat configured entitlement provider
     @_spi(Internal) public func entitlementProviderName() -> String {
         if self.apiKey.starts(with: "mac_") {
             return "mac_app_store"

--- a/Sources/Purchasing/Purchases/ConfiguredStoreEnvironment.swift
+++ b/Sources/Purchasing/Purchases/ConfiguredStoreEnvironment.swift
@@ -8,24 +8,29 @@
 import Foundation
 
 @objc(RCConfiguredStoreEnvironment)
-@_spi(Internal) public final class ConfiguredStoreEnvironment: NSObject {
-    private let systemInfo: SystemInfo
+@_spi(Internal) public final class ConfiguredStoreEnvironment: NSObject, @unchecked Sendable {
+    private let apiKey: String
+    private let fixedStoreFrontCountryCode: () -> String?
 
-    init(systemInfo: SystemInfo) {
-        self.systemInfo = systemInfo
+    convenience init(systemInfo: SystemInfo) {
+        self.init(apiKey: systemInfo.apiKey, storeFrontCountryCode: systemInfo.storefront?.countryCode)
+    }
+
+    @_spi(Internal) public init(apiKey: String, storeFrontCountryCode: @autoclosure @escaping () -> String?) {
+        self.apiKey = apiKey
+        self.fixedStoreFrontCountryCode = storeFrontCountryCode
     }
 
     @_spi(Internal) public var storeFrontCountryCode: String? {
-        return systemInfo.storefront?.countryCode
+        return self.fixedStoreFrontCountryCode()
     }
 
     @_spi(Internal) public func entitlementProviderName() -> String {
-        let apiKey = systemInfo.apiKey
-        if apiKey.starts(with: "mac_") {
+        if self.apiKey.starts(with: "mac_") {
             return "mac_app_store"
-        } else if apiKey.starts(with: "appl_") {
+        } else if self.apiKey.starts(with: "appl_") {
             return "app_store"
-        } else if apiKey.starts(with: "test_") {
+        } else if self.apiKey.starts(with: "test_") {
             return "test_store"
         }
         return "unknown"

--- a/Sources/Purchasing/Purchases/ConfiguredStoreEnvironment.swift
+++ b/Sources/Purchasing/Purchases/ConfiguredStoreEnvironment.swift
@@ -1,0 +1,43 @@
+//
+//  ConfiguredStoreEnvironment.swift
+//  RevenueCat
+//
+//  Created by Jacob Zivan Rakidzich on 8/28/26.
+// swiftlint:disable missing_docs
+
+import Foundation
+
+@_spi(Internal) public class ConfiguredStoreEnvironment {
+    init() { }
+
+    func entitlementProviderName() -> String {
+        if self is TestStore {
+            return "test_store"
+        }
+        if self is AppleAppStore {
+            return "app_store"
+        }
+        if self is AppleMacAppStore {
+            return "mac_app_store"
+        }
+        return "unknown"
+    }
+
+    static func from(apiKey: String) -> ConfiguredStoreEnvironment {
+        if apiKey.starts(with: "mac_") {
+            return AppleMacAppStore()
+        } else if apiKey.starts(with: "appl_") {
+            return AppleAppStore()
+        } else if apiKey.starts(with: "test_") {
+            return TestStore()
+        } else {
+            return ConfiguredStoreEnvironment()
+        }
+    }
+}
+
+@_spi(Internal) public final class TestStore: ConfiguredStoreEnvironment {}
+@_spi(Internal) public final class AppleAppStore: ConfiguredStoreEnvironment {}
+@_spi(Internal) public final class AppleMacAppStore: ConfiguredStoreEnvironment {}
+
+// swiftlint:enable missing_docs

--- a/Sources/Purchasing/Purchases/ConfiguredStoreEnvironment.swift
+++ b/Sources/Purchasing/Purchases/ConfiguredStoreEnvironment.swift
@@ -8,16 +8,18 @@
 import Foundation
 
 /// Describes the underlying store used to make purchases with the RenvenueCat SDK
-@objc(RCConfiguredStoreEnvironment)
-@_spi(Internal) public final class ConfiguredStoreEnvironment: NSObject, @unchecked Sendable {
+@_spi(Internal) public struct ConfiguredStoreEnvironment: Sendable {
     private let apiKey: String
-    private let _storeFrontCountryCode: () -> String?
+    private let _storeFrontCountryCode: @Sendable () -> String?
 
-    convenience init(systemInfo: SystemInfo) {
+    init(systemInfo: SystemInfo) {
         self.init(apiKey: systemInfo.apiKey, storeFrontCountryCode: systemInfo.storefront?.countryCode)
     }
 
-    @_spi(Internal) public init(apiKey: String, storeFrontCountryCode: @autoclosure @escaping () -> String?) {
+    @_spi(Internal) public init(
+        apiKey: String,
+        storeFrontCountryCode: @autoclosure @escaping @Sendable () -> String?
+    ) {
         self.apiKey = apiKey
         self._storeFrontCountryCode = storeFrontCountryCode
     }

--- a/Sources/Purchasing/Purchases/ConfiguredStoreEnvironment.swift
+++ b/Sources/Purchasing/Purchases/ConfiguredStoreEnvironment.swift
@@ -7,37 +7,29 @@
 
 import Foundation
 
-@_spi(Internal) public class ConfiguredStoreEnvironment {
-    init() { }
+@objc(RCConfiguredStoreEnvironment)
+@_spi(Internal) public final class ConfiguredStoreEnvironment: NSObject {
+    private let systemInfo: SystemInfo
 
-    func entitlementProviderName() -> String {
-        if self is TestStore {
-            return "test_store"
-        }
-        if self is AppleAppStore {
-            return "app_store"
-        }
-        if self is AppleMacAppStore {
+    init(systemInfo: SystemInfo) {
+        self.systemInfo = systemInfo
+    }
+
+    @_spi(Internal) public var storeFrontCountryCode: String? {
+        return systemInfo.storefront?.countryCode
+    }
+
+    @_spi(Internal) public func entitlementProviderName() -> String {
+        let apiKey = systemInfo.apiKey
+        if apiKey.starts(with: "mac_") {
             return "mac_app_store"
+        } else if apiKey.starts(with: "appl_") {
+            return "app_store"
+        } else if apiKey.starts(with: "test_") {
+            return "test_store"
         }
         return "unknown"
     }
-
-    static func from(apiKey: String) -> ConfiguredStoreEnvironment {
-        if apiKey.starts(with: "mac_") {
-            return AppleMacAppStore()
-        } else if apiKey.starts(with: "appl_") {
-            return AppleAppStore()
-        } else if apiKey.starts(with: "test_") {
-            return TestStore()
-        } else {
-            return ConfiguredStoreEnvironment()
-        }
-    }
 }
-
-@_spi(Internal) public final class TestStore: ConfiguredStoreEnvironment {}
-@_spi(Internal) public final class AppleAppStore: ConfiguredStoreEnvironment {}
-@_spi(Internal) public final class AppleMacAppStore: ConfiguredStoreEnvironment {}
 
 // swiftlint:enable missing_docs

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -341,10 +341,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
     @_spi(Internal) public let subscriptionHistoryTracker = SubscriptionHistoryTracker()
 
-    private let configuredStoreType: ConfiguredStoreEnvironment
-    @_spi(Internal) public var configuredStoreEnvironment: String {
-        configuredStoreType.entitlementProviderName()
-    }
+    @_spi(Internal) public let configuredStoreEnvironment: ConfiguredStoreEnvironment
 
     // swiftlint:disable:next function_body_length cyclomatic_complexity
     convenience init(apiKey: String,
@@ -885,7 +882,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
     ) {
         self.webBundleEventBus = webBundleEventBus
 
-        self.configuredStoreType = .from(apiKey: systemInfo.apiKey)
+        self.configuredStoreEnvironment = .init(systemInfo: systemInfo)
 
         if systemInfo.dangerousSettings.customEntitlementComputation {
             Logger.info(Strings.configure.custom_entitlements_computation_enabled)

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -3250,36 +3250,3 @@ extension Purchases {
     }
 }
 #endif
-
-@_spi(Internal) public class ConfiguredStoreEnvironment {
-    init() { }
-
-    func entitlementProviderName() -> String {
-        if self is TestStore {
-            return "test_store"
-        }
-        if self is AppleAppStore {
-            return "app_store"
-        }
-        if self is AppleMacAppStore {
-            return "mac_app_store"
-        }
-        return "unknown"
-    }
-
-    static func from(apiKey: String) -> ConfiguredStoreEnvironment {
-        if apiKey.starts(with: "mac_") {
-            return AppleMacAppStore()
-        } else if apiKey.starts(with: "appl_") {
-            return AppleAppStore()
-        } else if apiKey.starts(with: "test_") {
-            return TestStore()
-        } else {
-            return ConfiguredStoreEnvironment()
-        }
-    }
-}
-
-@_spi(Internal) public final class TestStore: ConfiguredStoreEnvironment {}
-@_spi(Internal) public final class AppleAppStore: ConfiguredStoreEnvironment {}
-@_spi(Internal) public final class AppleMacAppStore: ConfiguredStoreEnvironment {}

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -341,6 +341,11 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
     @_spi(Internal) public let subscriptionHistoryTracker = SubscriptionHistoryTracker()
 
+    private let configuredStoreType: ConfiguredStoreEnvironment
+    @_spi(Internal) public var configuredStoreEnvironment: String {
+        configuredStoreType.entitlementProviderName()
+    }
+
     // swiftlint:disable:next function_body_length cyclomatic_complexity
     convenience init(apiKey: String,
                      appUserID: String?,
@@ -879,6 +884,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
          webBundleEventBus: WebBundleEventBus
     ) {
         self.webBundleEventBus = webBundleEventBus
+
+        self.configuredStoreType = .from(apiKey: systemInfo.apiKey)
 
         if systemInfo.dangerousSettings.customEntitlementComputation {
             Logger.info(Strings.configure.custom_entitlements_computation_enabled)
@@ -3243,3 +3250,36 @@ extension Purchases {
     }
 }
 #endif
+
+@_spi(Internal) public class ConfiguredStoreEnvironment {
+    init() { }
+
+    func entitlementProviderName() -> String {
+        if self is TestStore {
+            return "test_store"
+        }
+        if self is AppleAppStore {
+            return "app_store"
+        }
+        if self is AppleMacAppStore {
+            return "mac_app_store"
+        }
+        return "unknown"
+    }
+
+    static func from(apiKey: String) -> ConfiguredStoreEnvironment {
+        if apiKey.starts(with: "mac_") {
+            return AppleMacAppStore()
+        } else if apiKey.starts(with: "appl_") {
+            return AppleAppStore()
+        } else if apiKey.starts(with: "test_") {
+            return TestStore()
+        } else {
+            return ConfiguredStoreEnvironment()
+        }
+    }
+}
+
+@_spi(Internal) public final class TestStore: ConfiguredStoreEnvironment {}
+@_spi(Internal) public final class AppleAppStore: ConfiguredStoreEnvironment {}
+@_spi(Internal) public final class AppleMacAppStore: ConfiguredStoreEnvironment {}

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -61,6 +61,9 @@ public protocol PurchasesType: AnyObject {
      */
     var delegate: PurchasesDelegate? { get set }
 
+    /// A description of the configured store environment
+    @_spi(Internal) var configuredStoreEnvironment: String { get }
+
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
         /**

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -62,7 +62,7 @@ public protocol PurchasesType: AnyObject {
     var delegate: PurchasesDelegate? { get set }
 
     /// A description of the configured store environment
-    @_spi(Internal) var configuredStoreEnvironment: String { get }
+    @_spi(Internal) var configuredStoreEnvironment: ConfiguredStoreEnvironment { get }
 
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -61,9 +61,6 @@ public protocol PurchasesType: AnyObject {
      */
     var delegate: PurchasesDelegate? { get set }
 
-    /// A description of the configured store environment
-    @_spi(Internal) var configuredStoreEnvironment: ConfiguredStoreEnvironment { get }
-
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
         /**

--- a/Tests/RevenueCatUITests/PaywallsV2/WebViewSessionTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WebViewSessionTests.swift
@@ -30,6 +30,39 @@ final class WebViewSessionTests: TestCase {
         XCTAssertEqual(envelopes[1].payload?["height"]?.boolValue, true)
     }
 
+    func testConnectIncludesLatestContextInInit() throws {
+        let harness = Harness()
+        harness.session.updateContext(Self.context(localeIdentifier: "en_US"))
+
+        harness.handle(.init(kind: .connect, componentID: "", protocolVersion: 1))
+
+        let envelope = try XCTUnwrap(harness.outboundEnvelopes().first)
+        XCTAssertEqual(envelope.kind, .`init`)
+        XCTAssertEqual(envelope.payload?["custom"]?.objectValue?["name"]?.stringValue, "Alex")
+        let deviceMeta = try XCTUnwrap(envelope.payload?["device_meta"]?.objectValue)
+        XCTAssertEqual(deviceMeta["locale"]?.stringValue, "en_US")
+        XCTAssertEqual(deviceMeta["updated_at"]?.numberValue, 1_787_000_000_000)
+    }
+
+    func testContextChangeSendsCompleteUpdateAndDeduplicatesUnchangedContext() throws {
+        let harness = Harness()
+        let initial = Self.context(localeIdentifier: "en_US")
+        let updated = Self.context(localeIdentifier: "es_ES")
+        harness.session.updateContext(initial)
+        harness.connect()
+
+        harness.session.updateContext(updated)
+        harness.session.updateContext(updated)
+
+        let envelopes = try harness.outboundEnvelopes()
+        XCTAssertEqual(envelopes.count, 1)
+        XCTAssertEqual(envelopes[0].kind, .message)
+        XCTAssertEqual(envelopes[0].type, WebViewEnvelope.messageTypeContextUpdate)
+        XCTAssertEqual(envelopes[0].payload?["device_meta"]?.objectValue?["locale"]?.stringValue, "es_ES")
+        XCTAssertNotNil(envelopes[0].payload?["packages"])
+        XCTAssertNotNil(envelopes[0].payload?["selected_package"])
+    }
+
     func testConnectV2Rejects() throws {
         let harness = Harness()
 
@@ -533,6 +566,20 @@ final class WebViewSessionTests: TestCase {
         return try JSONDecoder().decode(WebViewEnvelope.Envelope.self, from: Data(json.utf8))
     }
 
+    private static func context(localeIdentifier: String) -> PaywallWebViewContext {
+        return .init(
+            custom: .object(["name": .string("Alex")]),
+            offering: .object(["identifier": .string("default")]),
+            packages: .array([]),
+            package: .null,
+            selectedPackage: .null,
+            workflow: .null,
+            isPreview: false,
+            localeIdentifier: localeIdentifier,
+            isDarkMode: false
+        )
+    }
+
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
@@ -587,7 +634,8 @@ private final class Harness {
             expectedOrigin: expectedOrigin,
             fitAxes: size,
             evaluateJavaScript: { _ in false },
-            currentURL: { nil }
+            currentURL: { nil },
+            dateProvider: { Date(timeIntervalSince1970: 1_787_000_000) }
         )
         self.session.evaluateJavaScript = { [weak self] script in
             guard let self, self.deliverOutbound else {

--- a/Tests/RevenueCatUITests/PaywallsV2/WebViewSessionTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WebViewSessionTests.swift
@@ -38,8 +38,10 @@ final class WebViewSessionTests: TestCase {
 
         let envelope = try XCTUnwrap(harness.outboundEnvelopes().first)
         XCTAssertEqual(envelope.kind, .`init`)
-        XCTAssertEqual(envelope.payload?["custom"]?.objectValue?["name"]?.stringValue, "Alex")
-        let deviceMeta = try XCTUnwrap(envelope.payload?["device_meta"]?.objectValue)
+        XCTAssertNil(envelope.payload?["custom"])
+        let context = try XCTUnwrap(envelope.payload?[WebViewEnvelope.messageTypeContext]?.objectValue)
+        XCTAssertEqual(context["custom"]?.objectValue?["name"]?.stringValue, "Alex")
+        let deviceMeta = try XCTUnwrap(context["device_meta"]?.objectValue)
         XCTAssertEqual(deviceMeta["locale"]?.stringValue, "en_US")
         XCTAssertEqual(deviceMeta["updated_at"]?.numberValue, 1_787_000_000_000)
     }
@@ -57,7 +59,7 @@ final class WebViewSessionTests: TestCase {
         let envelopes = try harness.outboundEnvelopes()
         XCTAssertEqual(envelopes.count, 1)
         XCTAssertEqual(envelopes[0].kind, .message)
-        XCTAssertEqual(envelopes[0].type, WebViewEnvelope.messageTypeContextUpdate)
+        XCTAssertEqual(envelopes[0].type, WebViewEnvelope.messageTypeContext)
         XCTAssertEqual(envelopes[0].payload?["device_meta"]?.objectValue?["locale"]?.stringValue, "es_ES")
         XCTAssertNotNil(envelopes[0].payload?["packages"])
         XCTAssertNotNil(envelopes[0].payload?["selected_package"])

--- a/Tests/RevenueCatUITests/PaywallsV2/WebViewSessionTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WebViewSessionTests.swift
@@ -32,7 +32,7 @@ final class WebViewSessionTests: TestCase {
 
     func testConnectIncludesLatestContextInInit() throws {
         let harness = Harness()
-        harness.session.updateContext(Self.context(localeIdentifier: "en_US"))
+        harness.session.updateContext(Self.context(localeIdentifier: "en-US"))
 
         harness.handle(.init(kind: .connect, componentID: "", protocolVersion: 1))
 
@@ -42,14 +42,14 @@ final class WebViewSessionTests: TestCase {
         let context = try XCTUnwrap(envelope.payload?[WebViewEnvelope.messageTypeContext]?.objectValue)
         XCTAssertEqual(context["custom"]?.objectValue?["name"]?.stringValue, "Alex")
         let deviceMeta = try XCTUnwrap(context["device_meta"]?.objectValue)
-        XCTAssertEqual(deviceMeta["locale"]?.stringValue, "en_US")
+        XCTAssertEqual(deviceMeta["locale"]?.stringValue, "en-US")
         XCTAssertEqual(deviceMeta["updated_at"]?.numberValue, 1_787_000_000_000)
     }
 
     func testContextChangeSendsCompleteUpdateAndDeduplicatesUnchangedContext() throws {
         let harness = Harness()
-        let initial = Self.context(localeIdentifier: "en_US")
-        let updated = Self.context(localeIdentifier: "es_ES")
+        let initial = Self.context(localeIdentifier: "en-US")
+        let updated = Self.context(localeIdentifier: "es-ES")
         harness.session.updateContext(initial)
         harness.connect()
 
@@ -60,7 +60,7 @@ final class WebViewSessionTests: TestCase {
         XCTAssertEqual(envelopes.count, 1)
         XCTAssertEqual(envelopes[0].kind, .message)
         XCTAssertEqual(envelopes[0].type, WebViewEnvelope.messageTypeContext)
-        XCTAssertEqual(envelopes[0].payload?["device_meta"]?.objectValue?["locale"]?.stringValue, "es_ES")
+        XCTAssertEqual(envelopes[0].payload?["device_meta"]?.objectValue?["locale"]?.stringValue, "es-ES")
         XCTAssertNotNil(envelopes[0].payload?["packages"])
         XCTAssertNotNil(envelopes[0].payload?["selected_package"])
     }

--- a/Tests/RevenueCatUITests/PaywallsV2/WebViewSessionTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WebViewSessionTests.swift
@@ -571,12 +571,12 @@ final class WebViewSessionTests: TestCase {
     private static func context(localeIdentifier: String) -> PaywallWebViewContext {
         return .init(
             custom: .object(["name": .string("Alex")]),
+            inputs: .null,
             offering: .object(["identifier": .string("default")]),
             packages: .array([]),
             package: .null,
             selectedPackage: .null,
             workflow: .null,
-            isPreview: false,
             localeIdentifier: localeIdentifier,
             isDarkMode: false
         )

--- a/Tests/UnitTests/Mocks/MockPurchases.swift
+++ b/Tests/UnitTests/Mocks/MockPurchases.swift
@@ -11,7 +11,7 @@
 //
 //  Created by Nacho Soto on 10/10/22.
 
-@testable import RevenueCat
+@_spi(Internal) @testable import RevenueCat
 import StoreKit
 
 final class MockPurchases {
@@ -84,6 +84,9 @@ extension MockPurchases: InternalPurchasesType {
 }
 
 extension MockPurchases: PurchasesType {
+    var configuredStoreEnvironment: RevenueCat.ConfiguredStoreEnvironment {
+        return ConfiguredStoreEnvironment(apiKey: "test_", storeFrontCountryCode: "USA")
+    }
 
     func getCustomerInfo(completion: @escaping ((CustomerInfo?, PublicError?) -> Void)) {
         self.invokedGetCustomerInfo = true

--- a/Tests/UnitTests/Mocks/MockPurchases.swift
+++ b/Tests/UnitTests/Mocks/MockPurchases.swift
@@ -84,9 +84,6 @@ extension MockPurchases: InternalPurchasesType {
 }
 
 extension MockPurchases: PurchasesType {
-    var configuredStoreEnvironment: RevenueCat.ConfiguredStoreEnvironment {
-        return ConfiguredStoreEnvironment(apiKey: "test_", storeFrontCountryCode: "USA")
-    }
 
     func getCustomerInfo(completion: @escaping ((CustomerInfo?, PublicError?) -> Void)) {
         self.invokedGetCustomerInfo = true

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -28,6 +28,7 @@ class PurchasesConfiguringTests: BasePurchasesTests {
             ("mac_key", "mac_app_store"),
             ("appl_key", "app_store"),
             ("test_key", "test_store"),
+            ("legacykey", "app_store"),
             ("unknown_key", "unknown")
         ]
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -23,6 +23,32 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         expect(self.purchases).toNot(beNil())
     }
 
+    func testConfiguredStoreEnvironmentDerivesProviderNameFromAPIKey() {
+        let environments = [
+            ("mac_key", "mac_app_store"),
+            ("appl_key", "app_store"),
+            ("test_key", "test_store"),
+            ("unknown_key", "unknown")
+        ]
+
+        for (apiKey, expectedProviderName) in environments {
+            let environment = ConfiguredStoreEnvironment(apiKey: apiKey, storeFrontCountryCode: nil)
+
+            expect(environment.entitlementProviderName()) == expectedProviderName
+        }
+    }
+
+    func testConfiguredStoreEnvironmentReadsCurrentStorefront() {
+        let systemInfo = MockSystemInfo(finishTransactions: true, apiKey: "appl_key")
+        let environment = ConfiguredStoreEnvironment(systemInfo: systemInfo)
+
+        expect(environment.storeFrontCountryCode).to(beNil())
+
+        systemInfo.stubbedStorefront = MockStorefront(countryCode: "USA")
+
+        expect(environment.storeFrontCountryCode) == "USA"
+    }
+
     func testRemoteConfigRefreshesDuringLifecycleCacheUpdatesByDefault() {
         self.setupPurchases()
 


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->
<!-- AI agents: fill in this template, and also follow the "Pull Requests" section in AGENTS.md. -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->
We want to allow users to inject custom variables and other paywall data into a custom component
[linear issue PWENG-203](https://linear.app/revenuecat/issue/PWENG-203/ios-pass-custom-variables-into-the-custom-component)

### Recordings
#### Custom Variable injection -> countdown until end of black Friday
https://github.com/user-attachments/assets/40617ca6-efe6-4c96-a612-9db36adeb769
#### On paywall context update -> web view context gets updated
https://github.com/user-attachments/assets/4dadf5b7-1150-48ee-aa28-6362d9e53ccb

### Descriptions
Adds the initial context to the web view and then publishes context changes on update. In order to provide some of the required data, I had to make some changes to the purchases protocols and wire that together.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the paywall web bridge handshake and purchase-facing protocols; mistakes could leak stale context to embedded JS or mislabel store/workflow metadata, but changes are additive with unit tests on session behavior.
> 
> **Overview**
> Paywall V2 **web view components** can now receive live paywall data over the existing `rc-web-components` bridge. The host sends an initial **context** snapshot in the handshake `init` payload and pushes **`context`** messages when locale, dark mode, selected package, or merged custom variables change (deduplicated when unchanged).
> 
> **`PaywallsV2View`** builds a static context (offering, packages, optional workflow id/step/screen type, store provider, storefront) from the purchase handler and injects it via a new SwiftUI environment. **`WebViewComponentView`** merges UI-config defaults with paywall custom variables and snapshots dynamic fields before creating or updating the web view session.
> 
> To include store metadata in that snapshot, the PR adds **`ConfiguredStoreEnvironment`** on **`Purchases`** (API-key-derived entitlement provider + storefront country) and threads **`configuredStoreEnvironment`** through **`PaywallPurchasesType`**, mocks, and **`PurchaseHandler`**. Workflow rendering also passes **`workflowStepType`** from **`WorkflowStep.type`** (now SPI-public).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d7df172b97654348dd3b2e471b06af67f4f9084. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->