### PR TITLE
feat(Checkpoints): Reshape rule evaluation properties

### DIFF
--- a/Sources/LocalRules/DeviceDimensionProvider.swift
+++ b/Sources/LocalRules/DeviceDimensionProvider.swift
@@ -17,7 +17,7 @@ import Foundation
 /// Supplies app and device information to the local rules engine.
 struct DeviceDimensionProvider: DimensionProvider {
 
-    let namespace = DimensionNamespace.device
+    let name = "device"
 
     private let appVersion: String
     private let localeProvider: @Sendable () -> String?
@@ -43,7 +43,7 @@ struct DeviceDimensionProvider: DimensionProvider {
         var variables: [String: DimensionValue] = [:]
 
         if !self.appVersion.isEmpty {
-            variables["appVersion"] = .string(self.appVersion)
+            variables["app_version"] = .string(self.appVersion)
         }
 
         if let locale = self.localeProvider(), !locale.isEmpty {
@@ -54,10 +54,10 @@ struct DeviceDimensionProvider: DimensionProvider {
             variables["platform"] = .string(self.platform.lowercased())
         }
 
-        variables["platformVersion"] = .string(Self.semanticVersion(self.platformVersion))
+        variables["platform_version"] = .string(Self.semanticVersion(self.platformVersion))
 
         if let sdkVersion = Self.semanticVersion(self.sdkVersion) {
-            variables["sdkVersion"] = .string(sdkVersion)
+            variables["sdk_version"] = .string(sdkVersion)
         }
 
         return variables

--- a/Sources/LocalRules/DimensionProvider.swift
+++ b/Sources/LocalRules/DimensionProvider.swift
@@ -14,16 +14,6 @@
 
 import Foundation
 
-/// Roots containing dimensions that may be evaluated locally by the rules engine.
-enum DimensionNamespace: String, CaseIterable, Sendable {
-
-    case backend
-    case custom
-    case device
-    case store
-    case subscriberAttributes
-}
-
 /// A dimension exposed to the local rules engine.
 ///
 /// This keeps providers independent from the RulesEngine representation.
@@ -54,19 +44,19 @@ enum DimensionValue: Equatable, Sendable {
     case objectList([[String: DimensionValue]])
 }
 
-/// Supplies one current subtree of dimensions.
+/// Supplies part of the root scope of dimensions.
 ///
 /// Implementations may observe or persist state internally, but values are
 /// pulled only when a rules evaluation requests a new snapshot.
 protocol DimensionProvider: Sendable {
 
-    /// Root namespace containing the returned dimensions.
-    var namespace: DimensionNamespace { get }
+    /// Identifies this provider in diagnostics. It is not part of the evaluated scope.
+    var name: String { get }
 
-    /// Returns the complete current set of dimensions relative to ``namespace``.
+    /// Returns the complete current set of root dimensions owned by this provider.
     ///
-    /// Keys are lower camel-case names such as `appVersion`. The resolver
-    /// adds the provider's namespace and recursively ignores empty,
+    /// Keys are snake-case names such as `app_version`. The resolver merges
+    /// every provider into one root and recursively ignores empty,
     /// whitespace-only, or `.`-containing keys. Missing individual values must
     /// be omitted. Throwing is reserved for a systemic failure to produce the
     /// provider's dimensions.

--- a/Sources/LocalRules/DimensionResolver.swift
+++ b/Sources/LocalRules/DimensionResolver.swift
@@ -22,11 +22,11 @@ struct DimensionSnapshot: Equatable, Sendable {
 
 enum DimensionResolutionError: Error, Equatable, Sendable {
 
-    case providerFailed(namespace: DimensionNamespace, message: String)
+    case providerFailed(providerName: String, message: String)
     case conflictingValue(path: String)
 }
 
-/// Builds immutable, point-in-time dimension scopes for local rule evaluation.
+/// Builds an immutable, point-in-time root scope for local rule evaluation.
 struct DimensionResolver: Sendable {
 
     private let dimensionProviders: [any DimensionProvider]
@@ -41,16 +41,17 @@ struct DimensionResolver: Sendable {
         self.dateProvider = dateProvider
     }
 
-    /// Collects each provider once and merges its values under its namespace.
+    /// Collects each provider once and merges its values into the canonical root scope.
     ///
-    /// For example, device `appVersion: "1.2.3"` becomes
-    /// `device.appVersion: "1.2.3"` in the RulesEngine input.
+    /// `custom` and `backend` remain nested reserved objects. Every other value is flat.
     func snapshot(
         customVariables: [String: DimensionValue] = [:],
         backendValues: [String: DimensionValue] = [:]
     ) async throws -> DimensionSnapshot {
         let date = self.dateProvider.now()
-        var values: [String: RulesEngine.Value] = [:]
+        var values: [String: RulesEngine.Value] = [
+            Self.evaluatedAtKey: .int(Int64(date.timeIntervalSince1970 * 1_000))
+        ]
 
         for provider in self.dimensionProviders {
             try Task.checkCancellation()
@@ -62,43 +63,33 @@ struct DimensionResolver: Sendable {
                 throw error
             } catch {
                 throw DimensionResolutionError.providerFailed(
-                    namespace: provider.namespace,
+                    providerName: provider.name,
                     message: String(describing: error)
                 )
             }
 
-            let namespace = provider.namespace.rawValue
-            var namespaceValues: [String: RulesEngine.Value] = [:]
-            if case .object(let existing) = values[namespace] {
-                namespaceValues = existing
-            }
-
             for (name, value) in DimensionValueConverter.convert(
                 providerValues,
-                parentPath: namespace
+                parentPath: provider.name
             ) {
-                guard namespaceValues[name] == nil else {
+                guard !Self.reservedRootKeys.contains(name), values[name] == nil else {
                     throw DimensionResolutionError.conflictingValue(
-                        path: "\(namespace).\(name)"
+                        path: name
                     )
                 }
 
-                namespaceValues[name] = value
-            }
-
-            if !namespaceValues.isEmpty {
-                values[namespace] = .object(namespaceValues)
+                values[name] = value
             }
         }
 
         Self.addPerEvaluationValues(
             CustomVariableKeyValidator.validateAndFilter(customVariables),
-            namespace: .custom,
+            root: Self.customKey,
             to: &values
         )
         Self.addPerEvaluationValues(
             backendValues,
-            namespace: .backend,
+            root: Self.backendKey,
             to: &values
         )
 
@@ -109,14 +100,19 @@ struct DimensionResolver: Sendable {
 
     private static func addPerEvaluationValues(
         _ dimensions: [String: DimensionValue],
-        namespace: DimensionNamespace,
+        root: String,
         to values: inout [String: RulesEngine.Value]
     ) {
-        let converted = DimensionValueConverter.convert(dimensions, parentPath: namespace.rawValue)
+        let converted = DimensionValueConverter.convert(dimensions, parentPath: root)
         if !converted.isEmpty {
-            values[namespace.rawValue] = .object(converted)
+            values[root] = .object(converted)
         }
     }
+
+    private static let evaluatedAtKey = "evaluated_at"
+    private static let customKey = "custom"
+    private static let backendKey = "backend"
+    private static let reservedRootKeys: Set<String> = [Self.evaluatedAtKey, Self.customKey, Self.backendKey]
 }
 
 private enum DimensionValueConverter {

--- a/Sources/LocalRules/StoreDimensionProvider.swift
+++ b/Sources/LocalRules/StoreDimensionProvider.swift
@@ -17,7 +17,7 @@ import Foundation
 /// Supplies current App Store information to the local rules engine.
 struct StoreDimensionProvider: DimensionProvider {
 
-    let namespace = DimensionNamespace.store
+    let name = "store"
 
     private let storefrontCountryCodeProvider: @Sendable () async -> String?
 
@@ -36,7 +36,7 @@ struct StoreDimensionProvider: DimensionProvider {
         }
 
         // Storefront country codes use ISO 3166-1 alpha-3 format, such as "USA".
-        return ["country": .string(storefrontCountryCode)]
+        return ["storefront": .string(storefrontCountryCode)]
     }
 
 }

--- a/Sources/LocalRules/SubscriberAttributesDimensionProvider.swift
+++ b/Sources/LocalRules/SubscriberAttributesDimensionProvider.swift
@@ -17,7 +17,7 @@ import Foundation
 /// Supplies the subscriber attributes stored for the current customer to the local rules engine.
 struct SubscriberAttributesDimensionProvider: DimensionProvider {
 
-    let namespace = DimensionNamespace.subscriberAttributes
+    let name = "subscriber_attributes"
 
     private let attributesProvider: @Sendable () throws -> SubscriberAttribute.Dictionary
 
@@ -40,7 +40,7 @@ struct SubscriberAttributesDimensionProvider: DimensionProvider {
     ///
     /// A failed read contributes no dimensions rather than preventing the other
     /// dimensions from being evaluated.
-    func dimensions(at date: Date) async throws -> [String: DimensionValue] {
+    func dimensions(at _: Date) async throws -> [String: DimensionValue] {
         let attributes: SubscriberAttribute.Dictionary
         do {
             attributes = try self.attributesProvider()
@@ -49,20 +49,21 @@ struct SubscriberAttributesDimensionProvider: DimensionProvider {
             return [:]
         }
 
-        return attributes.values.reduce(into: [:]) { dimensions, attribute in
+        let records = attributes.values.reduce(into: [String: DimensionValue]()) { dimensions, attribute in
             // An empty value represents a deleted attribute, whether or not its tombstone has been synced.
             guard !attribute.value.isEmpty else { return }
 
             dimensions[attribute.key] = .object([
                 Self.valueKey: .string(attribute.value),
-                Self.updatedAtKey: .date(attribute.setTime),
-                Self.evaluatedAtKey: .date(date)
+                Self.updatedAtKey: .date(attribute.setTime)
             ])
         }
+
+        return records.isEmpty ? [:] : [Self.subscriberAttributesKey: .object(records)]
     }
 
-    private static let evaluatedAtKey = "evaluatedAt"
-    private static let updatedAtKey = "updatedAt"
+    private static let subscriberAttributesKey = "subscriber_attributes"
+    private static let updatedAtKey = "updated_at"
     private static let valueKey = "value"
 
 }

--- a/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
@@ -961,7 +961,7 @@ private struct CancellingDimensionProvider: DimensionProvider {
 
 private final class CallbackDimensionProvider: DimensionProvider, @unchecked Sendable {
 
-    let namespace = DimensionNamespace.device
+    let name = "device"
     let callback: () -> Void
 
     init(callback: @escaping () -> Void) {

--- a/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
@@ -939,7 +939,7 @@ private final class MockAudiencesConfigProvider: AudiencesConfigProviderType {
 
 private struct FailingDimensionProvider: DimensionProvider {
 
-    let namespace = DimensionNamespace.device
+    let name = "failing"
 
     func dimensions(at _: Date) async throws -> [String: DimensionValue] {
         throw FailingDimensionProviderError()
@@ -951,7 +951,7 @@ private struct FailingDimensionProviderError: Error {}
 
 private struct CancellingDimensionProvider: DimensionProvider {
 
-    let namespace = DimensionNamespace.device
+    let name = "cancelling"
 
     func dimensions(at _: Date) async throws -> [String: DimensionValue] {
         throw CancellationError()

--- a/Tests/UnitTests/LocalRules/DeviceDimensionProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/DeviceDimensionProviderTests.swift
@@ -25,7 +25,7 @@ import Testing
 struct DeviceDimensionProviderTests {
 
     @Test
-    func providesDeviceDimensionsInDeviceNamespace() async throws {
+    func providesCanonicalDeviceDimensionsAtTheRoot() async throws {
         let provider = DeviceDimensionProvider(
             appVersion: "1.2.3",
             localeProvider: { "NL-nl" },
@@ -34,13 +34,13 @@ struct DeviceDimensionProviderTests {
             sdkVersion: "5.84.0-SNAPSHOT"
         )
 
-        #expect(provider.namespace == .device)
+        #expect(provider.name == "device")
         #expect(try await provider.dimensions(at: Date()) == [
-            "appVersion": .string("1.2.3"),
+            "app_version": .string("1.2.3"),
             "locale": .string("nl_nl"),
             "platform": .string("ios"),
-            "platformVersion": .string("26.3.0"),
-            "sdkVersion": .string("5.84.0")
+            "platform_version": .string("26.3.0"),
+            "sdk_version": .string("5.84.0")
         ])
     }
 
@@ -55,7 +55,7 @@ struct DeviceDimensionProviderTests {
         )
 
         #expect(try await provider.dimensions(at: Date()) == [
-            "platformVersion": .string("26.3.0")
+            "platform_version": .string("26.3.0")
         ])
     }
 
@@ -93,7 +93,7 @@ struct DeviceDimensionProviderTests {
         let match = try await evaluator.match(in: [
             TestRule(
                 id: "matching-rule",
-                predicate: #"{"==":[{"var":"device.appVersion"},"1.2.3"]}"#
+                predicate: #"{"==":[{"var":"app_version"},"1.2.3"]}"#
             )
         ])
 
@@ -116,7 +116,7 @@ struct DeviceDimensionProviderTests {
         let match = try await evaluator.match(in: [
             TestRule(
                 id: "matching-rule",
-                predicate: #"{"==":[{"var":"device.locale"},"nl_nl"]}"#
+                predicate: #"{"==":[{"var":"locale"},"nl_nl"]}"#
             )
         ])
 
@@ -139,7 +139,7 @@ struct DeviceDimensionProviderTests {
         let match = try await evaluator.match(in: [
             TestRule(
                 id: "matching-rule",
-                predicate: #"{"==":[{"var":"device.platform"},"ios"]}"#
+                predicate: #"{"==":[{"var":"platform"},"ios"]}"#
             )
         ])
 
@@ -173,7 +173,7 @@ struct DeviceDimensionProviderTests {
         let match = try await evaluator.match(in: [
             TestRule(
                 id: "matching-rule",
-                predicate: #"{"==":[{"var":"device.platformVersion"},"26.3.0"]}"#
+                predicate: #"{"==":[{"var":"platform_version"},"26.3.0"]}"#
             )
         ])
 
@@ -197,7 +197,7 @@ struct DeviceDimensionProviderTests {
         let match = try await evaluator.match(in: [
             TestRule(
                 id: "matching-rule",
-                predicate: #"{"==":[{"var":"device.sdkVersion"},"5.84.0"]}"#
+                predicate: #"{"==":[{"var":"sdk_version"},"5.84.0"]}"#
             )
         ])
 

--- a/Tests/UnitTests/LocalRules/DimensionValueTests.swift
+++ b/Tests/UnitTests/LocalRules/DimensionValueTests.swift
@@ -52,28 +52,27 @@ struct DimensionValueTests {
             "date": .date(date),
             "record": .object([
                 "id": .string("one"),
-                "createdAt": .date(date)
+                "created_at": .date(date)
             ]),
             "records": .objectList([
                 [
                     "id": .string("one"),
-                    "createdAt": .date(date)
+                    "created_at": .date(date)
                 ]
             ])
         ])
 
         #expect(snapshot.values == [
-            "device": .object([
-                "date": .int(1_700_000_000_000),
-                "record": .object([
+            "evaluated_at": .int(123_000),
+            "date": .int(1_700_000_000_000),
+            "record": .object([
+                "id": .string("one"),
+                "created_at": .int(1_700_000_000_000)
+            ]),
+            "records": .array([
+                .object([
                     "id": .string("one"),
-                    "createdAt": .int(1_700_000_000_000)
-                ]),
-                "records": .array([
-                    .object([
-                        "id": .string("one"),
-                        "createdAt": .int(1_700_000_000_000)
-                    ])
+                    "created_at": .int(1_700_000_000_000)
                 ])
             ])
         ])
@@ -84,14 +83,14 @@ struct DimensionValueTests {
         let snapshot = try await Self.snapshot([
             "goal": .object([
                 "value": .string("lose_weight"),
-                "updatedAt": .date(Date(timeIntervalSince1970: 1_700_000_000))
+                "updated_at": .date(Date(timeIntervalSince1970: 1_700_000_000))
             ])
         ])
 
         let predicate = #"""
             {"and":[
-                {"==":[{"var":"device.goal.value"},"lose_weight"]},
-                {">":[{"var":"device.goal.updatedAt"},1699999999999]}
+                {"==":[{"var":"goal.value"},"lose_weight"]},
+                {">":[{"var":"goal.updated_at"},1699999999999]}
             ]}
             """#
 
@@ -101,15 +100,15 @@ struct DimensionValueTests {
     @Test
     func dateDimensionIsOrderedByPredicate() async throws {
         let snapshot = try await Self.snapshot([
-            "expiresAt": .date(Date(timeIntervalSince1970: 1_700_000_000))
+            "expires_at": .date(Date(timeIntervalSince1970: 1_700_000_000))
         ])
 
         #expect(try RulesEngine.evaluate(
-            predicate: #"{">":[{"var":"device.expiresAt"},1699999999999]}"#,
+            predicate: #"{">":[{"var":"expires_at"},1699999999999]}"#,
             variables: snapshot.values
         ).get())
         #expect(try !RulesEngine.evaluate(
-            predicate: #"{">":[{"var":"device.expiresAt"},1700000000001]}"#,
+            predicate: #"{">":[{"var":"expires_at"},1700000000001]}"#,
             variables: snapshot.values
         ).get())
     }
@@ -119,25 +118,25 @@ struct DimensionValueTests {
         let snapshot = try await Self.snapshot([
             "purchases": .objectList([
                 [
-                    "productId": .string("plus"),
-                    "isActive": .bool(false)
+                    "product_id": .string("plus"),
+                    "is_active": .bool(false)
                 ],
                 [
-                    "productId": .string("pro"),
-                    "isActive": .bool(true)
+                    "product_id": .string("pro"),
+                    "is_active": .bool(true)
                 ]
             ])
         ])
 
         let active =
-            #"{"some":[{"var":"device.purchases"},{"and":[{"==":[{"var":"productId"},"pro"]},{"var":"isActive"}]}]}"#
+            #"{"some":[{"var":"purchases"},{"and":[{"==":[{"var":"product_id"},"pro"]},{"var":"is_active"}]}]}"#
         #expect(try RulesEngine.evaluate(predicate: active, variables: snapshot.values).get())
 
         let inactive =
-            #"{"some":[{"var":"device.purchases"},{"and":[{"==":[{"var":"productId"},"plus"]},{"var":"isActive"}]}]}"#
+            #"{"some":[{"var":"purchases"},{"and":[{"==":[{"var":"product_id"},"plus"]},{"var":"is_active"}]}]}"#
         #expect(try !RulesEngine.evaluate(predicate: inactive, variables: snapshot.values).get())
 
-        let byIndex = #"{"==":[{"var":"device.purchases.1.productId"},"pro"]}"#
+        let byIndex = #"{"==":[{"var":"purchases.1.product_id"},"pro"]}"#
         #expect(try RulesEngine.evaluate(predicate: byIndex, variables: snapshot.values).get())
     }
 
@@ -148,10 +147,11 @@ struct DimensionValueTests {
         ])
 
         #expect(snapshot.values == [
-            "device": .object(["purchases": .array([])])
+            "evaluated_at": .int(123_000),
+            "purchases": .array([])
         ])
 
-        let none = #"{"none":[{"var":"device.purchases"},{"var":"isActive"}]}"#
+        let none = #"{"none":[{"var":"purchases"},{"var":"is_active"}]}"#
         #expect(try RulesEngine.evaluate(predicate: none, variables: snapshot.values).get())
     }
 
@@ -159,7 +159,8 @@ struct DimensionValueTests {
         _ values: [String: DimensionValue]
     ) async throws -> DimensionSnapshot {
         return try await DimensionResolver(
-            dimensionProviders: [StaticDimensionProvider(values: values)]
+            dimensionProviders: [StaticDimensionProvider(values: values)],
+            dateProvider: MockDateProvider(stubbedNow: Date(timeIntervalSince1970: 123))
         ).snapshot()
     }
 
@@ -167,7 +168,7 @@ struct DimensionValueTests {
 
 private struct StaticDimensionProvider: DimensionProvider {
 
-    let namespace: DimensionNamespace = .device
+    let name = "test"
     let values: [String: DimensionValue]
 
     func dimensions(at _: Date) async throws -> [String: DimensionValue] {

--- a/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
+++ b/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
@@ -28,10 +28,10 @@ struct LocalRulesEvaluatorTests {
     func batchUsesOneFreshSnapshotForEveryRule() async throws {
         let date = Date(timeIntervalSince1970: 1_234)
         let provider = TestDimensionProvider(
-            namespace: .device,
+            name: "device",
             snapshots: [
-                ["launchCount": .int(1)],
-                ["launchCount": .int(2)]
+                ["launch_count": .int(1)],
+                ["launch_count": .int(2)]
             ]
         )
         let evaluator = Self.evaluator(dimensionProviders: [provider], date: date)
@@ -39,11 +39,11 @@ struct LocalRulesEvaluatorTests {
         let rule = try await evaluator.match(in: [
             TestLocalRule(
                 id: TestRuleID.doesNotMatch,
-                predicate: #"{"==":[{"var":"device.launchCount"},2]}"#
+                predicate: #"{"==":[{"var":"launch_count"},2]}"#
             ),
             TestLocalRule(
                 id: TestRuleID.matches,
-                predicate: #"{"==":[{"var":"device.launchCount"},1]}"#
+                predicate: #"{"==":[{"var":"launch_count"},1]}"#
             ),
             TestLocalRule(
                 id: TestRuleID.notEvaluated,
@@ -59,7 +59,7 @@ struct LocalRulesEvaluatorTests {
     @Test
     func subsequentEvaluationPullsProviderAgain() async throws {
         let provider = TestDimensionProvider(
-            namespace: .store,
+            name: "store",
             snapshots: [
                 ["count": .int(1)],
                 ["count": .int(2)]
@@ -68,10 +68,10 @@ struct LocalRulesEvaluatorTests {
         let evaluator = Self.evaluator(dimensionProviders: [provider])
 
         let first = try await evaluator.match(in: [
-            TestLocalRule(id: "first", predicate: #"{"==":[{"var":"store.count"},1]}"#)
+            TestLocalRule(id: "first", predicate: #"{"==":[{"var":"count"},1]}"#)
         ])
         let second = try await evaluator.match(in: [
-            TestLocalRule(id: "second", predicate: #"{"==":[{"var":"store.count"},2]}"#)
+            TestLocalRule(id: "second", predicate: #"{"==":[{"var":"count"},2]}"#)
         ])
 
         #expect(first?.id == "first")
@@ -83,12 +83,12 @@ struct LocalRulesEvaluatorTests {
     func allProvidersReceiveSameDate() async throws {
         let date = Date(timeIntervalSince1970: 9_876)
         let device = TestDimensionProvider(
-            namespace: .device,
-            snapshots: [["ready": .bool(true)]]
+            name: "device",
+            snapshots: [["device_ready": .bool(true)]]
         )
         let store = TestDimensionProvider(
-            namespace: .store,
-            snapshots: [["ready": .bool(true)]]
+            name: "store",
+            snapshots: [["store_ready": .bool(true)]]
         )
         let evaluator = Self.evaluator(dimensionProviders: [device, store], date: date)
 
@@ -101,23 +101,23 @@ struct LocalRulesEvaluatorTests {
     }
 
     @Test
-    func mergesProviderValuesByNamespace() async throws {
+    func mergesProviderValuesAtRoot() async throws {
         let date = Date(timeIntervalSince1970: 5_432)
         let identity = TestDimensionProvider(
-            namespace: .device,
+            name: "identity",
             snapshots: [[
-                "appVersion": .string("1.2.3"),
-                "isDebugBuild": .bool(true),
-                "screenScale": .double(3)
+                "app_version": .string("1.2.3"),
+                "is_debug_build": .bool(true),
+                "screen_scale": .double(3)
             ]]
         )
         let environment = TestDimensionProvider(
-            namespace: .device,
-            snapshots: [["trackingEnabled": .bool(false)]]
+            name: "environment",
+            snapshots: [["tracking_enabled": .bool(false)]]
         )
         let store = TestDimensionProvider(
-            namespace: .store,
-            snapshots: [["shoeSize": .int(42)]]
+            name: "store",
+            snapshots: [["shoe_size": .int(42)]]
         )
 
         let snapshot = try await DimensionResolver(
@@ -127,20 +127,77 @@ struct LocalRulesEvaluatorTests {
 
         #expect(snapshot.evaluationDate == date)
         #expect(snapshot.values == [
-            "device": .object([
-                "appVersion": .string("1.2.3"),
-                "isDebugBuild": .bool(true),
-                "screenScale": .float(3),
-                "trackingEnabled": .bool(false)
+            "evaluated_at": .int(5_432_000),
+            "app_version": .string("1.2.3"),
+            "is_debug_build": .bool(true),
+            "screen_scale": .float(3),
+            "tracking_enabled": .bool(false),
+            "shoe_size": .int(42)
+        ])
+    }
+
+    @Test
+    func canonicalBaseSnapshotMatchesRFCShape() async throws {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let providers = [
+            TestDimensionProvider(
+                name: "device",
+                snapshots: [[
+                    "app_version": .string("1.2.3"),
+                    "platform": .string("ios"),
+                    "platform_version": .string("18.5"),
+                    "locale": .string("en_gb"),
+                    "sdk_version": .string("10.1.1")
+                ]]
+            ),
+            TestDimensionProvider(
+                name: "store",
+                snapshots: [["storefront": .string("GBR")]]
+            ),
+            TestDimensionProvider(
+                name: "subscriber_attributes",
+                snapshots: [[
+                    "subscriber_attributes": .object([
+                        "goal": .object([
+                            "updated_at": .date(Date(timeIntervalSince1970: 1_699_999_000)),
+                            "value": .string("make_more_money")
+                        ])
+                    ])
+                ]]
+            )
+        ]
+
+        let snapshot = try await DimensionResolver(
+            dimensionProviders: providers,
+            dateProvider: MockDateProvider(stubbedNow: date)
+        ).snapshot(
+            customVariables: ["attempt": .int(3)],
+            backendValues: ["condition_hash": .bool(true)]
+        )
+
+        #expect(snapshot.values == [
+            "evaluated_at": .int(1_700_000_000_000),
+            "app_version": .string("1.2.3"),
+            "platform": .string("ios"),
+            "platform_version": .string("18.5"),
+            "locale": .string("en_gb"),
+            "sdk_version": .string("10.1.1"),
+            "storefront": .string("GBR"),
+            "subscriber_attributes": .object([
+                "goal": .object([
+                    "updated_at": .int(1_699_999_000_000),
+                    "value": .string("make_more_money")
+                ])
             ]),
-            "store": .object(["shoeSize": .int(42)])
+            "custom": .object(["attempt": .int(3)]),
+            "backend": .object(["condition_hash": .bool(true)])
         ])
     }
 
     @Test
     func recursivelyOmitsInvalidProviderDimensionNames() async throws {
         let provider = TestDimensionProvider(
-            namespace: .device,
+            name: "device",
             snapshots: [[
                 "": .string("empty"),
                 " \n": .string("blank"),
@@ -153,10 +210,10 @@ struct LocalRulesEvaluatorTests {
                     "name": .string("Rick"),
                     "preferences": .object([
                         "invalid.key": .bool(false),
-                        "notificationsEnabled": .bool(true)
+                        "notifications_enabled": .bool(true)
                     ])
                 ]),
-                "invalidObject": .object([
+                "invalid_object": .object([
                     "invalid.key": .string("value")
                 ]),
                 "events": .objectList([
@@ -175,16 +232,12 @@ struct LocalRulesEvaluatorTests {
 
         let snapshot = try await DimensionResolver(dimensionProviders: [provider]).snapshot()
 
-        guard case .object(let deviceValues) = snapshot.values["device"] else {
-            Issue.record("Expected device dimensions")
-            return
-        }
-        #expect(deviceValues == [
+        #expect(snapshot.values.filter { $0.key != "evaluated_at" } == [
             "platform": .string("ios"),
             "profile": .object([
                 "name": .string("Rick"),
                 "preferences": .object([
-                    "notificationsEnabled": .bool(true)
+                    "notifications_enabled": .bool(true)
                 ])
             ]),
             "events": .array([
@@ -250,19 +303,36 @@ struct LocalRulesEvaluatorTests {
     @Test
     func duplicateLeafIsAConfigurationError() async {
         let first = TestDimensionProvider(
-            namespace: .device,
-            snapshots: [["appVersion": .string("1.2.3")]]
+            name: "first",
+            snapshots: [["app_version": .string("1.2.3")]]
         )
         let second = TestDimensionProvider(
-            namespace: .device,
-            snapshots: [["appVersion": .string("2.0.0")]]
+            name: "second",
+            snapshots: [["app_version": .string("2.0.0")]]
         )
 
         do {
             _ = try await DimensionResolver(dimensionProviders: [first, second]).snapshot()
             Issue.record("Expected duplicate ownership to fail")
         } catch let error as DimensionResolutionError {
-            #expect(error == .conflictingValue(path: "device.appVersion"))
+            #expect(error == .conflictingValue(path: "app_version"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test(arguments: ["evaluated_at", "custom", "backend"])
+    func providerCannotClaimReservedRoot(_ reservedRoot: String) async {
+        let provider = TestDimensionProvider(
+            name: "invalid",
+            snapshots: [[reservedRoot: .string("claimed")]]
+        )
+
+        do {
+            _ = try await DimensionResolver(dimensionProviders: [provider]).snapshot()
+            Issue.record("Expected reserved root ownership to fail")
+        } catch let error as DimensionResolutionError {
+            #expect(error == .conflictingValue(path: reservedRoot))
         } catch {
             Issue.record("Unexpected error: \(error)")
         }
@@ -271,7 +341,7 @@ struct LocalRulesEvaluatorTests {
     @Test
     func providerFailureIsThrown() async {
         let evaluator = Self.evaluator(dimensionProviders: [
-            FailingDimensionProvider(namespace: .store)
+            FailingDimensionProvider(name: "store")
         ])
 
         do {
@@ -280,11 +350,11 @@ struct LocalRulesEvaluatorTests {
             ])
             Issue.record("Expected provider failure to be thrown")
         } catch let error as DimensionResolutionError {
-            guard case .providerFailed(let namespace, _) = error else {
+            guard case .providerFailed(let providerName, _) = error else {
                 Issue.record("Unexpected resolution error: \(error)")
                 return
             }
-            #expect(namespace == .store)
+            #expect(providerName == "store")
         } catch {
             Issue.record("Unexpected error: \(error)")
         }
@@ -328,7 +398,7 @@ struct LocalRulesEvaluatorTests {
         // from a rule that was evaluated and did not match.
         let evaluator = Self.evaluator(dimensionProviders: [
             TestDimensionProvider(
-                namespace: .device,
+                name: "device",
                 snapshots: [["known": .bool(true)]]
             )
         ])
@@ -337,14 +407,14 @@ struct LocalRulesEvaluatorTests {
             _ = try await evaluator.match(in: [
                 TestLocalRule(
                     id: "reads-unknown-dimension",
-                    predicate: #"{"==":[{"var":"device.unknown"},null]}"#
+                    predicate: #"{"==":[{"var":"unknown"},null]}"#
                 )
             ])
             Issue.record("Expected predicate failure to be thrown")
         } catch let error as LocalRulesEvaluationError {
             #expect(error == .predicateEvaluation(
                 ruleIndex: 0,
-                error: .unresolvedVariable(path: "device.unknown")
+                error: .unresolvedVariable(path: "unknown")
             ))
         } catch {
             Issue.record("Unexpected error: \(error)")
@@ -357,7 +427,7 @@ struct LocalRulesEvaluatorTests {
         // second, so evaluation carries on and a later match still wins.
         let evaluator = Self.evaluator(dimensionProviders: [
             TestDimensionProvider(
-                namespace: .device,
+                name: "device",
                 snapshots: [["known": .bool(true)]]
             )
         ])
@@ -365,11 +435,11 @@ struct LocalRulesEvaluatorTests {
         let rule = try await evaluator.match(in: [
             TestLocalRule(
                 id: "reads-unknown-dimension",
-                predicate: #"{"==":[{"var":"device.unknown"},null]}"#
+                predicate: #"{"==":[{"var":"unknown"},null]}"#
             ),
             TestLocalRule(
                 id: "reads-known-dimension",
-                predicate: #"{"==":[{"var":"device.known"},true]}"#
+                predicate: #"{"==":[{"var":"known"},true]}"#
             )
         ])
 
@@ -379,7 +449,7 @@ struct LocalRulesEvaluatorTests {
     @Test
     func emptyBatchDoesNotCollectVariables() async throws {
         let provider = TestDimensionProvider(
-            namespace: .device,
+            name: "device",
             snapshots: [["value": .int(1)]]
         )
         let evaluator = Self.evaluator(dimensionProviders: [provider])
@@ -438,13 +508,13 @@ struct LocalRulesEvaluatorTests {
     @Test
     func resolvedPredicatesShareTheSingleSnapshot() async throws {
         let provider = TestDimensionProvider(
-            namespace: .device,
-            snapshots: [["launchCount": .int(1)], ["launchCount": .int(2)]]
+            name: "device",
+            snapshots: [["launch_count": .int(1)], ["launch_count": .int(2)]]
         )
         let evaluator = Self.evaluator(dimensionProviders: [provider])
 
         let rule = try await evaluator.match(in: ["a", "b"]) { _ in
-            #"{"==":[{"var":"device.launchCount"},1]}"#
+            #"{"==":[{"var":"launch_count"},1]}"#
         }
 
         #expect(rule == "a")
@@ -504,7 +574,7 @@ struct LocalRulesEvaluatorTests {
     @Test
     func cancellationIsThrownByMatch() async {
         let evaluator = Self.evaluator(dimensionProviders: [
-            CancellingDimensionProvider(namespace: .store)
+            CancellingDimensionProvider(name: "store")
         ])
 
         do {
@@ -552,17 +622,17 @@ private enum TestRuleID: Sendable {
 
 private actor TestDimensionProvider: DimensionProvider {
 
-    nonisolated let namespace: DimensionNamespace
+    nonisolated let name: String
 
     private let snapshots: [[String: DimensionValue]]
     private(set) var invocationCount = 0
     private(set) var receivedDates: [Date] = []
 
     init(
-        namespace: DimensionNamespace,
+        name: String,
         snapshots: [[String: DimensionValue]]
     ) {
-        self.namespace = namespace
+        self.name = name
         self.snapshots = snapshots
     }
 
@@ -578,7 +648,7 @@ private struct FailingDimensionProvider: DimensionProvider {
 
     struct ProviderError: Error {}
 
-    let namespace: DimensionNamespace
+    let name: String
 
     func dimensions(at date: Date) async throws -> [String: DimensionValue] {
         throw ProviderError()
@@ -587,7 +657,7 @@ private struct FailingDimensionProvider: DimensionProvider {
 
 private struct CancellingDimensionProvider: DimensionProvider {
 
-    let namespace: DimensionNamespace
+    let name: String
 
     func dimensions(at date: Date) async throws -> [String: DimensionValue] {
         throw CancellationError()

--- a/Tests/UnitTests/LocalRules/StoreDimensionProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/StoreDimensionProviderTests.swift
@@ -25,12 +25,12 @@ import Testing
 struct StoreDimensionProviderTests {
 
     @Test
-    func providesStoreCountryInStoreNamespace() async throws {
+    func providesCanonicalStorefrontAtTheRoot() async throws {
         let provider = StoreDimensionProvider(storefrontCountryCodeProvider: { "USA" })
 
-        #expect(provider.namespace == .store)
+        #expect(provider.name == "store")
         #expect(try await provider.dimensions(at: Date()) == [
-            "country": .string("USA")
+            "storefront": .string("USA")
         ])
     }
 
@@ -54,12 +54,12 @@ struct StoreDimensionProviderTests {
         storefrontCountryCode.value = "NLD"
         let second = try await provider.dimensions(at: Date())
 
-        #expect(first["country"] == .string("USA"))
-        #expect(second["country"] == .string("NLD"))
+        #expect(first["storefront"] == .string("USA"))
+        #expect(second["storefront"] == .string("NLD"))
     }
 
     @Test
-    func countryCanBeEvaluatedUsingSDKDimensionPath() async throws {
+    func storefrontCanBeEvaluatedUsingCanonicalPath() async throws {
         let evaluator = LocalRulesEvaluator(
             dimensionProviders: [
                 StoreDimensionProvider(storefrontCountryCodeProvider: { "NLD" })
@@ -68,7 +68,7 @@ struct StoreDimensionProviderTests {
 
         let match = try await evaluator.match(in: [
             TestStoreRule(
-                predicate: #"{"==":[{"var":"store.country"},"NLD"]}"#
+                predicate: #"{"==":[{"var":"storefront"},"NLD"]}"#
             )
         ])
 

--- a/Tests/UnitTests/LocalRules/SubscriberAttributesDimensionProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/SubscriberAttributesDimensionProviderTests.swift
@@ -32,22 +32,24 @@ struct SubscriberAttributesProviderTests {
         )
 
         let dimensions = try await provider.dimensions(at: Self.evaluationDate)
+        let attributes = Self.attributes(in: dimensions)
 
-        #expect(provider.namespace == .subscriberAttributes)
-        #expect(Set(dimensions.keys) == ["$email", "goal"])
+        #expect(provider.name == "subscriber_attributes")
+        #expect(Set(attributes.keys) == ["$email", "goal"])
     }
 
     @Test
-    func exposesValueUpdatedAtAndEvaluatedAt() async throws {
+    func exposesValueAndUpdatedAtUnderCanonicalRoot() async throws {
         let provider = Self.provider(Self.attribute("goal", value: "lose_weight"))
 
         let dimensions = try await provider.dimensions(at: Self.evaluationDate)
 
         #expect(dimensions == [
-            "goal": .object([
-                "value": .string("lose_weight"),
-                "updatedAt": .date(Self.setDate),
-                "evaluatedAt": .date(Self.evaluationDate)
+            "subscriber_attributes": .object([
+                "goal": .object([
+                    "value": .string("lose_weight"),
+                    "updated_at": .date(Self.setDate)
+                ])
             ])
         ])
     }
@@ -73,7 +75,7 @@ struct SubscriberAttributesProviderTests {
             Self.attribute("goal", value: "lose_weight")
         ).dimensions(at: Self.evaluationDate)
 
-        #expect(Set(dimensions.keys) == ["goal"])
+        #expect(Set(Self.attributes(in: dimensions).keys) == ["goal"])
     }
 
     @Test
@@ -88,7 +90,7 @@ struct SubscriberAttributesProviderTests {
             ]
         ).snapshot()
 
-        guard case .object(let attributes) = snapshot.values["subscriberAttributes"] else {
+        guard case .object(let attributes) = snapshot.values["subscriber_attributes"] else {
             Issue.record("Expected subscriber attribute dimensions")
             return
         }
@@ -101,7 +103,7 @@ struct SubscriberAttributesProviderTests {
             dimensionProviders: [Self.provider()]
         ).snapshot()
 
-        #expect(snapshot.values[DimensionNamespace.subscriberAttributes.rawValue] == nil)
+        #expect(snapshot.values["subscriber_attributes"] == nil)
     }
 
     @Test
@@ -113,11 +115,13 @@ struct SubscriberAttributesProviderTests {
             dimensionProviders: [
                 SubscriberAttributesTestDeviceProvider(),
                 provider
-            ]
+            ],
+            dateProvider: MockDateProvider(stubbedNow: Self.evaluationDate)
         ).snapshot()
 
         #expect(snapshot.values == [
-            "device": .object(["platform": .string("ios")])
+            "evaluated_at": .int(1_718_452_800_000),
+            "platform": .string("ios")
         ])
     }
 
@@ -182,27 +186,27 @@ struct SubscriberAttributesProviderTests {
         )
 
         let matchingPredicates = [
-            #"{"==":[{"var":"subscriberAttributes.$email.value"},"jane@example.com"]}"#,
-            #"{"==":[{"var":"subscriberAttributes.seats.value"},3]}"#,
-            #"{">":[{"var":"subscriberAttributes.seats.value"},2]}"#,
+            #"{"==":[{"var":"subscriber_attributes.$email.value"},"jane@example.com"]}"#,
+            #"{"==":[{"var":"subscriber_attributes.seats.value"},3]}"#,
+            #"{">":[{"var":"subscriber_attributes.seats.value"},2]}"#,
             #"""
             {"<":[
-                {"-":[{"var":"subscriberAttributes.tier.evaluatedAt"},
-                      {"var":"subscriberAttributes.tier.updatedAt"}]},
+                {"-":[{"var":"evaluated_at"},
+                      {"var":"subscriber_attributes.tier.updated_at"}]},
                 604800000
             ]}
             """#
         ]
         let nonMatchingPredicates = [
-            #"{"==":[{"var":"subscriberAttributes.goal.value"},"gain_muscle"]}"#,
+            #"{"==":[{"var":"subscriber_attributes.goal.value"},"gain_muscle"]}"#,
             // An attribute the app never set on this device, and one the SDK does not expose. Both
             // need a default, since reading a name that resolves to nothing is now an error.
-            #"{"!!":{"var":["subscriberAttributes.favoriteColor.value",false]}}"#,
-            #"{"!!":{"var":["subscriberAttributes.goal.isSynced",false]}}"#,
+            #"{"!!":{"var":["subscriber_attributes.favoriteColor.value",false]}}"#,
+            #"{"!!":{"var":["subscriber_attributes.goal.is_synced",false]}}"#,
             #"""
             {"<":[
-                {"-":[{"var":"subscriberAttributes.goal.evaluatedAt"},
-                      {"var":"subscriberAttributes.goal.updatedAt"}]},
+                {"-":[{"var":"evaluated_at"},
+                      {"var":"subscriber_attributes.goal.updated_at"}]},
                 604800000
             ]}
             """#
@@ -245,8 +249,15 @@ struct SubscriberAttributesProviderTests {
         of name: String,
         in dimensions: [String: DimensionValue]
     ) -> DimensionValue? {
-        guard case .object(let attribute) = dimensions[name] else { return nil }
+        guard case .object(let attribute) = Self.attributes(in: dimensions)[name] else { return nil }
         return attribute["value"]
+    }
+
+    private static func attributes(
+        in dimensions: [String: DimensionValue]
+    ) -> [String: DimensionValue] {
+        guard case .object(let attributes) = dimensions["subscriber_attributes"] else { return [:] }
+        return attributes
     }
 
 }
@@ -259,7 +270,7 @@ private struct TestSubscriberAttributeRule: LocalRule {
 
 private struct SubscriberAttributesTestDeviceProvider: DimensionProvider {
 
-    let namespace = DimensionNamespace.device
+    let name = "device"
 
     func dimensions(at _: Date) async throws -> [String: DimensionValue] {
         return ["platform": .string("ios")]


### PR DESCRIPTION
## Description
Restructures the data passed to the rule evaluator, removing the dimension types from the SDK supplied providers. Instead merging them all at the root, except externally supplied ones like `backend.*`, `custom.*` and `subscriber_attributes.*`.

Additionally also adds the `evaluated_at` property to the root of the snapshot.

```json
{
  "evaluated_at": 1787918400000,
  "platform": "ios",
  "platform_version": "26.3.0",
  "locale": "en_gb",
  "storefront": "GBR",
  "app_version": "1.2.3",
  "sdk_version": "5.84.0",
  "subscriber_attributes": {
    "goal": {
      "value": "make_more_money",
      "updated_at": 1787832000000
    }
  },
  "custom": {
    "string": "hello",
    "boolean": true,
    "integer": 42,
    "decimal": 4.2
  },
  "backend": {
    "predicate_hash": true,
    "object": {
      "nested": "value"
    },
    "list": [
      {
        "id": "first"
      }
    ]
  }
}
```

Related Android PR: https://github.com/RevenueCat/purchases-android/pull/4126

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change to rule/audience predicate variable paths and snapshot layout; misaligned server-authored rules would mis-target or fail evaluation until updated to canonical names.
> 
> **Overview**
> **Reshapes the variable snapshot** passed to the local rules engine so SDK-supplied dimensions live at the **root** with **snake_case** keys, aligned with the cross-platform RFC (paired Android change).
> 
> **`DimensionNamespace` is removed.** Providers expose a diagnostic `name` only; `DimensionResolver` **merges** provider output into one flat scope instead of nesting under `device`, `store`, etc. **`evaluated_at`** (epoch ms) is always injected at the root. **`custom`** and **`backend`** stay nested objects; **`subscriber_attributes`** is a single nested map of attributes (`value`, `updated_at` per key—no per-attribute `evaluated_at`).
> 
> **Renames / path changes for predicates:** e.g. `app_version`, `platform_version`, `sdk_version`, `storefront` (was `store.country`), `subscriber_attributes.*` (was `subscriberAttributes.*`). Duplicate root keys across providers or use of reserved roots (`evaluated_at`, `custom`, `backend`) now fail with `conflictingValue`. Provider errors report `providerName` instead of namespace.
> 
> Unit tests and checkpoint mocks are updated to the new paths and snapshot shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6dd3c134749fedb0258237bb54cad81356003ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->