### PR TITLE
fix(Checkpoints): Fail rule resolution when the app user changes

### DIFF
--- a/Sources/Checkpoints/CheckpointWorkflowResolver.swift
+++ b/Sources/Checkpoints/CheckpointWorkflowResolver.swift
@@ -185,7 +185,6 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
             audienceConfiguration: audienceConfiguration,
             checkpointIdentifier: identifier
         )
-
         guard self.isCurrent(rulesSnapshot, audienceConfiguration) else {
             return nil
         }

--- a/Sources/Checkpoints/CheckpointWorkflowResolver.swift
+++ b/Sources/Checkpoints/CheckpointWorkflowResolver.swift
@@ -182,14 +182,23 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
         let ruleEvaluation = try await self.evaluateRules(
             in: rulesSnapshot.ruleSet.rules,
             params: params,
-            audienceConfiguration: audienceConfiguration,
-            checkpointIdentifier: identifier
+            audienceConfiguration: audienceConfiguration
         )
         guard self.isCurrent(rulesSnapshot, audienceConfiguration) else {
             return nil
         }
 
-        guard case let .completed(rule) = ruleEvaluation else {
+        let rule: CheckpointRule?
+        switch ruleEvaluation {
+        case let .completed(matchedRule):
+            rule = matchedRule
+        case let .unavailable(error):
+            // An audience the SDK failed to evaluate is not the same answer as an audience the app user is
+            // outside of, so this can't report `noMatch`.
+            Logger.error(Strings.remoteConfig.checkpointAudiencesNotEvaluated(
+                checkpointID: identifier,
+                reason: "\(error)"
+            ))
             return .noAction(.configurationUnavailable)
         }
 
@@ -216,8 +225,7 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
     private func evaluateRules(
         in rules: [CheckpointRule],
         params: CheckpointParams,
-        audienceConfiguration: AudienceConfigurationSnapshot,
-        checkpointIdentifier: String
+        audienceConfiguration: AudienceConfigurationSnapshot
     ) async throws -> AudienceRuleEvaluation {
         do {
             return .completed(try await self.matchingRule(
@@ -228,13 +236,7 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
         } catch let error as CancellationError {
             throw error
         } catch {
-            // An audience the SDK failed to evaluate is not the same answer as an audience the customer is
-            // outside of, so this can't report `noMatch`.
-            Logger.error(Strings.remoteConfig.checkpointAudiencesNotEvaluated(
-                checkpointID: checkpointIdentifier,
-                reason: "\(error)"
-            ))
-            return .unavailable
+            return .unavailable(error)
         }
     }
 
@@ -387,5 +389,5 @@ private struct AudienceUnavailableError: Error, CustomStringConvertible {
 }
 private enum AudienceRuleEvaluation {
     case completed(CheckpointRule?)
-    case unavailable
+    case unavailable(any Error)
 }

--- a/Sources/Checkpoints/CheckpointWorkflowResolver.swift
+++ b/Sources/Checkpoints/CheckpointWorkflowResolver.swift
@@ -193,8 +193,9 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
         case let .completed(matchedRule):
             rule = matchedRule
         case let .unavailable(error):
-            // An audience the SDK failed to evaluate is not the same answer as an audience the app user is
-            // outside of, so this can't report `noMatch`.
+            // Only return `noMatch` when audience evaluation succeeds and no rule matches. If evaluation fails,
+            // the SDK can't determine whether the app user matches, so treat the checkpoint configuration as
+            // unavailable.
             Logger.error(Strings.remoteConfig.checkpointAudiencesNotEvaluated(
                 checkpointID: identifier,
                 reason: "\(error)"

--- a/Sources/LocalRules/CustomerInfoDimensionProvider.swift
+++ b/Sources/LocalRules/CustomerInfoDimensionProvider.swift
@@ -30,6 +30,10 @@ struct CustomerInfoDimensionProvider: DimensionProvider {
         self.customerInfoProvider = customerInfoProvider
     }
 
+    /// The app user ID is captured once for this provider invocation.
+    ///
+    /// The enclosing ``DimensionResolver`` verifies it again after all providers finish, because the customer can
+    /// change while CustomerInfo is being fetched or while another provider is suspended.
     func dimensions(at date: Date) async throws -> [String: DimensionValue] {
         let appUserID = self.currentAppUserIDProvider()
 

--- a/Sources/LocalRules/CustomerInfoDimensionProvider.swift
+++ b/Sources/LocalRules/CustomerInfoDimensionProvider.swift
@@ -32,7 +32,7 @@ struct CustomerInfoDimensionProvider: DimensionProvider {
 
     /// The app user ID is captured once for this provider invocation.
     ///
-    /// The enclosing ``DimensionResolver`` verifies it again after all providers finish, because the customer can
+    /// The enclosing ``DimensionResolver`` verifies it again after all providers finish, because the app user can
     /// change while CustomerInfo is being fetched or while another provider is suspended.
     func dimensions(at date: Date) async throws -> [String: DimensionValue] {
         let appUserID = self.currentAppUserIDProvider()

--- a/Sources/LocalRules/DimensionResolver.swift
+++ b/Sources/LocalRules/DimensionResolver.swift
@@ -24,22 +24,22 @@ enum DimensionResolutionError: Error, Equatable, Sendable {
 
     case providerFailed(providerName: String, message: String)
     case conflictingValue(path: String)
-    case customerChanged
+    case appUserChanged
 }
 
 /// Builds an immutable, point-in-time root scope for local rule evaluation.
 ///
 /// Providers can suspend while collecting values. The current app user ID is therefore read before collection and
-/// verified after every provider finishes, preventing a snapshot from combining values belonging to two customers.
+/// verified after every provider finishes, preventing a snapshot from combining values belonging to two app users.
 /// Identity changes also advance the remote-config generation, allowing checkpoint resolution to retry against the
-/// new customer instead of evaluating the invalid snapshot.
+/// new app user instead of evaluating the invalid snapshot.
 struct DimensionResolver: Sendable {
 
     private let dimensionProviders: [any DimensionProvider]
     private let currentAppUserIDProvider: @Sendable () -> String
     private let dateProvider: DateProvider
 
-    /// Creates a resolver from injected providers, the current customer, and a clock.
+    /// Creates a resolver from injected providers, the current app user, and a clock.
     init(
         dimensionProviders: [any DimensionProvider],
         currentAppUserIDProvider: @escaping @Sendable () -> String,
@@ -105,7 +105,7 @@ struct DimensionResolver: Sendable {
 
         try Task.checkCancellation()
         guard self.currentAppUserIDProvider() == appUserID else {
-            throw DimensionResolutionError.customerChanged
+            throw DimensionResolutionError.appUserChanged
         }
 
         return DimensionSnapshot(values: values, evaluationDate: date)

--- a/Sources/LocalRules/DimensionResolver.swift
+++ b/Sources/LocalRules/DimensionResolver.swift
@@ -24,20 +24,29 @@ enum DimensionResolutionError: Error, Equatable, Sendable {
 
     case providerFailed(providerName: String, message: String)
     case conflictingValue(path: String)
+    case customerChanged
 }
 
 /// Builds an immutable, point-in-time root scope for local rule evaluation.
+///
+/// Providers can suspend while collecting values. The current app user ID is therefore read before collection and
+/// verified after every provider finishes, preventing a snapshot from combining values belonging to two customers.
+/// Identity changes also advance the remote-config generation, allowing checkpoint resolution to retry against the
+/// new customer instead of evaluating the invalid snapshot.
 struct DimensionResolver: Sendable {
 
     private let dimensionProviders: [any DimensionProvider]
+    private let currentAppUserIDProvider: @Sendable () -> String
     private let dateProvider: DateProvider
 
-    /// Creates a resolver from injected providers and a clock.
+    /// Creates a resolver from injected providers, the current customer, and a clock.
     init(
         dimensionProviders: [any DimensionProvider],
+        currentAppUserIDProvider: @escaping @Sendable () -> String,
         dateProvider: DateProvider = DateProvider()
     ) {
         self.dimensionProviders = dimensionProviders
+        self.currentAppUserIDProvider = currentAppUserIDProvider
         self.dateProvider = dateProvider
     }
 
@@ -48,6 +57,7 @@ struct DimensionResolver: Sendable {
         customVariables: [String: DimensionValue] = [:],
         backendValues: [String: DimensionValue] = [:]
     ) async throws -> DimensionSnapshot {
+        let appUserID = self.currentAppUserIDProvider()
         let date = self.dateProvider.now()
         var values: [String: RulesEngine.Value] = [
             Self.evaluatedAtKey: .int(Int64(date.timeIntervalSince1970 * 1_000))
@@ -94,6 +104,9 @@ struct DimensionResolver: Sendable {
         )
 
         try Task.checkCancellation()
+        guard self.currentAppUserIDProvider() == appUserID else {
+            throw DimensionResolutionError.customerChanged
+        }
 
         return DimensionSnapshot(values: values, evaluationDate: date)
     }

--- a/Sources/LocalRules/LocalRulesEvaluator.swift
+++ b/Sources/LocalRules/LocalRulesEvaluator.swift
@@ -33,10 +33,12 @@ final class LocalRulesEvaluator: Sendable {
 
     init(
         dimensionProviders: [any DimensionProvider],
+        currentAppUserIDProvider: @escaping @Sendable () -> String,
         dateProvider: DateProvider = DateProvider()
     ) {
         self.dimensionResolver = DimensionResolver(
             dimensionProviders: dimensionProviders,
+            currentAppUserIDProvider: currentAppUserIDProvider,
             dateProvider: dateProvider
         )
     }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -693,7 +693,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                         deviceCache: deviceCache,
                         currentUserProvider: identityManager
                     )
-                ]
+                ],
+                currentAppUserIDProvider: { identityManager.currentAppUserID }
             )
             checkpointResolver = DefaultCheckpointWorkflowResolver(
                 checkpointsConfigProvider: checkpointsConfigProvider,

--- a/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
@@ -145,7 +145,10 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
 
     func testDimensionProviderFailureResolvesConfigurationUnavailableWithoutFetchingOfferings() async throws {
         let fetchCount = Atomic<Int>(0)
-        let evaluator = LocalRulesEvaluator(dimensionProviders: [FailingDimensionProvider()])
+        let evaluator = LocalRulesEvaluator(
+            dimensionProviders: [FailingDimensionProvider()],
+            currentAppUserIDProvider: { "user" }
+        )
         let resolver = self.makeResolver(
             offeringsProvider: {
                 fetchCount.modify { $0 += 1 }
@@ -162,7 +165,10 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
     }
 
     func testCancellationWhileCollectingDimensionsPropagates() async {
-        let evaluator = LocalRulesEvaluator(dimensionProviders: [CancellingDimensionProvider()])
+        let evaluator = LocalRulesEvaluator(
+            dimensionProviders: [CancellingDimensionProvider()],
+            currentAppUserIDProvider: { "user" }
+        )
         let resolver = self.makeResolver(localRulesEvaluator: evaluator)
 
         do {
@@ -351,6 +357,32 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
 
         XCTAssertEqual(Self.resolvedWorkflow(resolution)?.workflow.id, self.workflowID)
         XCTAssertEqual(rulesRequestCount.value, 2)
+    }
+
+    func testCustomerChangeDuringAudienceEvaluationRetriesAgainstTheNewGeneration() async throws {
+        let currentAppUserID = Atomic("user-a")
+        let evaluationCount = Atomic(0)
+        let provider = CheckpointTestDimensionProvider(name: "identity_flipper") { _ in
+            let count = evaluationCount.modify { $0 += 1; return $0 }
+            if count == 1 {
+                currentAppUserID.value = "user-b"
+                self.checkpointsProvider.configGeneration += 1
+                self.audiencesProvider.configGeneration += 1
+            }
+            return [:]
+        }
+        let evaluator = LocalRulesEvaluator(
+            dimensionProviders: [provider],
+            currentAppUserIDProvider: { currentAppUserID.value }
+        )
+
+        let resolution = try await self.makeResolver(localRulesEvaluator: evaluator).resolve(
+            identifier: self.checkpointIdentifier,
+            params: self.params
+        )
+
+        XCTAssertEqual(Self.resolvedWorkflow(resolution)?.workflow.id, self.workflowID)
+        XCTAssertEqual(evaluationCount.value, 2)
     }
 
     func testOfferingsAreFetchedOnceForTheMatchingRule() async throws {
@@ -812,7 +844,10 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
 
     private func makeResolver(
         offeringsProvider: (() async throws -> Offerings)? = nil,
-        localRulesEvaluator: LocalRulesEvaluator = LocalRulesEvaluator(dimensionProviders: [])
+        localRulesEvaluator: LocalRulesEvaluator = LocalRulesEvaluator(
+            dimensionProviders: [],
+            currentAppUserIDProvider: { "user" }
+        )
     ) -> DefaultCheckpointWorkflowResolver {
         return DefaultCheckpointWorkflowResolver(
             checkpointsConfigProvider: self.checkpointsProvider,
@@ -973,6 +1008,16 @@ private final class CallbackDimensionProvider: DimensionProvider, @unchecked Sen
         return [:]
     }
 
+}
+
+private struct CheckpointTestDimensionProvider: DimensionProvider {
+
+    let name: String
+    let dimensionsProvider: @MainActor @Sendable (Date) async throws -> [String: DimensionValue]
+
+    func dimensions(at date: Date) async throws -> [String: DimensionValue] {
+        return try await self.dimensionsProvider(date)
+    }
 }
 
 private final class MockCheckpointsConfigProvider: CheckpointsConfigProviderType {

--- a/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
@@ -359,7 +359,7 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
         XCTAssertEqual(rulesRequestCount.value, 2)
     }
 
-    func testCustomerChangeDuringAudienceEvaluationRetriesAgainstTheNewGeneration() async throws {
+    func testAppUserChangeDuringAudienceEvaluationRetriesAgainstTheNewGeneration() async throws {
         let currentAppUserID = Atomic("user-a")
         let evaluationCount = Atomic(0)
         let provider = CheckpointTestDimensionProvider(name: "identity_flipper") { _ in

--- a/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
@@ -162,6 +162,10 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
         XCTAssertEqual(Self.noActionReason(resolution), .configurationUnavailable)
         XCTAssertEqual(fetchCount.value, 0)
         XCTAssertTrue(self.workflowsProvider.invokedGetWorkflowParameters.isEmpty)
+        self.logger.verifyMessageWasLogged(
+            "The audiences for checkpoint '\(self.checkpointIdentifier)' could not be evaluated:",
+            level: .error
+        )
     }
 
     func testCancellationWhileCollectingDimensionsPropagates() async {
@@ -383,6 +387,11 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
 
         XCTAssertEqual(Self.resolvedWorkflow(resolution)?.workflow.id, self.workflowID)
         XCTAssertEqual(evaluationCount.value, 2)
+        self.logger.verifyMessageWasNotLogged(
+            "The audiences for checkpoint '\(self.checkpointIdentifier)' could not be evaluated:",
+            level: .error,
+            allowNoMessages: true
+        )
     }
 
     func testOfferingsAreFetchedOnceForTheMatchingRule() async throws {

--- a/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
@@ -567,13 +567,16 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
 
     func testStaleConfigurationAfterUnevaluatablePredicateRetriesBeforeReturningUnavailable() async throws {
         let dimensionEvaluationCount = Atomic<Int>(0)
-        let evaluator = LocalRulesEvaluator(dimensionProviders: [CallbackDimensionProvider {
-            let count = dimensionEvaluationCount.modify { $0 += 1; return $0 }
-            if count == 1 {
-                self.checkpointsProvider.configGeneration += 1
-                self.audiencesProvider.configGeneration += 1
-            }
-        }])
+        let evaluator = LocalRulesEvaluator(
+            dimensionProviders: [CallbackDimensionProvider {
+                let count = dimensionEvaluationCount.modify { $0 += 1; return $0 }
+                if count == 1 {
+                    self.checkpointsProvider.configGeneration += 1
+                    self.audiencesProvider.configGeneration += 1
+                }
+            }],
+            currentAppUserIDProvider: { "user" }
+        )
         self.audiencesProvider.defaultRules = "{not-json"
         let resolver = self.makeResolver(localRulesEvaluator: evaluator)
 

--- a/Tests/UnitTests/LocalRules/CustomVariableKeyValidatorTests.swift
+++ b/Tests/UnitTests/LocalRules/CustomVariableKeyValidatorTests.swift
@@ -56,7 +56,10 @@ struct CustomVariableKeyValidatorTests {
 
     @Test
     func invalidKeysAreOmittedFromCustomNamespace() async throws {
-        let snapshot = try await DimensionResolver(dimensionProviders: []).snapshot(customVariables: [
+        let snapshot = try await DimensionResolver(
+            dimensionProviders: [],
+            currentAppUserIDProvider: { "user" }
+        ).snapshot(customVariables: [
             "valid_key": .string("kept"),
             "my.property": .string("dropped"),
             "2fast": .string("also kept"),
@@ -71,7 +74,10 @@ struct CustomVariableKeyValidatorTests {
 
     @Test
     func onlyInvalidVariablesLeaveCustomNamespaceAbsent() async throws {
-        let snapshot = try await DimensionResolver(dimensionProviders: []).snapshot(customVariables: [
+        let snapshot = try await DimensionResolver(
+            dimensionProviders: [],
+            currentAppUserIDProvider: { "user" }
+        ).snapshot(customVariables: [
             "invalid.key": .string("dropped")
         ])
 

--- a/Tests/UnitTests/LocalRules/CustomerInfoDimensionProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/CustomerInfoDimensionProviderTests.swift
@@ -133,6 +133,46 @@ struct CustomerInfoDimensionProviderTests {
     }
 
     @Test
+    func customerChangeWhileCustomerInfoIsFetchedFailsTheSnapshot() async {
+        let currentAppUserID = Atomic(Self.appUserID)
+        let provider = CustomerInfoDimensionProvider(
+            currentAppUserIDProvider: { currentAppUserID.value },
+            customerInfoProvider: { _ in
+                currentAppUserID.value = "another_user"
+                return try Self.customerInfo()
+            }
+        )
+        let resolver = DimensionResolver(
+            dimensionProviders: [provider],
+            currentAppUserIDProvider: { currentAppUserID.value }
+        )
+
+        await #expect(throws: DimensionResolutionError.customerChanged) {
+            _ = try await resolver.snapshot()
+        }
+    }
+
+    @Test
+    func customerInfoFailureCausedByCustomerChangeFailsInsteadOfDegradingSnapshot() async {
+        let currentAppUserID = Atomic(Self.appUserID)
+        let provider = CustomerInfoDimensionProvider(
+            currentAppUserIDProvider: { currentAppUserID.value },
+            customerInfoProvider: { _ in
+                currentAppUserID.value = "another_user"
+                throw TestError.customerInfoUnavailable
+            }
+        )
+        let resolver = DimensionResolver(
+            dimensionProviders: [provider],
+            currentAppUserIDProvider: { currentAppUserID.value }
+        )
+
+        await #expect(throws: DimensionResolutionError.customerChanged) {
+            _ = try await resolver.snapshot()
+        }
+    }
+
+    @Test
     func cancellationPropagates() async {
         let provider = CustomerInfoDimensionProvider(
             currentAppUserIDProvider: { Self.appUserID },
@@ -146,7 +186,10 @@ struct CustomerInfoDimensionProviderTests {
 
     @Test
     func propertiesCanBeEvaluatedUsingCanonicalPaths() async throws {
-        let evaluator = LocalRulesEvaluator(dimensionProviders: [Self.provider()])
+        let evaluator = LocalRulesEvaluator(
+            dimensionProviders: [Self.provider()],
+            currentAppUserIDProvider: { Self.appUserID }
+        )
         let predicates = [
             #"{"==":[{"var":"app_user_id"},"current_user"]}"#,
             #"{"some":[{"var":"purchases"},{"and":[{"==":[{"var":"kind"},"subscription"]},{"var":"is_active"}]}]}"#,
@@ -161,7 +204,10 @@ struct CustomerInfoDimensionProviderTests {
 
     @Test
     func expandedPurchasePropertiesCanBeEvaluatedUsingCanonicalPaths() async throws {
-        let evaluator = LocalRulesEvaluator(dimensionProviders: [Self.provider()])
+        let evaluator = LocalRulesEvaluator(
+            dimensionProviders: [Self.provider()],
+            currentAppUserIDProvider: { Self.appUserID }
+        )
         let predicate = #"""
         {
             "some": [

--- a/Tests/UnitTests/LocalRules/CustomerInfoDimensionProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/CustomerInfoDimensionProviderTests.swift
@@ -133,7 +133,7 @@ struct CustomerInfoDimensionProviderTests {
     }
 
     @Test
-    func customerChangeWhileCustomerInfoIsFetchedFailsTheSnapshot() async {
+    func appUserChangeWhileCustomerInfoIsFetchedFailsTheSnapshot() async {
         let currentAppUserID = Atomic(Self.appUserID)
         let provider = CustomerInfoDimensionProvider(
             currentAppUserIDProvider: { currentAppUserID.value },
@@ -147,13 +147,13 @@ struct CustomerInfoDimensionProviderTests {
             currentAppUserIDProvider: { currentAppUserID.value }
         )
 
-        await #expect(throws: DimensionResolutionError.customerChanged) {
+        await #expect(throws: DimensionResolutionError.appUserChanged) {
             _ = try await resolver.snapshot()
         }
     }
 
     @Test
-    func customerInfoFailureCausedByCustomerChangeFailsInsteadOfDegradingSnapshot() async {
+    func customerInfoFailureCausedByAppUserChangeFailsInsteadOfDegradingSnapshot() async {
         let currentAppUserID = Atomic(Self.appUserID)
         let provider = CustomerInfoDimensionProvider(
             currentAppUserIDProvider: { currentAppUserID.value },
@@ -167,7 +167,7 @@ struct CustomerInfoDimensionProviderTests {
             currentAppUserIDProvider: { currentAppUserID.value }
         )
 
-        await #expect(throws: DimensionResolutionError.customerChanged) {
+        await #expect(throws: DimensionResolutionError.appUserChanged) {
             _ = try await resolver.snapshot()
         }
     }

--- a/Tests/UnitTests/LocalRules/DeviceDimensionProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/DeviceDimensionProviderTests.swift
@@ -87,7 +87,8 @@ struct DeviceDimensionProviderTests {
                     platform: "iOS",
                     platformVersion: Self.platformVersion
                 )
-            ]
+            ],
+            currentAppUserIDProvider: { "user" }
         )
 
         let match = try await evaluator.match(in: [
@@ -110,7 +111,8 @@ struct DeviceDimensionProviderTests {
                     platform: "iOS",
                     platformVersion: Self.platformVersion
                 )
-            ]
+            ],
+            currentAppUserIDProvider: { "user" }
         )
 
         let match = try await evaluator.match(in: [
@@ -133,7 +135,8 @@ struct DeviceDimensionProviderTests {
                     platform: "iOS",
                     platformVersion: Self.platformVersion
                 )
-            ]
+            ],
+            currentAppUserIDProvider: { "user" }
         )
 
         let match = try await evaluator.match(in: [
@@ -167,7 +170,8 @@ struct DeviceDimensionProviderTests {
                     platform: "iOS",
                     platformVersion: Self.platformVersion
                 )
-            ]
+            ],
+            currentAppUserIDProvider: { "user" }
         )
 
         let match = try await evaluator.match(in: [
@@ -191,7 +195,8 @@ struct DeviceDimensionProviderTests {
                     platformVersion: Self.platformVersion,
                     sdkVersion: "5.84.0-SNAPSHOT"
                 )
-            ]
+            ],
+            currentAppUserIDProvider: { "user" }
         )
 
         let match = try await evaluator.match(in: [

--- a/Tests/UnitTests/LocalRules/DimensionScopeTests.swift
+++ b/Tests/UnitTests/LocalRules/DimensionScopeTests.swift
@@ -57,6 +57,7 @@ struct DimensionScopeTests {
 
         let snapshot = try await DimensionResolver(
             dimensionProviders: providers,
+            currentAppUserIDProvider: { "user" },
             dateProvider: MockDateProvider(stubbedNow: date)
         ).snapshot(
             customVariables: ["attempt": .int(3)],

--- a/Tests/UnitTests/LocalRules/DimensionValueTests.swift
+++ b/Tests/UnitTests/LocalRules/DimensionValueTests.swift
@@ -194,6 +194,7 @@ struct DimensionValueTests {
     ) async throws -> DimensionSnapshot {
         return try await DimensionResolver(
             dimensionProviders: [StaticDimensionProvider(values: values)],
+            currentAppUserIDProvider: { "user" },
             dateProvider: MockDateProvider(stubbedNow: Date(timeIntervalSince1970: 123))
         ).snapshot()
     }

--- a/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
+++ b/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
@@ -122,6 +122,7 @@ struct LocalRulesEvaluatorTests {
 
         let snapshot = try await DimensionResolver(
             dimensionProviders: [identity, environment, store],
+            currentAppUserIDProvider: { "user" },
             dateProvider: MockDateProvider(stubbedNow: date)
         ).snapshot()
 
@@ -172,7 +173,10 @@ struct LocalRulesEvaluatorTests {
             ]]
         )
 
-        let snapshot = try await DimensionResolver(dimensionProviders: [provider]).snapshot()
+        let snapshot = try await DimensionResolver(
+            dimensionProviders: [provider],
+            currentAppUserIDProvider: { "user" }
+        ).snapshot()
 
         #expect(snapshot.values.filter { $0.key != "evaluated_at" } == [
             "platform": .string("ios"),
@@ -254,7 +258,10 @@ struct LocalRulesEvaluatorTests {
         )
 
         do {
-            _ = try await DimensionResolver(dimensionProviders: [first, second]).snapshot()
+            _ = try await DimensionResolver(
+                dimensionProviders: [first, second],
+                currentAppUserIDProvider: { "user" }
+            ).snapshot()
             Issue.record("Expected duplicate ownership to fail")
         } catch let error as DimensionResolutionError {
             #expect(error == .conflictingValue(path: "app_version"))
@@ -271,7 +278,10 @@ struct LocalRulesEvaluatorTests {
         )
 
         do {
-            _ = try await DimensionResolver(dimensionProviders: [provider]).snapshot()
+            _ = try await DimensionResolver(
+                dimensionProviders: [provider],
+                currentAppUserIDProvider: { "user" }
+            ).snapshot()
             Issue.record("Expected reserved root ownership to fail")
         } catch let error as DimensionResolutionError {
             #expect(error == .conflictingValue(path: reservedRoot))
@@ -297,6 +307,71 @@ struct LocalRulesEvaluatorTests {
                 return
             }
             #expect(providerName == "store")
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test
+    func customerChangeWhileDimensionsAreCollectedThrows() async {
+        let currentAppUserID = Atomic("user-a")
+        let provider = ClosureDimensionProvider(name: "identity_flipper") { _ in
+            currentAppUserID.value = "user-b"
+            return [:]
+        }
+        let resolver = DimensionResolver(
+            dimensionProviders: [provider],
+            currentAppUserIDProvider: { currentAppUserID.value }
+        )
+
+        do {
+            _ = try await resolver.snapshot()
+            Issue.record("Expected a customer change to fail the snapshot")
+        } catch let error as DimensionResolutionError {
+            #expect(error == .customerChanged)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test
+    func customerChangingBackBeforeCollectionFinishesDoesNotFailTheSnapshot() async throws {
+        let currentAppUserID = Atomic("user-a")
+        let changeCustomer = ClosureDimensionProvider(name: "identity_flipper") { _ in
+            currentAppUserID.value = "user-b"
+            return [:]
+        }
+        let restoreCustomer = ClosureDimensionProvider(name: "identity_flipper_back") { _ in
+            currentAppUserID.value = "user-a"
+            return [:]
+        }
+        let resolver = DimensionResolver(
+            dimensionProviders: [changeCustomer, restoreCustomer],
+            currentAppUserIDProvider: { currentAppUserID.value }
+        )
+
+        _ = try await resolver.snapshot()
+    }
+
+    @Test
+    func customerChangeDuringSnapshotFailsRuleEvaluation() async {
+        let currentAppUserID = Atomic("user-a")
+        let provider = ClosureDimensionProvider(name: "identity_flipper") { _ in
+            currentAppUserID.value = "user-b"
+            return [:]
+        }
+        let evaluator = Self.evaluator(
+            dimensionProviders: [provider],
+            currentAppUserIDProvider: { currentAppUserID.value }
+        )
+
+        do {
+            _ = try await evaluator.match(in: [
+                TestLocalRule(id: "test", predicate: "true")
+            ])
+            Issue.record("Expected a customer change to fail rule evaluation")
+        } catch let error as DimensionResolutionError {
+            #expect(error == .customerChanged)
         } catch {
             Issue.record("Unexpected error: \(error)")
         }
@@ -536,10 +611,12 @@ private extension LocalRulesEvaluatorTests {
 
     static func evaluator(
         dimensionProviders: [any DimensionProvider],
-        date: Date = Date(timeIntervalSince1970: 100)
+        date: Date = Date(timeIntervalSince1970: 100),
+        currentAppUserIDProvider: @escaping @Sendable () -> String = { "user" }
     ) -> LocalRulesEvaluator {
         LocalRulesEvaluator(
             dimensionProviders: dimensionProviders,
+            currentAppUserIDProvider: currentAppUserIDProvider,
             dateProvider: MockDateProvider(stubbedNow: date)
         )
     }
@@ -603,6 +680,16 @@ private struct CancellingDimensionProvider: DimensionProvider {
 
     func dimensions(at date: Date) async throws -> [String: DimensionValue] {
         throw CancellationError()
+    }
+}
+
+private struct ClosureDimensionProvider: DimensionProvider {
+
+    let name: String
+    let dimensionsProvider: @Sendable (Date) async throws -> [String: DimensionValue]
+
+    func dimensions(at date: Date) async throws -> [String: DimensionValue] {
+        return try await self.dimensionsProvider(date)
     }
 }
 

--- a/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
+++ b/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
@@ -313,7 +313,7 @@ struct LocalRulesEvaluatorTests {
     }
 
     @Test
-    func customerChangeWhileDimensionsAreCollectedThrows() async {
+    func appUserChangeWhileDimensionsAreCollectedThrows() async {
         let currentAppUserID = Atomic("user-a")
         let provider = ClosureDimensionProvider(name: "identity_flipper") { _ in
             currentAppUserID.value = "user-b"
@@ -326,27 +326,27 @@ struct LocalRulesEvaluatorTests {
 
         do {
             _ = try await resolver.snapshot()
-            Issue.record("Expected a customer change to fail the snapshot")
+            Issue.record("Expected an app user change to fail the snapshot")
         } catch let error as DimensionResolutionError {
-            #expect(error == .customerChanged)
+            #expect(error == .appUserChanged)
         } catch {
             Issue.record("Unexpected error: \(error)")
         }
     }
 
     @Test
-    func customerChangingBackBeforeCollectionFinishesDoesNotFailTheSnapshot() async throws {
+    func appUserChangingBackBeforeCollectionFinishesDoesNotFailTheSnapshot() async throws {
         let currentAppUserID = Atomic("user-a")
-        let changeCustomer = ClosureDimensionProvider(name: "identity_flipper") { _ in
+        let changeAppUser = ClosureDimensionProvider(name: "identity_flipper") { _ in
             currentAppUserID.value = "user-b"
             return [:]
         }
-        let restoreCustomer = ClosureDimensionProvider(name: "identity_flipper_back") { _ in
+        let restoreAppUser = ClosureDimensionProvider(name: "identity_flipper_back") { _ in
             currentAppUserID.value = "user-a"
             return [:]
         }
         let resolver = DimensionResolver(
-            dimensionProviders: [changeCustomer, restoreCustomer],
+            dimensionProviders: [changeAppUser, restoreAppUser],
             currentAppUserIDProvider: { currentAppUserID.value }
         )
 
@@ -354,7 +354,7 @@ struct LocalRulesEvaluatorTests {
     }
 
     @Test
-    func customerChangeDuringSnapshotFailsRuleEvaluation() async {
+    func appUserChangeDuringSnapshotFailsRuleEvaluation() async {
         let currentAppUserID = Atomic("user-a")
         let provider = ClosureDimensionProvider(name: "identity_flipper") { _ in
             currentAppUserID.value = "user-b"
@@ -369,9 +369,9 @@ struct LocalRulesEvaluatorTests {
             _ = try await evaluator.match(in: [
                 TestLocalRule(id: "test", predicate: "true")
             ])
-            Issue.record("Expected a customer change to fail rule evaluation")
+            Issue.record("Expected an app user change to fail rule evaluation")
         } catch let error as DimensionResolutionError {
-            #expect(error == .customerChanged)
+            #expect(error == .appUserChanged)
         } catch {
             Issue.record("Unexpected error: \(error)")
         }

--- a/Tests/UnitTests/LocalRules/StoreDimensionProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/StoreDimensionProviderTests.swift
@@ -63,7 +63,8 @@ struct StoreDimensionProviderTests {
         let evaluator = LocalRulesEvaluator(
             dimensionProviders: [
                 StoreDimensionProvider(storefrontCountryCodeProvider: { "NLD" })
-            ]
+            ],
+            currentAppUserIDProvider: { "user" }
         )
 
         let match = try await evaluator.match(in: [

--- a/Tests/UnitTests/LocalRules/SubscriberAttributesDimensionProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/SubscriberAttributesDimensionProviderTests.swift
@@ -87,7 +87,8 @@ struct SubscriberAttributesProviderTests {
                     Self.attribute("", value: "anything"),
                     Self.attribute("tier", value: "gold")
                 )
-            ]
+            ],
+            currentAppUserIDProvider: { "user" }
         ).snapshot()
 
         guard case .object(let attributes) = snapshot.values["subscriber_attributes"] else {
@@ -100,7 +101,8 @@ struct SubscriberAttributesProviderTests {
     @Test
     func omitsNamespaceWhenThereAreNoAttributes() async throws {
         let snapshot = try await DimensionResolver(
-            dimensionProviders: [Self.provider()]
+            dimensionProviders: [Self.provider()],
+            currentAppUserIDProvider: { "user" }
         ).snapshot()
 
         #expect(snapshot.values["subscriber_attributes"] == nil)
@@ -116,6 +118,7 @@ struct SubscriberAttributesProviderTests {
                 SubscriberAttributesTestDeviceProvider(),
                 provider
             ],
+            currentAppUserIDProvider: { "user" },
             dateProvider: MockDateProvider(stubbedNow: Self.evaluationDate)
         ).snapshot()
 
@@ -182,6 +185,7 @@ struct SubscriberAttributesProviderTests {
                     Self.attribute("tier", value: "gold", setTime: recentSetDate)
                 )
             ],
+            currentAppUserIDProvider: { "user" },
             dateProvider: MockDateProvider(stubbedNow: Self.evaluationDate)
         )
 

--- a/Tests/UnitTests/LocalRules/SubscriberDimensionsProviderTests.swift
+++ b/Tests/UnitTests/LocalRules/SubscriberDimensionsProviderTests.swift
@@ -139,9 +139,12 @@ struct SubscriberDimensionsProviderTests {
 
     @Test
     func dimensionsAreReadableByPredicates() async throws {
-        let snapshot = try await DimensionResolver(dimensionProviders: [
-            Self.provider(#"{"plan":"annual","seats":3,"profile":{"tier":"gold"}}"#)
-        ]).snapshot()
+        let snapshot = try await DimensionResolver(
+            dimensionProviders: [
+                Self.provider(#"{"plan":"annual","seats":3,"profile":{"tier":"gold"}}"#)
+            ],
+            currentAppUserIDProvider: { "user" }
+        ).snapshot()
 
         #expect(try RulesEngine.evaluate(
             predicate: #"{"==":[{"var":"plan"},"annual"]}"#,
@@ -163,7 +166,10 @@ struct SubscriberDimensionsProviderTests {
         let device = TestProvider(values: ["platform": .string("ios")])
 
         do {
-            _ = try await DimensionResolver(dimensionProviders: [device, subscriber]).snapshot()
+            _ = try await DimensionResolver(
+                dimensionProviders: [device, subscriber],
+                currentAppUserIDProvider: { "user" }
+            ).snapshot()
             Issue.record("Expected duplicate ownership to fail")
         } catch let error as DimensionResolutionError {
             #expect(error == .conflictingValue(path: "platform"))


### PR DESCRIPTION
## Description
This PR adds a guard against the user ID changing during rule evaluation. If such a change is detected rule evaluation will now fail by design.

Related Android PR: https://github.com/RevenueCat/purchases-android/pull/4135

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkpoint targeting and local rule evaluation during identity switches; wrong behavior could briefly show the wrong workflow or mark config unavailable, but it reduces mis-targeting across users.
> 
> **Overview**
> Prevents checkpoint audience rules from running on a **mixed or stale identity** when `logIn` / `logOut` happens while dimensions are being collected (e.g. during async `CustomerInfo` fetch).
> 
> **`DimensionResolver`** now takes a `currentAppUserIDProvider`, snapshots the ID at the start of `snapshot()`, and re-checks it after all providers finish. A mismatch throws **`DimensionResolutionError.appUserChanged`** instead of merging dimensions from two users.
> 
> That error propagates through **`LocalRulesEvaluator`** into **`CheckpointWorkflowResolver`**, which treats any failed audience evaluation (including identity change) as **`configurationUnavailable`** with error logging—not **`noMatch`**. **`AudienceRuleEvaluation.unavailable`** now carries the underlying error so logging happens at resolution time.
> 
> **`Purchases`** wires `identityManager.currentAppUserID` into the evaluator. Tests cover identity flips during dimension collection, CustomerInfo fetch, and checkpoint retry when remote-config generation advances mid-evaluation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c8848ce9d00f2f701628cb0b76e7ac5db30b815. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->