### PR TITLE
fix(checkpoints): ensure remote config reads are generation consistent

### DIFF
--- a/Sources/Checkpoints/CheckpointWorkflowResolver.swift
+++ b/Sources/Checkpoints/CheckpointWorkflowResolver.swift
@@ -146,6 +146,10 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
             rulesSnapshot = snapshot
         } catch let error as CancellationError {
             throw error
+        } catch CheckpointRulesProviderError.remoteConfigDisabled {
+            return .noAction(.configurationUnavailable)
+        } catch CheckpointRulesProviderError.stale {
+            return nil
         } catch {
             return .noAction(.configurationUnavailable)
         }

--- a/Sources/Checkpoints/CheckpointWorkflowResolver.swift
+++ b/Sources/Checkpoints/CheckpointWorkflowResolver.swift
@@ -146,8 +146,6 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
             rulesSnapshot = snapshot
         } catch let error as CancellationError {
             throw error
-        } catch CheckpointRulesProviderError.remoteConfigDisabled {
-            return .noAction(.configurationUnavailable)
         } catch CheckpointRulesProviderError.stale {
             return nil
         } catch {

--- a/Sources/Checkpoints/CheckpointWorkflowResolver.swift
+++ b/Sources/Checkpoints/CheckpointWorkflowResolver.swift
@@ -206,7 +206,7 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
         // The offering mapping is resolved per branch now, since only a UI workflow needs it.
         guard let rule else { return .noAction(.noMatch) }
 
-        let resolution = await self.resolve(rule)
+        let resolution = try await self.resolve(rule)
         guard self.isCurrent(rulesSnapshot, audienceConfiguration) else {
             return nil
         }
@@ -284,12 +284,14 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
         }
     }
 
