### PR TITLE
Remove access token revocation

### DIFF
--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -135,19 +135,6 @@ class IdentityManager: CurrentUserProvider {
         }
     }
 
-    func revokeCurrentAccessToken(completion: @escaping (PurchasesError?) -> Void) {
-        guard self.currentAppUserID != Self.uiPreviewModeAppUserID else {
-            completion(ErrorUtils.unsupportedInUIPreviewModeError())
-            return
-        }
-
-        if self.tokenManager.enabled {
-            self.performAccessTokenRevocation(for: self.currentAppUserID, completion: completion)
-        } else {
-            completion(nil)
-        }
-    }
-
     func switchUser(to newAppUserID: String) {
         guard self.currentAppUserID != Self.uiPreviewModeAppUserID &&
               newAppUserID != Self.uiPreviewModeAppUserID else {
@@ -231,12 +218,6 @@ private extension IdentityManager {
             case .failure(let error):
                 completion(.failure(error))
             }
-        }
-    }
-
-    func performAccessTokenRevocation(for appUserID: String, completion: @escaping (PurchasesError?) -> Void) {
-        self.backend.token.revokeAccessTokens(for: appUserID) { error in
-            completion(error?.asPurchasesError)
         }
     }
 

--- a/Sources/Networking/Operations/TokenOperations.swift
+++ b/Sources/Networking/Operations/TokenOperations.swift
@@ -170,24 +170,6 @@ final class TokenRevocationOperation: CacheableNetworkOperation, @unchecked Send
                      individualizedCacheKeyPart: appUserID)
     }
 
-    static func createFactory(
-        configuration: UserSpecificConfiguration,
-        accessToken: String,
-        appUserID: String,
-        callbackCache: CallbackCache<TokenRevokeCallback>
-    ) -> CacheableNetworkOperationFactory<TokenRevocationOperation> {
-        return .init({
-            .init(
-                configuration: configuration,
-                token: accessToken,
-                tokenTypeHint: "access_token",
-                appUserID: appUserID,
-                callbackCache: callbackCache,
-                cacheKey: $0
-            ) },
-                     individualizedCacheKeyPart: appUserID)
-    }
-
     private init(
         configuration: UserSpecificConfiguration,
         token: String,

--- a/Sources/Networking/TokenAPI.swift
+++ b/Sources/Networking/TokenAPI.swift
@@ -76,30 +76,6 @@ class TokenAPI {
         }
     }
 
-    func revokeAccessTokens(for appUserID: String, completion: @escaping (BackendError?) -> Void) {
-        if let accessToken = tokenManager.currentAccessToken {
-            let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
-                                                                    appUserID: appUserID)
-
-            let factory = TokenRevocationOperation.createFactory(configuration: config,
-                                                                 accessToken: accessToken,
-                                                                 appUserID: appUserID,
-                                                                 callbackCache: self.revokeCallbacksCache)
-
-            let revokeCallback = TokenRevokeCallback(cacheKey: factory.cacheKey) { error in
-                if error == nil {
-                    self.tokenManager.deleteAccessToken(for: appUserID)
-                }
-                completion(error)
-            }
-            let cacheStatus = self.revokeCallbacksCache.add(revokeCallback)
-
-            self.backendConfig.operationQueue.addCacheableOperation(with: factory, cacheStatus: cacheStatus)
-        } else {
-            completion(nil)
-        }
-    }
-
 }
 
 // @unchecked because:

--- a/Tests/UnitTests/Identity/IdentityManagerTests.swift
+++ b/Tests/UnitTests/Identity/IdentityManagerTests.swift
@@ -527,64 +527,6 @@ class IdentityManagerTests: TestCase {
         expect(self.mockDeviceCache.invokedCopySubscriberAttributesParameters?.newAppUserID) == "new_user_id"
     }
 
