### PR TITLE
feat(paywalls-v2): apply hover overrides on stack and text components

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
@@ -33,6 +33,11 @@ struct StackComponentView: View {
     @Environment(\.componentViewState)
     private var componentViewState
 
+    @Environment(\.componentHoverState)
+    private var componentHoverState
+
+    @State private var isHovered: Bool = false
+
     @Environment(\.screenCondition)
     private var screenCondition
 
@@ -89,6 +94,7 @@ struct StackComponentView: View {
         viewModel.styles(
             state: self.componentViewState,
             condition: self.screenCondition,
+            isHovered: self.isHovered || self.componentHoverState,
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             selectedPackageId: self.selectedPackageId,
@@ -101,6 +107,7 @@ struct StackComponentView: View {
                 self.make(style: style)
             }
         }
+        .componentHoverState(self.$isHovered, trackingEnabled: self.viewModel.hasHoverOverride)
     }
 
     @ViewBuilder

--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentViewHoverPreviews.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentViewHoverPreviews.swift
@@ -1,0 +1,125 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  StackComponentViewHoverPreviews.swift
+//
+//  Created by Josh Holtz on 9/2/26.
+
+@_spi(Internal) import RevenueCat
+import SwiftUI
+
+#if !os(tvOS) // For Paywalls V2
+
+#if DEBUG
+
+// In its own file so the canvas doesn't have to compile StackComponentView's large preview
+// provider to show these. The component is assembled from small explicitly-typed constants
+// because the canvas type-checker rejects it as one big nested literal.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct StackComponentViewHover_Previews: PreviewProvider {
+
+    private static let titleHoverOverride = PaywallComponent.ComponentOverride(
+        extendedConditions: [.hover],
+        properties: PaywallComponent.PartialTextComponent(
+            color: PaywallComponent.ColorScheme(light: .hex("#7C3AED"))
+        )
+    )
+
+    private static let title = PaywallComponent.TextComponent(
+        text: "title",
+        fontWeight: .bold,
+        color: PaywallComponent.ColorScheme(light: .hex("#111827")),
+        fontSize: 18,
+        horizontalAlignment: .leading,
+        overrides: [titleHoverOverride]
+    )
+
+    private static let subtitle = PaywallComponent.TextComponent(
+        text: "subtitle",
+        color: PaywallComponent.ColorScheme(light: .hex("#6B7280")),
+        fontSize: 15,
+        horizontalAlignment: .leading
+    )
+
+    private static let cardHoverOverride = PaywallComponent.ComponentOverride(
+        extendedConditions: [.hover],
+        properties: PaywallComponent.PartialStackComponent(
+            backgroundColor: PaywallComponent.ColorScheme(light: .hex("#F5F3FF")),
+            border: PaywallComponent.Border(
+                color: PaywallComponent.ColorScheme(light: .hex("#7C3AED")),
+                width: 2
+            )
+        )
+    )
+
+    private static let card = PaywallComponent.StackComponent(
+        components: [.text(title), .text(subtitle)],
+        dimension: .vertical(.leading, .start),
+        size: PaywallComponent.Size(width: .fixed(320), height: .fit(nil)),
+        spacing: 6,
+        backgroundColor: PaywallComponent.ColorScheme(light: .hex("#ffffff")),
+        padding: PaywallComponent.Padding(top: 20, bottom: 20, leading: 20, trailing: 20),
+        margin: PaywallComponent.Padding(top: 20, bottom: 20, leading: 20, trailing: 20),
+        shape: .rectangle(PaywallComponent.CornerRadiuses(
+            topLeading: 16,
+            topTrailing: 16,
+            bottomLeading: 16,
+            bottomTrailing: 16
+        )),
+        border: PaywallComponent.Border(
+            color: PaywallComponent.ColorScheme(light: .hex("#E5E7EB")),
+            width: 2
+        ),
+        overrides: [cardHoverOverride]
+    )
+
+    private static let localizations: PaywallComponent.LocalizationDictionary = [
+        "title": .string("Annual"),
+        "subtitle": .string("$49.99/yr · 7 days free")
+    ]
+
+    /// A package-style card: hovering it recolors the card's background and border, and the title
+    /// recolors too through subtree hover propagation (its own hover override, activated by the card).
+    private static var packageCardPreview: some View {
+        StackComponentView(
+            // swiftlint:disable:next force_try
+            viewModel: try! StackComponentViewModel(
+                component: card,
+                localizationProvider: LocalizationProvider(
+                    locale: Locale.current,
+                    localizedStrings: localizations
+                ),
+                colorScheme: .light
+            ),
+            onDismiss: {}
+        )
+    }
+
+    static var previews: some View {
+        // Hovered style forced through the environment, always renders the hovered card
+        packageCardPreview
+            .previewRequiredPaywallsV2Properties(
+                componentHoverState: true
+            )
+            .previewLayout(.sizeThatFits)
+            .previewDisplayName("Package Card - Hovered")
+
+        // Run live on a My Mac destination and mouse over the card to trigger .onHover.
+        // Touch destinations render the base style.
+        packageCardPreview
+            .previewRequiredPaywallsV2Properties()
+            .previewLayout(.sizeThatFits)
+            .previewDisplayName("Package Card - Hover (interactive)")
+    }
+
+}
+
+#endif
+
+#endif

