### PR TITLE
feat(Checkpoints): Add customer purchases and entitlements as rule evaluation properties

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		D22A00000000000000000001 /* AnyDecodable+DimensionValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22A00000000000000000002 /* AnyDecodable+DimensionValue.swift */; };
+		D23A00000000000000000001 /* Dictionary+DimensionValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23A00000000000000000002 /* Dictionary+DimensionValue.swift */; };
 		D17A00000000000000000001 /* StoreDimensionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17A00000000000000000002 /* StoreDimensionProvider.swift */; };
 		D17A00000000000000000003 /* StoreDimensionProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17A00000000000000000004 /* StoreDimensionProviderTests.swift */; };
 		D18A00000000000000000003 /* DimensionValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D18A00000000000000000004 /* DimensionValueTests.swift */; };
@@ -1680,6 +1681,7 @@
 
 /* Begin PBXFileReference section */
 		D22A00000000000000000002 /* AnyDecodable+DimensionValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnyDecodable+DimensionValue.swift"; sourceTree = "<group>"; };
+		D23A00000000000000000002 /* Dictionary+DimensionValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+DimensionValue.swift"; sourceTree = "<group>"; };
 		D17A00000000000000000002 /* StoreDimensionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreDimensionProvider.swift; sourceTree = "<group>"; };
 		D17A00000000000000000004 /* StoreDimensionProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreDimensionProviderTests.swift; sourceTree = "<group>"; };
 		D18A00000000000000000004 /* DimensionValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DimensionValueTests.swift; sourceTree = "<group>"; };
@@ -3456,6 +3458,7 @@
 				D20A00000000000000000002 /* CustomerInfoDimensionProvider.swift */,
 				D19A00000000000000000002 /* SubscriberAttributesDimensionProvider.swift */,
 				D22A00000000000000000002 /* AnyDecodable+DimensionValue.swift */,
+				D23A00000000000000000002 /* Dictionary+DimensionValue.swift */,
 				A0D200000000000000000002 /* DimensionProvider.swift */,
 				A0D200000000000000000003 /* DimensionResolver.swift */,
 			);
@@ -8219,6 +8222,7 @@
 				D20A00000000000000000001 /* CustomerInfoDimensionProvider.swift in Sources */,
 				D19A00000000000000000001 /* SubscriberAttributesDimensionProvider.swift in Sources */,
 				D22A00000000000000000001 /* AnyDecodable+DimensionValue.swift in Sources */,
+				D23A00000000000000000001 /* Dictionary+DimensionValue.swift in Sources */,
 				A0D100000000000000000002 /* DimensionProvider.swift in Sources */,
 				A0D100000000000000000003 /* DimensionResolver.swift in Sources */,
 				FA360650C0B87331F2EFF527 /* Checkpoints.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		D18A00000000000000000003 /* DimensionValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D18A00000000000000000004 /* DimensionValueTests.swift */; };
 		D19A00000000000000000001 /* SubscriberAttributesDimensionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D19A00000000000000000002 /* SubscriberAttributesDimensionProvider.swift */; };
 		D19A00000000000000000003 /* SubscriberAttributesDimensionProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D19A00000000000000000004 /* SubscriberAttributesDimensionProviderTests.swift */; };
+		D20A00000000000000000003 /* CustomerInfoDimensionProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20A00000000000000000004 /* CustomerInfoDimensionProviderTests.swift */; };
+		D20A00000000000000000001 /* CustomerInfoDimensionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20A00000000000000000002 /* CustomerInfoDimensionProvider.swift */; };
 		C05A00000000000000000001 /* CustomVariableKeyValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05A00000000000000000002 /* CustomVariableKeyValidator.swift */; };
 		C05A00000000000000000003 /* CustomVariableKeyValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05A00000000000000000004 /* CustomVariableKeyValidatorTests.swift */; };
 		A0D100000000000000000001 /* LocalRulesEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D200000000000000000001 /* LocalRulesEvaluator.swift */; };
@@ -1682,6 +1684,8 @@
 		D18A00000000000000000004 /* DimensionValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DimensionValueTests.swift; sourceTree = "<group>"; };
 		D19A00000000000000000002 /* SubscriberAttributesDimensionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriberAttributesDimensionProvider.swift; sourceTree = "<group>"; };
 		D19A00000000000000000004 /* SubscriberAttributesDimensionProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriberAttributesDimensionProviderTests.swift; sourceTree = "<group>"; };
+		D20A00000000000000000004 /* CustomerInfoDimensionProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoDimensionProviderTests.swift; sourceTree = "<group>"; };
+		D20A00000000000000000002 /* CustomerInfoDimensionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoDimensionProvider.swift; sourceTree = "<group>"; };
 		C05A00000000000000000002 /* CustomVariableKeyValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomVariableKeyValidator.swift; sourceTree = "<group>"; };
 		C05A00000000000000000004 /* CustomVariableKeyValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomVariableKeyValidatorTests.swift; sourceTree = "<group>"; };
 		A0D200000000000000000001 /* LocalRulesEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalRulesEvaluator.swift; sourceTree = "<group>"; };
@@ -3447,6 +3451,7 @@
 				A91C0A022FEA000000000001 /* RulesEngineLoggerBridge.swift */,
 				A0D200000000000000000006 /* DeviceDimensionProvider.swift */,
 				D17A00000000000000000002 /* StoreDimensionProvider.swift */,
+				D20A00000000000000000002 /* CustomerInfoDimensionProvider.swift */,
 				D19A00000000000000000002 /* SubscriberAttributesDimensionProvider.swift */,
 				D22A00000000000000000002 /* AnyDecodable+DimensionValue.swift */,
 				A0D200000000000000000002 /* DimensionProvider.swift */,
@@ -3464,6 +3469,7 @@
 				D17A00000000000000000004 /* StoreDimensionProviderTests.swift */,
 				D18A00000000000000000004 /* DimensionValueTests.swift */,
 				D19A00000000000000000004 /* SubscriberAttributesDimensionProviderTests.swift */,
+				D20A00000000000000000004 /* CustomerInfoDimensionProviderTests.swift */,
 			);
 			path = LocalRules;
 			sourceTree = "<group>";
@@ -8207,6 +8213,7 @@
 				A0D100000000000000000001 /* LocalRulesEvaluator.swift in Sources */,
 				A0D100000000000000000006 /* DeviceDimensionProvider.swift in Sources */,
 				D17A00000000000000000001 /* StoreDimensionProvider.swift in Sources */,
+				D20A00000000000000000001 /* CustomerInfoDimensionProvider.swift in Sources */,
 				D19A00000000000000000001 /* SubscriberAttributesDimensionProvider.swift in Sources */,
 				D22A00000000000000000001 /* AnyDecodable+DimensionValue.swift in Sources */,
 				A0D100000000000000000002 /* DimensionProvider.swift in Sources */,
@@ -8671,6 +8678,7 @@
 				D17A00000000000000000003 /* StoreDimensionProviderTests.swift in Sources */,
 				D18A00000000000000000003 /* DimensionValueTests.swift in Sources */,
 				D19A00000000000000000003 /* SubscriberAttributesDimensionProviderTests.swift in Sources */,
+				D20A00000000000000000003 /* CustomerInfoDimensionProviderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		D19A00000000000000000001 /* SubscriberAttributesDimensionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D19A00000000000000000002 /* SubscriberAttributesDimensionProvider.swift */; };
 		D19A00000000000000000003 /* SubscriberAttributesDimensionProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D19A00000000000000000004 /* SubscriberAttributesDimensionProviderTests.swift */; };
 		D20A00000000000000000003 /* CustomerInfoDimensionProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20A00000000000000000004 /* CustomerInfoDimensionProviderTests.swift */; };
+		D21A00000000000000000003 /* DimensionScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21A00000000000000000004 /* DimensionScopeTests.swift */; };
 		D20A00000000000000000001 /* CustomerInfoDimensionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20A00000000000000000002 /* CustomerInfoDimensionProvider.swift */; };
 		C05A00000000000000000001 /* CustomVariableKeyValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05A00000000000000000002 /* CustomVariableKeyValidator.swift */; };
 		C05A00000000000000000003 /* CustomVariableKeyValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05A00000000000000000004 /* CustomVariableKeyValidatorTests.swift */; };
@@ -1685,6 +1686,7 @@
 		D19A00000000000000000002 /* SubscriberAttributesDimensionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriberAttributesDimensionProvider.swift; sourceTree = "<group>"; };
 		D19A00000000000000000004 /* SubscriberAttributesDimensionProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriberAttributesDimensionProviderTests.swift; sourceTree = "<group>"; };
 		D20A00000000000000000004 /* CustomerInfoDimensionProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoDimensionProviderTests.swift; sourceTree = "<group>"; };
+		D21A00000000000000000004 /* DimensionScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DimensionScopeTests.swift; sourceTree = "<group>"; };
 		D20A00000000000000000002 /* CustomerInfoDimensionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoDimensionProvider.swift; sourceTree = "<group>"; };
 		C05A00000000000000000002 /* CustomVariableKeyValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomVariableKeyValidator.swift; sourceTree = "<group>"; };
 		C05A00000000000000000004 /* CustomVariableKeyValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomVariableKeyValidatorTests.swift; sourceTree = "<group>"; };
@@ -3470,6 +3472,7 @@
 				D18A00000000000000000004 /* DimensionValueTests.swift */,
 				D19A00000000000000000004 /* SubscriberAttributesDimensionProviderTests.swift */,
 				D20A00000000000000000004 /* CustomerInfoDimensionProviderTests.swift */,
+				D21A00000000000000000004 /* DimensionScopeTests.swift */,
 			);
 			path = LocalRules;
 			sourceTree = "<group>";
@@ -8679,6 +8682,7 @@
 				D18A00000000000000000003 /* DimensionValueTests.swift in Sources */,
 				D19A00000000000000000003 /* SubscriberAttributesDimensionProviderTests.swift in Sources */,
 				D20A00000000000000000003 /* CustomerInfoDimensionProviderTests.swift in Sources */,