-    private func resolve(_ rule: CheckpointRule) async -> CheckpointResolution {
+    private func resolve(_ rule: CheckpointRule) async throws -> CheckpointResolution {
         // Deliberately the non-prewarming read: an offering workflow renders nothing, and prewarming takes
         // its fonts from `uiConfig` rather than from the workflow's screens, so it isn't free here.
         let workflowData: WorkflowDataResult
         do {
             workflowData = try await self.workflowManager.workflowData(workflowId: rule.workflowId)
+        } catch let error as CancellationError {
+            throw error
         } catch {
             return Self.unservable(rule, reason: error.localizedDescription)
         }

--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -38,6 +38,7 @@ enum RemoteConfigStrings {
     case prefetchingBlobCount(Int)
     case receivedConfiguration(activeTopics: [String], changedTopics: [String])
     case refreshing(domain: String, manifestPresent: Bool, isAppBackgrounded: Bool)
+    case remoteConfigReadRetry
     case refreshFailed(BackendError)
     case skippingInvalidBlob(String)
     case persistedConfiguration(domain: String, activeTopicCount: Int, referencedBlobCount: Int)
@@ -122,6 +123,8 @@ extension RemoteConfigStrings: LogMessage {
         case let .refreshing(domain, manifestPresent, isAppBackgrounded):
             return "Refreshing remote config for domain '\(domain)' " +
                 "(manifestPresent: \(manifestPresent), isAppBackgrounded: \(isAppBackgrounded))."
+        case .remoteConfigReadRetry:
+            return "Remote configuration changed during a read; retrying once."
         case let .refreshFailed(error):
             return "Remote config refresh failed. Keeping cached configuration. Error: \(error)"
         case let .skippingInvalidBlob(ref):

--- a/Sources/Networking/AudiencesConfigProvider.swift
+++ b/Sources/Networking/AudiencesConfigProvider.swift
@@ -44,7 +44,7 @@ final class AudiencesConfigProvider: AudiencesConfigProviderType {
     }
 
     func configuration() async throws -> AudienceConfigurationSnapshot? {
-        return try await self.manager.readConsistent { _ in
+        return try await self.manager.readConsistent {
             try await self.loadConfiguration()
         }
     }

--- a/Sources/Networking/AudiencesConfigProvider.swift
+++ b/Sources/Networking/AudiencesConfigProvider.swift
@@ -44,7 +44,7 @@ final class AudiencesConfigProvider: AudiencesConfigProviderType {
     }
 
     func configuration() async throws -> AudienceConfigurationSnapshot? {
-        return try await self.manager.readConsistent {
+        return try await self.manager.readConsistent { _ in
             try await self.loadConfiguration()
         }
     }

--- a/Sources/Networking/AudiencesConfigProvider.swift
+++ b/Sources/Networking/AudiencesConfigProvider.swift
@@ -44,19 +44,19 @@ final class AudiencesConfigProvider: AudiencesConfigProviderType {
     }
 
     func configuration() async throws -> AudienceConfigurationSnapshot? {
-        try Task.checkCancellation()
-
-        guard let topicSnapshot = await self.manager.topicCacheSnapshot(.audiences) else {
-            return nil
+        return try await self.manager.readConsistent {
+            try await self.loadConfiguration()
         }
+    }
+
+    private func loadConfiguration() async throws -> AudienceConfigurationSnapshot? {
+        try Task.checkCancellation()
+        guard let topicSnapshot = await self.manager.topicCacheSnapshot(.audiences) else { return nil }
 
         let prefetchRefs = topicSnapshot.key.values.compactMap { $0.prefetch ? $0.blobRef : nil }
         await self.manager.ensureBlobsDownloaded(prefetchRefs)
         guard await self.manager.isCurrent(topicSnapshot, for: .audiences) else { return nil }
-
-        if let cached = self.cachedConfiguration.value(for: topicSnapshot) {
-            return cached
-        }
+        if let cached = self.cachedConfiguration.value(for: topicSnapshot) { return cached }
 
         do {
             guard topicSnapshot.key[Self.audiencesBlobItemKey] != nil,
@@ -66,17 +66,12 @@ final class AudiencesConfigProvider: AudiencesConfigProviderType {
                   ) else {
                 return nil
             }
-
-            let audiences = try Self.decodeAudiences(from: blob)
-            let backendPredicateResults = Self.decodeBackendPredicateResults(from: topicSnapshot.key)
-
-            guard await self.manager.isCurrent(topicSnapshot, for: .audiences) else { return nil }
-
             let configuration = AudienceConfigurationSnapshot(
-                audiences: audiences,
-                backendPredicateResults: backendPredicateResults,
+                audiences: try Self.decodeAudiences(from: blob),
+                backendPredicateResults: Self.decodeBackendPredicateResults(from: topicSnapshot.key),
                 configGeneration: topicSnapshot.generation
             )
+            guard await self.manager.isCurrent(topicSnapshot, for: .audiences) else { return nil }
             self.cachedConfiguration.store(configuration, for: topicSnapshot)
             return configuration
         } catch {

--- a/Sources/Networking/CheckpointsConfigProvider.swift
+++ b/Sources/Networking/CheckpointsConfigProvider.swift
@@ -24,6 +24,7 @@ struct CheckpointRulesSnapshot {
 enum CheckpointRulesProviderError: Error, Equatable {
 
     case payloadUnavailable
+    case stale
 
 }
 
@@ -40,11 +41,16 @@ final class CheckpointsConfigProvider: CheckpointsConfigProviderType {
     }
 
     func rules(for identifier: String) async throws -> CheckpointRulesSnapshot? {
-        return try await self.manager.readConsistent {
-            let rules = try await self.loadRules(for: identifier)
-            return rules.map {
-                CheckpointRulesSnapshot(ruleSet: $0, configGeneration: self.manager.configGeneration)
+        do {
+            return try await self.manager.readConsistent {
+                let generation = self.manager.configGeneration
+                let rules = try await self.loadRules(for: identifier)
+                return rules.map {
+                    CheckpointRulesSnapshot(ruleSet: $0, configGeneration: generation)
+                }
             }
+        } catch RemoteConfigConsistencyError.stale {
+            throw CheckpointRulesProviderError.stale
         }
     }
 

--- a/Sources/Networking/CheckpointsConfigProvider.swift
+++ b/Sources/Networking/CheckpointsConfigProvider.swift
@@ -40,7 +40,7 @@ final class CheckpointsConfigProvider: CheckpointsConfigProviderType {
     }
 
     func rules(for identifier: String) async throws -> CheckpointRulesSnapshot? {
-        return try await self.manager.readConsistent {
+        return try await self.manager.readConsistent { _ in
             let rules = try await self.loadRules(for: identifier)
             return rules.map {
                 CheckpointRulesSnapshot(ruleSet: $0, configGeneration: self.manager.configGeneration)

--- a/Sources/Networking/CheckpointsConfigProvider.swift
+++ b/Sources/Networking/CheckpointsConfigProvider.swift
@@ -40,7 +40,7 @@ final class CheckpointsConfigProvider: CheckpointsConfigProviderType {
     }
 
     func rules(for identifier: String) async throws -> CheckpointRulesSnapshot? {
-        return try await self.manager.readConsistent { _ in
+        return try await self.manager.readConsistent {
             let rules = try await self.loadRules(for: identifier)
             return rules.map {
                 CheckpointRulesSnapshot(ruleSet: $0, configGeneration: self.manager.configGeneration)

--- a/Sources/Networking/CheckpointsConfigProvider.swift
+++ b/Sources/Networking/CheckpointsConfigProvider.swift
@@ -40,20 +40,10 @@ final class CheckpointsConfigProvider: CheckpointsConfigProviderType {
     }
 
     func rules(for identifier: String) async throws -> CheckpointRulesSnapshot? {
-        while true {
-            try Task.checkCancellation()
-            let configGeneration = self.manager.configGeneration
-
-            do {
-                let rules = try await self.loadRules(for: identifier)
-                guard self.manager.configGeneration == configGeneration else { continue }
-
-                return rules.map {
-                    CheckpointRulesSnapshot(ruleSet: $0, configGeneration: configGeneration)
-                }
-            } catch {
-                guard self.manager.configGeneration == configGeneration else { continue }
-                throw error
+        return try await self.manager.readConsistent {
+            let rules = try await self.loadRules(for: identifier)
+            return rules.map {
+                CheckpointRulesSnapshot(ruleSet: $0, configGeneration: self.manager.configGeneration)
             }
         }
     }

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -93,9 +93,11 @@ extension RemoteConfigManagerType {
         _ operation: () async throws -> Value?
     ) async throws -> Value? {
         for attempt in 0...1 {
+            try Task.checkCancellation()
             let generation = self.configGeneration
             do {
                 let value = try await operation()
+                try Task.checkCancellation()
 
                 guard self.configGeneration == generation else {
                     guard attempt == 0 else {

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -151,7 +151,6 @@ extension RemoteConfigManagerType {
         }
     }
 
-
     func mergeItemsBlobData<T: Decodable>(
         for topic: RemoteConfigTopic,
         itemKeys: [String],

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -83,11 +83,11 @@ extension RemoteConfigManagerType {
     /// Performs a read against one config generation and retries once if a successful read was
     /// superseded while suspended. Errors and cancellation are propagated immediately.
     func readConsistent<Value>(
-        _ operation: (Int) async throws -> Value?
+        _ operation: () async throws -> Value?
     ) async throws -> Value? {
         for attempt in 0...1 {
             let generation = self.configGeneration
-            let value = try await operation(generation)
+            let value = try await operation()
 
             guard self.configGeneration == generation else {
                 guard attempt == 0 else { return nil }

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -80,6 +80,27 @@ protocol RemoteConfigManagerType: AnyObject {
 
 extension RemoteConfigManagerType {
 
+    /// Performs a read against one config generation and retries once if a successful read was
+    /// superseded while suspended. Errors and cancellation are propagated immediately.
+    func readConsistent<Value>(
+        _ operation: () async throws -> Value?
+    ) async throws -> Value? {
+        for attempt in 0...1 {
+            let generation = self.configGeneration
+            let value = try await operation()
+
+            guard self.configGeneration == generation else {
+                guard attempt == 0 else { return nil }
+                Logger.verbose(RemoteConfigStrings.remoteConfigReadRetry)
+                continue
+            }
+
+            return value
+        }
+
+        return nil
+    }
+
     func withCurrentConfigGeneration<T>(_ operation: (Int) -> T?) -> T? {
         let generation = self.configGeneration
         guard let value = operation(generation),
@@ -129,6 +150,7 @@ extension RemoteConfigManagerType {
             committed = latest
         }
     }
+
 
     func mergeItemsBlobData<T: Decodable>(
         for topic: RemoteConfigTopic,

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -83,11 +83,11 @@ extension RemoteConfigManagerType {
     /// Performs a read against one config generation and retries once if a successful read was
     /// superseded while suspended. Errors and cancellation are propagated immediately.
     func readConsistent<Value>(
-        _ operation: () async throws -> Value?
+        _ operation: (Int) async throws -> Value?
     ) async throws -> Value? {
         for attempt in 0...1 {
             let generation = self.configGeneration
-            let value = try await operation()
+            let value = try await operation(generation)
 
             guard self.configGeneration == generation else {
                 guard attempt == 0 else { return nil }

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -94,17 +94,27 @@ extension RemoteConfigManagerType {
     ) async throws -> Value? {
         for attempt in 0...1 {
             let generation = self.configGeneration
-            let value = try await operation()
+            do {
+                let value = try await operation()
 
-            guard self.configGeneration == generation else {
+                guard self.configGeneration == generation else {
+                    guard attempt == 0 else {
+                        throw RemoteConfigConsistencyError.stale
+                    }
+                    Logger.verbose(RemoteConfigStrings.remoteConfigReadRetry)
+                    continue
+                }
+
+                return value
+            } catch let error as CancellationError {
+                throw error
+            } catch {
+                guard self.configGeneration != generation else { throw error }
                 guard attempt == 0 else {
                     throw RemoteConfigConsistencyError.stale
                 }
                 Logger.verbose(RemoteConfigStrings.remoteConfigReadRetry)
-                continue
             }
-
-            return value
         }
 
         return nil

--- a/Sources/Networking/RemoteConfigManager.swift
+++ b/Sources/Networking/RemoteConfigManager.swift
@@ -78,10 +78,17 @@ protocol RemoteConfigManagerType: AnyObject {
 
 }
 
+enum RemoteConfigConsistencyError: Error, Equatable {
+
+    case stale
+
+}
+
 extension RemoteConfigManagerType {
 
     /// Performs a read against one config generation and retries once if a successful read was
-    /// superseded while suspended. Errors and cancellation are propagated immediately.
+    /// superseded while suspended. Errors and cancellation are propagated immediately. An exhausted
+    /// stale read throws `RemoteConfigConsistencyError.stale`.
     func readConsistent<Value>(
         _ operation: () async throws -> Value?
     ) async throws -> Value? {
@@ -90,7 +97,9 @@ extension RemoteConfigManagerType {
             let value = try await operation()
 
             guard self.configGeneration == generation else {
-                guard attempt == 0 else { return nil }
+                guard attempt == 0 else {
+                    throw RemoteConfigConsistencyError.stale
+                }
                 Logger.verbose(RemoteConfigStrings.remoteConfigReadRetry)
                 continue
             }

--- a/Sources/Networking/Responses/WorkflowsResponse.swift
+++ b/Sources/Networking/Responses/WorkflowsResponse.swift
@@ -262,6 +262,9 @@ import Foundation
     /// The workflow itself resolved, but its `ui_config` couldn't be assembled.
     case uiConfigUnavailable(workflowId: String)
 
+    /// The workflow read was superseded by a remote-config update before it could complete consistently.
+    case configurationUnavailable(workflowId: String)
+
 }
 
 // MARK: - Codable

--- a/Sources/Networking/UiConfigProvider.swift
+++ b/Sources/Networking/UiConfigProvider.swift
@@ -23,7 +23,7 @@ final class UiConfigProvider {
     /// Assembles a ``UIConfig`` from the `ui_config` topic's parts. Returns `nil` when any part is unavailable
     /// or fails to decode, so callers never render with a partially assembled configuration.
     func getUiConfig() async -> UIConfig? {
-        return try? await self.manager.readConsistent { _ in await self.getUiConfigOnce() }
+        return try? await self.manager.readConsistent { await self.getUiConfigOnce() }
     }
 
     private func getUiConfigOnce() async -> UIConfig? {
@@ -81,7 +81,7 @@ final class UiConfigProvider {
 #else
     // Paywalls V2 (and therefore workflows) aren't supported on tvOS, where `UIConfig` carries no fields.
     func getUiConfig() async -> UIConfig? {
-        return try? await self.manager.readConsistent { _ in await self.getUiConfigOnce() }
+        return try? await self.manager.readConsistent { await self.getUiConfigOnce() }
     }
 
     private func getUiConfigOnce() async -> UIConfig? {

--- a/Sources/Networking/UiConfigProvider.swift
+++ b/Sources/Networking/UiConfigProvider.swift
@@ -23,6 +23,10 @@ final class UiConfigProvider {
     /// Assembles a ``UIConfig`` from the `ui_config` topic's parts. Returns `nil` when any part is unavailable
     /// or fails to decode, so callers never render with a partially assembled configuration.
     func getUiConfig() async -> UIConfig? {
+        return try? await self.manager.readConsistent { await self.getUiConfigOnce() }
+    }
+
+    private func getUiConfigOnce() async -> UIConfig? {
         guard let snapshot = await self.topicSnapshotWithUiConfigParts() else {
             return nil
         }
@@ -77,6 +81,10 @@ final class UiConfigProvider {
 #else
     // Paywalls V2 (and therefore workflows) aren't supported on tvOS, where `UIConfig` carries no fields.
     func getUiConfig() async -> UIConfig? {
+        return try? await self.manager.readConsistent { await self.getUiConfigOnce() }
+    }
+
+    private func getUiConfigOnce() async -> UIConfig? {
         guard let snapshot = await self.topicSnapshotWithUiConfigParts() else {
             return nil
         }

--- a/Sources/Networking/UiConfigProvider.swift
+++ b/Sources/Networking/UiConfigProvider.swift
@@ -23,7 +23,7 @@ final class UiConfigProvider {
     /// Assembles a ``UIConfig`` from the `ui_config` topic's parts. Returns `nil` when any part is unavailable
     /// or fails to decode, so callers never render with a partially assembled configuration.
     func getUiConfig() async -> UIConfig? {
-        return try? await self.manager.readConsistent { await self.getUiConfigOnce() }
+        return try? await self.manager.readConsistent { _ in await self.getUiConfigOnce() }
     }
 
     private func getUiConfigOnce() async -> UIConfig? {
@@ -81,7 +81,7 @@ final class UiConfigProvider {
 #else
     // Paywalls V2 (and therefore workflows) aren't supported on tvOS, where `UIConfig` carries no fields.
     func getUiConfig() async -> UIConfig? {
-        return try? await self.manager.readConsistent { await self.getUiConfigOnce() }
+        return try? await self.manager.readConsistent { _ in await self.getUiConfigOnce() }
     }
 
     private func getUiConfigOnce() async -> UIConfig? {

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -137,6 +137,13 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     /// Cache misses validate the workflow topic's generation after `ui_config` resolves, so an in-flight
     /// config change fails the resolution instead of returning a mixed-generation workflow/config pair.
     func getWorkflow(workflowId: String) async -> Result<WorkflowDataResult, WorkflowResolutionError> {
+        return await self.readConsistent(
+            { await self.getWorkflowOnce(workflowId: workflowId) },
+            fallback: .failure(.notFound)
+        )
+    }
+
+    private func getWorkflowOnce(workflowId: String) async -> Result<WorkflowDataResult, WorkflowResolutionError> {
         // Deliberately sequential, not `async let`: a miss or malformed body returns without paying for
         // `ui_config`. A cached-body hit decodes synchronously from in-memory bytes on the caller's thread.
         if let cached = self.cachedWorkflowResult(workflowId: workflowId) {
@@ -161,6 +168,15 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     func decodeCachedWorkflowForAssetPrewarming(
         workflowId: String
     ) async -> Result<WorkflowDataResult, WorkflowResolutionError> {
+        return await self.readConsistent(
+            { await self.decodeCachedWorkflowForAssetPrewarmingOnce(workflowId: workflowId) },
+            fallback: .failure(.notFound)
+        )
+    }
+
+    private func decodeCachedWorkflowForAssetPrewarmingOnce(
+        workflowId: String
+    ) async -> Result<WorkflowDataResult, WorkflowResolutionError> {
         guard let cached = self.cachedWorkflowResult(workflowId: workflowId, retainDecodedResult: false) else {
             return .failure(.notFound)
         }
@@ -177,12 +193,18 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     /// its assets. Missing bodies are omitted so one failed download does not prevent the remaining workflows from
     /// proceeding.
     func cachePrefetchedWorkflowBodyData(includingOfferingId: String?) async -> [String] {
+        return await self.readConsistent(
+            { await self.cachePrefetchedWorkflowBodyDataOnce(includingOfferingId: includingOfferingId) },
+            fallback: []
+        )
+    }
+
+    private func cachePrefetchedWorkflowBodyDataOnce(includingOfferingId: String?) async -> [String] {
         if let cache = self.currentWorkflowCache(),
            cache.containsPrefetchedWorkflowBodyData(includingOfferingId: includingOfferingId) {
             return cache.workflowIDsWhoseBodiesShouldBeCached(includingOfferingId: includingOfferingId)
         }
         guard let topic = await self.manager.awaitTopicAndPrefetchBlobsReady(.workflows) else { return [] }
-
         let snapshot = GenerationGuardedCacheSnapshot(
             generation: self.manager.configGeneration,
             key: topic
@@ -226,6 +248,17 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         )
 
         return orderedWorkflowIDsToPrefetch.filter { workflows[$0] != nil }
+    }
+
+    private func readConsistent<Value>(
+        _ operation: () async -> Value?,
+        fallback: @autoclosure () -> Value
+    ) async -> Value {
+        do {
+            return try await self.manager.readConsistent(operation) ?? fallback()
+        } catch {
+            return fallback()
+        }
     }
 
     func cachedWorkflow(forOfferingId offeringId: String) -> WorkflowDataResult? {

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -138,7 +138,7 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     /// config change fails the resolution instead of returning a mixed-generation workflow/config pair.
     func getWorkflow(workflowId: String) async -> Result<WorkflowDataResult, WorkflowResolutionError> {
         return await self.readConsistent(
-            { await self.getWorkflowOnce(workflowId: workflowId) },
+            { _ in await self.getWorkflowOnce(workflowId: workflowId) },
             fallback: .failure(.notFound)
         )
     }
@@ -169,7 +169,7 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         workflowId: String
     ) async -> Result<WorkflowDataResult, WorkflowResolutionError> {
         return await self.readConsistent(
-            { await self.decodeCachedWorkflowForAssetPrewarmingOnce(workflowId: workflowId) },
+            { _ in await self.decodeCachedWorkflowForAssetPrewarmingOnce(workflowId: workflowId) },
             fallback: .failure(.notFound)
         )
     }
@@ -194,7 +194,7 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     /// proceeding.
     func cachePrefetchedWorkflowBodyData(includingOfferingId: String?) async -> [String] {
         return await self.readConsistent(
-            { await self.cachePrefetchedWorkflowBodyDataOnce(includingOfferingId: includingOfferingId) },
+            { _ in await self.cachePrefetchedWorkflowBodyDataOnce(includingOfferingId: includingOfferingId) },
             fallback: []
         )
     }
@@ -251,7 +251,7 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     }
 
     private func readConsistent<Value>(
-        _ operation: () async -> Value?,
+        _ operation: (Int) async -> Value?,
         fallback: @autoclosure () -> Value
     ) async -> Value {
         do {

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -138,7 +138,7 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     /// config change fails the resolution instead of returning a mixed-generation workflow/config pair.
     func getWorkflow(workflowId: String) async -> Result<WorkflowDataResult, WorkflowResolutionError> {
         return await self.readConsistent(
-            { _ in await self.getWorkflowOnce(workflowId: workflowId) },
+            { await self.getWorkflowOnce(workflowId: workflowId) },
             fallback: .failure(.notFound)
         )
     }
@@ -169,7 +169,7 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
         workflowId: String
     ) async -> Result<WorkflowDataResult, WorkflowResolutionError> {
         return await self.readConsistent(
-            { _ in await self.decodeCachedWorkflowForAssetPrewarmingOnce(workflowId: workflowId) },
+            { await self.decodeCachedWorkflowForAssetPrewarmingOnce(workflowId: workflowId) },
             fallback: .failure(.notFound)
         )
     }
@@ -194,7 +194,7 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     /// proceeding.
     func cachePrefetchedWorkflowBodyData(includingOfferingId: String?) async -> [String] {
         return await self.readConsistent(
-            { _ in await self.cachePrefetchedWorkflowBodyDataOnce(includingOfferingId: includingOfferingId) },
+            { await self.cachePrefetchedWorkflowBodyDataOnce(includingOfferingId: includingOfferingId) },
             fallback: []
         )
     }
@@ -251,14 +251,10 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     }
 
     private func readConsistent<Value>(
-        _ operation: (Int) async -> Value?,
+        _ operation: () async -> Value?,
         fallback: @autoclosure () -> Value
     ) async -> Value {
-        do {
-            return try await self.manager.readConsistent(operation) ?? fallback()
-        } catch {
-            return fallback()
-        }
+        return (try? await self.manager.readConsistent(operation)) ?? fallback()
     }
 
     func cachedWorkflow(forOfferingId offeringId: String) -> WorkflowDataResult? {

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -33,6 +33,9 @@ enum WorkflowResolutionError: Error, Equatable {
     /// The read was superseded by remote-config changes before it could complete consistently.
     case configurationUnavailable
 
+    /// The read was cancelled before it could complete.
+    case cancelled
+
     /// An item exists, but its body couldn't be decoded as a ``PublishedWorkflow``.
     case decodingFailed(NSError)
 
@@ -144,6 +147,8 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
             return try await self.manager.readConsistent {
                 await self.getWorkflowOnce(workflowId: workflowId)
             } ?? .failure(.notFound)
+        } catch is CancellationError {
+            return .failure(.cancelled)
         } catch RemoteConfigConsistencyError.stale {
             return .failure(.configurationUnavailable)
         } catch {
@@ -291,6 +296,8 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
                 return .failure(.notFound)
             }
             return .success(workflow)
+        } catch is CancellationError {
+            return .failure(.cancelled)
         } catch {
             Logger.error(Strings.codable.decoding_error(error, PublishedWorkflow.self))
             return .failure(.decodingFailed(error as NSError))

--- a/Sources/Networking/WorkflowsConfigProvider.swift
+++ b/Sources/Networking/WorkflowsConfigProvider.swift
@@ -30,6 +30,9 @@ enum WorkflowResolutionError: Error, Equatable {
     /// No item for this `workflowId` exists in the synced `workflows` topic.
     case notFound
 
+    /// The read was superseded by remote-config changes before it could complete consistently.
+    case configurationUnavailable
+
     /// An item exists, but its body couldn't be decoded as a ``PublishedWorkflow``.
     case decodingFailed(NSError)
 
@@ -137,10 +140,15 @@ final class WorkflowsConfigProvider: WorkflowsConfigProviderType {
     /// Cache misses validate the workflow topic's generation after `ui_config` resolves, so an in-flight
     /// config change fails the resolution instead of returning a mixed-generation workflow/config pair.
     func getWorkflow(workflowId: String) async -> Result<WorkflowDataResult, WorkflowResolutionError> {
-        return await self.readConsistent(
-            { await self.getWorkflowOnce(workflowId: workflowId) },
-            fallback: .failure(.notFound)
-        )
+        do {
+            return try await self.manager.readConsistent {
+                await self.getWorkflowOnce(workflowId: workflowId)
+            } ?? .failure(.notFound)
+        } catch RemoteConfigConsistencyError.stale {
+            return .failure(.configurationUnavailable)
+        } catch {
+            return .failure(.notFound)
+        }
     }
 
     private func getWorkflowOnce(workflowId: String) async -> Result<WorkflowDataResult, WorkflowResolutionError> {

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -81,7 +81,9 @@ class WorkflowManager: WorkflowAssetPrewarmingType {
         case .failure(.notFound):
             throw BackendError.workflowNotFound(workflowId: workflowId)
         case .failure(.configurationUnavailable):
-            throw WorkflowError.uiConfigUnavailable(workflowId: workflowId)
+            throw WorkflowError.configurationUnavailable(workflowId: workflowId)
+        case .failure(.cancelled):
+            throw CancellationError()
         case let .failure(.decodingFailed(error)):
             throw BackendError.workflowDecodingFailed(workflowId: workflowId, error: error)
         case .failure(.uiConfigUnavailable):

--- a/Sources/Purchasing/WorkflowManager.swift
+++ b/Sources/Purchasing/WorkflowManager.swift
@@ -80,6 +80,8 @@ class WorkflowManager: WorkflowAssetPrewarmingType {
             return result
         case .failure(.notFound):
             throw BackendError.workflowNotFound(workflowId: workflowId)
+        case .failure(.configurationUnavailable):
+            throw WorkflowError.uiConfigUnavailable(workflowId: workflowId)
         case let .failure(.decodingFailed(error)):
             throw BackendError.workflowDecodingFailed(workflowId: workflowId, error: error)
         case .failure(.uiConfigUnavailable):

--- a/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
@@ -120,6 +120,19 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
         }
     }
 
+    func testCancellationWhileLoadingWorkflowPropagates() async {
+        self.workflowsProvider.stubbedGetWorkflowError[self.workflowID] = .cancelled
+
+        do {
+            _ = try await self.resolve()
+            XCTFail("Expected resolution to throw")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
+    }
+
     func testCheckpointWithNoRulesResolvesNoMatch() async throws {
         self.checkpointsProvider.result = .success(CheckpointRuleSet(rules: []))
 

--- a/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
@@ -85,6 +85,21 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
         XCTAssertEqual(Self.noActionReason(resolution), .unknownCheckpoint)
     }
 
+    func testStaleRulesReadRetriesBeforeReportingUnknownCheckpoint() async throws {
+        self.checkpointsProvider.results = [
+            .failure(.stale),
+            .success(CheckpointRuleSet(rules: [Self.rule(workflowID: self.workflowID)]))
+        ]
+
+        let resolution = try await self.resolve()
+
+        XCTAssertEqual(Self.resolvedWorkflow(resolution)?.workflow.id, self.workflowID)
+        XCTAssertEqual(self.checkpointsProvider.requestedIdentifiers, [
+            self.checkpointIdentifier,
+            self.checkpointIdentifier
+        ])
+    }
+
     func testUnavailableRulesResolveConfigurationUnavailable() async throws {
         self.checkpointsProvider.result = .failure(.payloadUnavailable)
 
@@ -1028,6 +1043,7 @@ private struct CheckpointTestDimensionProvider: DimensionProvider {
 private final class MockCheckpointsConfigProvider: CheckpointsConfigProviderType {
 
     var result: Result<CheckpointRuleSet?, CheckpointRulesProviderError> = .success(nil)
+    var results: [Result<CheckpointRuleSet?, CheckpointRulesProviderError>] = []
     var error: Error?
     var configGeneration = 0
     var onRules: (() -> Void)?
@@ -1038,7 +1054,8 @@ private final class MockCheckpointsConfigProvider: CheckpointsConfigProviderType
         if let error = self.error {
             throw error
         }
-        let snapshot = try self.result.get().map {
+        let result = self.results.isEmpty ? self.result : self.results.removeFirst()
+        let snapshot = try result.get().map {
             CheckpointRulesSnapshot(ruleSet: $0, configGeneration: self.configGeneration)
         }
         self.onRules?()

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
@@ -226,7 +226,7 @@ final class RemoteConfigIntegrationTests: TestCase {
         expect(configuration).to(beNil())
     }
 
-    func testAudiencesProviderLeavesStaleSnapshotRetryToCaller() async throws {
+    func testAudiencesProviderRetriesStaleSnapshotBeforeReturningConfiguration() async throws {
         let manager = MockRemoteConfigManager()
         let payload = #"{ "aud_123": { "id": "aud_123", "rules": {} } }"#.asData
         manager.stubbedTopics[.audiences] = [
@@ -243,8 +243,8 @@ final class RemoteConfigIntegrationTests: TestCase {
 
         let configuration = try await AudiencesConfigProvider(manager: manager).configuration()
 
-        expect(configuration).to(beNil())
-        expect(manager.invokedTopicCount) == 1
+        expect(configuration).toNot(beNil())
+        expect(manager.invokedTopicCount).to(beGreaterThan(1))
     }
 
     func testAudiencesProviderReturnsEmptyBackendResultsWhenItemIsAbsent() async throws {

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
@@ -5,8 +5,6 @@
 //  Created by Rick van der Linden.
 //  Copyright © 2026 RevenueCat, Inc. All rights reserved.
 
-// swiftlint:disable file_length type_body_length function_body_length
-
 import Foundation
 import Nimble
 @preconcurrency @testable import RevenueCat

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
@@ -5,6 +5,8 @@
 //  Created by Rick van der Linden.
 //  Copyright © 2026 RevenueCat, Inc. All rights reserved.
 
+// swiftlint:disable file_length type_body_length function_body_length
+
 import Foundation
 import Nimble
 @preconcurrency @testable import RevenueCat

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -5,7 +5,7 @@
 //  Created by Rick van der Linden.
 //  Copyright © 2026 RevenueCat, Inc. All rights reserved.
 
-// swiftlint:disable file_length type_body_length
+// swiftlint:disable file_length type_body_length function_body_length force_unwrapping
 
 import Foundation
 import Nimble

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -5,6 +5,8 @@
 //  Created by Rick van der Linden.
 //  Copyright © 2026 RevenueCat, Inc. All rights reserved.
 
+// swiftlint:disable file_length type_body_length
+
 import Foundation
 import Nimble
 @testable import RevenueCat

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -3165,6 +3165,56 @@ private extension RemoteConfigManagerTests {
         let defaultValue: String
     }
 
+    func testReadConsistentlyRetriesOnceWhenSuccessfulReadIsSuperseded() async throws {
+        let manager = MockRemoteConfigManager()
+        var generationReads = 0
+        manager.onConfigGenerationRead = {
+            generationReads += 1
+            if generationReads == 2 {
+                manager.configGeneration = 1
+            }
+        }
+
+        let result = try await manager.readConsistent { _ in "value" }
+
+        expect(result) == "value"
+        expect(generationReads) == 4
+    }
+
+    func testReadConsistentlyReturnsSupersededAfterTwoStaleReads() async throws {
+        let manager = MockRemoteConfigManager()
+        var generationReads = 0
+        manager.onConfigGenerationRead = {
+            generationReads += 1
+            if generationReads == 2 || generationReads == 4 {
+                manager.configGeneration += 1
+            }
+        }
+
+        let result = try await manager.readConsistent { _ in "value" }
+
+        expect(result).to(beNil())
+        expect(generationReads) == 4
+    }
+
+    func testReadConsistentlyPropagatesErrorsWithoutRetrying() async {
+        let manager = MockRemoteConfigManager()
+        var invocationCount = 0
+
+        do {
+            _ = try await manager.readConsistent { _ in
+                invocationCount += 1
+                throw NSError(domain: "test", code: 1)
+            }
+            XCTFail("Expected the read error to be propagated")
+        } catch let error as NSError {
+            expect(error.domain) == "test"
+            expect(invocationCount) == 1
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
 }
 
 private extension RemoteConfigFetchResult {

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -2986,18 +2986,19 @@ final class RemoteConfigManagerTests: TestCase {
     func testReadConsistentlyStopsWhenTaskIsCanceledBeforeTheRead() async {
         let manager = MockRemoteConfigManager()
         let readStarted = XCTestExpectation(description: "Read started")
-        let gate = AsyncStream<Void>.makeStream()
+        var gateContinuation: AsyncStream<Void>.Continuation!
+        let gate = AsyncStream<Void> { gateContinuation = $0 }
         let task = Task {
             try await manager.readConsistent {
                 readStarted.fulfill()
-                for await _ in gate.stream { break }
+                for await _ in gate { break }
                 return "value"
             }
         }
         await fulfillment(of: [readStarted], timeout: 1)
         task.cancel()
-        gate.continuation.yield(())
-        gate.continuation.finish()
+        gateContinuation.yield(())
+        gateContinuation.finish()
 
         do {
             _ = try await task.value

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -3202,6 +3202,23 @@ private extension RemoteConfigManagerTests {
         }
     }
 
+    func testReadConsistentlyRetriesWhenThrowingReadIsSuperseded() async throws {
+        let manager = MockRemoteConfigManager()
+        var invocationCount = 0
+
+        let result = try await manager.readConsistent {
+            invocationCount += 1
+            if invocationCount == 1 {
+                manager.configGeneration += 1
+                throw CheckpointRulesProviderError.payloadUnavailable
+            }
+            return "value"
+        }
+
+        expect(result) == "value"
+        expect(invocationCount) == 2
+    }
+
     func testReadConsistentlyPropagatesErrorsWithoutRetrying() async {
         let manager = MockRemoteConfigManager()
         var invocationCount = 0

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -5,8 +5,6 @@
 //  Created by Rick van der Linden.
 //  Copyright © 2026 RevenueCat, Inc. All rights reserved.
 
-// swiftlint:disable file_length type_body_length function_body_length force_unwrapping
-
 import Foundation
 import Nimble
 @testable import RevenueCat
@@ -3177,7 +3175,7 @@ private extension RemoteConfigManagerTests {
             }
         }
 
-        let result = try await manager.readConsistent { _ in "value" }
+        let result = try await manager.readConsistent { "value" }
 
         expect(result) == "value"
         expect(generationReads) == 4
@@ -3193,7 +3191,7 @@ private extension RemoteConfigManagerTests {
             }
         }
 
-        let result = try await manager.readConsistent { _ in "value" }
+        let result = try await manager.readConsistent { "value" }
 
         expect(result).to(beNil())
         expect(generationReads) == 4
@@ -3204,7 +3202,7 @@ private extension RemoteConfigManagerTests {
         var invocationCount = 0
 
         do {
-            _ = try await manager.readConsistent { _ in
+            _ = try await manager.readConsistent {
                 invocationCount += 1
                 throw NSError(domain: "test", code: 1)
             }

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -3181,7 +3181,7 @@ private extension RemoteConfigManagerTests {
         expect(generationReads) == 4
     }
 
-    func testReadConsistentlyReturnsSupersededAfterTwoStaleReads() async throws {
+    func testReadConsistentlyThrowsStaleAfterTwoStaleReads() async {
         let manager = MockRemoteConfigManager()
         var generationReads = 0
         manager.onConfigGenerationRead = {
@@ -3191,10 +3191,15 @@ private extension RemoteConfigManagerTests {
             }
         }
 
-        let result = try await manager.readConsistent { "value" }
-
-        expect(result).to(beNil())
-        expect(generationReads) == 4
+        do {
+            _ = try await manager.readConsistent { "value" }
+            XCTFail("Expected the stale-read error to be thrown")
+        } catch let error as RemoteConfigConsistencyError {
+            expect(error) == .stale
+            expect(generationReads) == 4
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
     }
 
     func testReadConsistentlyPropagatesErrorsWithoutRetrying() async {

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -2983,6 +2983,32 @@ final class RemoteConfigManagerTests: TestCase {
         expect(self.diskCache.invokedClearCount) == 1
     }
 
+    func testReadConsistentlyStopsWhenTaskIsCanceledBeforeTheRead() async {
+        let manager = MockRemoteConfigManager()
+        let readStarted = XCTestExpectation(description: "Read started")
+        let gate = AsyncStream<Void>.makeStream()
+        let task = Task {
+            try await manager.readConsistent {
+                readStarted.fulfill()
+                for await _ in gate.stream { break }
+                return "value"
+            }
+        }
+        await fulfillment(of: [readStarted], timeout: 1)
+        task.cancel()
+        gate.continuation.yield(())
+        gate.continuation.finish()
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation to stop the read")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
 }
 
 private extension RemoteConfigManagerTests {

--- a/Tests/UnitTests/Networking/UiConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/UiConfigProviderTests.swift
@@ -213,7 +213,7 @@ class UiConfigProviderTests: TestCase {
         expect(self.provider.cachedUiConfig()).toNot(beNil())
     }
 
-    func testReturnsNilAndDoesNotCacheUiConfigWhenGenerationChangesDuringDecode() async throws {
+    func testRetriesAndCachesUiConfigWhenGenerationChangesDuringDecode() async throws {
         self.stub(
             app: #"{"colors": {}, "fonts": {}}"#,
             localizations: #"{"en_US": {"day": "Day"}}"#,
@@ -228,8 +228,8 @@ class UiConfigProviderTests: TestCase {
         self.mockManager.completeStoredBlobReads()
 
         let resolvedUiConfig = await uiConfig
-        expect(resolvedUiConfig).to(beNil())
-        expect(self.provider.cachedUiConfig()).to(beNil())
+        expect(resolvedUiConfig).toNot(beNil())
+        expect(self.provider.cachedUiConfig()).toNot(beNil())
     }
 
     func testCachedUiConfigReturnsNilWhenGenerationChangesWithoutRewarming() async throws {

--- a/Tests/UnitTests/Networking/UiConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/UiConfigProviderTests.swift
@@ -15,6 +15,8 @@ import Foundation
 import Nimble
 import XCTest
 
+// swiftlint:disable type_body_length
+
 @_spi(Internal) @testable import RevenueCat
 
 class UiConfigProviderTests: TestCase {

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -200,6 +200,51 @@ class WorkflowsConfigProviderTests: TestCase {
         }
     }
 
+    func testPreservesCancellationWhenWorkflowReadIsCancelled() async throws {
+        let manager = MockRemoteConfigManager()
+        let provider = WorkflowsConfigProvider(
+            manager: manager,
+            uiConfigProvider: UiConfigProvider(manager: manager)
+        )
+
+        let task = Task {
+            await provider.getWorkflow(workflowId: "wf-1")
+        }
+        task.cancel()
+
+        let result = await task.value
+
+        expect(result.error) == .cancelled
+    }
+
+    func testPreservesCancellationWhenWorkflowReadIsCancelledAfterTheBodyRead() async throws {
+        let manager = MockRemoteConfigManager()
+        let provider = WorkflowsConfigProvider(
+            manager: manager,
+            uiConfigProvider: UiConfigProvider(manager: manager)
+        )
+        manager.stubbedTopics[.workflows] = [
+            "wf-1": .init(blobRef: "wf-1-ref", content: [:])
+        ]
+        manager.stubbedBlobData[.workflows] = [
+            "wf-1": try Self.workflowJSON(id: "wf-1")
+        ]
+        manager.shouldStoreBlobDataCompletion = true
+
+        let task = Task {
+            await provider.getWorkflow(workflowId: "wf-1")
+        }
+        while manager.invokedBlobDataParameters.isEmpty {
+            await Task.yield()
+        }
+        task.cancel()
+        manager.completeStoredBlobReads()
+
+        let result = await task.value
+
+        expect(result.error) == .cancelled
+    }
+
     func testFailsWithDecodingFailedForAMalformedWorkflowBody() async {
         self.commit(
             workflows: ["wf-1": .init(blobRef: "wf-1-ref", content: [:])],

--- a/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/WorkflowsConfigProviderTests.swift
@@ -174,6 +174,32 @@ class WorkflowsConfigProviderTests: TestCase {
         expect(result.error) == .notFound
     }
 
+    func testExhaustedStaleReadsDoNotReportAnExistingWorkflowAsNotFound() async throws {
+        let manager = MockRemoteConfigManager()
+        let provider = WorkflowsConfigProvider(
+            manager: manager,
+            uiConfigProvider: UiConfigProvider(manager: manager)
+        )
+        manager.stubbedTopics[.workflows] = [
+            "wf-1": .init(blobRef: "wf-1-ref", content: [:])
+        ]
+        manager.stubbedBlobData[.workflows] = [
+            "wf-1": Data(#"{"not": "a workflow"}"#.utf8)
+        ]
+        var generationReads = 0
+        manager.onConfigGenerationRead = {
+            generationReads += 1
+            manager.configGeneration = generationReads
+        }
+
+        let result = await provider.getWorkflow(workflowId: "wf-1")
+
+        guard result.error == .configurationUnavailable else {
+            XCTFail("Expected stale workflow resolution to report unavailable configuration")
+            return
+        }
+    }
+
     func testFailsWithDecodingFailedForAMalformedWorkflowBody() async {
         self.commit(
             workflows: ["wf-1": .init(blobRef: "wf-1-ref", content: [:])],

--- a/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/WorkflowManagerTests.swift
@@ -120,6 +120,32 @@ class WorkflowManagerTests: TestCase {
         }
     }
 
+    func testGetWorkflowFailsWithConfigurationUnavailableWhenProviderReportsAStaleRead() async {
+        self.mockProvider.stubbedGetWorkflowError = ["wf_1": .configurationUnavailable]
+
+        do {
+            _ = try await self.manager.getWorkflow(workflowId: "wf_1")
+            fail("Expected getWorkflow to throw")
+        } catch WorkflowError.configurationUnavailable(let workflowId) {
+            expect(workflowId) == "wf_1"
+        } catch {
+            fail("Unexpected error: \(error)")
+        }
+    }
+
+    func testGetWorkflowPropagatesCancellationWhenProviderReportsCancellation() async {
+        self.mockProvider.stubbedGetWorkflowError = ["wf_1": .cancelled]
+
+        do {
+            _ = try await self.manager.getWorkflow(workflowId: "wf_1")
+            fail("Expected getWorkflow to throw")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            fail("Unexpected error: \(error)")
+        }
+    }
+
     // MARK: - cachedWorkflow(forOfferingId:)
 
     func testCachedWorkflowSchedulesAssetPrewarmingOnSuccess() async throws {


### PR DESCRIPTION
## Description
Multiple remote config topic providers were doing (cache) staleness checks against the current config generation. Essentially duplicating work in the config providers that ultimately should be part of the infrastructure layer.

This PR addresses that by introducing a `RemoteConfigManager.readConsistent {}` helper that will ensure the remote config generation being stable for as long as the operation. All config topic providers were updated to use this new helper.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how remote config, workflows, and checkpoints behave under concurrent refreshes; mis-handling could cause wrong paywall/checkpoint outcomes or spurious unavailable errors, though behavior is heavily tested.
> 
> **Overview**
> Introduces **`RemoteConfigManager.readConsistent`**, which pins a read to the current config generation and **retries once** if remote config advances while the operation is suspended; a second stale outcome surfaces **`RemoteConfigConsistencyError.stale`** (with a verbose retry log).
> 
> **Audiences**, **checkpoints**, **UI config**, and **workflows** providers now route their multi-step loads through this helper instead of ad-hoc generation loops or scattered `isCurrent` guards. Checkpoints map stale reads to **`CheckpointRulesProviderError.stale`**; workflows add **`configurationUnavailable`** and **`cancelled`** so stale or cancelled reads are not misreported as **not found**.
> 
> **Checkpoint resolution** treats stale rules as a retry signal (`nil`), propagates **cancellation** through workflow loading, and **`WorkflowManager`** maps the new workflow resolution failures to **`WorkflowError.configurationUnavailable`** or **`CancellationError`**.
> 
> Tests are updated to expect **automatic retry and success** where generation flips mid-read, rather than returning `nil` on the first stale snapshot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91de34586be926c5f731f3e17d2566c091a833d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->