### PR TITLE
feat(paywalls-v2): decode and evaluate the hover override condition

### DIFF
--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
@@ -79,6 +79,7 @@ extension PresentedPartial {
     /// - Parameters:
     ///   - state: Current view state (selected/unselected)
     ///   - condition: Current screen condition (compact/medium/expanded)
+    ///   - isHovered: Whether the component is currently hovered (pointer devices only)
     ///   - isEligibleForIntroOffer: Whether the user is eligible for an intro offer
     ///   - isEligibleForPromoOffer: Whether the user is eligible for a promo offer
     ///   - conditionContext: Additional context for evaluating new condition types
@@ -89,6 +90,7 @@ extension PresentedPartial {
     static func buildPartial(
         state: ComponentViewState,
         condition: ScreenCondition,
+        isHovered: Bool = false,
         isEligibleForIntroOffer: Bool,
         isEligibleForPromoOffer: Bool,
         conditionContext: ConditionContext,
@@ -104,6 +106,7 @@ extension PresentedPartial {
             for: presentedOverride.conditions,
             state: state,
             activeCondition: condition,
+            isHovered: isHovered,
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             conditionContext: conditionContext
@@ -120,6 +123,7 @@ extension PresentedPartial {
         for conditions: [PaywallComponent.ExtendedCondition],
         state: ComponentViewState,
         activeCondition: ScreenCondition,
+        isHovered: Bool,
         isEligibleForIntroOffer: Bool,
         isEligibleForPromoOffer: Bool,
         conditionContext: ConditionContext
@@ -128,6 +132,7 @@ extension PresentedPartial {
             condition,
             state: state,
             activeCondition: activeCondition,
+            isHovered: isHovered,
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             conditionContext: conditionContext
@@ -143,6 +148,7 @@ extension PresentedPartial {
         _ condition: PaywallComponent.ExtendedCondition,
         state: ComponentViewState,
         activeCondition: ScreenCondition,
+        isHovered: Bool,
         isEligibleForIntroOffer: Bool,
         isEligibleForPromoOffer: Bool,
         conditionContext: ConditionContext
@@ -155,6 +161,10 @@ extension PresentedPartial {
         // Selection state
         case .selected:
             return state == .selected
+
+        // Hover state (pointer devices only; never matches on touch)
+        case .hover:
+            return isHovered
 
         // Offer eligibility (legacy simple boolean check)
         case .introOffer:

--- a/Sources/Paywalls/Components/Common/ComponentOverrides.swift
+++ b/Sources/Paywalls/Components/Common/ComponentOverrides.swift
@@ -168,6 +168,9 @@ extension PaywallComponent {
         // MARK: - Selection state
         case selected
 
+        // MARK: - Hover state (pointer devices only; never matches on touch)
+        case hover
+
         // MARK: - Offer eligibility (legacy simple boolean check)
         case introOffer
         case promoOffer
@@ -197,7 +200,7 @@ extension PaywallComponent {
         /// fallback for unrecognized condition types. It always evaluates to `false` at runtime.
         @_spi(Internal) public var isRule: Bool {
             switch self {
-            case .compact, .medium, .expanded, .selected, .introOffer, .promoOffer,
+            case .compact, .medium, .expanded, .selected, .hover, .introOffer, .promoOffer,
                  .multipleIntroOffers, .unsupported:
                 return false
             case .introOfferCondition, .promoOfferCondition, .variable, .selectedPackage, .state:
@@ -215,7 +218,7 @@ extension PaywallComponent {
             case .selected: return .selected
             case .introOffer, .introOfferCondition: return .introOffer
             case .promoOffer, .promoOfferCondition: return .promoOffer
-            case .multipleIntroOffers, .variable, .selectedPackage, .state, .unsupported: return .unsupported
+            case .hover, .multipleIntroOffers, .variable, .selectedPackage, .state, .unsupported: return .unsupported
             }
         }
 
@@ -246,6 +249,8 @@ extension PaywallComponent {
                 try container.encode(ConditionType.expanded.rawValue, forKey: .type)
             case .selected:
                 try container.encode(ConditionType.selected.rawValue, forKey: .type)
+            case .hover:
+                try container.encode(ConditionType.hover.rawValue, forKey: .type)
             case .introOffer:
                 try container.encode(ConditionType.introOffer.rawValue, forKey: .type)
             case .promoOffer:
@@ -309,6 +314,8 @@ extension PaywallComponent {
                 return .expanded
             case .selected:
                 return .selected
+            case .hover:
+                return .hover
             case .introOffer:
                 return .introOffer
             case .introOfferCondition:
@@ -364,6 +371,7 @@ extension PaywallComponent {
             case promoOfferCondition = "promo_offer_condition"
             case multipleIntroOffers = "multiple_intro_offers"
             case selected
+            case hover
             case variableCondition = "variable_condition"
             case selectedPackageCondition = "selected_package_condition"
             case stateCondition = "state_condition"

--- a/Tests/RevenueCatUITests/PaywallsV2/ConditionDeserializationTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/ConditionDeserializationTests.swift
@@ -74,6 +74,16 @@ class ConditionDeserializationTests: TestCase {
         expect(condition).to(equal(.promoOffer))
     }
 
+    // MARK: - Hover Condition Tests
+
+    func testDecodeHoverCondition() throws {
+        let json = """
+        {"type": "hover"}
+        """
+        let condition = try decode(json)
+        expect(condition).to(equal(.hover))
+    }
+
     // MARK: - Extended Intro Offer Condition Tests
 
     func testDecodeExtendedIntroOfferConditionEqualsTrue() throws {

--- a/Tests/RevenueCatUITests/PaywallsV2/PresentedPartialsTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/PresentedPartialsTests.swift
@@ -100,6 +100,101 @@ class PresentedPartialsTests: TestCase {
         expect(result).to(beNil())
     }
 
+    // MARK: - Hover Condition Tests
+
+    func testHoverCondition_Hovered_Matches() throws {
+        let conditions: [PaywallComponent.ExtendedCondition] = [.hover]
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isHovered: true,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: ConditionContext(),
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).toNot(beNil())
+    }
+
+    func testHoverCondition_NotHovered_DoesNotMatch() throws {
+        let conditions: [PaywallComponent.ExtendedCondition] = [.hover]
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isHovered: false,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: ConditionContext(),
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).to(beNil())
+    }
+
+    func testHoverCondition_DefaultsToNotHovered() throws {
+        let conditions: [PaywallComponent.ExtendedCondition] = [.hover]
+
+        let result = TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: ConditionContext(),
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+
+        expect(result).to(beNil())
+    }
+
+    func testHoverCondition_WithSelected_RequiresBothConditions() throws {
+        let conditions: [PaywallComponent.ExtendedCondition] = [.hover, .selected]
+        let overrides = [PresentedOverride(conditions: conditions, properties: TestPartial())]
+
+        let selectedButNotHovered = TestPartial.buildPartial(
+            state: .selected,
+            condition: .compact,
+            isHovered: false,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: ConditionContext(),
+            with: overrides
+        )
+        let selectedAndHovered = TestPartial.buildPartial(
+            state: .selected,
+            condition: .compact,
+            isHovered: true,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: ConditionContext(),
+            with: overrides
+        )
+
+        expect(selectedButNotHovered).to(beNil())
+        expect(selectedAndHovered).toNot(beNil())
+    }
+
+    func testHoverCondition_LaterMatchingOverrideWins() throws {
+        let overrides = [
+            PresentedOverride(conditions: [.hover], properties: TestPartial(value: "hover")),
+            PresentedOverride(conditions: [.selected], properties: TestPartial(value: "selected"))
+        ]
+
+        let result = TestPartial.buildPartial(
+            state: .selected,
+            condition: .compact,
+            isHovered: true,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: ConditionContext(),
+            with: overrides
+        )
+
+        expect(result?.value).to(equal("selected"))
+    }
+
     // MARK: - Variable Condition Tests
 
     func testVariableCondition_StringEquals_Matches() throws {

--- a/Tests/RevenueCatUITests/PaywallsV2/ToPresentedOverridesTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/ToPresentedOverridesTests.swift
@@ -94,6 +94,30 @@ class ToPresentedOverridesTests: TestCase {
         expect(overrides.hasUnsupportedCondition()).to(beFalse())
     }
 
+    // MARK: - Hover Compatibility
+
+    func testHasUnsupportedCondition_WithHover_ReturnsFalse() throws {
+        let overrides: PaywallComponent.ComponentOverrides<PaywallComponent.PartialStackComponent> = [
+            .init(extendedConditions: [.hover], properties: .init())
+        ]
+
+        expect(overrides.hasUnsupportedCondition()).to(beFalse())
+    }
+
+    func testToPresentedOverrides_WithDiscardRulesTrue_KeepsHoverOverrides() throws {
+        // Hover is not a rule, so it survives default-paywall degradation like other legacy conditions
+        let overrides: PaywallComponent.ComponentOverrides<PaywallComponent.PartialStackComponent> = [
+            .init(extendedConditions: [.hover], properties: .init()),
+            .init(extendedConditions: [
+                .selectedPackage(operator: .in, packages: ["monthly"])
+            ], properties: .init())
+        ]
+
+        let result = overrides.toPresentedOverrides(discardRules: true) { $0 }
+        expect(result.count).to(equal(1))
+        expect(result[0].conditions).to(equal([PaywallComponent.ExtendedCondition.hover]))
+    }
+
     // MARK: - Recursive containsUnsupportedConditions Tests
 
     func testStackWithUnsupportedCondition_ReturnsTrue() throws {


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Khepri already serves `{"type": "hover"}` override conditions to every platform (the web renderer supports them), but this SDK decodes them as `.unsupported` — which triggers default-paywall degradation and discards all rule-based overrides paywall-wide.

### Description
Adds `hover` to the condition codemodel as a non-rule condition (so paywalls using it stop degrading, and it survives `discardRules` like other legacy conditions), and evaluates it in `buildPartial` via a new `isHovered` parameter defaulting to `false`. No view tracks hover yet — that lands in the stacked follow-ups (#7586, #7587), so on this PR alone hover overrides decode cleanly and never apply.

Bottom of a 3-PR stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Paywalls V2 condition decoding and override evaluation; default `isHovered: false` preserves existing behavior until hover is wired in views.
> 
> **Overview**
> Adds first-class support for the **`hover`** paywall override condition so templates that include it no longer decode as **`.unsupported`** and trigger paywall-wide default-paywall degradation.
> 
> **`ExtendedCondition.hover`** is wired through JSON encode/decode, treated as a **legacy (non-rule)** condition (so it is kept when **`discardRules`** strips rule-based overrides), and maps to **`.unsupported`** on the public **`Condition`** API. Override evaluation in **`buildPartial`** gains an **`isHovered`** argument (default **`false`**) and a **`.hover`** branch that matches only when that flag is true.
> 
> Unit tests cover deserialization, **`buildPartial`** matching/combination with **`selected`**, and compatibility with unsupported-condition / **`discardRules`** filtering. **No UI passes **`isHovered`** yet**, so hover-specific overrides still do not apply at runtime until follow-up work wires pointer hover.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dd565fb915866f1236551194c6939177eb0148f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->