--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentViewModel.swift
@@ -28,6 +28,11 @@ class StackComponentViewModel {
     let viewModels: [PaywallComponentViewModel]
     let badgeViewModels: [PaywallComponentViewModel]
 
+    /// Whether any override is gated on the hover condition, so the view attaches hover tracking.
+    var hasHoverOverride: Bool {
+        self.presentedOverrides?.hasHoverCondition() == true
+    }
+
     /// Whether the first child is a full-width image, video, or web view.
     /// Used by ZStack rendering to push non-hero children below the safe area.
     var firstChildIsFullWidthMedia: Bool {
@@ -110,6 +115,7 @@ class StackComponentViewModel {
     func styles(
         state: ComponentViewState,
         condition: ScreenCondition,
+        isHovered: Bool = false,
         isEligibleForIntroOffer: Bool,
         isEligibleForPromoOffer: Bool,
         selectedPackageId: String?,
@@ -128,6 +134,7 @@ class StackComponentViewModel {
         let partial = PresentedStackPartial.buildPartial(
             state: state,
             condition: condition,
+            isHovered: isHovered,
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             conditionContext: conditionContext,
@@ -159,6 +166,7 @@ class StackComponentViewModel {
     func styles(
         state: ComponentViewState,
         condition: ScreenCondition,
+        isHovered: Bool = false,
         isEligibleForIntroOffer: Bool,
         isEligibleForPromoOffer: Bool,
         selectedPackageId: String?,
@@ -171,6 +179,7 @@ class StackComponentViewModel {
         let style = styles(
             state: state,
             condition: condition,
+            isHovered: isHovered,
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             selectedPackageId: selectedPackageId,

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -34,6 +34,11 @@ struct TextComponentView: View {
     @Environment(\.componentViewState)
     private var componentViewState
 
+    @Environment(\.componentHoverState)
+    private var componentHoverState
+
+    @State private var isHovered: Bool = false
+
     @Environment(\.screenCondition)
     private var screenCondition
 
@@ -74,6 +79,7 @@ struct TextComponentView: View {
         viewModel.styles(
             state: self.componentViewState,
             condition: self.screenCondition,
+            isHovered: self.isHovered || self.componentHoverState,
             selectedPackageId: self.selectedPackageId,
             packageContext: self.packageContext,
             isEligibleForIntroOffer: isEligibleForIntroOffer,
@@ -101,6 +107,7 @@ struct TextComponentView: View {
                     .padding(style.margin)
             }
         }
+        .componentHoverState(self.$isHovered, trackingEnabled: self.viewModel.hasHoverOverride)
     }
 
 }

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -841,6 +841,58 @@ struct TextComponentView_Previews: PreviewProvider {
     }
 }
 
+// Separate provider: Xcode's canvas shows at most 15 previews per provider,
+// and TextComponentView_Previews is already over that limit.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct TextComponentViewHover_Previews: PreviewProvider {
+
+    private static var hoverPreview: some View {
+        TextComponentView(
+            // swiftlint:disable:next force_try
+            viewModel: try! .init(
+                localizationProvider: .init(
+                    locale: Locale.current,
+                    localizedStrings: [
+                        "id_1": .string("Hello, world")
+                    ]
+                ),
+                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+                component: .init(
+                    text: "id_1",
+                    color: .init(light: .hex("#000000")),
+                    overrides: [
+                        .init(extendedConditions: [
+                            .hover
+                        ], properties: .init(
+                            fontWeight: .black,
+                            color: .init(light: .hex("#ffffff")),
+                            backgroundColor: .init(light: .hex("#8000ff")),
+                            fontSize: 34
+                        ))
+                    ]
+                )
+            )
+        )
+    }
+
+    static var previews: some View {
+        // State - Hovered (forced through the environment, always renders the hovered style)
+        hoverPreview
+            .previewRequiredPaywallsV2Properties(
+                componentHoverState: true
+            )
+            .previewLayout(.sizeThatFits)
+            .previewDisplayName("State - Hovered")
+
+        // State - Hovered (interactive): run live on a My Mac destination and mouse over the text
+        // to trigger the component's own .onHover tracking. Touch destinations render the base style.
+        hoverPreview
+            .previewRequiredPaywallsV2Properties()
+            .previewLayout(.sizeThatFits)
+            .previewDisplayName("State - Hovered (interactive)")
+    }
+}
+
 #endif
 
 #endif

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
@@ -30,6 +30,11 @@ class TextComponentViewModel {
     private let text: String
     private let presentedOverrides: PresentedOverrides<LocalizedTextPartial>?
 
+    /// Whether any override is gated on the hover condition, so the view attaches hover tracking.
+    var hasHoverOverride: Bool {
+        self.presentedOverrides?.hasHoverCondition() == true
+    }
+
     /// Whether this component renders anything a screen reader can announce. An empty base string
     /// still counts when overrides exist, since an override can supply text of its own.
     ///
@@ -70,6 +75,7 @@ class TextComponentViewModel {
     func styles(
         state: ComponentViewState,
         condition: ScreenCondition,
+        isHovered: Bool = false,
         selectedPackageId: String?,
         packageContext: PackageContext,
         isEligibleForIntroOffer: Bool,
@@ -90,6 +96,7 @@ class TextComponentViewModel {
         let localizedPartial = LocalizedTextPartial.buildPartial(
             state: state,
             condition: condition,
+            isHovered: isHovered,
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             conditionContext: conditionContext,

--- a/RevenueCatUI/Templates/V2/EnvironmentObjects/ComponentHoverState.swift
+++ b/RevenueCatUI/Templates/V2/EnvironmentObjects/ComponentHoverState.swift
@@ -1,0 +1,77 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ComponentHoverState.swift
+//
+//  Created by Josh Holtz on 9/2/26.
+
+import Foundation
+import SwiftUI
+
+#if !os(tvOS) // For Paywalls V2
+
+struct ComponentHoverStateKey: EnvironmentKey {
+
+    static let defaultValue: Bool = false
+
+}
+
+extension EnvironmentValues {
+
+    /// Whether this component, or an ancestor that declares hover overrides, is currently hovered.
+    var componentHoverState: Bool {
+        get { self[ComponentHoverStateKey.self] }
+        set { self[ComponentHoverStateKey.self] = newValue }
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension View {
+
+    /// Tracks pointer hover for a component and propagates the hover state to its subtree,
+    /// so descendants' hover overrides also apply while an ancestor is hovered (like CSS `:hover`).
+    /// Hover tracking is only attached when the component declares hover overrides
+    /// (`trackingEnabled`), so components without them add no pointer tracking.
+    func componentHoverState(_ isHovered: Binding<Bool>, trackingEnabled: Bool) -> some View {
+        modifier(ComponentHoverStateModifier(isHovered: isHovered, trackingEnabled: trackingEnabled))
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private struct ComponentHoverStateModifier: ViewModifier {
+
+    @Binding var isHovered: Bool
+    let trackingEnabled: Bool
+
+    @Environment(\.componentHoverState)
+    private var inheritedHoverState
+
+    func body(content: Content) -> some View {
+        self.trackingHover(content)
+            .environment(\.componentHoverState, self.isHovered || self.inheritedHoverState)
+    }
+
+    @ViewBuilder
+    private func trackingHover(_ content: Content) -> some View {
+        #if os(watchOS)
+        content
+        #else
+        if self.trackingEnabled {
+            content.onHover { self.isHovered = $0 }
+        } else {
+            content
+        }
+        #endif
+    }
+
+}
+
+#endif

--- a/RevenueCatUI/Templates/V2/Previews/PreviewMock.swift
+++ b/RevenueCatUI/Templates/V2/Previews/PreviewMock.swift
@@ -85,6 +85,7 @@ struct PreviewRequiredPaywallsV2Properties: ViewModifier {
 
     let screenCondition: ScreenCondition
     let componentViewState: ComponentViewState
+    let componentHoverState: Bool
     let packageContext: PackageContext?
 
     func body(content: Content) -> some View {
@@ -96,6 +97,7 @@ struct PreviewRequiredPaywallsV2Properties: ViewModifier {
             .environment(\.selectedPackageId, (self.packageContext ?? Self.defaultPackageContext).package?.identifier)
             .environment(\.screenCondition, screenCondition)
             .environment(\.componentViewState, componentViewState)
+            .environment(\.componentHoverState, componentHoverState)
             .environment(\.safeAreaInsets, EdgeInsets())
             .fixMacButtons() // Matches the properties applied in LoadedPaywallsV2View
     }
@@ -107,11 +109,13 @@ extension View {
     func previewRequiredPaywallsV2Properties(
         screenCondition: ScreenCondition = .compact,
         componentViewState: ComponentViewState = .default,
+        componentHoverState: Bool = false,
         packageContext: PackageContext? = nil
     ) -> some View {
         self.modifier(PreviewRequiredPaywallsV2Properties(
             screenCondition: screenCondition,
             componentViewState: componentViewState,
+            componentHoverState: componentHoverState,
             packageContext: packageContext
         ))
     }

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
@@ -424,6 +424,13 @@ extension Array {
         contains { $0.extendedConditions.contains(.unsupported) }
     }
 
+    /// Whether any override is gated on the hover condition. Component views use this to
+    /// decide whether to attach pointer hover tracking at all.
+    func hasHoverCondition<T: PresentedPartial>() -> Bool
+    where Element == PresentedOverride<T> {
+        contains { $0.conditions.contains(.hover) }
+    }
+
 }
 
 // MARK: - Unsupported Condition Validation

--- a/Tests/RevenueCatUITests/PaywallsV2/HoverOverrideStylesTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/HoverOverrideStylesTests.swift
@@ -1,0 +1,172 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  HoverOverrideStylesTests.swift
+//
+//  Created by Josh Holtz on 9/2/26.
+
+import Nimble
+@_spi(Internal) import RevenueCat
+@testable import RevenueCatUI
+import SwiftUI
+import XCTest
+
+#if !os(tvOS) // For Paywalls V2
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+class HoverOverrideStylesTests: TestCase {
+
+    // MARK: - Stack
+
+    func testStackHoverOverride_AppliedOnlyWhenHovered() throws {
+        let viewModel = try makeStackViewModel(overrides: [
+            .init(extendedConditions: [.hover], properties: .init(visible: false))
+        ])
+
+        let base = viewModel.styles(
+            state: .default,
+            condition: .compact,
+            isHovered: false,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            selectedPackageId: nil,
+            customVariables: [:],
+            colorScheme: .light
+        )
+        let hovered = viewModel.styles(
+            state: .default,
+            condition: .compact,
+            isHovered: true,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            selectedPackageId: nil,
+            customVariables: [:],
+            colorScheme: .light
+        )
+
+        expect(base.visible).to(beTrue())
+        expect(hovered.visible).to(beFalse())
+    }
+
+    func testStackHasHoverOverride() throws {
+        let withHover = try makeStackViewModel(overrides: [
+            .init(extendedConditions: [.hover], properties: .init(visible: false))
+        ])
+        let withoutHover = try makeStackViewModel(overrides: [
+            .init(extendedConditions: [.selected], properties: .init(visible: false))
+        ])
+
+        expect(withHover.hasHoverOverride).to(beTrue())
+        expect(withoutHover.hasHoverOverride).to(beFalse())
+    }
+
+    // MARK: - Text
+
+    @MainActor
+    func testTextHoverOverride_AppliedOnlyWhenHovered() throws {
+        let viewModel = try makeTextViewModel(overrides: [
+            .init(extendedConditions: [.hover], properties: .init(visible: false))
+        ])
+
+        expect(try self.capturedVisible(from: viewModel, isHovered: false)).to(beTrue())
+        expect(try self.capturedVisible(from: viewModel, isHovered: true)).to(beFalse())
+    }
+
+    func testTextHasHoverOverride() throws {
+        let withHover = try makeTextViewModel(overrides: [
+            .init(extendedConditions: [.hover], properties: .init(visible: false))
+        ])
+        let withoutHover = try makeTextViewModel(overrides: [
+            .init(extendedConditions: [.selected], properties: .init(visible: false))
+        ])
+
+        expect(withHover.hasHoverOverride).to(beTrue())
+        expect(withoutHover.hasHoverOverride).to(beFalse())
+    }
+
+    // MARK: - Helpers
+
+    private static let black = PaywallComponent.ColorScheme(
+        light: .hex("#000000")
+    )
+
+    private static func createUIConfigProvider() throws -> UIConfigProvider {
+        let json = """
+        {
+          "app": {
+            "colors": {},
+            "fonts": {}
+          },
+          "localizations": {},
+          "variable_config": {
+            "variable_compatibility_map": {},
+            "function_compatibility_map": {}
+          }
+        }
+        """
+        let jsonData = try XCTUnwrap(json.data(using: .utf8))
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let uiConfig = try decoder.decode(UIConfig.self, from: jsonData)
+        return UIConfigProvider(uiConfig: uiConfig)
+    }
+
+    private func makeStackViewModel(
+        overrides: PaywallComponent.ComponentOverrides<PaywallComponent.PartialStackComponent>
+    ) throws -> StackComponentViewModel {
+        StackComponentViewModel(
+            component: PaywallComponent.StackComponent(
+                components: [],
+                overrides: overrides
+            ),
+            viewModels: [],
+            badgeViewModels: [],
+            uiConfigProvider: try Self.createUIConfigProvider()
+        )
+    }
+
+    private func makeTextViewModel(
+        overrides: PaywallComponent.ComponentOverrides<PaywallComponent.PartialTextComponent>
+    ) throws -> TextComponentViewModel {
+        let localizations: PaywallComponent.LocalizationDictionary = [
+            "text_lid": .string("Hello")
+        ]
+
+        return try TextComponentViewModel(
+            localizationProvider: LocalizationProvider(locale: .current, localizedStrings: localizations),
+            uiConfigProvider: try Self.createUIConfigProvider(),
+            component: PaywallComponent.TextComponent(
+                text: "text_lid",
+                color: Self.black,
+                overrides: overrides
+            )
+        )
+    }
+
+    @MainActor
+    private func capturedVisible(from viewModel: TextComponentViewModel, isHovered: Bool) throws -> Bool {
+        var capturedVisible: Bool?
+        _ = viewModel.styles(
+            state: .default,
+            condition: .compact,
+            isHovered: isHovered,
+            selectedPackageId: nil,
+            packageContext: PackageContext(package: nil, variableContext: .init()),
+            isEligibleForIntroOffer: false,
+            promoOffer: nil
+        ) { style -> EmptyView in
+            capturedVisible = style.visible
+            return EmptyView()
+        }
+        return try XCTUnwrap(capturedVisible)
+    }
+
+}
+
+#endif

--- a/Tests/RevenueCatUITests/PaywallsV2/HoverStateRenderingTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/HoverStateRenderingTests.swift
@@ -1,0 +1,142 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  HoverStateRenderingTests.swift
+//
+//  Created by Josh Holtz on 9/2/26.
+
+@_spi(Internal) import RevenueCat
+@testable import RevenueCatUI
+import SwiftUI
+import XCTest
+
+#if os(iOS)
+import UIKit
+
+/// Measures components hosted with the hover environment injected, asserting that the hover state
+/// actually flows from the environment through the view into the resolved styles. Layout size is
+/// compared because SwiftUI content is not reachable through UIKit subviews, and `drawHierarchy`
+/// renders blank in unit tests.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@MainActor
+final class HoverStateRenderingTests: TestCase {
+
+    func testTextHoverOverride_ChangesLayoutWhenHoverEnvironmentIsActive() throws {
+        let viewModel = try Self.makeTextViewModel()
+
+        let defaultHeight = Self.fittedHeight(TextComponentView(viewModel: viewModel), hovered: false)
+        let hoveredHeight = Self.fittedHeight(TextComponentView(viewModel: viewModel), hovered: true)
+
+        XCTAssertGreaterThan(defaultHeight, 0)
+        XCTAssertGreaterThan(
+            hoveredHeight,
+            defaultHeight,
+            "The .hover override bumps the font size, so the hovered text should measure taller."
+        )
+    }
+
+    func testStackHoverOverrideVisibleFalse_ChangesLayoutWhenHoverEnvironmentIsActive() throws {
+        let viewModel = try Self.makeStackViewModel()
+
+        let defaultHeight = Self.fittedHeight(
+            StackComponentView(viewModel: viewModel, onDismiss: {}), hovered: false
+        )
+        let hoveredHeight = Self.fittedHeight(
+            StackComponentView(viewModel: viewModel, onDismiss: {}), hovered: true
+        )
+
+        XCTAssertGreaterThan(defaultHeight, 0)
+        XCTAssertLessThan(
+            hoveredHeight,
+            defaultHeight,
+            "A stack with a .hover override that hides should measure smaller when hovered."
+        )
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension HoverStateRenderingTests {
+
+    static let localizations: PaywallComponent.LocalizationDictionary = [
+        "id_1": .string("Hello"),
+        "id_2": .string("Hovered")
+    ]
+
+    static func makeTextViewModel() throws -> TextComponentViewModel {
+        return try TextComponentViewModel(
+            localizationProvider: LocalizationProvider(
+                locale: Locale(identifier: "en_US"),
+                localizedStrings: Self.localizations
+            ),
+            uiConfigProvider: UIConfigProvider(uiConfig: PreviewUIConfig.make()),
+            component: PaywallComponent.TextComponent(
+                text: "id_1",
+                color: .init(light: .hex("#000000")),
+                overrides: [
+                    .init(extendedConditions: [.hover], properties: .init(text: "id_2", fontSize: 40))
+                ]
+            )
+        )
+    }
+
+    static func makeStackViewModel() throws -> StackComponentViewModel {
+        let localizationProvider = LocalizationProvider(
+            locale: Locale(identifier: "en_US"),
+            localizedStrings: Self.localizations
+        )
+        let uiConfigProvider = UIConfigProvider(uiConfig: PreviewUIConfig.make())
+        let factory = ViewModelFactory()
+
+        return try factory.toStackViewModel(
+            component: PaywallComponent.StackComponent(
+                components: [
+                    .text(PaywallComponent.TextComponent(
+                        text: "id_1",
+                        color: .init(light: .hex("#000000"))
+                    ))
+                ],
+                overrides: [
+                    .init(extendedConditions: [.hover], properties: .init(visible: false))
+                ]
+            ),
+            packageValidator: factory.packageValidator,
+            purchaseButtonCollector: nil,
+            localizationProvider: localizationProvider,
+            uiConfigProvider: uiConfigProvider,
+            offering: Offering(
+                identifier: "default",
+                serverDescription: "",
+                availablePackages: [],
+                webCheckoutUrl: nil
+            ),
+            colorScheme: .light
+        )
+    }
+
+    static func fittedHeight<Content: View>(_ view: Content, hovered: Bool) -> CGFloat {
+        let controller = UIHostingController(
+            rootView: view
+                .environmentObject(PackageContext(package: nil, variableContext: .init(packages: [])))
+                .environmentObject(
+                    IntroOfferEligibilityContext(introEligibilityChecker: BaseSnapshotTest.eligibleChecker)
+                )
+                .environmentObject(
+                    PaywallPromoOfferCache(subscriptionHistoryTracker: SubscriptionHistoryTracker())
+                )
+                .environment(\.componentHoverState, hovered)
+                .environment(\.screenCondition, .compact)
+                .environment(\.safeAreaInsets, EdgeInsets())
+        )
+        return controller.sizeThatFits(in: CGSize(width: 300, height: CGFloat.greatestFiniteMagnitude)).height
+    }
+
+}
+
+#endif


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Makes hover overrides (macOS / iPad pointer) actually render, starting with the two primary style carriers: stack and text.

### Description
Adds a `componentHoverState` environment value and a `componentHoverState(_:trackingEnabled:)` view modifier that attaches `.onHover` only when a component declares hover overrides, and propagates the hovered state down the subtree — so a hover override on a package's stack also activates hover overrides on its child text (CSS `:hover` semantics). Hover is orthogonal to `selected` (both can be active; overrides apply in array order, last match wins, and compound `[hover, selected]` conditions AND). Never activates on touch or watchOS.

Testing: view-model style resolution is unit tested; the `.onHover` gesture itself isn't snapshot-testable.

Stacked on #7585.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
