### PR TITLE
Chore(Paywalls): Update models to support min/max sizes

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -3204,6 +3204,7 @@
 		DBAA1FBA2F8D45C2000E8C81 /* HeaderTextBodyHeroSafeAreaPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderTextBodyHeroSafeAreaPreview.swift; sourceTree = "<group>"; };
 		DBAA1FC12F8D4ED8000E8C81 /* HeaderNestedHeroZLayerSafeAreaPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderNestedHeroZLayerSafeAreaPreview.swift; sourceTree = "<group>"; };
 		DBB32F183007CACD00A86DC7 /* BottomSheetSwitchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetSwitchTests.swift; sourceTree = "<group>"; };
+		A5C7E90130F8000100ABCDEF /* SizeModifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SizeModifierTests.swift; sourceTree = "<group>"; };
 		DBD243292EBDF4B80066AC6F /* PromotionalOfferViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionalOfferViewTests.swift; sourceTree = "<group>"; };
 		DBD2A167300E81E20019DB7F /* VideoAudioSessionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAudioSessionHandler.swift; sourceTree = "<group>"; };
 		DBD2A16E300E833F0019DB7F /* VideoAudioSessionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAudioSessionHandlerTests.swift; sourceTree = "<group>"; };
@@ -3530,6 +3531,7 @@
 				B413E5A12F97B3B900B5F0CA /* TabsWorkflowDefaultPackageTests.swift */,
 				F4A8C1D25E3B47A9B0D6E718 /* MixedTabsDefaultPackageVisibilityTests.swift */,
 				DBB32F183007CACD00A86DC7 /* BottomSheetSwitchTests.swift */,
+				A5C7E90130F8000100ABCDEF /* SizeModifierTests.swift */,
 				DB1FC9592F9A1B74009A95EA /* WorkflowScreenMapperTests.swift */,
 				F468C7BCEB786BEC80277ECA /* WorkflowNavigatorTests.swift */,
 				C07759C930F712D2D53B9333 /* WorkflowStepEventTrackerTests.swift */,

--- a/RevenueCatUI/Templates/V2/Components/Button/BottomSheetView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/BottomSheetView.swift
@@ -60,7 +60,7 @@ struct BottomSheetOverlayModifier: ViewModifier {
             return nil
         case .fixed(let height):
             return CGFloat(height)
-        case .relative(let percent):
+        case .relative(let percent, _):
             guard let parentHeight = self.parentHeight else {
                 return nil
             }

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -398,7 +398,7 @@ struct ImageComponentView_Previews: PreviewProvider {
             case .relative:
                 estimatedContentWidth = min(availableContentWidth, intrinsicWidth)
             }
-        case .relative(let value):
+        case .relative(let value, _):
             estimatedContentWidth = max(0, availableContentWidth * CGFloat(value))
         }
 