-    // MARK: - RevokeCurrentAccessToken
-
-    func testRevokeCurrentAccessTokenFailsInUIPreviewMode() {
-        let dangerousSettings = DangerousSettings(uiPreviewMode: true)
-        self.mockSystemInfo = MockSystemInfo(
-            platformInfo: nil,
-            finishTransactions: false,
-            dangerousSettings: dangerousSettings
-        )
-        let manager = create(appUserID: "my_user_id")
-
-        let receivedError = waitUntilValue { completed in
-            manager.revokeCurrentAccessToken { error in completed(error as NSError?) }
-        }
-
-        expect(receivedError?.code) == ErrorCode.unsupportedError.rawValue
-        expect(self.mockTokenAPI.invokedRevokeAccessTokens) == false
-    }
-
-    func testRevokeCurrentAccessTokenDoesNothingWhenTokenManagerIsDisabled() {
-        let manager = self.create(appUserID: nil)
-        self.mockDeviceCache.stubbedAppUserID = "myUser"
-
-        let receivedError = waitUntilValue { completed in
-            manager.revokeCurrentAccessToken(completion: completed)
-        }
-
-        expect(receivedError).to(beNil())
-        expect(self.mockTokenAPI.invokedRevokeAccessTokens) == false
-    }
-
-    func testRevokeCurrentAccessTokenCallsTokenAPIWhenTokenManagerIsEnabled() {
-        self.mockTokenManager = MockTokenManager(enabled: true)
-        let manager = self.create(appUserID: nil)
-        self.mockDeviceCache.stubbedAppUserID = "myUser"
-
-        let receivedError = waitUntilValue { completed in
-            manager.revokeCurrentAccessToken(completion: completed)
-        }
-
-        expect(receivedError).to(beNil())
-        expect(self.mockTokenAPI.invokedRevokeAccessTokensCount) == 1
-        expect(self.mockTokenAPI.invokedRevokeAccessTokensParametersList) == ["myUser"]
-    }
-
-    func testRevokeCurrentAccessTokenPassesThroughTokenAPIErrors() {
-        self.mockTokenManager = MockTokenManager(enabled: true)
-        let manager = self.create(appUserID: nil)
-        self.mockDeviceCache.stubbedAppUserID = "myUser"
-        self.mockTokenAPI.stubbedRevokeAccessTokensResult = .missingAppUserID()
-
-        let receivedError = waitUntilValue { completed in
-            manager.revokeCurrentAccessToken { error in completed(error as NSError?) }
-        }
-
-        expect(receivedError?.code) == ErrorCode.invalidAppUserIdError.rawValue
-    }
-
     // MARK: - LogOut with IAM enabled
 
     func testLogOutDoesNotRevokeTokensWhenTokenManagerIsDisabled() {

--- a/Tests/UnitTests/Mocks/MockTokenAPI.swift
+++ b/Tests/UnitTests/Mocks/MockTokenAPI.swift
@@ -52,20 +52,6 @@ class MockTokenAPI: TokenAPI {
         completion(stubbedRevokeTokensResult)
     }
 
-    // MARK: - revokeAccessTokens(for:completion:)
-
-    var invokedRevokeAccessTokens = false
-    var invokedRevokeAccessTokensCount = 0
-    var invokedRevokeAccessTokensParametersList: [String] = []
-    var stubbedRevokeAccessTokensResult: BackendError?
-
-    override func revokeAccessTokens(for appUserID: String, completion: @escaping (BackendError?) -> Void) {
-        invokedRevokeAccessTokens = true
-        invokedRevokeAccessTokensCount += 1
-        invokedRevokeAccessTokensParametersList.append(appUserID)
-        completion(stubbedRevokeAccessTokensResult)
-    }
-
 }
 
 extension MockTokenAPI: @unchecked Sendable {}

--- a/Tests/UnitTests/Networking/Backend/BackendTokenRevocationTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendTokenRevocationTests.swift
@@ -84,47 +84,4 @@ class BackendTokenRevocationTests: BaseBackendTokenRevocationTests {
         expect(self.tokenManager.invokedDeleteTokens) == false
     }
 
-    // MARK: - revokeAccessTokens(for:completion:)
-
-    func testRevokeAccessTokensDoesNothingWithoutANetworkCallWhenThereIsNoAccessToken() {
-        self.tokenManager.stubbedCurrentAccessToken = nil
-
-        let receivedError = waitUntilValue { completed in
-            self.token.revokeAccessTokens(for: "user-id", completion: completed)
-        }
-
-        expect(receivedError).to(beNil())
-        expect(self.httpClient.calls).to(beEmpty())
-        expect(self.tokenManager.invokedDeleteAccessToken) == false
-    }
-
-    func testRevokeAccessTokensSendsTheAccessTokenAndDeletesItLocallyOnSuccess() throws {
-        self.tokenManager.stubbedCurrentAccessToken = "access-token-value"
-        self.httpClient.mock(requestPath: .tokenLogOut, response: .init(statusCode: .success))
-
-        let receivedError = waitUntilValue { completed in
-            self.token.revokeAccessTokens(for: "user-id", completion: completed)
-        }
-
-        expect(receivedError).to(beNil())
-        expect(self.tokenManager.invokedDeleteAccessTokenParametersList) == ["user-id"]
-
-        let body = try XCTUnwrap(self.httpClient.calls.first?.request.requestBody as? TokenRevocationOperation.Body)
-        expect(body.token) == "access-token-value"
-        expect(body.tokenTypeHint) == "access_token"
-    }
-
-    func testRevokeAccessTokensPassesNetworkErrorsAndDoesNotDeleteItLocally() {
-        self.tokenManager.stubbedCurrentAccessToken = "access-token-value"
-        let stubbedError: NetworkError = .unexpectedResponse(nil)
-        self.httpClient.mock(requestPath: .tokenLogOut, response: .init(error: stubbedError))
-
-        let receivedError = waitUntilValue { completed in
-            self.token.revokeAccessTokens(for: "user-id", completion: completed)
-        }
-
-        expect(receivedError) == .networkError(stubbedError)
-        expect(self.tokenManager.invokedDeleteAccessToken) == false
-    }
-
 }


### PR DESCRIPTION
This was added as part of testing token functionality, but revoking the access token also revokes the session token, and we already have the `logOut` method for that.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletion of an unused/redundant API with no changes to the existing `logOut` refresh-token revocation flow.
> 
> **Overview**
> Removes the **access-token-only** revocation path that was added for IAM testing. **`revokeCurrentAccessToken`**, **`TokenAPI.revokeAccessTokens`**, and the access-token **`TokenRevocationOperation`** factory are deleted end-to-end, along with their unit tests and **`MockTokenAPI`** hooks.
> 
> **Full logout is unchanged:** when the token manager is enabled, **`logOut`** still revokes via **`revokeTokens`** (refresh token + local token cleanup) through **`performTokenRevocation`**, which the PR description notes already invalidates the session in practice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98784e971c8c2f272163f5b5a29be725437f9e26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->