### PR TITLE
Unify internal authentication delegate

### DIFF
--- a/Sources/Authentication/Authentication.swift
+++ b/Sources/Authentication/Authentication.swift
@@ -31,9 +31,15 @@ public protocol AuthenticationDelegate: NSObjectProtocol {
     func authenticatorDidEncounterError(_ error: PublicError)
 }
 
+internal enum IdentityChangeReason {
+    case logIn
+    case logOut
+    case identified
+}
+
 internal protocol InternalAuthenticatorDelegate: AnyObject {
-    func authenticatorDidLogIn(info: CustomerInfo)
-    func authenticatorDidChangeIdentity(completion: @escaping (Result<CustomerInfo, PublicError>) -> Void)
+    func authenticatorDidChangeIdentity(reason: IdentityChangeReason,
+                                        didHandle: ((Result<CustomerInfo, PublicError>?) -> Void)?)
 }
 
 /// A namespace for providing authentication-related functionality to the ``Purchases`` instance
@@ -125,9 +131,16 @@ public final class Authentication: NSObject {
 
             self.operationDispatcher.dispatchOnMainThread {
                 if case let .success(values) = result {
-                    self.internalDelegate?.authenticatorDidLogIn(info: values.info)
+                    self.internalDelegate?.authenticatorDidChangeIdentity(reason: .identified) { newResult in
+                        let customerInfo = newResult?.value ?? values.info
+                        let didCreate = values.created
+                        let error = newResult?.error ?? nil
+
+                        completion(customerInfo, didCreate, error)
+                    }
+                } else {
+                    completion(result.value?.info, result.value?.created ?? false, result.error?.asPublicError)
                 }
-                completion(result.value?.info, result.value?.created ?? false, result.error?.asPublicError)
             }
         }
 
@@ -219,19 +232,18 @@ public final class Authentication: NSObject {
         self.identityManager.logIn(identity: identity) { result in
             if userInitiated { self.ongoingUserInitiatedRequestCount.decrement() }
 
-            if let completion {
-                self.operationDispatcher.dispatchOnMainThread {
-                    completion(result.value?.info, result.error?.asPublicError)
-                }
-            }
-
             switch result {
-            case .success(let result):
-                self.internalDelegate?.authenticatorDidLogIn(info: result.info)
+            case .success:
+                self.internalDelegate?.authenticatorDidChangeIdentity(reason: .logIn, didHandle: { newResult in
+                    let info = newResult?.value ?? result.value?.info
+                    let error = newResult?.error ?? result.error?.asPublicError
+                    completion?(info, error)
+                })
             case .failure(let error):
                 if userInitiated == false {
                     self.reportAuthenticationError(error.asPublicError)
                 }
+                completion?(nil, error.asPublicError)
             }
 
         }
@@ -271,8 +283,8 @@ public final class Authentication: NSObject {
                         completion?(nil, error.asPublicError)
                         return
                     }
-                    delegate.authenticatorDidChangeIdentity { result in
-                        completion?(result.value, result.error)
+                    delegate.authenticatorDidChangeIdentity(reason: .logOut) { result in
+                        completion?(result?.value, result?.error)
                     }
                 }
             }

