### PR TITLE
fix(checkpoints): fix audience loading and missing-dimension evaluation

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1280,6 +1280,8 @@
 		A1B2C3D42FE2000000000002 /* RemoteConfigDiskCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE2000000000001 /* RemoteConfigDiskCache.swift */; };
 		A1B2C3D42FE2000000000004 /* RemoteConfigManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE2000000000003 /* RemoteConfigManager.swift */; };
 		A1B2C3D42FE2000000000006 /* RemoteConfigStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE2000000000005 /* RemoteConfigStrings.swift */; };
+		A1B2C3D52FE2000000000002 /* CheckpointsStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D52FE2000000000001 /* CheckpointsStrings.swift */; };
+		A1B2C3D62FE2000000000002 /* LocalRulesStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D62FE2000000000001 /* LocalRulesStrings.swift */; };
 		A1B2C3D42FE2000000000009 /* RemoteConfigDiskCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE2000000000008 /* RemoteConfigDiskCacheTests.swift */; };
 		A1B2C3D42FE200000000000B /* RemoteConfigManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE200000000000A /* RemoteConfigManagerTests.swift */; };
 		A1B2C3D42FE200000000000D /* RemoteConfigBlobStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FE200000000000C /* RemoteConfigBlobStore.swift */; };
@@ -3092,6 +3094,8 @@
 		A1B2C3D42FE2000000000001 /* RemoteConfigDiskCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigDiskCache.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE2000000000003 /* RemoteConfigManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigManager.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE2000000000005 /* RemoteConfigStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigStrings.swift; sourceTree = "<group>"; };
+		A1B2C3D52FE2000000000001 /* CheckpointsStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckpointsStrings.swift; sourceTree = "<group>"; };
+		A1B2C3D62FE2000000000001 /* LocalRulesStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalRulesStrings.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE2000000000008 /* RemoteConfigDiskCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigDiskCacheTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE200000000000A /* RemoteConfigManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigManagerTests.swift; sourceTree = "<group>"; };
 		A1B2C3D42FE200000000000C /* RemoteConfigBlobStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigBlobStore.swift; sourceTree = "<group>"; };
@@ -4156,6 +4160,7 @@
 				55DACFCC30366625005EE017 /* AuthenticationStrings.swift */,
 				B302206D2728B798008F1A0D /* BackendErrorStrings.swift */,
 				F5714EE426DC2F1D00635477 /* CodableStrings.swift */,
+				A1B2C3D52FE2000000000001 /* CheckpointsStrings.swift */,
 				9A65E03525918B0500DE00B0 /* ConfigureStrings.swift */,
 				9A65E03A25918B0900DE00B0 /* CustomerInfoStrings.swift */,
 				4FF8464C2A32554300617F00 /* DiagnosticsStrings.swift */,
@@ -4165,6 +4170,7 @@
 				AAAA44740000000000000021 /* ExternalPurchaseStrings.swift */,
 				1E2F91712CCFA98C00BDB016 /* WebRedemptionStrings.swift */,
 				9A65E0752591977200DE00B0 /* IdentityStrings.swift */,
+				A1B2C3D62FE2000000000001 /* LocalRulesStrings.swift */,
 				2D00A41C2767C08300FC3DD8 /* ManageSubscriptionsStrings.swift */,
 				9A65E07A2591977500DE00B0 /* NetworkStrings.swift */,
 				9A65E09F2591A23200DE00B0 /* OfferingStrings.swift */,
@@ -7903,6 +7909,8 @@
 				A7D200000000000000000002 /* Audience.swift in Sources */,
 				A7D100000000000000000002 /* AudiencesConfigProvider.swift in Sources */,
 				A1B2C3D42FE2000000000006 /* RemoteConfigStrings.swift in Sources */,
+				A1B2C3D52FE2000000000002 /* CheckpointsStrings.swift in Sources */,
+				A1B2C3D62FE2000000000002 /* LocalRulesStrings.swift in Sources */,
 				A1B2C3D42FE7000000000002 /* RemoteConfigTopic.swift in Sources */,
 				A1B2C3D42FE1000000000010 /* RemoteConfigSignatureContextProvider.swift in Sources */,
 				2CD72944268A826F00BFC976 /* Date+Extensions.swift in Sources */,

