### PR TITLE
feat(paywalls): add five discount variables

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
@@ -167,6 +167,7 @@ class TextComponentViewModel {
             variableCompatibilityMap: config.variableConfig.variableCompatibilityMap,
             functionCompatibilityMap: config.variableConfig.functionCompatibilityMap,
             discountRelativeToMostExpensivePerMonth: discount,
+            mostExpensivePricePerMonth: config.packageContext.variableContext.mostExpensivePricePerMonth,
             showZeroDecimalPlacePrices: config.packageContext.variableContext.showZeroDecimalPlacePrices,
             customVariables: config.customVariables,
             defaultCustomVariables: config.defaultCustomVariables

--- a/RevenueCatUI/Templates/V2/Variables/VariableHandlerV2.swift
+++ b/RevenueCatUI/Templates/V2/Variables/VariableHandlerV2.swift
@@ -266,6 +266,8 @@ enum VariablesV2: String {
     case productAbsoluteDiscount = "product.absolute_discount"
     case productOfferRelativeDiscount = "product.offer_relative_discount"
     case productOfferAbsoluteDiscount = "product.offer_absolute_discount"
+    case productRelativeDiscountWithOffer = "product.relative_discount_with_offer"
+    case productAbsoluteDiscountWithOffer = "product.absolute_discount_with_offer"
     case productStoreProductName = "product.store_product_name"
 
     // Countdown variables
@@ -554,6 +556,24 @@ extension VariablesV2 {
         case .productOfferAbsoluteDiscount:
             if let package {
                 return self.productOfferAbsoluteDiscount(
+                    package: package,
+                    showZeroDecimalPlacePrices: showZeroDecimalPlacePrices,
+                    offerContext: offerContext
+                )
+            }
+        case .productRelativeDiscountWithOffer:
+            if let package {
+                return self.productRelativeDiscountWithOffer(
+                    mostExpensivePricePerMonth: mostExpensivePricePerMonth,
+                    package: package,
+                    localizations: localizations,
+                    offerContext: offerContext
+                )
+            }
+        case .productAbsoluteDiscountWithOffer:
+            if let package {
+                return self.productAbsoluteDiscountWithOffer(
+                    mostExpensivePricePerMonth: mostExpensivePricePerMonth,
                     package: package,
                     showZeroDecimalPlacePrices: showZeroDecimalPlacePrices,
                     offerContext: offerContext
@@ -1136,6 +1156,66 @@ extension VariablesV2 {
         )
     }
 
+    /// Same cross-package comparison as `product.relative_discount`, but priced off the offer the
+    /// customer would actually get. With no usable offer the effective rate is the package's own,
+    /// so this collapses to `relative_discount`.
+    func productRelativeDiscountWithOffer(
+        mostExpensivePricePerMonth: Double?,
+        package: Package,
+        localizations: [String: String],
+        offerContext: OfferContext
+    ) -> String {
+        guard let mostExpensivePricePerMonth,
+              let term = effectiveOfferTerm(for: package, offerContext: offerContext),
+              term.months > 0,
+              let localizedFormat = localizations[VariableLocalizationKey.percent.rawValue] else {
+            return ""
+        }
+
+        let anchor = Decimal(mostExpensivePricePerMonth)
+        let rate = term.total / term.months
+        guard rate < anchor else {
+            return ""
+        }
+
+        let fraction = (anchor - rate) / anchor
+        let percent = Int((NSDecimalNumber(decimal: fraction).doubleValue * 100).rounded(.toNearestOrAwayFromZero))
+        return String(format: localizedFormat, percent)
+    }
+
+    /// The saving against the most expensive package across the span the offer actually runs for.
+    /// Renders empty when that span can't be determined, matching how the other discount variables
+    /// treat a package with no period.
+    func productAbsoluteDiscountWithOffer(
+        mostExpensivePricePerMonth: Double?,
+        package: Package,
+        showZeroDecimalPlacePrices: Bool,
+        offerContext: OfferContext
+    ) -> String {
+        guard let mostExpensivePricePerMonth,
+              let term = effectiveOfferTerm(for: package, offerContext: offerContext),
+              term.months > 0 else {
+            return ""
+        }
+
+        let anchor = Decimal(mostExpensivePricePerMonth)
+        guard term.total < anchor * term.months else {
+            return ""
+        }
+
+        let saving = ((anchor * term.months) - term.total as NSDecimalNumber)
+            .rounding(accordingToBehavior: Self.savingRoundingBehavior) as Decimal
+        guard saving > 0 else {
+            return ""
+        }
+
+        return formatDiscountPrice(
+            saving,
+            package: package,
+            showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
+        )
+    }
+
     func productStoreProductName(package: Package) -> String {
         return package.storeProduct.localizedTitle
     }
@@ -1188,6 +1268,32 @@ private extension VariablesV2 {
         case .payAsYouGo, .payUpFront:
             return false
         }
+    }
+
+    /// What the customer actually pays, and over how long: the resolved offer's total across all of
+    /// its periods, or the package's own price and period when there is no usable offer. A free offer
+    /// counts as no offer — "100% off" isn't the claim these variables make.
+    ///
+    /// Returns the total rather than a monthly rate on purpose. `StoreProductDiscount.pricePerMonth`
+    /// is already rounded to two places, and multiplying that back up by the duration would amplify
+    /// the rounding error by the number of months.
+    func effectiveOfferTerm(
+        for package: Package,
+        offerContext: VariablesV2.OfferContext
+    ) -> (total: Decimal, months: Decimal)? {
+        if let discount = resolvedDiscount(for: package, offerContext: offerContext), discount.price > 0 {
+            let periods = Decimal(discount.numberOfPeriods)
+            return (
+                total: discount.price * periods,
+                months: discount.subscriptionPeriod.numberOfUnitsAs(unit: .month) * periods
+            )
+        }
+
+        guard let period = package.storeProduct.subscriptionPeriod else {
+            return nil
+        }
+
+        return (total: package.storeProduct.price, months: period.numberOfUnitsAs(unit: .month))
     }
 
     /// The resolved offer's price, but only when it can be compared like-for-like against the standard

--- a/RevenueCatUI/Templates/V2/Variables/VariableHandlerV2.swift
+++ b/RevenueCatUI/Templates/V2/Variables/VariableHandlerV2.swift
@@ -27,6 +27,7 @@ struct VariableHandlerV2 {
 
     private let showZeroDecimalPlacePrices: Bool
     private let discountRelativeToMostExpensivePerMonth: Double?
+    private let mostExpensivePricePerMonth: Double?
     private let dateProvider: () -> Date
 
     /// Custom variables provided by the SDK at runtime.
@@ -38,6 +39,7 @@ struct VariableHandlerV2 {
         variableCompatibilityMap: [String: String],
         functionCompatibilityMap: [String: String],
         discountRelativeToMostExpensivePerMonth: Double?,
+        mostExpensivePricePerMonth: Double? = nil,
         showZeroDecimalPlacePrices: Bool,
         customVariables: [String: CustomVariableValue] = [:],
         defaultCustomVariables: [String: CustomVariableValue] = [:],
@@ -46,6 +48,7 @@ struct VariableHandlerV2 {
         self.variableCompatibilityMap = variableCompatibilityMap
         self.functionCompatibilityMap = functionCompatibilityMap
         self.discountRelativeToMostExpensivePerMonth = discountRelativeToMostExpensivePerMonth
+        self.mostExpensivePricePerMonth = mostExpensivePricePerMonth
         self.showZeroDecimalPlacePrices = showZeroDecimalPlacePrices
         self.customVariables = customVariables
         self.defaultCustomVariables = defaultCustomVariables
@@ -66,6 +69,7 @@ struct VariableHandlerV2 {
             locale: locale,
             localizations: localizations,
             discountRelativeToMostExpensivePerMonth: self.discountRelativeToMostExpensivePerMonth,
+            mostExpensivePricePerMonth: self.mostExpensivePricePerMonth,
             showZeroDecimalPlacePrices: self.showZeroDecimalPlacePrices,
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             date: self.dateProvider(),
@@ -259,6 +263,9 @@ enum VariablesV2: String {
     case productSecondaryOfferPeriod = "product.secondary_offer_period"
     case productSecondaryOfferPeriodAbbreviated = "product.secondary_offer_period_abbreviated"
     case productRelativeDiscount = "product.relative_discount"
+    case productAbsoluteDiscount = "product.absolute_discount"
+    case productOfferRelativeDiscount = "product.offer_relative_discount"
+    case productOfferAbsoluteDiscount = "product.offer_absolute_discount"
     case productStoreProductName = "product.store_product_name"
 
     // Countdown variables
@@ -290,6 +297,7 @@ extension VariablesV2 {
         let locale: Locale
         let localizations: [String: String]
         let discountRelativeToMostExpensivePerMonth: Double?
+        let mostExpensivePricePerMonth: Double?
         let showZeroDecimalPlacePrices: Bool
         let isEligibleForIntroOffer: Bool
         let date: Date
@@ -309,6 +317,7 @@ extension VariablesV2 {
         let locale = context.locale
         let localizations = context.localizations
         let discountRelativeToMostExpensivePerMonth = context.discountRelativeToMostExpensivePerMonth
+        let mostExpensivePricePerMonth = context.mostExpensivePricePerMonth
         let showZeroDecimalPlacePrices = context.showZeroDecimalPlacePrices
         let isEligibleForIntroOffer = context.isEligibleForIntroOffer
         let date = context.date
@@ -526,6 +535,30 @@ extension VariablesV2 {
                 discountRelativeToMostExpensivePerMonth: discountRelativeToMostExpensivePerMonth,
                 localizations: localizations
             )
+        case .productAbsoluteDiscount:
+            if let package {
+                return self.productAbsoluteDiscount(
+                    mostExpensivePricePerMonth: mostExpensivePricePerMonth,
+                    package: package,
+                    showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
+                )
+            }
+        case .productOfferRelativeDiscount:
+            if let package {
+                return self.productOfferRelativeDiscount(
+                    package: package,
+                    localizations: localizations,
+                    offerContext: offerContext
+                )
+            }
+        case .productOfferAbsoluteDiscount:
+            if let package {
+                return self.productOfferAbsoluteDiscount(
+                    package: package,
+                    showZeroDecimalPlacePrices: showZeroDecimalPlacePrices,
+                    offerContext: offerContext
+                )
+            }
         case .productStoreProductName:
             if let package {
                 return self.productStoreProductName(package: package)
@@ -1015,6 +1048,94 @@ extension VariablesV2 {
         return String(format: localizedFormat, percent)
     }
 
+    /// The saving against the most expensive package, expressed over this package's own period.
+    ///
+    /// The anchor is picked by per-month price, exactly as `product.relative_discount` does, so the two
+    /// variables always compare the same pair of packages. The amount is then normalized to the period
+    /// being purchased: a ratio is period-invariant, but a currency amount is not, so quoting it per
+    /// month would peg the number to an arbitrary unit rather than to what the customer actually buys.
+    func productAbsoluteDiscount(
+        mostExpensivePricePerMonth: Double?,
+        package: Package,
+        showZeroDecimalPlacePrices: Bool
+    ) -> String {
+        guard let mostExpensivePricePerMonth,
+              let pricePerMonth = package.storeProduct.pricePerMonth?.doubleValue,
+              pricePerMonth < mostExpensivePricePerMonth,
+              let period = package.storeProduct.subscriptionPeriod else {
+            return ""
+        }
+
+        let anchorPriceForThisPeriod =
+            Decimal(mostExpensivePricePerMonth) * period.numberOfUnitsAs(unit: .month)
+        // Round down, matching `SubscriptionPeriod.pricePerPeriod`, so a derived saving
+        // never overstates what the customer actually saves.
+        let saving = ((anchorPriceForThisPeriod - package.storeProduct.price) as NSDecimalNumber)
+            .rounding(accordingToBehavior: Self.savingRoundingBehavior) as Decimal
+
+        // A per-month price fractions of a cent below the anchor can round to zero. Render
+        // nothing rather than "Save $0.00", matching the offer discount variables.
+        guard saving > 0 else {
+            return ""
+        }
+
+        return formatDiscountPrice(
+            saving,
+            package: package,
+            showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
+        )
+    }
+
+    private static let savingRoundingBehavior = NSDecimalNumberHandler(
+        roundingMode: .down,
+        scale: 2,
+        raiseOnExactness: false,
+        raiseOnOverflow: false,
+        raiseOnUnderflow: false,
+        raiseOnDivideByZero: false
+    )
+
+    func productOfferRelativeDiscount(
+        package: Package,
+        localizations: [String: String],
+        offerContext: OfferContext
+    ) -> String {
+        guard let offerPrice = comparableOfferPrice(for: package, offerContext: offerContext) else {
+            return ""
+        }
+
+        let standardPrice = package.storeProduct.price
+        guard standardPrice > offerPrice,
+              let localizedFormat = localizations[VariableLocalizationKey.percent.rawValue] else {
+            return ""
+        }
+
+        let fraction = (standardPrice - offerPrice) / standardPrice
+        let percent = Int((NSDecimalNumber(decimal: fraction).doubleValue * 100).rounded(.toNearestOrAwayFromZero))
+        return String(format: localizedFormat, percent)
+    }
+
+    func productOfferAbsoluteDiscount(
+        package: Package,
+        showZeroDecimalPlacePrices: Bool,
+        offerContext: OfferContext
+    ) -> String {
+        guard let offerPrice = comparableOfferPrice(for: package, offerContext: offerContext) else {
+            return ""
+        }
+
+        let standardPrice = package.storeProduct.price
+        guard standardPrice > offerPrice else {
+            return ""
+        }
+
+        return formatDiscountPrice(
+            standardPrice - offerPrice,
+            package: package,
+            showZeroDecimalPlacePrices: showZeroDecimalPlacePrices
+        )
+    }
+
     func productStoreProductName(package: Package) -> String {
         return package.storeProduct.localizedTitle
     }
@@ -1067,6 +1188,23 @@ private extension VariablesV2 {
         case .payAsYouGo, .payUpFront:
             return false
         }
+    }
+
+    /// The resolved offer's price, but only when it can be compared like-for-like against the standard
+    /// price: same billing period, and not free. Returns `nil` otherwise so the offer discount variables
+    /// render empty rather than a misleading number (a 7-day trial on a monthly product would otherwise
+    /// read as a full month's saving). Takes the discount from `resolvedDiscount` so that adding the
+    /// secondary-offer variants later only needs a different discount passed in.
+    func comparableOfferPrice(for package: Package, offerContext: VariablesV2.OfferContext) -> Decimal? {
+        guard let discount = resolvedDiscount(for: package, offerContext: offerContext),
+              let period = package.storeProduct.subscriptionPeriod,
+              discount.subscriptionPeriod.unit == period.unit,
+              discount.subscriptionPeriod.value == period.value,
+              discount.price > 0 else {
+            return nil
+        }
+
+        return discount.price
     }
 
     func resolvedDiscount(

--- a/Tests/RevenueCatUITests/PaywallsV2/VariableHandlerV2Tests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/VariableHandlerV2Tests.swift
@@ -787,6 +787,248 @@ class VariableHandlerV2Test: TestCase {
         expect(result).to(equal("30%"))
     }
 
+    // MARK: - Discount variables
+
+    private func packageWithPricedIntroOffer(
+        price: Decimal,
+        localizedPriceString: String,
+        introPrice: Decimal,
+        introLocalizedPriceString: String,
+        introPeriod: SubscriptionPeriod,
+        period: SubscriptionPeriod = .init(value: 1, unit: .month)
+    ) -> Package {
+        return Package(
+            identifier: PackageType.monthly.identifier,
+            packageType: .monthly,
+            storeProduct: TestStoreProduct(
+                localizedTitle: "Monthly",
+                price: price,
+                currencyCode: "USD",
+                localizedPriceString: localizedPriceString,
+                productIdentifier: "com.revenuecat.product.offer_discount",
+                productType: .autoRenewableSubscription,
+                localizedDescription: "PRO monthly",
+                subscriptionGroupIdentifier: "group",
+                subscriptionPeriod: period,
+                introductoryDiscount: .init(
+                    identifier: "intro",
+                    price: introPrice,
+                    localizedPriceString: introLocalizedPriceString,
+                    paymentMode: .payAsYouGo,
+                    subscriptionPeriod: introPeriod,
+                    numberOfPeriods: 3,
+                    type: .introductory
+                ),
+                locale: Locale(identifier: "en_US")
+            ).toStoreProduct(),
+            offeringIdentifier: "offering",
+            webCheckoutUrl: nil
+        )
+    }
+
+    func testProductAbsoluteDiscountIsExpressedOverThePackagePeriod() {
+        // $10.00/mo anchor vs. a $60.00 annual package: the annual buyer saves
+        // ($10.00 x 12) - $60.00 = $60.00 over the year they're actually buying,
+        // not the $5.00 the per-month gap would suggest.
+        let variableHandler = VariableHandlerV2(
+            variableCompatibilityMap: Self.variableMapping,
+            functionCompatibilityMap: Self.functionMapping,
+            discountRelativeToMostExpensivePerMonth: nil,
+            mostExpensivePricePerMonth: 10.00,
+            showZeroDecimalPlacePrices: false
+        )
+
+        let result = variableHandler.processVariables(
+            in: "{{ product.absolute_discount }}",
+            with: TestData.annualPackage60,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+        expect(result).to(equal("$60.00"))
+    }
+
+    func testProductAbsoluteDiscountIsEmptyForTheAnchorPackageItself() {
+        // monthlyPackage is $6.99/mo, so an anchor of $6.99 leaves nothing to save.
+        let variableHandler = VariableHandlerV2(
+            variableCompatibilityMap: Self.variableMapping,
+            functionCompatibilityMap: Self.functionMapping,
+            discountRelativeToMostExpensivePerMonth: nil,
+            mostExpensivePricePerMonth: 6.99,
+            showZeroDecimalPlacePrices: false
+        )
+
+        let result = variableHandler.processVariables(
+            in: "{{ product.absolute_discount }}",
+            with: TestData.monthlyPackage,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+        expect(result).to(equal(""))
+    }
+
+    func testProductAbsoluteDiscountIsEmptyWithoutAnAnchor() {
+        let result = variableHandler.processVariables(
+            in: "{{ product.absolute_discount }}",
+            with: TestData.annualPackage60,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+        expect(result).to(equal(""))
+    }
+
+    func testProductAbsoluteDiscountIsEmptyForNonSubscriptions() {
+        // Lifetime has no period to normalize the anchor to.
+        let variableHandler = VariableHandlerV2(
+            variableCompatibilityMap: Self.variableMapping,
+            functionCompatibilityMap: Self.functionMapping,
+            discountRelativeToMostExpensivePerMonth: nil,
+            mostExpensivePricePerMonth: 10.00,
+            showZeroDecimalPlacePrices: false
+        )
+
+        let result = variableHandler.processVariables(
+            in: "{{ product.absolute_discount }}",
+            with: TestData.lifetimePackage,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+        expect(result).to(equal(""))
+    }
+
+    func testProductOfferDiscountsCompareOfferToStandardPrice() {
+        // $9.99/mo with a $5.99/mo intro: saves $4.00, 40% off.
+        let package = self.packageWithPricedIntroOffer(
+            price: 9.99,
+            localizedPriceString: "$9.99",
+            introPrice: 5.99,
+            introLocalizedPriceString: "$5.99",
+            introPeriod: .init(value: 1, unit: .month)
+        )
+
+        let relative = variableHandler.processVariables(
+            in: "{{ product.offer_relative_discount }}",
+            with: package,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+        expect(relative).to(equal("40%"))
+
+        let absolute = variableHandler.processVariables(
+            in: "{{ product.offer_absolute_discount }}",
+            with: package,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+        expect(absolute).to(equal("$4.00"))
+    }
+
+    func testProductOfferDiscountsWorkOnANonMonthlyBasePeriod() {
+        // Guards against over-rejecting: a 3-month offer on a 3-month base plan is
+        // comparable. The equivalent case is what regressed in purchases-js.
+        let package = self.packageWithPricedIntroOffer(
+            price: 27.00,
+            localizedPriceString: "$27.00",
+            introPrice: 15.00,
+            introLocalizedPriceString: "$15.00",
+            introPeriod: .init(value: 3, unit: .month),
+            period: .init(value: 3, unit: .month)
+        )
+
+        let relative = variableHandler.processVariables(
+            in: "{{ product.offer_relative_discount }}",
+            with: package,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+        expect(relative).to(equal("44%"))
+
+        let absolute = variableHandler.processVariables(
+            in: "{{ product.offer_absolute_discount }}",
+            with: package,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+        expect(absolute).to(equal("$12.00"))
+    }
+
+    func testProductOfferDiscountsAreEmptyWhenOfferPeriodDiffersFromBasePeriod() {
+        // $15.00 for the first 3 months isn't comparable to a $9.99 monthly price.
+        let package = self.packageWithPricedIntroOffer(
+            price: 9.99,
+            localizedPriceString: "$9.99",
+            introPrice: 15.00,
+            introLocalizedPriceString: "$15.00",
+            introPeriod: .init(value: 3, unit: .month)
+        )
+
+        let relative = variableHandler.processVariables(
+            in: "{{ product.offer_relative_discount }}",
+            with: package,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+        expect(relative).to(equal(""))
+
+        let absolute = variableHandler.processVariables(
+            in: "{{ product.offer_absolute_discount }}",
+            with: package,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+        expect(absolute).to(equal(""))
+    }
+
+    func testProductOfferDiscountsAreEmptyForAFreeTrial() {
+        // packageWithIntroOffer is a free 1-week trial: it would otherwise read as
+        // "100%" off, and its period doesn't match the monthly base either.
+        let relative = variableHandler.processVariables(
+            in: "{{ product.offer_relative_discount }}",
+            with: TestData.packageWithIntroOffer,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+        expect(relative).to(equal(""))
+
+        let absolute = variableHandler.processVariables(
+            in: "{{ product.offer_absolute_discount }}",
+            with: TestData.packageWithIntroOffer,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+        expect(absolute).to(equal(""))
+    }
+
+    func testProductOfferDiscountsAreEmptyWhenNotEligibleForTheOffer() {
+        let package = self.packageWithPricedIntroOffer(
+            price: 9.99,
+            localizedPriceString: "$9.99",
+            introPrice: 5.99,
+            introLocalizedPriceString: "$5.99",
+            introPeriod: .init(value: 1, unit: .month)
+        )
+
+        let result = variableHandler.processVariables(
+            in: "{{ product.offer_absolute_discount }}",
+            with: package,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: false
+        )
+        expect(result).to(equal(""))
+    }
+
     func testFunctionUppercase() {
         let result = variableHandler.processVariables(
             in: "{{ product.period | uppercase }}",

--- a/Tests/RevenueCatUITests/PaywallsV2/VariableHandlerV2Tests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/VariableHandlerV2Tests.swift
@@ -795,7 +795,8 @@ class VariableHandlerV2Test: TestCase {
         introPrice: Decimal,
         introLocalizedPriceString: String,
         introPeriod: SubscriptionPeriod,
-        period: SubscriptionPeriod = .init(value: 1, unit: .month)
+        period: SubscriptionPeriod = .init(value: 1, unit: .month),
+        numberOfPeriods: Int = 3
     ) -> Package {
         return Package(
             identifier: PackageType.monthly.identifier,
@@ -816,7 +817,7 @@ class VariableHandlerV2Test: TestCase {
                     localizedPriceString: introLocalizedPriceString,
                     paymentMode: .payAsYouGo,
                     subscriptionPeriod: introPeriod,
-                    numberOfPeriods: 3,
+                    numberOfPeriods: numberOfPeriods,
                     type: .introductory
                 ),
                 locale: Locale(identifier: "en_US")
@@ -1025,6 +1026,117 @@ class VariableHandlerV2Test: TestCase {
             locale: locale,
             localizations: localizations["en_US"]!,
             isEligibleForIntroOffer: false
+        )
+        expect(result).to(equal(""))
+    }
+
+    // MARK: - Discount variables priced off the current offer
+
+    private func handler(mostExpensivePricePerMonth: Double?) -> VariableHandlerV2 {
+        return VariableHandlerV2(
+            variableCompatibilityMap: Self.variableMapping,
+            functionCompatibilityMap: Self.functionMapping,
+            discountRelativeToMostExpensivePerMonth: nil,
+            mostExpensivePricePerMonth: mostExpensivePricePerMonth,
+            showZeroDecimalPlacePrices: false
+        )
+    }
+
+    func testRelativeDiscountWithOfferPricesTheOfferAgainstTheAnchor() {
+        // The Yousician case: $9.99/mo anchor, annual $99.99/yr with a paid intro year at
+        // $52.99 -> $4.42/mo. The base-price comparison would say 17% instead.
+        let package = self.packageWithPricedIntroOffer(
+            price: 99.99,
+            localizedPriceString: "$99.99",
+            introPrice: 52.99,
+            introLocalizedPriceString: "$52.99",
+            introPeriod: .init(value: 1, unit: .year),
+            period: .init(value: 1, unit: .year),
+            numberOfPeriods: 1
+        )
+
+        let result = self.handler(mostExpensivePricePerMonth: 9.99).processVariables(
+            in: "{{ product.relative_discount_with_offer }}",
+            with: package,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+        expect(result).to(equal("56%"))
+    }
+
+    func testAbsoluteDiscountWithOfferSpansTheOfferDuration() {
+        let package = self.packageWithPricedIntroOffer(
+            price: 99.99,
+            localizedPriceString: "$99.99",
+            introPrice: 52.99,
+            introLocalizedPriceString: "$52.99",
+            introPeriod: .init(value: 1, unit: .year),
+            period: .init(value: 1, unit: .year),
+            numberOfPeriods: 1
+        )
+
+        let result = self.handler(mostExpensivePricePerMonth: 9.99).processVariables(
+            in: "{{ product.absolute_discount_with_offer }}",
+            with: package,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+        expect(result).to(equal("$66.89"))
+    }
+
+    func testWithOfferVariablesFallBackToTheBaseComparisonWithoutAnOffer() {
+        // annualPackage60 has only a free 14-day trial, so there is no usable offer and
+        // these should match `relative_discount` / `absolute_discount`.
+        let handler = self.handler(mostExpensivePricePerMonth: 10.00)
+
+        let relative = handler.processVariables(
+            in: "{{ product.relative_discount_with_offer }}",
+            with: TestData.annualPackage60,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+        expect(relative).to(equal("50%"))
+
+        let absolute = handler.processVariables(
+            in: "{{ product.absolute_discount_with_offer }}",
+            with: TestData.annualPackage60,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+        expect(absolute).to(equal("$60.00"))
+    }
+
+    func testAbsoluteDiscountWithOfferSpansEveryOfferCycle() {
+        // 3 cycles at $5.99/mo against a $9.99/mo anchor: $4.00/mo x 3 = $12.00.
+        let package = self.packageWithPricedIntroOffer(
+            price: 9.99,
+            localizedPriceString: "$9.99",
+            introPrice: 5.99,
+            introLocalizedPriceString: "$5.99",
+            introPeriod: .init(value: 1, unit: .month)
+        )
+
+        let result = self.handler(mostExpensivePricePerMonth: 9.99).processVariables(
+            in: "{{ product.absolute_discount_with_offer }}",
+            with: package,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
+        )
+        expect(result).to(equal("$12.00"))
+    }
+
+    func testWithOfferVariablesAreEmptyForNonSubscriptions() {
+        let result = self.handler(mostExpensivePricePerMonth: 10.00).processVariables(
+            in: "{{ product.absolute_discount_with_offer }}",
+            with: TestData.lifetimePackage,
+            locale: locale,
+            localizations: localizations["en_US"]!,
+            isEligibleForIntroOffer: true
         )
         expect(result).to(equal(""))
     }


### PR DESCRIPTION
Reference implementation for five new Paywalls V2 variables. Part of [Paywall variables: discounts & secondary offer parity](https://app.notion.com/p/361cb1a108b08189a94def9fab1e8752) — Milestone 1 of 2; the secondary-offer variables and the iOS secondary-offer gap fix are Milestone 2.

Siblings: [purchases-android#4134](https://github.com/RevenueCat/purchases-android/pull/4134), [purchases-js#1099](https://github.com/RevenueCat/purchases-js/pull/1099), [purchases-ui-js#376](https://github.com/RevenueCat/purchases-ui-js/pull/376), [revenuecat-app#11647](https://github.com/RevenueCat/revenuecat-app/pull/11647).

## Two comparison axes

| Variable | Compares | Example |
|---|---|---|
| `absolute_discount` | this package vs. the most expensive package | `$60.00` |
| `offer_relative_discount` / `offer_absolute_discount` | an offer vs. **its own package's** standard price | `40%` / `$4.00` |
| `relative_discount_with_offer` / `absolute_discount_with_offer` | this package **with its offer applied** vs. the most expensive package | `56%` / `$66.89` |

All five select the same anchor — most-expensive per-month base price — so they never disagree about which packages are being compared.

## `absolute_discount`

```
(mostExpensivePricePerMonth × thisPackagePeriodInMonths) − thisPackagePrice
```

The anchor is *selected* by per-month price, exactly as `product.relative_discount` does. The saving is then expressed over **the purchased package's own period**, not per month. A ratio is period-invariant — per week, month or year all give the same percentage — so the unit `relative_discount` normalises on is arbitrary and harmless. A currency amount has no such property, so the unit has to be a deliberate choice. Anchoring it to the term actually being purchased is what makes it meaningful, and avoids shipping an `absolute_discount_per_day/_week/_month/_year` family just to disambiguate.

## `offer_relative_discount` / `offer_absolute_discount`

The resolved offer's price against the same package's standard renewal price, compared raw. Both render empty unless the offer's billing period matches the base period **and** the offer price is above zero:

| Offer shape | Renders |
|---|---|
| 3 cycles @ $5.99 on a $9.99/mo base | `40%` / `$4.00` |
| 3 months @ $15.00 on a $27.00/3mo base | `44%` / `$12.00` |
| 7-day trial on a monthly product | `""` |
| Pay-up-front "$5.99 for 3 months" on a $9.99/mo base | `""` |

The period comparison checks `unit` and `value` explicitly rather than `==` on `SubscriptionPeriod`, which is an `NSObject` subclass where value equality isn't obvious at the call site.

## `relative_discount_with_offer` / `absolute_discount_with_offer`

The same cross-package comparison as `absolute_discount`, but priced off the offer the customer would actually get. This is the "56% off annual" badge on a paywall where annual carries a paid intro offer — `offer_relative_discount` does **not** produce that number, since it compares annual's offer to annual's own base.

- The absolute variant spans the offer's **full duration** (billing period × `numberOfPeriods`), since that's the term being purchased.
- With no usable offer both collapse to the bare variables, so they can be used unconditionally rather than behind show/hide rules. A free trial counts as no offer rather than "100% off".

`effectiveOfferTerm` returns the offer's **total** price and span rather than a monthly rate on purpose: `StoreProductDiscount.pricePerMonth` is already rounded to two places, and scaling that back up by the duration amplifies the rounding error by the number of months. A $52.99 intro year against a $9.99/mo anchor rendered **$200.88 instead of $66.89** before this was fixed; there's a test pinning the correct value.

## Notes on shape

- The anchor reaches the handler as `mostExpensivePricePerMonth` rather than a precomputed amount, so the normalisation is unit-testable alongside every other variable instead of living in `TextComponentViewModel`. There's exactly one non-test construction site for `VariableHandlerV2`.
- Derived savings round **down** via `NSDecimalNumberHandler`, matching `SubscriptionPeriod.pricePerPeriod`, so a saving is never overstated. A saving that rounds to zero renders empty rather than `"Save $0.00"`.
- `comparableOfferPrice` takes the discount as a parameter, so adding the secondary-offer variants later only needs a different discount passed in.
- No new localization keys — percentages reuse `percent`, the same key `relative_discount` uses.
- `VariablesV2` is internal, so no public API surface changes and no new public enum.

**Known limitation:** the `offer_*` pair renders empty for products with a free trial *and* a discounted intro phase, since `resolvedDiscount` prefers the trial. That needs `secondary_offer_*_discount`, which is Milestone 2 and depends on the iOS secondary-offer gap fix.

## Verification

- `swift build` — clean
- `swift test --filter VariableHandlerV2Test` — 100 passed, including 14 new
- swiftlint not run locally (not installed on this machine); no added line exceeds 120 chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)