--- a/Sources/Authentication/Authentication.swift
+++ b/Sources/Authentication/Authentication.swift
@@ -130,16 +130,17 @@ public final class Authentication: NSObject {
             self.ongoingUserInitiatedRequestCount.decrement()
 
             self.operationDispatcher.dispatchOnMainThread {
-                if case let .success(values) = result {
-                    self.internalDelegate?.authenticatorDidChangeIdentity(reason: .identified) { newResult in
-                        let customerInfo = newResult?.value ?? values.info
-                        let didCreate = values.created
-                        let error = newResult?.error ?? nil
-
-                        completion(customerInfo, didCreate, error)
+                switch result {
+                case .success(let values):
+                    if let delegate = self.internalDelegate {
+                        delegate.authenticatorDidChangeIdentity(reason: .identified) { _ in
+                            completion(values.info, values.created, nil)
+                        }
+                    } else {
+                        completion(values.info, values.created, nil)
                     }
-                } else {
-                    completion(result.value?.info, result.value?.created ?? false, result.error?.asPublicError)
+                case .failure(let error):
+                    completion(nil, false, error.asPublicError)
                 }
             }
         }
@@ -233,17 +234,19 @@ public final class Authentication: NSObject {
             if userInitiated { self.ongoingUserInitiatedRequestCount.decrement() }
 
             switch result {
-            case .success:
-                self.internalDelegate?.authenticatorDidChangeIdentity(reason: .logIn, didHandle: { newResult in
-                    let info = newResult?.value ?? result.value?.info
-                    let error = newResult?.error ?? result.error?.asPublicError
-                    completion?(info, error)
+            case .success(let value):
+                self.internalDelegate?.authenticatorDidChangeIdentity(reason: .logIn, didHandle: { _ in
+                    completion?(value.info, nil)
                 })
             case .failure(let error):
                 if userInitiated == false {
                     self.reportAuthenticationError(error.asPublicError)
                 }
-                completion?(nil, error.asPublicError)
+                if let completion {
+                    self.operationDispatcher.dispatchOnMainThread {
+                        completion(nil, error.asPublicError)
+                    }
+                }
             }
 
         }

--- a/Sources/Authentication/Authentication.swift
+++ b/Sources/Authentication/Authentication.swift
@@ -31,7 +31,7 @@ public protocol AuthenticationDelegate: NSObjectProtocol {
     func authenticatorDidEncounterError(_ error: PublicError)
 }
 
-internal enum IdentityChangeReason {
+internal enum IdentityChangeReason: Equatable {
     case logIn
     case logOut
     case identified
@@ -39,7 +39,7 @@ internal enum IdentityChangeReason {
 
 internal protocol InternalAuthenticatorDelegate: AnyObject {
     func authenticatorDidChangeIdentity(reason: IdentityChangeReason,
-                                        didHandle: ((Result<CustomerInfo, PublicError>?) -> Void)?)
+                                        didHandle: @escaping (Result<CustomerInfo, PublicError>?) -> Void)
 }
 
 /// A namespace for providing authentication-related functionality to the ``Purchases`` instance

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1286,7 +1286,7 @@ public extension Purchases {
 extension Purchases: InternalAuthenticatorDelegate {
 
     func authenticatorDidChangeIdentity(reason: IdentityChangeReason,
-                                        didHandle: ((Result<CustomerInfo, PublicError>?) -> Void)?) {
+                                        didHandle: @escaping (Result<CustomerInfo, PublicError>?) -> Void) {
         switch reason {
         case .logIn:
             self.systemInfo.isApplicationBackgrounded { isAppBackgrounded in
@@ -1295,7 +1295,7 @@ extension Purchases: InternalAuthenticatorDelegate {
                     fetchContext: .identityChange,
                     isAppBackgrounded: isAppBackgrounded
                 )
-                didHandle?(nil)
+                didHandle(nil)
             }
 
         case .logOut:

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1285,23 +1285,31 @@ public extension Purchases {
 
 extension Purchases: InternalAuthenticatorDelegate {
 
-    func authenticatorDidLogIn(info: CustomerInfo) {
-        self.systemInfo.isApplicationBackgrounded { isAppBackgrounded in
-            self.updateOfferingsCache(isAppBackgrounded: isAppBackgrounded)
-            self.remoteConfigManager.refreshRemoteConfig(
-                fetchContext: .identityChange,
-                isAppBackgrounded: isAppBackgrounded
-            )
-        }
-    }
+    func authenticatorDidChangeIdentity(reason: IdentityChangeReason,
+                                        didHandle: ((Result<CustomerInfo, PublicError>?) -> Void)?) {
+        switch reason {
+        case .logIn:
+            self.systemInfo.isApplicationBackgrounded { isAppBackgrounded in
+                self.updateOfferingsCache(isAppBackgrounded: isAppBackgrounded)
+                self.remoteConfigManager.refreshRemoteConfig(
+                    fetchContext: .identityChange,
+                    isAppBackgrounded: isAppBackgrounded
+                )
+                didHandle?(nil)
+            }
 
-    func authenticatorDidChangeIdentity(completion: @escaping (Result<CustomerInfo, PublicError>) -> Void) {
-        // The web view cache must retain the cache on login to support multipage paywalls and workflows
-        // making `.identityChange` an insufficient signal.
-        // Currently, this is only invoked on logout, but in the event that this gets invoked from login
-        // we would have an issue. 
-        Task { await self.webBundleEventBus.clearCache() }
-        self.updateAllCaches(fetchContext: .identityChange, completion: completion)
+        case .logOut:
+            // The web view cache retains the cache on login to support multipage paywalls and workflows,
+            // and clears the cache when the current user "logs out"
+            Task { await self.webBundleEventBus.clearCache() }
+
+            // .logOut and .identified are both considered "identity changes"
+            self.updateAllCaches(fetchContext: .identityChange, completion: didHandle)
+
+        case .identified:
+            // .logOut and .identified are both considered "identity changes"
+            self.updateAllCaches(fetchContext: .identityChange, completion: didHandle)
+        }
     }
 
 }

--- a/Tests/UnitTests/Authentication/AuthenticationTests.swift
+++ b/Tests/UnitTests/Authentication/AuthenticationTests.swift
@@ -90,8 +90,8 @@ class AuthenticationTests: TestCase {
         expect(receivedCreated) == true
         expect(receivedError).to(beNil())
         expect(self.identityManager.invokedLogInParametersList) == [Self.appUserID]
-        expect(self.internalDelegate.invokedAuthenticatorDidLogIn) == true
-        expect(self.internalDelegate.invokedAuthenticatorDidLogInParametersList.last) == expectedInfo
+        expect(self.internalDelegate.invokedAuthenticatorDidChangeIdentity) == true
+        expect(self.internalDelegate.invokedAuthenticatorDidChangeIdentityParametersList.last) == .identified
     }
 
     func testIdentifyCurrentUserWithStringFailureDoesNotNotifyInternalDelegate() {
@@ -112,7 +112,7 @@ class AuthenticationTests: TestCase {
         expect(receivedInfo).to(beNil())
         expect(receivedCreated) == false
         expect(receivedError).to(matchError(backendError.asPurchasesError))
-        expect(self.internalDelegate.invokedAuthenticatorDidLogIn) == false
+        expect(self.internalDelegate.invokedAuthenticatorDidChangeIdentity) == false
     }
 
     func testIdentifyCurrentUserWithStringTrimsWhitespaceBeforeLoggingIn() throws {
@@ -136,7 +136,7 @@ class AuthenticationTests: TestCase {
 
         expect(receivedError).to(matchError(ErrorCode.unsupportedError))
         expect(self.identityManager.invokedLogIn) == false
-        expect(self.internalDelegate.invokedAuthenticatorDidLogIn) == false
+        expect(self.internalDelegate.invokedAuthenticatorDidChangeIdentity) == false
     }
 
     // MARK: - identifyCurrentUser(as: StaticString, completion:) [deprecated]
@@ -228,7 +228,8 @@ class AuthenticationTests: TestCase {
         expect(receivedError).to(beNil())
         expect(self.identityManager.invokedLogInWithIdentityCount) == 1
         expect(self.identityManager.invokedLogInWithIdentityParametersList.first?.identitySource) == .anonymous
-        expect(self.internalDelegate.invokedAuthenticatorDidLogIn) == true
+        expect(self.internalDelegate.invokedAuthenticatorDidChangeIdentity) == true
+        expect(self.internalDelegate.invokedAuthenticatorDidChangeIdentityParametersList.last) == .logIn
     }
 
     func testLogInUsingIdentityFailureDoesNotNotifyInternalDelegate() {
@@ -246,7 +247,7 @@ class AuthenticationTests: TestCase {
 
         expect(receivedInfo).to(beNil())
         expect(receivedError).to(matchError(backendError.asPurchasesError))
-        expect(self.internalDelegate.invokedAuthenticatorDidLogIn) == false
+        expect(self.internalDelegate.invokedAuthenticatorDidChangeIdentity) == false
     }
 
     func testLogInUsingIdentityPassesTheProvidedIdentityToTheIdentityManager() {
@@ -279,6 +280,7 @@ class AuthenticationTests: TestCase {
         expect(receivedError).to(beNil())
         expect(self.identityManager.invokedLogOutCount) == 1
         expect(self.internalDelegate.invokedAuthenticatorDidChangeIdentity) == true
+        expect(self.internalDelegate.invokedAuthenticatorDidChangeIdentityParametersList.last) == .logOut
     }
 
     func testLogOutForwardsIdentityManagerErrorToCompletionAndDoesNotChangeIdentity() {

--- a/Tests/UnitTests/Mocks/MockInternalAuthenticatorDelegate.swift
+++ b/Tests/UnitTests/Mocks/MockInternalAuthenticatorDelegate.swift
@@ -15,31 +15,24 @@
 
 final class MockInternalAuthenticatorDelegate: InternalAuthenticatorDelegate {
 
-    private(set) var invokedAuthenticatorDidLogIn = false
-    private(set) var invokedAuthenticatorDidLogInCount = 0
-    private(set) var invokedAuthenticatorDidLogInParametersList: [CustomerInfo] = []
-
-    func authenticatorDidLogIn(info: CustomerInfo) {
-        self.invokedAuthenticatorDidLogIn = true
-        self.invokedAuthenticatorDidLogInCount += 1
-        self.invokedAuthenticatorDidLogInParametersList.append(info)
-    }
-
     private(set) var invokedAuthenticatorDidChangeIdentity = false
     private(set) var invokedAuthenticatorDidChangeIdentityCount = 0
+    private(set) var invokedAuthenticatorDidChangeIdentityParametersList: [IdentityChangeReason] = []
 
-    /// The result that will be handed to the completion passed to ``authenticatorDidChangeIdentity(completion:)``.
-    /// If left `nil`, the completion is never invoked, to make it easy to test that a caller correctly
-    /// waits for this delegate callback.
+    /// The result that will be handed to the `didHandle` closure passed to
+    /// ``authenticatorDidChangeIdentity(reason:didHandle:)``.
+    /// If left `nil`, `didHandle` is invoked with `nil`, mirroring the real delegate's behavior when there
+    /// isn't a more specific `CustomerInfo` to hand back (e.g. after a `.logIn`, where the SDK falls back
+    /// to the `CustomerInfo` it already has).
     var stubbedAuthenticatorDidChangeIdentityResult: Result<CustomerInfo, PublicError>?
 
-    func authenticatorDidChangeIdentity(completion: @escaping (Result<CustomerInfo, PublicError>) -> Void) {
+    func authenticatorDidChangeIdentity(reason: IdentityChangeReason,
+                                        didHandle: @escaping (Result<CustomerInfo, PublicError>?) -> Void) {
         self.invokedAuthenticatorDidChangeIdentity = true
         self.invokedAuthenticatorDidChangeIdentityCount += 1
+        self.invokedAuthenticatorDidChangeIdentityParametersList.append(reason)
 
-        if let result = self.stubbedAuthenticatorDidChangeIdentityResult {
-            completion(result)
-        }
+        didHandle(self.stubbedAuthenticatorDidChangeIdentityResult)
     }
 
 }


### PR DESCRIPTION
Unifies the two different InternalAuthenticationDelegate methods into a single call

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Internal-only, but identity flows now differ for identify vs token login (full cache refresh on identify) and completion timing depends on delegate handling.
> 
> **Overview**
> **Unifies** `InternalAuthenticatorDelegate` into a single `authenticatorDidChangeIdentity(reason:didHandle:)` callback, with a new `IdentityChangeReason` (`.logIn`, `.logOut`, `.identified`) replacing separate `authenticatorDidLogIn` and `authenticatorDidChangeIdentity` methods.
> 
> `Authentication` routes **identify**, **token log-in**, and **log-out** through that API and defers public completions until `didHandle` runs where appropriate. **`Purchases`** handles each reason differently: **`.logIn`** still refreshes offerings and remote config only (and calls `didHandle(nil)`); **`.logOut`** clears the web bundle cache then runs `updateAllCaches`; **`.identified`** now also runs **`updateAllCaches`**, so alias/identify success waits on a full identity-change cache refresh instead of the lighter login-side updates.
> 
> Tests and `MockInternalAuthenticatorDelegate` are updated for the new signature and reason tracking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c845cf921aaf688d4a609f81e015a7afefbd5b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->