### PR TITLE
feat(paywalls-v2): apply hover overrides on remaining V2 components

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
@@ -33,6 +33,11 @@ struct CarouselComponentView: View {
     @Environment(\.componentViewState)
     private var componentViewState
 
+    @Environment(\.componentHoverState)
+    private var componentHoverState
+
+    @State private var isHovered: Bool = false
+
     @Environment(\.screenCondition)
     private var screenCondition
 
@@ -55,6 +60,7 @@ struct CarouselComponentView: View {
         viewModel.styles(
             state: self.componentViewState,
             condition: self.screenCondition,
+            isHovered: self.isHovered || self.componentHoverState,
             isEligibleForIntroOffer: self.introOfferEligibilityContext.isEligible(
                 package: self.packageContext.package
             ),
@@ -118,6 +124,7 @@ struct CarouselComponentView: View {
                 .padding(style.margin)
             }
         }
+        .componentHoverState(self.$isHovered, trackingEnabled: self.viewModel.hasHoverOverride)
     }
 
     private func trackCarouselComponentInteraction(

--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentViewModel.swift
@@ -30,6 +30,11 @@ class CarouselComponentViewModel {
 
     private let presentedOverrides: PresentedOverrides<PresentedCarouselPartial>?
 
+    /// Whether any override is gated on the hover condition, so the view attaches hover tracking.
+    var hasHoverOverride: Bool {
+        self.presentedOverrides?.hasHoverCondition() == true
+    }
+
     init(
         localizationProvider: LocalizationProvider,
         uiConfigProvider: UIConfigProvider,
@@ -67,6 +72,7 @@ class CarouselComponentViewModel {
     func styles(
         state: ComponentViewState,
         condition: ScreenCondition,
+        isHovered: Bool = false,
         isEligibleForIntroOffer: Bool,
         isEligibleForPromoOffer: Bool,
         selectedPackageId: String?,
@@ -81,6 +87,7 @@ class CarouselComponentViewModel {
         let partial = PresentedCarouselPartial.buildPartial(
             state: state,
             condition: condition,
+            isHovered: isHovered,
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             conditionContext: conditionContext,

--- a/RevenueCatUI/Templates/V2/Components/Icon/IconComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Icon/IconComponentView.swift
@@ -32,6 +32,11 @@ struct IconComponentView: View {
     @Environment(\.componentViewState)
     private var componentViewState
 
+    @Environment(\.componentHoverState)
+    private var componentHoverState
+
+    @State private var isHovered: Bool = false
+
     @Environment(\.screenCondition)
     private var screenCondition
 
@@ -54,6 +59,7 @@ struct IconComponentView: View {
         self.viewModel.styles(
             state: self.componentViewState,
             condition: self.screenCondition,
+            isHovered: self.isHovered || self.componentHoverState,
             isEligibleForIntroOffer: self.introOfferEligibilityContext.isEligible(
                 package: self.packageContext.package
             ),
@@ -86,6 +92,7 @@ struct IconComponentView: View {
                 .padding(style.margin)
             }
         }
+        .componentHoverState(self.$isHovered, trackingEnabled: self.viewModel.hasHoverOverride)
     }
 
     private func aspectRatio(style: ImageComponentStyle) -> Double {

--- a/RevenueCatUI/Templates/V2/Components/Icon/IconComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Icon/IconComponentViewModel.swift
@@ -28,6 +28,11 @@ class IconComponentViewModel {
 
     private let presentedOverrides: PresentedOverrides<PresentedIconPartial>?
 
+    /// Whether any override is gated on the hover condition, so the view attaches hover tracking.
+    var hasHoverOverride: Bool {
+        self.presentedOverrides?.hasHoverCondition() == true
+    }
+
     init(
         localizationProvider: LocalizationProvider,
         uiConfigProvider: UIConfigProvider,
@@ -91,6 +96,7 @@ class IconComponentViewModel {
     func styles(
         state: ComponentViewState,
         condition: ScreenCondition,
+        isHovered: Bool = false,
         isEligibleForIntroOffer: Bool,
         isEligibleForPromoOffer: Bool,
         selectedPackageId: String?,
@@ -109,6 +115,7 @@ class IconComponentViewModel {
         let partial = PresentedIconPartial.buildPartial(
             state: state,
             condition: condition,
+            isHovered: isHovered,
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             conditionContext: conditionContext,

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -55,6 +55,11 @@ struct ImageComponentView: View {
     @Environment(\.componentViewState)
     private var componentViewState
 
+    @Environment(\.componentHoverState)
+    private var componentHoverState
+
+    @State private var isHovered: Bool = false
+
     @Environment(\.screenCondition)
     private var screenCondition
 
@@ -105,6 +110,7 @@ struct ImageComponentView: View {
         viewModel.styles(
             state: self.componentViewState,
             condition: self.screenCondition,
+            isHovered: self.isHovered || self.componentHoverState,
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             selectedPackageId: self.selectedPackageId,
@@ -195,6 +201,7 @@ struct ImageComponentView: View {
                 }
             }
         }
+        .componentHoverState(self.$isHovered, trackingEnabled: self.viewModel.hasHoverOverride)
     }
 
     /// Whether a newly measured size should be written into this view's local `@State`.

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentViewModel.swift
@@ -28,6 +28,11 @@ class ImageComponentViewModel {
     private let imageInfo: PaywallComponent.ThemeImageUrls
     private let presentedOverrides: PresentedOverrides<LocalizedImagePartial>?
 
+    /// Whether any override is gated on the hover condition, so the view attaches hover tracking.
+    var hasHoverOverride: Bool {
+        self.presentedOverrides?.hasHoverCondition() == true
+    }
+
     init(
         localizationProvider: LocalizationProvider,
         uiConfigProvider: UIConfigProvider,
@@ -53,6 +58,7 @@ class ImageComponentViewModel {
     func styles(
         state: ComponentViewState,
         condition: ScreenCondition,
+        isHovered: Bool = false,
         isEligibleForIntroOffer: Bool,
         isEligibleForPromoOffer: Bool,
         selectedPackageId: String?,
@@ -71,6 +77,7 @@ class ImageComponentViewModel {
         let localizedPartial = LocalizedImagePartial.buildPartial(
             state: state,
             condition: condition,
+            isHovered: isHovered,
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             conditionContext: conditionContext,
@@ -99,6 +106,7 @@ class ImageComponentViewModel {
     func styles(
         state: ComponentViewState,
         condition: ScreenCondition,
+        isHovered: Bool = false,
         isEligibleForIntroOffer: Bool,
         isEligibleForPromoOffer: Bool,
         selectedPackageId: String?,
@@ -111,6 +119,7 @@ class ImageComponentViewModel {
         let style = styles(
             state: state,
             condition: condition,
+            isHovered: isHovered,
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             selectedPackageId: selectedPackageId,

--- a/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentView.swift
@@ -102,6 +102,9 @@ struct LoadedTabsComponentView: View {
     @Environment(\.componentViewState)
     private var componentViewState
 
+    @Environment(\.componentHoverState)
+    private var componentHoverState
+
     @Environment(\.screenCondition)
     private var screenCondition
 
@@ -308,6 +311,7 @@ struct LoadedTabsComponentView: View {
         let style = viewModel.styles(
             state: self.componentViewState,
             condition: self.screenCondition,
+            isHovered: self.componentHoverState,
             isEligibleForIntroOffer: self.introOfferEligibilityContext.isEligible(
                 package: self.packageContext.package
             ),

--- a/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentViewModel.swift
@@ -25,6 +25,11 @@ class TabsComponentViewModel {
     let uiConfigProvider: UIConfigProvider
     private let presentedOverrides: PresentedOverrides<PresentedTabsPartial>?
 
+    /// Whether any override is gated on the hover condition, so the view attaches hover tracking.
+    var hasHoverOverride: Bool {
+        self.presentedOverrides?.hasHoverCondition() == true
+    }
+
     let controlStackViewModel: StackComponentViewModel
     let tabViewModels: [String: TabViewModel]
     let tabIds: [String]
@@ -84,6 +89,7 @@ class TabsComponentViewModel {
     func styles(
         state: ComponentViewState,
         condition: ScreenCondition,
+        isHovered: Bool = false,
         isEligibleForIntroOffer: Bool,
         isEligibleForPromoOffer: Bool,
         selectedPackageId: String?,
@@ -98,6 +104,7 @@ class TabsComponentViewModel {
         let partial = PresentedTabsPartial.buildPartial(
             state: state,
             condition: condition,
+            isHovered: isHovered,
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             conditionContext: conditionContext,

--- a/RevenueCatUI/Templates/V2/Components/Timeline/TimelineComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Timeline/TimelineComponentView.swift
@@ -34,6 +34,11 @@ struct TimelineComponentView: View {
     @Environment(\.componentViewState)
     private var componentViewState
 
+    @Environment(\.componentHoverState)
+    private var componentHoverState
+
+    @State private var isHovered: Bool = false
+
     @Environment(\.screenCondition)
     private var screenCondition
 
@@ -55,6 +60,7 @@ struct TimelineComponentView: View {
         viewModel.styles(
             state: self.componentViewState,
             condition: self.screenCondition,
+            isHovered: self.isHovered || self.componentHoverState,
             isEligibleForIntroOffer: self.introOfferEligibilityContext.isEligible(
                 package: self.packageContext.package
             ),
@@ -68,6 +74,7 @@ struct TimelineComponentView: View {
                 timeline(style: style)
             }
         }
+        .componentHoverState(self.$isHovered, trackingEnabled: self.viewModel.hasHoverOverride)
     }
 
     @ViewBuilder
@@ -79,6 +86,7 @@ struct TimelineComponentView: View {
                 item.styles(
                     state: self.componentViewState,
                     condition: self.screenCondition,
+                    isHovered: self.isHovered || self.componentHoverState,
                     isEligibleForIntroOffer: self.introOfferEligibilityContext.isEligible(
                         package: self.packageContext.package
                     ),
@@ -106,6 +114,7 @@ struct TimelineComponentView: View {
                     item.styles(
                         state: self.componentViewState,
                         condition: self.screenCondition,
+                        isHovered: self.isHovered || self.componentHoverState,
                         isEligibleForIntroOffer: self.introOfferEligibilityContext.isEligible(
                             package: self.packageContext.package
                         ),

--- a/RevenueCatUI/Templates/V2/Components/Timeline/TimelineComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Timeline/TimelineComponentViewModel.swift
@@ -31,6 +31,11 @@ class TimelineComponentViewModel {
 
     private let presentedOverrides: PresentedOverrides<PresentedTimelinePartial>?
 
+    /// Whether any override is gated on the hover condition, so the view attaches hover tracking.
+    var hasHoverOverride: Bool {
+        self.presentedOverrides?.hasHoverCondition() == true
+    }
+
     init(
         component: PaywallComponent.TimelineComponent,
         items: [TimelineItemViewModel],
@@ -49,6 +54,7 @@ class TimelineComponentViewModel {
     func styles(
         state: ComponentViewState,
         condition: ScreenCondition,
+        isHovered: Bool = false,
         isEligibleForIntroOffer: Bool,
         isEligibleForPromoOffer: Bool,
         selectedPackageId: String?,
@@ -62,6 +68,7 @@ class TimelineComponentViewModel {
         let partial = PresentedTimelinePartial.buildPartial(
             state: state,
             condition: condition,
+            isHovered: isHovered,
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             conditionContext: conditionContext,
@@ -116,6 +123,7 @@ class TimelineItemViewModel {
     func styles(
         state: ComponentViewState,
         condition: ScreenCondition,
+        isHovered: Bool = false,
         isEligibleForIntroOffer: Bool,
         isEligibleForPromoOffer: Bool,
         selectedPackageId: String?,
@@ -129,6 +137,7 @@ class TimelineItemViewModel {
         let partial = PresentedTimelineItemPartial.buildPartial(
             state: state,
             condition: condition,
+            isHovered: isHovered,
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             conditionContext: conditionContext,

--- a/RevenueCatUI/Templates/V2/Components/Video/VideoComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoComponentView.swift
@@ -32,6 +32,11 @@ struct VideoComponentView: View {
     @Environment(\.componentViewState)
     private var componentViewState
 
+    @Environment(\.componentHoverState)
+    private var componentHoverState
+
+    @State private var isHovered: Bool = false
+
     @Environment(\.screenCondition)
     private var screenCondition
 
@@ -73,6 +78,7 @@ struct VideoComponentView: View {
             .styles(
                 state: componentViewState,
                 condition: screenCondition,
+                isHovered: isHovered || componentHoverState,
                 isEligibleForIntroOffer: self.introOfferEligibilityContext.isEligible(
                     package: self.packageContext.package
                 ),
@@ -163,6 +169,7 @@ struct VideoComponentView: View {
             .onChangeOf(carouselState) { newState in
                 updatePlayableState(isPlayable: newState?.isActiveOrNeighbor ?? true)
             }
+            .componentHoverState($isHovered, trackingEnabled: viewModel.hasHoverOverride)
 
     }
 

--- a/RevenueCatUI/Templates/V2/Components/Video/VideoComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoComponentViewModel.swift
@@ -28,6 +28,11 @@ class VideoComponentViewModel {
 
     private let presentedOverrides: PresentedOverrides<LocalizedVideoPartial>?
 
+    /// Whether any override is gated on the hover condition, so the view attaches hover tracking.
+    var hasHoverOverride: Bool {
+        self.presentedOverrides?.hasHoverCondition() == true
+    }
+
     init(
         localizationProvider: LocalizationProvider,
         uiConfigProvider: UIConfigProvider,
@@ -75,6 +80,7 @@ class VideoComponentViewModel {
     func styles(
         state: ComponentViewState,
         condition: ScreenCondition,
+        isHovered: Bool = false,
         isEligibleForIntroOffer: Bool,
         isEligibleForPromoOffer: Bool,
         selectedPackageId: String?,
@@ -89,6 +95,7 @@ class VideoComponentViewModel {
         let localizedPartial = LocalizedVideoPartial.buildPartial(
             state: state,
             condition: condition,
+            isHovered: isHovered,
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             conditionContext: conditionContext,

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
@@ -26,6 +26,9 @@ struct WebViewComponentView: View {
     @Environment(\.componentViewState)
     private var componentViewState
 
+    @Environment(\.componentHoverState)
+    private var componentHoverState
+
     @Environment(\.screenCondition)
     private var screenCondition
 
@@ -57,6 +60,7 @@ struct WebViewComponentView: View {
         return self.viewModel.style(
             state: self.componentViewState,
             condition: self.screenCondition,
+            isHovered: self.componentHoverState,
             isEligibleForIntroOffer: self.introOfferEligibilityContext.isEligible(package: currentPackage),
             isEligibleForPromoOffer: self.paywallPromoOfferCache.isMostLikelyEligible(for: currentPackage),
             selectedPackageId: self.selectedPackageId,

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentViewModel.swift
@@ -17,6 +17,11 @@ final class WebViewComponentViewModel: Hashable {
     private let uiConfigProvider: UIConfigProvider
     private let presentedOverrides: PresentedOverrides<PresentedWebViewPartial>?
 
+    /// Whether any override is gated on the hover condition, so the view attaches hover tracking.
+    var hasHoverOverride: Bool {
+        self.presentedOverrides?.hasHoverCondition() == true
+    }
+
     #if !os(watchOS) && canImport(WebKit)
     @MainActor
     private var storedWebViewInstance: WebViewInstance?
@@ -84,6 +89,7 @@ final class WebViewComponentViewModel: Hashable {
     func style(
         state: ComponentViewState,
         condition: ScreenCondition,
+        isHovered: Bool = false,
         isEligibleForIntroOffer: Bool,
         isEligibleForPromoOffer: Bool,
         selectedPackageId: String?,
@@ -101,6 +107,7 @@ final class WebViewComponentViewModel: Hashable {
         let partial = PresentedWebViewPartial.buildPartial(
             state: state,
             condition: condition,
+            isHovered: isHovered,
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             conditionContext: conditionContext,

--- a/Tests/RevenueCatUITests/PaywallsV2/HoverOverrideStylesTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/HoverOverrideStylesTests.swift
@@ -90,6 +90,18 @@ class HoverOverrideStylesTests: TestCase {
         expect(withoutHover.hasHoverOverride).to(beFalse())
     }
 
+    // MARK: - Icon (representative of the remaining components' shared threading)
+
+    func testIconHoverOverride_AppliedOnlyWhenHovered() throws {
+        let viewModel = try makeIconViewModel(overrides: [
+            .init(extendedConditions: [.hover], properties: .init(visible: false))
+        ])
+
+        expect(viewModel.hasHoverOverride).to(beTrue())
+        expect(try self.capturedIconVisible(from: viewModel, isHovered: false)).to(beTrue())
+        expect(try self.capturedIconVisible(from: viewModel, isHovered: true)).to(beFalse())
+    }
+
     // MARK: - Helpers
 
     private static let black = PaywallComponent.ColorScheme(
@@ -147,6 +159,44 @@ class HoverOverrideStylesTests: TestCase {
                 overrides: overrides
             )
         )
+    }
+
+    private func makeIconViewModel(
+        overrides: PaywallComponent.ComponentOverrides<PaywallComponent.PartialIconComponent>
+    ) throws -> IconComponentViewModel {
+        IconComponentViewModel(
+            localizationProvider: LocalizationProvider(locale: .current, localizedStrings: [:]),
+            uiConfigProvider: try Self.createUIConfigProvider(),
+            component: PaywallComponent.IconComponent(
+                baseUrl: "https://icons.pawwalls.com",
+                iconName: "star",
+                formats: .init(svg: "star.svg", png: "star.png", heic: "star.heic", webp: "star.webp"),
+                size: .init(width: .fixed(20), height: .fixed(20)),
+                padding: nil,
+                margin: nil,
+                color: Self.black,
+                iconBackground: nil,
+                overrides: overrides
+            )
+        )
+    }
+
+    private func capturedIconVisible(from viewModel: IconComponentViewModel, isHovered: Bool) throws -> Bool {
+        var capturedVisible: Bool?
+        _ = viewModel.styles(
+            state: .default,
+            condition: .compact,
+            isHovered: isHovered,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            selectedPackageId: nil,
+            customVariables: [:],
+            colorScheme: .light
+        ) { style -> EmptyView in
+            capturedVisible = style.visible
+            return EmptyView()
+        }
+        return try XCTUnwrap(capturedVisible)
     }
 
     @MainActor


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Completes hover override support across the V2 component set so any component with hover overrides in its schema responds on pointer devices.

### Description
Threads `isHovered` through image, icon, video, web view, carousel, tabs, and timeline (including timeline items), using the same pattern as #7586. Image, icon, video, carousel, and timeline attach their own hover tracking; tabs and web view only inherit hover from ancestors (tab chrome is composed of stacks that already track their own hover, and WKWebView swallows pointer events). Button and package are deliberately untouched: their partials are visibility-only, so hover styling lives on their inner stacks — and hover-toggled visibility would flicker (hover → hide → un-hover → show).

Top of the stack: #7585 ← #7586 ← this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
