### PR TITLE
ci: notify external PRs feed on PRs from outside the org

### DIFF
--- a/.github/workflows/external-pr-notifications.yml
+++ b/.github/workflows/external-pr-notifications.yml
@@ -1,0 +1,13 @@
+name: External PR Notifications
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  notify:
+    uses: revenuecat/sdk-github-workflows/.github/workflows/external-pr-notifications.yml@3765ddb1c650fba52875e793217f737727425bdf # v7
+    secrets:
+      EXTERNAL_PR_SLACK_WEBHOOK_URL: ${{ secrets.EXTERNAL_PR_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
- Adds a workflow that posts to an internal Slack feed when a PR is opened by someone outside the RevenueCat org.
- Uses `pull_request_target` so the job has the webhook secret on fork PRs; it never checks out or runs PR code and holds a `GITHUB_TOKEN` with no permissions.


### Checklist

- [x] `actionlint` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change using an empty-permission `pull_request_target` wrapper and a pinned reusable workflow; no application code or data paths are modified.
> 
> **Overview**
> Adds a new GitHub Actions workflow that alerts an internal Slack channel when someone **outside the RevenueCat org** opens a pull request.
> 
> The workflow runs on `pull_request_target` with `types: [opened]` so forked PRs can use the webhook secret, and sets **`permissions: {}`** so the default `GITHUB_TOKEN` has no scopes. Notification logic is delegated to the shared **`revenuecat/sdk-github-workflows`** reusable workflow (pinned to **v7**), with `EXTERNAL_PR_SLACK_WEBHOOK_URL` passed from repo secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1be19c71294e76703e39e9b93fcbd0af30f9a020. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->