### PR TITLE
feat(Checkpoints): Cache subscriber dimensions and evaluate rules against them

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		D19A00000000000000000003 /* SubscriberAttributesDimensionProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D19A00000000000000000004 /* SubscriberAttributesDimensionProviderTests.swift */; };
 		D20A00000000000000000003 /* CustomerInfoDimensionProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20A00000000000000000004 /* CustomerInfoDimensionProviderTests.swift */; };
 		D21A00000000000000000003 /* DimensionScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21A00000000000000000004 /* DimensionScopeTests.swift */; };
+		D22A00000000000000000003 /* SubscriberDimensionsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22A00000000000000000004 /* SubscriberDimensionsProvider.swift */; };
+		D22A00000000000000000005 /* SubscriberDimensionsProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22A00000000000000000006 /* SubscriberDimensionsProviderTests.swift */; };
 		D20A00000000000000000001 /* CustomerInfoDimensionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20A00000000000000000002 /* CustomerInfoDimensionProvider.swift */; };
 		C05A00000000000000000001 /* CustomVariableKeyValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05A00000000000000000002 /* CustomVariableKeyValidator.swift */; };
 		C05A00000000000000000003 /* CustomVariableKeyValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05A00000000000000000004 /* CustomVariableKeyValidatorTests.swift */; };
@@ -1689,6 +1691,8 @@
 		D19A00000000000000000004 /* SubscriberAttributesDimensionProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriberAttributesDimensionProviderTests.swift; sourceTree = "<group>"; };
 		D20A00000000000000000004 /* CustomerInfoDimensionProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoDimensionProviderTests.swift; sourceTree = "<group>"; };
 		D21A00000000000000000004 /* DimensionScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DimensionScopeTests.swift; sourceTree = "<group>"; };
+		D22A00000000000000000004 /* SubscriberDimensionsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriberDimensionsProvider.swift; sourceTree = "<group>"; };
+		D22A00000000000000000006 /* SubscriberDimensionsProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriberDimensionsProviderTests.swift; sourceTree = "<group>"; };
 		D20A00000000000000000002 /* CustomerInfoDimensionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoDimensionProvider.swift; sourceTree = "<group>"; };
 		C05A00000000000000000002 /* CustomVariableKeyValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomVariableKeyValidator.swift; sourceTree = "<group>"; };
 		C05A00000000000000000004 /* CustomVariableKeyValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomVariableKeyValidatorTests.swift; sourceTree = "<group>"; };
@@ -3457,6 +3461,7 @@
 				D17A00000000000000000002 /* StoreDimensionProvider.swift */,
 				D20A00000000000000000002 /* CustomerInfoDimensionProvider.swift */,
 				D19A00000000000000000002 /* SubscriberAttributesDimensionProvider.swift */,
+				D22A00000000000000000004 /* SubscriberDimensionsProvider.swift */,
 				D22A00000000000000000002 /* AnyDecodable+DimensionValue.swift */,
 				D23A00000000000000000002 /* Dictionary+DimensionValue.swift */,
 				A0D200000000000000000002 /* DimensionProvider.swift */,
@@ -3476,6 +3481,7 @@
 				D19A00000000000000000004 /* SubscriberAttributesDimensionProviderTests.swift */,
 				D20A00000000000000000004 /* CustomerInfoDimensionProviderTests.swift */,
 				D21A00000000000000000004 /* DimensionScopeTests.swift */,
+				D22A00000000000000000006 /* SubscriberDimensionsProviderTests.swift */,
 			);
 			path = LocalRules;
 			sourceTree = "<group>";
@@ -8221,6 +8227,7 @@
 				D17A00000000000000000001 /* StoreDimensionProvider.swift in Sources */,
 				D20A00000000000000000001 /* CustomerInfoDimensionProvider.swift in Sources */,
 				D19A00000000000000000001 /* SubscriberAttributesDimensionProvider.swift in Sources */,
+				D22A00000000000000000003 /* SubscriberDimensionsProvider.swift in Sources */,
 				D22A00000000000000000001 /* AnyDecodable+DimensionValue.swift in Sources */,
 				D23A00000000000000000001 /* Dictionary+DimensionValue.swift in Sources */,
 				A0D100000000000000000002 /* DimensionProvider.swift in Sources */,
@@ -8687,6 +8694,7 @@
 				D19A00000000000000000003 /* SubscriberAttributesDimensionProviderTests.swift in Sources */,
 				D20A00000000000000000003 /* CustomerInfoDimensionProviderTests.swift in Sources */,
 				D21A00000000000000000003 /* DimensionScopeTests.swift in Sources */,
