### PR TITLE
fix(customer center): hide refund and change plan on family-shared subs

### DIFF
--- a/RevenueCatUI/CustomerCenter/Actions/CustomerCenterConfigData.HelpPath+PurchaseInformation.swift
+++ b/RevenueCatUI/CustomerCenter/Actions/CustomerCenterConfigData.HelpPath+PurchaseInformation.swift
@@ -33,6 +33,11 @@ extension Array<CustomerCenterConfigData.HelpPath> {
                 return false
             }
 
+            // family members can't refund or change a subscription they don't own
+            if purchaseInformation.ownershipType == .familyShared && $0.type.requiresPurchaseOwnership {
+                return false
+            }
+
             let isNonAppStorePurchase = purchaseInformation.store != .appStore
             let isAppStoreOnlyPath = $0.type.isAppStoreOnly
 
@@ -75,6 +80,20 @@ extension Array<CustomerCenterConfigData.HelpPath> {
 }
 
 private extension CustomerCenterConfigData.HelpPath.PathType {
+
+    /// Whether the App Store rejects this action unless the customer owns the purchase.
+    var requiresPurchaseOwnership: Bool {
+        switch self {
+        case .refundRequest, .changePlans:
+            return true
+
+        case .cancel, .customUrl, .customAction, .missingPurchase, .unknown:
+            return false
+
+        @unknown default:
+            return false
+        }
+    }
 
     var isAppStoreOnly: Bool {
         switch self {

--- a/Tests/RevenueCatUITests/CustomerCenter/BaseManageSubscriptionViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/BaseManageSubscriptionViewModelTests.swift
@@ -904,6 +904,68 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
         expect(viewModel.relevantPathsForPurchase.contains(where: { $0.type == .changePlans })).to(beFalse())
     }
 
+    // MARK: - Family Sharing Path Filtering Tests
+
+    func testFamilySharedSubscriptionDoesNotShowRefundRequest() {
+        let viewModel = BaseManageSubscriptionViewModel(
+            screen: BaseManageSubscriptionViewModelTests.default,
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchaseInformation: Self.appStoreSubscription(ownershipType: .familyShared),
+            purchasesProvider: MockCustomerCenterPurchases()
+        )
+
+        // Only the purchaser can request a refund, Apple rejects it for family members
+        expect(viewModel.relevantPathsForPurchase.contains(where: { $0.type == .refundRequest })).to(beFalse())
+    }
+
+    func testFamilySharedSubscriptionDoesNotShowChangePlans() {
+        let viewModel = BaseManageSubscriptionViewModel(
+            screen: BaseManageSubscriptionViewModelTests.default,
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchaseInformation: Self.appStoreSubscription(ownershipType: .familyShared),
+            purchasesProvider: MockCustomerCenterPurchases()
+        )
+
+        // Only the purchaser can change the plan, Apple rejects it for family members
+        expect(viewModel.relevantPathsForPurchase.contains(where: { $0.type == .changePlans })).to(beFalse())
+    }
+
+    func testFamilySharedSubscriptionStillShowsCancel() {
+        let viewModel = BaseManageSubscriptionViewModel(
+            screen: BaseManageSubscriptionViewModelTests.default,
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchaseInformation: Self.appStoreSubscription(ownershipType: .familyShared),
+            purchasesProvider: MockCustomerCenterPurchases()
+        )
+
+        expect(viewModel.relevantPathsForPurchase.contains(where: { $0.type == .cancel })).to(beTrue())
+    }
+
+    func testPurchasedSubscriptionShowsRefundRequestAndChangePlans() {
+        let viewModel = BaseManageSubscriptionViewModel(
+            screen: BaseManageSubscriptionViewModelTests.default,
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchaseInformation: Self.appStoreSubscription(ownershipType: .purchased),
+            purchasesProvider: MockCustomerCenterPurchases()
+        )
+
+        expect(viewModel.relevantPathsForPurchase.contains(where: { $0.type == .refundRequest })).to(beTrue())
+        expect(viewModel.relevantPathsForPurchase.contains(where: { $0.type == .changePlans })).to(beTrue())
+    }
+
+    func testUnknownOwnershipSubscriptionShowsRefundRequestAndChangePlans() {
+        let viewModel = BaseManageSubscriptionViewModel(
+            screen: BaseManageSubscriptionViewModelTests.default,
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchaseInformation: Self.appStoreSubscription(ownershipType: .unknown),
+            purchasesProvider: MockCustomerCenterPurchases()
+        )
+
+        // We only hide these when we know the purchase is shared
+        expect(viewModel.relevantPathsForPurchase.contains(where: { $0.type == .refundRequest })).to(beTrue())
+        expect(viewModel.relevantPathsForPurchase.contains(where: { $0.type == .changePlans })).to(beTrue())
+    }
+
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
@@ -911,6 +973,17 @@ private extension BaseManageSubscriptionViewModelTests {
 
     static let `default`: CustomerCenterConfigData.Screen =
     CustomerCenterConfigData.default.screens[.management]!
+
+    static func appStoreSubscription(ownershipType: PurchaseOwnershipType) -> PurchaseInformation {
+        PurchaseInformation.mock(
+            store: .appStore,
+            isSubscription: true,
+            productType: .autoRenewableSubscription,
+            isCancelled: false,
+            renewalDate: Date().addingTimeInterval(86400),
+            ownershipType: ownershipType
+        )
+    }
 
     static func managementScreen(
         refundWindowDuration: CustomerCenterConfigData.HelpPath.RefundWindowDuration


### PR DESCRIPTION
### Motivation

On a family shared subscription we still offer "Request a refund" and "Change plan" and Apple rejects both. 

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: this PR
- Branch: `facundo/pw-1361-fix-customer-center-platform-implementation-gaps`
- Author / human owner: facumenzella
- Agent(s): Claude Opus 5 (1M context), Claude Code
- Session source: current conversation
- Generated: 2026-09-04
- Context document version: 1

## Goal

Fix the iOS half of PW-1361: stop offering "Request a refund" and "Change plan" in Customer Center for App Store subscriptions the customer received through Family Sharing, since Apple rejects both.

## Initial Prompt

Investigate and fix the family-shared Customer Center bug recorded in PW-1361 (opener was a pointer to a Slack thread, `revenuecat.slack.com/archives/C072SLPSTQS/p1788455118725699`, where the bug was identified while comparing our Customer Center with Superwall's port).

## Important Follow-up Prompts

- "How does the iOS fix look?" -> produce the root cause and proposed fix shape before editing.
- "can we ship this with unit tests too?" -> implement, with RED to GREEN evidence.
- "open a draft PR".

## Agent Contribution

- Traced the bug to a single filter, `relevantPaths(for:allowMissingPurchase:)`, and confirmed `PurchaseInformation.ownershipType` is already populated on both construction paths but read nowhere except a label in `PurchaseDetailViewModel`.
- Wrote 5 unit tests first, confirmed 2 fail for the right reason, then applied the fix.
- Verified the Maestro/StoreKit limitation by inspecting the StoreKit config schema rather than assuming it.

## Human Decisions

- Scope confirmed as the iOS half of PW-1361 only; Android flags deferred.
- Agent proposed two open questions (include `.cancel`? hide vs disable?); human did not answer them and the agent proceeded with the conservative defaults, flagged in the PR body and in the session for override.

## Key Implementation Decisions

- Decision: gate in `relevantPaths` rather than at the action handlers.
  - Rationale: single chokepoint, both call sites (`BaseManageSubscriptionViewModel`, `RelevantPurchasesListViewModel`) already funnel through it, and it matches how every other inapplicable path is dropped.
  - Rejected: failing at `handleRefundRequest` / `.showingChangePlans`, which would still show a dead button.
- Decision: match on `== .familyShared`, not `!= .purchased`.
  - Rationale: `PurchaseOwnershipType` has a third case, `.unknown`. Hiding on unknown would regress purchases whose ownership the backend could not determine.
  - Rejected: `!= .purchased`.
- Decision: hide the paths rather than disable them with an explanation.
  - Rationale: consistent with the existing filter. Noted that `sharedThroughFamilyMember` localization exists if a visible reason is preferred later.
- Decision: leave `.cancel` untouched.
  - Rationale: same bug class but outside PW-1361's stated scope. Pinned by `testFamilySharedSubscriptionStillShowsCancel` so the choice is explicit and a future change is deliberate.

## Files / Symbols Touched

- `RevenueCatUI/CustomerCenter/Actions/CustomerCenterConfigData.HelpPath+PurchaseInformation.swift`
  - Why: the only place help paths are filtered per purchase.
  - Symbols: `Array<CustomerCenterConfigData.HelpPath>.relevantPaths(for:allowMissingPurchase:)`, new private `CustomerCenterConfigData.HelpPath.PathType.requiresPurchaseOwnership`.
  - Review relevance: check the new guard sits before the App Store checks and that `requiresPurchaseOwnership` covers the right cases.
- `Tests/RevenueCatUITests/CustomerCenter/BaseManageSubscriptionViewModelTests.swift`
  - Why: 5 new tests plus a local `appStoreSubscription(ownershipType:)` fixture.
  - Symbols: `testFamilySharedSubscriptionDoesNotShowRefundRequest`, `testFamilySharedSubscriptionDoesNotShowChangePlans`, `testFamilySharedSubscriptionStillShowsCancel`, `testPurchasedSubscriptionShowsRefundRequestAndChangePlans`, `testUnknownOwnershipSubscriptionShowsRefundRequestAndChangePlans`.
  - Review relevance: the last three pin boundaries, not the fix. Removing them would let an over-broad gate pass.

## Dependencies / Config / Migrations

- None. No public API change, no new types outside a private extension.
- `tuist generate --no-open` was needed once because the pre-existing workspace referenced files not on `origin/main`.

## Validation

- Commands run:
  - `xcodebuild test -workspace RevenueCat-Tuist.xcworkspace -scheme "RevenueCatUITests (RevenueCatTests project)" -destination 'platform=iOS Simulator,id=<iPhone 14 Pro>' -only-testing:RevenueCatUITests/BaseManageSubscriptionViewModelTests` before the fix: `Executed 32 tests, with 2 failures`. Both new family-shared tests failed with "expected to be false, got <true>".
  - Same command after the fix: `Executed 32 tests, with 0 failures`.
  - Full target: `Executed 1761 tests, with 3 tests skipped and 72 failures`. Zero in Customer Center. All 72 are paywall snapshot tests reporting "Record mode is on. Automatically recorded snapshot" plus `ImageLoaderTests` missing `background.heic` and hitting "Invalid API Key". Pre-existing local environment noise.
  - `swiftlint lint` on both changed files: no violations.
- Manual verification:
  - Not run. Requires a real Family Sharing group on two devices.
- CI:
  - Not captured at time of writing.

## Validation Gaps

- No end-to-end coverage. StoreKit's config schema exposes only `familyShareable`; there is no way to make the simulator's test account a family recipient, and `ownershipType` comes from backend CustomerInfo derived from Apple's `in_app_ownership_type`. Every existing flow under `Examples/rc-maestro/maestro/customer_center/` purchases as the sim's own account and lands on `.purchased`.
- The full-target snapshot failures were shown to be unrelated by inspecting the failure reasons, not by running a clean baseline on `origin/main`.
- The claim that Apple rejects change plans specifically was taken from the Slack report and reasoned from the code path, not observed directly.

## Review Focus

- Is hiding right, or should a family member see the action with an explanation? `sharedThroughFamilyMember` already exists in localization.
- Should `.cancel` be gated too? A family member cannot cancel, and the App Store branch would open manageSubscriptions showing nothing.
- Does any non-App Store store report `.familyShared`? The new guard runs before the store check, so it would apply there too. Believed harmless since those paths are already App Store only, worth a second look.
- `PurchaseInformation.ownershipType` is optional and nil for non-subscriptions. Confirm no non-subscription flow depended on refund showing.

## Risks / Reviewer Notes

- Risk: over-filtering hides refund from customers who should have it.
  - Evidence: `testPurchasedSubscriptionShowsRefundRequestAndChangePlans` and `testUnknownOwnershipSubscriptionShowsRefundRequestAndChangePlans` cover `.purchased` and `.unknown`.
  - Mitigation: match is on `.familyShared` only.
- Risk: backend reports the wrong `ownershipType` and a legitimate owner loses both actions.
  - Evidence: not investigated. `ownershipType` comes straight from CustomerInfo.
  - Mitigation: none in this PR. `.unknown` failing open limits the blast radius.

## Non-goals / Out of Scope

- The Android half of PW-1361: `shouldWarnCustomerToUpdate`, `displayUserDetailsSection`, `shouldWarnCustomersAboutMultipleSubscriptions` being no-ops.
- Gating `.cancel`.
- Any change to the refund or change-plan handlers themselves.

## Omitted Context

- Raw transcript, unrelated exploration, sensitive details, repetitive attempts, and chain-of-thought-style content were omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI filtering in Customer Center with explicit tests; only hides actions when ownership is known to be family-shared.
> 
> **Overview**
> Customer Center no longer shows **Request a refund** or **Change plan** when the selected purchase has `ownershipType == .familyShared`, since the App Store rejects those actions for family recipients.
> 
> The change extends `relevantPaths(for:allowMissingPurchase:)` with a guard that drops paths whose type is marked by a new private `requiresPurchaseOwnership` flag (`.refundRequest` and `.changePlans` only). **Cancel** and other paths are unchanged; `.purchased` and `.unknown` ownership still show refund and change plan.
> 
> Five unit tests in `BaseManageSubscriptionViewModelTests` cover family-shared hiding, purchased/unknown regressions, and that cancel remains visible for family-shared subs, plus a shared `appStoreSubscription(ownershipType:)` fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cdcfd7e4aec36e63b855c358f060590394053be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->