### PR TITLE
Gate the iOS 17 scroll anchor snapshot test behind Xcode 15

### DIFF
--- a/Tests/RevenueCatUITests/PaywallsV2/RootViewLayoutSnapshotTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/RootViewLayoutSnapshotTests.swift
@@ -59,6 +59,8 @@ final class RootViewLayoutSnapshotTests: BaseSnapshotTest {
         )
     }
 
+    // defaultScrollAnchor only exists in the iOS 17 SDK, so Xcode 14 cannot compile this at all.
+    #if compiler(>=5.9)
     /// Scrolled to the bottom, the last row must still clear the sticky footer once the footer
     /// gains its minimum padding.
     func testStickyFooterReservesScrollSpaceOnIPadCard() throws {
@@ -81,6 +83,7 @@ final class RootViewLayoutSnapshotTests: BaseSnapshotTest {
             separateOSVersions: false
         )
     }
+    #endif
 
     func testStickyFooterRootZLayerOnIPhoneFullScreen() throws {
         let viewModel = try PaywallsV2LayoutFixtures.makeStickyFooterRootZLayerViewModel()

--- a/Tests/RevenueCatUITests/PaywallsV2/RootViewLayoutSnapshotTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/RootViewLayoutSnapshotTests.swift
@@ -62,6 +62,8 @@ final class RootViewLayoutSnapshotTests: BaseSnapshotTest {
     /// Scrolled to the bottom, the last row must still clear the sticky footer once the footer
     /// gains its minimum padding.
     func testStickyFooterReservesScrollSpaceOnIPadCard() throws {
+        // defaultScrollAnchor is an iOS 17 SDK symbol, so Xcode 14 cannot compile the call at all.
+        #if swift(>=5.9)
         guard #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) else {
             throw XCTSkip("defaultScrollAnchor requires iOS 17")
         }
@@ -73,13 +75,16 @@ final class RootViewLayoutSnapshotTests: BaseSnapshotTest {
             safeAreaInsets: EdgeInsets(top: 47, leading: 0, bottom: 0, trailing: 0)
         )
         .environment(\.userInterfaceIdiom, .pad)
-        .defaultScrollAnchorBottom()
+        .defaultScrollAnchor(.bottom)
 
         view.snapshot(
             size: PaywallsV2LayoutFixtures.iPadFormSheetSize,
             record: Self.shouldRecordSnapshots,
             separateOSVersions: false
         )
+        #else
+        throw XCTSkip("defaultScrollAnchor requires the iOS 17 SDK")
+        #endif
     }
 
     func testStickyFooterRootZLayerOnIPhoneFullScreen() throws {
@@ -130,26 +135,6 @@ final class RootViewLayoutSnapshotTests: BaseSnapshotTest {
 
     private func makeFullScreenSnapshotView(_ makeViewModel: () throws -> RootViewModel) throws -> some View {
         PaywallsV2LayoutFixtures.makeRootView(viewModel: try makeViewModel(), size: Self.fullScreenSize)
-    }
-
-}
-
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-private extension View {
-
-    /// `defaultScrollAnchor` only exists in the iOS 17 SDK, so it needs the compiler check as well
-    /// as the availability one to build with older Xcode versions.
-    @ViewBuilder
-    func defaultScrollAnchorBottom() -> some View {
-        #if swift(>=5.9)
-        if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
-            AnyView(self.defaultScrollAnchor(.bottom))
-        } else {
-            AnyView(self)
-        }
-        #else
-        self
-        #endif
     }
 
 }

--- a/Tests/RevenueCatUITests/PaywallsV2/RootViewLayoutSnapshotTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/RootViewLayoutSnapshotTests.swift
@@ -59,8 +59,6 @@ final class RootViewLayoutSnapshotTests: BaseSnapshotTest {
         )
     }
 
-    // defaultScrollAnchor only exists in the iOS 17 SDK, so Xcode 14 cannot compile this at all.
-    #if compiler(>=5.9)
     /// Scrolled to the bottom, the last row must still clear the sticky footer once the footer
     /// gains its minimum padding.
     func testStickyFooterReservesScrollSpaceOnIPadCard() throws {
@@ -75,7 +73,7 @@ final class RootViewLayoutSnapshotTests: BaseSnapshotTest {
             safeAreaInsets: EdgeInsets(top: 47, leading: 0, bottom: 0, trailing: 0)
         )
         .environment(\.userInterfaceIdiom, .pad)
-        .defaultScrollAnchor(.bottom)
+        .defaultScrollAnchorBottom()
 
         view.snapshot(
             size: PaywallsV2LayoutFixtures.iPadFormSheetSize,
@@ -83,7 +81,6 @@ final class RootViewLayoutSnapshotTests: BaseSnapshotTest {
             separateOSVersions: false
         )
     }
-    #endif
 
     func testStickyFooterRootZLayerOnIPhoneFullScreen() throws {
         let viewModel = try PaywallsV2LayoutFixtures.makeStickyFooterRootZLayerViewModel()
@@ -133,6 +130,26 @@ final class RootViewLayoutSnapshotTests: BaseSnapshotTest {
 
     private func makeFullScreenSnapshotView(_ makeViewModel: () throws -> RootViewModel) throws -> some View {
         PaywallsV2LayoutFixtures.makeRootView(viewModel: try makeViewModel(), size: Self.fullScreenSize)
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension View {
+
+    /// `defaultScrollAnchor` only exists in the iOS 17 SDK, so it needs the compiler check as well
+    /// as the availability one to build with older Xcode versions.
+    @ViewBuilder
+    func defaultScrollAnchorBottom() -> some View {
+        #if swift(>=5.9)
+        if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
+            AnyView(self.defaultScrollAnchor(.bottom))
+        } else {
+            AnyView(self)
+        }
+        #else
+        self
+        #endif
     }
 
 }


### PR DESCRIPTION
Fixes main. 

#7560 added a snapshot test using `defaultScrollAnchor` which only exists in the iOS 17 SDK.

Wraps the body in `#if swift(>=5.9)` and skips with `XCTSkip`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only compile-time gating with no production or runtime behavior changes.
> 
> **Overview**
> Restores **RevenueCatUITests** compilation on **Xcode 14** by wrapping `testStickyFooterReservesScrollSpaceOnIPadCard` in `#if swift(>=5.9)`.
> 
> The test uses `.defaultScrollAnchor(.bottom)`, which is only in the iOS 17 SDK, so a runtime `#available` check was not enough—the call still failed to compile on CI (`spm-revenuecat-ui-ios-15` with Xcode 14.3.1). On Swift 5.9+ the test is unchanged (availability skip on older OS, snapshot when supported). On older toolchains it **skips** with a clear message instead of referencing the missing API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 709ed114598d3d8f191ab88f1face757c9d6ddfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->