### PR TITLE
Add `DangerousSettings.forceAllowTestStoreInReleaseBuilds`

### DIFF
--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -60,6 +60,7 @@ import Foundation
         let autoSyncPurchases: Bool
         let uiPreviewMode: Bool
         let customEntitlementComputation: Bool
+        let forceAllowTestStoreInReleaseBuilds: Bool
     }
 
     internal let storage: Storage
@@ -95,6 +96,16 @@ import Foundation
      */
     @objc public var customEntitlementComputation: Bool { self.storage.customEntitlementComputation }
 
+    /**
+     * Forces the SDK to allow using a Test Store API key in Release builds.
+     * By default, configuring the SDK with a Test Store API key in a Release build crashes the app to prevent
+     * uploading it to the App Store.
+     *
+     * - Important: Avoid enabling this except when necessary (e.g. internal builds compiled in Release that are
+     * never uploaded to the App Store), to make sure no builds using the Test Store reach the stores.
+     */
+    @objc public var forceAllowTestStoreInReleaseBuilds: Bool { self.storage.forceAllowTestStoreInReleaseBuilds }
+
     @objc public override convenience init() {
         self.init(autoSyncPurchases: true)
     }
@@ -110,6 +121,24 @@ import Foundation
         self.init(autoSyncPurchases: autoSyncPurchases,
                   customEntitlementComputation: false)
 
+    }
+
+    /**
+     * Only use a Dangerous Setting if suggested by RevenueCat support team.
+     *
+     * - Parameter autoSyncPurchases: Disable or enable subscribing to the StoreKit queue.
+     * If this is disabled, RevenueCat won't observe the StoreKit queue, and it will not sync any purchase
+     * automatically.
+     * - Parameter forceAllowTestStoreInReleaseBuilds: Forces the SDK to allow using a Test Store API key in
+     * Release builds. Avoid enabling this except when necessary, to make sure no builds using the Test Store
+     * reach the stores.
+     */
+    @objc public convenience init(autoSyncPurchases: Bool,
+                                  forceAllowTestStoreInReleaseBuilds: Bool) {
+        self.init(autoSyncPurchases: autoSyncPurchases,
+                  customEntitlementComputation: false,
+                  internalSettings: Internal.default,
+                  forceAllowTestStoreInReleaseBuilds: forceAllowTestStoreInReleaseBuilds)
     }
 
     /// - Note: this is `internal` only so the only `public` way to enable `customEntitlementComputation`
