### PR TITLE
refactor(workflows): resolve a step's exits when it is entered

### DIFF
--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowNavigator.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/WorkflowNavigator.swift
@@ -24,12 +24,16 @@ struct WorkflowBackNavigationDestination {
 final class WorkflowNavigator: ObservableObject {
 
     @Published private(set) var currentStepId: String
+    /// Destination per exit (`actionId` -> step id), resolved when the step is entered so a tap is a
+    /// lookup rather than a decision.
+    private(set) var resolvedExits: [String: String] = [:]
     private let workflow: PublishedWorkflow
     private var backStack: [String] = []
 
     init(workflow: PublishedWorkflow) {
         self.workflow = workflow
         self.currentStepId = workflow.initialStepId
+        self.resolvedExits = Self.resolveExits(for: workflow.steps[workflow.initialStepId], in: workflow)
     }
 
     var currentStep: WorkflowStep? {
@@ -59,14 +63,13 @@ final class WorkflowNavigator: ObservableObject {
                   $0.componentId == componentId && $0.type == triggerType
               }),
               let actionId = trigger.actionId,
-              let triggerAction = step.stepTriggerActions[actionId],
-              case .step(let stepId) = triggerAction,
+              let stepId = resolvedExits[actionId],
               let nextStep = workflow.steps[stepId] else {
             return nil
         }
 
         backStack.append(currentStepId)
-        currentStepId = nextStep.id
+        moveTo(nextStep.id)
         return nextStep
     }
 
@@ -75,8 +78,27 @@ final class WorkflowNavigator: ObservableObject {
         guard let previousStepId = backStack.popLast() else {
             return nil
         }
-        currentStepId = previousStepId
+        moveTo(previousStepId)
         return workflow.steps[previousStepId]
+    }
+
+    private func moveTo(_ stepId: String) {
+        currentStepId = stepId
+        resolvedExits = Self.resolveExits(for: workflow.steps[stepId], in: workflow)
+    }
+
+    /// Only `.step` exits resolve today. A `.conditions` exit needs the rules engine, which this
+    /// layer cannot reach yet, so it is left unresolved and does not navigate.
+    private static func resolveExits(
+        for step: WorkflowStep?,
+        in workflow: PublishedWorkflow
+    ) -> [String: String] {
+        guard let step else { return [:] }
+
+        return step.stepTriggerActions.reduce(into: [:]) { exits, entry in
+            guard case let .step(stepId) = entry.value, workflow.steps[stepId] != nil else { return }
+            exits[entry.key] = stepId
+        }
     }
 
 }

--- a/Tests/RevenueCatUITests/PaywallsV2/WorkflowNavigatorTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WorkflowNavigatorTests.swift
@@ -164,6 +164,65 @@ final class WorkflowNavigatorTests: TestCase {
         expect(navigator.canNavigateBack) == false
     }
 
+    // MARK: - resolvedExits
+
+    func testResolvedExitsIsPopulatedOnLandingForStepActions() throws {
+        let workflow = try Self.makeWorkflow(
+            steps: [
+                makeStep(id: "step_1", triggers: [("btn_abc", "btn_abc")], triggerActions: [("btn_abc", "step_2")]),
+                makeStep(id: "step_2")
+            ],
+            initialStepId: "step_1"
+        )
+        let navigator = WorkflowNavigator(workflow: workflow)
+
+        expect(navigator.resolvedExits) == ["btn_abc": "step_2"]
+    }
+
+    func testResolvedExitsIsRecomputedAfterNavigating() throws {
+        let workflow = try Self.makeWorkflow(
+            steps: [
+                makeStep(id: "step_1", triggers: [("btn_abc", "btn_abc")], triggerActions: [("btn_abc", "step_2")]),
+                makeStep(id: "step_2", triggers: [("btn_def", "btn_def")], triggerActions: [("btn_def", "step_3")]),
+                makeStep(id: "step_3")
+            ],
+            initialStepId: "step_1"
+        )
+        let navigator = WorkflowNavigator(workflow: workflow)
+
+        navigator.triggerAction(componentId: "btn_abc")
+
+        expect(navigator.resolvedExits) == ["btn_def": "step_3"]
+    }
+
+    func testResolvedExitsIsRecomputedAfterNavigatingBack() throws {
+        let workflow = try Self.makeWorkflow(
+            steps: [
+                makeStep(id: "step_1", triggers: [("btn_abc", "btn_abc")], triggerActions: [("btn_abc", "step_2")]),
+                makeStep(id: "step_2")
+            ],
+            initialStepId: "step_1"
+        )
+        let navigator = WorkflowNavigator(workflow: workflow)
+
+        navigator.triggerAction(componentId: "btn_abc")
+        navigator.navigateBack()
+
+        expect(navigator.resolvedExits) == ["btn_abc": "step_2"]
+    }
+
+    func testResolvedExitsOmitsExitsPointingAtAMissingStep() throws {
+        let workflow = try Self.makeWorkflow(
+            steps: [
+                makeStep(id: "step_1", triggers: [("btn_abc", "btn_abc")], triggerActions: [("btn_abc", "nope")])
+            ],
+            initialStepId: "step_1"
+        )
+        let navigator = WorkflowNavigator(workflow: workflow)
+
+        expect(navigator.resolvedExits).to(beEmpty())
+    }
+
     func testTriggerActionWithConditionsTypeReturnsNil() throws {
         // A "conditions" trigger action has no step_id. The navigator must not crash
         // and must return nil (no navigation), leaving the current step unchanged.


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

A branch's destination has to be known before the tap, so Continue stays instant and we don't put a spinner on it. That means deciding when the step is entered rather than when a button is pressed.

### Description

No behavior change. `step` actions resolve to the same destinations they did before, and an exit pointing at a step the workflow doesn't contain is dropped on entry instead of surfacing as a tap that does nothing.

Independent of the branch wire format, which is still being agreed.
