### PR TITLE
refactor(checkpoints): remove backend predicate results

### DIFF
--- a/Sources/Checkpoints/CheckpointWorkflowResolver.swift
+++ b/Sources/Checkpoints/CheckpointWorkflowResolver.swift
@@ -250,10 +250,7 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
         return try await self.localRulesEvaluator.match(
             in: rules,
             // Already filtered to valid keys by `DimensionResolver`, which exposes them under `custom.*`.
-            customVariables: params.customVariables.mapValues(\.dimensionValue),
-            // Supplied by the same generation-bound snapshot as the audience predicates, rather than retained
-            // by a provider that could outlive this evaluation.
-            backendValues: audienceConfiguration.backendPredicateResults
+            customVariables: params.customVariables.mapValues(\.dimensionValue)
         ) { rule in
             guard let audience = audienceConfiguration.audiences[rule.audienceId] else {
                 throw AudienceUnavailableError(audienceID: rule.audienceId)

--- a/Sources/LocalRules/DimensionResolver.swift
+++ b/Sources/LocalRules/DimensionResolver.swift
@@ -52,10 +52,9 @@ struct DimensionResolver: Sendable {
 
     /// Collects each provider once and merges its values into the canonical root scope.
     ///
-    /// `custom` and `backend` remain nested reserved objects. Every other value is flat.
+    /// `custom` remains a nested reserved object. Every other value is flat.
     func snapshot(
-        customVariables: [String: DimensionValue] = [:],
-        backendValues: [String: DimensionValue] = [:]
+        customVariables: [String: DimensionValue] = [:]
     ) async throws -> DimensionSnapshot {
         let appUserID = self.currentAppUserIDProvider()
         let date = self.dateProvider.now()
@@ -97,12 +96,6 @@ struct DimensionResolver: Sendable {
             root: Self.customKey,
             to: &values
         )
-        Self.addPerEvaluationValues(
-            backendValues,
-            root: Self.backendKey,
-            to: &values
-        )
-
         try Task.checkCancellation()
         guard self.currentAppUserIDProvider() == appUserID else {
             throw DimensionResolutionError.appUserChanged
@@ -124,8 +117,7 @@ struct DimensionResolver: Sendable {
 
     private static let evaluatedAtKey = "evaluated_at"
     private static let customKey = "custom"
-    private static let backendKey = "backend"
-    private static let reservedRootKeys: Set<String> = [Self.evaluatedAtKey, Self.customKey, Self.backendKey]
+    private static let reservedRootKeys: Set<String> = [Self.evaluatedAtKey, Self.customKey]
 }
 
 private enum DimensionValueConverter {

--- a/Sources/LocalRules/LocalRulesEvaluator.swift
+++ b/Sources/LocalRules/LocalRulesEvaluator.swift
@@ -47,16 +47,13 @@ final class LocalRulesEvaluator: Sendable {
     ///
     /// For example, rules `[("a", false), ("b", true)]` return the second rule.
     /// Developer-supplied values are available to predicates under `custom.*`.
-    /// Backend-supplied values for this evaluation are available under `backend.*`.
     func match<Rule: LocalRule>(
         in rules: [Rule],
-        customVariables: [String: DimensionValue] = [:],
-        backendValues: [String: DimensionValue] = [:]
+        customVariables: [String: DimensionValue] = [:]
     ) async throws -> Rule? {
         return try await self.match(
             in: rules,
-            customVariables: customVariables,
-            backendValues: backendValues
+            customVariables: customVariables
         ) { $0.predicate }
     }
 
@@ -69,7 +66,6 @@ final class LocalRulesEvaluator: Sendable {
     func match<Rule: Sendable>(
         in rules: [Rule],
         customVariables: [String: DimensionValue] = [:],
-        backendValues: [String: DimensionValue] = [:],
         predicate resolvePredicate: (Rule) async throws -> String
     ) async throws -> Rule? {
         guard !rules.isEmpty else {
@@ -77,8 +73,7 @@ final class LocalRulesEvaluator: Sendable {
         }
 
         let snapshot = try await self.dimensionResolver.snapshot(
-            customVariables: customVariables,
-            backendValues: backendValues
+            customVariables: customVariables
         )
 
         var firstEvaluationError: LocalRulesEvaluationError?

--- a/Sources/Logging/Strings/RemoteConfigStrings.swift
+++ b/Sources/Logging/Strings/RemoteConfigStrings.swift
@@ -11,7 +11,6 @@ enum RemoteConfigStrings {
 
     case audienceConfigurationDecodeFailed(Error)
     case audienceDecodeFailed(identifier: String, error: Error)
-    case backendPredicateResultUnsupported(String)
     case cacheURLNotAvailable
     case failedToClearBlobStore(Error)
     case failedToDeleteBlob(String, Error)
@@ -53,8 +52,6 @@ extension RemoteConfigStrings: LogMessage {
         case let .audienceDecodeFailed(identifier, error):
             return "Ignoring audience '\(identifier)' in the canonical audience configuration: " +
                 "\(error.localizedDescription)"
-        case let .backendPredicateResultUnsupported(identifier):
-            return "Ignoring backend predicate result '\(identifier)': its value can't be read by a rule."
         case .cacheURLNotAvailable:
             return "Remote config cache URL is not available."
         case let .failedToClearBlobStore(error):

--- a/Sources/Networking/AudiencesConfigProvider.swift
+++ b/Sources/Networking/AudiencesConfigProvider.swift
@@ -14,23 +14,17 @@ protocol AudiencesConfigProviderType {
 
 }
 
-/// One immutable view of the audience rules and subscriber-specific protected values served together by
-/// the `audiences` topic.
+/// One immutable view of the audience rules served by the `audiences` topic.
 struct AudienceConfigurationSnapshot: Equatable, Sendable {
 
     let audiences: [String: Audience]
-
-    /// Opaque values keyed by the hashes used as placeholders in the canonical audience rules.
-    let backendPredicateResults: [String: DimensionValue]
     let configGeneration: Int
 
 }
 
 /// The topic-specific front door for canonical audience configuration.
 ///
-/// All published audience rules live in the immutable `default` blob. Subscriber-specific protected values
-/// remain inline under `backend_predicate_results`. Both values are loaded from one committed topic
-/// generation so callers can never evaluate rules with results belonging to a different configuration.
+/// All published audience rules live in the immutable `default` blob.
 final class AudiencesConfigProvider: AudiencesConfigProviderType {
 
     private let manager: RemoteConfigManagerType
@@ -69,7 +63,6 @@ final class AudiencesConfigProvider: AudiencesConfigProviderType {
             }
             let configuration = AudienceConfigurationSnapshot(
                 audiences: try Self.decodeAudiences(from: blob),
-                backendPredicateResults: Self.decodeBackendPredicateResults(from: topicSnapshot.key),
                 configGeneration: topicSnapshot.generation
             )
             guard await self.manager.isCurrent(topicSnapshot, for: .audiences) else { return nil }
@@ -100,23 +93,7 @@ final class AudiencesConfigProvider: AudiencesConfigProviderType {
         }
     }
 
-    private static func decodeBackendPredicateResults(
-        from topic: RemoteConfiguration.ConfigTopic
-    ) -> [String: DimensionValue] {
-        guard let item = topic[Self.backendPredicateResultsItemKey] else { return [:] }
-
-        return item.content.reduce(into: [:]) { results, entry in
-            let (conditionHash, value) = entry
-            guard let dimensionValue = value.dimensionValue else {
-                Logger.warn(Strings.remoteConfig.backendPredicateResultUnsupported(conditionHash))
-                return
-            }
-            results[conditionHash] = dimensionValue
-        }
-    }
-
     private static let audiencesBlobItemKey = "default"
-    private static let backendPredicateResultsItemKey = "backend_predicate_results"
 
 }
 

--- a/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
@@ -499,68 +499,6 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
         XCTAssertEqual(Self.noActionReason(missed), .noMatch)
     }
 
-    func testTrueBackendPredicateResultMatchesAudience() async throws {
-        let hash = "condition_hash"
-        self.audiencesProvider.defaultRules = #"{"var":["backend.\#(hash)",false]}"#
-        self.audiencesProvider.backendPredicateResults = [hash: .bool(true)]
-
-        let resolution = try await self.resolve()
-
-        XCTAssertEqual(Self.resolvedWorkflow(resolution)?.workflow.id, self.workflowID)
-    }
-
-    func testFalseBackendPredicateResultDoesNotMatchAudience() async throws {
-        let hash = "condition_hash"
-        self.audiencesProvider.defaultRules = #"{"var":["backend.\#(hash)",true]}"#
-        self.audiencesProvider.backendPredicateResults = [hash: .bool(false)]
-
-        let resolution = try await self.resolve()
-
-        XCTAssertEqual(Self.noActionReason(resolution), .noMatch)
-    }
-
-    func testMissingBackendPredicateResultUsesAuthoredDefault() async throws {
-        self.audiencesProvider.defaultRules = #"{"var":["backend.missing_hash",true]}"#
-
-        let resolution = try await self.resolve()
-
-        XCTAssertEqual(Self.resolvedWorkflow(resolution)?.workflow.id, self.workflowID)
-    }
-
-    func testBackendPredicateResultsAreScopedToOneEvaluation() async throws {
-        let hash = "condition_hash"
-        self.audiencesProvider.defaultRules = #"{"var":["backend.\#(hash)",false]}"#
-        self.audiencesProvider.backendPredicateResults = [hash: .bool(true)]
-
-        let matched = try await self.resolve()
-        self.audiencesProvider.backendPredicateResults = [:]
-        let missed = try await self.resolve()
-
-        XCTAssertEqual(Self.resolvedWorkflow(matched)?.workflow.id, self.workflowID)
-        XCTAssertEqual(Self.noActionReason(missed), .noMatch)
-    }
-
-    func testNonBooleanBackendPredicateResultsAreAvailableToAudiencePredicates() async throws {
-        self.audiencesProvider.defaultRules = #"""
-        {"and":[
-            {"==":[{"var":"backend.variant"},"variant_b"]},
-            {"==":[{"var":"backend.count"},3]},
-            {"==":[{"var":"backend.score"},1.5]},
-            {"==":[{"var":"backend.profile.tier"},"pro"]}
-        ]}
-        """#
-        self.audiencesProvider.backendPredicateResults = [
-            "variant": .string("variant_b"),
-            "count": .int(3),
-            "score": .double(1.5),
-            "profile": .object(["tier": .string("pro")])
-        ]
-
-        let resolution = try await self.resolve()
-
-        XCTAssertEqual(Self.resolvedWorkflow(resolution)?.workflow.id, self.workflowID)
-    }
-
     /// A malformed predicate is an evaluation failure, not a lookup failure: the audience was read, the engine
     /// just couldn't run it. That doesn't block a lower-priority rule from winning on its own merits.
     func testMalformedAudienceBeforeAMatchDoesNotPreventALaterWorkflow() async throws {
@@ -975,7 +913,6 @@ private final class MockAudiencesConfigProvider: AudiencesConfigProviderType {
         }
     }
     var configGeneration = 0
-    var backendPredicateResults: [String: DimensionValue] = [:]
     var configurationUnavailable = false
     var onConfiguration: (() -> Void)?
     private(set) var configurationRequestCount = 0
@@ -1002,7 +939,6 @@ private final class MockAudiencesConfigProvider: AudiencesConfigProviderType {
             audiences: Dictionary(uniqueKeysWithValues: self.rulesByAudienceID.map { identifier, rules in
                 (identifier, Audience(id: identifier, rules: rules))
             }),
-            backendPredicateResults: self.backendPredicateResults,
             configGeneration: self.configGeneration
         )
     }

--- a/Tests/UnitTests/LocalRules/DimensionScopeTests.swift
+++ b/Tests/UnitTests/LocalRules/DimensionScopeTests.swift
@@ -60,8 +60,7 @@ struct DimensionScopeTests {
             currentAppUserIDProvider: { "user" },
             dateProvider: MockDateProvider(stubbedNow: date)
         ).snapshot(
-            customVariables: ["attempt": .int(3)],
-            backendValues: ["condition_hash": .bool(true)]
+            customVariables: ["attempt": .int(3)]
         )
 
         #expect(snapshot.values == Self.expectedValues)
@@ -139,8 +138,7 @@ private extension DimensionScopeTests {
                 "value": .string("make_more_money")
             ])
         ]),
-        "custom": .object(["attempt": .int(3)]),
-        "backend": .object(["condition_hash": .bool(true)])
+        "custom": .object(["attempt": .int(3)])
     ]
 
     static let customerInfoData: [String: Any] = [

--- a/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
+++ b/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
@@ -270,7 +270,7 @@ struct LocalRulesEvaluatorTests {
         }
     }
 
-    @Test(arguments: ["evaluated_at", "custom", "backend"])
+    @Test(arguments: ["evaluated_at", "custom"])
     func providerCannotClaimReservedRoot(_ reservedRoot: String) async {
         let provider = TestDimensionProvider(
             name: "invalid",

--- a/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
+++ b/Tests/UnitTests/Networking/RemoteConfig/RemoteConfigIntegrationTests.swift
@@ -109,8 +109,7 @@ final class RemoteConfigIntegrationTests: TestCase {
         let ref = RCContainerTestData.blobRef(for: opaquePayload)
         let source = Self.blobSource("primary")
         let audiences: RemoteConfiguration.ConfigTopic = [
-            "default": .init(blobRef: ref, prefetch: true),
-            "backend_predicate_results": .init(content: ["condition_hash": true])
+            "default": .init(blobRef: ref, prefetch: true)
         ]
         let container = try Self.containerData(topics: .init(entries: [
             RemoteConfigTopic.sources.wireName: Self.sourcesTopic(blobSources: [source]),
@@ -123,13 +122,13 @@ final class RemoteConfigIntegrationTests: TestCase {
         let prefetchedData = self.blobStore.read(ref: ref)
         let defaultData = await self.manager.blobData(for: .audiences, itemKey: "default")
 
-        expect(topic?.keys.sorted()) == ["backend_predicate_results", "default"]
+        expect(topic?.keys.sorted()) == ["default"]
         expect(topic?["default"]?.prefetch) == true
         expect(prefetchedData) == opaquePayload
         expect(defaultData) == opaquePayload
     }
 
-    func testAudiencesProviderLoadsCanonicalRFCFixtures() async throws {
+    func testAudiencesProviderLoadsAudienceConfiguration() async throws {
         let configData = #"""
         {
           "domain": "app",
@@ -141,19 +140,6 @@ final class RemoteConfigIntegrationTests: TestCase {
               "default": {
                 "blob_ref": "S_uSSVFaiTCvj2BIpm59ccs1aBHsJNGH",
                 "prefetch": true
-              },
-              "backend_predicate_results": {
-                "349OzehoTyCAdiZblj9w0J0yD-Uow8X3": false,
-                "5Ycn7VItkR0DTZfStFMgDwp-TaW6Iz_v": false,
-                "PROg2cJoAVWa3sWx-6djaRxQQbDPpWwW": false,
-                "X0_JjigFEYQ7KH7t7wU-F2A2v1p2Lp7S": false,
-                "XqFWYkTPQ8nar-o5bNAOsLftD3bfrj1F": false,
-                "avK8u8K5UAZ5oKubPAqXeNH2iNp30sDZ": false,
-                "gjqkac4Vg2300MezDymaMcjvMjeT_5Jb": false,
-                "oKtDH_RDdJrpIygtn60hvZ-06iK9W0WP": false,
-                "tUsHN1KxMmy8y80xuBnAnpoEAGd4ipTk": false,
-                "vMJD7UOr50TLaRj06GisbcrR5R0Gptsx": false,
-                "vfcKkz9ze13J_lVBwkaiRbsmbfe84mD9": false
               }
             }
           }
@@ -172,22 +158,17 @@ final class RemoteConfigIntegrationTests: TestCase {
           },
           "aud063b1964fd804276": {
             "id": "aud063b1964fd804276",
-            "rules": {
-              "or": [
-                { "var": ["backend.PROg2cJoAVWa3sWx-6djaRxQQbDPpWwW", false] },
-                { "==": [{ "var": "country" }, "PL"] }
-              ]
-            }
+            "rules": { "==": [{ "var": "country" }, "PL"] }
           }
         }
         """#.asData
         let remoteConfiguration = try JSONDecoder.default.decode(RemoteConfiguration.self, from: configData)
-        let rfcTopic = try XCTUnwrap(remoteConfiguration.topics.entries[RemoteConfigTopic.audiences.wireName])
-        let defaultItem = try XCTUnwrap(rfcTopic["default"])
+        let audiencesTopic = try XCTUnwrap(
+            remoteConfiguration.topics.entries[RemoteConfigTopic.audiences.wireName]
+        )
+        let defaultItem = try XCTUnwrap(audiencesTopic["default"])
         let ref = RCContainerTestData.blobRef(for: payload)
-        var topic = rfcTopic
-        // The RFC's blob ref points to the complete canary artifact, while its readable example shows a subset.
-        // Address that example by its own content hash so the production checksum path remains in the test.
+        var topic = audiencesTopic
         topic["default"] = .init(blobRef: ref, prefetch: defaultItem.prefetch)
         let container = try Self.containerData(
             topics: .init(entries: [
@@ -209,16 +190,11 @@ final class RemoteConfigIntegrationTests: TestCase {
             #"{"==":[{"var":"latest_auto_renew_intent"},false]}]}"#
         expect(configuration?.audiences["audf98ea481c76049a3"]?.rules)
             == expectedRules
-        expect(configuration?.backendPredicateResults).to(haveCount(11))
-        expect(configuration?.backendPredicateResults["5Ycn7VItkR0DTZfStFMgDwp-TaW6Iz_v"]) == .bool(false)
-        expect(configuration?.backendPredicateResults["PROg2cJoAVWa3sWx-6djaRxQQbDPpWwW"]) == .bool(false)
     }
 
     func testAudiencesProviderReturnsNilWithoutDefaultBlob() async throws {
         let container = try Self.containerData(topics: .init(entries: [
-            RemoteConfigTopic.audiences.wireName: [
-                "backend_predicate_results": .init(content: ["condition_hash": true])
-            ]
+            RemoteConfigTopic.audiences.wireName: [:]
         ]))
 
         await self.refresh(with: container)
@@ -247,25 +223,6 @@ final class RemoteConfigIntegrationTests: TestCase {
 
         expect(configuration).toNot(beNil())
         expect(manager.invokedTopicCount).to(beGreaterThan(1))
-    }
-
-    func testAudiencesProviderReturnsEmptyBackendResultsWhenItemIsAbsent() async throws {
-        let payload = #"{ "aud_123": { "id": "aud_123", "rules": {} } }"#.asData
-        let ref = RCContainerTestData.blobRef(for: payload)
-        let container = try Self.containerData(
-            topics: .init(entries: [
-                RemoteConfigTopic.audiences.wireName: [
-                    "default": .init(blobRef: ref, prefetch: true)
-                ]
-            ]),
-            contentElements: [(payload, .none)]
-        )
-
-        await self.refresh(with: container)
-
-        let configuration = try await AudiencesConfigProvider(manager: self.manager).configuration()
-
-        expect(configuration?.backendPredicateResults).to(beEmpty())
     }
 
     func testAudiencesProviderDropsMalformedAudienceWithoutDroppingValidSiblings() async throws {
@@ -311,153 +268,6 @@ final class RemoteConfigIntegrationTests: TestCase {
         let configuration = try await AudiencesConfigProvider(manager: self.manager).configuration()
 
         expect(configuration?.audiences["map_key"]) == Audience(id: "different_id", rules: "{}")
-    }
-
-    func testAudiencesProviderAcceptsRuleDimensionBackendValues() async throws {
-        let payload = #"{ "aud_123": { "id": "aud_123", "rules": {} } }"#.asData
-        let ref = RCContainerTestData.blobRef(for: payload)
-        let container = try Self.containerData(
-            topics: .init(entries: [
-                RemoteConfigTopic.audiences.wireName: [
-                    "default": .init(blobRef: ref, prefetch: true),
-                    "backend_predicate_results": .init(content: [
-                        "bool": true,
-                        "string": "value",
-                        "int": 42,
-                        "double": 4.2,
-                        "object": [
-                            "nested": "value",
-                            "ignored": nil
-                        ],
-                        "object_list": [
-                            ["id": "first", "enabled": true],
-                            ["id": "second", "enabled": false]
-                        ]
-                    ])
-                ]
-            ]),
-            contentElements: [(payload, .none)]
-        )
-
-        await self.refresh(with: container)
-
-        let configuration = try await AudiencesConfigProvider(manager: self.manager).configuration()
-
-        expect(configuration?.backendPredicateResults) == [
-            "bool": .bool(true),
-            "string": .string("value"),
-            "int": .int(42),
-            "double": .double(4.2),
-            "object": .object([
-                "nested": .string("value"),
-                "ignored": .null
-            ]),
-            "object_list": .objectList([
-                ["id": .string("first"), "enabled": .bool(true)],
-                ["id": .string("second"), "enabled": .bool(false)]
-            ])
-        ]
-    }
-
-    func testAudiencesProviderOmitsUnsupportedBackendValuesIndividually() async throws {
-        let payload = #"{ "aud_123": { "id": "aud_123", "rules": {} } }"#.asData
-        let ref = RCContainerTestData.blobRef(for: payload)
-        let container = try Self.containerData(
-            topics: .init(entries: [
-                RemoteConfigTopic.audiences.wireName: [
-                    "default": .init(blobRef: ref, prefetch: true),
-                    "backend_predicate_results": .init(content: [
-                        "valid": true,
-                        "null": nil,
-                        "scalar_array": [1, 2],
-                        "mixed_array": [["id": "first"], "second"]
-                    ])
-                ]
-            ]),
-            contentElements: [(payload, .none)]
-        )
-
-        await self.refresh(with: container)
-        self.logger.clearMessages()
-
-        let configuration = try await AudiencesConfigProvider(manager: self.manager).configuration()
-
-        expect(configuration?.backendPredicateResults) == ["valid": .bool(true), "null": .null]
-        for identifier in ["scalar_array", "mixed_array"] {
-            self.logger.verifyMessageWasLogged(
-                "Ignoring backend predicate result '\(identifier)': its value can't be read by a rule.",
-                level: .warn,
-                expectedCount: 1
-            )
-        }
-        expect(self.logger.messages.filter { $0.level == .warn }).to(haveCount(2))
-    }
-
-    func testAudiencesProviderRecursivelyOmitsUnsupportedNestedBackendValues() async throws {
-        let payload = #"{ "aud_123": { "id": "aud_123", "rules": {} } }"#.asData
-        let ref = RCContainerTestData.blobRef(for: payload)
-        let container = try Self.containerData(
-            topics: .init(entries: [
-                RemoteConfigTopic.audiences.wireName: [
-                    "default": .init(blobRef: ref, prefetch: true),
-                    "backend_predicate_results": .init(content: [
-                        "nested": [
-                            "level_one": [
-                                "level_two": [
-                                    "valid": "value",
-                                    "null": nil,
-                                    "unsupported_array": [1, 2]
-                                ]
-                            ]
-                        ]
-                    ])
-                ]
-            ]),
-            contentElements: [(payload, .none)]
-        )
-
-        await self.refresh(with: container)
-
-        let configuration = try await AudiencesConfigProvider(manager: self.manager).configuration()
-
-        expect(configuration?.backendPredicateResults) == [
-            "nested": .object([
-                "level_one": .object([
-                    "level_two": .object([
-                        "valid": .string("value"),
-                        "null": .null
-                    ])
-                ])
-            ])
-        ]
-    }
-
-    func testAudiencesProviderPreservesEmptyBackendObjectsAndObjectLists() async throws {
-        let payload = #"{ "aud_123": { "id": "aud_123", "rules": {} } }"#.asData
-        let ref = RCContainerTestData.blobRef(for: payload)
-        let container = try Self.containerData(
-            topics: .init(entries: [
-                RemoteConfigTopic.audiences.wireName: [
-                    "default": .init(blobRef: ref, prefetch: true),
-                    "backend_predicate_results": .init(content: [
-                        "empty_object": [:],
-                        "empty_object_list": [],
-                        "list_with_empty_object": [[:]]
-                    ])
-                ]
-            ]),
-            contentElements: [(payload, .none)]
-        )
-
-        await self.refresh(with: container)
-
-        let configuration = try await AudiencesConfigProvider(manager: self.manager).configuration()
-
-        expect(configuration?.backendPredicateResults) == [
-            "empty_object": .object([:]),
-            "empty_object_list": .objectList([]),
-            "list_with_empty_object": .objectList([[:]])
-        ]
     }
 
     func testUncompressedConfigAndInlineBlobCanBeReadThroughFacade() async throws {


### PR DESCRIPTION
## Description
Removes the `backend_predicate_results` concept, both from the audiences topic provider as well as passing it to the rules evaluator. We won't be using this concept for now, so this PR removes all references to it

Relevant Android PR https://github.com/RevenueCat/purchases-android/pull/4174

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Audience and checkpoint matching no longer honor `backend.*` in predicates, so any server rules still referencing those values will evaluate as missing dimensions rather than using subscriber-specific backend results.
> 
> **Overview**
> Removes **backend predicate results** end-to-end: the audiences remote-config topic no longer loads or exposes `backend_predicate_results`, and `AudienceConfigurationSnapshot` only carries audience rules plus generation.
> 
> Local rule evaluation no longer accepts or merges **backend** values into the dimension snapshot (`backend.*` is gone; **`custom.*`** is unchanged). Checkpoint workflow resolution stops forwarding audience backend results into `LocalRulesEvaluator.match`.
> 
> Related logging (`backendPredicateResultUnsupported`) and unit/integration tests for decoding, scoping, and predicate matching on `backend.*` are deleted or simplified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc9e851a8744fd1fcb8bf5be37977e9221e5a50a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->