### PR TITLE
Share one arity check across the strict operators

### DIFF
--- a/Sources/RulesEngine/CustomOperators/LetOperator.swift
+++ b/Sources/RulesEngine/CustomOperators/LetOperator.swift
@@ -39,11 +39,7 @@ extension RulesEngine {
         static func opLet(args: Value, vars: Scope) throws -> Value {
             let raw = Operators.argsAsList(args)
 
-            guard raw.count == 2 else {
-                throw EvaluationError.typeMismatch(
-                    message: "operator '\(operatorName)' expects 2 arguments, got \(raw.count)"
-                )
-            }
+            try Operators.checkArity(raw.count, allowed: [2], operatorName: operatorName)
 
             guard case .object(let declarations) = raw[0] else {
                 throw EvaluationError.typeMismatch(

--- a/Sources/RulesEngine/CustomOperators/RegexOperators.swift
+++ b/Sources/RulesEngine/CustomOperators/RegexOperators.swift
@@ -26,7 +26,7 @@ extension RulesEngine {
         static func opRegexMatch(args: Value, vars: Scope) throws -> Value {
             let operatorName = "rc.regexMatch"
             let evaluated = try Operators.evalArgs(args, vars: vars)
-            try Self.checkArity(evaluated.count, allowed: [2], operatorName: operatorName)
+            try Operators.checkArity(evaluated.count, allowed: [2], operatorName: operatorName)
 
             let operands = try Self.operands(evaluated, operatorName: operatorName)
             return .bool(Self.firstMatch(of: operands.regex, in: operands.input) != nil)
@@ -47,7 +47,7 @@ extension RulesEngine {
         static func opRegexExtract(args: Value, vars: Scope) throws -> Value {
             let operatorName = "rc.regexExtract"
             let evaluated = try Operators.evalArgs(args, vars: vars)
-            try Self.checkArity(evaluated.count, allowed: [2, 3], operatorName: operatorName)
+            try Operators.checkArity(evaluated.count, allowed: [2, 3], operatorName: operatorName)
 
             let operands = try Self.operands(evaluated, operatorName: operatorName)
             let group = try Self.group(evaluated.count == 3 ? evaluated[2] : nil,
@@ -80,7 +80,7 @@ extension RulesEngine {
         static func opRegexReplace(args: Value, vars: Scope) throws -> Value {
             let operatorName = "rc.regexReplace"
             let evaluated = try Operators.evalArgs(args, vars: vars)
-            try Self.checkArity(evaluated.count, allowed: [3], operatorName: operatorName)
+            try Operators.checkArity(evaluated.count, allowed: [3], operatorName: operatorName)
 
             let operands = try Self.operands(evaluated, operatorName: operatorName)
 
@@ -99,17 +99,6 @@ extension RulesEngine {
                     withTemplate: NSRegularExpression.escapedTemplate(for: replacement)
                 )
             )
-        }
-
-        /// Rejects an argument count no overload accepts.
-        static func checkArity(_ count: Int, allowed: [Int], operatorName: String) throws {
-            guard allowed.contains(count) else {
-                let expected = allowed.map(String.init).joined(separator: " or ")
-                throw EvaluationError.typeMismatch(
-                    message: "operator '\(operatorName)' expects \(expected) arguments, "
-                        + "got \(count)"
-                )
-            }
         }
 
         /// Type-checks the `[input, pattern]` pair every regex operator starts

--- a/Sources/RulesEngine/CustomOperators/SemverOperator.swift
+++ b/Sources/RulesEngine/CustomOperators/SemverOperator.swift
@@ -30,12 +30,7 @@ extension RulesEngine {
         static func opSemverCompare(args: Value, vars: Scope) throws -> Value {
             let evaluated = try Operators.evalArgs(args, vars: vars)
 
-            guard evaluated.count == 2 else {
-                throw EvaluationError.typeMismatch(
-                    message: "operator '\(operatorName)' expects 2 arguments, "
-                        + "got \(evaluated.count)"
-                )
-            }
+            try Operators.checkArity(evaluated.count, allowed: [2], operatorName: operatorName)
 
             let left = try SemanticVersion(parsing: evaluated[0])
             let right = try SemanticVersion(parsing: evaluated[1])

--- a/Sources/RulesEngine/CustomOperators/SliceOperator.swift
+++ b/Sources/RulesEngine/CustomOperators/SliceOperator.swift
@@ -29,12 +29,7 @@ extension RulesEngine {
         static func opSlice(args: Value, vars: Scope) throws -> Value {
             let evaluated = try Operators.evalArgs(args, vars: vars)
 
-            guard evaluated.count == 2 || evaluated.count == 3 else {
-                throw EvaluationError.typeMismatch(
-                    message: "operator '\(operatorName)' expects 2 or 3 arguments, "
-                        + "got \(evaluated.count)"
-                )
-            }
+            try Operators.checkArity(evaluated.count, allowed: [2, 3], operatorName: operatorName)
 
             guard case .array(let items) = evaluated[0] else {
                 var hint = ""

--- a/Sources/RulesEngine/CustomOperators/SortByOperator.swift
+++ b/Sources/RulesEngine/CustomOperators/SortByOperator.swift
@@ -27,11 +27,7 @@ extension RulesEngine {
         static func opSortBy(args: Value, vars: Scope) throws -> Value {
             let raw = Operators.argsAsList(args)
 
-            guard raw.count == 2 else {
-                throw EvaluationError.typeMismatch(
-                    message: "operator '\(operatorName)' expects 2 arguments, got \(raw.count)"
-                )
-            }
+            try Operators.checkArity(raw.count, allowed: [2], operatorName: operatorName)
 
             let source = try Evaluator.evaluateValue(raw[0], vars: vars)
             guard case .array(let items) = source else {

--- a/Sources/RulesEngine/CustomOperators/SplitOperator.swift
+++ b/Sources/RulesEngine/CustomOperators/SplitOperator.swift
@@ -37,11 +37,7 @@ extension RulesEngine {
         static func opSplit(args: Value, vars: Scope) throws -> Value {
             let evaluated = try Operators.evalArgs(args, vars: vars)
 
-            guard evaluated.count == 2 else {
-                throw EvaluationError.typeMismatch(
-                    message: "operator 'rc.split' expects 2 arguments, got \(evaluated.count)"
-                )
-            }
+            try Operators.checkArity(evaluated.count, allowed: [2], operatorName: "rc.split")
 
             guard case .string(let input) = evaluated[0] else {
                 throw EvaluationError.typeMismatch(

--- a/Sources/RulesEngine/Operators/AccessorOperators.swift
+++ b/Sources/RulesEngine/Operators/AccessorOperators.swift
@@ -105,11 +105,7 @@ extension RulesEngine {
         /// returns `[]`.
         static func opMissingSome(args: Value, vars: Scope) throws -> Value {
             let evaluated = try Operators.evalArgs(args, vars: vars)
-            guard evaluated.count == 2 else {
-                throw RulesEngine.EvaluationError.typeMismatch(
-                    message: "operator 'missing_some' expects 2 arguments, got \(evaluated.count)"
-                )
-            }
+            try Operators.checkArity(evaluated.count, allowed: [2], operatorName: "missing_some")
             let needCountValue = evaluated[0]
             let options = evaluated[1]
 

--- a/Sources/RulesEngine/Operators/Operators.swift
+++ b/Sources/RulesEngine/Operators/Operators.swift
@@ -132,6 +132,25 @@ extension RulesEngine {
             try argsAsList(args).map { try Evaluator.evaluateValue($0, vars: vars) }
         }
 
+        /// Rejects an argument count no overload of `operatorName` accepts.
+        ///
+        /// Only for operators that are strict about arity. Several others take
+        /// a fixed number of arguments and silently ignore extras — `substr`,
+        /// `<`, `reduce`, and anything reading through `firstArgEvaluated` —
+        /// matching `json-logic-js`, where a spread call simply drops what the
+        /// function does not declare. Whether an operator is strict is a
+        /// decision each one makes; this only spells the refusal the same way
+        /// every time.
+        static func checkArity(_ count: Int, allowed: [Int], operatorName: String) throws {
+            guard allowed.contains(count) else {
+                let expected = allowed.map(String.init).joined(separator: " or ")
+                throw EvaluationError.typeMismatch(
+                    message: "operator '\(operatorName)' expects \(expected) arguments, "
+                        + "got \(count)"
+                )
+            }
+        }
+
         /// Evaluate exactly two arguments. Used by binary operators (`==`,
         /// `!=`, `===`, `!==`).
         /// Evaluate args and return the first two operands. Missing


### PR DESCRIPTION
### Motivation

Follow-up to https://github.com/RevenueCat/purchases-android/pull/4144#discussion_r3905379358. Seven operators hand-wrote the same count check and the same message, most recently the regex ones. Stacked on #7558; Android counterpart is https://github.com/RevenueCat/purchases-android/pull/4157.

### Description

- `Operators.checkArity` lives next to `evalArgs`, whose result it always checks, rather than in a utility of its own.
- Every message it produces is byte-identical to what each operator wrote before, including `rc.slice`'s "2 or 3", so no fixture moves and no behavior changes.
- It only serves operators that are *strict* about arity. `substr`, `<`, `reduce` and anything on `firstArgEvaluated` deliberately ignore extra arguments, as `json-logic-js` does, and their fixtures pin that.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication of arity validation with identical error messages; no new operators or evaluation semantics.
> 
> **Overview**
> Introduces shared **`Operators.checkArity`** beside `evalArgs` and routes strict operators through it instead of duplicating `guard` blocks and error strings.
> 
> **`rc.let`**, **`rc.sortBy`**, **`rc.semverCompare`**, **`rc.slice`**, **`rc.split`**, **`missing_some`**, and all three regex operators now call the helper with their allowed counts (e.g. `[2]`, `[2, 3]`). The private **`RegexOperators.checkArity`** is removed. Documented intent: only operators that reject wrong arity use this; others that mirror **`json-logic-js`** by ignoring extra args are unchanged.
> 
> Arity failure messages stay the same wording (including multi-arity forms like “2 or 3”), so evaluation behavior and fixtures should be unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24c20ed44d46b63cee2f8a47c717a4a6b4decd17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->