### PR TITLE
Add IAM-specific webbilling paths

### DIFF
--- a/Sources/Networking/WebBillingHTTPRequestPath.swift
+++ b/Sources/Networking/WebBillingHTTPRequestPath.swift
@@ -67,6 +67,18 @@ extension HTTPRequest.WebBillingPath: HTTPRequestPath {
         }
     }
 
+    var relativeIAMPath: String {
+        switch self {
+        case .getWebOfferingProducts:
+            return "/rcbilling/v1/customer/offering_products"
+        case let .getWebBillingProducts(userId: _, productIds: productIds):
+            let encodedProductIds = productIds.map { productId in
+                "id=\(productId.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? productId)"
+            }.joined(separator: "&")
+            return "/rcbilling/v1/customer/products?\(encodedProductIds)"
+        }
+    }
+
     var name: String {
         switch self {
         case .getWebOfferingProducts:

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -300,6 +300,87 @@ class HTTPRequestTests: TestCase {
         }
     }
 
+    func testWebBillingOfferingProductsRelativePathIncludesAppUserID() {
+        let path = HTTPRequest.WebBillingPath.getWebOfferingProducts(appUserID: Self.userID)
+
+        expect(path.relativePath) == "/rcbilling/v1/subscribers/\(Self.userID)/offering_products"
+    }
+
+    func testWebBillingOfferingProductsRelativeIAMPathOmitsAppUserID() {
+        let path = HTTPRequest.WebBillingPath.getWebOfferingProducts(appUserID: Self.userID)
+
+        expect(path.relativeIAMPath) == "/rcbilling/v1/customer/offering_products"
+        expect(path.relativeIAMPath).toNot(contain(Self.userID))
+        expect(path.relativeIAMPath) != path.relativePath
+    }
+
+    func testWebBillingProductsRelativePathIncludesUserIDAndProductIDs() {
+        let path = HTTPRequest.WebBillingPath.getWebBillingProducts(userId: Self.userID, productIds: ["product_1"])
+
+        expect(path.relativePath) == "/rcbilling/v1/subscribers/\(Self.userID)/products?id=product_1"
+    }
+
+    func testWebBillingProductsRelativeIAMPathOmitsUserID() {
+        let path = HTTPRequest.WebBillingPath.getWebBillingProducts(userId: Self.userID, productIds: ["product_1"])
+
+        expect(path.relativeIAMPath) == "/rcbilling/v1/customer/products?id=product_1"
+        expect(path.relativeIAMPath).toNot(contain(Self.userID))
+        expect(path.relativeIAMPath) != path.relativePath
+    }
+
+    func testWebBillingProductsRelativeIAMPathJoinsMultipleProductIDs() {
+        // `productIds` is a `Set`, so its iteration order isn't guaranteed: compare the
+        // resulting query items as an unordered set of `id=` tokens instead of an exact string.
+        let productIds: Set<String> = ["product_1", "product_2", "product_3"]
+        let path = HTTPRequest.WebBillingPath.getWebBillingProducts(userId: Self.userID, productIds: productIds)
+
+        expect(path.relativeIAMPath).to(beginWith("/rcbilling/v1/customer/products?"))
+
+        let query = path.relativeIAMPath.replacingOccurrences(
+            of: "/rcbilling/v1/customer/products?",
+            with: ""
+        )
+        let actualTokens = Set(query.components(separatedBy: "&"))
+        let expectedTokens = Set(productIds.map { "id=\($0)" })
+
+        expect(actualTokens) == expectedTokens
+    }
+
+    func testWebBillingProductsRelativeIAMPathPercentEncodesProductIDs() {
+        let productIdWithSpace = "product with space"
+        let path = HTTPRequest.WebBillingPath.getWebBillingProducts(
+            userId: Self.userID,
+            productIds: [productIdWithSpace]
+        )
+
+        expect(path.relativeIAMPath) == "/rcbilling/v1/customer/products?id=product%20with%20space"
+        expect(path.relativeIAMPath).toNot(contain(" "))
+    }
+
+    func testWebBillingProductsRelativeIAMPathWithNoProductIDsHasEmptyQuery() {
+        let path = HTTPRequest.WebBillingPath.getWebBillingProducts(userId: Self.userID, productIds: [])
+
+        expect(path.relativeIAMPath) == "/rcbilling/v1/customer/products?"
+    }
+
+    func testWebBillingPathsURLPreferringIAMPathUsesIAMRelativePath() {
+        let offeringProductsPath = HTTPRequest.WebBillingPath.getWebOfferingProducts(appUserID: Self.userID)
+        let productsPath = HTTPRequest.WebBillingPath.getWebBillingProducts(
+            userId: Self.userID,
+            productIds: ["product_1"]
+        )
+
+        expect(offeringProductsPath.url(preferIAMPath: true)?.absoluteString)
+            == "https://api.revenuecat.com/rcbilling/v1/customer/offering_products"
+        expect(offeringProductsPath.url(preferIAMPath: false)?.absoluteString)
+            == "https://api.revenuecat.com/rcbilling/v1/subscribers/\(Self.userID)/offering_products"
+
+        expect(productsPath.url(preferIAMPath: true)?.absoluteString)
+            == "https://api.revenuecat.com/rcbilling/v1/customer/products?id=product_1"
+        expect(productsPath.url(preferIAMPath: false)?.absoluteString)
+            == "https://api.revenuecat.com/rcbilling/v1/subscribers/\(Self.userID)/products?id=product_1"
+    }
+
     func testNonMainPathsDoNotUseAPISources() {
         let paths: [any HTTPRequestPath] = [
             HTTPRequest.DiagnosticsPath.postDiagnostics


### PR DESCRIPTION
Updates the WebBilling paths to support their IAM-specific alternatives.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized URL construction for web billing with existing IAM routing; covered by unit tests and no auth or payment logic changes.
> 
> **Overview**
> Adds **`relativeIAMPath`** on `HTTPRequest.WebBillingPath` so web billing calls can use token-based `/rcbilling/v1/customer/...` URLs instead of subscriber-scoped paths when **`preferIAMPath`** is true.
> 
> Offering products and product lookups keep the same query encoding for product IDs, but IAM routes drop the app user ID from the path (e.g. `/customer/offering_products` and `/customer/products?id=...`). Unit tests cover path shape, percent-encoding, multi-product queries, and full URL resolution for both IAM and legacy modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fbb2726adba97d79c5e182898a0bac40340d5e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->