### PR TITLE
feat: send the checkpoint outcome on checkpoint_hit

### DIFF
--- a/Sources/Checkpoints/CheckpointEvent.swift
+++ b/Sources/Checkpoints/CheckpointEvent.swift
@@ -24,21 +24,111 @@ enum CheckpointEvent: FeatureEvent {
 
 }
 
+/// What a checkpoint resolved to, reported in the `result` field of a checkpoint hit.
+enum CheckpointHitResult: String {
+
+    case workflow
+    case offering
+    case noMatch = "no_match"
+    case configurationUnavailable = "configuration_unavailable"
+    case unknownCheckpoint = "unknown_checkpoint"
+    case disabled
+
+}
+
 extension CheckpointEvent {
 
     /// The content of a ``CheckpointEvent``.
+    ///
+    /// `date` is when the user reached the checkpoint, not when the event was created, so hit volume over time
+    /// stays comparable with events recorded before the outcome was attached.
     struct Data {
 
         var id: UUID
         var identifier: String
         var date: Date
+        /// What the checkpoint resolved to. `nil` only for hits stored by an SDK version that recorded them
+        /// before evaluating the checkpoint.
+        var result: CheckpointHitResult?
+        /// The workflow the checkpoint matched, when it matched one.
+        var workflowID: String?
+        /// The offering the checkpoint resolved to, when it resolved to one.
+        var offeringID: String?
 
-        init(id: UUID = .init(), identifier: String, date: Date) {
+        init(
+            id: UUID = .init(),
+            identifier: String,
+            date: Date,
+            result: CheckpointHitResult? = nil,
+            workflowID: String? = nil,
+            offeringID: String? = nil
+        ) {
             self.id = id
             self.identifier = identifier
             self.date = date
+            self.result = result
+            self.workflowID = workflowID
+            self.offeringID = offeringID
         }
 
+    }
+
+}
+
+extension CheckpointEvent.Data {
+
+    // The `ID` suffix has to be spelled out: the events store encodes with `convertToSnakeCase` and decodes with
+    // `convertFromSnakeCase`, which turns `workflow_id` back into `workflowId` and would otherwise miss these
+    // keys on the way in.
+    private enum CodingKeys: String, CodingKey {
+
+        case id
+        case identifier
+        case date
+        case result
+        case workflowID = "workflowId"
+        case offeringID = "offeringId"
+
+    }
+
+}
+
+extension CheckpointEvent {
+
+    /// Builds the hit event for a resolved checkpoint.
+    ///
+    /// - Parameter date: when the checkpoint was reached, captured before resolution started.
+    static func hit(identifier: String, date: Date, resolution: CheckpointResolution) -> CheckpointEvent {
+        switch resolution {
+        case let .matchedWorkflow(resolved):
+            return .hit(.init(identifier: identifier,
+                              date: date,
+                              result: .workflow,
+                              workflowID: resolved.workflow.id,
+                              offeringID: resolved.offering.identifier))
+
+        case let .matchedOffering(offering):
+            return .hit(.init(identifier: identifier,
+                              date: date,
+                              result: .offering,
+                              offeringID: offering.identifier))
+
+        case let .noAction(reason):
+            return .hit(.init(identifier: identifier, date: date, result: .init(reason)))
+        }
+    }
+
+}
+
+extension CheckpointHitResult {
+
+    init(_ reason: CheckpointResolutionReason) {
+        switch reason {
+        case .noMatch: self = .noMatch
+        case .configurationUnavailable: self = .configurationUnavailable
+        case .disabled: self = .disabled
+        case .unknownCheckpoint: self = .unknownCheckpoint
+        }
     }
 
 }
@@ -62,5 +152,6 @@ extension CheckpointEvent {
 
 }
 
+extension CheckpointHitResult: Equatable, Codable, Sendable {}
 extension CheckpointEvent.Data: Equatable, Codable, Sendable {}
 extension CheckpointEvent: Equatable, Codable, Sendable {}

--- a/Sources/Checkpoints/CheckpointEvent.swift
+++ b/Sources/Checkpoints/CheckpointEvent.swift
@@ -35,11 +35,11 @@ enum CheckpointType: String {
 
 }
 
-/// What a checkpoint resolved to, reported in the `result` field of a checkpoint hit.
+/// What the SDK did after resolving a checkpoint, reported in the `result` field of a checkpoint hit.
 enum CheckpointHitResult: String {
 
-    case workflow
-    case offering
+    case presentUI = "present_ui"
+    case returnData = "return_data"
     case noMatch = "no_match"
     case configurationUnavailable = "configuration_unavailable"
     case unknownCheckpoint = "unknown_checkpoint"
@@ -120,7 +120,7 @@ extension CheckpointEvent {
             return .hit(.init(identifier: identifier,
                               date: date,
                               checkpointType: .custom,
-                              result: .workflow,
+                              result: .presentUI,
                               workflowID: matched.workflow.id,
                               offeringID: matched.offering.identifier,
                               checkpointRuleID: resolved.checkpointRuleID))
@@ -129,7 +129,7 @@ extension CheckpointEvent {
             return .hit(.init(identifier: identifier,
                               date: date,
                               checkpointType: .custom,
-                              result: .offering,
+                              result: .returnData,
                               offeringID: offering.identifier,
                               checkpointRuleID: resolved.checkpointRuleID))
 

--- a/Sources/Checkpoints/CheckpointEvent.swift
+++ b/Sources/Checkpoints/CheckpointEvent.swift
@@ -32,7 +32,6 @@ enum CheckpointHitResult: String {
     case noMatch = "no_match"
     case configurationUnavailable = "configuration_unavailable"
     case unknownCheckpoint = "unknown_checkpoint"
-    case disabled
 
 }
 
@@ -125,8 +124,10 @@ extension CheckpointHitResult {
     init(_ reason: CheckpointResolutionReason) {
         switch reason {
         case .noMatch: self = .noMatch
-        case .configurationUnavailable: self = .configurationUnavailable
-        case .disabled: self = .disabled
+        // A checkpoint reached while remote config is off is, for analytics, the same
+        // story as configuration that could not be read — and it is what Android
+        // reports for its own kill switch.
+        case .configurationUnavailable, .disabled: self = .configurationUnavailable
         case .unknownCheckpoint: self = .unknownCheckpoint
         }
     }

--- a/Sources/Checkpoints/CheckpointEvent.swift
+++ b/Sources/Checkpoints/CheckpointEvent.swift
@@ -53,6 +53,8 @@ extension CheckpointEvent {
         var workflowID: String?
         /// The offering the checkpoint resolved to, when it resolved to one.
         var offeringID: String?
+        /// The checkpoint rule that was served, when the checkpoint matched one.
+        var checkpointRuleID: String?
 
         init(
             id: UUID = .init(),
@@ -60,7 +62,8 @@ extension CheckpointEvent {
             date: Date,
             result: CheckpointHitResult? = nil,
             workflowID: String? = nil,
-            offeringID: String? = nil
+            offeringID: String? = nil,
+            checkpointRuleID: String? = nil
         ) {
             self.id = id
             self.identifier = identifier
@@ -68,6 +71,7 @@ extension CheckpointEvent {
             self.result = result
             self.workflowID = workflowID
             self.offeringID = offeringID
+            self.checkpointRuleID = checkpointRuleID
         }
 
     }
@@ -87,6 +91,7 @@ extension CheckpointEvent.Data {
         case result
         case workflowID = "workflowId"
         case offeringID = "offeringId"
+        case checkpointRuleID = "checkpointRuleId"
 
     }
 
@@ -97,20 +102,22 @@ extension CheckpointEvent {
     /// Builds the hit event for a resolved checkpoint.
     ///
     /// - Parameter date: when the checkpoint was reached, captured before resolution started.
-    static func hit(identifier: String, date: Date, resolution: CheckpointResolution) -> CheckpointEvent {
-        switch resolution {
-        case let .matchedWorkflow(resolved):
+    static func hit(identifier: String, date: Date, resolved: ResolvedCheckpoint) -> CheckpointEvent {
+        switch resolved.resolution {
+        case let .matchedWorkflow(matched):
             return .hit(.init(identifier: identifier,
                               date: date,
                               result: .workflow,
-                              workflowID: resolved.workflow.id,
-                              offeringID: resolved.offering.identifier))
+                              workflowID: matched.workflow.id,
+                              offeringID: matched.offering.identifier,
+                              checkpointRuleID: resolved.checkpointRuleID))
 
         case let .matchedOffering(offering):
             return .hit(.init(identifier: identifier,
                               date: date,
                               result: .offering,
-                              offeringID: offering.identifier))
+                              offeringID: offering.identifier,
+                              checkpointRuleID: resolved.checkpointRuleID))
 
         case let .noAction(reason):
             return .hit(.init(identifier: identifier, date: date, result: .init(reason)))

--- a/Sources/Checkpoints/CheckpointEvent.swift
+++ b/Sources/Checkpoints/CheckpointEvent.swift
@@ -24,6 +24,17 @@ enum CheckpointEvent: FeatureEvent {
 
 }
 
+/// Whether a checkpoint is one RevenueCat defines or one the app declares.
+///
+/// Every checkpoint is `custom` today. `standard` is declared so this vocabulary and the backend's stay in step,
+/// and so producing it later is a one-line change rather than a new type.
+enum CheckpointType: String {
+
+    case standard
+    case custom
+
+}
+
 /// What a checkpoint resolved to, reported in the `result` field of a checkpoint hit.
 enum CheckpointHitResult: String {
 
@@ -46,6 +57,9 @@ extension CheckpointEvent {
         var id: UUID
         var identifier: String
         var date: Date
+        /// Whether the checkpoint is one RevenueCat defines or one the app declares. `nil` only for hits stored
+        /// by an SDK version that predates the field.
+        var checkpointType: CheckpointType?
         /// What the checkpoint resolved to. `nil` only for hits stored by an SDK version that recorded them
         /// before evaluating the checkpoint.
         var result: CheckpointHitResult?
@@ -60,6 +74,7 @@ extension CheckpointEvent {
             id: UUID = .init(),
             identifier: String,
             date: Date,
+            checkpointType: CheckpointType? = nil,
             result: CheckpointHitResult? = nil,
             workflowID: String? = nil,
             offeringID: String? = nil,
@@ -68,6 +83,7 @@ extension CheckpointEvent {
             self.id = id
             self.identifier = identifier
             self.date = date
+            self.checkpointType = checkpointType
             self.result = result
             self.workflowID = workflowID
             self.offeringID = offeringID
@@ -88,6 +104,7 @@ extension CheckpointEvent.Data {
         case id
         case identifier
         case date
+        case checkpointType
         case result
         case workflowID = "workflowId"
         case offeringID = "offeringId"
@@ -107,6 +124,7 @@ extension CheckpointEvent {
         case let .matchedWorkflow(matched):
             return .hit(.init(identifier: identifier,
                               date: date,
+                              checkpointType: .custom,
                               result: .workflow,
                               workflowID: matched.workflow.id,
                               offeringID: matched.offering.identifier,
@@ -115,12 +133,16 @@ extension CheckpointEvent {
         case let .matchedOffering(offering):
             return .hit(.init(identifier: identifier,
                               date: date,
+                              checkpointType: .custom,
                               result: .offering,
                               offeringID: offering.identifier,
                               checkpointRuleID: resolved.checkpointRuleID))
 
         case let .noAction(reason):
-            return .hit(.init(identifier: identifier, date: date, result: .init(reason)))
+            return .hit(.init(identifier: identifier,
+                              date: date,
+                              checkpointType: .custom,
+                              result: .init(reason)))
         }
     }
 
@@ -160,6 +182,7 @@ extension CheckpointEvent {
 
 }
 
+extension CheckpointType: Equatable, Codable, Sendable {}
 extension CheckpointHitResult: Equatable, Codable, Sendable {}
 extension CheckpointEvent.Data: Equatable, Codable, Sendable {}
 extension CheckpointEvent: Equatable, Codable, Sendable {}

--- a/Sources/Checkpoints/CheckpointEvent.swift
+++ b/Sources/Checkpoints/CheckpointEvent.swift
@@ -49,9 +49,6 @@ enum CheckpointHitResult: String {
 extension CheckpointEvent {
 
     /// The content of a ``CheckpointEvent``.
-    ///
-    /// `date` is when the user reached the checkpoint, not when the event was created, so hit volume over time
-    /// stays comparable with events recorded before the outcome was attached.
     struct Data {
 
         var id: UUID
@@ -117,8 +114,6 @@ extension CheckpointEvent.Data {
 extension CheckpointEvent {
 
     /// Builds the hit event for a resolved checkpoint.
-    ///
-    /// - Parameter date: when the checkpoint was reached, captured before resolution started.
     static func hit(identifier: String, date: Date, resolved: ResolvedCheckpoint) -> CheckpointEvent {
         switch resolved.resolution {
         case let .matchedWorkflow(matched):

--- a/Sources/Checkpoints/CheckpointWorkflowResolver.swift
+++ b/Sources/Checkpoints/CheckpointWorkflowResolver.swift
@@ -62,17 +62,45 @@ import Foundation
 
 }
 
+/// A ``CheckpointResolution`` together with the checkpoint rule that produced it, when a rule matched.
+///
+/// The rule id is only needed to attribute the hit event, so it travels here rather than on
+/// ``CheckpointResolution``, which RevenueCatUI consumes and which stays free of event-only fields.
+struct ResolvedCheckpoint {
+
+    let resolution: CheckpointResolution
+    let checkpointRuleID: String?
+
+    init(_ resolution: CheckpointResolution, checkpointRuleID: String? = nil) {
+        self.resolution = resolution
+        self.checkpointRuleID = checkpointRuleID
+    }
+
+    /// Reports `rule` only when it was actually served. A rule that matched but could not be served resolves to
+    /// `configurationUnavailable`, which describes this SDK's state rather than the rule.
+    init(_ resolution: CheckpointResolution, servedBy rule: CheckpointRule) {
+        switch resolution {
+        case .matchedWorkflow, .matchedOffering:
+            self.init(resolution, checkpointRuleID: rule.id)
+
+        case .noAction:
+            self.init(resolution)
+        }
+    }
+
+}
+
 /// Resolves a checkpoint to the workflow that should run, or the reason no workflow should run.
 protocol CheckpointWorkflowResolver: AnyObject {
 
-    func resolve(identifier: String, params: CheckpointParams) async throws -> CheckpointResolution
+    func resolve(identifier: String, params: CheckpointParams) async throws -> ResolvedCheckpoint
 
 }
 
 final class DisabledCheckpointWorkflowResolver: CheckpointWorkflowResolver {
 
-    func resolve(identifier: String, params: CheckpointParams) async throws -> CheckpointResolution {
-        return .noAction(.disabled)
+    func resolve(identifier: String, params: CheckpointParams) async throws -> ResolvedCheckpoint {
+        return .init(.noAction(.disabled))
     }
 
 }
@@ -110,7 +138,7 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
         self.offeringsProvider = offeringsProvider
     }
 
-    func resolve(identifier: String, params: CheckpointParams) async throws -> CheckpointResolution {
+    func resolve(identifier: String, params: CheckpointParams) async throws -> ResolvedCheckpoint {
         #if DEBUG
         // Temporary CheckpointTester escape hatch. Config-backed resolution has no natural throwing case yet.
         if identifier == Self.simulatedErrorCheckpointIdentifier {
@@ -126,19 +154,19 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
     private func resolveConfiguredWorkflow(
         identifier: String,
         params: CheckpointParams
-    ) async throws -> CheckpointResolution {
+    ) async throws -> ResolvedCheckpoint {
         let rulesSnapshot: CheckpointRulesSnapshot
         do {
             guard let snapshot = try await self.checkpointsConfigProvider.rules(for: identifier) else {
-                return .noAction(.unknownCheckpoint)
+                return .init(.noAction(.unknownCheckpoint))
             }
             rulesSnapshot = snapshot
         } catch let error as CancellationError {
             throw error
         } catch CheckpointRulesProviderError.remoteConfigDisabled {
-            return .noAction(.disabled)
+            return .init(.noAction(.disabled))
         } catch {
-            return .noAction(.configurationUnavailable)
+            return .init(.noAction(.configurationUnavailable))
         }
 
         let rule: CheckpointRule?
@@ -153,24 +181,24 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
                 checkpointID: identifier,
                 reason: "\(error)"
             ))
-            return .noAction(.configurationUnavailable)
+            return .init(.noAction(.configurationUnavailable))
         }
 
         // Audiences are read live rather than pinned to this snapshot, so a refresh landing mid-walk leaves
         // the match built from config that is already gone.
         guard self.checkpointsConfigProvider.isCurrent(rulesSnapshot) else {
-            return .noAction(.configurationUnavailable)
+            return .init(.noAction(.configurationUnavailable))
         }
 
         // The offering mapping is resolved per branch now, since only a UI workflow needs it.
-        guard let rule else { return .noAction(.noMatch) }
+        guard let rule else { return .init(.noAction(.noMatch)) }
 
         let resolution = await self.resolve(rule)
         guard self.checkpointsConfigProvider.isCurrent(rulesSnapshot) else {
-            return .noAction(.configurationUnavailable)
+            return .init(.noAction(.configurationUnavailable))
         }
 
-        return resolution
+        return .init(resolution, servedBy: rule)
     }
 
     /// Walks the served rules in priority order and returns the first one whose audience matches.

--- a/Sources/Events/FeatureEvents/FeatureEvent.swift
+++ b/Sources/Events/FeatureEvents/FeatureEvent.swift
@@ -273,13 +273,19 @@ private extension WorkflowEvent {
 private extension CheckpointEvent {
 
     func checkpointEventMap() -> [String: Any] {
-        return [
+        var result: [String: Any] = [
             "discriminator": "checkpoint",
             "type": self.eventType,
             "id": self.data.id.uuidString,
             "timestamp": self.data.date.millisecondsSince1970,
             "identifier": self.data.identifier
         ]
+
+        if let checkpointResult = self.data.result { result["result"] = checkpointResult.rawValue }
+        if let workflowID = self.data.workflowID { result["workflow_id"] = workflowID }
+        if let offeringID = self.data.offeringID { result["offering_id"] = offeringID }
+
+        return result
     }
 
 }

--- a/Sources/Events/FeatureEvents/FeatureEvent.swift
+++ b/Sources/Events/FeatureEvents/FeatureEvent.swift
@@ -284,6 +284,7 @@ private extension CheckpointEvent {
         if let checkpointResult = self.data.result { result["result"] = checkpointResult.rawValue }
         if let workflowID = self.data.workflowID { result["workflow_id"] = workflowID }
         if let offeringID = self.data.offeringID { result["offering_id"] = offeringID }
+        if let ruleID = self.data.checkpointRuleID { result["checkpoint_rule_id"] = ruleID }
 
         return result
     }

--- a/Sources/Events/FeatureEvents/FeatureEvent.swift
+++ b/Sources/Events/FeatureEvents/FeatureEvent.swift
@@ -281,6 +281,7 @@ private extension CheckpointEvent {
             "identifier": self.data.identifier
         ]
 
+        if let checkpointType = self.data.checkpointType { result["checkpoint_type"] = checkpointType.rawValue }
         if let checkpointResult = self.data.result { result["result"] = checkpointResult.rawValue }
         if let workflowID = self.data.workflowID { result["workflow_id"] = workflowID }
         if let offeringID = self.data.offeringID { result["offering_id"] = offeringID }

--- a/Sources/Events/FeatureEvents/Networking/FeatureEventsRequest+CheckpointEvent.swift
+++ b/Sources/Events/FeatureEvents/Networking/FeatureEventsRequest+CheckpointEvent.swift
@@ -26,6 +26,9 @@ extension FeatureEventsRequest {
         let appUserID: String
         let appSessionID: String
         let timestamp: UInt64
+        let result: CheckpointHitResult?
+        let workflowID: String?
+        let offeringID: String?
 
     }
 
@@ -57,7 +60,10 @@ extension FeatureEventsRequest.CheckpointEvent {
                 identifier: event.data.identifier,
                 appUserID: storedEvent.userID,
                 appSessionID: appSessionID.uuidString,
-                timestamp: event.data.date.millisecondsSince1970
+                timestamp: event.data.date.millisecondsSince1970,
+                result: event.data.result,
+                workflowID: event.data.workflowID,
+                offeringID: event.data.offeringID
             )
         } catch {
             Logger.error(Strings.paywalls.event_cannot_deserialize(error))
@@ -82,6 +88,9 @@ extension FeatureEventsRequest.CheckpointEvent: Encodable {
         case appUserID = "app_user_id"
         case appSessionID = "app_session_id"
         case timestamp
+        case result
+        case workflowID = "workflow_id"
+        case offeringID = "offering_id"
 
     }
 
@@ -94,6 +103,9 @@ extension FeatureEventsRequest.CheckpointEvent: Encodable {
         try container.encode(self.appUserID, forKey: .appUserID)
         try container.encode(self.appSessionID, forKey: .appSessionID)
         try container.encode(self.timestamp, forKey: .timestamp)
+        try container.encodeIfPresent(self.result, forKey: .result)
+        try container.encodeIfPresent(self.workflowID, forKey: .workflowID)
+        try container.encodeIfPresent(self.offeringID, forKey: .offeringID)
     }
 
 }

--- a/Sources/Events/FeatureEvents/Networking/FeatureEventsRequest+CheckpointEvent.swift
+++ b/Sources/Events/FeatureEvents/Networking/FeatureEventsRequest+CheckpointEvent.swift
@@ -23,6 +23,7 @@ extension FeatureEventsRequest {
         let version: Int
         let type: String
         let identifier: String
+        let checkpointType: CheckpointType?
         let appUserID: String
         let appSessionID: String
         let timestamp: UInt64
@@ -59,6 +60,7 @@ extension FeatureEventsRequest.CheckpointEvent {
                 version: Self.schemaVersion,
                 type: event.eventType,
                 identifier: event.data.identifier,
+                checkpointType: event.data.checkpointType,
                 appUserID: storedEvent.userID,
                 appSessionID: appSessionID.uuidString,
                 timestamp: event.data.date.millisecondsSince1970,
@@ -87,6 +89,7 @@ extension FeatureEventsRequest.CheckpointEvent: Encodable {
         case version
         case type
         case identifier
+        case checkpointType = "checkpoint_type"
         case appUserID = "app_user_id"
         case appSessionID = "app_session_id"
         case timestamp
@@ -103,6 +106,7 @@ extension FeatureEventsRequest.CheckpointEvent: Encodable {
         try container.encode(self.version, forKey: .version)
         try container.encode(self.type, forKey: .type)
         try container.encode(self.identifier, forKey: .identifier)
+        try container.encodeIfPresent(self.checkpointType, forKey: .checkpointType)
         try container.encode(self.appUserID, forKey: .appUserID)
         try container.encode(self.appSessionID, forKey: .appSessionID)
         try container.encode(self.timestamp, forKey: .timestamp)

--- a/Sources/Events/FeatureEvents/Networking/FeatureEventsRequest+CheckpointEvent.swift
+++ b/Sources/Events/FeatureEvents/Networking/FeatureEventsRequest+CheckpointEvent.swift
@@ -29,6 +29,7 @@ extension FeatureEventsRequest {
         let result: CheckpointHitResult?
         let workflowID: String?
         let offeringID: String?
+        let checkpointRuleID: String?
 
     }
 
@@ -63,7 +64,8 @@ extension FeatureEventsRequest.CheckpointEvent {
                 timestamp: event.data.date.millisecondsSince1970,
                 result: event.data.result,
                 workflowID: event.data.workflowID,
-                offeringID: event.data.offeringID
+                offeringID: event.data.offeringID,
+                checkpointRuleID: event.data.checkpointRuleID
             )
         } catch {
             Logger.error(Strings.paywalls.event_cannot_deserialize(error))
@@ -91,6 +93,7 @@ extension FeatureEventsRequest.CheckpointEvent: Encodable {
         case result
         case workflowID = "workflow_id"
         case offeringID = "offering_id"
+        case checkpointRuleID = "checkpoint_rule_id"
 
     }
 
@@ -106,6 +109,7 @@ extension FeatureEventsRequest.CheckpointEvent: Encodable {
         try container.encodeIfPresent(self.result, forKey: .result)
         try container.encodeIfPresent(self.workflowID, forKey: .workflowID)
         try container.encodeIfPresent(self.offeringID, forKey: .offeringID)
+        try container.encodeIfPresent(self.checkpointRuleID, forKey: .checkpointRuleID)
     }
 
 }

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -303,29 +303,25 @@ final class PurchasesOrchestrator {
         identifier: String,
         params: CheckpointParams
     ) async throws -> CheckpointResolution {
-        // Captured before resolving: the date is when the user reached the checkpoint, not when we finished
-        // evaluating it.
-        let hitDate = self.dateProvider.now()
-
         let resolved = try await self.checkpointResolver.resolve(
             identifier: identifier,
             params: params
         )
-        await self.trackCheckpointHit(identifier: identifier, date: hitDate, resolved: resolved)
+        await self.trackCheckpointHit(identifier: identifier, resolved: resolved)
 
         return resolved.resolution
     }
 
-    private func trackCheckpointHit(
-        identifier: String,
-        date: Date,
-        resolved: ResolvedCheckpoint
-    ) async {
+    private func trackCheckpointHit(identifier: String, resolved: ResolvedCheckpoint) async {
         guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *),
               let manager = self.eventsManager else { return }
 
         await manager.track(
-            featureEvent: CheckpointEvent.hit(identifier: identifier, date: date, resolved: resolved)
+            featureEvent: CheckpointEvent.hit(
+                identifier: identifier,
+                date: self.dateProvider.now(),
+                resolved: resolved
+            )
         )
     }
 

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -308,25 +308,25 @@ final class PurchasesOrchestrator {
         // configured for still emits a hit, which is how the backend learns the checkpoint exists.
         let hitDate = self.dateProvider.now()
 
-        let resolution = try await self.checkpointResolver.resolve(
+        let resolved = try await self.checkpointResolver.resolve(
             identifier: identifier,
             params: params
         )
-        await self.trackCheckpointHit(identifier: identifier, date: hitDate, resolution: resolution)
+        await self.trackCheckpointHit(identifier: identifier, date: hitDate, resolved: resolved)
 
-        return resolution
+        return resolved.resolution
     }
 
     private func trackCheckpointHit(
         identifier: String,
         date: Date,
-        resolution: CheckpointResolution
+        resolved: ResolvedCheckpoint
     ) async {
         guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *),
               let manager = self.eventsManager else { return }
 
         await manager.track(
-            featureEvent: CheckpointEvent.hit(identifier: identifier, date: date, resolution: resolution)
+            featureEvent: CheckpointEvent.hit(identifier: identifier, date: date, resolved: resolved)
         )
     }
 

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -303,22 +303,30 @@ final class PurchasesOrchestrator {
         identifier: String,
         params: CheckpointParams
     ) async throws -> CheckpointResolution {
-        // Tracked before resolving, and regardless of the outcome: the hit is also how the backend learns the
-        // checkpoint exists, so it has to be reported even when nothing is configured for it yet.
-        await self.trackCheckpointHit(identifier: identifier)
+        // The date is captured before resolving so the event keeps reporting when the user reached the
+        // checkpoint, while its payload reports what the checkpoint resolved to. An identifier nothing is
+        // configured for still emits a hit, which is how the backend learns the checkpoint exists.
+        let hitDate = self.dateProvider.now()
 
-        return try await self.checkpointResolver.resolve(
+        let resolution = try await self.checkpointResolver.resolve(
             identifier: identifier,
             params: params
         )
+        await self.trackCheckpointHit(identifier: identifier, date: hitDate, resolution: resolution)
+
+        return resolution
     }
 
-    private func trackCheckpointHit(identifier: String) async {
+    private func trackCheckpointHit(
+        identifier: String,
+        date: Date,
+        resolution: CheckpointResolution
+    ) async {
         guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *),
               let manager = self.eventsManager else { return }
 
         await manager.track(
-            featureEvent: CheckpointEvent.hit(.init(identifier: identifier, date: self.dateProvider.now()))
+            featureEvent: CheckpointEvent.hit(identifier: identifier, date: date, resolution: resolution)
         )
     }
 

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -303,9 +303,8 @@ final class PurchasesOrchestrator {
         identifier: String,
         params: CheckpointParams
     ) async throws -> CheckpointResolution {
-        // The date is captured before resolving so the event keeps reporting when the user reached the
-        // checkpoint, while its payload reports what the checkpoint resolved to. An identifier nothing is
-        // configured for still emits a hit, which is how the backend learns the checkpoint exists.
+        // Captured before resolving: the date is when the user reached the checkpoint, not when we finished
+        // evaluating it.
         let hitDate = self.dateProvider.now()
 
         let resolved = try await self.checkpointResolver.resolve(

--- a/Tests/UnitTests/Checkpoints/CheckpointEventsRequestTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointEventsRequestTests.swift
@@ -36,6 +36,7 @@ class CheckpointEventsRequestTests: TestCase {
         expect(request.version) == 1
         expect(request.type) == "checkpoint_hit"
         expect(request.identifier) == "onboarding_complete"
+        expect(request.checkpointType) == .custom
         expect(request.appUserID) == Self.userID
         expect(request.appSessionID) == Self.appSessionID.uuidString
         expect(request.timestamp) == self.date.millisecondsSince1970
@@ -52,6 +53,7 @@ class CheckpointEventsRequestTests: TestCase {
         expect(json).to(contain("\"version\":1"))
         expect(json).to(contain("\"type\":\"checkpoint_hit\""))
         expect(json).to(contain("\"identifier\":\"onboarding_complete\""))
+        expect(json).to(contain("\"checkpoint_type\":\"custom\""))
         expect(json).to(contain("\"app_user_id\":\"\(Self.userID)\""))
         expect(json).to(contain("\"app_session_id\":\"\(Self.appSessionID.uuidString)\""))
         expect(json).to(contain("\"timestamp\":\(self.date.millisecondsSince1970)"))
@@ -100,16 +102,19 @@ class CheckpointEventsRequestTests: TestCase {
         let stored = try self.storedEvent(result: nil,
                                           workflowID: nil,
                                           offeringID: nil,
-                                          checkpointRuleID: nil)
+                                          checkpointRuleID: nil,
+                                          checkpointType: nil)
 
         expect(stored.encodedEvent).toNot(contain("result"))
         expect(stored.encodedEvent).toNot(contain("workflow_id"))
         expect(stored.encodedEvent).toNot(contain("offering_id"))
         expect(stored.encodedEvent).toNot(contain("checkpoint_rule_id"))
+        expect(stored.encodedEvent).toNot(contain("checkpoint_type"))
 
         let request = try XCTUnwrap(FeatureEventsRequest.CheckpointEvent(storedEvent: stored))
 
         expect(request.identifier) == "onboarding_complete"
+        expect(request.checkpointType).to(beNil())
         expect(request.result).to(beNil())
         expect(request.workflowID).to(beNil())
         expect(request.offeringID).to(beNil())
@@ -149,11 +154,13 @@ class CheckpointEventsRequestTests: TestCase {
         result: CheckpointHitResult? = .workflow,
         workflowID: String? = "wf_123",
         offeringID: String? = "offering_id",
-        checkpointRuleID: String? = "rule_123"
+        checkpointRuleID: String? = "rule_123",
+        checkpointType: CheckpointType? = .custom
     ) throws -> StoredFeatureEvent {
         let event = CheckpointEvent.hit(.init(id: self.id,
                                               identifier: "onboarding_complete",
                                               date: self.date,
+                                              checkpointType: checkpointType,
                                               result: result,
                                               workflowID: workflowID,
                                               offeringID: offeringID,

--- a/Tests/UnitTests/Checkpoints/CheckpointEventsRequestTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointEventsRequestTests.swift
@@ -39,6 +39,9 @@ class CheckpointEventsRequestTests: TestCase {
         expect(request.appUserID) == Self.userID
         expect(request.appSessionID) == Self.appSessionID.uuidString
         expect(request.timestamp) == self.date.millisecondsSince1970
+        expect(request.result) == .workflow
+        expect(request.workflowID) == "wf_123"
+        expect(request.offeringID) == "offering_id"
     }
 
     func testKhepriCompatibleShape() throws {
@@ -51,6 +54,53 @@ class CheckpointEventsRequestTests: TestCase {
         expect(json).to(contain("\"app_user_id\":\"\(Self.userID)\""))
         expect(json).to(contain("\"app_session_id\":\"\(Self.appSessionID.uuidString)\""))
         expect(json).to(contain("\"timestamp\":\(self.date.millisecondsSince1970)"))
+        expect(json).to(contain("\"result\":\"workflow\""))
+        expect(json).to(contain("\"workflow_id\":\"wf_123\""))
+        expect(json).to(contain("\"offering_id\":\"offering_id\""))
+    }
+
+    func testEachResultIsEncodedWithItsWireValue() throws {
+        let expectedValues: [CheckpointHitResult: String] = [
+            .workflow: "workflow",
+            .offering: "offering",
+            .noMatch: "no_match",
+            .configurationUnavailable: "configuration_unavailable",
+            .unknownCheckpoint: "unknown_checkpoint",
+            .disabled: "disabled"
+        ]
+
+        for (result, expectedValue) in expectedValues {
+            let json = try self.encodedJSON(result: result, workflowID: nil, offeringID: nil)
+
+            expect(json).to(contain("\"result\":\"\(expectedValue)\""))
+        }
+    }
+
+    /// `checkpoint_hit` keeps the shape it had before the outcome was attached when there is no outcome to
+    /// report, which is the case for hits already stored by an older SDK version.
+    func testOmitsOutcomeFieldsWhenAbsent() throws {
+        let json = try self.encodedJSON(result: nil, workflowID: nil, offeringID: nil)
+
+        expect(json).toNot(contain("result"))
+        expect(json).toNot(contain("workflow_id"))
+        expect(json).toNot(contain("offering_id"))
+    }
+
+    /// Events persisted by an SDK version that recorded hits before evaluating them carry none of the outcome
+    /// fields, and still have to be readable off disk.
+    func testReadsStoredEventWithoutOutcomeFields() throws {
+        let stored = try self.storedEvent(result: nil, workflowID: nil, offeringID: nil)
+
+        expect(stored.encodedEvent).toNot(contain("result"))
+        expect(stored.encodedEvent).toNot(contain("workflow_id"))
+        expect(stored.encodedEvent).toNot(contain("offering_id"))
+
+        let request = try XCTUnwrap(FeatureEventsRequest.CheckpointEvent(storedEvent: stored))
+
+        expect(request.identifier) == "onboarding_complete"
+        expect(request.result).to(beNil())
+        expect(request.workflowID).to(beNil())
+        expect(request.offeringID).to(beNil())
     }
 
     /// khepri discriminates the events union on `type`, so nothing downstream reads a `discriminator` key.
@@ -81,9 +131,18 @@ class CheckpointEventsRequestTests: TestCase {
 
     // MARK: - Helpers
 
-    private func storedEvent(appSessionID: UUID? = CheckpointEventsRequestTests.appSessionID) throws
-    -> StoredFeatureEvent {
-        let event = CheckpointEvent.hit(.init(id: self.id, identifier: "onboarding_complete", date: self.date))
+    private func storedEvent(
+        appSessionID: UUID? = CheckpointEventsRequestTests.appSessionID,
+        result: CheckpointHitResult? = .workflow,
+        workflowID: String? = "wf_123",
+        offeringID: String? = "offering_id"
+    ) throws -> StoredFeatureEvent {
+        let event = CheckpointEvent.hit(.init(id: self.id,
+                                              identifier: "onboarding_complete",
+                                              date: self.date,
+                                              result: result,
+                                              workflowID: workflowID,
+                                              offeringID: offeringID))
 
         return try XCTUnwrap(StoredFeatureEvent(
             event: event,
@@ -94,8 +153,12 @@ class CheckpointEventsRequestTests: TestCase {
         ))
     }
 
-    private func encodedJSON() throws -> String {
-        let stored = try self.storedEvent()
+    private func encodedJSON(
+        result: CheckpointHitResult? = .workflow,
+        workflowID: String? = "wf_123",
+        offeringID: String? = "offering_id"
+    ) throws -> String {
+        let stored = try self.storedEvent(result: result, workflowID: workflowID, offeringID: offeringID)
         let request = try XCTUnwrap(FeatureEventsRequest.CheckpointEvent(storedEvent: stored))
         let encoder = JSONEncoder()
         encoder.outputFormatting = .sortedKeys

--- a/Tests/UnitTests/Checkpoints/CheckpointEventsRequestTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointEventsRequestTests.swift
@@ -65,8 +65,7 @@ class CheckpointEventsRequestTests: TestCase {
             .offering: "offering",
             .noMatch: "no_match",
             .configurationUnavailable: "configuration_unavailable",
-            .unknownCheckpoint: "unknown_checkpoint",
-            .disabled: "disabled"
+            .unknownCheckpoint: "unknown_checkpoint"
         ]
 
         for (result, expectedValue) in expectedValues {

--- a/Tests/UnitTests/Checkpoints/CheckpointEventsRequestTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointEventsRequestTests.swift
@@ -42,6 +42,7 @@ class CheckpointEventsRequestTests: TestCase {
         expect(request.result) == .workflow
         expect(request.workflowID) == "wf_123"
         expect(request.offeringID) == "offering_id"
+        expect(request.checkpointRuleID) == "rule_123"
     }
 
     func testKhepriCompatibleShape() throws {
@@ -57,6 +58,7 @@ class CheckpointEventsRequestTests: TestCase {
         expect(json).to(contain("\"result\":\"workflow\""))
         expect(json).to(contain("\"workflow_id\":\"wf_123\""))
         expect(json).to(contain("\"offering_id\":\"offering_id\""))
+        expect(json).to(contain("\"checkpoint_rule_id\":\"rule_123\""))
     }
 
     func testEachResultIsEncodedWithItsWireValue() throws {
@@ -69,7 +71,10 @@ class CheckpointEventsRequestTests: TestCase {
         ]
 
         for (result, expectedValue) in expectedValues {
-            let json = try self.encodedJSON(result: result, workflowID: nil, offeringID: nil)
+            let json = try self.encodedJSON(result: result,
+                                            workflowID: nil,
+                                            offeringID: nil,
+                                            checkpointRuleID: nil)
 
             expect(json).to(contain("\"result\":\"\(expectedValue)\""))
         }
@@ -78,21 +83,29 @@ class CheckpointEventsRequestTests: TestCase {
     /// `checkpoint_hit` keeps the shape it had before the outcome was attached when there is no outcome to
     /// report, which is the case for hits already stored by an older SDK version.
     func testOmitsOutcomeFieldsWhenAbsent() throws {
-        let json = try self.encodedJSON(result: nil, workflowID: nil, offeringID: nil)
+        let json = try self.encodedJSON(result: nil,
+                                        workflowID: nil,
+                                        offeringID: nil,
+                                        checkpointRuleID: nil)
 
         expect(json).toNot(contain("result"))
         expect(json).toNot(contain("workflow_id"))
         expect(json).toNot(contain("offering_id"))
+        expect(json).toNot(contain("checkpoint_rule_id"))
     }
 
     /// Events persisted by an SDK version that recorded hits before evaluating them carry none of the outcome
     /// fields, and still have to be readable off disk.
     func testReadsStoredEventWithoutOutcomeFields() throws {
-        let stored = try self.storedEvent(result: nil, workflowID: nil, offeringID: nil)
+        let stored = try self.storedEvent(result: nil,
+                                          workflowID: nil,
+                                          offeringID: nil,
+                                          checkpointRuleID: nil)
 
         expect(stored.encodedEvent).toNot(contain("result"))
         expect(stored.encodedEvent).toNot(contain("workflow_id"))
         expect(stored.encodedEvent).toNot(contain("offering_id"))
+        expect(stored.encodedEvent).toNot(contain("checkpoint_rule_id"))
 
         let request = try XCTUnwrap(FeatureEventsRequest.CheckpointEvent(storedEvent: stored))
 
@@ -100,6 +113,7 @@ class CheckpointEventsRequestTests: TestCase {
         expect(request.result).to(beNil())
         expect(request.workflowID).to(beNil())
         expect(request.offeringID).to(beNil())
+        expect(request.checkpointRuleID).to(beNil())
     }
 
     /// khepri discriminates the events union on `type`, so nothing downstream reads a `discriminator` key.
@@ -134,14 +148,16 @@ class CheckpointEventsRequestTests: TestCase {
         appSessionID: UUID? = CheckpointEventsRequestTests.appSessionID,
         result: CheckpointHitResult? = .workflow,
         workflowID: String? = "wf_123",
-        offeringID: String? = "offering_id"
+        offeringID: String? = "offering_id",
+        checkpointRuleID: String? = "rule_123"
     ) throws -> StoredFeatureEvent {
         let event = CheckpointEvent.hit(.init(id: self.id,
                                               identifier: "onboarding_complete",
                                               date: self.date,
                                               result: result,
                                               workflowID: workflowID,
-                                              offeringID: offeringID))
+                                              offeringID: offeringID,
+                                              checkpointRuleID: checkpointRuleID))
 
         return try XCTUnwrap(StoredFeatureEvent(
             event: event,
@@ -155,9 +171,13 @@ class CheckpointEventsRequestTests: TestCase {
     private func encodedJSON(
         result: CheckpointHitResult? = .workflow,
         workflowID: String? = "wf_123",
-        offeringID: String? = "offering_id"
+        offeringID: String? = "offering_id",
+        checkpointRuleID: String? = "rule_123"
     ) throws -> String {
-        let stored = try self.storedEvent(result: result, workflowID: workflowID, offeringID: offeringID)
+        let stored = try self.storedEvent(result: result,
+                                          workflowID: workflowID,
+                                          offeringID: offeringID,
+                                          checkpointRuleID: checkpointRuleID)
         let request = try XCTUnwrap(FeatureEventsRequest.CheckpointEvent(storedEvent: stored))
         let encoder = JSONEncoder()
         encoder.outputFormatting = .sortedKeys

--- a/Tests/UnitTests/Checkpoints/CheckpointEventsRequestTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointEventsRequestTests.swift
@@ -40,7 +40,7 @@ class CheckpointEventsRequestTests: TestCase {
         expect(request.appUserID) == Self.userID
         expect(request.appSessionID) == Self.appSessionID.uuidString
         expect(request.timestamp) == self.date.millisecondsSince1970
-        expect(request.result) == .workflow
+        expect(request.result) == .presentUI
         expect(request.workflowID) == "wf_123"
         expect(request.offeringID) == "offering_id"
         expect(request.checkpointRuleID) == "rule_123"
@@ -57,7 +57,7 @@ class CheckpointEventsRequestTests: TestCase {
         expect(json).to(contain("\"app_user_id\":\"\(Self.userID)\""))
         expect(json).to(contain("\"app_session_id\":\"\(Self.appSessionID.uuidString)\""))
         expect(json).to(contain("\"timestamp\":\(self.date.millisecondsSince1970)"))
-        expect(json).to(contain("\"result\":\"workflow\""))
+        expect(json).to(contain("\"result\":\"present_ui\""))
         expect(json).to(contain("\"workflow_id\":\"wf_123\""))
         expect(json).to(contain("\"offering_id\":\"offering_id\""))
         expect(json).to(contain("\"checkpoint_rule_id\":\"rule_123\""))
@@ -65,8 +65,8 @@ class CheckpointEventsRequestTests: TestCase {
 
     func testEachResultIsEncodedWithItsWireValue() throws {
         let expectedValues: [CheckpointHitResult: String] = [
-            .workflow: "workflow",
-            .offering: "offering",
+            .presentUI: "present_ui",
+            .returnData: "return_data",
             .noMatch: "no_match",
             .configurationUnavailable: "configuration_unavailable",
             .unknownCheckpoint: "unknown_checkpoint"
@@ -151,7 +151,7 @@ class CheckpointEventsRequestTests: TestCase {
 
     private func storedEvent(
         appSessionID: UUID? = CheckpointEventsRequestTests.appSessionID,
-        result: CheckpointHitResult? = .workflow,
+        result: CheckpointHitResult? = .presentUI,
         workflowID: String? = "wf_123",
         offeringID: String? = "offering_id",
         checkpointRuleID: String? = "rule_123",
@@ -176,7 +176,7 @@ class CheckpointEventsRequestTests: TestCase {
     }
 
     private func encodedJSON(
-        result: CheckpointHitResult? = .workflow,
+        result: CheckpointHitResult? = .presentUI,
         workflowID: String? = "wf_123",
         offeringID: String? = "offering_id",
         checkpointRuleID: String? = "rule_123"

--- a/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
@@ -73,7 +73,10 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
     func testDisabledResolverResolvesDisabled() async throws {
         let resolver = DisabledCheckpointWorkflowResolver()
 
-        let resolution = try await resolver.resolve(identifier: self.checkpointIdentifier, params: self.params)
+        let resolution = try await resolver.resolve(
+            identifier: self.checkpointIdentifier,
+            params: self.params
+        ).resolution
 
         XCTAssertEqual(Self.noActionReason(resolution), .disabled)
     }
@@ -143,6 +146,35 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
         XCTAssertEqual(self.workflowsProvider.invokedGetWorkflowParameters, [self.workflowID])
     }
 
+    func testMatchedWorkflowReportsTheServedRule() async throws {
+        let resolved = try await self.resolveCheckpoint()
+
+        XCTAssertNotNil(Self.resolvedWorkflow(resolved.resolution))
+        XCTAssertEqual(resolved.checkpointRuleID, "rule_\(self.workflowID)")
+    }
+
+    func testMatchedWorkflowReportsNoRuleWhenTheRulesTopicOmitsIt() async throws {
+        self.checkpointsProvider.result = .success(
+            CheckpointRuleSet(rules: [CheckpointRule(audienceId: "audience", workflowId: self.workflowID)])
+        )
+
+        let resolved = try await self.resolveCheckpoint()
+
+        XCTAssertNotNil(Self.resolvedWorkflow(resolved.resolution))
+        XCTAssertNil(resolved.checkpointRuleID)
+    }
+
+    /// `configurationUnavailable` describes this SDK's state rather than the rule, so a rule that matched but
+    /// could not be served reports no rule id.
+    func testUnservableRuleReportsNoRuleID() async throws {
+        self.workflowsProvider.stubbedOfferingIdByWorkflowId = [:]
+
+        let resolved = try await self.resolveCheckpoint()
+
+        XCTAssertEqual(Self.noActionReason(resolved.resolution), .configurationUnavailable)
+        XCTAssertNil(resolved.checkpointRuleID)
+    }
+
     func testDimensionProviderFailureResolvesConfigurationUnavailableWithoutFetchingOfferings() async throws {
         let fetchCount = Atomic<Int>(0)
         let evaluator = LocalRulesEvaluator(dimensionProviders: [FailingDimensionProvider()])
@@ -154,7 +186,10 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
             localRulesEvaluator: evaluator
         )
 
-        let resolution = try await resolver.resolve(identifier: self.checkpointIdentifier, params: self.params)
+        let resolution = try await resolver.resolve(
+            identifier: self.checkpointIdentifier,
+            params: self.params
+        ).resolution
 
         XCTAssertEqual(Self.noActionReason(resolution), .configurationUnavailable)
         XCTAssertEqual(fetchCount.value, 0)
@@ -233,7 +268,10 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
             return self.offerings
         }
 
-        let resolution = try await resolver.resolve(identifier: self.checkpointIdentifier, params: self.params)
+        let resolution = try await resolver.resolve(
+            identifier: self.checkpointIdentifier,
+            params: self.params
+        ).resolution
 
         XCTAssertEqual(Self.noActionReason(resolution), .configurationUnavailable)
         XCTAssertEqual(fetchCount.value, 0)
@@ -244,7 +282,10 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
             throw ErrorUtils.networkError(message: "Offline")
         }
 
-        let resolution = try await resolver.resolve(identifier: self.checkpointIdentifier, params: self.params)
+        let resolution = try await resolver.resolve(
+            identifier: self.checkpointIdentifier,
+            params: self.params
+        ).resolution
 
         XCTAssertEqual(Self.noActionReason(resolution), .configurationUnavailable)
     }
@@ -268,7 +309,10 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
             return self.offerings
         }
 
-        let resolution = try await resolver.resolve(identifier: self.checkpointIdentifier, params: self.params)
+        let resolution = try await resolver.resolve(
+            identifier: self.checkpointIdentifier,
+            params: self.params
+        ).resolution
 
         XCTAssertEqual(Self.noActionReason(resolution), .configurationUnavailable)
     }
@@ -285,7 +329,10 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
             self.checkpointsProvider.configGeneration += 1
         }
 
-        let resolution = try await resolver.resolve(identifier: self.checkpointIdentifier, params: self.params)
+        let resolution = try await resolver.resolve(
+            identifier: self.checkpointIdentifier,
+            params: self.params
+        ).resolution
 
         XCTAssertEqual(Self.noActionReason(resolution), .configurationUnavailable)
         XCTAssertEqual(fetchCount.value, 0, "A rule matched against stale config should not be resolved")
@@ -365,11 +412,11 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
         let matched = try await resolver.resolve(
             identifier: self.checkpointIdentifier,
             params: CheckpointParams(customVariables: ["plan": .string("pro")])
-        )
+        ).resolution
         let missed = try await resolver.resolve(
             identifier: self.checkpointIdentifier,
             params: CheckpointParams(customVariables: ["plan": .string("free")])
-        )
+        ).resolution
 
         XCTAssertEqual(Self.resolvedWorkflow(matched)?.workflow.id, self.workflowID)
         XCTAssertEqual(Self.noActionReason(missed), .noMatch)
@@ -660,6 +707,10 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
     }
 
     private func resolve(identifier: String? = nil) async throws -> CheckpointResolution {
+        return try await self.resolveCheckpoint(identifier: identifier).resolution
+    }
+
+    private func resolveCheckpoint(identifier: String? = nil) async throws -> ResolvedCheckpoint {
         return try await self.makeResolver().resolve(
             identifier: identifier ?? self.checkpointIdentifier,
             params: self.params

--- a/Tests/UnitTests/Events/EventsManagerTests.swift
+++ b/Tests/UnitTests/Events/EventsManagerTests.swift
@@ -161,7 +161,7 @@ class EventsManagerTests: TestCase {
             .init(identifier: "onboarding_complete",
                   date: Date(timeIntervalSince1970: 1_699_270_688.995),
                   checkpointType: .custom,
-                  result: .workflow,
+                  result: .presentUI,
                   workflowID: "wf_123",
                   offeringID: "offering_id")
         )
@@ -169,7 +169,7 @@ class EventsManagerTests: TestCase {
         let map = event.toMap()
 
         expect(map["checkpoint_type"] as? String) == "custom"
-        expect(map["result"] as? String) == "workflow"
+        expect(map["result"] as? String) == "present_ui"
         expect(map["workflow_id"] as? String) == "wf_123"
         expect(map["offering_id"] as? String) == "offering_id"
     }

--- a/Tests/UnitTests/Events/EventsManagerTests.swift
+++ b/Tests/UnitTests/Events/EventsManagerTests.swift
@@ -160,6 +160,7 @@ class EventsManagerTests: TestCase {
         let event = CheckpointEvent.hit(
             .init(identifier: "onboarding_complete",
                   date: Date(timeIntervalSince1970: 1_699_270_688.995),
+                  checkpointType: .custom,
                   result: .workflow,
                   workflowID: "wf_123",
                   offeringID: "offering_id")
@@ -167,6 +168,7 @@ class EventsManagerTests: TestCase {
 
         let map = event.toMap()
 
+        expect(map["checkpoint_type"] as? String) == "custom"
         expect(map["result"] as? String) == "workflow"
         expect(map["workflow_id"] as? String) == "wf_123"
         expect(map["offering_id"] as? String) == "offering_id"

--- a/Tests/UnitTests/Events/EventsManagerTests.swift
+++ b/Tests/UnitTests/Events/EventsManagerTests.swift
@@ -151,6 +151,25 @@ class EventsManagerTests: TestCase {
         expect(map["id"] as? String) == event.data.id.uuidString
         expect(map["timestamp"] as? UInt64) == event.data.date.millisecondsSince1970
         expect(map["identifier"] as? String) == "onboarding_complete"
+        expect(map["result"]).to(beNil())
+        expect(map["workflow_id"]).to(beNil())
+        expect(map["offering_id"]).to(beNil())
+    }
+
+    func testCheckpointHitToMapIncludesTheOutcome() {
+        let event = CheckpointEvent.hit(
+            .init(identifier: "onboarding_complete",
+                  date: Date(timeIntervalSince1970: 1_699_270_688.995),
+                  result: .workflow,
+                  workflowID: "wf_123",
+                  offeringID: "offering_id")
+        )
+
+        let map = event.toMap()
+
+        expect(map["result"] as? String) == "workflow"
+        expect(map["workflow_id"] as? String) == "wf_123"
+        expect(map["offering_id"] as? String) == "offering_id"
     }
 
     func testPaywallCloseToMap() {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesCheckpointEventsTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesCheckpointEventsTests.swift
@@ -31,6 +31,7 @@ class PurchasesCheckpointEventsTests: BasePurchasesTests {
 
         let event = try await self.singleTrackedCheckpointEvent()
         expect(event.data.identifier) == "onboarding_complete"
+        expect(event.data.checkpointType) == .custom
         expect(event.data.date) == Self.hitDate
     }
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesCheckpointEventsTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesCheckpointEventsTests.swift
@@ -89,7 +89,7 @@ class PurchasesCheckpointEventsTests: BasePurchasesTests {
         _ = try await self.purchases.resolveCheckpoint(identifier: "onboarding_complete", params: .init())
 
         let event = try await self.singleTrackedCheckpointEvent()
-        expect(event.data.result) == .offering
+        expect(event.data.result) == .returnData
         expect(event.data.offeringID) == offering.identifier
         expect(event.data.checkpointRuleID) == "rule_123"
         expect(event.data.workflowID).to(beNil())
@@ -113,7 +113,7 @@ class PurchasesCheckpointEventsTests: BasePurchasesTests {
         _ = try await self.purchases.resolveCheckpoint(identifier: "onboarding_complete", params: .init())
 
         let event = try await self.singleTrackedCheckpointEvent()
-        expect(event.data.result) == .workflow
+        expect(event.data.result) == .presentUI
         expect(event.data.workflowID) == workflow.id
         expect(event.data.offeringID) == offering.identifier
         expect(event.data.checkpointRuleID) == "rule_123"

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesCheckpointEventsTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesCheckpointEventsTests.swift
@@ -48,10 +48,69 @@ class PurchasesCheckpointEventsTests: BasePurchasesTests {
             fail("Expected resolution to report no action, got \(resolution)")
             return
         }
-        _ = try await self.singleTrackedCheckpointEvent()
+
+        let event = try await self.singleTrackedCheckpointEvent()
+        expect(event.data.result) == .disabled
+        expect(event.data.workflowID).to(beNil())
+        expect(event.data.offeringID).to(beNil())
     }
 
-    func testTracksHitWhenResolutionFails() async throws {
+    func testTracksNoActionReasonOnTheHit() async throws {
+        let reasons: [CheckpointResolutionReason] = [
+            .noMatch, .configurationUnavailable, .unknownCheckpoint, .disabled
+        ]
+        self.setUpCheckpointPurchases(
+            resolver: StubCheckpointWorkflowResolver(resolutions: reasons.map { .noAction($0) })
+        )
+
+        for _ in reasons {
+            _ = try await self.purchases.resolveCheckpoint(identifier: "onboarding_complete", params: .init())
+        }
+
+        let tracked = await (try self.mockEventsManager).trackedEvents.compactMap { $0 as? CheckpointEvent }
+        expect(tracked.map { $0.data.result }) == [
+            .noMatch, .configurationUnavailable, .unknownCheckpoint, .disabled
+        ]
+    }
+
+    func testTracksMatchedOfferingOnTheHit() async throws {
+        let offering = Self.offering
+        self.setUpCheckpointPurchases(
+            resolver: StubCheckpointWorkflowResolver(resolution: .matchedOffering(offering))
+        )
+
+        _ = try await self.purchases.resolveCheckpoint(identifier: "onboarding_complete", params: .init())
+
+        let event = try await self.singleTrackedCheckpointEvent()
+        expect(event.data.result) == .offering
+        expect(event.data.offeringID) == offering.identifier
+        expect(event.data.workflowID).to(beNil())
+    }
+
+    func testTracksMatchedWorkflowOnTheHit() async throws {
+        let offering = Self.offering
+        let workflow = Self.workflow
+        self.setUpCheckpointPurchases(
+            resolver: StubCheckpointWorkflowResolver(resolution: .matchedWorkflow(.init(
+                workflow: workflow,
+                uiConfig: Self.uiConfig,
+                offering: offering,
+                offerings: .preview(offerings: [offering])
+            )))
+        )
+
+        _ = try await self.purchases.resolveCheckpoint(identifier: "onboarding_complete", params: .init())
+
+        let event = try await self.singleTrackedCheckpointEvent()
+        expect(event.data.result) == .workflow
+        expect(event.data.workflowID) == workflow.id
+        expect(event.data.offeringID) == offering.identifier
+        expect(event.data.date) == Self.hitDate
+    }
+
+    /// The hit reports what the checkpoint resolved to, so a resolution that never completes has nothing to
+    /// report. Registration of the identifier is lost only in that case.
+    func testTracksNothingWhenResolutionFails() async throws {
         self.setUpCheckpointPurchases(resolver: ThrowingCheckpointWorkflowResolver())
 
         do {
@@ -59,10 +118,33 @@ class PurchasesCheckpointEventsTests: BasePurchasesTests {
             fail("Expected resolution to throw")
         } catch {}
 
-        _ = try await self.singleTrackedCheckpointEvent()
+        let tracked = await (try self.mockEventsManager).trackedEvents
+        expect(tracked).to(beEmpty())
     }
 
     // MARK: - Helpers
+
+    private static let offering = Offering(
+        identifier: "onboarding",
+        serverDescription: "Onboarding offering",
+        availablePackages: [],
+        webCheckoutUrl: nil
+    )
+
+    private static let uiConfig = UIConfig(
+        app: .init(colors: [:], fonts: [:]),
+        localizations: [:],
+        variableConfig: .init(variableCompatibilityMap: [:], functionCompatibilityMap: [:])
+    )
+
+    private static let workflow = PublishedWorkflow(
+        id: "wf_123",
+        displayName: "Onboarding",
+        initialStepId: "step_1",
+        singleStepFallbackId: nil,
+        steps: [:],
+        screens: [:]
+    )
 
     private func setUpCheckpointPurchases(
         resolver: CheckpointWorkflowResolver = DisabledCheckpointWorkflowResolver()
@@ -79,6 +161,28 @@ class PurchasesCheckpointEventsTests: BasePurchasesTests {
         let tracked = await (try self.mockEventsManager).trackedEvents
         expect(tracked).to(haveCount(1))
         return try XCTUnwrap(tracked.first as? CheckpointEvent)
+    }
+
+}
+
+@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+private final class StubCheckpointWorkflowResolver: CheckpointWorkflowResolver {
+
+    private let resolutions: Atomic<[CheckpointResolution]>
+
+    convenience init(resolution: CheckpointResolution) {
+        self.init(resolutions: [resolution])
+    }
+
+    init(resolutions: [CheckpointResolution]) {
+        self.resolutions = .init(resolutions)
+    }
+
+    /// Returns each resolution in turn, repeating the last one once they run out.
+    func resolve(identifier: String, params: CheckpointParams) async throws -> CheckpointResolution {
+        return self.resolutions.modify { pending in
+            pending.count > 1 ? pending.removeFirst() : pending[0]
+        }
     }
 
 }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesCheckpointEventsTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesCheckpointEventsTests.swift
@@ -50,7 +50,7 @@ class PurchasesCheckpointEventsTests: BasePurchasesTests {
         }
 
         let event = try await self.singleTrackedCheckpointEvent()
-        expect(event.data.result) == .disabled
+        expect(event.data.result) == .configurationUnavailable
         expect(event.data.workflowID).to(beNil())
         expect(event.data.offeringID).to(beNil())
     }
@@ -67,9 +67,11 @@ class PurchasesCheckpointEventsTests: BasePurchasesTests {
             _ = try await self.purchases.resolveCheckpoint(identifier: "onboarding_complete", params: .init())
         }
 
+        // `.disabled` has no result of its own: a checkpoint reached with remote config
+        // off reports the same thing as configuration that could not be read.
         let tracked = await (try self.mockEventsManager).trackedEvents.compactMap { $0 as? CheckpointEvent }
         expect(tracked.map { $0.data.result }) == [
-            .noMatch, .configurationUnavailable, .unknownCheckpoint, .disabled
+            .noMatch, .configurationUnavailable, .unknownCheckpoint, .configurationUnavailable
         ]
     }
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesCheckpointEventsTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesCheckpointEventsTests.swift
@@ -53,6 +53,7 @@ class PurchasesCheckpointEventsTests: BasePurchasesTests {
         expect(event.data.result) == .configurationUnavailable
         expect(event.data.workflowID).to(beNil())
         expect(event.data.offeringID).to(beNil())
+        expect(event.data.checkpointRuleID).to(beNil())
     }
 
     func testTracksNoActionReasonOnTheHit() async throws {
@@ -78,7 +79,10 @@ class PurchasesCheckpointEventsTests: BasePurchasesTests {
     func testTracksMatchedOfferingOnTheHit() async throws {
         let offering = Self.offering
         self.setUpCheckpointPurchases(
-            resolver: StubCheckpointWorkflowResolver(resolution: .matchedOffering(offering))
+            resolver: StubCheckpointWorkflowResolver(
+                resolution: .matchedOffering(offering),
+                checkpointRuleID: "rule_123"
+            )
         )
 
         _ = try await self.purchases.resolveCheckpoint(identifier: "onboarding_complete", params: .init())
@@ -86,6 +90,7 @@ class PurchasesCheckpointEventsTests: BasePurchasesTests {
         let event = try await self.singleTrackedCheckpointEvent()
         expect(event.data.result) == .offering
         expect(event.data.offeringID) == offering.identifier
+        expect(event.data.checkpointRuleID) == "rule_123"
         expect(event.data.workflowID).to(beNil())
     }
 
@@ -93,12 +98,15 @@ class PurchasesCheckpointEventsTests: BasePurchasesTests {
         let offering = Self.offering
         let workflow = Self.workflow
         self.setUpCheckpointPurchases(
-            resolver: StubCheckpointWorkflowResolver(resolution: .matchedWorkflow(.init(
-                workflow: workflow,
-                uiConfig: Self.uiConfig,
-                offering: offering,
-                offerings: .preview(offerings: [offering])
-            )))
+            resolver: StubCheckpointWorkflowResolver(
+                resolution: .matchedWorkflow(.init(
+                    workflow: workflow,
+                    uiConfig: Self.uiConfig,
+                    offering: offering,
+                    offerings: .preview(offerings: [offering])
+                )),
+                checkpointRuleID: "rule_123"
+            )
         )
 
         _ = try await self.purchases.resolveCheckpoint(identifier: "onboarding_complete", params: .init())
@@ -107,6 +115,7 @@ class PurchasesCheckpointEventsTests: BasePurchasesTests {
         expect(event.data.result) == .workflow
         expect(event.data.workflowID) == workflow.id
         expect(event.data.offeringID) == offering.identifier
+        expect(event.data.checkpointRuleID) == "rule_123"
         expect(event.data.date) == Self.hitDate
     }
 
@@ -170,19 +179,23 @@ class PurchasesCheckpointEventsTests: BasePurchasesTests {
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
 private final class StubCheckpointWorkflowResolver: CheckpointWorkflowResolver {
 
-    private let resolutions: Atomic<[CheckpointResolution]>
+    private let resolved: Atomic<[ResolvedCheckpoint]>
 
-    convenience init(resolution: CheckpointResolution) {
-        self.init(resolutions: [resolution])
+    convenience init(resolution: CheckpointResolution, checkpointRuleID: String? = nil) {
+        self.init(resolved: [.init(resolution, checkpointRuleID: checkpointRuleID)])
     }
 
-    init(resolutions: [CheckpointResolution]) {
-        self.resolutions = .init(resolutions)
+    convenience init(resolutions: [CheckpointResolution]) {
+        self.init(resolved: resolutions.map { .init($0) })
+    }
+
+    init(resolved: [ResolvedCheckpoint]) {
+        self.resolved = .init(resolved)
     }
 
     /// Returns each resolution in turn, repeating the last one once they run out.
-    func resolve(identifier: String, params: CheckpointParams) async throws -> CheckpointResolution {
-        return self.resolutions.modify { pending in
+    func resolve(identifier: String, params: CheckpointParams) async throws -> ResolvedCheckpoint {
+        return self.resolved.modify { pending in
             pending.count > 1 ? pending.removeFirst() : pending[0]
         }
     }
@@ -194,7 +207,7 @@ private final class ThrowingCheckpointWorkflowResolver: CheckpointWorkflowResolv
 
     private struct ResolutionError: Error {}
 
-    func resolve(identifier: String, params: CheckpointParams) async throws -> CheckpointResolution {
+    func resolve(identifier: String, params: CheckpointParams) async throws -> ResolvedCheckpoint {
         throw ResolutionError()
     }
 


### PR DESCRIPTION
## Description

The SDKs are moving `checkpoint_hit` to after evaluation so the hit reports what the checkpoint resolved to. This accepts the result and carries it through to `CheckpointUserEvent`.

The result names describe what the SDK does. `present_ui` presents a workflow UI and `return_data` returns data to the app.

Android: https://github.com/RevenueCat/purchases-android/pull/4150/

Linear: https://linear.app/revenuecat/issue/WFL-523/move-checkpoint-hit-after-evaluation-and-attach-the-checkpoints