+				D22A00000000000000000005 /* SubscriberDimensionsProviderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Caching/DeviceCache.swift
+++ b/Sources/Caching/DeviceCache.swift
@@ -132,6 +132,9 @@ class DeviceCache {
             userDefaults.removeObject(
                 forKey: CacheKey.customerInfo(oldAppUserID)
             )
+            userDefaults.removeObject(
+                forKey: CacheKey.subscriberDimensions(oldAppUserID)
+            )
 
             // Clear CustomerInfo cache timestamp for oldAppUserID.
             userDefaults.removeObject(forKey: CacheKey.customerInfoLastUpdated(oldAppUserID))
@@ -177,6 +180,20 @@ class DeviceCache {
         self.userDefaults.write {
             $0.set(customerInfo, forKey: CacheKey.customerInfo(appUserID))
             Self.setCustomerInfoCacheTimestampToNow($0, appUserID: appUserID)
+        }
+    }
+
+    // MARK: - Subscriber dimensions
+
+    func cachedSubscriberDimensionsData(appUserID: String) -> Data? {
+        return self.userDefaults.read {
+            $0.data(forKey: CacheKey.subscriberDimensions(appUserID))
+        }
+    }
+
+    func cache(subscriberDimensions: Data, appUserID: String) {
+        self.userDefaults.write {
+            $0.set(subscriberDimensions, forKey: CacheKey.subscriberDimensions(appUserID))
         }
     }
 
@@ -568,6 +585,7 @@ class DeviceCache {
 
         case customerInfo(String)
         case customerInfoLastUpdated(String)
+        case subscriberDimensions(String)
         case offerings(String)
         case legacySubscriberAttributes(String)
         case attributionDataDefaults(String)
@@ -579,6 +597,7 @@ class DeviceCache {
             switch self {
             case let .customerInfo(userID): return "\(Self.base)purchaserInfo.\(userID)"
             case let .customerInfoLastUpdated(userID): return "\(Self.base)purchaserInfoLastUpdated.\(userID)"
+            case let .subscriberDimensions(userID): return "\(Self.base)subscriberDimensions.\(userID)"
             case let .offerings(userID): return "\(Self.base)offerings.\(userID)"
             case let .legacySubscriberAttributes(userID): return "\(Self.legacySubscriberAttributesBase)\(userID)"
             case let .attributionDataDefaults(userID): return "\(Self.base)attribution.\(userID)"

--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -266,6 +266,7 @@ class CustomerInfoManager {
 
         if customerInfo.shouldCache {
             do {
+                self.cacheSubscriberDimensionsIfPresent(from: customerInfo, appUserID: appUserID)
                 let jsonData = try JSONEncoder.default.encode(customerInfo)
                 self.deviceCache.cache(customerInfo: jsonData, appUserID: appUserID)
             } catch {
@@ -277,6 +278,24 @@ class CustomerInfoManager {
         }
 
         self.sendUpdateIfChanged(customerInfo: customerInfo)
+    }
+
+    private func cacheSubscriberDimensionsIfPresent(
+        from customerInfo: CustomerInfo,
+        appUserID: String
+    ) {
+        guard !customerInfo.isLoadedFromCache,
+              let dimensions = customerInfo.rawData["dimensions"] as? [String: Any],
+              !dimensions.isEmpty else {
+            return
+        }
+
+        do {
+            let data = try JSONSerialization.data(withJSONObject: dimensions)
+            self.deviceCache.cache(subscriberDimensions: data, appUserID: appUserID)
+        } catch {
+            Logger.warn(Strings.remoteConfig.subscriberDimensionsUnavailable(error))
+        }
     }
 
     func clearCustomerInfoCache(forAppUserID appUserID: String) {

--- a/Sources/LocalRules/AnyDecodable+DimensionValue.swift
+++ b/Sources/LocalRules/AnyDecodable+DimensionValue.swift
@@ -30,7 +30,7 @@ extension AnyDecodable {
                 return object.compactMapValues(\AnyDecodable.dimensionValue)
             }
             return objects.count == value.count ? .objectList(objects) : nil
-        case .null: return nil
+        case .null: return .null
         }
     }
 

--- a/Sources/LocalRules/DimensionProvider.swift
+++ b/Sources/LocalRules/DimensionProvider.swift
@@ -19,6 +19,9 @@ import Foundation
 /// This keeps providers independent from the RulesEngine representation.
 enum DimensionValue: Equatable, Sendable {
 
+    /// An explicit null value supplied by the provider.
+    case null
+
     case string(String)
     case bool(Bool)
     case int(Int64)

--- a/Sources/LocalRules/DimensionResolver.swift
+++ b/Sources/LocalRules/DimensionResolver.swift
@@ -139,6 +139,7 @@ private enum DimensionValueConverter {
     /// Converts a provider value into its RulesEngine equivalent while filtering invalid nested names.
     private static func convert(_ dimension: DimensionValue, path: String) -> RulesEngine.Value? {
         switch dimension {
+        case .null: return .null
         case .string(let value): return .string(value)
         case .bool(let value): return .bool(value)
         case .int(let value): return .int(value)

--- a/Sources/LocalRules/SubscriberDimensionsProvider.swift
+++ b/Sources/LocalRules/SubscriberDimensionsProvider.swift
@@ -19,24 +19,22 @@ struct SubscriberDimensionsProvider: DimensionProvider {
 
     let name = "subscriber_dimensions"
 
-    private let cachedDimensionsProvider: @Sendable () throws -> Data?
+    private let deviceCache: DeviceCache
+    private let currentUserProvider: any CurrentUserProvider
 
     init(
         deviceCache: DeviceCache,
         currentUserProvider: CurrentUserProvider
     ) {
-        self.init {
-            deviceCache.cachedSubscriberDimensionsData(appUserID: currentUserProvider.currentAppUserID)
-        }
-    }
-
-    init(cachedDimensionsProvider: @escaping @Sendable () throws -> Data?) {
-        self.cachedDimensionsProvider = cachedDimensionsProvider
+        self.deviceCache = deviceCache
+        self.currentUserProvider = currentUserProvider
     }
 
     func dimensions(at _: Date) -> [String: DimensionValue] {
         do {
-            guard let data = try self.cachedDimensionsProvider() else { return [:] }
+            guard let data = self.deviceCache.cachedSubscriberDimensionsData(
+                appUserID: self.currentUserProvider.currentAppUserID
+            ) else { return [:] }
             let values = try JSONDecoder.default.decode([String: AnyDecodable].self, from: data)
 
             return values.compactMapValues(\AnyDecodable.dimensionValue)

--- a/Sources/LocalRules/SubscriberDimensionsProvider.swift
+++ b/Sources/LocalRules/SubscriberDimensionsProvider.swift
@@ -1,0 +1,49 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SubscriberDimensionsProvider.swift
+//
+//  Created by Rick van der Linden on 8/31/26.
+//
+
+import Foundation
+
+/// Supplies the latest dimensions delivered alongside the subscriber as root-level rule values.
+struct SubscriberDimensionsProvider: DimensionProvider {
+
+    let name = "subscriber_dimensions"
+
+    private let cachedDimensionsProvider: @Sendable () throws -> Data?
+
+    init(
+        deviceCache: DeviceCache,
+        currentUserProvider: CurrentUserProvider
+    ) {
+        self.init {
+            deviceCache.cachedSubscriberDimensionsData(appUserID: currentUserProvider.currentAppUserID)
+        }
+    }
+
+    init(cachedDimensionsProvider: @escaping @Sendable () throws -> Data?) {
+        self.cachedDimensionsProvider = cachedDimensionsProvider
+    }
+
+    func dimensions(at _: Date) -> [String: DimensionValue] {
+        do {
+            guard let data = try self.cachedDimensionsProvider() else { return [:] }
+            let values = try JSONDecoder.default.decode([String: AnyDecodable].self, from: data)
+
+            return values.compactMapValues(\AnyDecodable.dimensionValue)
+        } catch {
+            Logger.warn(Strings.remoteConfig.subscriberDimensionsUnavailable(error))
+            return [:]
+        }
+    }
+
+}

--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -48,6 +48,7 @@ enum RemoteConfigStrings {
     case storedBlob(String, byteCount: Int, URL)
     case storedInlineBlob(String, byteCount: Int)
     case subscriberAttributesUnavailable(Error)
+    case subscriberDimensionsUnavailable(Error)
     case invalidDimensionName(String, parentPath: String)
     case uiConfigDecodeFailed(Error)
     case uiConfigMissingRequiredPart
@@ -147,6 +148,8 @@ extension RemoteConfigStrings: LogMessage {
             return "Stored inline remote config blob '\(ref)' with \(byteCount) bytes."
         case let .subscriberAttributesUnavailable(error):
             return "The subscriber attributes are unavailable, so they cannot be evaluated: \(error)."
+        case let .subscriberDimensionsUnavailable(error):
+            return "The subscriber dimensions are unavailable, so they cannot be evaluated: \(error)."
         case let .invalidDimensionName(name, parentPath):
             return "Ignoring dimension name '\(name)' under '\(parentPath)': " +
                 "a dimension name cannot be empty, whitespace-only, or contain '.'."

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -688,6 +688,10 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                     SubscriberAttributesDimensionProvider(
                         deviceCache: deviceCache,
                         currentUserProvider: identityManager
+                    ),
+                    SubscriberDimensionsProvider(
+                        deviceCache: deviceCache,
+                        currentUserProvider: identityManager
                     )
                 ]
             )

--- a/Tests/UnitTests/Caching/DeviceCacheTests.swift
+++ b/Tests/UnitTests/Caching/DeviceCacheTests.swift
@@ -237,6 +237,27 @@ class DeviceCacheTests: TestCase {
         expect(self.deviceCache.isCustomerInfoCacheStale(appUserID: "cesar", isAppBackgrounded: false)) == false
     }
 
+    func testSubscriberDimensionsAreCachedPerAppUserID() {
+        let data = Data(#"{"plan":"annual"}"#.utf8)
+
+        self.deviceCache.cache(subscriberDimensions: data, appUserID: "cesar")
+
+        expect(self.deviceCache.cachedSubscriberDimensionsData(appUserID: "cesar")) == data
+        expect(self.deviceCache.cachedSubscriberDimensionsData(appUserID: "other")).to(beNil())
+    }
+
+    func testClearCachesRemovesSubscriberDimensionsForOldAppUserID() {
+        let appUserID = "cesar"
+        self.deviceCache.cache(
+            subscriberDimensions: Data(#"{"plan":"annual"}"#.utf8),
+            appUserID: appUserID
+        )
+
+        self.deviceCache.clearCaches(oldAppUserID: appUserID, andSaveWithNewUserID: "newUser")
+
+        expect(self.deviceCache.cachedSubscriberDimensionsData(appUserID: appUserID)).to(beNil())
+    }
+
     func testOfferingsAreProperlyCached() throws {
         let expectedOfferings = try Self.createSampleOfferings()
 

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -588,6 +588,48 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
         expect(dimensions) == ["plan": "annual"]
     }
 
+    func testSubscriberDimensionsRoundTripFromCustomerInfoThroughProvider() throws {
+        let info = try Self.customerInfo(dimensions: [
+            "plan": "annual",
+            "beta": true,
+            "seats": 3,
+            "score": 0.75,
+            "profile": [
+                "tier": "gold",
+                "age": 42,
+                "ignored_null": NSNull(),
+                "ignored_primitive_array": [1, 2]
+            ] as [String: Any],
+            "teams": [
+                ["id": "a", "active": true] as [String: Any],
+                ["id": "b", "active": false] as [String: Any]
+            ],
+            "ignored_null": NSNull(),
+            "ignored_primitive_array": ["a", "b"]
+        ])
+
+        self.customerInfoManager.cache(customerInfo: info, appUserID: Self.appUserID)
+
+        let provider = SubscriberDimensionsProvider(
+            deviceCache: self.mockDeviceCache,
+            currentUserProvider: MockCurrentUserProvider(mockAppUserID: Self.appUserID)
+        )
+        expect(provider.dimensions(at: Date())) == [
+            "plan": .string("annual"),
+            "beta": .bool(true),
+            "seats": .int(3),
+            "score": .double(0.75),
+            "profile": .object([
+                "tier": .string("gold"),
+                "age": .int(42)
+            ]),
+            "teams": .objectList([
+                ["id": .string("a"), "active": .bool(true)],
+                ["id": .string("b"), "active": .bool(false)]
+            ])
+        ]
+    }
+
     func testNonEmptySubscriberDimensionsReplaceCompletePreviousSnapshot() throws {
         self.customerInfoManager.cache(
             customerInfo: try Self.customerInfo(dimensions: [

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -621,12 +621,14 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
             "score": .double(0.75),
             "profile": .object([
                 "tier": .string("gold"),
+                "ignored_null": .null,
                 "age": .int(42)
             ]),
             "teams": .objectList([
                 ["id": .string("a"), "active": .bool(true)],
                 ["id": .string("b"), "active": .bool(false)]
-            ])
+            ]),
+            "ignored_null": .null
         ]
     }
 

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -576,6 +576,70 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
         expect(self.mockDeviceCache.cacheCustomerInfoCount) == 1
     }
 
+    func testCacheCustomerInfoStoresNonEmptySubscriberDimensionsSeparately() throws {
+        let info = try Self.customerInfo(dimensions: ["plan": "annual"])
+
+        self.customerInfoManager.cache(customerInfo: info, appUserID: Self.appUserID)
+
+        let data = try XCTUnwrap(
+            self.mockDeviceCache.cachedSubscriberDimensionsData(appUserID: Self.appUserID)
+        )
+        let dimensions = try JSONDecoder.default.decode([String: AnyDecodable].self, from: data)
+        expect(dimensions) == ["plan": "annual"]
+    }
+
+    func testNonEmptySubscriberDimensionsReplaceCompletePreviousSnapshot() throws {
+        self.customerInfoManager.cache(
+            customerInfo: try Self.customerInfo(dimensions: [
+                "plan": "annual",
+                "segment": "high_value"
+            ]),
+            appUserID: Self.appUserID
+        )
+
+        self.customerInfoManager.cache(
+            customerInfo: try Self.customerInfo(dimensions: ["plan": "monthly"]),
+            appUserID: Self.appUserID
+        )
+
+        let data = try XCTUnwrap(
+            self.mockDeviceCache.cachedSubscriberDimensionsData(appUserID: Self.appUserID)
+        )
+        let dimensions = try JSONDecoder.default.decode([String: AnyDecodable].self, from: data)
+        expect(dimensions) == ["plan": "monthly"]
+    }
+
+    func testCacheCustomerInfoWithoutDimensionsKeepsPreviousSubscriberDimensions() throws {
+        let previous = Data(#"{"plan":"annual"}"#.utf8)
+        self.mockDeviceCache.cache(subscriberDimensions: previous, appUserID: Self.appUserID)
+
+        self.customerInfoManager.cache(customerInfo: self.mockCustomerInfo, appUserID: Self.appUserID)
+
+        expect(self.mockDeviceCache.cachedSubscriberDimensionsData(appUserID: Self.appUserID)) == previous
+    }
+
+    func testCacheCustomerInfoWithEmptyDimensionsKeepsPreviousSubscriberDimensions() throws {
+        let previous = Data(#"{"plan":"annual"}"#.utf8)
+        self.mockDeviceCache.cache(subscriberDimensions: previous, appUserID: Self.appUserID)
+
+        self.customerInfoManager.cache(
+            customerInfo: try Self.customerInfo(dimensions: [:]),
+            appUserID: Self.appUserID
+        )
+
+        expect(self.mockDeviceCache.cachedSubscriberDimensionsData(appUserID: Self.appUserID)) == previous
+    }
+
+    func testCacheLoadedCustomerInfoDoesNotReplaceSubscriberDimensions() throws {
+        let previous = Data(#"{"plan":"annual"}"#.utf8)
+        self.mockDeviceCache.cache(subscriberDimensions: previous, appUserID: Self.appUserID)
+        let loadedFromCache = try Self.customerInfo(dimensions: ["plan": "monthly"]).loadedFromCache()
+
+        self.customerInfoManager.cache(customerInfo: loadedFromCache, appUserID: Self.appUserID)
+
+        expect(self.mockDeviceCache.cachedSubscriberDimensionsData(appUserID: Self.appUserID)) == previous
+    }
+
     func testCachesCustomerInfoWithVerifiedEntitlements() throws {
         let appUserID = "myUser"
         let info = self.mockCustomerInfo.copy(with: .verified, httpResponseOriginalSource: .mainServer)
@@ -727,6 +791,24 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
         expect(cachedLoadShedderInfo) == loadShedderInfo
         expect(cachedLoadShedderInfo?.isLoadedFromCache).to(beTrue())
         expect(cachedLoadShedderInfo?.originalSource) == .loadShedder
+    }
+
+}
+
+private extension CustomerInfoManagerTests {
+
+    static func customerInfo(dimensions: [String: Any]) throws -> CustomerInfo {
+        return try CustomerInfo(data: [
+            "request_date": "2023-12-21T02:40:36Z",
+            "dimensions": dimensions,
+            "subscriber": [
+                "original_app_user_id": Self.appUserID,
+                "first_seen": "2019-06-17T16:05:33Z",
+                "subscriptions": [String: Any](),
+                "other_purchases": [String: Any](),
+                "original_application_version": NSNull()
+            ] as [String: Any]
+        ])
     }
 
 }

--- a/Tests/UnitTests/LocalRules/DimensionScopeTests.swift
+++ b/Tests/UnitTests/LocalRules/DimensionScopeTests.swift
@@ -46,7 +46,10 @@ struct DimensionScopeTests {
                 currentAppUserIDProvider: { "current_user" },
                 customerInfoProvider: { _ in try CustomerInfo(data: Self.customerInfoData) }
             ),
-            SubscriberAttributesDimensionProvider(attributesProvider: { ["goal": attribute] })
+            SubscriberAttributesDimensionProvider(attributesProvider: { ["goal": attribute] }),
+            SubscriberDimensionsProvider(cachedDimensionsProvider: {
+                Data(#"{"acquisition_channel":"paid_search","predicted_ltv_band":3}"#.utf8)
+            })
         ]
 
         let snapshot = try await DimensionResolver(
@@ -71,6 +74,8 @@ private extension DimensionScopeTests {
         "locale": .string("en_gb"),
         "sdk_version": .string("10.1.1"),
         "storefront": .string("GBR"),
+        "acquisition_channel": .string("paid_search"),
+        "predicted_ltv_band": .int(3),
         "app_user_id": .string("current_user"),
         "original_app_user_id": .string("original_user"),
         "first_seen_at": .int(1_672_531_200_000),

--- a/Tests/UnitTests/LocalRules/DimensionScopeTests.swift
+++ b/Tests/UnitTests/LocalRules/DimensionScopeTests.swift
@@ -47,9 +47,12 @@ struct DimensionScopeTests {
                 customerInfoProvider: { _ in try CustomerInfo(data: Self.customerInfoData) }
             ),
             SubscriberAttributesDimensionProvider(attributesProvider: { ["goal": attribute] }),
-            SubscriberDimensionsProvider(cachedDimensionsProvider: {
-                Data(#"{"acquisition_channel":"paid_search","predicted_ltv_band":3}"#.utf8)
-            })
+            SubscriberDimensionsProvider(
+                deviceCache: Self.deviceCache(
+                    with: #"{"acquisition_channel":"paid_search","predicted_ltv_band":3}"#
+                ),
+                currentUserProvider: MockCurrentUserProvider(mockAppUserID: "current_user")
+            )
         ]
 
         let snapshot = try await DimensionResolver(
@@ -62,6 +65,19 @@ struct DimensionScopeTests {
 
         #expect(snapshot.values == Self.expectedValues)
     }
+}
+
+private extension DimensionScopeTests {
+
+    static func deviceCache(with json: String) -> MockDeviceCache {
+        let deviceCache = MockDeviceCache()
+        deviceCache.cache(
+            subscriberDimensions: Data(json.utf8),
+            appUserID: "current_user"
+        )
+        return deviceCache
+    }
+
 }
 
 private extension DimensionScopeTests {

--- a/Tests/UnitTests/LocalRules/DimensionValueTests.swift
+++ b/Tests/UnitTests/LocalRules/DimensionValueTests.swift
@@ -49,7 +49,7 @@ struct DimensionValueTests {
             from: json.asData
         )
 
-        #expect(values["null"]?.dimensionValue == nil)
+        #expect(values["null"]?.dimensionValue == .null)
         #expect(values["nested"]?.dimensionValue == .object(["kept": .bool(true)]))
         #expect(values["records"]?.dimensionValue == .objectList([["id": .string("one")]]))
         #expect(values["mixed"]?.dimensionValue == nil)

--- a/Tests/UnitTests/LocalRules/DimensionValueTests.swift
+++ b/Tests/UnitTests/LocalRules/DimensionValueTests.swift
@@ -60,13 +60,16 @@ struct DimensionValueTests {
         let date = Date(timeIntervalSince1970: 1_700_000_000)
         let snapshot = try await Self.snapshot([
             "date": .date(date),
+            "missing": .null,
             "record": .object([
                 "id": .string("one"),
+                "missing": .null,
                 "created_at": .date(date)
             ]),
             "records": .objectList([
                 [
                     "id": .string("one"),
+                    "missing": .null,
                     "created_at": .date(date)
                 ]
             ])
@@ -75,13 +78,16 @@ struct DimensionValueTests {
         #expect(snapshot.values == [
             "evaluated_at": .int(123_000),
             "date": .int(1_700_000_000_000),
+            "missing": .null,
             "record": .object([
                 "id": .string("one"),
+                "missing": .null,
                 "created_at": .int(1_700_000_000_000)
             ]),
             "records": .array([
                 .object([
                     "id": .string("one"),
+                    "missing": .null,
                     "created_at": .int(1_700_000_000_000)
                 ])
             ])
@@ -105,6 +111,24 @@ struct DimensionValueTests {
             """#
 
         #expect(try RulesEngine.evaluate(predicate: predicate, variables: snapshot.values).get())
+    }
+
+    @Test
+    func explicitNullIsResolvedAndFalsyWhileMissingUsesItsDefault() async throws {
+        let snapshot = try await Self.snapshot(["present": .null])
+
+        #expect(try RulesEngine.evaluate(
+            predicate: #"{"==":[{"var":"present"},null]}"#,
+            variables: snapshot.values
+        ).get())
+        #expect(try !RulesEngine.evaluate(
+            predicate: #"{"!!":{"var":"present"}}"#,
+            variables: snapshot.values
+        ).get())
+        #expect(try RulesEngine.evaluate(
+            predicate: #"{"var":["missing",true]}"#,
+            variables: snapshot.values
+        ).get())
     }
 
     @Test

--- a/Tests/UnitTests/LocalRules/SubscriberDimensionsProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/SubscriberDimensionsProviderTests.swift
@@ -1,0 +1,178 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SubscriberDimensionsProviderTests.swift
+//
+//  Created by Rick van der Linden on 8/31/26.
+//
+
+// Swift Testing is only available with the Xcode 16+ toolchain
+#if compiler(>=5.9)
+#if canImport(Testing)
+
+import Foundation
+import Testing
+
+@testable import RevenueCat
+
+@Suite("Subscriber dimensions")
+struct SubscriberDimensionsProviderTests {
+
+    @Test
+    func everySupportedValueShapeIsKept() {
+        let dimensions = Self.provider(#"""
+            {
+                "plan": "annual",
+                "beta": true,
+                "seats": 3,
+                "score": 0.75,
+                "profile": {"tier": "gold", "age": 42},
+                "teams": [{"id": "a"}, {"id": "b"}]
+            }
+            """#).dimensions(at: Date())
+
+        #expect(dimensions == [
+            "plan": .string("annual"),
+            "beta": .bool(true),
+            "seats": .int(3),
+            "score": .double(0.75),
+            "profile": .object([
+                "tier": .string("gold"),
+                "age": .int(42)
+            ]),
+            "teams": .objectList([
+                ["id": .string("a")],
+                ["id": .string("b")]
+            ])
+        ])
+    }
+
+    @Test
+    func unreadableValuesAreDroppedWithoutDroppingOthers() {
+        let dimensions = Self.provider(
+            #"{"gone":null,"codes":[1,2],"plan":"annual"}"#
+        ).dimensions(at: Date())
+
+        #expect(dimensions == ["plan": .string("annual")])
+    }
+
+    @Test(arguments: ["not json", #"["an","array"]"#, #""a string""#, "42"])
+    func nonObjectCacheContributesNothing(_ json: String) {
+        #expect(Self.provider(json).dimensions(at: Date()).isEmpty)
+    }
+
+    @Test
+    func missingCacheContributesNothing() {
+        let provider = SubscriberDimensionsProvider(cachedDimensionsProvider: { nil })
+
+        #expect(provider.dimensions(at: Date()).isEmpty)
+    }
+
+    @Test
+    func cacheReadFailureContributesNothing() {
+        let provider = SubscriberDimensionsProvider(cachedDimensionsProvider: {
+            throw TestError.unavailable
+        })
+
+        #expect(provider.dimensions(at: Date()).isEmpty)
+    }
+
+    @Test
+    func cacheIsReadForEveryEvaluation() {
+        let data = Atomic(Data(#"{"plan":"annual"}"#.utf8))
+        let provider = SubscriberDimensionsProvider(cachedDimensionsProvider: { data.value })
+
+        #expect(provider.dimensions(at: Date())["plan"] == .string("annual"))
+
+        data.value = Data(#"{"plan":"monthly"}"#.utf8)
+
+        #expect(provider.dimensions(at: Date())["plan"] == .string("monthly"))
+    }
+
+    @Test
+    func productionProviderReadsDimensionsForCurrentIdentityOnEveryEvaluation() {
+        let deviceCache = MockDeviceCache()
+        let currentUserProvider = MockCurrentUserProvider(mockAppUserID: "user-a")
+        deviceCache.cache(
+            subscriberDimensions: Data(#"{"plan":"annual"}"#.utf8),
+            appUserID: "user-a"
+        )
+        deviceCache.cache(
+            subscriberDimensions: Data(#"{"plan":"monthly"}"#.utf8),
+            appUserID: "user-b"
+        )
+        let provider = SubscriberDimensionsProvider(
+            deviceCache: deviceCache,
+            currentUserProvider: currentUserProvider
+        )
+
+        #expect(provider.dimensions(at: Date())["plan"] == .string("annual"))
+
+        currentUserProvider.mockAppUserID = "user-b"
+
+        #expect(provider.dimensions(at: Date())["plan"] == .string("monthly"))
+    }
+
+    @Test
+    func dimensionsAreReadableByPredicates() async throws {
+        let snapshot = try await DimensionResolver(dimensionProviders: [
+            Self.provider(#"{"plan":"annual","seats":3,"profile":{"tier":"gold"}}"#)
+        ]).snapshot()
+
+        #expect(try RulesEngine.evaluate(
+            predicate: #"{"==":[{"var":"plan"},"annual"]}"#,
+            variables: snapshot.values
+        ).get())
+        #expect(try RulesEngine.evaluate(
+            predicate: #"{">":[{"var":"seats"},2]}"#,
+            variables: snapshot.values
+        ).get())
+        #expect(try RulesEngine.evaluate(
+            predicate: #"{"==":[{"var":"profile.tier"},"gold"]}"#,
+            variables: snapshot.values
+        ).get())
+    }
+
+    @Test
+    func collisionWithSDKDimensionFailsSnapshot() async {
+        let subscriber = Self.provider(#"{"platform":"spoofed"}"#)
+        let device = TestProvider(values: ["platform": .string("ios")])
+
+        do {
+            _ = try await DimensionResolver(dimensionProviders: [device, subscriber]).snapshot()
+            Issue.record("Expected duplicate ownership to fail")
+        } catch let error as DimensionResolutionError {
+            #expect(error == .conflictingValue(path: "platform"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    private static func provider(_ json: String) -> SubscriberDimensionsProvider {
+        return SubscriberDimensionsProvider(cachedDimensionsProvider: { Data(json.utf8) })
+    }
+
+}
+
+private enum TestError: Error {
+    case unavailable
+}
+
+private struct TestProvider: DimensionProvider {
+
+    let name = "test"
+    let values: [String: DimensionValue]
+
+    func dimensions(at _: Date) -> [String: DimensionValue] {
+        return self.values
+    }
+}
+
+#endif
+#endif

--- a/Tests/UnitTests/LocalRules/SubscriberDimensionsProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/SubscriberDimensionsProviderTests.swift
@@ -193,7 +193,6 @@ struct SubscriberDimensionsProviderTests {
 
 }
 
-
 private struct TestProvider: DimensionProvider {
 
     let name = "test"

--- a/Tests/UnitTests/LocalRules/SubscriberDimensionsProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/SubscriberDimensionsProviderTests.swift
@@ -54,12 +54,27 @@ struct SubscriberDimensionsProviderTests {
     }
 
     @Test
-    func unreadableValuesAreDroppedWithoutDroppingOthers() {
+    func explicitNullValuesAreKeptWithoutDroppingOthers() {
         let dimensions = Self.provider(
             #"{"gone":null,"codes":[1,2],"plan":"annual"}"#
         ).dimensions(at: Date())
 
-        #expect(dimensions == ["plan": .string("annual")])
+        #expect(dimensions == ["gone": .null, "plan": .string("annual")])
+    }
+
+    @Test
+    func explicitNullValuesAreKeptInsideObjects() {
+        let dimensions = Self.provider(
+            #"{"profile":{"nickname":null,"tier":"gold"},"plan":"annual"}"#
+        ).dimensions(at: Date())
+
+        #expect(dimensions == [
+            "profile": .object([
+                "nickname": .null,
+                "tier": .string("gold")
+            ]),
+            "plan": .string("annual")
+        ])
     }
 
     @Test(arguments: ["not json", #"["an","array"]"#, #""a string""#, "42"])

--- a/Tests/UnitTests/LocalRules/SubscriberDimensionsProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/SubscriberDimensionsProviderTests.swift
@@ -60,6 +60,7 @@ struct SubscriberDimensionsProviderTests {
         ).dimensions(at: Date())
 
         #expect(dimensions == ["gone": .null, "plan": .string("annual")])
+        #expect(dimensions["missing"] == nil)
     }
 
     @Test

--- a/Tests/UnitTests/LocalRules/SubscriberDimensionsProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/SubscriberDimensionsProviderTests.swift
@@ -84,28 +84,30 @@ struct SubscriberDimensionsProviderTests {
 
     @Test
     func missingCacheContributesNothing() {
-        let provider = SubscriberDimensionsProvider(cachedDimensionsProvider: { nil })
-
-        #expect(provider.dimensions(at: Date()).isEmpty)
-    }
-
-    @Test
-    func cacheReadFailureContributesNothing() {
-        let provider = SubscriberDimensionsProvider(cachedDimensionsProvider: {
-            throw TestError.unavailable
-        })
+        let provider = Self.providerWithoutCache()
 
         #expect(provider.dimensions(at: Date()).isEmpty)
     }
 
     @Test
     func cacheIsReadForEveryEvaluation() {
-        let data = Atomic(Data(#"{"plan":"annual"}"#.utf8))
-        let provider = SubscriberDimensionsProvider(cachedDimensionsProvider: { data.value })
+        let deviceCache = MockDeviceCache()
+        let currentUserProvider = MockCurrentUserProvider(mockAppUserID: "test")
+        let provider = SubscriberDimensionsProvider(
+            deviceCache: deviceCache,
+            currentUserProvider: currentUserProvider
+        )
+        deviceCache.cache(
+            subscriberDimensions: Data(#"{"plan":"annual"}"#.utf8),
+            appUserID: "test"
+        )
 
         #expect(provider.dimensions(at: Date())["plan"] == .string("annual"))
 
-        data.value = Data(#"{"plan":"monthly"}"#.utf8)
+        deviceCache.cache(
+            subscriberDimensions: Data(#"{"plan":"monthly"}"#.utf8),
+            appUserID: "test"
+        )
 
         #expect(provider.dimensions(at: Date())["plan"] == .string("monthly"))
     }
@@ -170,14 +172,27 @@ struct SubscriberDimensionsProviderTests {
     }
 
     private static func provider(_ json: String) -> SubscriberDimensionsProvider {
-        return SubscriberDimensionsProvider(cachedDimensionsProvider: { Data(json.utf8) })
+        let deviceCache = MockDeviceCache()
+        let currentUserProvider = MockCurrentUserProvider(mockAppUserID: "test")
+        deviceCache.cache(
+            subscriberDimensions: Data(json.utf8),
+            appUserID: "test"
+        )
+        return SubscriberDimensionsProvider(
+            deviceCache: deviceCache,
+            currentUserProvider: currentUserProvider
+        )
+    }
+
+    private static func providerWithoutCache() -> SubscriberDimensionsProvider {
+        return SubscriberDimensionsProvider(
+            deviceCache: MockDeviceCache(),
+            currentUserProvider: MockCurrentUserProvider(mockAppUserID: "test")
+        )
     }
 
 }
 
-private enum TestError: Error {
-    case unavailable
-}
 
 private struct TestProvider: DimensionProvider {
 

--- a/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
@@ -71,6 +71,42 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
         expect(customerInfo?.value?.entitlements.verification) == .notRequested
     }
 
+    func testGetCustomerInfoPreservesUnparsedResponseDataOfEveryJSONType() throws {
+        self.httpClient.disableSnapshotTesting()
+        var response = Self.validCustomerResponse
+        response["future_data"] = [
+            "string": "value",
+            "boolean": true,
+            "integer": 3,
+            "double": 0.75,
+            "object": ["nested": "value"],
+            "array": ["a", "b"],
+            "null": NSNull()
+        ]
+        self.httpClient.mock(
+            requestPath: .getCustomerInfo(appUserID: Self.userID),
+            response: .init(statusCode: .success, response: response)
+        )
+
+        let result = waitUntilValue { completed in
+            self.backend.getCustomerInfo(
+                appUserID: Self.userID,
+                isAppBackgrounded: false,
+                completion: completed
+            )
+        }
+        expect(result).to(beSuccess())
+
+        let futureData = try XCTUnwrap(result?.value?.rawData["future_data"] as? [String: Any])
+        expect(futureData["string"] as? String) == "value"
+        expect(futureData["boolean"] as? Bool) == true
+        expect(futureData["integer"] as? Int) == 3
+        expect(futureData["double"] as? Double) == 0.75
+        expect(futureData["object"] as? [String: String]) == ["nested": "value"]
+        expect(futureData["array"] as? [String]) == ["a", "b"]
+        expect(futureData["null"] is NSNull) == true
+    }
+
     func testHandlesGetCustomerInfoErrors() throws {
         let mockedError = NetworkError.unexpectedResponse(nil)
 

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
@@ -346,7 +346,10 @@ final class RemoteConfigIntegrationTests: TestCase {
             "string": .string("value"),
             "int": .int(42),
             "double": .double(4.2),
-            "object": .object(["nested": .string("value")]),
+            "object": .object([
+                "nested": .string("value"),
+                "ignored": .null
+            ]),
             "object_list": .objectList([
                 ["id": .string("first"), "enabled": .bool(true)],
                 ["id": .string("second"), "enabled": .bool(false)]

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
@@ -377,15 +377,15 @@ final class RemoteConfigIntegrationTests: TestCase {
 
         let configuration = try await AudiencesConfigProvider(manager: self.manager).configuration()
 
-        expect(configuration?.backendPredicateResults) == ["valid": .bool(true)]
-        for identifier in ["null", "scalar_array", "mixed_array"] {
+        expect(configuration?.backendPredicateResults) == ["valid": .bool(true), "null": .null]
+        for identifier in ["scalar_array", "mixed_array"] {
             self.logger.verifyMessageWasLogged(
                 "Ignoring backend predicate result '\(identifier)': its value can't be read by a rule.",
                 level: .warn,
                 expectedCount: 1
             )
         }
-        expect(self.logger.messages.filter { $0.level == .warn }).to(haveCount(3))
+        expect(self.logger.messages.filter { $0.level == .warn }).to(haveCount(2))
     }
 
     func testAudiencesProviderRecursivelyOmitsUnsupportedNestedBackendValues() async throws {
@@ -419,7 +419,8 @@ final class RemoteConfigIntegrationTests: TestCase {
             "nested": .object([
                 "level_one": .object([
                     "level_two": .object([
-                        "valid": .string("value")
+                        "valid": .string("value"),
+                        "null": .null
                     ])
                 ])
             ])


### PR DESCRIPTION
## Description
When storing the updated `CustomerInfo` we'll now separately cache the `dimensions` received. This is an object containing customer dimension values that will be passed to the rules engine as variables. 

Related Android PR: https://github.com/RevenueCat/purchases-android/pull/4133

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkpoint/audience rule inputs and CustomerInfo caching semantics; mis-cached or stale dimensions could skew targeting, though behavior is guarded by tests and only updates on fresh network CustomerInfo.
> 
> **Overview**
> Fresh **CustomerInfo** responses can include a top-level **`dimensions`** object; this PR persists that payload separately in **`DeviceCache`** (per `appUserID`, cleared on identity switch) whenever a non-empty snapshot arrives from the network—not from cache reloads. Empty or missing **`dimensions`** leaves the prior cached snapshot in place.
> 
> A new **`SubscriberDimensionsProvider`** reads that cache on each rules snapshot and exposes values as **root-level** variables for checkpoints/local rules (wired in **`Purchases`** alongside existing dimension providers). **Explicit JSON `null`** is now modeled as **`DimensionValue.null`** and flows through to **`RulesEngine.Value`**, including remote-config backend predicate results, so predicates can distinguish “present but null” from a missing key.
> 
> Coverage adds round-trip, replacement, identity, collision, and cache-behavior tests plus a **`getCustomerInfo`** check that unparsed response fields are preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff6eb91ceec0a7630020b1976b4e68b751540f6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->