@@ -136,11 +165,13 @@ import Foundation
     internal init(autoSyncPurchases: Bool,
                   customEntitlementComputation: Bool = false,
                   internalSettings: InternalDangerousSettingsType,
-                  uiPreviewMode: Bool = false) {
+                  uiPreviewMode: Bool = false,
+                  forceAllowTestStoreInReleaseBuilds: Bool = false) {
         self.storage = Storage(
             autoSyncPurchases: autoSyncPurchases,
             uiPreviewMode: uiPreviewMode,
-            customEntitlementComputation: customEntitlementComputation
+            customEntitlementComputation: customEntitlementComputation,
+            forceAllowTestStoreInReleaseBuilds: forceAllowTestStoreInReleaseBuilds
         )
         self.internalSettings = internalSettings
     }

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -535,6 +535,15 @@ extension Configuration {
 
 extension Configuration.APIKeyValidationResult {
 
+    /// Whether configuring the SDK with this API key must be blocked in Release builds.
+    /// `uiPreviewMode` and `forceAllowTestStoreInReleaseBuilds` are opt-ins that intentionally bypass the guard.
+    // Visible for testing
+    func shouldBlockSimulatedStoreAPIKeyInRelease(dangerousSettings: DangerousSettings) -> Bool {
+        return self == .simulatedStore
+            && !dangerousSettings.uiPreviewMode
+            && !dangerousSettings.forceAllowTestStoreInReleaseBuilds
+    }
+
     func checkForSimulatedStoreAPIKeyInRelease(systemInfo: SystemInfo, apiKey: String) {
         // The `BYPASS_SIMULATED_STORE_RELEASE_CHECK` compilation flag opts out of the Release-build
         // safeguard. It exists for SDK consumers (e.g. purchases-kmp) that ship the SDK as a
@@ -542,7 +551,7 @@ extension Configuration.APIKeyValidationResult {
         // otherwise crash apps that use a Test Store API key during development. Setting this flag
         // means apps shipped to production with a Test Store API key won't be caught at runtime.
         #if !DEBUG && !BYPASS_SIMULATED_STORE_RELEASE_CHECK
-        guard self == .simulatedStore, !systemInfo.dangerousSettings.uiPreviewMode else {
+        guard self.shouldBlockSimulatedStoreAPIKeyInRelease(dangerousSettings: systemInfo.dangerousSettings) else {
             return
         }
 

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCDangerousSettingsAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCDangerousSettingsAPI.m
@@ -22,9 +22,12 @@
 + (void)checkAPI {
     RCDangerousSettings *defaultSettings __unused = [[RCDangerousSettings alloc] init];
     RCDangerousSettings *settings = [[RCDangerousSettings alloc] initWithAutoSyncPurchases:true];
+    RCDangerousSettings *forceAllowSettings __unused = [[RCDangerousSettings alloc] initWithAutoSyncPurchases:true
+                                                                        forceAllowTestStoreInReleaseBuilds:true];
 
     BOOL autoSyncPurchases __unused = settings.autoSyncPurchases;
     BOOL customEntitlementComputation __unused = settings.customEntitlementComputation;
+    BOOL forceAllowTestStoreInReleaseBuilds __unused = settings.forceAllowTestStoreInReleaseBuilds;
 }
 
 @end

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/DangerousSettingsAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/DangerousSettingsAPI.swift
@@ -16,9 +16,11 @@
 func checkDangerousSettingsAPI() {
     let _: DangerousSettings = DangerousSettings()
     let _: DangerousSettings = DangerousSettings(autoSyncPurchases: true)
+    let _: DangerousSettings = DangerousSettings(autoSyncPurchases: true, forceAllowTestStoreInReleaseBuilds: true)
     let settings: DangerousSettings = DangerousSettings(uiPreviewMode: true)
 
     let _: Bool = settings.autoSyncPurchases
     let _: Bool = settings.customEntitlementComputation
     let _: Bool = settings.uiPreviewMode
+    let _: Bool = settings.forceAllowTestStoreInReleaseBuilds
 }

--- a/Tests/UnitTests/Misc/DangerousSettingsTests.swift
+++ b/Tests/UnitTests/Misc/DangerousSettingsTests.swift
@@ -50,6 +50,11 @@ final class DangerousSettingsTests: TestCase {
             != DangerousSettings(uiPreviewMode: false)
     }
 
+    func testDifferentForceAllowTestStoreInReleaseBuildsIsNotEqual() {
+        expect(DangerousSettings(autoSyncPurchases: true, forceAllowTestStoreInReleaseBuilds: true))
+            != DangerousSettings(autoSyncPurchases: true, forceAllowTestStoreInReleaseBuilds: false)
+    }
+
     func testInternalSettingsAreExcludedFromEquality() {
         let defaultInternal: InternalDangerousSettingsType = DangerousSettings.Internal.default
         let customInternal: InternalDangerousSettingsType = DangerousSettings.Internal(enableReceiptFetchRetry: true)
@@ -59,6 +64,23 @@ final class DangerousSettingsTests: TestCase {
 
         expect(lhs) == rhs
         expect(lhs.hashValue) == rhs.hashValue
+    }
+
+    // MARK: - forceAllowTestStoreInReleaseBuilds
+
+    func testForceAllowTestStoreInReleaseBuildsIsDisabledByDefault() {
+        expect(DangerousSettings().forceAllowTestStoreInReleaseBuilds) == false
+        expect(DangerousSettings(autoSyncPurchases: false).forceAllowTestStoreInReleaseBuilds) == false
+        expect(DangerousSettings(uiPreviewMode: true).forceAllowTestStoreInReleaseBuilds) == false
+    }
+
+    func testForceAllowTestStoreInReleaseBuildsCanBeEnabled() {
+        let settings = DangerousSettings(autoSyncPurchases: false, forceAllowTestStoreInReleaseBuilds: true)
+
+        expect(settings.forceAllowTestStoreInReleaseBuilds) == true
+        expect(settings.autoSyncPurchases) == false
+        expect(settings.uiPreviewMode) == false
+        expect(settings.customEntitlementComputation) == false
     }
 
     // MARK: - Internal settings

--- a/Tests/UnitTests/Purchasing/ConfigurationTests.swift
+++ b/Tests/UnitTests/Purchasing/ConfigurationTests.swift
@@ -39,6 +39,33 @@ class ConfigurationTests: TestCase {
         expect(Configuration.validateAndLog(apiKey: "test_eg2t9g3098bgqqn")) == .simulatedStore
     }
 
+    func testTestStoreKeyIsBlockedInReleaseByDefault() {
+        expect(Configuration.APIKeyValidationResult.simulatedStore
+            .shouldBlockSimulatedStoreAPIKeyInRelease(dangerousSettings: DangerousSettings())) == true
+    }
+
+    func testTestStoreKeyIsNotBlockedInReleaseWhenForceAllowTestStoreInReleaseBuilds() {
+        let settings = DangerousSettings(autoSyncPurchases: true, forceAllowTestStoreInReleaseBuilds: true)
+
+        expect(Configuration.APIKeyValidationResult.simulatedStore
+            .shouldBlockSimulatedStoreAPIKeyInRelease(dangerousSettings: settings)) == false
+    }
+
+    func testTestStoreKeyIsNotBlockedInReleaseWhenUIPreviewMode() {
+        let settings = DangerousSettings(uiPreviewMode: true)
+
+        expect(Configuration.APIKeyValidationResult.simulatedStore
+            .shouldBlockSimulatedStoreAPIKeyInRelease(dangerousSettings: settings)) == false
+    }
+
+    func testNonTestStoreKeysAreNotBlockedInRelease() {
+        let results: [Configuration.APIKeyValidationResult] = [.validApplePlatform, .otherPlatforms, .legacy]
+
+        for result in results {
+            expect(result.shouldBlockSimulatedStoreAPIKeyInRelease(dangerousSettings: DangerousSettings())) == false
+        }
+    }
+
     func testNoObserverModeWithStoreKit1() {
         let configuration = Configuration.Builder(withAPIKey: "test")
             .with(storeKitVersion: .storeKit1)

--- a/api/revenuecat-api-ios-simulator.swiftinterface
+++ b/api/revenuecat-api-ios-simulator.swiftinterface
@@ -451,8 +451,12 @@ extension RevenueCat.Purchases {
   @objc final public var customEntitlementComputation: Swift.Bool {
     @objc get
   }
+  @objc final public var forceAllowTestStoreInReleaseBuilds: Swift.Bool {
+    @objc get
+  }
   @objc override convenience dynamic public init()
   @objc convenience public init(autoSyncPurchases: Swift.Bool = true)
+  @objc convenience public init(autoSyncPurchases: Swift.Bool, forceAllowTestStoreInReleaseBuilds: Swift.Bool)
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   @objc override final public var hash: Swift.Int {
     @objc get

--- a/api/revenuecat-api-ios.swiftinterface
+++ b/api/revenuecat-api-ios.swiftinterface
@@ -451,8 +451,12 @@ extension RevenueCat.Purchases {
   @objc final public var customEntitlementComputation: Swift.Bool {
     @objc get
   }
+  @objc final public var forceAllowTestStoreInReleaseBuilds: Swift.Bool {
+    @objc get
+  }
   @objc override convenience dynamic public init()
   @objc convenience public init(autoSyncPurchases: Swift.Bool = true)
+  @objc convenience public init(autoSyncPurchases: Swift.Bool, forceAllowTestStoreInReleaseBuilds: Swift.Bool)
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   @objc override final public var hash: Swift.Int {
     @objc get

--- a/api/revenuecat-api-macos.swiftinterface
+++ b/api/revenuecat-api-macos.swiftinterface
@@ -420,8 +420,12 @@ public protocol RawDataContainer {
   @objc final public var customEntitlementComputation: Swift.Bool {
     @objc get
   }
+  @objc final public var forceAllowTestStoreInReleaseBuilds: Swift.Bool {
+    @objc get
+  }
   @objc override convenience dynamic public init()
   @objc convenience public init(autoSyncPurchases: Swift.Bool = true)
+  @objc convenience public init(autoSyncPurchases: Swift.Bool, forceAllowTestStoreInReleaseBuilds: Swift.Bool)
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   @objc override final public var hash: Swift.Int {
     @objc get

--- a/api/revenuecat-api-tvos-simulator.swiftinterface
+++ b/api/revenuecat-api-tvos-simulator.swiftinterface
@@ -418,8 +418,12 @@ public protocol RawDataContainer {
   @objc final public var customEntitlementComputation: Swift.Bool {
     @objc get
   }
+  @objc final public var forceAllowTestStoreInReleaseBuilds: Swift.Bool {
+    @objc get
+  }
   @objc override convenience dynamic public init()
   @objc convenience public init(autoSyncPurchases: Swift.Bool = true)
+  @objc convenience public init(autoSyncPurchases: Swift.Bool, forceAllowTestStoreInReleaseBuilds: Swift.Bool)
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   @objc override final public var hash: Swift.Int {
     @objc get

--- a/api/revenuecat-api-tvos.swiftinterface
+++ b/api/revenuecat-api-tvos.swiftinterface
@@ -418,8 +418,12 @@ public protocol RawDataContainer {
   @objc final public var customEntitlementComputation: Swift.Bool {
     @objc get
   }
+  @objc final public var forceAllowTestStoreInReleaseBuilds: Swift.Bool {
+    @objc get
+  }
   @objc override convenience dynamic public init()
   @objc convenience public init(autoSyncPurchases: Swift.Bool = true)
+  @objc convenience public init(autoSyncPurchases: Swift.Bool, forceAllowTestStoreInReleaseBuilds: Swift.Bool)
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   @objc override final public var hash: Swift.Int {
     @objc get

--- a/api/revenuecat-api-visionos-simulator.swiftinterface
+++ b/api/revenuecat-api-visionos-simulator.swiftinterface
@@ -451,8 +451,12 @@ extension RevenueCat.Purchases {
   @objc final public var customEntitlementComputation: Swift.Bool {
     @objc get
   }
+  @objc final public var forceAllowTestStoreInReleaseBuilds: Swift.Bool {
+    @objc get
+  }
   @objc override convenience dynamic public init()
   @objc convenience public init(autoSyncPurchases: Swift.Bool = true)
+  @objc convenience public init(autoSyncPurchases: Swift.Bool, forceAllowTestStoreInReleaseBuilds: Swift.Bool)
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   @objc override final public var hash: Swift.Int {
     @objc get

--- a/api/revenuecat-api-visionos.swiftinterface
+++ b/api/revenuecat-api-visionos.swiftinterface
@@ -451,8 +451,12 @@ extension RevenueCat.Purchases {
   @objc final public var customEntitlementComputation: Swift.Bool {
     @objc get
   }
+  @objc final public var forceAllowTestStoreInReleaseBuilds: Swift.Bool {
+    @objc get
+  }
   @objc override convenience dynamic public init()
   @objc convenience public init(autoSyncPurchases: Swift.Bool = true)
+  @objc convenience public init(autoSyncPurchases: Swift.Bool, forceAllowTestStoreInReleaseBuilds: Swift.Bool)
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   @objc override final public var hash: Swift.Int {
     @objc get

--- a/api/revenuecat-api-watchos-simulator.swiftinterface
+++ b/api/revenuecat-api-watchos-simulator.swiftinterface
@@ -419,8 +419,12 @@ public protocol RawDataContainer {
   @objc final public var customEntitlementComputation: Swift.Bool {
     @objc get
   }
+  @objc final public var forceAllowTestStoreInReleaseBuilds: Swift.Bool {
+    @objc get
+  }
   @objc override convenience dynamic public init()
   @objc convenience public init(autoSyncPurchases: Swift.Bool = true)
+  @objc convenience public init(autoSyncPurchases: Swift.Bool, forceAllowTestStoreInReleaseBuilds: Swift.Bool)
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   @objc override final public var hash: Swift.Int {
     @objc get

--- a/api/revenuecat-api-watchos.swiftinterface
+++ b/api/revenuecat-api-watchos.swiftinterface
@@ -419,8 +419,12 @@ public protocol RawDataContainer {
   @objc final public var customEntitlementComputation: Swift.Bool {
     @objc get
   }
+  @objc final public var forceAllowTestStoreInReleaseBuilds: Swift.Bool {
+    @objc get
+  }
   @objc override convenience dynamic public init()
   @objc convenience public init(autoSyncPurchases: Swift.Bool = true)
+  @objc convenience public init(autoSyncPurchases: Swift.Bool, forceAllowTestStoreInReleaseBuilds: Swift.Bool)
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   @objc override final public var hash: Swift.Int {
     @objc get


### PR DESCRIPTION
Adds a new `forceAllowTestStoreInReleaseBuilds` dangerous setting that allows configuring the SDK with a Test Store API key in Release builds. By default, doing so still shows the alert and crashes to prevent submitting a Test Store build to the App Store.

This is meant for builds compiled in Release that are never uploaded to the App Store (e.g. internal nightlies). It should be avoided otherwise.

```swift
let settings = DangerousSettings(autoSyncPurchases: true, forceAllowTestStoreInReleaseBuilds: true)
let configuration = Configuration.Builder(withAPIKey: "test_...")
    .with(dangerousSettings: settings)
    .build()
Purchases.configure(with: configuration)
```

Counterpart of RevenueCat/purchases-android#4169.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change weakens a deliberate Release safeguard against shipping Test Store keys; misuse could allow store builds with test configuration, though default behavior is unchanged.
> 
> **Overview**
> Adds **`DangerousSettings.forceAllowTestStoreInReleaseBuilds`** (default `false`) plus an `@objc` convenience initializer so Release builds can opt out of the Test Store API key guard without using `uiPreviewMode`.
> 
> Release blocking logic is centralized in **`shouldBlockSimulatedStoreAPIKeyInRelease`**, which still crashes on `test_` keys unless **`uiPreviewMode`** or the new flag is set; **`checkForSimulatedStoreAPIKeyInRelease`** now delegates to that helper. Public API surface, unit tests, and generated **`swiftinterface`** files are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c9d10766467427879f85e0ae16dcc564a59387b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->