--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
@@ -197,7 +197,7 @@ fileprivate extension View {
             if enabled {
                 self.scrollableIfNecessaryWhenAvailable(
                     .horizontal,
-                    fillContent: size.width == .fill,
+                    fillContent: size.width.isFill,
                     alignment: Alignment(
                         horizontal: distribution.horizontalFrameAlignment.horizontal,
                         vertical: verticalAlignment.frameAlignment.vertical
@@ -210,7 +210,7 @@ fileprivate extension View {
             if enabled {
                 self.scrollableIfNecessaryWhenAvailable(
                     .vertical,
-                    fillContent: size.height == .fill,
+                    fillContent: size.height.isFill,
                     alignment: Alignment(
                         horizontal: horizontalAlignment.frameAlignment.horizontal,
                         vertical: distribution.verticalFrameAlignment.vertical

--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentViewModel.swift
@@ -38,11 +38,11 @@ class StackComponentViewModel {
         }) else { return false }
         switch first {
         case .image(let image):
-            return image.size.width == .fill
+            return image.size.width.isFill
         case .video(let video):
-            return video.size.width == .fill
+            return video.size.width.isFill
         case .webView(let webView):
-            return webView.size.width == .fill
+            return webView.size.width.isFill
         default:
             return false
         }

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
@@ -444,7 +444,7 @@ private extension View {
         measuredWidth: CGFloat?
     ) -> some View {
         switch constraint {
-        case .fit(let defaultSize):
+        case .fit(let defaultSize, _):
             self.frame(
                 width: WebViewSizing.resolvedDimension(
                     measured: measuredWidth,
@@ -467,7 +467,7 @@ private extension View {
         measuredHeight: CGFloat?
     ) -> some View {
         switch constraint {
-        case .fit(let defaultSize):
+        case .fit(let defaultSize, _):
             self.frame(
                 height: WebViewSizing.resolvedDimension(
                     measured: measuredHeight,

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -715,7 +715,7 @@ struct LoadedPaywallsV2View: View {
                 view
                     .edgesIgnoringSafeArea(.top)
             })
-            .applyIf(paywallState.rootViewModel.stackViewModel.component.size.height == .fill, apply: { view in
+            .applyIf(paywallState.rootViewModel.stackViewModel.component.size.height.isFill, apply: { view in
                 view.frame(maxHeight: .infinity, alignment: paywallState.rootViewModel.frameAlignment)
             })
             .backgroundStyle(

--- a/RevenueCatUI/Templates/V2/ViewHelpers/ApplySizing.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/ApplySizing.swift
@@ -14,49 +14,57 @@
 @_spi(Internal) import RevenueCat
 import SwiftUI
 
+#if !os(tvOS) // For Paywalls V2
+
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension View {
 
     @ViewBuilder
     func applyMediaWidth(size: PaywallComponent.Size) -> some View {
         switch size.width {
-        case .fit:
+        case let .fit(_, minMax):
+            self.applyWidthLimits(minMax, alignment: .center)
+        case let .fill(minMax):
             self
-        case .fill:
-            self.frame(maxWidth: .infinity)
+                .frame(maxWidth: .infinity)
+                .applyWidthLimits(minMax, alignment: .center)
         case .fixed(let value):
             self.frame(width: Double(value))
-        default:
-            self
+        case let .relative(_, minMax):
+            self.applyWidthLimits(minMax, alignment: .center)
         }
     }
 
     @ViewBuilder
     func applyMediaHeight(size: PaywallComponent.Size, aspectRatio: Double) -> some View {
         switch size.height {
-        case .fit:
+        case let .fit(_, minMax):
             switch size.width {
             case .fit:
-                self
+                self.applyHeightLimits(minMax, alignment: .center)
             case .fill:
-                self
+                self.applyHeightLimits(minMax, alignment: .center)
             case .fixed(let value):
                 // This is the only change versus the regular .size() modifier.
                 // When the image or videoa has height=fit and fixed width, we manually set a
                 // fixed height according to the aspect ratio.
                 // Otherwise the view would grow vertically to occupy available space.
                 // See "Image streching vertically" preview
-                self.frame(height: Double(value) / aspectRatio)
-            default:
-                self
+                self.frame(height: minMax.clamped(Double(value) / aspectRatio))
+            case .relative:
+                self.applyHeightLimits(minMax, alignment: .center)
             }
-        case .fill:
-            self.frame(maxHeight: .infinity)
+        case let .fill(minMax):
+            self
+                .frame(maxHeight: .infinity)
+                .applyHeightLimits(minMax, alignment: .center)
         case .fixed(let value):
             self.frame(height: Double(value))
-        default:
-            self
+        case let .relative(_, minMax):
+            self.applyHeightLimits(minMax, alignment: .center)
         }
     }
 
 }
+
+#endif

--- a/RevenueCatUI/Templates/V2/ViewHelpers/SizeModifier.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/SizeModifier.swift
@@ -30,40 +30,104 @@ struct SizeModifier: ViewModifier {
 
 }
 
-fileprivate extension View {
+extension View {
 
     @ViewBuilder
     func applyWidth(_ sizeConstraint: PaywallComponent.SizeConstraint, alignment: Alignment) -> some View {
         switch sizeConstraint {
-        case .fit:
-            self
-        case .fill:
+        case let .fit(_, minMax):
+            self.applyWidthLimits(minMax, alignment: alignment)
+        case let .fill(minMax):
             self
                 .frame(maxWidth: .infinity, alignment: alignment)
+                .applyWidthLimits(minMax, alignment: alignment)
         case .fixed(let value):
             self
                 .frame(width: CGFloat(value), alignment: alignment)
-        case .relative:
-            // WIP: Maybe handle
-            self
+        case let .relative(_, minMax):
+            // WIP: Maybe handle % value here
+            self.applyWidthLimits(minMax, alignment: alignment)
         }
     }
 
     @ViewBuilder
     func applyHeight(_ sizeConstraint: PaywallComponent.SizeConstraint, alignment: Alignment) -> some View {
         switch sizeConstraint {
-        case .fit:
-            self
-        case .fill:
+        case let .fit(_, minMax):
+            self.applyHeightLimits(minMax, alignment: alignment)
+        case let .fill(minMax):
             self
                 .frame(maxHeight: .infinity, alignment: alignment)
+                .applyHeightLimits(minMax, alignment: alignment)
         case .fixed(let value):
             self
                 .frame(height: CGFloat(value), alignment: alignment)
-        case .relative:
-            // WIP: Maybe handle
+        case let .relative(_, minMax):
+            // WIP: Maybe handle % value here
+            self.applyHeightLimits(minMax, alignment: alignment)
+        }
+    }
+
+    @ViewBuilder
+    func applyWidthLimits(_ minMax: MinMax, alignment: Alignment) -> some View {
+        if minMax.hasLimit {
+            self.frame(
+                minWidth: minMax.minDimension,
+                maxWidth: minMax.effectiveMaxDimension,
+                alignment: alignment
+            )
+        } else {
             self
         }
+    }
+
+    @ViewBuilder
+    func applyHeightLimits(_ minMax: MinMax, alignment: Alignment) -> some View {
+        if minMax.hasLimit {
+            self.frame(
+                minHeight: minMax.minDimension,
+                maxHeight: minMax.effectiveMaxDimension,
+                alignment: alignment
+            )
+        } else {
+            self
+        }
+    }
+
+}
+
+extension MinMax {
+
+    fileprivate var hasLimit: Bool {
+        return self != .null
+    }
+
+    fileprivate var minDimension: CGFloat? {
+        return self.min.map { CGFloat($0) }
+    }
+
+    /// Aligned with CSS - minimum gets precedence when it is greater than the maximum.
+    fileprivate var effectiveMaxDimension: CGFloat? {
+        switch (self.min, self.max) {
+        case let (.some(minimum), .some(maximum)):
+            return CGFloat(Swift.max(minimum, maximum))
+        case let (_, .some(maximum)):
+            return CGFloat(maximum)
+        default:
+            return nil
+        }
+    }
+
+    func clamped(_ value: CGFloat) -> CGFloat {
+        if let minimum = self.minDimension, value < minimum {
+            return minimum
+        }
+
+        if let maximum = self.effectiveMaxDimension, value > maximum {
+            return maximum
+        }
+
+        return value
     }
 
 }

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
@@ -594,11 +594,11 @@ struct ViewModelFactory {
     ) -> FirstMediaType? {
         switch component {
         case .image(let image):
-            return image.size.width == .fill ? .image : nil
+            return image.size.width.isFill ? .image : nil
         case .video(let video):
-            return video.size.width == .fill ? .video : nil
+            return video.size.width.isFill ? .video : nil
         case .webView(let webView):
-            return webView.size.width == .fill ? .webView : nil
+            return webView.size.width.isFill ? .webView : nil
         case .stack(let stack):
             guard let first = stack.components.first(where: {
                 if case .fallbackHeader = $0 { return false }

--- a/Sources/Paywalls/Components/Common/PaywallComponentPropertyTypes.swift
+++ b/Sources/Paywalls/Components/Common/PaywallComponentPropertyTypes.swift
@@ -411,28 +411,46 @@ import Foundation
 
     enum SizeConstraint: Codable, Sendable, Hashable {
 
-        case fit(UInt?) // optional default size to show during loading and initial content size calculations
-        case fill
+        // optional default size to show during loading and initial content size calculations
+        case fit(UInt?, MinMax = .null)
+        case fill(MinMax)
         case fixed(UInt)
 
         // Only used for button sheet for now
-        case relative(Double)
+        case relative(Double, MinMax = .null)
+
+        /// Preserves the existing `.fill` syntax while allowing constrained fill values.
+        public static var fill: Self { .fill(.null) }
+
+        public var isFill: Bool {
+            if case .fill = self {
+                return true
+            }
+
+            return false
+        }
 
         public func encode(to encoder: any Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
 
             switch self {
-            case .fit(let value):
+            case let .fit(value, minMax):
                 try container.encode(SizeConstraintType.fit.rawValue, forKey: .type)
                 if let value {
                     try container.encode(value, forKey: .default)
                 }
-            case .fill:
+                try container.encodeIfPresent(minMax.min, forKey: .min)
+                try container.encodeIfPresent(minMax.max, forKey: .max)
+            case let .fill(minMax):
                 try container.encode(SizeConstraintType.fill.rawValue, forKey: .type)
-            case .fixed(let value):
+                try container.encodeIfPresent(minMax.min, forKey: .min)
+                try container.encodeIfPresent(minMax.max, forKey: .max)
+            case let .fixed(value):
                 try container.encode(SizeConstraintType.fixed.rawValue, forKey: .type)
                 try container.encode(value, forKey: .value)
-            case .relative(let value):
+            case let .relative(value, minMax):
+                try container.encodeIfPresent(minMax.min, forKey: .min)
+                try container.encodeIfPresent(minMax.max, forKey: .max)
                 try container.encode(SizeConstraintType.relative.rawValue, forKey: .type)
                 try container.encode(value, forKey: .value)
             }
@@ -441,23 +459,24 @@ import Foundation
         public init(from decoder: Decoder) throws {
             do {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
+                let minMax = (try? MinMax(from: decoder)) ?? .null
                 let type = try container.decode(SizeConstraintType.self, forKey: .type)
 
                 switch type {
                 case .fit:
                     let value = try container.decodeIfPresent(UInt.self, forKey: .default)
-                    self = .fit(value)
+                    self = .fit(value, minMax)
                 case .fill:
-                    self = .fill
+                    self = .fill(minMax)
                 case .fixed:
                     let value = try container.decode(UInt.self, forKey: .value)
                     self = .fixed(value)
                 case .relative:
                     let value = try container.decode(Double.self, forKey: .value)
-                    self = .relative(value)
+                    self = .relative(value, minMax)
                 }
             } catch {
-                self = .fit(nil)
+                self = .fit(nil, .null)
             }
         }
 
@@ -467,7 +486,8 @@ import Foundation
             case type
             case value
             case `default`
-
+            case min
+            case max
         }
 
         // swiftlint:disable:next nesting
@@ -482,14 +502,14 @@ import Foundation
 
         public static func == (lhs: SizeConstraint, rhs: SizeConstraint) -> Bool {
             switch (lhs, rhs) {
-            case let (.fit(left), .fit(right)):
+            case let (.fit(leftDefault, leftMinMax), .fit(rightDefault, rightMinMax)):
+                return leftDefault == rightDefault && leftMinMax == rightMinMax
+            case let (.fill(left), .fill(right)):
                 return left == right
-            case (.fill, .fill):
-                return true
             case let (.fixed(left), .fixed(right)):
                 return left == right
-            case let (.relative(left), .relative(right)):
-                return left == right
+            case let (.relative(leftValue, leftMinMax), .relative(rightValue, rightMinMax)):
+                return leftValue == rightValue && leftMinMax == rightMinMax
             default:
                 return false
             }
@@ -675,4 +695,16 @@ import Foundation
 
     }
 
+}
+
+@_spi(Internal) public struct MinMax: Codable, Hashable, Sendable {
+    public let min: UInt?
+    public let max: UInt?
+
+    public init(min: UInt?, max: UInt?) {
+        self.min = min
+        self.max = max
+    }
+
+    public static let null = MinMax(min: nil, max: nil)
 }

--- a/Tests/RevenueCatUITests/PaywallsV2/SizeModifierTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/SizeModifierTests.swift
@@ -1,0 +1,86 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SizeModifierTests.swift
+
+@_spi(Internal) import RevenueCat
+@testable import RevenueCatUI
+import SwiftUI
+import XCTest
+
+#if os(iOS)
+
+@available(iOS 15.0, *)
+@MainActor
+final class SizeModifierTests: TestCase {
+
+    func testConstrainedFillIsStillClassifiedAsFill() {
+        XCTAssertTrue(PaywallComponent.SizeConstraint.fill(.init(min: 20, max: 30)).isFill)
+        XCTAssertFalse(PaywallComponent.SizeConstraint.fit(nil, .init(min: 20, max: 30)).isFill)
+    }
+
+    func testFitContentRespectsMinimumWidthAndHeight() {
+        let view = Color.clear
+            .frame(width: 10, height: 10)
+            .size(
+                .init(
+                    width: .fit(nil, .init(min: 20, max: nil)),
+                    height: .fit(nil, .init(min: 30, max: nil))
+                )
+            )
+
+        XCTAssertEqual(
+            Self.fittingSize(of: view, in: .init(width: 100, height: 100)),
+            .init(width: 20, height: 30)
+        )
+    }
+
+    func testFillRespectsMaximumWidth() {
+        let view = Color.clear
+            .size(
+                .init(
+                    width: .fill(.init(min: nil, max: 20)),
+                    height: .fixed(10)
+                )
+            )
+
+        XCTAssertEqual(Self.fittingSize(of: view, in: .init(width: 100, height: 100)).width, 20)
+    }
+
+    func testFillMinimumCanExceedParentWidth() {
+        let view = Color.clear
+            .size(
+                .init(
+                    width: .fill(.init(min: 120, max: nil)),
+                    height: .fixed(10)
+                )
+            )
+
+        XCTAssertEqual(Self.fittingSize(of: view, in: .init(width: 100, height: 100)).width, 120)
+    }
+
+    func testMinimumTakesPrecedenceOverMaximum() {
+        let view = Color.clear
+            .size(
+                .init(
+                    width: .fill(.init(min: 40, max: 20)),
+                    height: .fixed(10)
+                )
+            )
+
+        XCTAssertEqual(Self.fittingSize(of: view, in: .init(width: 100, height: 100)).width, 40)
+    }
+
+    private static func fittingSize<Content: View>(of view: Content, in proposal: CGSize) -> CGSize {
+        UIHostingController(rootView: view).sizeThatFits(in: proposal)
+    }
+
+}
+
+#endif

--- a/Tests/UnitTests/Paywalls/Components/JSON/SizeConstraints.json
+++ b/Tests/UnitTests/Paywalls/Components/JSON/SizeConstraints.json
@@ -14,5 +14,45 @@
     "fill_fit_withDefault": {
         "width": { "type": "fill" },
         "height": { "type": "fit", "default": 2 }
+    },
+    "fit_withMin": {
+        "width": { "type": "fit", "min": 2 },
+        "height": { "type": "fit", "min": 2 }
+    },
+    "fit_withMax": {
+        "width": { "type": "fit", "max": 2 },
+        "height": { "type": "fit", "max": 2 }
+    },
+    "fit_withMinMax": {
+        "width": { "type": "fit", "min": 2, "max": 3 },
+        "height": { "type": "fit", "min": 2, "max": 3 }
+    },
+    "fill_withMin": {
+        "width": { "type": "fill", "min": 2 },
+        "height": { "type": "fill", "min": 2 }
+    },
+    "fill_withMax": {
+        "width": { "type": "fill", "max": 2 },
+        "height": { "type": "fill", "max": 2 }
+    },
+    "fill_withMinMax": {
+        "width": { "type": "fill", "min": 2, "max": 3 },
+        "height": { "type": "fill", "min": 2, "max": 3 }
+    },
+    "relative_withMin": {
+        "width": { "type": "relative", "min": 2, "value": 0.8 },
+        "height": { "type": "relative", "min": 2, "value": 0.8 }
+    },
+    "relative_withMax": {
+        "width": { "type": "relative", "max": 3, "value": 0.8 },
+        "height": { "type": "relative", "max": 3, "value": 0.8 }
+    },
+    "relative_withMinMax": {
+        "width": { "type": "relative", "min": 2, "max": 3, "value": 0.8 },
+        "height": { "type": "relative", "min": 2, "max": 3, "value": 0.8 }
+    },
+    "fixed_fit": {
+        "width": { "type": "fixed", "value": 80 },
+        "height": { "type": "fit" }
     }
 }

--- a/Tests/UnitTests/Paywalls/Components/Properties/SizeConstraintTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/Properties/SizeConstraintTests.swift
@@ -24,6 +24,36 @@ final class SizeConstraintTests: TestCase {
         XCTAssertEqual(sizes.fillFill, .init(width: .fill, height: .fill))
         XCTAssertEqual(sizes.fitFill, .init(width: .fit(2), height: .fill))
         XCTAssertEqual(sizes.fillFit, .init(width: .fill, height: .fit(2)))
+        XCTAssertEqual(
+            sizes.fitWithMin,
+            .init(
+                width: .fit(nil, .init(min: 2, max: nil)),
+                height: .fit(nil, .init(min: 2, max: nil))
+            )
+        )
+        XCTAssertEqual(
+            sizes.fitWithMax,
+            .init(
+                width: .fit(nil, .init(min: nil, max: 2)),
+                height: .fit(nil, .init(min: nil, max: 2))
+            )
+        )
+        XCTAssertEqual(
+            sizes.fillWithMinMax,
+            .init(
+                width: .fill(.init(min: 2, max: 3)),
+                height: .fill(.init(min: 2, max: 3))
+            )
+        )
+        XCTAssertEqual(
+            sizes.relativeWithMinMax,
+            .init(
+                width: .relative(0.8, .init(min: 2, max: 3)),
+                height: .relative(0.8, .init(min: 2, max: 3))
+            )
+        )
+        XCTAssertTrue(sizes.fillWithMinMax.width.isFill)
+        XCTAssertFalse(sizes.fitWithMin.width.isFill)
     }
 }
 
@@ -32,11 +62,19 @@ struct Sizes: Codable {
     let fillFill: PaywallComponent.Size
     let fitFill: PaywallComponent.Size
     let fillFit: PaywallComponent.Size
+    let fitWithMin: PaywallComponent.Size
+    let fitWithMax: PaywallComponent.Size
+    let fillWithMinMax: PaywallComponent.Size
+    let relativeWithMinMax: PaywallComponent.Size
 
     enum CodingKeys: String, CodingKey {
         case fitFit = "fit_fit"
         case fillFill = "fill_fill"
         case fitFill = "fit_withDefault_fill"
         case fillFit = "fill_fit_withDefault"
+        case fitWithMin = "fit_withMin"
+        case fitWithMax = "fit_withMax"
+        case fillWithMinMax = "fill_withMinMax"
+        case relativeWithMinMax = "relative_withMinMax"
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->
<!-- AI agents: fill in this template, and also follow the "Pull Requests" section in AGENTS.md. -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->
We need to support min/max sizes soon.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
Update the models to begin to support this feature

> [!NOTE]
> This is not live in the backend or dashboard, and therefore will not be used for a bit, Other PRs incoming soon to finish the implementation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared paywall layout and `SizeConstraint` decoding across many V2 components; behavior is guarded by tests and defaults preserve existing payloads, but incorrect min/max handling could visibly affect paywall layout once enabled.
> 
> **Overview**
> Adds **optional `min` / `max` dimensions** to Paywalls V2 `SizeConstraint` values by introducing a `MinMax` type and threading it through **fit**, **fill**, and **relative** cases (JSON encode/decode included). **`.fill` stays source-compatible** via a `static var fill` alias and an **`isFill`** helper so layout logic still treats constrained fill as fill.
> 
> **Paywalls V2 sizing** now applies those bounds in `SizeModifier` and media helpers (`applyWidthLimits` / `applyHeightLimits`, with **min winning when min > max**), and call sites are updated for the new enum shapes (stacks, root paywall, bottom sheets, web views, full-width media detection).
> 
> **Tests**: JSON decoding cases, new `SizeModifierTests` for layout behavior, and Xcode project wiring for the test target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4b8992f4cfd455d10c8efb8bfe1c9b481e03e8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->