### PR TITLE
[EXTERNAL] Give the paywall sticky footer a bottom margin where there is no safe area

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Root/RootView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Root/RootView.swift
@@ -23,6 +23,9 @@ struct RootView: View {
     @Environment(\.safeAreaInsets)
     private var safeAreaInsets
 
+    @Environment(\.userInterfaceIdiom)
+    private var userInterfaceIdiom
+
     @EnvironmentObject
     private var packageContext: PackageContext
 
@@ -66,6 +69,20 @@ struct RootView: View {
             return true
         }
         return false
+    }
+
+    /// Bottom spacing for the sticky footer.
+    ///
+    /// The safe area inset alone is not enough. Where there is no bottom safe area to avoid —
+    /// an iPad presenting the paywall in a card, in either orientation — the footer's last row
+    /// ends up flush against the card's edge, while the same paywall has a comfortable margin
+    /// on iPhone. Falling back to the idiom's default vertical padding restores that margin,
+    /// and reuses the value the rest of the SDK already uses to give iPad breathing room.
+    ///
+    /// Takes the larger of the two rather than replacing, so a device that does report a bottom
+    /// inset (a phone's home indicator) keeps the spacing it has today.
+    static func stickyFooterBottomPadding(safeAreaBottom: CGFloat, idiom: UserInterfaceIdiom) -> CGFloat {
+        return max(safeAreaBottom, Constants.defaultVerticalPaddingLength(idiom) ?? 0)
     }
 
     var body: some View {
@@ -116,7 +133,15 @@ struct RootView: View {
                     StackComponentView(
                         viewModel: stickyFooterViewModel.stackViewModel,
                         onDismiss: onDismiss,
-                        additionalPadding: EdgeInsets(top: 0, leading: 0, bottom: safeAreaInsets.bottom, trailing: 0)
+                        additionalPadding: EdgeInsets(
+                            top: 0,
+                            leading: 0,
+                            bottom: Self.stickyFooterBottomPadding(
+                                safeAreaBottom: safeAreaInsets.bottom,
+                                idiom: self.userInterfaceIdiom
+                            ),
+                            trailing: 0
+                        )
                     )
                     .fixedSize(horizontal: false, vertical: true)
                     .onSizeChange { overlaidFooterHeight = $0.height }

--- a/Tests/RevenueCatUITests/PaywallsV2/StickyFooterPaddingTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/StickyFooterPaddingTests.swift
@@ -1,0 +1,51 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  StickyFooterPaddingTests.swift
+//
+//  Created by Michael S. Muegel on 8/29/26.
+
+import Nimble
+@testable import RevenueCatUI
+import SwiftUI
+import XCTest
+
+#if !os(tvOS) // For Paywalls V2
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+class StickyFooterPaddingTests: TestCase {
+
+    /// The case this fixes: an iPad presents the paywall in a card with no bottom safe area, so
+    /// the footer had no spacing at all and sat flush against the card's edge.
+    func testPadsAnIPadWithNoBottomSafeArea() {
+        expect(RootView.stickyFooterBottomPadding(safeAreaBottom: 0, idiom: .pad)).to(equal(16))
+    }
+
+    /// A phone's home indicator already provides the spacing, and must keep exactly what it has.
+    func testLeavesAPhoneWithABottomSafeAreaUnchanged() {
+        expect(RootView.stickyFooterBottomPadding(safeAreaBottom: 34, idiom: .phone)).to(equal(34))
+    }
+
+    /// A real bottom inset wins when it is larger, so a full screen iPad is not reduced to the
+    /// default padding.
+    func testKeepsALargerSafeAreaOverTheDefault() {
+        expect(RootView.stickyFooterBottomPadding(safeAreaBottom: 20, idiom: .pad)).to(equal(20))
+    }
+
+    /// Idioms with no default padding keep today's behavior rather than gaining spacing they
+    /// never had.
+    func testLeavesOtherIdiomsAlone() {
+        expect(RootView.stickyFooterBottomPadding(safeAreaBottom: 0, idiom: .phone)).to(equal(0))
+        expect(RootView.stickyFooterBottomPadding(safeAreaBottom: 0, idiom: .mac)).to(equal(0))
+        expect(RootView.stickyFooterBottomPadding(safeAreaBottom: 0, idiom: .unknown)).to(equal(0))
+    }
+
+}
+
+#endif


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

Resolves #7548. On iPad a Paywalls V2 sticky footer sits flush against the bottom edge of the paywall's card, in both orientations, while the same paywall has a comfortable margin on iPhone and renders with one in the dashboard's web preview.

### Description

The footer's only source of bottom spacing was `safeAreaInsets.bottom`. That reads as the amount of inset to avoid, so where there is no bottom safe area — an iPad presenting the paywall in a card — it resolves to zero and the footer's last row has no spacing at all.

It now falls back to `Constants.defaultVerticalPaddingLength`, which is the value the SDK already uses to give iPad breathing room in the V1 templates, rather than a new number. The larger of the two wins, so a device that does report a bottom inset keeps exactly the spacing it has today:

```swift
static func stickyFooterBottomPadding(safeAreaBottom: CGFloat, idiom: UserInterfaceIdiom) -> CGFloat {
    return max(safeAreaBottom, Constants.defaultVerticalPaddingLength(idiom) ?? 0)
}
```

Only `.pad` has a default vertical padding, so iPhone, Mac and unknown idioms are unaffected.

I am happy to change the value or the approach — the constant seemed the most conservative choice available, but the right amount of margin is a design call.

### Testing

Verified on an iPad device: the footer gains a margin in both orientations, and iPhone is visually unchanged.

The padding calculation is extracted as a pure function, following the precedent of `ImageRenderPlan` in the neighbouring image component, so it is covered by unit tests without hosting the view. Reverting the fix to `return safeAreaBottom` fails only the iPad case and leaves the other assertions passing, so the tests pin the behavior rather than the implementation.

| Before | After |
| --- | --- |
| <img width="1376" height="1032" alt="Screenshot 2026-08-29 at 8 04 04 AM" src="https://github.com/user-attachments/assets/1ae8fd5e-baa9-4866-9967-34aef8e7e8e5" /> | <img width="1376" height="1032" alt="Screenshot 2026-08-29 at 9 15 33 AM" src="https://github.com/user-attachments/assets/d1ef534f-47bc-4ffd-8089-29467a1e2c6a" /> |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Paywalls V2 footer padding change with unit tests; no auth, payments, or data handling.
> 
> **Overview**
> Fixes Paywalls V2 sticky footers sitting flush against the bottom of an iPad card when `safeAreaInsets.bottom` is zero.
> 
> **RootView** now reads `userInterfaceIdiom` and applies bottom padding via `stickyFooterBottomPadding`, which uses **`max(safeAreaBottom, Constants.defaultVerticalPaddingLength(idiom) ?? 0)`** so iPad gets the SDK’s existing 16pt fallback while phones with a home-indicator inset keep their current spacing. Only the overlaid sticky footer’s `additionalPadding` changes; other layout is untouched.
> 
> Adds **`StickyFooterPaddingTests`** for the pure helper (iPad zero inset, phone unchanged, larger safe area wins, other idioms unaffected).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c31fe5bf37c406d9882de5eaf74f9030b914a292. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->