+				D21A00000000000000000003 /* DimensionScopeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/LocalRules/CustomerInfoDimensionProvider.swift
+++ b/Sources/LocalRules/CustomerInfoDimensionProvider.swift
@@ -32,7 +32,6 @@ struct CustomerInfoDimensionProvider: DimensionProvider {
 
     func dimensions(at date: Date) async throws -> [String: DimensionValue] {
         let appUserID = self.currentAppUserIDProvider()
-        guard !appUserID.isEmpty else { return [:] }
 
         var dimensions: [String: DimensionValue] = [
             "app_user_id": .string(appUserID)
@@ -87,8 +86,8 @@ private extension CustomerInfoDimensionProvider {
             )
         }
 
-        // Match Android's stable date sort explicitly: subscriptions are placed first and sorted by product,
-        // followed by CustomerInfo's existing non-subscription order. Equal dates preserve that combined order.
+        // Subscriptions are placed first and sorted by product, followed by CustomerInfo's existing
+        // non-subscription order. Equal dates preserve that combined order.
         return (subscriptions + nonSubscriptions)
             .enumerated()
             .sorted {

--- a/Sources/LocalRules/CustomerInfoDimensionProvider.swift
+++ b/Sources/LocalRules/CustomerInfoDimensionProvider.swift
@@ -276,7 +276,7 @@ private extension Store {
         case .playStore: return "play_store"
         case .stripe: return "stripe"
         case .promotional: return "promotional"
-        case .unknownStore: return nil
+        case .unknownStore: return "unknown"
         case .amazon: return "amazon"
         case .rcBilling: return "rc_billing"
         case .external: return "external"

--- a/Sources/LocalRules/CustomerInfoDimensionProvider.swift
+++ b/Sources/LocalRules/CustomerInfoDimensionProvider.swift
@@ -86,8 +86,8 @@ private extension CustomerInfoDimensionProvider {
             )
         }
 
-        // Subscriptions are placed first and sorted by product, followed by CustomerInfo's existing
-        // non-subscription order. Equal dates preserve that combined order.
+        // Purchases are sorted from newest to oldest. Equal dates preserve source order,
+        // with subscriptions ordered by product before non-subscriptions.
         return (subscriptions + nonSubscriptions)
             .enumerated()
             .sorted {
@@ -99,10 +99,10 @@ private extension CustomerInfoDimensionProvider {
             }
             .map { indexedPurchase in
                 let purchase = indexedPurchase.element
-                guard let store = purchase.store.dimensionValue else { return purchase.values }
-
                 var values = purchase.values
-                values["store"] = .string(store)
+                if let store = purchase.store.dimensionValue {
+                    values["store"] = .string(store)
+                }
                 return values
             }
     }
@@ -204,34 +204,6 @@ private extension CustomerInfoDimensionProvider {
             productIdentifier: productIdentifier,
             productPlanIdentifier: productPlanIdentifier
         )?.compoundProductIdentifier ?? productIdentifier
-    }
-
-}
-
-private extension Dictionary where Key == String, Value == DimensionValue {
-
-    mutating func set(_ key: String, string: String?) {
-        guard let string, !string.isEmpty else { return }
-        self[key] = .string(string)
-    }
-
-    mutating func set(_ key: String, date: Date?) {
-        guard let date else { return }
-        self[key] = .date(date)
-    }
-
-    mutating func set(price: ProductPaidPrice?) {
-        guard let price else { return }
-
-        let amountMicros = price.amount * 1_000_000
-        if amountMicros.isFinite,
-           amountMicros >= Double(Int64.min),
-           amountMicros < Double(Int64.max) {
-            self["price_amount_micros"] = .int(Int64(amountMicros))
-        }
-        if !price.currency.isEmpty {
-            self["price_currency"] = .string(price.currency)
-        }
     }
 
 }

--- a/Sources/LocalRules/CustomerInfoDimensionProvider.swift
+++ b/Sources/LocalRules/CustomerInfoDimensionProvider.swift
@@ -1,0 +1,164 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CustomerInfoDimensionProvider.swift
+//
+//  Created by Rick van der Linden on 8/31/26.
+//
+
+import Foundation
+
+/// Supplies CustomerInfo dimensions to the local rules engine.
+struct CustomerInfoDimensionProvider: DimensionProvider {
+
+    let name = "customer_info"
+
+    private let currentAppUserIDProvider: @Sendable () -> String
+    private let customerInfoProvider: @Sendable (String) async throws -> CustomerInfo
+
+    init(
+        currentAppUserIDProvider: @escaping @Sendable () -> String,
+        customerInfoProvider: @escaping @Sendable (String) async throws -> CustomerInfo
+    ) {
+        self.currentAppUserIDProvider = currentAppUserIDProvider
+        self.customerInfoProvider = customerInfoProvider
+    }
+
+    func dimensions(at _: Date) async throws -> [String: DimensionValue] {
+        let appUserID = self.currentAppUserIDProvider()
+        guard !appUserID.isEmpty else { return [:] }
+
+        var dimensions: [String: DimensionValue] = [
+            "app_user_id": .string(appUserID)
+        ]
+
+        do {
+            let customerInfo = try await self.customerInfoProvider(appUserID)
+            if !customerInfo.originalAppUserId.isEmpty {
+                dimensions["original_app_user_id"] = .string(customerInfo.originalAppUserId)
+            }
+            dimensions["purchases"] = .objectList(Self.purchases(from: customerInfo))
+            dimensions["entitlements"] = .objectList(Self.entitlements(from: customerInfo))
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            // The current app user ID is still useful when CustomerInfo is temporarily unavailable.
+            Logger.warn(Strings.remoteConfig.customerInfoUnavailable(error))
+        }
+
+        return dimensions
+    }
+
+}
+
+private extension CustomerInfoDimensionProvider {
+
+    struct DatedPurchase {
+
+        let purchaseDate: Date
+        let productIdentifier: String
+        let store: Store
+        let values: [String: DimensionValue]
+    }
+
+    static func purchases(from customerInfo: CustomerInfo) -> [[String: DimensionValue]] {
+        let subscriptions = customerInfo.subscriptionsByProductIdentifier.values.map { subscription in
+            DatedPurchase(
+                purchaseDate: subscription.purchaseDate,
+                productIdentifier: subscription.productIdentifier,
+                store: subscription.store,
+                values: [
+                    "kind": .string("subscription"),
+                    "is_active": .bool(subscription.isActive),
+                    "is_sandbox": .bool(subscription.isSandbox),
+                    "product_identifier": .string(subscription.productIdentifier),
+                    "period_type": .string(subscription.periodType.dimensionValue)
+                ]
+            )
+        }
+
+        let nonSubscriptions = customerInfo.nonSubscriptions.map { transaction in
+            DatedPurchase(
+                purchaseDate: transaction.purchaseDate,
+                productIdentifier: transaction.productIdentifier,
+                store: transaction.store,
+                // `is_active` and `period_type` describe subscription state and do not have
+                // meaningful equivalents for a non-subscription transaction.
+                values: [
+                    "kind": .string("non_subscription"),
+                    "is_sandbox": .bool(transaction.isSandbox),
+                    "product_identifier": .string(transaction.productIdentifier)
+                ]
+            )
+        }
+
+        return (subscriptions + nonSubscriptions)
+            .sorted {
+                if $0.purchaseDate != $1.purchaseDate {
+                    return $0.purchaseDate > $1.purchaseDate
+                }
+
+                return $0.productIdentifier < $1.productIdentifier
+            }
+            .map { purchase in
+                guard let store = purchase.store.dimensionValue else { return purchase.values }
+
+                var values = purchase.values
+                values["store"] = .string(store)
+                return values
+            }
+    }
+
+    static func entitlements(from customerInfo: CustomerInfo) -> [[String: DimensionValue]] {
+        return customerInfo.entitlements.all.values
+            .sorted { $0.identifier < $1.identifier }
+            .map { entitlement in
+                [
+                    "identifier": .string(entitlement.identifier),
+                    "is_active": .bool(entitlement.isActive),
+                    "is_sandbox": .bool(entitlement.isSandbox)
+                ]
+            }
+    }
+
+}
+
+private extension Store {
+
+    var dimensionValue: String? {
+        switch self {
+        case .appStore: return "app_store"
+        case .macAppStore: return "mac_app_store"
+        case .playStore: return "play_store"
+        case .stripe: return "stripe"
+        case .promotional: return "promotional"
+        case .unknownStore: return nil
+        case .amazon: return "amazon"
+        case .rcBilling: return "rc_billing"
+        case .external: return "external"
+        case .paddle: return "paddle"
+        case .testStore: return "test_store"
+        case .galaxy: return "galaxy"
+        }
+    }
+
+}
+
+private extension PeriodType {
+
+    var dimensionValue: String {
+        switch self {
+        case .normal: return "normal"
+        case .intro: return "intro"
+        case .trial: return "trial"
+        case .prepaid: return "prepaid"
+        }
+    }
+
+}

--- a/Sources/LocalRules/CustomerInfoDimensionProvider.swift
+++ b/Sources/LocalRules/CustomerInfoDimensionProvider.swift
@@ -64,39 +64,42 @@ private extension CustomerInfoDimensionProvider {
     struct DatedPurchase {
 
         let purchaseDate: Date
-        let productIdentifier: String
         let store: Store
         let values: [String: DimensionValue]
     }
 
     static func purchases(from customerInfo: CustomerInfo, at date: Date) -> [[String: DimensionValue]] {
-        let subscriptions = customerInfo.subscriptionsByProductIdentifier.values.map { subscription in
-            DatedPurchase(
-                purchaseDate: subscription.purchaseDate,
-                productIdentifier: subscription.productIdentifier,
-                store: subscription.store,
-                values: Self.values(for: subscription, at: date)
-            )
-        }
+        let subscriptions = customerInfo.subscriptionsByProductIdentifier.values
+            .sorted { $0.productIdentifier < $1.productIdentifier }
+            .map { subscription in
+                DatedPurchase(
+                    purchaseDate: subscription.purchaseDate,
+                    store: subscription.store,
+                    values: Self.values(for: subscription, at: date)
+                )
+            }
 
         let nonSubscriptions = customerInfo.nonSubscriptions.map { transaction in
             DatedPurchase(
                 purchaseDate: transaction.purchaseDate,
-                productIdentifier: transaction.productIdentifier,
                 store: transaction.store,
                 values: Self.values(for: transaction)
             )
         }
 
+        // Match Android's stable date sort explicitly: subscriptions are placed first and sorted by product,
+        // followed by CustomerInfo's existing non-subscription order. Equal dates preserve that combined order.
         return (subscriptions + nonSubscriptions)
+            .enumerated()
             .sorted {
-                if $0.purchaseDate != $1.purchaseDate {
-                    return $0.purchaseDate > $1.purchaseDate
+                if $0.element.purchaseDate != $1.element.purchaseDate {
+                    return $0.element.purchaseDate > $1.element.purchaseDate
                 }
 
-                return $0.productIdentifier < $1.productIdentifier
+                return $0.offset < $1.offset
             }
-            .map { purchase in
+            .map { indexedPurchase in
+                let purchase = indexedPurchase.element
                 guard let store = purchase.store.dimensionValue else { return purchase.values }
 
                 var values = purchase.values
@@ -221,7 +224,7 @@ private extension Dictionary where Key == String, Value == DimensionValue {
     mutating func set(price: ProductPaidPrice?) {
         guard let price else { return }
 
-        let amountMicros = (price.amount * 1_000_000).rounded()
+        let amountMicros = price.amount * 1_000_000
         if amountMicros.isFinite,
            amountMicros >= Double(Int64.min),
            amountMicros < Double(Int64.max) {

--- a/Sources/LocalRules/CustomerInfoDimensionProvider.swift
+++ b/Sources/LocalRules/CustomerInfoDimensionProvider.swift
@@ -30,7 +30,7 @@ struct CustomerInfoDimensionProvider: DimensionProvider {
         self.customerInfoProvider = customerInfoProvider
     }
 
-    func dimensions(at _: Date) async throws -> [String: DimensionValue] {
+    func dimensions(at date: Date) async throws -> [String: DimensionValue] {
         let appUserID = self.currentAppUserIDProvider()
         guard !appUserID.isEmpty else { return [:] }
 
@@ -43,7 +43,9 @@ struct CustomerInfoDimensionProvider: DimensionProvider {
             if !customerInfo.originalAppUserId.isEmpty {
                 dimensions["original_app_user_id"] = .string(customerInfo.originalAppUserId)
             }
-            dimensions["purchases"] = .objectList(Self.purchases(from: customerInfo))
+            dimensions["first_seen_at"] = .date(customerInfo.firstSeen)
+            dimensions.set("original_purchased_at", date: customerInfo.originalPurchaseDate)
+            dimensions["purchases"] = .objectList(Self.purchases(from: customerInfo, at: date))
             dimensions["entitlements"] = .objectList(Self.entitlements(from: customerInfo))
         } catch is CancellationError {
             throw CancellationError()
@@ -67,19 +69,13 @@ private extension CustomerInfoDimensionProvider {
         let values: [String: DimensionValue]
     }
 
-    static func purchases(from customerInfo: CustomerInfo) -> [[String: DimensionValue]] {
+    static func purchases(from customerInfo: CustomerInfo, at date: Date) -> [[String: DimensionValue]] {
         let subscriptions = customerInfo.subscriptionsByProductIdentifier.values.map { subscription in
             DatedPurchase(
                 purchaseDate: subscription.purchaseDate,
                 productIdentifier: subscription.productIdentifier,
                 store: subscription.store,
-                values: [
-                    "kind": .string("subscription"),
-                    "is_active": .bool(subscription.isActive),
-                    "is_sandbox": .bool(subscription.isSandbox),
-                    "product_identifier": .string(subscription.productIdentifier),
-                    "period_type": .string(subscription.periodType.dimensionValue)
-                ]
+                values: Self.values(for: subscription, at: date)
             )
         }
 
@@ -88,13 +84,7 @@ private extension CustomerInfoDimensionProvider {
                 purchaseDate: transaction.purchaseDate,
                 productIdentifier: transaction.productIdentifier,
                 store: transaction.store,
-                // `is_active` and `period_type` describe subscription state and do not have
-                // meaningful equivalents for a non-subscription transaction.
-                values: [
-                    "kind": .string("non_subscription"),
-                    "is_sandbox": .bool(transaction.isSandbox),
-                    "product_identifier": .string(transaction.productIdentifier)
-                ]
+                values: Self.values(for: transaction)
             )
         }
 
@@ -119,12 +109,157 @@ private extension CustomerInfoDimensionProvider {
         return customerInfo.entitlements.all.values
             .sorted { $0.identifier < $1.identifier }
             .map { entitlement in
-                [
+                var values: [String: DimensionValue] = [
                     "identifier": .string(entitlement.identifier),
+                    "product_identifier": .string(entitlement.productIdentifier),
+                    "purchased_product_identifier": .string(
+                        Self.purchasedProductIdentifier(
+                            productIdentifier: entitlement.productIdentifier,
+                            productPlanIdentifier: entitlement.productPlanIdentifier
+                        )
+                    ),
+                    "period_type": .string(entitlement.periodType.dimensionValue),
                     "is_active": .bool(entitlement.isActive),
-                    "is_sandbox": .bool(entitlement.isSandbox)
+                    "is_sandbox": .bool(entitlement.isSandbox),
+                    "will_renew": .bool(entitlement.willRenew)
                 ]
+
+                values.set("product_plan_identifier", string: entitlement.productPlanIdentifier)
+                values.set("ownership_type", string: entitlement.ownershipType.dimensionValue)
+                values.set("latest_purchased_at", date: entitlement.latestPurchaseDate)
+                values.set("original_purchased_at", date: entitlement.originalPurchaseDate)
+                values.set("expires_at", date: entitlement.expirationDate)
+                values.set("unsubscribe_detected_at", date: entitlement.unsubscribeDetectedAt)
+                values.set("billing_issue_detected_at", date: entitlement.billingIssueDetectedAt)
+                values.set("store", string: entitlement.store.dimensionValue)
+
+                return values
             }
+    }
+
+    static func values(for subscription: SubscriptionInfo, at date: Date) -> [String: DimensionValue] {
+        let isInGracePeriod = subscription.gracePeriodExpiresDate.map { $0 > date } ?? false
+
+        var values: [String: DimensionValue] = [
+            "kind": .string("subscription"),
+            "product_identifier": .string(subscription.productIdentifier),
+            "purchased_product_identifier": .string(
+                Self.purchasedProductIdentifier(
+                    productIdentifier: subscription.productIdentifier,
+                    productPlanIdentifier: subscription.productPlanIdentifier
+                )
+            ),
+            "period_type": .string(subscription.periodType.dimensionValue),
+            "status": .string(subscription.status(isInGracePeriod: isInGracePeriod)),
+            "purchased_at": .date(subscription.purchaseDate),
+            "is_active": .bool(subscription.isActive),
+            "is_sandbox": .bool(subscription.isSandbox),
+            "will_renew": .bool(subscription.willRenew),
+            "is_in_grace_period": .bool(isInGracePeriod),
+            "is_refunded": .bool(subscription.refundedAt != nil),
+            "is_paused": .bool(subscription.autoResumeDate != nil)
+        ]
+
+        values.set("product_plan_identifier", string: subscription.productPlanIdentifier)
+        values.set("store_transaction_id", string: subscription.storeTransactionId)
+        values.set("display_name", string: subscription.displayName)
+        values.set("ownership_type", string: subscription.ownershipType.dimensionValue)
+        values.set(price: subscription.price)
+        values.set("original_purchased_at", date: subscription.originalPurchaseDate)
+        values.set("expires_at", date: subscription.expiresDate)
+        values.set("unsubscribe_detected_at", date: subscription.unsubscribeDetectedAt)
+        values.set("billing_issue_detected_at", date: subscription.billingIssuesDetectedAt)
+        values.set("grace_period_expires_at", date: subscription.gracePeriodExpiresDate)
+        values.set("refunded_at", date: subscription.refundedAt)
+        values.set("auto_resume_at", date: subscription.autoResumeDate)
+
+        return values
+    }
+
+    static func values(for transaction: NonSubscriptionTransaction) -> [String: DimensionValue] {
+        var values: [String: DimensionValue] = [
+            "kind": .string("non_subscription"),
+            "product_identifier": .string(transaction.productIdentifier),
+            "purchased_product_identifier": .string(transaction.productIdentifier),
+            "transaction_identifier": .string(transaction.transactionIdentifier),
+            "store_transaction_id": .string(transaction.storeTransactionIdentifier),
+            "purchased_at": .date(transaction.purchaseDate),
+            "is_sandbox": .bool(transaction.isSandbox)
+        ]
+
+        values.set("display_name", string: transaction.displayName)
+        values.set(price: transaction.price)
+        values.set("original_purchased_at", date: transaction.originalPurchaseDate)
+
+        return values
+    }
+
+    static func purchasedProductIdentifier(
+        productIdentifier: String,
+        productPlanIdentifier: String?
+    ) -> String {
+        return CompoundProductIdentifier(
+            productIdentifier: productIdentifier,
+            productPlanIdentifier: productPlanIdentifier
+        )?.compoundProductIdentifier ?? productIdentifier
+    }
+
+}
+
+private extension Dictionary where Key == String, Value == DimensionValue {
+
+    mutating func set(_ key: String, string: String?) {
+        guard let string, !string.isEmpty else { return }
+        self[key] = .string(string)
+    }
+
+    mutating func set(_ key: String, date: Date?) {
+        guard let date else { return }
+        self[key] = .date(date)
+    }
+
+    mutating func set(price: ProductPaidPrice?) {
+        guard let price else { return }
+
+        let amountMicros = (price.amount * 1_000_000).rounded()
+        if amountMicros.isFinite,
+           amountMicros >= Double(Int64.min),
+           amountMicros < Double(Int64.max) {
+            self["price_amount_micros"] = .int(Int64(amountMicros))
+        }
+        if !price.currency.isEmpty {
+            self["price_currency"] = .string(price.currency)
+        }
+    }
+
+}
+
+private extension SubscriptionInfo {
+
+    func status(isInGracePeriod: Bool) -> String {
+        if self.autoResumeDate != nil {
+            return "paused"
+        } else if isInGracePeriod {
+            return "in_grace_period"
+        } else if self.isActive, self.periodType == .trial {
+            return "trialing"
+        } else if self.isActive {
+            return "active"
+        } else {
+            return "expired"
+        }
+    }
+
+}
+
+private extension PurchaseOwnershipType {
+
+    var dimensionValue: String? {
+        switch self {
+        case .purchased: return "PURCHASED"
+        case .familyShared: return "FAMILY_SHARED"
+        case .unknown: return nil
+        }
     }
 
 }

--- a/Sources/LocalRules/Dictionary+DimensionValue.swift
+++ b/Sources/LocalRules/Dictionary+DimensionValue.swift
@@ -1,0 +1,43 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Dictionary+DimensionValue.swift
+//
+//  Created by Rick van der Linden on 9/2/26.
+//
+
+import Foundation
+
+extension Dictionary where Key == String, Value == DimensionValue {
+
+    mutating func set(_ key: String, string: String?) {
+        guard let string, !string.isEmpty else { return }
+        self[key] = .string(string)
+    }
+
+    mutating func set(_ key: String, date: Date?) {
+        guard let date else { return }
+        self[key] = .date(date)
+    }
+
+    mutating func set(price: ProductPaidPrice?) {
+        guard let price else { return }
+
+        let amountMicros = price.amount * 1_000_000
+        if amountMicros.isFinite,
+           amountMicros >= Double(Int64.min),
+           amountMicros < Double(Int64.max) {
+            self["price_amount_micros"] = .int(Int64(amountMicros))
+        }
+        if !price.currency.isEmpty {
+            self["price_currency"] = .string(price.currency)
+        }
+    }
+
+}

--- a/Sources/LocalRules/Dictionary+DimensionValue.swift
+++ b/Sources/LocalRules/Dictionary+DimensionValue.swift
@@ -29,7 +29,7 @@ extension Dictionary where Key == String, Value == DimensionValue {
     mutating func set(price: ProductPaidPrice?) {
         guard let price else { return }
 
-        let amountMicros = price.amount * 1_000_000
+        let amountMicros = (price.amount * 1_000_000).rounded(.toNearestOrEven)
         if amountMicros.isFinite,
            amountMicros >= Double(Int64.min),
            amountMicros < Double(Int64.max) {

--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -18,6 +18,7 @@ enum RemoteConfigStrings {
     case checkpointResolutionRetry(identifier: String)
     case checkpointRuleSkipped(reason: String)
     case checkpointWorkflowRuleSkipped(workflowID: String, reason: String)
+    case customerInfoUnavailable(Error)
     case failedToClearBlobStore(Error)
     case failedToDeleteBlob(String, Error)
     case failedToReadBlob(String, Error)
@@ -76,6 +77,8 @@ extension RemoteConfigStrings: LogMessage {
             return "Skipping malformed checkpoint rule: \(reason)."
         case let .checkpointWorkflowRuleSkipped(workflowID, reason):
             return "Skipping checkpoint rule for workflow '\(workflowID)': \(reason)."
+        case let .customerInfoUnavailable(error):
+            return "The customer info is unavailable, so its checkpoint dimensions cannot be evaluated: \(error)."
         case let .failedToClearBlobStore(error):
             return "Failed to clear remote config blob store: \(error.localizedDescription)"
         case let .failedToDeleteBlob(ref, error):

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -672,6 +672,19 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                 dimensionProviders: [
                     DeviceDimensionProvider(),
                     StoreDimensionProvider(),
+                    CustomerInfoDimensionProvider(
+                        currentAppUserIDProvider: { identityManager.currentAppUserID },
+                        customerInfoProvider: { appUserID in
+                            try await withCheckedThrowingContinuation { continuation in
+                                customerInfoManager.customerInfo(
+                                    appUserID: appUserID,
+                                    fetchPolicy: .default,
+                                    trackDiagnostics: false,
+                                    completion: { result in continuation.resume(with: result) }
+                                )
+                            }
+                        }
+                    ),
                     SubscriberAttributesDimensionProvider(
                         deviceCache: deviceCache,
                         currentUserProvider: identityManager

--- a/Tests/UnitTests/LocalRules/CustomerInfoDimensionProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/CustomerInfoDimensionProviderTests.swift
@@ -117,23 +117,6 @@ struct CustomerInfoDimensionProviderTests {
     }
 
     @Test
-    func emptyAppUserIDContributesNothingWithoutFetchingCustomerInfo() async throws {
-        let fetchCount = Atomic(0)
-        let provider = CustomerInfoDimensionProvider(
-            currentAppUserIDProvider: { "" },
-            customerInfoProvider: { _ in
-                fetchCount.modify { $0 += 1 }
-                return try Self.customerInfo()
-            }
-        )
-
-        let dimensions = try await provider.dimensions(at: Self.evaluationDate)
-
-        #expect(dimensions.isEmpty)
-        #expect(fetchCount.value == 0)
-    }
-
-    @Test
     func unavailableCustomerInfoStillExposesTheCurrentAppUserID() async throws {
         let provider = CustomerInfoDimensionProvider(
             currentAppUserIDProvider: { Self.appUserID },

--- a/Tests/UnitTests/LocalRules/CustomerInfoDimensionProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/CustomerInfoDimensionProviderTests.swift
@@ -232,14 +232,14 @@ struct CustomerInfoDimensionProviderTests {
     }
 
     @Test
-    func mapsEveryStoreAndOmitsAnUnknownStore() async throws {
-        let stores: [(rawValue: Any, expected: String?)] = [
+    func mapsEveryStoreIncludingUnknown() async throws {
+        let stores: [(rawValue: Any, expected: String)] = [
             ("app_store", "app_store"),
             ("mac_app_store", "mac_app_store"),
             ("play_store", "play_store"),
             ("stripe", "stripe"),
             ("promotional", "promotional"),
-            (NSNull(), nil),
+            (NSNull(), "unknown"),
             ("amazon", "amazon"),
             ("rc_billing", "rc_billing"),
             ("external", "external"),
@@ -257,7 +257,7 @@ struct CustomerInfoDimensionProviderTests {
 
         for (index, store) in stores.enumerated() {
             let identifier = String(format: "product_%02d", index)
-            #expect(purchases[identifier]?["store"] == store.expected.map(DimensionValue.string))
+            #expect(purchases[identifier]?["store"] == .string(store.expected))
         }
     }
 

--- a/Tests/UnitTests/LocalRules/CustomerInfoDimensionProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/CustomerInfoDimensionProviderTests.swift
@@ -12,6 +12,10 @@
 //  Created by Rick van der Linden on 8/31/26.
 //
 
+// Swift Testing is only available with the Xcode 16+ toolchain
+#if compiler(>=5.9)
+#if canImport(Testing)
+
 import Foundation
 import Testing
 
@@ -674,3 +678,6 @@ private extension CustomerInfoDimensionProviderTests {
     }
 
 }
+
+#endif
+#endif

--- a/Tests/UnitTests/LocalRules/CustomerInfoDimensionProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/CustomerInfoDimensionProviderTests.swift
@@ -17,9 +17,12 @@ import Testing
 
 @testable import RevenueCat
 
+// swiftlint:disable file_length
+
 struct CustomerInfoDimensionProviderTests {
 
     @Test
+    // swiftlint:disable:next function_body_length
     func exposesTheCustomerInfoScope() async throws {
         let provider = Self.provider()
 
@@ -29,27 +32,69 @@ struct CustomerInfoDimensionProviderTests {
         #expect(dimensions == [
             "app_user_id": .string(Self.appUserID),
             "original_app_user_id": .string("original_user"),
+            "first_seen_at": .date(Self.date("2022-01-01T00:00:00Z")),
+            "original_purchased_at": .date(Self.date("2021-01-01T00:00:00Z")),
             "purchases": .objectList([
                 [
                     "kind": .string("subscription"),
+                    "product_identifier": .string("premium"),
+                    "product_plan_identifier": .string("monthly"),
+                    "purchased_product_identifier": .string("premium:monthly"),
+                    "store_transaction_id": .string("2000000123456789"),
+                    "display_name": .string("Premium Monthly"),
+                    "store": .string("app_store"),
+                    "ownership_type": .string("PURCHASED"),
+                    "period_type": .string("trial"),
+                    "status": .string("paused"),
+                    "price_amount_micros": .int(4_990_000),
+                    "price_currency": .string("USD"),
+                    "purchased_at": .date(Self.date("2024-05-01T00:00:00Z")),
+                    "original_purchased_at": .date(Self.date("2021-01-01T00:00:00Z")),
+                    "expires_at": .date(Self.date("2100-01-01T00:00:00Z")),
+                    "unsubscribe_detected_at": .date(Self.date("2024-05-03T00:00:00Z")),
+                    "billing_issue_detected_at": .date(Self.date("2024-05-04T00:00:00Z")),
+                    "grace_period_expires_at": .date(Self.date("2024-05-10T00:00:00Z")),
+                    "refunded_at": .date(Self.date("2024-05-05T00:00:00Z")),
+                    "auto_resume_at": .date(Self.date("2024-07-01T00:00:00Z")),
                     "is_active": .bool(true),
                     "is_sandbox": .bool(true),
-                    "store": .string("app_store"),
-                    "product_identifier": .string("premium"),
-                    "period_type": .string("trial")
+                    "will_renew": .bool(false),
+                    "is_in_grace_period": .bool(false),
+                    "is_refunded": .bool(true),
+                    "is_paused": .bool(true)
                 ],
                 [
                     "kind": .string("non_subscription"),
-                    "is_sandbox": .bool(false),
+                    "product_identifier": .string("coins"),
+                    "purchased_product_identifier": .string("coins"),
+                    "transaction_identifier": .string("rc_transaction_id"),
+                    "store_transaction_id": .string("2000000987654321"),
+                    "display_name": .string("100 Coins"),
                     "store": .string("app_store"),
-                    "product_identifier": .string("coins")
+                    "price_amount_micros": .int(1_990_000),
+                    "price_currency": .string("EUR"),
+                    "purchased_at": .date(Self.date("2023-03-03T00:00:00Z")),
+                    "original_purchased_at": .date(Self.date("2023-03-01T00:00:00Z")),
+                    "is_sandbox": .bool(false)
                 ]
             ]),
             "entitlements": .objectList([
                 [
                     "identifier": .string("premium"),
+                    "product_identifier": .string("premium"),
+                    "product_plan_identifier": .string("monthly"),
+                    "purchased_product_identifier": .string("premium:monthly"),
+                    "store": .string("app_store"),
+                    "ownership_type": .string("PURCHASED"),
+                    "period_type": .string("trial"),
+                    "latest_purchased_at": .date(Self.date("2024-05-01T00:00:00Z")),
+                    "original_purchased_at": .date(Self.date("2021-01-01T00:00:00Z")),
+                    "expires_at": .date(Self.date("2100-01-01T00:00:00Z")),
+                    "unsubscribe_detected_at": .date(Self.date("2024-05-03T00:00:00Z")),
+                    "billing_issue_detected_at": .date(Self.date("2024-05-04T00:00:00Z")),
                     "is_active": .bool(true),
-                    "is_sandbox": .bool(true)
+                    "is_sandbox": .bool(true),
+                    "will_renew": .bool(false)
                 ]
             ])
         ])
@@ -125,6 +170,29 @@ struct CustomerInfoDimensionProviderTests {
             let match = try await evaluator.match(in: [TestRule(predicate: predicate)])
             #expect(match != nil, Comment(rawValue: predicate))
         }
+    }
+
+    @Test
+    func expandedPurchasePropertiesCanBeEvaluatedUsingCanonicalPaths() async throws {
+        let evaluator = LocalRulesEvaluator(dimensionProviders: [Self.provider()])
+        let predicate = #"""
+        {
+            "some": [
+                { "var": "purchases" },
+                {
+                    "and": [
+                        { "==": [{ "var": "purchased_product_identifier" }, "premium:monthly"] },
+                        { ">": [{ "var": "expires_at" }, 4000000000000] },
+                        { "==": [{ "var": ["missing_property", "fallback"] }, "fallback"] }
+                    ]
+                }
+            ]
+        }
+        """#
+
+        let match = try await evaluator.match(in: [TestRule(predicate: predicate)])
+
+        #expect(match != nil)
     }
 
     @Test
@@ -204,16 +272,230 @@ struct CustomerInfoDimensionProviderTests {
 
         #expect(dimensions == [
             "app_user_id": .string(Self.appUserID),
+            "first_seen_at": .date(Self.date("2022-01-01T00:00:00Z")),
             "purchases": .objectList([]),
             "entitlements": .objectList([])
         ])
     }
 
-    private static func provider() -> CustomerInfoDimensionProvider {
+}
+
+extension CustomerInfoDimensionProviderTests {
+
+    @Test
+    func mapsKnownOwnershipTypesAndOmitsUnknownOwnership() async throws {
+        let ownershipTypes: [(rawValue: String, expected: String?)] = [
+            ("PURCHASED", "PURCHASED"),
+            ("FAMILY_SHARED", "FAMILY_SHARED"),
+            ("UNKNOWN", nil)
+        ]
+        let subscriptions = ownershipTypes.enumerated().reduce(into: [String: Any]()) { result, element in
+            result["product_\(element.offset)"] = Self.subscription(ownershipType: element.element.rawValue)
+        }
+        let provider = Self.provider(customerInfoData: Self.customerInfoData(subscriptions: subscriptions))
+
+        let dimensions = try await provider.dimensions(at: Self.evaluationDate)
+        let purchases = Self.purchasesByProductIdentifier(from: dimensions)
+
+        for (index, ownershipType) in ownershipTypes.enumerated() {
+            #expect(
+                purchases["product_\(index)"]?["ownership_type"]
+                    == ownershipType.expected.map(DimensionValue.string)
+            )
+        }
+    }
+
+    @Test
+    func derivesEverySubscriptionLifecycleStatus() async throws {
+        let cases: [(label: String, expected: String, subscription: [String: Any])] = [
+            ("active", "active", Self.subscription()),
+            ("trial", "trialing", Self.subscription(periodType: "trial")),
+            (
+                "grace period",
+                "in_grace_period",
+                Self.subscription(
+                    expiresDate: "2024-05-01T00:00:00Z",
+                    billingIssuesDetectedAt: "2024-05-02T00:00:00Z",
+                    gracePeriodExpiresDate: "2024-07-01T00:00:00Z"
+                )
+            ),
+            ("paused", "paused", Self.subscription(autoResumeDate: "2024-07-01T00:00:00Z")),
+            ("expired", "expired", Self.subscription(expiresDate: "2024-05-01T00:00:00Z"))
+        ]
+
+        for testCase in cases {
+            let provider = Self.provider(
+                customerInfoData: Self.customerInfoData(subscriptions: ["premium": testCase.subscription])
+            )
+
+            let dimensions = try await provider.dimensions(at: Self.evaluationDate)
+            let purchase = Self.purchasesByProductIdentifier(from: dimensions)["premium"]
+
+            #expect(purchase?["status"] == .string(testCase.expected), Comment(rawValue: testCase.label))
+        }
+    }
+
+    @Test
+    func lifetimeSubscriptionHasNoExpiryAndRemainsActiveWithoutRenewing() async throws {
+        let provider = Self.provider(
+            customerInfoData: Self.customerInfoData(
+                subscriptions: ["lifetime": Self.subscription(expiresDate: NSNull())]
+            )
+        )
+
+        let dimensions = try await provider.dimensions(at: Self.evaluationDate)
+        let purchase = Self.purchasesByProductIdentifier(from: dimensions)["lifetime"]
+
+        #expect(purchase?["expires_at"] == nil)
+        #expect(purchase?["status"] == .string("active"))
+        #expect(purchase?["is_active"] == .bool(true))
+        #expect(purchase?["will_renew"] == .bool(false))
+    }
+
+    @Test
+    func gracePeriodUsesTheEvaluationDateAndKeepsStatusAndFlagConsistent() async throws {
+        let cases: [(expiry: String, isInGracePeriod: Bool, status: String)] = [
+            ("2024-06-15T11:59:59Z", false, "expired"),
+            ("2024-06-15T12:00:00Z", false, "expired"),
+            ("2024-06-15T12:00:01Z", true, "in_grace_period")
+        ]
+
+        for testCase in cases {
+            let subscription = Self.subscription(
+                periodType: "trial",
+                expiresDate: "2024-05-01T00:00:00Z",
+                billingIssuesDetectedAt: "2024-05-02T00:00:00Z",
+                gracePeriodExpiresDate: testCase.expiry
+            )
+            let provider = Self.provider(
+                customerInfoData: Self.customerInfoData(subscriptions: ["premium": subscription])
+            )
+
+            let dimensions = try await provider.dimensions(at: Self.evaluationDate)
+            let purchase = Self.purchasesByProductIdentifier(from: dimensions)["premium"]
+
+            #expect(purchase?["status"] == .string(testCase.status))
+            #expect(purchase?["is_in_grace_period"] == .bool(testCase.isInGracePeriod))
+            #expect(purchase?["is_active"] == .bool(false))
+        }
+    }
+
+    @Test
+    func exposesBothValuesForSubscriptionLifecycleFlags() async throws {
+        let activeProvider = Self.provider(
+            customerInfoData: Self.customerInfoData(subscriptions: ["premium": Self.subscription()])
+        )
+        let activeDimensions = try await activeProvider.dimensions(at: Self.evaluationDate)
+        let activePurchase = Self.purchasesByProductIdentifier(from: activeDimensions)["premium"]
+
+        #expect(activePurchase?["will_renew"] == .bool(true))
+        #expect(activePurchase?["is_in_grace_period"] == .bool(false))
+        #expect(activePurchase?["is_refunded"] == .bool(false))
+        #expect(activePurchase?["is_paused"] == .bool(false))
+
+        var affectedSubscription = Self.subscription(
+            expiresDate: "2024-05-01T00:00:00Z",
+            gracePeriodExpiresDate: "2024-07-01T00:00:00Z",
+            autoResumeDate: "2024-07-01T00:00:00Z"
+        )
+        affectedSubscription["refunded_at"] = "2024-05-05T00:00:00Z"
+        let affectedProvider = Self.provider(
+            customerInfoData: Self.customerInfoData(subscriptions: ["premium": affectedSubscription])
+        )
+        let affectedDimensions = try await affectedProvider.dimensions(at: Self.evaluationDate)
+        let affectedPurchase = Self.purchasesByProductIdentifier(from: affectedDimensions)["premium"]
+
+        #expect(affectedPurchase?["is_in_grace_period"] == .bool(true))
+        #expect(affectedPurchase?["is_refunded"] == .bool(true))
+        #expect(affectedPurchase?["is_paused"] == .bool(true))
+    }
+
+}
+
+extension CustomerInfoDimensionProviderTests {
+
+    @Test
+    func fetchesFreshCustomerInfoForEveryEvaluation() async throws {
+        let fetchCount = Atomic(0)
+        let provider = CustomerInfoDimensionProvider(
+            currentAppUserIDProvider: { Self.appUserID },
+            customerInfoProvider: { _ in
+                let count: Int = fetchCount.modify { $0 += 1; return $0 }
+                let subscriptions = count == 1 ? [:] : ["premium": Self.subscription()]
+                return try CustomerInfo(data: Self.customerInfoData(subscriptions: subscriptions))
+            }
+        )
+
+        let firstDimensions = try await provider.dimensions(at: Self.evaluationDate)
+        let secondDimensions = try await provider.dimensions(at: Self.evaluationDate)
+
+        #expect(Self.productIdentifiers(from: firstDimensions).isEmpty)
+        #expect(Self.productIdentifiers(from: secondDimensions) == ["premium"])
+        #expect(fetchCount.value == 2)
+    }
+
+    @Test
+    func convertsPricesToMicrosUsingNearestRounding() async throws {
+        let cases: [(amount: Double, expectedMicros: Int64)] = [
+            (1.234567, 1_234_567),
+            (0.0000005, 1)
+        ]
+
+        for (index, testCase) in cases.enumerated() {
+            var subscription = Self.subscription()
+            subscription["price"] = ["amount": testCase.amount, "currency": "USD"]
+            let identifier = "product_\(index)"
+            let provider = Self.provider(
+                customerInfoData: Self.customerInfoData(subscriptions: [identifier: subscription])
+            )
+
+            let dimensions = try await provider.dimensions(at: Self.evaluationDate)
+            let purchase = Self.purchasesByProductIdentifier(from: dimensions)[identifier]
+
+            #expect(purchase?["price_amount_micros"] == .int(testCase.expectedMicros))
+        }
+    }
+
+    @Test
+    func entitlementsAreOrderedAndExposeNonDefaultValues() async throws {
+        let subscriptions: [String: Any] = [
+            "zeta_product": Self.subscription(),
+            "alpha_product": Self.subscription(
+                expiresDate: "2024-05-01T00:00:00Z",
+                ownershipType: "FAMILY_SHARED"
+            )
+        ]
+        let entitlements: [String: Any] = [
+            "zeta": Self.entitlement(productIdentifier: "zeta_product"),
+            "alpha": Self.entitlement(
+                productIdentifier: "alpha_product",
+                expiresDate: "2024-05-01T00:00:00Z"
+            )
+        ]
+        let provider = Self.provider(
+            customerInfoData: Self.customerInfoData(
+                subscriptions: subscriptions,
+                entitlements: entitlements
+            )
+        )
+
+        let dimensions = try await provider.dimensions(at: Self.evaluationDate)
+        let entitlementValues = Self.entitlements(from: dimensions)
+
+        #expect(entitlementValues.compactMap(Self.identifier(from:)) == ["alpha", "zeta"])
+        #expect(entitlementValues[0]["is_active"] == .bool(false))
+        #expect(entitlementValues[0]["ownership_type"] == .string("FAMILY_SHARED"))
+    }
+
+}
+
+private extension CustomerInfoDimensionProviderTests {
+
+    static func provider() -> CustomerInfoDimensionProvider {
         return Self.provider(customerInfoData: Self.customerInfoData)
     }
 
-    private static func provider(customerInfoData: [String: Any]) -> CustomerInfoDimensionProvider {
+    static func provider(customerInfoData: [String: Any]) -> CustomerInfoDimensionProvider {
         return CustomerInfoDimensionProvider(
             currentAppUserIDProvider: { Self.appUserID },
             customerInfoProvider: { _ in try CustomerInfo(data: customerInfoData) }
@@ -249,26 +531,46 @@ struct CustomerInfoDimensionProviderTests {
     private static func subscription(
         store: Any = "app_store",
         purchaseDate: String = "2024-05-01T00:00:00Z",
-        periodType: String = "normal"
+        periodType: String = "normal",
+        expiresDate: Any = "2100-01-01T00:00:00Z",
+        billingIssuesDetectedAt: String? = nil,
+        gracePeriodExpiresDate: String? = nil,
+        autoResumeDate: String? = nil,
+        ownershipType: String = "PURCHASED"
     ) -> [String: Any] {
         return [
             "store": store,
             "purchase_date": purchaseDate,
             "original_purchase_date": "2021-01-01T00:00:00Z",
-            "expires_date": "2100-01-01T00:00:00Z",
+            "expires_date": expiresDate,
             "period_type": periodType,
-            "is_sandbox": true
+            "is_sandbox": true,
+            "ownership_type": ownershipType,
+            "billing_issues_detected_at": billingIssuesDetectedAt ?? NSNull(),
+            "grace_period_expires_date": gracePeriodExpiresDate ?? NSNull(),
+            "auto_resume_date": autoResumeDate ?? NSNull()
         ]
     }
 
     private static func nonSubscription(purchaseDate: String) -> [String: Any] {
         return [
-            "id": "transaction_id",
-            "store_transaction_id": "store_transaction_id",
+            "id": "rc_transaction_id",
+            "store_transaction_id": "2000000987654321",
             "is_sandbox": false,
             "original_purchase_date": purchaseDate,
             "purchase_date": purchaseDate,
             "store": "app_store"
+        ]
+    }
+
+    private static func entitlement(
+        productIdentifier: String,
+        expiresDate: String = "2100-01-01T00:00:00Z"
+    ) -> [String: Any] {
+        return [
+            "expires_date": expiresDate,
+            "product_identifier": productIdentifier,
+            "purchase_date": "2024-05-01T00:00:00Z"
         ]
     }
 
@@ -292,20 +594,40 @@ struct CustomerInfoDimensionProviderTests {
         }
     }
 
+    private static func entitlements(from dimensions: [String: DimensionValue]) -> [[String: DimensionValue]] {
+        guard case let .objectList(entitlements) = dimensions["entitlements"] else { return [] }
+        return entitlements
+    }
+
+    private static func identifier(from values: [String: DimensionValue]) -> String? {
+        guard case let .string(identifier) = values["identifier"] else { return nil }
+        return identifier
+    }
+
+    static func date(_ value: String) -> Date {
+        guard let date = ISO8601DateFormatter.default.date(from: value) else {
+            preconditionFailure("Invalid test date: \(value)")
+        }
+        return date
+    }
+
     private static let customerInfoData: [String: Any] = [
         "request_date": "2024-06-01T00:00:00Z",
         "subscriber": [
             "first_seen": "2022-01-01T00:00:00Z",
             "original_app_user_id": "original_user",
             "original_application_version": "1.0",
+            "original_purchase_date": "2021-01-01T00:00:00Z",
             "non_subscriptions": [
                 "coins": [[
-                    "id": "transaction_id",
-                    "store_transaction_id": "store_transaction_id",
+                    "id": "rc_transaction_id",
+                    "store_transaction_id": "2000000987654321",
                     "is_sandbox": false,
-                    "original_purchase_date": "2023-03-03T00:00:00Z",
+                    "original_purchase_date": "2023-03-01T00:00:00Z",
                     "purchase_date": "2023-03-03T00:00:00Z",
-                    "store": "app_store"
+                    "store": "app_store",
+                    "display_name": "100 Coins",
+                    "price": ["amount": 1.99, "currency": "EUR"]
                 ]]
             ],
             "subscriptions": [
@@ -315,7 +637,17 @@ struct CustomerInfoDimensionProviderTests {
                     "original_purchase_date": "2021-01-01T00:00:00Z",
                     "expires_date": "2100-01-01T00:00:00Z",
                     "period_type": "trial",
-                    "is_sandbox": true
+                    "is_sandbox": true,
+                    "ownership_type": "PURCHASED",
+                    "product_plan_identifier": "monthly",
+                    "store_transaction_id": "2000000123456789",
+                    "display_name": "Premium Monthly",
+                    "price": ["amount": 4.99, "currency": "USD"],
+                    "unsubscribe_detected_at": "2024-05-03T00:00:00Z",
+                    "billing_issues_detected_at": "2024-05-04T00:00:00Z",
+                    "grace_period_expires_date": "2024-05-10T00:00:00Z",
+                    "refunded_at": "2024-05-05T00:00:00Z",
+                    "auto_resume_date": "2024-07-01T00:00:00Z"
                 ]
             ],
             "entitlements": [

--- a/Tests/UnitTests/LocalRules/CustomerInfoDimensionProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/CustomerInfoDimensionProviderTests.swift
@@ -217,6 +217,21 @@ struct CustomerInfoDimensionProviderTests {
     }
 
     @Test
+    func subscriptionsComeBeforeNonSubscriptionsWithTheSamePurchaseDate() async throws {
+        let purchaseDate = "2024-05-01T00:00:00Z"
+        let provider = Self.provider(
+            customerInfoData: Self.customerInfoData(
+                subscriptions: ["zeta": Self.subscription(purchaseDate: purchaseDate)],
+                nonSubscriptions: ["alpha": [Self.nonSubscription(purchaseDate: purchaseDate)]]
+            )
+        )
+
+        let dimensions = try await provider.dimensions(at: Self.evaluationDate)
+
+        #expect(Self.productIdentifiers(from: dimensions) == ["zeta", "alpha"])
+    }
+
+    @Test
     func mapsEveryStoreAndOmitsAnUnknownStore() async throws {
         let stores: [(rawValue: Any, expected: String?)] = [
             ("app_store", "app_store"),
@@ -435,10 +450,10 @@ extension CustomerInfoDimensionProviderTests {
     }
 
     @Test
-    func convertsPricesToMicrosUsingNearestRounding() async throws {
+    func convertsPricesToMicrosByTruncatingFractionalMicros() async throws {
         let cases: [(amount: Double, expectedMicros: Int64)] = [
             (1.234567, 1_234_567),
-            (0.0000005, 1)
+            (0.0000005, 0)
         ]
 
         for (index, testCase) in cases.enumerated() {

--- a/Tests/UnitTests/LocalRules/CustomerInfoDimensionProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/CustomerInfoDimensionProviderTests.swift
@@ -1,0 +1,346 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CustomerInfoDimensionProviderTests.swift
+//
+//  Created by Rick van der Linden on 8/31/26.
+//
+
+import Foundation
+import Testing
+
+@testable import RevenueCat
+
+struct CustomerInfoDimensionProviderTests {
+
+    @Test
+    func exposesTheCustomerInfoScope() async throws {
+        let provider = Self.provider()
+
+        let dimensions = try await provider.dimensions(at: Self.evaluationDate)
+
+        #expect(provider.name == "customer_info")
+        #expect(dimensions == [
+            "app_user_id": .string(Self.appUserID),
+            "original_app_user_id": .string("original_user"),
+            "purchases": .objectList([
+                [
+                    "kind": .string("subscription"),
+                    "is_active": .bool(true),
+                    "is_sandbox": .bool(true),
+                    "store": .string("app_store"),
+                    "product_identifier": .string("premium"),
+                    "period_type": .string("trial")
+                ],
+                [
+                    "kind": .string("non_subscription"),
+                    "is_sandbox": .bool(false),
+                    "store": .string("app_store"),
+                    "product_identifier": .string("coins")
+                ]
+            ]),
+            "entitlements": .objectList([
+                [
+                    "identifier": .string("premium"),
+                    "is_active": .bool(true),
+                    "is_sandbox": .bool(true)
+                ]
+            ])
+        ])
+    }
+
+    @Test
+    func fetchesCustomerInfoForTheSingleCapturedAppUserID() async throws {
+        let receivedAppUserID = Atomic<String?>(nil)
+        let provider = CustomerInfoDimensionProvider(
+            currentAppUserIDProvider: { Self.appUserID },
+            customerInfoProvider: { appUserID in
+                receivedAppUserID.modify { $0 = appUserID }
+                return try Self.customerInfo()
+            }
+        )
+
+        _ = try await provider.dimensions(at: Self.evaluationDate)
+
+        #expect(receivedAppUserID.value == Self.appUserID)
+    }
+
+    @Test
+    func emptyAppUserIDContributesNothingWithoutFetchingCustomerInfo() async throws {
+        let fetchCount = Atomic(0)
+        let provider = CustomerInfoDimensionProvider(
+            currentAppUserIDProvider: { "" },
+            customerInfoProvider: { _ in
+                fetchCount.modify { $0 += 1 }
+                return try Self.customerInfo()
+            }
+        )
+
+        let dimensions = try await provider.dimensions(at: Self.evaluationDate)
+
+        #expect(dimensions.isEmpty)
+        #expect(fetchCount.value == 0)
+    }
+
+    @Test
+    func unavailableCustomerInfoStillExposesTheCurrentAppUserID() async throws {
+        let provider = CustomerInfoDimensionProvider(
+            currentAppUserIDProvider: { Self.appUserID },
+            customerInfoProvider: { _ in throw TestError.customerInfoUnavailable }
+        )
+
+        let dimensions = try await provider.dimensions(at: Self.evaluationDate)
+
+        #expect(dimensions == ["app_user_id": .string(Self.appUserID)])
+    }
+
+    @Test
+    func cancellationPropagates() async {
+        let provider = CustomerInfoDimensionProvider(
+            currentAppUserIDProvider: { Self.appUserID },
+            customerInfoProvider: { _ in throw CancellationError() }
+        )
+
+        await #expect(throws: CancellationError.self) {
+            _ = try await provider.dimensions(at: Self.evaluationDate)
+        }
+    }
+
+    @Test
+    func propertiesCanBeEvaluatedUsingCanonicalPaths() async throws {
+        let evaluator = LocalRulesEvaluator(dimensionProviders: [Self.provider()])
+        let predicates = [
+            #"{"==":[{"var":"app_user_id"},"current_user"]}"#,
+            #"{"some":[{"var":"purchases"},{"and":[{"==":[{"var":"kind"},"subscription"]},{"var":"is_active"}]}]}"#,
+            #"{"some":[{"var":"entitlements"},{"and":[{"==":[{"var":"identifier"},"premium"]},{"var":"is_active"}]}]}"#
+        ]
+
+        for predicate in predicates {
+            let match = try await evaluator.match(in: [TestRule(predicate: predicate)])
+            #expect(match != nil, Comment(rawValue: predicate))
+        }
+    }
+
+    @Test
+    func purchasesAreOrderedNewestFirstAndTiesAreDeterministic() async throws {
+        let subscriptions: [String: Any] = [
+            "zeta": Self.subscription(purchaseDate: "2024-05-01T00:00:00Z"),
+            "alpha": Self.subscription(purchaseDate: "2024-05-01T00:00:00Z")
+        ]
+        let nonSubscriptions: [String: Any] = [
+            "newest": [Self.nonSubscription(purchaseDate: "2024-06-01T00:00:00Z")]
+        ]
+        let provider = Self.provider(
+            customerInfoData: Self.customerInfoData(
+                subscriptions: subscriptions,
+                nonSubscriptions: nonSubscriptions
+            )
+        )
+
+        let dimensions = try await provider.dimensions(at: Self.evaluationDate)
+
+        #expect(Self.productIdentifiers(from: dimensions) == ["newest", "alpha", "zeta"])
+    }
+
+    @Test
+    func mapsEveryStoreAndOmitsAnUnknownStore() async throws {
+        let stores: [(rawValue: Any, expected: String?)] = [
+            ("app_store", "app_store"),
+            ("mac_app_store", "mac_app_store"),
+            ("play_store", "play_store"),
+            ("stripe", "stripe"),
+            ("promotional", "promotional"),
+            (NSNull(), nil),
+            ("amazon", "amazon"),
+            ("rc_billing", "rc_billing"),
+            ("external", "external"),
+            ("paddle", "paddle"),
+            ("test_store", "test_store"),
+            ("galaxy", "galaxy")
+        ]
+        let subscriptions = stores.enumerated().reduce(into: [String: Any]()) { result, element in
+            result[String(format: "product_%02d", element.offset)] = Self.subscription(store: element.element.rawValue)
+        }
+        let provider = Self.provider(customerInfoData: Self.customerInfoData(subscriptions: subscriptions))
+
+        let dimensions = try await provider.dimensions(at: Self.evaluationDate)
+        let purchases = Self.purchasesByProductIdentifier(from: dimensions)
+
+        for (index, store) in stores.enumerated() {
+            let identifier = String(format: "product_%02d", index)
+            #expect(purchases[identifier]?["store"] == store.expected.map(DimensionValue.string))
+        }
+    }
+
+    @Test
+    func mapsEverySubscriptionPeriodType() async throws {
+        let periodTypes = ["normal", "intro", "trial", "prepaid"]
+        let subscriptions = periodTypes.enumerated().reduce(into: [String: Any]()) { result, element in
+            result["product_\(element.offset)"] = Self.subscription(periodType: element.element)
+        }
+        let provider = Self.provider(customerInfoData: Self.customerInfoData(subscriptions: subscriptions))
+
+        let dimensions = try await provider.dimensions(at: Self.evaluationDate)
+        let purchases = Self.purchasesByProductIdentifier(from: dimensions)
+
+        for (index, periodType) in periodTypes.enumerated() {
+            #expect(purchases["product_\(index)"]?["period_type"] == .string(periodType))
+        }
+    }
+
+    @Test
+    func emptyCustomerInfoCollectionsRemainReadableAndAnEmptyOriginalAppUserIDIsOmitted() async throws {
+        let provider = Self.provider(
+            customerInfoData: Self.customerInfoData(originalAppUserID: "")
+        )
+
+        let dimensions = try await provider.dimensions(at: Self.evaluationDate)
+
+        #expect(dimensions == [
+            "app_user_id": .string(Self.appUserID),
+            "purchases": .objectList([]),
+            "entitlements": .objectList([])
+        ])
+    }
+
+    private static func provider() -> CustomerInfoDimensionProvider {
+        return Self.provider(customerInfoData: Self.customerInfoData)
+    }
+
+    private static func provider(customerInfoData: [String: Any]) -> CustomerInfoDimensionProvider {
+        return CustomerInfoDimensionProvider(
+            currentAppUserIDProvider: { Self.appUserID },
+            customerInfoProvider: { _ in try CustomerInfo(data: customerInfoData) }
+        )
+    }
+
+    private static func customerInfo() throws -> CustomerInfo {
+        return try CustomerInfo(data: Self.customerInfoData)
+    }
+
+    private static let appUserID = "current_user"
+    private static let evaluationDate = Date(timeIntervalSince1970: 1_718_452_800)
+
+    private static func customerInfoData(
+        originalAppUserID: String = "original_user",
+        subscriptions: [String: Any] = [:],
+        nonSubscriptions: [String: Any] = [:],
+        entitlements: [String: Any] = [:]
+    ) -> [String: Any] {
+        return [
+            "request_date": "2024-06-01T00:00:00Z",
+            "subscriber": [
+                "first_seen": "2022-01-01T00:00:00Z",
+                "original_app_user_id": originalAppUserID,
+                "original_application_version": "1.0",
+                "non_subscriptions": nonSubscriptions,
+                "subscriptions": subscriptions,
+                "entitlements": entitlements
+            ]
+        ]
+    }
+
+    private static func subscription(
+        store: Any = "app_store",
+        purchaseDate: String = "2024-05-01T00:00:00Z",
+        periodType: String = "normal"
+    ) -> [String: Any] {
+        return [
+            "store": store,
+            "purchase_date": purchaseDate,
+            "original_purchase_date": "2021-01-01T00:00:00Z",
+            "expires_date": "2100-01-01T00:00:00Z",
+            "period_type": periodType,
+            "is_sandbox": true
+        ]
+    }
+
+    private static func nonSubscription(purchaseDate: String) -> [String: Any] {
+        return [
+            "id": "transaction_id",
+            "store_transaction_id": "store_transaction_id",
+            "is_sandbox": false,
+            "original_purchase_date": purchaseDate,
+            "purchase_date": purchaseDate,
+            "store": "app_store"
+        ]
+    }
+
+    private static func productIdentifiers(from dimensions: [String: DimensionValue]) -> [String] {
+        guard case let .objectList(purchases) = dimensions["purchases"] else { return [] }
+
+        return purchases.compactMap { purchase in
+            guard case let .string(identifier) = purchase["product_identifier"] else { return nil }
+            return identifier
+        }
+    }
+
+    private static func purchasesByProductIdentifier(
+        from dimensions: [String: DimensionValue]
+    ) -> [String: [String: DimensionValue]] {
+        guard case let .objectList(purchases) = dimensions["purchases"] else { return [:] }
+
+        return purchases.reduce(into: [:]) { result, purchase in
+            guard case let .string(identifier) = purchase["product_identifier"] else { return }
+            result[identifier] = purchase
+        }
+    }
+
+    private static let customerInfoData: [String: Any] = [
+        "request_date": "2024-06-01T00:00:00Z",
+        "subscriber": [
+            "first_seen": "2022-01-01T00:00:00Z",
+            "original_app_user_id": "original_user",
+            "original_application_version": "1.0",
+            "non_subscriptions": [
+                "coins": [[
+                    "id": "transaction_id",
+                    "store_transaction_id": "store_transaction_id",
+                    "is_sandbox": false,
+                    "original_purchase_date": "2023-03-03T00:00:00Z",
+                    "purchase_date": "2023-03-03T00:00:00Z",
+                    "store": "app_store"
+                ]]
+            ],
+            "subscriptions": [
+                "premium": [
+                    "store": "app_store",
+                    "purchase_date": "2024-05-01T00:00:00Z",
+                    "original_purchase_date": "2021-01-01T00:00:00Z",
+                    "expires_date": "2100-01-01T00:00:00Z",
+                    "period_type": "trial",
+                    "is_sandbox": true
+                ]
+            ],
+            "entitlements": [
+                "premium": [
+                    "expires_date": "2100-01-01T00:00:00Z",
+                    "product_identifier": "premium",
+                    "purchase_date": "2024-05-01T00:00:00Z"
+                ]
+            ]
+        ]
+    ]
+
+}
+
+private extension CustomerInfoDimensionProviderTests {
+
+    struct TestRule: LocalRule {
+
+        let id = "test_rule"
+        let predicate: String
+    }
+
+    enum TestError: Error {
+
+        case customerInfoUnavailable
+    }
+
+}

--- a/Tests/UnitTests/LocalRules/CustomerInfoDimensionProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/CustomerInfoDimensionProviderTests.swift
@@ -437,10 +437,14 @@ extension CustomerInfoDimensionProviderTests {
     }
 
     @Test
-    func convertsPricesToMicrosByTruncatingFractionalMicros() async throws {
+    func convertsPricesToMicros() async throws {
         let cases: [(amount: Double, expectedMicros: Int64)] = [
             (1.234567, 1_234_567),
-            (0.0000005, 0)
+            (0.0000005, 0),
+            (0.0000006, 1),
+            // A price that is one representable step below 1.99 still represents 1.99
+            // at micros precision, but multiplying it as a Double produces 1_989_999.999...
+            (1.99.nextDown, 1_990_000)
         ]
 
         for (index, testCase) in cases.enumerated() {

--- a/Tests/UnitTests/LocalRules/DimensionScopeTests.swift
+++ b/Tests/UnitTests/LocalRules/DimensionScopeTests.swift
@@ -1,0 +1,155 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  DimensionScopeTests.swift
+//
+//  Created by Rick van der Linden on 8/31/26.
+//
+
+// Swift Testing is only available with the Xcode 16+ toolchain
+#if compiler(>=5.9)
+#if canImport(Testing)
+
+import Foundation
+import Testing
+
+@testable import RevenueCat
+
+@Suite("Dimension scope")
+struct DimensionScopeTests {
+
+    @Test
+    func canonicalSnapshotCombinesEveryDimensionSource() async throws {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let attribute = SubscriberAttribute(
+            withKey: "goal",
+            value: "make_more_money",
+            isSynced: true,
+            setTime: Date(timeIntervalSince1970: 1_699_999_000)
+        )
+        let providers: [any DimensionProvider] = [
+            DeviceDimensionProvider(
+                appVersion: "1.2.3",
+                localeProvider: { "en-GB" },
+                platform: "iOS",
+                platformVersion: OperatingSystemVersion(majorVersion: 18, minorVersion: 5, patchVersion: 0),
+                sdkVersion: "10.1.1"
+            ),
+            StoreDimensionProvider(storefrontCountryCodeProvider: { "GBR" }),
+            CustomerInfoDimensionProvider(
+                currentAppUserIDProvider: { "current_user" },
+                customerInfoProvider: { _ in try CustomerInfo(data: Self.customerInfoData) }
+            ),
+            SubscriberAttributesDimensionProvider(attributesProvider: { ["goal": attribute] })
+        ]
+
+        let snapshot = try await DimensionResolver(
+            dimensionProviders: providers,
+            dateProvider: MockDateProvider(stubbedNow: date)
+        ).snapshot(
+            customVariables: ["attempt": .int(3)],
+            backendValues: ["condition_hash": .bool(true)]
+        )
+
+        #expect(snapshot.values == Self.expectedValues)
+    }
+}
+
+private extension DimensionScopeTests {
+
+    static let expectedValues: [String: RulesEngine.Value] = [
+        "evaluated_at": .int(1_700_000_000_000),
+        "app_version": .string("1.2.3"),
+        "platform": .string("ios"),
+        "platform_version": .string("18.5.0"),
+        "locale": .string("en_gb"),
+        "sdk_version": .string("10.1.1"),
+        "storefront": .string("GBR"),
+        "app_user_id": .string("current_user"),
+        "original_app_user_id": .string("original_user"),
+        "first_seen_at": .int(1_672_531_200_000),
+        "original_purchased_at": .int(1_675_209_600_000),
+        "purchases": .array([
+            .object([
+                "kind": .string("subscription"),
+                "product_identifier": .string("premium"),
+                "purchased_product_identifier": .string("premium"),
+                "store": .string("app_store"),
+                "ownership_type": .string("PURCHASED"),
+                "period_type": .string("normal"),
+                "status": .string("active"),
+                "purchased_at": .int(1_698_796_800_000),
+                "original_purchased_at": .int(1_675_209_600_000),
+                "expires_at": .int(4_102_444_800_000),
+                "is_active": .bool(true),
+                "is_sandbox": .bool(false),
+                "will_renew": .bool(true),
+                "is_in_grace_period": .bool(false),
+                "is_refunded": .bool(false),
+                "is_paused": .bool(false)
+            ])
+        ]),
+        "entitlements": .array([
+            .object([
+                "identifier": .string("premium"),
+                "product_identifier": .string("premium"),
+                "purchased_product_identifier": .string("premium"),
+                "store": .string("app_store"),
+                "ownership_type": .string("PURCHASED"),
+                "period_type": .string("normal"),
+                "latest_purchased_at": .int(1_698_796_800_000),
+                "original_purchased_at": .int(1_675_209_600_000),
+                "expires_at": .int(4_102_444_800_000),
+                "is_active": .bool(true),
+                "is_sandbox": .bool(false),
+                "will_renew": .bool(true)
+            ])
+        ]),
+        "subscriber_attributes": .object([
+            "goal": .object([
+                "updated_at": .int(1_699_999_000_000),
+                "value": .string("make_more_money")
+            ])
+        ]),
+        "custom": .object(["attempt": .int(3)]),
+        "backend": .object(["condition_hash": .bool(true)])
+    ]
+
+    static let customerInfoData: [String: Any] = [
+        "request_date": "2023-11-14T22:13:20Z",
+        "subscriber": [
+            "first_seen": "2023-01-01T00:00:00Z",
+            "original_app_user_id": "original_user",
+            "original_application_version": "1.0",
+            "original_purchase_date": "2023-02-01T00:00:00Z",
+            "non_subscriptions": [String: Any](),
+            "subscriptions": [
+                "premium": [
+                    "store": "app_store",
+                    "purchase_date": "2023-11-01T00:00:00Z",
+                    "original_purchase_date": "2023-02-01T00:00:00Z",
+                    "expires_date": "2100-01-01T00:00:00Z",
+                    "period_type": "normal",
+                    "ownership_type": "PURCHASED",
+                    "is_sandbox": false
+                ]
+            ],
+            "entitlements": [
+                "premium": [
+                    "expires_date": "2100-01-01T00:00:00Z",
+                    "product_identifier": "premium",
+                    "purchase_date": "2023-11-01T00:00:00Z"
+                ]
+            ]
+        ]
+    ]
+}
+
+#endif
+#endif

--- a/Tests/UnitTests/LocalRules/DimensionValueTests.swift
+++ b/Tests/UnitTests/LocalRules/DimensionValueTests.swift
@@ -25,6 +25,16 @@ import Testing
 struct DimensionValueTests {
 
     @Test
+    func priceAmountMicrosRoundsFloatingPointArtifacts() {
+        let price = ProductPaidPrice(currency: "USD", amount: 1.99 - Double.ulpOfOne)
+        var values: [String: DimensionValue] = [:]
+
+        values.set(price: price)
+
+        #expect(values["price_amount_micros"] == .int(1_990_000))
+    }
+
+    @Test
     func anyDecodableConvertsSupportedDimensionValues() throws {
         let json = #"""
         {

--- a/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
+++ b/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
@@ -137,64 +137,6 @@ struct LocalRulesEvaluatorTests {
     }
 
     @Test
-    func canonicalBaseSnapshotMatchesRFCShape() async throws {
-        let date = Date(timeIntervalSince1970: 1_700_000_000)
-        let providers = [
-            TestDimensionProvider(
-                name: "device",
-                snapshots: [[
-                    "app_version": .string("1.2.3"),
-                    "platform": .string("ios"),
-                    "platform_version": .string("18.5"),
-                    "locale": .string("en_gb"),
-                    "sdk_version": .string("10.1.1")
-                ]]
-            ),
-            TestDimensionProvider(
-                name: "store",
-                snapshots: [["storefront": .string("GBR")]]
-            ),
-            TestDimensionProvider(
-                name: "subscriber_attributes",
-                snapshots: [[
-                    "subscriber_attributes": .object([
-                        "goal": .object([
-                            "updated_at": .date(Date(timeIntervalSince1970: 1_699_999_000)),
-                            "value": .string("make_more_money")
-                        ])
-                    ])
-                ]]
-            )
-        ]
-
-        let snapshot = try await DimensionResolver(
-            dimensionProviders: providers,
-            dateProvider: MockDateProvider(stubbedNow: date)
-        ).snapshot(
-            customVariables: ["attempt": .int(3)],
-            backendValues: ["condition_hash": .bool(true)]
-        )
-
-        #expect(snapshot.values == [
-            "evaluated_at": .int(1_700_000_000_000),
-            "app_version": .string("1.2.3"),
-            "platform": .string("ios"),
-            "platform_version": .string("18.5"),
-            "locale": .string("en_gb"),
-            "sdk_version": .string("10.1.1"),
-            "storefront": .string("GBR"),
-            "subscriber_attributes": .object([
-                "goal": .object([
-                    "updated_at": .int(1_699_999_000_000),
-                    "value": .string("make_more_money")
-                ])
-            ]),
-            "custom": .object(["attempt": .int(3)]),
-            "backend": .object(["condition_hash": .bool(true)])
-        ])
-    }
-
-    @Test
     func recursivelyOmitsInvalidProviderDimensionNames() async throws {
         let provider = TestDimensionProvider(
             name: "device",


### PR DESCRIPTION
## Description
Adds the `CustomerInfo` dimension provider, supplying purchase related information to the rules evaluator.

Example of information exposed to the engine
```json
{
  "app_user_id": "current_user",
  "original_app_user_id": "original_user",
  "first_seen_at": 1640995200000,
  "original_purchased_at": 1609459200000,
  "purchases": [
    {
      "auto_resume_at": 1719792000000,
      "billing_issue_detected_at": 1714780800000,
      "display_name": "Premium Monthly",
      "expires_at": 4102444800000,
      "grace_period_expires_at": 1715299200000,
      "is_active": true,
      "is_in_grace_period": false,
      "is_paused": true,
      "is_refunded": true,
      "is_sandbox": true,
      "kind": "subscription",
      "original_purchased_at": 1609459200000,
      "ownership_type": "PURCHASED",
      "period_type": "trial",
      "price_amount_micros": 4990000,
      "price_currency": "USD",
      "product_identifier": "premium",
      "product_plan_identifier": "monthly",
      "purchased_at": 1714521600000,
      "purchased_product_identifier": "premium:monthly",
      "refunded_at": 1714867200000,
      "status": "paused",
      "store": "app_store",
      "store_transaction_id": "2000000123456789",
      "unsubscribe_detected_at": 1714694400000,
      "will_renew": false
    },
    {
      "display_name": "100 Coins",
      "is_sandbox": false,
      "kind": "non_subscription",
      "original_purchased_at": 1677628800000,
      "price_amount_micros": 1990000,
      "price_currency": "EUR",
      "product_identifier": "coins",
      "purchased_at": 1677801600000,
      "purchased_product_identifier": "coins",
      "store": "app_store",
      "store_transaction_id": "2000000987654321",
      "transaction_identifier": "rc_transaction_id"
    }
  ],
  "entitlements": [
    {
      "billing_issue_detected_at": 1714780800000,
      "expires_at": 4102444800000,
      "identifier": "premium",
      "is_active": true,
      "is_sandbox": true,
      "latest_purchased_at": 1714521600000,
      "original_purchased_at": 1609459200000,
      "ownership_type": "PURCHASED",
      "period_type": "trial",
      "product_identifier": "premium",
      "product_plan_identifier": "monthly",
      "purchased_product_identifier": "premium:monthly",
      "store": "app_store",
      "unsubscribe_detected_at": 1714694400000,
      "will_renew": false
    }
  ]
}
```

Related Android PR: https://github.com/RevenueCat/purchases-android/pull/4130

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Checkpoint evaluation now depends on async CustomerInfo fetches on every rules pass, which can change audience outcomes if purchase data is stale or unavailable, though failures degrade to partial dimensions.
> 
> **Overview**
> Adds a **`customer_info`** dimension provider so checkpoint/local rules can target subscription state, purchase history, and entitlements—not just device and store context.
> 
> On each evaluation it loads **`CustomerInfo`** for the current app user and flattens user IDs, **`purchases`** (subscriptions and non-subscriptions, newest-first with deterministic tie-breaking), and **`entitlements`** into rule variables, including derived subscription **`status`**, store/ownership mappings, and **`price_amount_micros`** via new **`Dictionary+DimensionValue`** helpers. If **`CustomerInfo`** fails, evaluation still gets **`app_user_id`** and logs **`customerInfoUnavailable`**; cancellation still propagates.
> 
> **`Purchases`** registers the provider on **`LocalRulesEvaluator`** when remote config is enabled (async fetch through **`customerInfoManager`**). Tests cover mapping, ordering, predicates, and a moved end-to-end **`DimensionScopeTests`** snapshot that includes the new fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b45032d2d0eaf319f768c3714cd937ef5469f346. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->