### PR TITLE
Add window size conditions for paywall component overrides

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
@@ -48,6 +48,9 @@ struct ButtonComponentView: View {
     @Environment(\.screenCondition)
     private var screenCondition
 
+    @Environment(\.paywallWindowSize)
+    private var paywallWindowSize
+
     @Environment(\.customPaywallVariables)
     private var customVariables
 
@@ -101,7 +104,8 @@ struct ButtonComponentView: View {
                    for: self.packageContext.package
                ),
                selectedPackageId: self.selectedPackageId,
-               customVariables: self.customVariables
+               customVariables: self.customVariables,
+               windowSize: self.paywallWindowSize
            ) {
             AsyncButton {
                 try await performAction()

--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentViewModel.swift
@@ -210,11 +210,13 @@ class ButtonComponentViewModel {
         isEligibleForIntroOffer: Bool,
         isEligibleForPromoOffer: Bool,
         selectedPackageId: String?,
-        customVariables: [String: CustomVariableValue]
+        customVariables: [String: CustomVariableValue],
+        windowSize: CGSize? = nil
     ) -> Bool {
         let conditionContext = self.uiConfigProvider.conditionContext(
             selectedPackageId: selectedPackageId,
-            customVariables: customVariables
+            customVariables: customVariables,
+            windowSize: windowSize
         )
 
         let partial = PresentedButtonPartial.buildPartial(

--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
@@ -36,6 +36,9 @@ struct CarouselComponentView: View {
     @Environment(\.screenCondition)
     private var screenCondition
 
+    @Environment(\.paywallWindowSize)
+    private var paywallWindowSize
+
     @Environment(\.colorScheme)
     private var colorScheme
 
@@ -63,6 +66,7 @@ struct CarouselComponentView: View {
             ),
             selectedPackageId: self.selectedPackageId,
             customVariables: self.customVariables,
+            windowSize: self.paywallWindowSize,
             colorScheme: colorScheme
         ) { style in
             if style.visible {

--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentViewModel.swift
@@ -71,12 +71,14 @@ class CarouselComponentViewModel {
         isEligibleForPromoOffer: Bool,
         selectedPackageId: String?,
         customVariables: [String: CustomVariableValue],
+        windowSize: CGSize? = nil,
         colorScheme: ColorScheme,
         @ViewBuilder apply: @escaping (CarouselComponentStyle) -> some View
     ) -> some View {
         let conditionContext = self.uiConfigProvider.conditionContext(
             selectedPackageId: selectedPackageId,
-            customVariables: customVariables
+            customVariables: customVariables,
+            windowSize: windowSize
         )
         let partial = PresentedCarouselPartial.buildPartial(
             state: state,

--- a/RevenueCatUI/Templates/V2/Components/Icon/IconComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Icon/IconComponentView.swift
@@ -35,6 +35,9 @@ struct IconComponentView: View {
     @Environment(\.screenCondition)
     private var screenCondition
 
+    @Environment(\.paywallWindowSize)
+    private var paywallWindowSize
+
     @Environment(\.colorScheme)
     private var colorScheme
 
@@ -64,6 +67,7 @@ struct IconComponentView: View {
             customVariables: self.customVariables,
             stateValues: self.paywallStateValues,
             stateDefaults: self.paywallStateDefaults,
+            windowSize: self.paywallWindowSize,
             colorScheme: colorScheme
         ) { style in
             if style.visible {

--- a/RevenueCatUI/Templates/V2/Components/Icon/IconComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Icon/IconComponentViewModel.swift
@@ -97,6 +97,7 @@ class IconComponentViewModel {
         customVariables: [String: CustomVariableValue],
         stateValues: [String: PaywallComponent.ConditionValue] = [:],
         stateDefaults: [String: PaywallComponent.ConditionValue] = [:],
+        windowSize: CGSize? = nil,
         colorScheme: ColorScheme,
         @ViewBuilder apply: @escaping (IconComponentStyle) -> some View
     ) -> some View {
@@ -104,7 +105,8 @@ class IconComponentViewModel {
             selectedPackageId: selectedPackageId,
             customVariables: customVariables,
             stateValues: stateValues,
-            stateDefaults: stateDefaults
+            stateDefaults: stateDefaults,
+            windowSize: windowSize
         )
         let partial = PresentedIconPartial.buildPartial(
             state: state,

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -58,6 +58,9 @@ struct ImageComponentView: View {
     @Environment(\.screenCondition)
     private var screenCondition
 
+    @Environment(\.paywallWindowSize)
+    private var paywallWindowSize
+
     @Environment(\.colorScheme)
     private var colorScheme
 
@@ -111,6 +114,7 @@ struct ImageComponentView: View {
             customVariables: self.customVariables,
             stateValues: self.paywallStateValues,
             stateDefaults: self.paywallStateDefaults,
+            windowSize: self.paywallWindowSize,
             colorScheme: colorScheme
         ) { style in
             if style.visible {

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentViewModel.swift
@@ -59,13 +59,15 @@ class ImageComponentViewModel {
         customVariables: [String: CustomVariableValue],
         stateValues: [String: PaywallComponent.ConditionValue] = [:],
         stateDefaults: [String: PaywallComponent.ConditionValue] = [:],
+        windowSize: CGSize? = nil,
         colorScheme: ColorScheme
     ) -> ImageComponentStyle {
         let conditionContext = self.uiConfigProvider.conditionContext(
             selectedPackageId: selectedPackageId,
             customVariables: customVariables,
             stateValues: stateValues,
-            stateDefaults: stateDefaults
+            stateDefaults: stateDefaults,
+            windowSize: windowSize
         )
 
         let localizedPartial = LocalizedImagePartial.buildPartial(
@@ -105,6 +107,7 @@ class ImageComponentViewModel {
         customVariables: [String: CustomVariableValue],
         stateValues: [String: PaywallComponent.ConditionValue] = [:],
         stateDefaults: [String: PaywallComponent.ConditionValue] = [:],
+        windowSize: CGSize? = nil,
         colorScheme: ColorScheme,
         @ViewBuilder apply: @escaping (ImageComponentStyle) -> some View
     ) -> some View {
@@ -117,6 +120,7 @@ class ImageComponentViewModel {
             customVariables: customVariables,
             stateValues: stateValues,
             stateDefaults: stateDefaults,
+            windowSize: windowSize,
             colorScheme: colorScheme
         )
         apply(style)

--- a/RevenueCatUI/Templates/V2/Components/Packages/Package/PackageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/Package/PackageComponentView.swift
@@ -32,6 +32,9 @@ struct PackageComponentView: View {
     @Environment(\.screenCondition)
     private var screenCondition
 
+    @Environment(\.paywallWindowSize)
+    private var paywallWindowSize
+
     @Environment(\.customPaywallVariables)
     private var customVariables
 
@@ -63,7 +66,8 @@ struct PackageComponentView: View {
                    for: package
                ),
                selectedPackageId: selectedPackageId,
-               customVariables: customVariables
+               customVariables: customVariables,
+               windowSize: paywallWindowSize
            ) {
             StackComponentView(
                 viewModel: self.viewModel.stackViewModel,

--- a/RevenueCatUI/Templates/V2/Components/Packages/Package/PackageComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/Package/PackageComponentViewModel.swift
@@ -65,7 +65,8 @@ class PackageComponentViewModel {
         isEligibleForIntroOffer: Bool,
         isEligibleForPromoOffer: Bool,
         selectedPackageId: String?,
-        customVariables: [String: CustomVariableValue]
+        customVariables: [String: CustomVariableValue],
+        windowSize: CGSize? = nil
     ) -> Bool {
         return self.visibilityResolver.visible(
             state: state,
@@ -73,7 +74,8 @@ class PackageComponentViewModel {
             isEligibleForIntroOffer: isEligibleForIntroOffer,
             isEligibleForPromoOffer: isEligibleForPromoOffer,
             selectedPackageId: selectedPackageId,
-            customVariables: customVariables
+            customVariables: customVariables,
+            windowSize: windowSize
         )
     }
 

--- a/RevenueCatUI/Templates/V2/Components/Packages/Package/PackageVisibilityResolver.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/Package/PackageVisibilityResolver.swift
@@ -46,11 +46,13 @@ struct PackageVisibilityResolver {
         isEligibleForIntroOffer: Bool,
         isEligibleForPromoOffer: Bool,
         selectedPackageId: String?,
-        customVariables: [String: CustomVariableValue]
+        customVariables: [String: CustomVariableValue],
+        windowSize: CGSize? = nil
     ) -> Bool {
         let conditionContext = self.uiConfigProvider.conditionContext(
             selectedPackageId: selectedPackageId,
-            customVariables: customVariables
+            customVariables: customVariables,
+            windowSize: windowSize
         )
 
         let partial = PresentedPackagePartial.buildPartial(

--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
@@ -36,6 +36,9 @@ struct StackComponentView: View {
     @Environment(\.screenCondition)
     private var screenCondition
 
+    @Environment(\.paywallWindowSize)
+    private var paywallWindowSize
+
     @Environment(\.colorScheme)
     private var colorScheme
 
@@ -95,6 +98,7 @@ struct StackComponentView: View {
             customVariables: self.customVariables,
             stateValues: self.paywallStateValues,
             stateDefaults: self.paywallStateDefaults,
+            windowSize: self.paywallWindowSize,
             colorScheme: colorScheme
         ) { style in
             if style.visible {

--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentViewModel.swift
@@ -127,13 +127,15 @@ class StackComponentViewModel {
         customVariables: [String: CustomVariableValue],
         stateValues: [String: PaywallComponent.ConditionValue] = [:],
         stateDefaults: [String: PaywallComponent.ConditionValue] = [:],
+        windowSize: CGSize? = nil,
         colorScheme: ColorScheme
     ) -> StackComponentStyle {
         let conditionContext = self.uiConfigProvider.conditionContext(
             selectedPackageId: selectedPackageId,
             customVariables: customVariables,
             stateValues: stateValues,
-            stateDefaults: stateDefaults
+            stateDefaults: stateDefaults,
+            windowSize: windowSize
         )
 
         let partial = PresentedStackPartial.buildPartial(
@@ -180,6 +182,7 @@ class StackComponentViewModel {
         customVariables: [String: CustomVariableValue],
         stateValues: [String: PaywallComponent.ConditionValue] = [:],
         stateDefaults: [String: PaywallComponent.ConditionValue] = [:],
+        windowSize: CGSize? = nil,
         colorScheme: ColorScheme,
         @ViewBuilder apply: @escaping (StackComponentStyle) -> some View
     ) -> some View {
@@ -192,6 +195,7 @@ class StackComponentViewModel {
             customVariables: customVariables,
             stateValues: stateValues,
             stateDefaults: stateDefaults,
+            windowSize: windowSize,
             colorScheme: colorScheme
         )
         apply(style)

--- a/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentView.swift
@@ -105,6 +105,9 @@ struct LoadedTabsComponentView: View {
     @Environment(\.screenCondition)
     private var screenCondition
 
+    @Environment(\.paywallWindowSize)
+    private var paywallWindowSize
+
     @Environment(\.colorScheme)
     private var colorScheme
 
@@ -238,6 +241,7 @@ struct LoadedTabsComponentView: View {
         return PackageSelectionContext(
             condition: self.screenCondition,
             customVariables: self.customVariables,
+            windowSize: self.paywallWindowSize,
             isEligibleForIntroOffer: { [introOfferEligibilityContext] in
                 introOfferEligibilityContext.isEligible(package: $0)
             },
@@ -316,6 +320,7 @@ struct LoadedTabsComponentView: View {
             ),
             selectedPackageId: self.selectedPackageId,
             customVariables: self.customVariables,
+            windowSize: self.paywallWindowSize,
             colorScheme: self.colorScheme
         )
 
@@ -352,6 +357,11 @@ struct LoadedTabsComponentView: View {
             // Intro and promo eligibility both land after first render and can flip a package's
             // visibility. `isPaywallLoading` goes false once both have resolved.
             .onChangeOf(self.isPaywallLoading) { _ in
+                self.reconcileSelection(tierPackageContext, tabViewModel: activeTabViewModel)
+            }
+            // A window resize (rotation, Split View, Stage Manager) can hide the
+            // selected package via a window size condition.
+            .onChangeOf(self.paywallWindowSize) { _ in
                 self.reconcileSelection(tierPackageContext, tabViewModel: activeTabViewModel)
             }
             .onAppear {

--- a/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Tabs/TabsComponentViewModel.swift
@@ -88,11 +88,13 @@ class TabsComponentViewModel {
         isEligibleForPromoOffer: Bool,
         selectedPackageId: String?,
         customVariables: [String: CustomVariableValue],
+        windowSize: CGSize? = nil,
         colorScheme: ColorScheme
     ) -> TabsComponentStyle {
         let conditionContext = self.uiConfigProvider.conditionContext(
             selectedPackageId: selectedPackageId,
-            customVariables: customVariables
+            customVariables: customVariables,
+            windowSize: windowSize
         )
 
         let partial = PresentedTabsPartial.buildPartial(

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentView.swift
@@ -37,6 +37,9 @@ struct TextComponentView: View {
     @Environment(\.screenCondition)
     private var screenCondition
 
+    @Environment(\.paywallWindowSize)
+    private var paywallWindowSize
+
     @Environment(\.countdownTime)
     private var countdownTime: CountdownTime?
 
@@ -81,7 +84,8 @@ struct TextComponentView: View {
             countdownTime: countdownTime,
             customVariables: self.customVariables,
             stateValues: self.paywallStateValues,
-            stateDefaults: self.paywallStateDefaults
+            stateDefaults: self.paywallStateDefaults,
+            windowSize: self.paywallWindowSize
         ) { style in
             if style.visible {
                 NonLocalizedMarkdownText(

--- a/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Text/TextComponentViewModel.swift
@@ -78,6 +78,7 @@ class TextComponentViewModel {
         customVariables: [String: CustomVariableValue] = [:],
         stateValues: [String: PaywallComponent.ConditionValue] = [:],
         stateDefaults: [String: PaywallComponent.ConditionValue] = [:],
+        windowSize: CGSize? = nil,
         @ViewBuilder apply: @escaping (TextComponentStyle) -> some View
     ) -> some View {
         let isEligibleForPromoOffer = promoOffer != nil
@@ -85,7 +86,8 @@ class TextComponentViewModel {
             selectedPackageId: selectedPackageId,
             customVariables: customVariables,
             stateValues: stateValues,
-            stateDefaults: stateDefaults
+            stateDefaults: stateDefaults,
+            windowSize: windowSize
         )
         let localizedPartial = LocalizedTextPartial.buildPartial(
             state: state,

--- a/RevenueCatUI/Templates/V2/Components/Timeline/TimelineComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Timeline/TimelineComponentView.swift
@@ -37,6 +37,9 @@ struct TimelineComponentView: View {
     @Environment(\.screenCondition)
     private var screenCondition
 
+    @Environment(\.paywallWindowSize)
+    private var paywallWindowSize
+
     @Environment(\.colorScheme)
     private var colorScheme
 
@@ -62,7 +65,8 @@ struct TimelineComponentView: View {
                 for: self.packageContext.package
             ),
             selectedPackageId: self.selectedPackageId,
-            customVariables: self.customVariables
+            customVariables: self.customVariables,
+            windowSize: self.paywallWindowSize
         ) { style in
             if style.visible {
                 timeline(style: style)
@@ -86,7 +90,8 @@ struct TimelineComponentView: View {
                         for: self.packageContext.package
                     ),
                     selectedPackageId: self.selectedPackageId,
-                    customVariables: self.customVariables
+                    customVariables: self.customVariables,
+                    windowSize: self.paywallWindowSize
                 ) { itemStyle in
                     if itemStyle.visible {
                         timelineRow(itemStyle: itemStyle, style: style)
@@ -113,7 +118,8 @@ struct TimelineComponentView: View {
                             for: self.packageContext.package
                         ),
                         selectedPackageId: self.selectedPackageId,
-                        customVariables: self.customVariables
+                        customVariables: self.customVariables,
+                        windowSize: self.paywallWindowSize
                     ) { itemStyle in
                         if itemStyle.visible {
                             let next = viewModel.items.indices.contains(index + 1) ? viewModel.items[index + 1] : nil

--- a/RevenueCatUI/Templates/V2/Components/Timeline/TimelineComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Timeline/TimelineComponentViewModel.swift
@@ -53,11 +53,13 @@ class TimelineComponentViewModel {
         isEligibleForPromoOffer: Bool,
         selectedPackageId: String?,
         customVariables: [String: CustomVariableValue],
+        windowSize: CGSize? = nil,
         @ViewBuilder apply: @escaping (TimelineComponentStyle) -> some View
     ) -> some View {
         let conditionContext = self.uiConfigProvider.conditionContext(
             selectedPackageId: selectedPackageId,
-            customVariables: customVariables
+            customVariables: customVariables,
+            windowSize: windowSize
         )
         let partial = PresentedTimelinePartial.buildPartial(
             state: state,
@@ -120,11 +122,13 @@ class TimelineItemViewModel {
         isEligibleForPromoOffer: Bool,
         selectedPackageId: String?,
         customVariables: [String: CustomVariableValue],
+        windowSize: CGSize? = nil,
         @ViewBuilder apply: @escaping (TimelineItemStyle) -> some View
     ) -> some View {
         let conditionContext = self.uiConfigProvider.conditionContext(
             selectedPackageId: selectedPackageId,
-            customVariables: customVariables
+            customVariables: customVariables,
+            windowSize: windowSize
         )
         let partial = PresentedTimelineItemPartial.buildPartial(
             state: state,

--- a/RevenueCatUI/Templates/V2/Components/Video/VideoComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoComponentView.swift
@@ -35,6 +35,9 @@ struct VideoComponentView: View {
     @Environment(\.screenCondition)
     private var screenCondition
 
+    @Environment(\.paywallWindowSize)
+    private var paywallWindowSize
+
     @Environment(\.colorScheme)
     private var colorScheme
 
@@ -81,6 +84,7 @@ struct VideoComponentView: View {
                 ),
                 selectedPackageId: self.selectedPackageId,
                 customVariables: self.customVariables,
+                windowSize: self.paywallWindowSize,
                 colorScheme: colorScheme
             ) { style in
                 if style.visible {

--- a/RevenueCatUI/Templates/V2/Components/Video/VideoComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Video/VideoComponentViewModel.swift
@@ -79,12 +79,14 @@ class VideoComponentViewModel {
         isEligibleForPromoOffer: Bool,
         selectedPackageId: String?,
         customVariables: [String: CustomVariableValue],
+        windowSize: CGSize? = nil,
         colorScheme: ColorScheme,
         @ViewBuilder apply: @escaping (VideoComponentStyle) -> some View
     ) -> some View {
         let conditionContext = self.uiConfigProvider.conditionContext(
             selectedPackageId: selectedPackageId,
-            customVariables: customVariables
+            customVariables: customVariables,
+            windowSize: windowSize
         )
         let localizedPartial = LocalizedVideoPartial.buildPartial(
             state: state,

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
@@ -29,6 +29,9 @@ struct WebViewComponentView: View {
     @Environment(\.screenCondition)
     private var screenCondition
 
+    @Environment(\.paywallWindowSize)
+    private var paywallWindowSize
+
     @Environment(\.customPaywallVariables)
     private var customVariables
 
@@ -62,7 +65,8 @@ struct WebViewComponentView: View {
             selectedPackageId: self.selectedPackageId,
             customVariables: self.customVariables,
             stateValues: self.paywallStateValues,
-            stateDefaults: self.paywallStateDefaults
+            stateDefaults: self.paywallStateDefaults,
+            windowSize: self.paywallWindowSize
         )
     }
 

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentViewModel.swift
@@ -89,13 +89,15 @@ final class WebViewComponentViewModel: Hashable {
         selectedPackageId: String?,
         customVariables: [String: CustomVariableValue],
         stateValues: [String: PaywallComponent.ConditionValue] = [:],
-        stateDefaults: [String: PaywallComponent.ConditionValue] = [:]
+        stateDefaults: [String: PaywallComponent.ConditionValue] = [:],
+        windowSize: CGSize? = nil
     ) -> WebViewComponentStyle {
         let conditionContext = self.uiConfigProvider.conditionContext(
             selectedPackageId: selectedPackageId,
             customVariables: customVariables,
             stateValues: stateValues,
-            stateDefaults: stateDefaults
+            stateDefaults: stateDefaults,
+            windowSize: windowSize
         )
 
         let partial = PresentedWebViewPartial.buildPartial(

--- a/RevenueCatUI/Templates/V2/EnvironmentObjects/ScreenCondition.swift
+++ b/RevenueCatUI/Templates/V2/EnvironmentObjects/ScreenCondition.swift
@@ -40,11 +40,38 @@ struct ScreenConditionKey: EnvironmentKey {
     static let defaultValue = ScreenCondition.compact
 }
 
+/// The paywall's rendered bounds in points — not the device screen, so a
+/// Split View pane or sheet reports its own size. `nil` where no paywall root
+/// has published a size, in which case window size conditions never match.
+struct PaywallWindowSizeKey: EnvironmentKey {
+    static let defaultValue: CGSize? = nil
+}
+
 extension EnvironmentValues {
 
     var screenCondition: ScreenCondition {
         get { self[ScreenConditionKey.self] }
         set { self[ScreenConditionKey.self] = newValue }
+    }
+
+    var paywallWindowSize: CGSize? {
+        get { self[PaywallWindowSizeKey.self] }
+        set { self[PaywallWindowSizeKey.self] = newValue }
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension View {
+
+    /// Publishes the proposed size as `\.paywallWindowSize` so window size
+    /// conditions evaluate synchronously on first layout and re-evaluate live
+    /// on rotation and window resize. Apply at the paywall root: the
+    /// `GeometryReader` fills its container, so the content must too.
+    func measurePaywallWindowSize() -> some View {
+        GeometryReader { proxy in
+            self.environment(\.paywallWindowSize, proxy.size)
+        }
     }
 
 }

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -308,6 +308,7 @@ struct PaywallsV2View: View {
         .environment(\.locale, contentLocale)
         .environment(\.layoutDirection, contentLocale.swiftUILayoutDirection)
         .environment(\.screenCondition, ScreenCondition.from(self.horizontalSizeClass))
+        .measurePaywallWindowSize()
         .environment(\.paywallWebViewStaticContext, webViewContext)
         .environment(\.urlOpenedNotifier, URLOpenedNotifier { [purchaseHandler] url in
             purchaseHandler.signalURLOpened(url)
@@ -619,6 +620,9 @@ struct LoadedPaywallsV2View: View {
     @Environment(\.screenCondition)
     private var screenCondition
 
+    @Environment(\.paywallWindowSize)
+    private var paywallWindowSize
+
     @Environment(\.customPaywallVariables)
     private var customVariables
 
@@ -652,6 +656,7 @@ struct LoadedPaywallsV2View: View {
         return PackageSelectionContext(
             condition: self.screenCondition,
             customVariables: self.customVariables,
+            windowSize: self.paywallWindowSize,
             isEligibleForIntroOffer: { [introOfferEligibilityContext] in
                 introOfferEligibilityContext.isEligible(package: $0)
             },
@@ -741,6 +746,11 @@ struct LoadedPaywallsV2View: View {
             // Leaving a tab can restore a package a rule hides, and this doesn't depend on
             // `onAppear` ordering.
             .onChangeOf(self.selectedPackageContext.package?.identifier) { _ in
+                self.reconcileSelection()
+            }
+            // A window resize (rotation, Split View, Stage Manager) can hide the
+            // selected package via a window size condition.
+            .onChangeOf(self.paywallWindowSize) { _ in
                 self.reconcileSelection()
             }
         }

--- a/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/WindowSizeConditionsPreview.swift
+++ b/RevenueCatUI/Templates/V2/Previews/TemplateComponentsViewPreviews/WindowSizeConditionsPreview.swift
@@ -1,0 +1,269 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WindowSizeConditionsPreview.swift
+//
+//  Created by Josh Holtz on 9/2/26.
+//
+import Foundation
+@_spi(Internal) import RevenueCat
+import SwiftUI
+
+#if !os(tvOS) // For Paywalls V2
+
+#if DEBUG
+
+private enum WindowSizeConditionsPreview {
+
+    static let catUrl = URL(string: "https://assets.pawwalls.com/954459_1701163461.jpg")!
+
+    static let heroImage = PaywallComponent.ImageComponent(
+        source: .init(
+            light: .init(
+                width: 750,
+                height: 530,
+                original: catUrl,
+                heic: catUrl,
+                heicLowRes: catUrl
+            )
+        ),
+        size: .init(width: .fill, height: .fixed(260)),
+        fitMode: .fill
+    )
+
+    static let title = PaywallComponent.TextComponent(
+        text: "title",
+        fontWeight: .black,
+        color: .init(light: .hex("#000000")),
+        padding: .init(top: 20, bottom: 0, leading: 20, trailing: 20),
+        margin: .zero,
+        fontSize: 28,
+        horizontalAlignment: .center
+    )
+
+    static let body = PaywallComponent.TextComponent(
+        text: "body",
+        color: .init(light: .hex("#000000")),
+        padding: .init(top: 8, bottom: 0, leading: 20, trailing: 20),
+        margin: .zero,
+        fontSize: 15,
+        horizontalAlignment: .center
+    )
+
+    static let package = PaywallComponent.PackageComponent(
+        packageID: "monthly",
+        isSelectedByDefault: true,
+        applePromoOfferProductCode: nil,
+        stack: .init(
+            components: [
+                .text(.init(
+                    text: "package_name",
+                    fontWeight: .bold,
+                    color: .init(light: .hex("#000000")),
+                    padding: .zero,
+                    margin: .zero
+                )),
+                .text(.init(
+                    text: "package_detail",
+                    color: .init(light: .hex("#000000")),
+                    padding: .zero,
+                    margin: .zero
+                ))
+            ],
+            dimension: .vertical(.center, .start),
+            size: .init(width: .fill, height: .fit(nil)),
+            spacing: 0,
+            backgroundColor: nil,
+            padding: .init(top: 12, bottom: 12, leading: 12, trailing: 12),
+            shape: .rectangle(.init(topLeading: 12, topTrailing: 12, bottomLeading: 12, bottomTrailing: 12)),
+            border: .init(color: .init(light: .hex("#cccccc")), width: 1)
+        )
+    )
+
+    static let purchaseButton = PaywallComponent.PurchaseButtonComponent(
+        stack: .init(
+            components: [
+                .text(.init(
+                    text: "cta",
+                    fontWeight: .bold,
+                    color: .init(light: .hex("#ffffff")),
+                    backgroundColor: .init(light: .hex("#e89d89")),
+                    size: .init(width: .fill, height: .fit(nil)),
+                    padding: .init(top: 12, bottom: 12, leading: 30, trailing: 30)
+                ))
+            ],
+            size: .init(width: .fill, height: .fit(nil)),
+            shape: .pill
+        ),
+        action: nil,
+        method: nil,
+        name: nil
+    )
+
+    static let legal = PaywallComponent.TextComponent(
+        text: "legal",
+        color: .init(light: .hex("#999999")),
+        padding: .zero,
+        margin: .zero,
+        fontSize: 12,
+        horizontalAlignment: .center
+    )
+
+    static let contentPane = PaywallComponent.StackComponent(
+        components: [
+            .image(heroImage),
+            .text(title),
+            .text(body)
+        ],
+        dimension: .vertical(.center, .start),
+        size: .init(width: .fill, height: .fit(nil)),
+        spacing: 0,
+        backgroundColor: nil
+    )
+
+    static let purchasePane = PaywallComponent.StackComponent(
+        components: [
+            .package(package),
+            .purchaseButton(purchaseButton),
+            .text(legal)
+        ],
+        dimension: .vertical(.center, .center),
+        size: .init(width: .fill, height: .fit(nil)),
+        spacing: 16,
+        backgroundColor: nil,
+        padding: .init(top: 16, bottom: 16, leading: 16, trailing: 16)
+    )
+
+    /// The split wrapper: vertical by default, horizontal when the window is
+    /// at least 700pt wide AND 480pt tall (so landscape phones stay vertical).
+    static let splitWrapper = PaywallComponent.StackComponent(
+        components: [
+            .stack(contentPane),
+            .stack(purchasePane)
+        ],
+        dimension: .vertical(.center, .start),
+        size: .init(width: .fill, height: .fit(nil)),
+        spacing: 0,
+        backgroundColor: nil,
+        overrides: [
+            .init(
+                extendedConditions: [
+                    .windowWidth(operator: .greaterThanOrEqual, value: 700),
+                    .windowHeight(operator: .greaterThanOrEqual, value: 480)
+                ],
+                properties: .init(
+                    dimension: .horizontal(.top, .start)
+                )
+            )
+        ]
+    )
+
+    static let paywallComponents: Offering.PaywallComponents = .init(
+        uiConfig: .init(
+            app: .init(
+                colors: [:],
+                fonts: [:]
+            ),
+            localizations: [:],
+            variableConfig: .init(
+                variableCompatibilityMap: [:],
+                functionCompatibilityMap: [:]
+            )
+        ),
+        data: data
+    )
+
+    static let data: PaywallComponentsData = .init(
+        templateName: "components",
+        assetBaseURL: URL(string: "https://assets.pawwalls.com")!,
+        componentsConfig: .init(
+            base: .init(
+                stack: .init(
+                    components: [
+                        .stack(splitWrapper)
+                    ],
+                    overflow: .default
+                ),
+                stickyFooter: nil,
+                background: .color(.init(
+                    light: .hex("#ffffff")
+                ))
+            )
+        ),
+        componentsLocalizations: ["en_US": [
+            "title": .string("Experience Pro today!"),
+            "body": .string("Check out the power of all we offer."),
+            "package_name": .string("Monthly"),
+            "package_detail": .string("$9.99/mo"),
+            "cta": .string("Continue"),
+            "legal": .string("Cancel anytime. Restore purchases.")
+        ]],
+        revision: 1,
+        defaultLocaleIdentifier: "en_US"
+    )
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct WindowSizeConditionsPreview_Previews: PreviewProvider {
+
+    static let baseUrl = "https://pay.revenuecat.com/abcd1234/the-app-user-id"
+
+    static var monthlyPackage: Package {
+        return .init(identifier: "monthly",
+                     packageType: .monthly,
+                     storeProduct: .init(sk1Product: .init()),
+                     offeringIdentifier: "default",
+                     webCheckoutUrl: URL(string: "\(baseUrl)?package_id=monthly")!)
+    }
+
+    static var offering: Offering {
+        .init(identifier: "default",
+              serverDescription: "",
+              availablePackages: [monthlyPackage],
+              webCheckoutUrl: URL(string: baseUrl)!)
+    }
+
+    static func paywall() -> some View {
+        PaywallsV2View(
+            paywallComponents: WindowSizeConditionsPreview.paywallComponents,
+            offering: offering,
+            purchaseHandler: PurchaseHandler.default(),
+            introEligibilityChecker: .default(),
+            showZeroDecimalPlacePrices: true,
+            onDismiss: { },
+            failedToLoadFont: { _ in },
+            colorScheme: .light
+        )
+        .previewRequiredPaywallsV2Properties()
+    }
+
+    static var previews: some View {
+
+        paywall()
+            .previewLayout(.fixed(width: 402, height: 874))
+            .previewDisplayName("Phone portrait (stacked)")
+
+        paywall()
+            .previewLayout(.fixed(width: 874, height: 402))
+            .previewDisplayName("Phone landscape (stacked: height floor)")
+
+        paywall()
+            .previewLayout(.fixed(width: 904, height: 640))
+            .previewDisplayName("Unfolded foldable (side by side)")
+
+        paywall()
+            .previewLayout(.fixed(width: 1024, height: 768))
+            .previewDisplayName("iPad (side by side)")
+    }
+
+}
+
+#endif
+
+#endif

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PackageValidator.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PackageValidator.swift
@@ -23,17 +23,20 @@ struct PackageSelectionContext {
 
     let condition: ScreenCondition
     let customVariables: [String: CustomVariableValue]
+    let windowSize: CGSize?
     let isEligibleForIntroOffer: (Package) -> Bool
     let isEligibleForPromoOffer: (Package) -> Bool
 
     init(
         condition: ScreenCondition,
         customVariables: [String: CustomVariableValue],
+        windowSize: CGSize? = nil,
         isEligibleForIntroOffer: @escaping (Package) -> Bool,
         isEligibleForPromoOffer: @escaping (Package) -> Bool
     ) {
         self.condition = condition
         self.customVariables = customVariables
+        self.windowSize = windowSize
         self.isEligibleForIntroOffer = isEligibleForIntroOffer
         self.isEligibleForPromoOffer = isEligibleForPromoOffer
     }
@@ -110,7 +113,8 @@ class PackageValidator {
             isEligibleForIntroOffer: context.isEligibleForIntroOffer(info.package),
             isEligibleForPromoOffer: context.isEligibleForPromoOffer(info.package),
             selectedPackageId: nil,
-            customVariables: context.customVariables
+            customVariables: context.customVariables,
+            windowSize: context.windowSize
         )
     }
 

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/PresentedPartials.swift
@@ -56,6 +56,10 @@ struct ConditionContext {
     /// Declared defaults for state keys, used when a key has no value in the store snapshot.
     let stateDefaults: [String: PaywallComponent.ConditionValue]
 
+    /// The paywall's rendered bounds, for window size condition evaluation.
+    /// `nil` when unknown, in which case window size conditions never match.
+    let windowSize: CGSize?
+
     /// Creates a context with the given parameters.
     /// Developer-provided `customVariables` take priority over `defaultCustomVariables` from the dashboard.
     init(
@@ -63,12 +67,14 @@ struct ConditionContext {
         customVariables: [String: CustomVariableValue] = [:],
         defaultCustomVariables: [String: CustomVariableValue] = [:],
         stateValues: [String: PaywallComponent.ConditionValue] = [:],
-        stateDefaults: [String: PaywallComponent.ConditionValue] = [:]
+        stateDefaults: [String: PaywallComponent.ConditionValue] = [:],
+        windowSize: CGSize? = nil
     ) {
         self.selectedPackageId = selectedPackageId
         self.customVariables = defaultCustomVariables.merging(customVariables) { _, developer in developer }
         self.stateValues = stateValues
         self.stateDefaults = stateDefaults
+        self.windowSize = windowSize
     }
 
 }
@@ -207,9 +213,45 @@ extension PresentedPartial {
                 stateDefaults: conditionContext.stateDefaults
             )
 
+        // Window size conditions
+        case .windowWidth(let conditionOperator, let value):
+            guard let windowSize = conditionContext.windowSize else { return false }
+            return evaluateComparison(
+                actual: windowSize.width,
+                expected: value,
+                operator: conditionOperator
+            )
+        case .windowHeight(let conditionOperator, let value):
+            guard let windowSize = conditionContext.windowSize else { return false }
+            return evaluateComparison(
+                actual: windowSize.height,
+                expected: value,
+                operator: conditionOperator
+            )
+
         // Unknown/unsupported conditions never match
         case .unsupported:
             return false
+        }
+    }
+
+    private static func evaluateComparison(
+        actual: CGFloat,
+        expected: Double,
+        operator conditionOperator: PaywallComponent.ComparisonOperator
+    ) -> Bool {
+        let actualValue = Double(actual)
+        switch conditionOperator {
+        case .greaterThanOrEqual:
+            return actualValue >= expected
+        case .greaterThan:
+            return actualValue > expected
+        case .lessThanOrEqual:
+            return actualValue <= expected
+        case .lessThan:
+            return actualValue < expected
+        case .equal:
+            return doublesMatch(actualValue, expected)
         }
     }
 

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/UIConfigProvider.swift
@@ -79,14 +79,16 @@ final class UIConfigProvider {
         selectedPackageId: String?,
         customVariables: [String: CustomVariableValue],
         stateValues: [String: PaywallComponent.ConditionValue] = [:],
-        stateDefaults: [String: PaywallComponent.ConditionValue] = [:]
+        stateDefaults: [String: PaywallComponent.ConditionValue] = [:],
+        windowSize: CGSize? = nil
     ) -> ConditionContext {
         ConditionContext(
             selectedPackageId: selectedPackageId,
             customVariables: customVariables,
             defaultCustomVariables: self.defaultCustomVariables,
             stateValues: stateValues,
-            stateDefaults: stateDefaults
+            stateDefaults: stateDefaults,
+            windowSize: windowSize
         )
     }
 

--- a/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
+++ b/RevenueCatUI/Templates/V2/WorkflowPaywallView.swift
@@ -356,6 +356,10 @@ struct WorkflowPaywallView: View {
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            // Window size for window size condition evaluation (e.g. the
+            // workflow header, which renders outside PaywallsV2View's own
+            // measurement).
+            .environment(\.paywallWindowSize, proxy.size)
             .transitionClipMask(geometry: geometry)
         }
         .allowsHitTesting(!self.transitionState.isTransitioning)
@@ -934,6 +938,9 @@ private struct WorkflowHeaderOverlayPageView: View {
 
     @StateObject private var stateManager: WorkflowHeaderOverlayStateManager
 
+    @Environment(\.paywallWindowSize)
+    private var paywallWindowSize
+
     @Environment(\.customPaywallVariables)
     private var customVariables
 
@@ -1015,6 +1022,7 @@ private struct WorkflowHeaderOverlayPageView: View {
                     in: PackageSelectionContext(
                         condition: ScreenCondition.from(self.horizontalSizeClass),
                         customVariables: self.customVariables,
+                        windowSize: self.paywallWindowSize,
                         isEligibleForIntroOffer: { [introOfferEligibilityContext] in
                             introOfferEligibilityContext.isEligible(package: $0)
                         },

--- a/Sources/Paywalls/Components/Common/ComponentOverrides.swift
+++ b/Sources/Paywalls/Components/Common/ComponentOverrides.swift
@@ -11,7 +11,7 @@
 //
 //  Created by Josh Holtz on 10/26/24.
 //
-// swiftlint:disable missing_docs
+// swiftlint:disable missing_docs file_length
 
 import Foundation
 
@@ -155,6 +155,20 @@ extension PaywallComponent {
 
     }
 
+    /// Numeric comparison operators for layout condition evaluation (window size).
+    /// `equal` compares with an epsilon tolerance (1e-10) to absorb JSON round-trip
+    /// noise; it is still fragile against measured fractional sizes and is intended
+    /// for authored integer breakpoints.
+    @_spi(Internal) public enum ComparisonOperator: String, Codable, Sendable, Hashable, Equatable {
+
+        case greaterThanOrEqual = ">="
+        case greaterThan = ">"
+        case lessThanOrEqual = "<="
+        case lessThan = "<"
+        case equal = "="
+
+    }
+
     /// Internal condition type that preserves full type information including associated values.
     /// This is used internally for condition evaluation while the public `Condition` type
     /// maintains API stability.
@@ -186,6 +200,17 @@ extension PaywallComponent {
         // MARK: - Paywall component state (state-driven paywalls)
         case state(operator: EqualityOperator, name: String, value: ConditionValue)
 
+        // MARK: - Window size conditions
+
+        /// Match against the paywall's rendered bounds — not the device screen, so a
+        /// Split View pane or sheet reports its own size. `value` is density-independent
+        /// (iOS points / Android dp). Evaluates to false until the first layout pass and
+        /// re-evaluates live as the window resizes. Conditions within one override AND
+        /// together, so `windowWidth >= 700` plus `windowHeight >= 480` targets large
+        /// windows while excluding landscape phones.
+        case windowWidth(operator: ComparisonOperator, value: Double)
+        case windowHeight(operator: ComparisonOperator, value: Double)
+
         // MARK: - Fallback for unknown conditions
         case unsupported
 
@@ -200,7 +225,8 @@ extension PaywallComponent {
             case .compact, .medium, .expanded, .selected, .introOffer, .promoOffer,
                  .multipleIntroOffers, .unsupported:
                 return false
-            case .introOfferCondition, .promoOfferCondition, .variable, .selectedPackage, .state:
+            case .introOfferCondition, .promoOfferCondition, .variable, .selectedPackage, .state,
+                 .windowWidth, .windowHeight:
                 return true
             }
         }
@@ -215,7 +241,8 @@ extension PaywallComponent {
             case .selected: return .selected
             case .introOffer, .introOfferCondition: return .introOffer
             case .promoOffer, .promoOfferCondition: return .promoOffer
-            case .multipleIntroOffers, .variable, .selectedPackage, .state, .unsupported: return .unsupported
+            case .multipleIntroOffers, .variable, .selectedPackage, .state,
+                 .windowWidth, .windowHeight, .unsupported: return .unsupported
             }
         }
 
@@ -274,6 +301,14 @@ extension PaywallComponent {
                 try container.encode(condOp, forKey: .operator)
                 try container.encode(name, forKey: .name)
                 try container.encode(value, forKey: .value)
+            case .windowWidth(let condOp, let value):
+                try container.encode(ConditionType.windowWidthCondition.rawValue, forKey: .type)
+                try container.encode(condOp, forKey: .operator)
+                try container.encode(value, forKey: .value)
+            case .windowHeight(let condOp, let value):
+                try container.encode(ConditionType.windowHeightCondition.rawValue, forKey: .type)
+                try container.encode(condOp, forKey: .operator)
+                try container.encode(value, forKey: .value)
             case .unsupported:
                 try container.encode("unsupported", forKey: .type)
             }
@@ -290,7 +325,7 @@ extension PaywallComponent {
             }
         }
 
-        // swiftlint:disable:next cyclomatic_complexity
+        // swiftlint:disable:next cyclomatic_complexity function_body_length
         private static func decodeCondition(from decoder: Decoder) throws -> Self {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             let rawValue = try container.decode(String.self, forKey: .type)
@@ -337,6 +372,14 @@ extension PaywallComponent {
                 let name = try container.decode(String.self, forKey: .name)
                 let value = try container.decode(ConditionValue.self, forKey: .value)
                 return .state(operator: condOp, name: name, value: value)
+            case .windowWidthCondition:
+                let condOp = try container.decode(ComparisonOperator.self, forKey: .operator)
+                let value = try container.decode(Double.self, forKey: .value)
+                return .windowWidth(operator: condOp, value: value)
+            case .windowHeightCondition:
+                let condOp = try container.decode(ComparisonOperator.self, forKey: .operator)
+                let value = try container.decode(Double.self, forKey: .value)
+                return .windowHeight(operator: condOp, value: value)
             }
         }
 
@@ -367,6 +410,8 @@ extension PaywallComponent {
             case variableCondition = "variable_condition"
             case selectedPackageCondition = "selected_package_condition"
             case stateCondition = "state_condition"
+            case windowWidthCondition = "window_width_condition"
+            case windowHeightCondition = "window_height_condition"
 
         }
 

--- a/Tests/RevenueCatUITests/PaywallsV2/WindowSizeConditionTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WindowSizeConditionTests.swift
@@ -1,0 +1,206 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WindowSizeConditionTests.swift
+//
+//  Created by Josh Holtz on 9/2/26.
+//
+
+import Nimble
+@_spi(Internal) import RevenueCat
+@testable import RevenueCatUI
+import XCTest
+
+#if !os(tvOS) // For Paywalls V2
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+class WindowSizeConditionTests: TestCase {
+
+    // MARK: - Deserialization
+
+    func testDecodeWindowWidthCondition() throws {
+        let json = """
+        {"type": "window_width_condition", "operator": ">=", "value": 700}
+        """
+        let condition = try decode(json)
+        expect(condition).to(equal(.windowWidth(operator: .greaterThanOrEqual, value: 700)))
+    }
+
+    func testDecodeWindowHeightCondition() throws {
+        let json = """
+        {"type": "window_height_condition", "operator": ">=", "value": 480}
+        """
+        let condition = try decode(json)
+        expect(condition).to(equal(.windowHeight(operator: .greaterThanOrEqual, value: 480)))
+    }
+
+    func testWindowConditionsRoundTripThroughEncoding() throws {
+        let conditions: [PaywallComponent.ExtendedCondition] = [
+            .windowWidth(operator: .greaterThanOrEqual, value: 700),
+            .windowHeight(operator: .lessThan, value: 480)
+        ]
+
+        let encoded = try JSONEncoder().encode(conditions)
+        let decoded = try JSONDecoder().decode(
+            [PaywallComponent.ExtendedCondition].self,
+            from: encoded
+        )
+
+        expect(decoded).to(equal(conditions))
+    }
+
+    func testMalformedWindowConditionsDecodeAsUnsupported() throws {
+        let unknownOperator = try decode("""
+        {"type": "window_width_condition", "operator": "~=", "value": 700}
+        """)
+        expect(unknownOperator).to(equal(.unsupported))
+
+        let missingValue = try decode("""
+        {"type": "window_height_condition", "operator": ">="}
+        """)
+        expect(missingValue).to(equal(.unsupported))
+
+        let nonNumericValue = try decode("""
+        {"type": "window_width_condition", "operator": ">=", "value": "wide"}
+        """)
+        expect(nonNumericValue).to(equal(.unsupported))
+    }
+
+    func testWindowConditionsConvertToUnsupportedPublicCondition() {
+        expect(PaywallComponent.ExtendedCondition
+            .windowWidth(operator: .greaterThanOrEqual, value: 700)
+            .toCondition()) == .unsupported
+        expect(PaywallComponent.ExtendedCondition
+            .windowHeight(operator: .greaterThanOrEqual, value: 480)
+            .toCondition()) == .unsupported
+    }
+
+    func testWindowConditionsAreRules() {
+        expect(PaywallComponent.ExtendedCondition
+            .windowWidth(operator: .greaterThanOrEqual, value: 700).isRule) == true
+        expect(PaywallComponent.ExtendedCondition
+            .windowHeight(operator: .greaterThanOrEqual, value: 480).isRule) == true
+    }
+
+    // MARK: - Evaluation
+
+    private func buildPartial(
+        conditions: [PaywallComponent.ExtendedCondition],
+        windowSize: CGSize?
+    ) -> TestPartial? {
+        TestPartial.buildPartial(
+            state: .default,
+            condition: .compact,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            conditionContext: ConditionContext(windowSize: windowSize),
+            with: [PresentedOverride(conditions: conditions, properties: TestPartial())]
+        )
+    }
+
+    func testWindowWidthConditionMatchesWideWindow() {
+        let result = self.buildPartial(
+            conditions: [.windowWidth(operator: .greaterThanOrEqual, value: 700)],
+            windowSize: CGSize(width: 904, height: 640)
+        )
+        expect(result).toNot(beNil())
+    }
+
+    func testWindowWidthConditionDoesNotMatchNarrowWindow() {
+        let result = self.buildPartial(
+            conditions: [.windowWidth(operator: .greaterThanOrEqual, value: 700)],
+            windowSize: CGSize(width: 402, height: 874)
+        )
+        expect(result).to(beNil())
+    }
+
+    func testWindowConditionsDoNotMatchWithoutWindowSize() {
+        expect(self.buildPartial(
+            conditions: [.windowWidth(operator: .greaterThanOrEqual, value: 700)],
+            windowSize: nil
+        )).to(beNil())
+        expect(self.buildPartial(
+            conditions: [.windowHeight(operator: .greaterThanOrEqual, value: 480)],
+            windowSize: nil
+        )).to(beNil())
+    }
+
+    func testEqualOperatorUsesEpsilonTolerance() {
+        expect(self.buildPartial(
+            conditions: [.windowWidth(operator: .equal, value: 700)],
+            windowSize: CGSize(width: 700 + 1e-12, height: 480)
+        )).toNot(beNil())
+        expect(self.buildPartial(
+            conditions: [.windowWidth(operator: .equal, value: 700)],
+            windowSize: CGSize(width: 700.5, height: 480)
+        )).to(beNil())
+    }
+
+    func testWidthAndHeightConditionsRequireBoth() {
+        let splitConditions: [PaywallComponent.ExtendedCondition] = [
+            .windowWidth(operator: .greaterThanOrEqual, value: 700),
+            .windowHeight(operator: .greaterThanOrEqual, value: 480)
+        ]
+
+        // Landscape phone: wide enough but too short.
+        expect(self.buildPartial(
+            conditions: splitConditions,
+            windowSize: CGSize(width: 874, height: 402)
+        )).to(beNil())
+
+        // Unfolded foldable: both dimensions qualify.
+        expect(self.buildPartial(
+            conditions: splitConditions,
+            windowSize: CGSize(width: 904, height: 640)
+        )).toNot(beNil())
+    }
+
+    func testComparisonOperators() {
+        let size = CGSize(width: 700, height: 480)
+
+        expect(self.buildPartial(
+            conditions: [.windowWidth(operator: .greaterThanOrEqual, value: 700)],
+            windowSize: size
+        )).toNot(beNil())
+        expect(self.buildPartial(
+            conditions: [.windowWidth(operator: .greaterThan, value: 700)],
+            windowSize: size
+        )).to(beNil())
+        expect(self.buildPartial(
+            conditions: [.windowWidth(operator: .lessThanOrEqual, value: 700)],
+            windowSize: size
+        )).toNot(beNil())
+        expect(self.buildPartial(
+            conditions: [.windowWidth(operator: .lessThan, value: 700)],
+            windowSize: size
+        )).to(beNil())
+        expect(self.buildPartial(
+            conditions: [.windowHeight(operator: .equal, value: 480)],
+            windowSize: size
+        )).toNot(beNil())
+    }
+
+    // MARK: - Helpers
+
+    private func decode(_ json: String) throws -> PaywallComponent.ExtendedCondition {
+        let decoder = JSONDecoder()
+        return try decoder.decode(PaywallComponent.ExtendedCondition.self, from: json.data(using: .utf8)!)
+    }
+
+}
+
+private struct TestPartial: PresentedPartial {
+
+    static func combine(_ base: TestPartial?, with other: TestPartial?) -> TestPartial {
+        return other ?? base ?? TestPartial()
+    }
+
+}
+
+#endif

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/SamplePaywalls.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Config/SamplePaywalls.swift
@@ -868,6 +868,182 @@ extension SamplePaywallLoader {
 
 }
 
+// MARK: - Window size conditions
+
+extension SamplePaywallLoader {
+
+    /// Two stacked panes that flip side by side when the window is at least
+    /// 700x480pt. Resize the window (Stage Manager / Split View) to reflow live.
+    static func windowSplitComponentsData() -> PaywallComponentsData {
+        return .init(
+            templateName: "window-split-demo",
+            assetBaseURL: Self.paywallAssetBaseURL,
+            componentsConfig: .init(base: .init(
+                stack: .init(
+                    components: [
+                        .stack(Self.windowSplitWrapper())
+                    ],
+                    overflow: .default
+                ),
+                stickyFooter: nil,
+                background: .color(.init(light: .hex("#ffffff")))
+            )),
+            componentsLocalizations: [
+                "en_US": [
+                    "split_title": .string("Experience Pro today!"),
+                    "split_body": .string("Check out the power of all we offer."),
+                    "split_package_name": .string("Monthly"),
+                    "split_package_detail": .string("$9.99/mo"),
+                    "split_cta": .string("Continue"),
+                    "split_legal": .string("Cancel anytime. Restore purchases.")
+                ]
+            ],
+            revision: 1,
+            defaultLocaleIdentifier: "en_US"
+        )
+    }
+
+    private static func windowSplitWrapper() -> PaywallComponent.StackComponent {
+        return .init(
+            components: [
+                .stack(Self.windowSplitContentPane()),
+                .stack(Self.windowSplitPurchasePane())
+            ],
+            dimension: .vertical(.center, .start),
+            size: .init(width: .fill, height: .fit(nil)),
+            spacing: 0,
+            backgroundColor: nil,
+            overrides: [
+                .init(
+                    extendedConditions: [
+                        .windowWidth(operator: .greaterThanOrEqual, value: 700),
+                        .windowHeight(operator: .greaterThanOrEqual, value: 480)
+                    ],
+                    properties: .init(
+                        dimension: .horizontal(.top, .start)
+                    )
+                )
+            ]
+        )
+    }
+
+    private static func windowSplitContentPane() -> PaywallComponent.StackComponent {
+        let imageUrl = URL(string: "https://assets.pawwalls.com/954459_1701163461.jpg")!
+        return .init(
+            components: [
+                .image(.init(
+                    source: .init(
+                        light: .init(
+                            width: 750,
+                            height: 530,
+                            original: imageUrl,
+                            heic: imageUrl,
+                            heicLowRes: imageUrl
+                        )
+                    ),
+                    size: .init(width: .fill, height: .fixed(260)),
+                    fitMode: .fill
+                )),
+                .text(.init(
+                    text: "split_title",
+                    fontWeight: .black,
+                    color: .init(light: .hex("#000000")),
+                    padding: .init(top: 20, bottom: 0, leading: 20, trailing: 20),
+                    margin: .zero,
+                    fontSize: 28,
+                    horizontalAlignment: .center
+                )),
+                .text(.init(
+                    text: "split_body",
+                    color: .init(light: .hex("#000000")),
+                    padding: .init(top: 8, bottom: 0, leading: 20, trailing: 20),
+                    margin: .zero,
+                    fontSize: 15,
+                    horizontalAlignment: .center
+                ))
+            ],
+            dimension: .vertical(.center, .start),
+            size: .init(width: .fill, height: .fit(nil)),
+            spacing: 0,
+            backgroundColor: nil
+        )
+    }
+
+    private static func windowSplitPurchasePane() -> PaywallComponent.StackComponent {
+        return .init(
+            components: [
+                .package(.init(
+                    packageID: Self.monthlyPackage.identifier,
+                    isSelectedByDefault: true,
+                    applePromoOfferProductCode: nil,
+                    stack: .init(
+                        components: [
+                            .text(.init(
+                                text: "split_package_name",
+                                fontWeight: .bold,
+                                color: .init(light: .hex("#000000")),
+                                padding: .zero,
+                                margin: .zero
+                            )),
+                            .text(.init(
+                                text: "split_package_detail",
+                                color: .init(light: .hex("#000000")),
+                                padding: .zero,
+                                margin: .zero
+                            ))
+                        ],
+                        dimension: .vertical(.center, .start),
+                        size: .init(width: .fill, height: .fit(nil)),
+                        spacing: 0,
+                        backgroundColor: nil,
+                        padding: .init(top: 12, bottom: 12, leading: 12, trailing: 12),
+                        shape: .rectangle(.init(
+                            topLeading: 12,
+                            topTrailing: 12,
+                            bottomLeading: 12,
+                            bottomTrailing: 12
+                        )),
+                        border: .init(color: .init(light: .hex("#cccccc")), width: 1)
+                    )
+                )),
+                .purchaseButton(.init(
+                    stack: .init(
+                        components: [
+                            .text(.init(
+                                text: "split_cta",
+                                fontWeight: .bold,
+                                color: .init(light: .hex("#ffffff")),
+                                backgroundColor: .init(light: .hex("#e89d89")),
+                                size: .init(width: .fill, height: .fit(nil)),
+                                padding: .init(top: 12, bottom: 12, leading: 30, trailing: 30)
+                            ))
+                        ],
+                        size: .init(width: .fill, height: .fit(nil)),
+                        shape: .pill
+                    ),
+                    action: nil,
+                    method: nil,
+                    name: nil
+                )),
+                .text(.init(
+                    text: "split_legal",
+                    color: .init(light: .hex("#999999")),
+                    padding: .zero,
+                    margin: .zero,
+                    fontSize: 12,
+                    horizontalAlignment: .center
+                ))
+            ],
+            dimension: .vertical(.center, .center),
+            size: .init(width: .fill, height: .fit(nil)),
+            spacing: 16,
+            backgroundColor: nil,
+            padding: .init(top: 16, bottom: 16, leading: 16, trailing: 16)
+        )
+    }
+
+}
+
 #endif
 
 #endif

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/UI/Views/SamplePaywallsList.swift
@@ -182,6 +182,12 @@ struct SamplePaywallsList: View {
                 } label: {
                     TemplateLabel(name: "State-driven tabs", icon: "rectangle.stack")
                 }
+
+                Button {
+                    self.display = .componentPaywall(SamplePaywallLoader.windowSplitComponentsData())
+                } label: {
+                    TemplateLabel(name: "Window split (foldable/iPad)", icon: "rectangle.split.2x1")
+                }
                 #endif
             }
             #endif


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Paywalls render as stretched phone layouts on iPads, foldables, and resizable windows (Stage Manager, Split View, desktop). This adds window size conditions to component overrides so a single paywall can adapt its layout to the window it is rendered in — the SDK half of upcoming responsive paywall rules in the dashboard.

### Description
- New `ExtendedCondition` cases `window_width_condition` / `window_height_condition` (operators `>=`, `>`, `<=`, `<`, `=`; density-independent point values) evaluated against the paywall's rendered bounds — not the device screen — and re-evaluated live on rotation/resize. Conditions AND together within an override, so `width >= 700` plus `height >= 480` targets large windows while excluding landscape phones.
- They are conditional-configurability rules: older SDKs decode them as `unsupported` and render the default layout, and conditions never match while the window size is unknown.
- Package selection reconciles on window size changes, so a resize that hides the selected package via a window condition cannot leave it selected.

Testing: unit coverage for decoding (including malformed-payload fallback), encode round-trip, every operator including `=` epsilon tolerance, unknown-window behavior, and combined width+height conditions. The PaywallsTester "Window split (foldable/iPad)" sample reflows live in Stage Manager / Split View for manual verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