--- a/Sources/Checkpoints/CheckpointWorkflowResolver.swift
+++ b/Sources/Checkpoints/CheckpointWorkflowResolver.swift
@@ -121,14 +121,14 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
         if let resolution = try await self.attemptResolveConfiguredWorkflow(identifier: identifier, params: params) {
             return resolution
         }
-        Logger.verbose(Strings.remoteConfig.checkpointResolutionRetry(identifier: identifier))
+        Logger.verbose(Strings.checkpoints.resolutionRetry(identifier: identifier))
 
         // A `nil` attempt means its configuration became stale while resolving.
         // Retry once against the latest generation before treating repeated staleness as unavailable.
         if let resolution = try await self.attemptResolveConfiguredWorkflow(identifier: identifier, params: params) {
             return resolution
         }
-        Logger.error(Strings.remoteConfig.checkpointResolutionRepeatedlyStale(identifier: identifier))
+        Logger.error(Strings.checkpoints.resolutionRepeatedlyStale(identifier: identifier))
         return .noAction(.configurationUnavailable)
     }
 
@@ -168,7 +168,7 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
             throw error
         } catch {
             guard self.checkpointsConfigProvider.isCurrent(rulesSnapshot) else { return nil }
-            Logger.error(Strings.remoteConfig.checkpointAudiencesNotEvaluated(
+            Logger.error(Strings.checkpoints.audiencesNotEvaluated(
                 checkpointID: identifier,
                 reason: "\(error)"
             ))
@@ -196,7 +196,7 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
             // Only return `noMatch` when audience evaluation succeeds and no rule matches. If evaluation fails,
             // the SDK can't determine whether the app user matches, so treat the checkpoint configuration as
             // unavailable.
-            Logger.error(Strings.remoteConfig.checkpointAudiencesNotEvaluated(
+            Logger.error(Strings.checkpoints.audiencesNotEvaluated(
                 checkpointID: identifier,
                 reason: "\(error)"
             ))
@@ -266,7 +266,7 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
     private func offeringID(for rule: CheckpointRule) async -> String? {
         let offeringIdByWorkflowId = await self.workflowManager.offeringIdByWorkflowId()
         guard let offeringID = offeringIdByWorkflowId[rule.workflowId] ?? nil else {
-            Logger.warn(Strings.remoteConfig.checkpointWorkflowRuleSkipped(
+            Logger.warn(Strings.checkpoints.workflowRuleSkipped(
                 workflowID: rule.workflowId,
                 reason: "no offering identifier is configured"
             ))
@@ -369,7 +369,7 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
 
     @discardableResult
     private static func unservable(_ rule: CheckpointRule, reason: String) -> CheckpointResolution {
-        Logger.warn(Strings.remoteConfig.checkpointWorkflowRuleSkipped(
+        Logger.warn(Strings.checkpoints.workflowRuleSkipped(
             workflowID: rule.workflowId,
             reason: reason
         ))

--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -294,7 +294,7 @@ class CustomerInfoManager {
             let data = try JSONSerialization.data(withJSONObject: dimensions)
             self.deviceCache.cache(subscriberDimensions: data, appUserID: appUserID)
         } catch {
-            Logger.warn(Strings.remoteConfig.subscriberDimensionsUnavailable(error))
+            Logger.warn(Strings.localRules.subscriberDimensionsUnavailable(error))
         }
     }
 

--- a/Sources/LocalRules/CustomerInfoDimensionProvider.swift
+++ b/Sources/LocalRules/CustomerInfoDimensionProvider.swift
@@ -54,7 +54,7 @@ struct CustomerInfoDimensionProvider: DimensionProvider {
             throw CancellationError()
         } catch {
             // The current app user ID is still useful when CustomerInfo is temporarily unavailable.
-            Logger.warn(Strings.remoteConfig.customerInfoUnavailable(error))
+            Logger.warn(Strings.localRules.customerInfoUnavailable(error))
         }
 
         return dimensions

--- a/Sources/LocalRules/DimensionResolver.swift
+++ b/Sources/LocalRules/DimensionResolver.swift
@@ -137,7 +137,7 @@ private enum DimensionValueConverter {
         return dimensions.reduce(into: [:]) { result, dimension in
             let (name, value) = dimension
             guard Self.isValidName(name) else {
-                Logger.warn(Strings.remoteConfig.invalidDimensionName(name, parentPath: parentPath))
+                Logger.warn(Strings.localRules.invalidDimensionName(name, parentPath: parentPath))
                 return
             }
 

--- a/Sources/LocalRules/LocalRulesEvaluator.swift
+++ b/Sources/LocalRules/LocalRulesEvaluator.swift
@@ -97,7 +97,8 @@ final class LocalRulesEvaluator: Sendable {
                 continue
             case .failure(let error):
                 switch error {
-                case .unresolvedVariable:
+                case .unresolvedVariable(let path):
+                    Logger.debug(Strings.localRules.ruleUnresolvedVariable(ruleIndex: index, path: path))
                     continue
                 default:
                     if firstEvaluationError == nil {

--- a/Sources/LocalRules/LocalRulesEvaluator.swift
+++ b/Sources/LocalRules/LocalRulesEvaluator.swift
@@ -20,7 +20,7 @@ protocol LocalRule: Sendable {
     var predicate: String { get }
 }
 
-/// A predicate failure that prevented local rules from producing a definitive non-match.
+/// A predicate failure encountered while evaluating local rules.
 enum LocalRulesEvaluationError: Error, Equatable, Sendable {
 
     case predicateEvaluation(ruleIndex: Int, error: RulesEngine.EvaluationError)
@@ -63,8 +63,9 @@ final class LocalRulesEvaluator: Sendable {
     /// Same, for rules that don't carry their own predicate and have to look it up.
     ///
     /// The predicate is resolved one rule at a time, so a rule after the match never pays for a lookup. A
-    /// lookup that throws ends the call: a predicate the SDK couldn't obtain is not the same answer as one
-    /// that evaluated to false, so the remaining rules can't be walked as if it hadn't matched.
+    /// predicate that references an unavailable local value is treated as a non-match, allowing evaluation
+    /// to continue with the remaining rules. Other evaluation errors are retained and thrown if no rule
+    /// matches.
     func match<Rule: Sendable>(
         in rules: [Rule],
         customVariables: [String: DimensionValue] = [:],
@@ -95,8 +96,13 @@ final class LocalRulesEvaluator: Sendable {
             case .success(false):
                 continue
             case .failure(let error):
-                if firstEvaluationError == nil {
-                    firstEvaluationError = .predicateEvaluation(ruleIndex: index, error: error)
+                switch error {
+                case .unresolvedVariable:
+                    continue
+                default:
+                    if firstEvaluationError == nil {
+                        firstEvaluationError = .predicateEvaluation(ruleIndex: index, error: error)
+                    }
                 }
             }
         }

--- a/Sources/LocalRules/SubscriberAttributesDimensionProvider.swift
+++ b/Sources/LocalRules/SubscriberAttributesDimensionProvider.swift
@@ -45,7 +45,7 @@ struct SubscriberAttributesDimensionProvider: DimensionProvider {
         do {
             attributes = try self.attributesProvider()
         } catch {
-            Logger.warn(Strings.remoteConfig.subscriberAttributesUnavailable(error))
+            Logger.warn(Strings.localRules.subscriberAttributesUnavailable(error))
             return [:]
         }
 

--- a/Sources/LocalRules/SubscriberDimensionsProvider.swift
+++ b/Sources/LocalRules/SubscriberDimensionsProvider.swift
@@ -39,7 +39,7 @@ struct SubscriberDimensionsProvider: DimensionProvider {
 
             return values.compactMapValues(\AnyDecodable.dimensionValue)
         } catch {
-            Logger.warn(Strings.remoteConfig.subscriberDimensionsUnavailable(error))
+            Logger.warn(Strings.localRules.subscriberDimensionsUnavailable(error))
             return [:]
         }
     }

--- a/Sources/Logging/Strings/CheckpointsStrings.swift
+++ b/Sources/Logging/Strings/CheckpointsStrings.swift
@@ -1,0 +1,39 @@
+//
+//  CheckpointsStrings.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+
+enum CheckpointsStrings {
+
+    case audiencesNotEvaluated(checkpointID: String, reason: String)
+    case resolutionRepeatedlyStale(identifier: String)
+    case resolutionRetry(identifier: String)
+    case ruleSkipped(reason: String)
+    case workflowRuleSkipped(workflowID: String, reason: String)
+
+}
+
+extension CheckpointsStrings: LogMessage {
+
+    var description: String {
+        switch self {
+        case let .audiencesNotEvaluated(checkpointID, reason):
+            return "The audiences for checkpoint '\(checkpointID)' could not be evaluated: \(reason)."
+        case let .resolutionRepeatedlyStale(identifier):
+            return "Remote configuration kept changing while resolving checkpoint '\(identifier)'."
+        case let .resolutionRetry(identifier):
+            return "Remote configuration changed while resolving checkpoint '\(identifier)'; resolving it again."
+        case let .ruleSkipped(reason):
+            return "Skipping malformed checkpoint rule: \(reason)."
+        case let .workflowRuleSkipped(workflowID, reason):
+            return "Skipping checkpoint rule for workflow '\(workflowID)': \(reason)."
+        }
+    }
+
+    var category: String { return "checkpoints" }
+
+}

--- a/Sources/Logging/Strings/LocalRulesStrings.swift
+++ b/Sources/Logging/Strings/LocalRulesStrings.swift
@@ -1,0 +1,37 @@
+//
+//  LocalRulesStrings.swift
+//  RevenueCat
+//
+//  Created by Rick van der Linden.
+//  Copyright © 2026 RevenueCat, Inc. All rights reserved.
+
+import Foundation
+
+enum LocalRulesStrings {
+
+    case customerInfoUnavailable(Error)
+    case invalidDimensionName(String, parentPath: String)
+    case subscriberAttributesUnavailable(Error)
+    case subscriberDimensionsUnavailable(Error)
+
+}
+
+extension LocalRulesStrings: LogMessage {
+
+    var description: String {
+        switch self {
+        case let .customerInfoUnavailable(error):
+            return "The customer info is unavailable, so its checkpoint dimensions cannot be evaluated: \(error)."
+        case let .invalidDimensionName(name, parentPath):
+            return "Ignoring dimension name '\(name)' under '\(parentPath)': " +
+                "a dimension name cannot be empty, whitespace-only, or contain '.'."
+        case let .subscriberAttributesUnavailable(error):
+            return "The subscriber attributes are unavailable, so they cannot be evaluated: \(error)."
+        case let .subscriberDimensionsUnavailable(error):
+            return "The subscriber dimensions are unavailable, so they cannot be evaluated: \(error)."
+        }
+    }
+
+    var category: String { return "local_rules" }
+
+}

--- a/Sources/Logging/Strings/LocalRulesStrings.swift
+++ b/Sources/Logging/Strings/LocalRulesStrings.swift
@@ -11,6 +11,7 @@ enum LocalRulesStrings {
 
     case customerInfoUnavailable(Error)
     case invalidDimensionName(String, parentPath: String)
+    case ruleUnresolvedVariable(ruleIndex: Int, path: String)
     case subscriberAttributesUnavailable(Error)
     case subscriberDimensionsUnavailable(Error)
 
@@ -25,6 +26,8 @@ extension LocalRulesStrings: LogMessage {
         case let .invalidDimensionName(name, parentPath):
             return "Ignoring dimension name '\(name)' under '\(parentPath)': " +
                 "a dimension name cannot be empty, whitespace-only, or contain '.'."
+        case let .ruleUnresolvedVariable(ruleIndex, path):
+            return "Rule at index \(ruleIndex) did not match because variable '\(path)' could not be resolved."
         case let .subscriberAttributesUnavailable(error):
             return "The subscriber attributes are unavailable, so they cannot be evaluated: \(error)."
         case let .subscriberDimensionsUnavailable(error):

--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -13,12 +13,6 @@ enum RemoteConfigStrings {
     case audienceDecodeFailed(identifier: String, error: Error)
     case backendPredicateResultUnsupported(String)
     case cacheURLNotAvailable
-    case checkpointAudiencesNotEvaluated(checkpointID: String, reason: String)
-    case checkpointResolutionRepeatedlyStale(identifier: String)
-    case checkpointResolutionRetry(identifier: String)
-    case checkpointRuleSkipped(reason: String)
-    case checkpointWorkflowRuleSkipped(workflowID: String, reason: String)
-    case customerInfoUnavailable(Error)
     case failedToClearBlobStore(Error)
     case failedToDeleteBlob(String, Error)
     case failedToReadBlob(String, Error)
@@ -45,9 +39,6 @@ enum RemoteConfigStrings {
     case sourceUnhealthy(ref: String, hasNextSource: Bool)
     case storedBlob(String, byteCount: Int, URL)
     case storedInlineBlob(String, byteCount: Int)
-    case subscriberAttributesUnavailable(Error)
-    case subscriberDimensionsUnavailable(Error)
-    case invalidDimensionName(String, parentPath: String)
     case uiConfigDecodeFailed(Error)
     case uiConfigMissingRequiredPart
 
@@ -66,18 +57,6 @@ extension RemoteConfigStrings: LogMessage {
             return "Ignoring backend predicate result '\(identifier)': its value can't be read by a rule."
         case .cacheURLNotAvailable:
             return "Remote config cache URL is not available."
-        case let .checkpointAudiencesNotEvaluated(checkpointID, reason):
-            return "The audiences for checkpoint '\(checkpointID)' could not be evaluated: \(reason)."
-        case let .checkpointResolutionRepeatedlyStale(identifier):
-            return "Remote configuration kept changing while resolving checkpoint '\(identifier)'."
-        case let .checkpointResolutionRetry(identifier):
-            return "Remote configuration changed while resolving checkpoint '\(identifier)'; resolving it again."
-        case let .checkpointRuleSkipped(reason):
-            return "Skipping malformed checkpoint rule: \(reason)."
-        case let .checkpointWorkflowRuleSkipped(workflowID, reason):
-            return "Skipping checkpoint rule for workflow '\(workflowID)': \(reason)."
-        case let .customerInfoUnavailable(error):
-            return "The customer info is unavailable, so its checkpoint dimensions cannot be evaluated: \(error)."
         case let .failedToClearBlobStore(error):
             return "Failed to clear remote config blob store: \(error.localizedDescription)"
         case let .failedToDeleteBlob(ref, error):
@@ -139,13 +118,6 @@ extension RemoteConfigStrings: LogMessage {
             return "Stored remote config blob '\(ref)' with \(byteCount) bytes downloaded from \(url.absoluteString)."
         case let .storedInlineBlob(ref, byteCount):
             return "Stored inline remote config blob '\(ref)' with \(byteCount) bytes."
-        case let .subscriberAttributesUnavailable(error):
-            return "The subscriber attributes are unavailable, so they cannot be evaluated: \(error)."
-        case let .subscriberDimensionsUnavailable(error):
-            return "The subscriber dimensions are unavailable, so they cannot be evaluated: \(error)."
-        case let .invalidDimensionName(name, parentPath):
-            return "Ignoring dimension name '\(name)' under '\(parentPath)': " +
-                "a dimension name cannot be empty, whitespace-only, or contain '.'."
         case let .uiConfigDecodeFailed(error):
             return "Failed to decode merged ui_config: \(error.localizedDescription)"
         case .uiConfigMissingRequiredPart:

--- a/Sources/Logging/Strings/Strings.swift
+++ b/Sources/Logging/Strings/Strings.swift
@@ -18,6 +18,7 @@ enum Strings {
     static let analytics = AnalyticsStrings.self
     static let authentication = AuthenticationStrings.self
     static let cache = CacheStrings.self
+    static let checkpoints = CheckpointsStrings.self
     static let codable = CodableStrings.self
     static let configure = ConfigureStrings.self
     static let backendError = BackendErrorStrings.self
@@ -28,6 +29,7 @@ enum Strings {
     static let externalPurchase = ExternalPurchaseStrings.self
     static let fileRepository = FileRepositoryStrings.self
     static let identity = IdentityStrings.self
+    static let localRules = LocalRulesStrings.self
     static let network = NetworkStrings.self
     static let offering = OfferingStrings.self
     static let offlineEntitlements = OfflineEntitlementsStrings.self

--- a/Sources/Networking/AudiencesConfigProvider.swift
+++ b/Sources/Networking/AudiencesConfigProvider.swift
@@ -51,10 +51,11 @@ final class AudiencesConfigProvider: AudiencesConfigProviderType {
 
     private func loadConfiguration() async throws -> AudienceConfigurationSnapshot? {
         try Task.checkCancellation()
-        guard let topicSnapshot = await self.manager.topicCacheSnapshot(.audiences) else { return nil }
-
-        let prefetchRefs = topicSnapshot.key.values.compactMap { $0.prefetch ? $0.blobRef : nil }
-        await self.manager.ensureBlobsDownloaded(prefetchRefs)
+        guard let topic = await self.manager.awaitTopicAndPrefetchBlobsReady(.audiences) else { return nil }
+        let topicSnapshot = GenerationGuardedCacheSnapshot(
+            generation: self.manager.configGeneration,
+            key: topic
+        )
         guard await self.manager.isCurrent(topicSnapshot, for: .audiences) else { return nil }
         if let cached = self.cachedConfiguration.value(for: topicSnapshot) { return cached }
 

--- a/Sources/Networking/CheckpointRules.swift
+++ b/Sources/Networking/CheckpointRules.swift
@@ -92,7 +92,7 @@ private struct SkippableRule: Decodable {
         do {
             self.rule = try CheckpointRule(from: decoder)
         } catch {
-            Logger.warn(Strings.remoteConfig.checkpointRuleSkipped(reason: "\(error)"))
+            Logger.warn(Strings.checkpoints.ruleSkipped(reason: "\(error)"))
             self.rule = nil
         }
     }

--- a/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
@@ -634,10 +634,8 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
         XCTAssertEqual(Self.noActionReason(resolution), .noMatch)
     }
 
-    /// No dimension provider supplies `last_seen.*`, so the lookup fails and the audience cannot be
-    /// answered at all. That is not the same answer as a customer who falls outside it, so it is reported
-    /// as unavailable rather than as `noMatch`.
-    func testAudienceOnAnUnsuppliedVariableIsNotReportedAsNoMatch() async throws {
+    /// No dimension provider supplies `last_seen.*`, so the audience rule is treated as a non-match.
+    func testAudienceOnAnUnsuppliedVariableResolvesNoMatch() async throws {
         self.audiencesProvider.rulesByAudienceID = [
             "audience": try Self.servedRules(
                 #"{ "id": "audience", "rules": { "in": [{ "var": "last_seen.country" }, ["ES"]] } }"#
@@ -646,13 +644,11 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
 
         let resolution = try await self.resolve()
 
-        XCTAssertEqual(Self.noActionReason(resolution), .configurationUnavailable)
+        XCTAssertEqual(Self.noActionReason(resolution), .noMatch)
     }
 
-    /// Negation used to invert an unsupplied variable into a match: `null == "NL"` was false, so `!` made it
-    /// true and the audience matched *everyone*, including the customers it was meant to exclude. The lookup
-    /// fails ahead of the negation now, so an unresolvable path can no longer manufacture a match.
-    func testNegatedAudienceOnAnUnsuppliedVariableDoesNotMatch() async throws {
+    /// An unresolved variable must not be converted into a match by negation.
+    func testNegatedAudienceOnAnUnsuppliedVariableResolvesNoMatch() async throws {
         self.audiencesProvider.rulesByAudienceID = [
             "audience": try Self.servedRules(
                 #"{ "id": "audience", "rules": { "!": [{ "==": [{ "var": "last_seen.country" }, "NL"] }] } }"#
@@ -662,7 +658,19 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
         let resolution = try await self.resolve()
 
         XCTAssertNil(Self.resolvedWorkflow(resolution))
-        XCTAssertEqual(Self.noActionReason(resolution), .configurationUnavailable)
+        XCTAssertEqual(Self.noActionReason(resolution), .noMatch)
+    }
+
+    func testAudienceOnAnUnsuppliedVariableDoesNotBlockALaterMatch() async throws {
+        let secondWorkflowID = "wf5678"
+        self.stubTwoRules(secondWorkflowID: secondWorkflowID)
+        self.audiencesProvider.rulesByAudienceID["audience_\(self.workflowID)"] =
+            #"{ "in": [{ "var": "last_seen.country" }, ["ES"]] }"#
+        self.audiencesProvider.rulesByAudienceID["audience_\(secondWorkflowID)"] = "true"
+
+        let resolution = try await self.resolve()
+
+        XCTAssertEqual(Self.resolvedWorkflow(resolution)?.workflow.id, secondWorkflowID)
     }
 
     /// Decodes with the real `Audience` decoder, so what gets evaluated is the string a served payload

--- a/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
+++ b/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
@@ -409,10 +409,9 @@ struct LocalRulesEvaluatorTests {
     }
 
     @Test
-    func omittedVariableSurfacesAsAnErrorRatherThanMatching() async throws {
-        // A dimension this SDK version cannot resolve makes the rule
-        // unanswerable. Reporting that is what lets the caller tell it apart
-        // from a rule that was evaluated and did not match.
+    func omittedVariableIsTreatedAsNoMatch() async throws {
+        // A missing local value means this audience does not match. It should
+        // not make the complete rules configuration unavailable.
         let evaluator = Self.evaluator(dimensionProviders: [
             TestDimensionProvider(
                 name: "device",
@@ -420,22 +419,14 @@ struct LocalRulesEvaluatorTests {
             )
         ])
 
-        do {
-            _ = try await evaluator.match(in: [
-                TestLocalRule(
-                    id: "reads-unknown-dimension",
-                    predicate: #"{"==":[{"var":"unknown"},null]}"#
-                )
-            ])
-            Issue.record("Expected predicate failure to be thrown")
-        } catch let error as LocalRulesEvaluationError {
-            #expect(error == .predicateEvaluation(
-                ruleIndex: 0,
-                error: .unresolvedVariable(path: "unknown")
-            ))
-        } catch {
-            Issue.record("Unexpected error: \(error)")
-        }
+        let rule = try await evaluator.match(in: [
+            TestLocalRule(
+                id: "reads-unknown-dimension",
+                predicate: #"{"==":[{"var":"unknown"},null]}"#
+            )
+        ])
+
+        #expect(rule == nil)
     }
 
     @Test

--- a/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
+++ b/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
@@ -412,6 +412,7 @@ struct LocalRulesEvaluatorTests {
     func omittedVariableIsTreatedAsNoMatch() async throws {
         // A missing local value means this audience does not match. It should
         // not make the complete rules configuration unavailable.
+        let logger = TestLogHandler(testIdentifier: #function)
         let evaluator = Self.evaluator(dimensionProviders: [
             TestDimensionProvider(
                 name: "device",
@@ -427,6 +428,10 @@ struct LocalRulesEvaluatorTests {
         ])
 
         #expect(rule == nil)
+        let expectedMessage = Strings.localRules.ruleUnresolvedVariable(ruleIndex: 0, path: "unknown")
+        #expect(logger.messages.contains {
+            $0.level == .debug && $0.message.contains(expectedMessage.description)
+        })
     }
 
     @Test

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
@@ -5,6 +5,8 @@
 //  Created by Rick van der Linden.
 //  Copyright © 2026 RevenueCat, Inc. All rights reserved.
 
+// swiftlint:disable file_length type_body_length function_body_length
+
 import Foundation
 import Nimble
 @preconcurrency @testable import RevenueCat

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigManagerTests.swift
@@ -5,6 +5,8 @@
 //  Created by Rick van der Linden.
 //  Copyright © 2026 RevenueCat, Inc. All rights reserved.
 
+// swiftlint:disable file_length type_body_length
+
 import Foundation
 import Nimble
 @testable import RevenueCat

--- a/Tests/UnitTests/Networking/UiConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/UiConfigProviderTests.swift
@@ -215,7 +215,7 @@ class UiConfigProviderTests: TestCase {
         expect(self.provider.cachedUiConfig()).toNot(beNil())
     }
 
-    func testReturnsNilAndDoesNotCacheUiConfigWhenGenerationChangesDuringDecode() async throws {
+    func testRetriesAndCachesUiConfigWhenGenerationChangesDuringDecode() async throws {
         self.stub(
             app: #"{"colors": {}, "fonts": {}}"#,
             localizations: #"{"en_US": {"day": "Day"}}"#,
@@ -230,8 +230,9 @@ class UiConfigProviderTests: TestCase {
         self.mockManager.completeStoredBlobReads()
 
         let resolvedUiConfig = await uiConfig
-        expect(resolvedUiConfig).to(beNil())
-        expect(self.provider.cachedUiConfig()).to(beNil())
+        expect(resolvedUiConfig).toNot(beNil())
+        expect(self.provider.cachedUiConfig()).toNot(beNil())
+        expect(self.mockManager.invokedMergeItemsBlobDataParameters.count) == 2
     }
 
     func testCachedUiConfigReturnsNilWhenGenerationChangesWithoutRewarming() async throws {

--- a/Tests/UnitTests/Networking/UiConfigProviderTests.swift
+++ b/Tests/UnitTests/Networking/UiConfigProviderTests.swift
@@ -215,7 +215,7 @@ class UiConfigProviderTests: TestCase {
         expect(self.provider.cachedUiConfig()).toNot(beNil())
     }
 
-    func testRetriesAndCachesUiConfigWhenGenerationChangesDuringDecode() async throws {
+    func testReturnsNilAndDoesNotCacheUiConfigWhenGenerationChangesDuringDecode() async throws {
         self.stub(
             app: #"{"colors": {}, "fonts": {}}"#,
             localizations: #"{"en_US": {"day": "Day"}}"#,
@@ -230,8 +230,8 @@ class UiConfigProviderTests: TestCase {
         self.mockManager.completeStoredBlobReads()
 
         let resolvedUiConfig = await uiConfig
-        expect(resolvedUiConfig).toNot(beNil())
-        expect(self.provider.cachedUiConfig()).toNot(beNil())
+        expect(resolvedUiConfig).to(beNil())
+        expect(self.provider.cachedUiConfig()).to(beNil())
     }
 
     func testCachedUiConfigReturnsNilWhenGenerationChangesWithoutRewarming() async throws {


### PR DESCRIPTION
## Description
Introduces two small improvements

- Changes `LocalRulesEvaluator` to no longer return `.noAction(.configurationUnavailable)` when a variable used in the rule is missing, but rather `.noAction(.noMatch)` instead as described in the RFC.
- Updated `awaitTopicAndPrefetchBlobsReady` to return the snapshot right away, simplifying the implementation of ensuring the blobs are downloaded and retrieving the snapshot in the audiences topic provider. Also took the liberty to rename a few types here.
- Added logging for the case where the local rules evaluator encountered an undefined variable + took the liberty of cleaning up and separating the error strings. Previously checkpoints + audience related strings were organized under the remote config strings list. Now they're split up

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkpoint and audience matching when local dimensions are missing, which can alter which workflow or offering is selected versus reporting configuration unavailable.
> 
> **Overview**
> **Local rule evaluation** now treats predicates that reference **unresolved variables** as a **non-match** instead of failing the whole walk. Evaluation **continues** to later rules, emits a **debug** log via new `Strings.localRules.ruleUnresolvedVariable`, and still throws for other predicate errors when nothing matches. Checkpoint audience rules on dimensions the SDK does not supply (including **negated** predicates) therefore resolve **`noMatch`** rather than **`configurationUnavailable`**, with new tests for fall-through to a later matching rule.
> 
> **Logging** is reorganized: checkpoint messages move to **`CheckpointsStrings`**, local-rules/dimension messages to **`LocalRulesStrings`**, with call sites updated (`Strings.checkpoints` / `Strings.localRules`).
> 
> **Audience config loading** uses **`awaitTopicAndPrefetchBlobsReady(.audiences)`** and builds the generation-guarded topic snapshot from that result instead of the previous topic-cache + separate prefetch path.
> 
> Minor test updates: **`UiConfigProvider`** expects a second merge after a generation bump during blob reads; swiftlint disables on large remote-config test files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35edd29f6ace47fcc82653c9da04e387dd010a83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->