### PR TITLE
feat(Checkpoints): namespace checkpoint result and context types

### DIFF
--- a/Examples/CheckpointTester/CheckpointTester/Sources/CheckpointDemoModel.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/CheckpointDemoModel.swift
@@ -75,12 +75,12 @@ final class CheckpointDemoModel: ObservableObject {
 
     private static func describe(_ result: CheckpointResult, checkpointIdentifier: String) -> String {
         switch result {
-        case let presented as CheckpointPaywallPresentedResult:
+        case let presented as CheckpointResult.PaywallPresented:
             return "Paywall presented · \(checkpointIdentifier)\n\n" +
                 "Paywall outcome: \(Self.describe(presented.paywallOutcome))"
-        case let received as CheckpointReceivedOfferingResult:
+        case let received as CheckpointResult.ReceivedOffering:
             return "Received offering · \(checkpointIdentifier) · \(received.offering.identifier)"
-        case let noAction as CheckpointNoActionResult:
+        case let noAction as CheckpointResult.NoAction:
             return "No action · \(checkpointIdentifier) · \(noAction.reason)"
         default:
             return "Unknown checkpoint result · \(checkpointIdentifier)"

--- a/Examples/CheckpointTester/CheckpointTester/Sources/GlobalCheckpointAnalyticsTracker.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/GlobalCheckpointAnalyticsTracker.swift
@@ -31,13 +31,13 @@ final class GlobalCheckpointAnalyticsTracker: ObservableObject, CheckpointListen
     // MARK: - New checkpoint public API implementation
 
     // These callbacks demonstrate an app-wide analytics integration using CheckpointListener.
-    func onCheckpointHit(_ context: CheckpointHitContext) {
+    func onCheckpointHit(_ context: CheckpointContext.Hit) {
         self.track(
             "Hit · \(context.identifier) · customVariables=\(context.customVariables)"
         )
     }
 
-    func onCheckpointCompleted(_ context: CheckpointCompletedContext) {
+    func onCheckpointCompleted(_ context: CheckpointContext.Completed) {
         self.track(
             "Completed · \(context.identifier) · \(Self.describe(context.result)) · " +
                 "customVariables=\(context.customVariables)"

--- a/Examples/CheckpointTester/CheckpointTester/Sources/GlobalCheckpointAnalyticsTracker.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/GlobalCheckpointAnalyticsTracker.swift
@@ -58,11 +58,11 @@ final class GlobalCheckpointAnalyticsTracker: ObservableObject, CheckpointListen
 
     private static func describe(_ result: CheckpointResult) -> String {
         switch result {
-        case let presented as CheckpointPaywallPresentedResult:
+        case let presented as CheckpointResult.PaywallPresented:
             return "Paywall presented · \(Self.describe(presented.paywallOutcome))"
-        case let received as CheckpointReceivedOfferingResult:
+        case let received as CheckpointResult.ReceivedOffering:
             return "Received offering · \(received.offering.identifier)"
-        case let noAction as CheckpointNoActionResult:
+        case let noAction as CheckpointResult.NoAction:
             return "No action · \(noAction.reason)"
         default:
             return "Unknown result"

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/EntitlementGateUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/EntitlementGateUseCaseView.swift
@@ -101,11 +101,11 @@ struct EntitlementGateUseCaseView: View {
     @MainActor
     private func handle(_ result: CheckpointResult) {
         switch result {
-        case let presented as CheckpointPaywallPresentedResult:
+        case let presented as CheckpointResult.PaywallPresented:
             self.handle(presented.paywallOutcome)
-        case let received as CheckpointReceivedOfferingResult:
+        case let received as CheckpointResult.ReceivedOffering:
             self.status = "Received offering '\(received.offering.identifier)'. The app owns what happens next."
-        case let noAction as CheckpointNoActionResult:
+        case let noAction as CheckpointResult.NoAction:
             self.status = "No paywall shown (\(noAction.reason)). Content remains locked."
         default:
             self.status = "Unknown checkpoint result. Content remains locked."

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/HardPaywallUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/HardPaywallUseCaseView.swift
@@ -92,11 +92,11 @@ struct HardPaywallUseCaseView: View {
     @MainActor
     private func handle(_ result: CheckpointResult) {
         switch result {
-        case let presented as CheckpointPaywallPresentedResult:
+        case let presented as CheckpointResult.PaywallPresented:
             self.handle(presented.paywallOutcome)
-        case let received as CheckpointReceivedOfferingResult:
+        case let received as CheckpointResult.ReceivedOffering:
             self.status = "Received offering '\(received.offering.identifier)'. The app owns what happens next."
-        case let noAction as CheckpointNoActionResult:
+        case let noAction as CheckpointResult.NoAction:
             self.status = "No paywall shown (\(noAction.reason)). Content remains locked."
         default:
             self.status = "Unknown checkpoint result. Content remains locked."

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/OnboardingUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/OnboardingUseCaseView.swift
@@ -126,11 +126,11 @@ struct OnboardingUseCaseView: View {
 
     private static func describe(_ result: CheckpointResult) -> String {
         switch result {
-        case let presented as CheckpointPaywallPresentedResult:
+        case let presented as CheckpointResult.PaywallPresented:
             return Self.describe(presented.paywallOutcome)
-        case let received as CheckpointReceivedOfferingResult:
+        case let received as CheckpointResult.ReceivedOffering:
             return "Received offering '\(received.offering.identifier)'."
-        case let noAction as CheckpointNoActionResult:
+        case let noAction as CheckpointResult.NoAction:
             return "No paywall shown (\(noAction.reason))."
         default:
             return "Unknown checkpoint result."

--- a/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/SoftPaywallUseCaseView.swift
+++ b/Examples/CheckpointTester/CheckpointTester/Sources/UseCases/SoftPaywallUseCaseView.swift
@@ -83,11 +83,11 @@ struct SoftPaywallUseCaseView: View {
     @MainActor
     private func handle(_ result: CheckpointResult) {
         switch result {
-        case let presented as CheckpointPaywallPresentedResult:
+        case let presented as CheckpointResult.PaywallPresented:
             self.handle(presented.paywallOutcome)
-        case let received as CheckpointReceivedOfferingResult:
+        case let received as CheckpointResult.ReceivedOffering:
             self.status = "Received offering '\(received.offering.identifier)'. The app owns what happens next."
-        case let noAction as CheckpointNoActionResult:
+        case let noAction as CheckpointResult.NoAction:
             self.status = "No paywall shown (\(noAction.reason)). Content remains available."
         default:
             self.status = "Unknown checkpoint result. Content remains available."

--- a/RevenueCatUI/Checkpoints/CheckpointResults.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointResults.swift
@@ -23,11 +23,11 @@ import Foundation
 /// let result = try await Purchases.shared.checkpoint("onboarding_complete")
 ///
 /// switch result {
-/// case let result as CheckpointPaywallPresentedResult:
+/// case let result as CheckpointResult.PaywallPresented:
 ///     handlePaywallOutcome(result.paywallOutcome)
-/// case let result as CheckpointReceivedOfferingResult:
+/// case let result as CheckpointResult.ReceivedOffering:
 ///     showOffering(result.offering)
-/// case let result as CheckpointNoActionResult:
+/// case let result as CheckpointResult.NoAction:
 ///     handleNoAction(result.reason)
 /// default:
 ///     // Handle result types added in future SDK versions.
@@ -45,62 +45,56 @@ public class CheckpointResult: CustomStringConvertible {
         return "CheckpointResult"
     }
 
-}
+    /// Nothing was served for a checkpoint.
+    public final class NoAction: CheckpointResult {
 
-/// Nothing was served for a checkpoint.
-@_spi(CheckpointsInternal)
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-public final class CheckpointNoActionResult: CheckpointResult {
+        /// The reason no experience was served.
+        public let reason: CheckpointNoActionReason
 
-    /// The reason no experience was served.
-    public let reason: CheckpointNoActionReason
+        init(reason: CheckpointNoActionReason) {
+            self.reason = reason
+            super.init()
+        }
 
-    init(reason: CheckpointNoActionReason) {
-        self.reason = reason
-        super.init()
+        public override var description: String {
+            return "NoAction(reason=\(self.reason))"
+        }
+
     }
 
-    public override var description: String {
-        return "NoAction(reason=\(self.reason))"
+    /// An offering was selected for a checkpoint, with no RevenueCat-managed UI presented. The app decides
+    /// whether and how to use it.
+    public final class ReceivedOffering: CheckpointResult {
+
+        /// The offering the checkpoint selected.
+        public let offering: Offering
+
+        init(offering: Offering) {
+            self.offering = offering
+            super.init()
+        }
+
+        public override var description: String {
+            return "ReceivedOffering(offering=\(self.offering.identifier))"
+        }
+
     }
 
-}
+    /// A checkpoint-triggered paywall was presented and finished.
+    public final class PaywallPresented: CheckpointResult {
 
-/// An offering was selected for a checkpoint, with no RevenueCat-managed UI presented. The app decides
-/// whether and how to use it.
-@_spi(CheckpointsInternal)
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-public final class CheckpointReceivedOfferingResult: CheckpointResult {
+        /// The terminal outcome of the presented paywall.
+        public let paywallOutcome: CheckpointPaywallOutcome
 
-    /// The offering the checkpoint selected.
-    public let offering: Offering
+        init(paywallOutcome: CheckpointPaywallOutcome) {
+            self.paywallOutcome = paywallOutcome
+            super.init()
+        }
 
-    init(offering: Offering) {
-        self.offering = offering
-        super.init()
-    }
+        public override var description: String {
+            return "PaywallPresented(paywallOutcome=\(self.paywallOutcome))"
+        }
 
-    public override var description: String {
-        return "ReceivedOffering(offering=\(self.offering.identifier))"
-    }
-
-}
-
-/// A checkpoint-triggered paywall was presented and finished.
-@_spi(CheckpointsInternal)
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-public final class CheckpointPaywallPresentedResult: CheckpointResult {
-
-    /// The terminal outcome of the presented paywall.
-    public let paywallOutcome: CheckpointPaywallOutcome
-
-    init(paywallOutcome: CheckpointPaywallOutcome) {
-        self.paywallOutcome = paywallOutcome
-        super.init()
-    }
-
-    public override var description: String {
-        return "PaywallPresented(paywallOutcome=\(self.paywallOutcome))"
     }
 
 }

--- a/RevenueCatUI/Checkpoints/Checkpoints.swift
+++ b/RevenueCatUI/Checkpoints/Checkpoints.swift
@@ -63,39 +63,36 @@ public class CheckpointContext: CustomStringConvertible, @unchecked Sendable {
         return "CheckpointContext(identifier='\(self.identifier)', customVariables=\(self.customVariables))"
     }
 
-}
+    /// Context delivered when a checkpoint is hit, before evaluation starts.
+    public final class Hit: CheckpointContext, @unchecked Sendable {
 
-/// Context delivered when a checkpoint is hit, before evaluation starts.
-@_spi(CheckpointsInternal)
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-public final class CheckpointHitContext: CheckpointContext, @unchecked Sendable {
+        override init(identifier: String, params: CheckpointCallParams) {
+            super.init(identifier: identifier, params: params)
+        }
 
-    override init(identifier: String, params: CheckpointCallParams) {
-        super.init(identifier: identifier, params: params)
+        public override var description: String {
+            return "CheckpointContext.Hit(identifier='\(self.identifier)', " +
+                "customVariables=\(self.customVariables))"
+        }
+
     }
 
-    public override var description: String {
-        return "CheckpointHitContext(identifier='\(self.identifier)', customVariables=\(self.customVariables))"
-    }
+    /// Context delivered when a checkpoint completes.
+    public final class Completed: CheckpointContext, @unchecked Sendable {
 
-}
+        /// What the checkpoint resolved to.
+        public let result: CheckpointResult
 
-/// Context delivered when a checkpoint completes.
-@_spi(CheckpointsInternal)
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-public final class CheckpointCompletedContext: CheckpointContext, @unchecked Sendable {
+        init(identifier: String, params: CheckpointCallParams, result: CheckpointResult) {
+            self.result = result
+            super.init(identifier: identifier, params: params)
+        }
 
-    /// What the checkpoint resolved to.
-    public let result: CheckpointResult
+        public override var description: String {
+            return "CheckpointContext.Completed(identifier='\(self.identifier)', " +
+                "customVariables=\(self.customVariables), result=\(self.result))"
+        }
 
-    init(identifier: String, params: CheckpointCallParams, result: CheckpointResult) {
-        self.result = result
-        super.init(identifier: identifier, params: params)
-    }
-
-    public override var description: String {
-        return "CheckpointCompletedContext(identifier='\(self.identifier)', " +
-            "customVariables=\(self.customVariables), result=\(self.result))"
     }
 
 }
@@ -149,11 +146,11 @@ public protocol CheckpointListener: AnyObject {
     /// A checkpoint was hit and evaluation is about to start.
     ///
     /// This does not indicate that a targeting rule matched or that UI will be presented.
-    func onCheckpointHit(_ context: CheckpointHitContext)
+    func onCheckpointHit(_ context: CheckpointContext.Hit)
     /// Checkpoint evaluation and any presented UI finished.
     ///
     /// This is called before the per-call checkpoint API delivers its result.
-    func onCheckpointCompleted(_ context: CheckpointCompletedContext)
+    func onCheckpointCompleted(_ context: CheckpointContext.Completed)
 
 }
 
@@ -162,8 +159,8 @@ public protocol CheckpointListener: AnyObject {
 public extension CheckpointListener {
 
     /// Default no-op implementation.
-    func onCheckpointHit(_ context: CheckpointHitContext) {}
+    func onCheckpointHit(_ context: CheckpointContext.Hit) {}
     /// Default no-op implementation.
-    func onCheckpointCompleted(_ context: CheckpointCompletedContext) {}
+    func onCheckpointCompleted(_ context: CheckpointContext.Completed) {}
 
 }

--- a/RevenueCatUI/Checkpoints/CheckpointsManager.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointsManager.swift
@@ -76,13 +76,13 @@ final class CheckpointsManager {
         identifier: String,
         params: CheckpointCallParams
     ) async throws -> CheckpointResult {
-        self.listener?.onCheckpointHit(CheckpointHitContext(identifier: identifier, params: params))
+        self.listener?.onCheckpointHit(CheckpointContext.Hit(identifier: identifier, params: params))
 
         guard CheckpointIdentifierValidator.isValid(identifier) else {
             Logger.error(CheckpointIdentifierValidator.invalidIdentifierLogMessage(identifier))
             let result = CheckpointResult.NoAction(reason: .invalidCheckpointIdentifier)
             self.listener?.onCheckpointCompleted(
-                CheckpointCompletedContext(identifier: identifier, params: params, result: result)
+                CheckpointContext.Completed(identifier: identifier, params: params, result: result)
             )
             return result
         }
@@ -104,7 +104,7 @@ final class CheckpointsManager {
         }
 
         self.listener?.onCheckpointCompleted(
-            CheckpointCompletedContext(identifier: identifier, params: params, result: result)
+            CheckpointContext.Completed(identifier: identifier, params: params, result: result)
         )
         return result
     }

--- a/RevenueCatUI/Checkpoints/CheckpointsManager.swift
+++ b/RevenueCatUI/Checkpoints/CheckpointsManager.swift
@@ -80,7 +80,7 @@ final class CheckpointsManager {
 
         guard CheckpointIdentifierValidator.isValid(identifier) else {
             Logger.error(CheckpointIdentifierValidator.invalidIdentifierLogMessage(identifier))
-            let result = CheckpointNoActionResult(reason: .invalidCheckpointIdentifier)
+            let result = CheckpointResult.NoAction(reason: .invalidCheckpointIdentifier)
             self.listener?.onCheckpointCompleted(
                 CheckpointCompletedContext(identifier: identifier, params: params, result: result)
             )
@@ -95,12 +95,12 @@ final class CheckpointsManager {
                 customVariables: params.customVariables
             )
             let outcome = try await self.executor.execute(presentation)
-            result = CheckpointPaywallPresentedResult(paywallOutcome: outcome)
+            result = CheckpointResult.PaywallPresented(paywallOutcome: outcome)
         case let .matchedOffering(offering):
             // Data-only, so this never claims the presentation slot the executor owns.
-            result = CheckpointReceivedOfferingResult(offering: offering)
+            result = CheckpointResult.ReceivedOffering(offering: offering)
         case let .noAction(reason):
-            result = CheckpointNoActionResult(reason: reason.noActionReason)
+            result = CheckpointResult.NoAction(reason: reason.noActionReason)
         }
 
         self.listener?.onCheckpointCompleted(

--- a/RevenueCatUI/Checkpoints/Purchases+Checkpoints.swift
+++ b/RevenueCatUI/Checkpoints/Purchases+Checkpoints.swift
@@ -32,7 +32,7 @@ public extension Purchases {
     /// Evaluates a checkpoint and calls `completion` with its result.
     ///
     /// Depending on the configured targeting rules, this may automatically present an experience or return a
-    /// ``CheckpointNoActionResult`` without presenting UI. If an experience is presented, `completion` is called
+    /// ``CheckpointResult/NoAction`` without presenting UI. If an experience is presented, `completion` is called
     /// after the experience finishes.
     /// - Parameters:
     ///   - identifier: The checkpoint identifier configured in the RevenueCat dashboard. It must start with a letter,
@@ -54,7 +54,7 @@ public extension Purchases {
     /// Evaluates a checkpoint and returns its result.
     ///
     /// Depending on the configured targeting rules, this may automatically present an experience or return a
-    /// ``CheckpointNoActionResult`` without presenting UI. If an experience is presented, this method returns
+    /// ``CheckpointResult/NoAction`` without presenting UI. If an experience is presented, this method returns
     /// after the experience finishes.
     /// - Parameters:
     ///   - identifier: The checkpoint identifier configured in the RevenueCat dashboard. It must start with a letter,

--- a/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
+++ b/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
@@ -29,7 +29,7 @@ private final class CheckpointListenerAPITester: CheckpointListener {
         let _: [String: CustomVariableValue] = context.customVariables
         let result: CheckpointResult = context.result
 
-        if let presented = result as? CheckpointPaywallPresentedResult {
+        if let presented = result as? CheckpointResult.PaywallPresented {
             let outcome: CheckpointPaywallOutcome = presented.paywallOutcome
 
             if let purchased = outcome as? CheckpointPaywallOutcome.Purchased {
@@ -46,9 +46,9 @@ private final class CheckpointListenerAPITester: CheckpointListener {
             }
 
             let _: String = outcome.description
-        } else if let receivedOffering = result as? CheckpointReceivedOfferingResult {
+        } else if let receivedOffering = result as? CheckpointResult.ReceivedOffering {
             let _: Offering = receivedOffering.offering
-        } else if let noAction = result as? CheckpointNoActionResult {
+        } else if let noAction = result as? CheckpointResult.NoAction {
             let _: CheckpointNoActionReason = noAction.reason
             let _: String = noAction.reason.description
         }

--- a/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
+++ b/Tests/APITesters/AllAPITests/RevenueCatUISwiftAPITester/CheckpointAPI.swift
@@ -17,13 +17,13 @@ import RevenueCat
 
 private final class CheckpointListenerAPITester: CheckpointListener {
 
-    func onCheckpointHit(_ context: CheckpointHitContext) {
+    func onCheckpointHit(_ context: CheckpointContext.Hit) {
         let _: CheckpointContext = context
         let _: String = context.identifier
         let _: [String: CustomVariableValue] = context.customVariables
     }
 
-    func onCheckpointCompleted(_ context: CheckpointCompletedContext) {
+    func onCheckpointCompleted(_ context: CheckpointContext.Completed) {
         let _: CheckpointContext = context
         let _: String = context.identifier
         let _: [String: CustomVariableValue] = context.customVariables

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
@@ -584,15 +584,15 @@ private final class ListenerRecorder: CheckpointListener {
     }
 
     private(set) var events: [Event] = []
-    private(set) var hitContexts: [CheckpointHitContext] = []
-    private(set) var completedContexts: [CheckpointCompletedContext] = []
+    private(set) var hitContexts: [CheckpointContext.Hit] = []
+    private(set) var completedContexts: [CheckpointContext.Completed] = []
 
-    func onCheckpointHit(_ context: CheckpointHitContext) {
+    func onCheckpointHit(_ context: CheckpointContext.Hit) {
         self.hitContexts.append(context)
         self.events.append(.hit(context.identifier))
     }
 
-    func onCheckpointCompleted(_ context: CheckpointCompletedContext) {
+    func onCheckpointCompleted(_ context: CheckpointContext.Completed) {
         self.completedContexts.append(context)
         self.events.append(.completed(context.identifier))
     }

--- a/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
+++ b/Tests/RevenueCatUITests/Checkpoints/CheckpointsManagerTests.swift
@@ -69,7 +69,7 @@ final class CheckpointsManagerTests: TestCase {
             params: CheckpointCallParams(customVariables: ["name": "Rick"])
         )
 
-        guard let noAction = result as? CheckpointNoActionResult else {
+        guard let noAction = result as? CheckpointResult.NoAction else {
             return XCTFail("Expected a no-action result")
         }
         XCTAssertEqual(noAction.reason, .unknownCheckpoint)
@@ -80,7 +80,7 @@ final class CheckpointsManagerTests: TestCase {
         XCTAssertEqual(listener.hitContexts.first?.customVariables["name"], "Rick")
         XCTAssertEqual(listener.completedContexts.first?.customVariables["name"], "Rick")
         XCTAssertEqual(
-            (listener.completedContexts.first?.result as? CheckpointNoActionResult)?.reason,
+            (listener.completedContexts.first?.result as? CheckpointResult.NoAction)?.reason,
             noAction.reason
         )
     }
@@ -122,7 +122,7 @@ final class CheckpointsManagerTests: TestCase {
             params: .init(customVariables: customVariables)
         )
 
-        guard let presented = result as? CheckpointPaywallPresentedResult else {
+        guard let presented = result as? CheckpointResult.PaywallPresented else {
             return XCTFail("Expected a presented-paywall result")
         }
         XCTAssertTrue(presented.paywallOutcome is CheckpointPaywallOutcome.Dismissed)
@@ -145,7 +145,7 @@ final class CheckpointsManagerTests: TestCase {
 
         let result = try await manager.checkpoint(identifier: "onboarding", params: .init())
 
-        guard let received = result as? CheckpointReceivedOfferingResult else {
+        guard let received = result as? CheckpointResult.ReceivedOffering else {
             return XCTFail("Expected a received-offering result")
         }
         XCTAssertEqual(received.offering.identifier, "offering-id")
@@ -196,7 +196,7 @@ final class CheckpointsManagerTests: TestCase {
         let manager = CheckpointsManager { _, _ in .noAction(.configurationUnavailable) }
 
         manager.checkpoint(identifier: "disabled", params: .init()) { result in
-            guard case let .success(noAction as CheckpointNoActionResult) = result else {
+            guard case let .success(noAction as CheckpointResult.NoAction) = result else {
                 return XCTFail("Expected a no-action result")
             }
             XCTAssertEqual(noAction.reason, .configurationUnavailable)
@@ -233,7 +233,7 @@ final class CheckpointsManagerTests: TestCase {
 
         let result = try await manager.checkpoint(identifier: invalidIdentifier, params: .init())
 
-        guard let noActionResult = result as? CheckpointNoActionResult else {
+        guard let noActionResult = result as? CheckpointResult.NoAction else {
             return XCTFail("Expected a no-action result")
         }
 
@@ -255,7 +255,7 @@ final class CheckpointsManagerTests: TestCase {
         }
 
         manager.checkpoint(identifier: "invalid checkpoint", params: .init()) { result in
-            guard case let .success(noAction as CheckpointNoActionResult) = result else {
+            guard case let .success(noAction as CheckpointResult.NoAction) = result else {
                 return XCTFail("Expected an invalid-identifier no-action result")
             }
 


### PR DESCRIPTION
## Description
In https://github.com/RevenueCat/purchases-ios/pull/7526#discussion_r3903694545 @ajpallares suggested namespacing the `CheckpointPaywallOutcome` types for improved discoverability, which we did in a follow up commit. For consistency we're now also namespacing the `CheckpointResult` and `CheckpointContext` types in this follow up PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking SPI/API rename across RevenueCatUI checkpoints; integrators must update type casts and listener signatures, but runtime checkpoint logic is unchanged.
> 
> **Overview**
> **Namespaces checkpoint result and listener context types** under `CheckpointResult` and `CheckpointContext`, matching the earlier `CheckpointPaywallOutcome` pattern for discoverability.
> 
> Concrete types move from top-level names (`CheckpointPaywallPresentedResult`, `CheckpointNoActionResult`, `CheckpointReceivedOfferingResult`, `CheckpointHitContext`, `CheckpointCompletedContext`) to nested types such as `CheckpointResult.PaywallPresented`, `CheckpointResult.NoAction`, `CheckpointResult.ReceivedOffering`, `CheckpointContext.Hit`, and `CheckpointContext.Completed`. The SDK nests the result subclasses inside `CheckpointResult` and the context subclasses inside `CheckpointContext`; `CheckpointListener`, `CheckpointsManager`, doc comments, CheckpointTester examples, API testers, and unit tests are updated to the new names only—**no behavior change**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b02ab3cbfb4942826fa8ccc38dc883f55345ced2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->