### PR TITLE
Add the checkout web view host

### DIFF
--- a/.github/workflows/external-pr-notifications.yml
+++ b/.github/workflows/external-pr-notifications.yml
@@ -8,6 +8,6 @@ permissions: {}
 
 jobs:
   notify:
-    uses: revenuecat/sdk-github-workflows/.github/workflows/external-pr-notifications.yml@3765ddb1c650fba52875e793217f737727425bdf # v7
+    uses: revenuecat/sdk-github-workflows/.github/workflows/external-pr-notifications.yml@b679120ce2931ac2e5c02166f84ad1f9b263fb96 # v8
     secrets:
       EXTERNAL_PR_SLACK_WEBHOOK_URL: ${{ secrets.EXTERNAL_PR_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/external-pr-notifications.yml
+++ b/.github/workflows/external-pr-notifications.yml
@@ -1,0 +1,13 @@
+name: External PR Notifications
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  notify:
+    uses: revenuecat/sdk-github-workflows/.github/workflows/external-pr-notifications.yml@3765ddb1c650fba52875e793217f737727425bdf # v7
+    secrets:
+      EXTERNAL_PR_SLACK_WEBHOOK_URL: ${{ secrets.EXTERNAL_PR_SLACK_WEBHOOK_URL }}

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -608,6 +608,7 @@
 		551800772FF46C8A0055FD1B /* KeychainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551800762FF46C8A0055FD1B /* KeychainTests.swift */; };
 		552CE0E12FD323EF006E41B4 /* Purchases+PreviewPaywall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 552CE0E02FD323EF006E41B4 /* Purchases+PreviewPaywall.swift */; };
 		552CE1022FEF22AC006E41B4 /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 552CE1012FEF22AC006E41B4 /* Keychain.swift */; };
+		5583B0113048918E00E87D02 /* CustomerInfoResponseIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5583B0103048918E00E87D02 /* CustomerInfoResponseIdentityTests.swift */; };
 		55DACDE4302BC2C3005EE017 /* TokenAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDE3302BC2C3005EE017 /* TokenAPI.swift */; };
 		55DACDEC302BC2D1005EE017 /* TokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDEA302BC2D1005EE017 /* TokenManager.swift */; };
 		55DACDED302BC2D1005EE017 /* URLMessage+Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DACDEB302BC2D1005EE017 /* URLMessage+Description.swift */; };
@@ -2361,6 +2362,7 @@
 		552CE0E02FD323EF006E41B4 /* Purchases+PreviewPaywall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Purchases+PreviewPaywall.swift"; sourceTree = "<group>"; };
 		552CE0E72FD32413006E41B4 /* Purchases+PreviewPaywallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Purchases+PreviewPaywallTests.swift"; sourceTree = "<group>"; };
 		552CE1012FEF22AC006E41B4 /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
+		5583B0103048918E00E87D02 /* CustomerInfoResponseIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoResponseIdentityTests.swift; sourceTree = "<group>"; };
 		55DACDE3302BC2C3005EE017 /* TokenAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenAPI.swift; sourceTree = "<group>"; };
 		55DACDEA302BC2D1005EE017 /* TokenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenManager.swift; sourceTree = "<group>"; };
 		55DACDEB302BC2D1005EE017 /* URLMessage+Description.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLMessage+Description.swift"; sourceTree = "<group>"; };
@@ -5567,6 +5569,7 @@
 				5774F9BD2805E71100997128 /* Fixtures */,
 				57DB9EE7281B3C6100BBAA21 /* __Snapshots__ */,
 				5774F9B92805E6E200997128 /* CustomerInfoDecodingTests.swift */,
+				5583B0103048918E00E87D02 /* CustomerInfoResponseIdentityTests.swift */,
 				60EDE5BA3C330B7FD037C4D1 /* CustomerInfoResponseSubscriberAttributesTests.swift */,
 				5774F9C02805EA3000997128 /* BaseHTTPResponseTest.swift */,
 				574A2F3E282D75E300150D40 /* OfferingsDecodingTests.swift */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -3209,6 +3209,7 @@
 		DBAA1FBA2F8D45C2000E8C81 /* HeaderTextBodyHeroSafeAreaPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderTextBodyHeroSafeAreaPreview.swift; sourceTree = "<group>"; };
 		DBAA1FC12F8D4ED8000E8C81 /* HeaderNestedHeroZLayerSafeAreaPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderNestedHeroZLayerSafeAreaPreview.swift; sourceTree = "<group>"; };
 		DBB32F183007CACD00A86DC7 /* BottomSheetSwitchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetSwitchTests.swift; sourceTree = "<group>"; };
+		A5C7E90130F8000100ABCDEF /* SizeModifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SizeModifierTests.swift; sourceTree = "<group>"; };
 		DBD243292EBDF4B80066AC6F /* PromotionalOfferViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionalOfferViewTests.swift; sourceTree = "<group>"; };
 		DBD2A167300E81E20019DB7F /* VideoAudioSessionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAudioSessionHandler.swift; sourceTree = "<group>"; };
 		DBD2A16E300E833F0019DB7F /* VideoAudioSessionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAudioSessionHandlerTests.swift; sourceTree = "<group>"; };
@@ -3534,6 +3535,7 @@
 				B413E5A12F97B3B900B5F0CA /* TabsWorkflowDefaultPackageTests.swift */,
 				F4A8C1D25E3B47A9B0D6E718 /* MixedTabsDefaultPackageVisibilityTests.swift */,
 				DBB32F183007CACD00A86DC7 /* BottomSheetSwitchTests.swift */,
+				A5C7E90130F8000100ABCDEF /* SizeModifierTests.swift */,
 				DB1FC9592F9A1B74009A95EA /* WorkflowScreenMapperTests.swift */,
 				F468C7BCEB786BEC80277ECA /* WorkflowNavigatorTests.swift */,
 				C07759C930F712D2D53B9333 /* WorkflowStepEventTrackerTests.swift */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1468,6 +1468,10 @@
 		FA6ABC7C2A81673F00353AF7 /* SystemFontRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6ABC7B2A81673F00353AF8 /* SystemFontRegistryTests.swift */; };
 		FACD000C2F61A1230073D2DE /* PackageVisibilityPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACD000B2F61A1230073D2DE /* PackageVisibilityPreview.swift */; };
 		FACE0000000000000000A001 /* BackendRemoteConfigLaneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACE0000000000000000A002 /* BackendRemoteConfigLaneTests.swift */; };
+		C4E00000000000000000A007 /* WebCheckoutReturnURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E00000000000000000A006 /* WebCheckoutReturnURL.swift */; };
+		C4E00000000000000000A009 /* WebCheckoutViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E00000000000000000A008 /* WebCheckoutViewModel.swift */; };
+		C4E00000000000000000A00B /* WebCheckoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E00000000000000000A00A /* WebCheckoutView.swift */; };
+		C4E10000000000000000B009 /* WebViewNavigationFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E10000000000000000B008 /* WebViewNavigationFailure.swift */; };
 		C4E10000000000000000B002 /* WebViewHTTPStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E10000000000000000B001 /* WebViewHTTPStatus.swift */; };
 		C4E10000000000000000B004 /* WebViewComponentNavigationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E10000000000000000B003 /* WebViewComponentNavigationPolicy.swift */; };
 		FC5AE63E8F81C3EC2FFDA408 /* WebViewOrigin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28661C6CE3F64078A0138080 /* WebViewOrigin.swift */; };
@@ -1889,6 +1893,12 @@
 		A91C0A022FEA000000000001 /* RulesEngineLoggerBridge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RulesEngineLoggerBridge.swift; sourceTree = "<group>"; };
 		26AAFBADBA3F4E339D041135 /* WorkflowStepEventCoordinatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowStepEventCoordinatorTests.swift; sourceTree = "<group>"; };
 		28661C6CE3F64078A0138080 /* WebViewOrigin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewOrigin.swift; sourceTree = "<group>"; };
+		C4E00000000000000000A006 /* WebCheckoutReturnURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCheckoutReturnURL.swift; sourceTree = "<group>"; };
+		C4E00000000000000000A008 /* WebCheckoutViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCheckoutViewModel.swift; sourceTree = "<group>"; };
+		C4E00000000000000000A00A /* WebCheckoutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCheckoutView.swift; sourceTree = "<group>"; };
+		C4E00000000000000000A00C /* WebCheckoutReturnURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCheckoutReturnURLTests.swift; sourceTree = "<group>"; };
+		C4E10000000000000000B008 /* WebViewNavigationFailure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewNavigationFailure.swift; sourceTree = "<group>"; };
+		C4E10000000000000000B00A /* WebViewNavigationFailureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewNavigationFailureTests.swift; sourceTree = "<group>"; };
 		C4E10000000000000000B001 /* WebViewHTTPStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewHTTPStatus.swift; sourceTree = "<group>"; };
 		C4E10000000000000000B003 /* WebViewComponentNavigationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewComponentNavigationPolicy.swift; sourceTree = "<group>"; };
 		C4E10000000000000000B006 /* WebViewHTTPStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewHTTPStatusTests.swift; sourceTree = "<group>"; };
@@ -3774,11 +3784,30 @@
 			path = DeepLink;
 			sourceTree = "<group>";
 		};
+		C4E00000000000000000A003 /* WebCheckout */ = {
+			isa = PBXGroup;
+			children = (
+				C4E00000000000000000A006 /* WebCheckoutReturnURL.swift */,
+				C4E00000000000000000A008 /* WebCheckoutViewModel.swift */,
+				C4E00000000000000000A00A /* WebCheckoutView.swift */,
+			);
+			path = WebCheckout;
+			sourceTree = "<group>";
+		};
+		C4E00000000000000000A005 /* WebCheckout */ = {
+			isa = PBXGroup;
+			children = (
+				C4E00000000000000000A00C /* WebCheckoutReturnURLTests.swift */,
+			);
+			path = WebCheckout;
+			sourceTree = "<group>";
+		};
 		C4E10000000000000000B005 /* WebView */ = {
 			isa = PBXGroup;
 			children = (
 				28661C6CE3F64078A0138080 /* WebViewOrigin.swift */,
 				C4E10000000000000000B001 /* WebViewHTTPStatus.swift */,
+				C4E10000000000000000B008 /* WebViewNavigationFailure.swift */,
 			);
 			path = WebView;
 			sourceTree = "<group>";
@@ -3788,6 +3817,7 @@
 			children = (
 				AAB0C0DE00000000000A0601 /* WebViewOriginTests.swift */,
 				C4E10000000000000000B006 /* WebViewHTTPStatusTests.swift */,
+				C4E10000000000000000B00A /* WebViewNavigationFailureTests.swift */,
 			);
 			path = WebView;
 			sourceTree = "<group>";
@@ -6282,6 +6312,7 @@
 				887A604F2C1D037000E1A461 /* Templates */,
 				887A60522C1D037000E1A461 /* UIKit */,
 				887A605F2C1D037000E1A461 /* Views */,
+				C4E00000000000000000A003 /* WebCheckout */,
 				C4E10000000000000000B005 /* WebView */,
 				2D2AFE902C6A9EF500D1B0B4 /* Binding+Extensions.swift */,
 				887A60602C1D037000E1A461 /* PaywallFontProvider.swift */,
@@ -6409,6 +6440,7 @@
 				887A613B2C1D168B00E1A461 /* Resources */,
 				887A62172C1D168B00E1A461 /* Templates */,
 				FACE0000000000000000F003 /* UIKit */,
+				C4E00000000000000000A005 /* WebCheckout */,
 				C4E10000000000000000B007 /* WebView */,
 				887A621C2C1D168B00E1A461 /* TestPlans */,
 				887A621D2C1D168B00E1A461 /* BaseSnapshotTest.swift */,
@@ -8874,6 +8906,10 @@
 				164681D62E6B577600854AA5 /* VideoPlayerLayerUIView.swift in Sources */,
 				FC5AE63E8F81C3EC2FFDA408 /* WebViewOrigin.swift in Sources */,
 				C4E10000000000000000B002 /* WebViewHTTPStatus.swift in Sources */,
+				C4E00000000000000000A007 /* WebCheckoutReturnURL.swift in Sources */,
+				C4E00000000000000000A009 /* WebCheckoutViewModel.swift in Sources */,
+				C4E00000000000000000A00B /* WebCheckoutView.swift in Sources */,
+				C4E10000000000000000B009 /* WebViewNavigationFailure.swift in Sources */,
 				C4E10000000000000000B004 /* WebViewComponentNavigationPolicy.swift in Sources */,
 				FA4A2DF41FC434A9401F08CC /* PaywallWebViewValue.swift in Sources */,
 				11CC2EA83C56933E40D8E5D8 /* WebViewEnvelope.swift in Sources */,

--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -121,6 +121,13 @@ enum Strings {
     case web_view_data_store_removal_failed(UUID, Error)
     case web_view_context_encoding_failed(Error)
 
+    // Web checkout
+    case web_checkout_unusable_return_url(URL)
+    case web_checkout_return_status_missing
+    case web_checkout_load_failed(String)
+    case web_checkout_http_error(statusCode: Int)
+    case web_checkout_content_process_terminated
+
     // Exit Offers
     case errorFetchingOfferings(Error)
     case exitOfferNotFound(String)
@@ -398,6 +405,18 @@ extension Strings: CustomStringConvertible {
                 "The server responded with HTTP status code \(statusCode)."
         case let .web_view_data_store_removal_failed(identifier, error):
             return "Failed to remove web view website data store '\(identifier)': \(error)"
+
+        case .web_checkout_unusable_return_url(let url):
+            return "Web checkout return URL '\(url.absoluteString)' has no resolvable origin. " +
+                "The end of the checkout will not be detected."
+        case .web_checkout_return_status_missing:
+            return "Web checkout returned without a recognizable status. Treating it as a cancellation."
+        case .web_checkout_load_failed(let error):
+            return "Web checkout failed to load. Error: \(error)"
+        case .web_checkout_http_error(let statusCode):
+            return "Web checkout failed to load. The server responded with HTTP status code \(statusCode)."
+        case .web_checkout_content_process_terminated:
+            return "Web checkout content process terminated."
 
         case .errorFetchingOfferings(let error):
             return "Error fetching offerings: \(error)"

--- a/RevenueCatUI/Templates/V2/Components/Button/BottomSheetView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/BottomSheetView.swift
@@ -60,7 +60,7 @@ struct BottomSheetOverlayModifier: ViewModifier {
             return nil
         case .fixed(let height):
             return CGFloat(height)
-        case .relative(let percent):
+        case .relative(let percent, _):
             guard let parentHeight = self.parentHeight else {
                 return nil
             }

--- a/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Image/ImageComponentView.swift
@@ -398,7 +398,7 @@ struct ImageComponentView_Previews: PreviewProvider {
             case .relative:
                 estimatedContentWidth = min(availableContentWidth, intrinsicWidth)
             }
-        case .relative(let value):
+        case .relative(let value, _):
             estimatedContentWidth = max(0, availableContentWidth * CGFloat(value))
         }
 

--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentView.swift
@@ -197,7 +197,7 @@ fileprivate extension View {
             if enabled {
                 self.scrollableIfNecessaryWhenAvailable(
                     .horizontal,
-                    fillContent: size.width == .fill,
+                    fillContent: size.width.isFill,
                     alignment: Alignment(
                         horizontal: distribution.horizontalFrameAlignment.horizontal,
                         vertical: verticalAlignment.frameAlignment.vertical
@@ -210,7 +210,7 @@ fileprivate extension View {
             if enabled {
                 self.scrollableIfNecessaryWhenAvailable(
                     .vertical,
-                    fillContent: size.height == .fill,
+                    fillContent: size.height.isFill,
                     alignment: Alignment(
                         horizontal: horizontalAlignment.frameAlignment.horizontal,
                         vertical: distribution.verticalFrameAlignment.vertical

--- a/RevenueCatUI/Templates/V2/Components/Stack/StackComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Stack/StackComponentViewModel.swift
@@ -38,11 +38,11 @@ class StackComponentViewModel {
         }) else { return false }
         switch first {
         case .image(let image):
-            return image.size.width == .fill
+            return image.size.width.isFill
         case .video(let video):
-            return video.size.width == .fill
+            return video.size.width.isFill
         case .webView(let webView):
-            return webView.size.width == .fill
+            return webView.size.width.isFill
         default:
             return false
         }

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
@@ -444,7 +444,7 @@ private extension View {
         measuredWidth: CGFloat?
     ) -> some View {
         switch constraint {
-        case .fit(let defaultSize):
+        case .fit(let defaultSize, _):
             self.frame(
                 width: WebViewSizing.resolvedDimension(
                     measured: measuredWidth,
@@ -467,7 +467,7 @@ private extension View {
         measuredHeight: CGFloat?
     ) -> some View {
         switch constraint {
-        case .fit(let defaultSize):
+        case .fit(let defaultSize, _):
             self.frame(
                 height: WebViewSizing.resolvedDimension(
                     measured: measuredHeight,

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
@@ -407,16 +407,10 @@ struct WebViewRepresentable: PlatformViewRepresentable {
         /// surfaces here) as a reason to remove the web view. Cancellations are ignored: we
         /// deliberately cancel cross-origin navigations in `decidePolicyFor`, and those surface here.
         private func handleLoadFailure(_ error: Error) {
-            let nsError = error as NSError
-            if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorCancelled {
+            guard !WebViewNavigationFailure.isCancellation(error) else {
                 return
             }
-            // Cancelling via the navigation policy can also surface as WebKitErrorDomain 102
-            // ("frame load interrupted by a policy change"), which is not a real failure.
-            if nsError.domain == "WebKitErrorDomain", nsError.code == 102 {
-                return
-            }
-            Logger.error(Strings.paywall_web_view_load_failed(nsError.localizedDescription))
+            Logger.error(Strings.paywall_web_view_load_failed((error as NSError).localizedDescription))
             self.onLoadFailed?()
         }
 

--- a/RevenueCatUI/Templates/V2/PaywallsV2View.swift
+++ b/RevenueCatUI/Templates/V2/PaywallsV2View.swift
@@ -715,7 +715,7 @@ struct LoadedPaywallsV2View: View {
                 view
                     .edgesIgnoringSafeArea(.top)
             })
-            .applyIf(paywallState.rootViewModel.stackViewModel.component.size.height == .fill, apply: { view in
+            .applyIf(paywallState.rootViewModel.stackViewModel.component.size.height.isFill, apply: { view in
                 view.frame(maxHeight: .infinity, alignment: paywallState.rootViewModel.frameAlignment)
             })
             .backgroundStyle(

--- a/RevenueCatUI/Templates/V2/ViewHelpers/ApplySizing.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/ApplySizing.swift
@@ -14,49 +14,57 @@
 @_spi(Internal) import RevenueCat
 import SwiftUI
 
+#if !os(tvOS) // For Paywalls V2
+
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension View {
 
     @ViewBuilder
     func applyMediaWidth(size: PaywallComponent.Size) -> some View {
         switch size.width {
-        case .fit:
+        case let .fit(_, minMax):
+            self.applyWidthLimits(minMax, alignment: .center)
+        case let .fill(minMax):
             self
-        case .fill:
-            self.frame(maxWidth: .infinity)
+                .frame(maxWidth: .infinity)
+                .applyWidthLimits(minMax, alignment: .center)
         case .fixed(let value):
             self.frame(width: Double(value))
-        default:
-            self
+        case let .relative(_, minMax):
+            self.applyWidthLimits(minMax, alignment: .center)
         }
     }
 
     @ViewBuilder
     func applyMediaHeight(size: PaywallComponent.Size, aspectRatio: Double) -> some View {
         switch size.height {
-        case .fit:
+        case let .fit(_, minMax):
             switch size.width {
             case .fit:
-                self
+                self.applyHeightLimits(minMax, alignment: .center)
             case .fill:
-                self
+                self.applyHeightLimits(minMax, alignment: .center)
             case .fixed(let value):
                 // This is the only change versus the regular .size() modifier.
                 // When the image or videoa has height=fit and fixed width, we manually set a
                 // fixed height according to the aspect ratio.
                 // Otherwise the view would grow vertically to occupy available space.
                 // See "Image streching vertically" preview
-                self.frame(height: Double(value) / aspectRatio)
-            default:
-                self
+                self.frame(height: minMax.clamped(Double(value) / aspectRatio))
+            case .relative:
+                self.applyHeightLimits(minMax, alignment: .center)
             }
-        case .fill:
-            self.frame(maxHeight: .infinity)
+        case let .fill(minMax):
+            self
+                .frame(maxHeight: .infinity)
+                .applyHeightLimits(minMax, alignment: .center)
         case .fixed(let value):
             self.frame(height: Double(value))
-        default:
-            self
+        case let .relative(_, minMax):
+            self.applyHeightLimits(minMax, alignment: .center)
         }
     }
 
 }
+
+#endif

--- a/RevenueCatUI/Templates/V2/ViewHelpers/SizeModifier.swift
+++ b/RevenueCatUI/Templates/V2/ViewHelpers/SizeModifier.swift
@@ -30,40 +30,104 @@ struct SizeModifier: ViewModifier {
 
 }
 
-fileprivate extension View {
+extension View {
 
     @ViewBuilder
     func applyWidth(_ sizeConstraint: PaywallComponent.SizeConstraint, alignment: Alignment) -> some View {
         switch sizeConstraint {
-        case .fit:
-            self
-        case .fill:
+        case let .fit(_, minMax):
+            self.applyWidthLimits(minMax, alignment: alignment)
+        case let .fill(minMax):
             self
                 .frame(maxWidth: .infinity, alignment: alignment)
+                .applyWidthLimits(minMax, alignment: alignment)
         case .fixed(let value):
             self
                 .frame(width: CGFloat(value), alignment: alignment)
-        case .relative:
-            // WIP: Maybe handle
-            self
+        case let .relative(_, minMax):
+            // WIP: Maybe handle % value here
+            self.applyWidthLimits(minMax, alignment: alignment)
         }
     }
 
     @ViewBuilder
     func applyHeight(_ sizeConstraint: PaywallComponent.SizeConstraint, alignment: Alignment) -> some View {
         switch sizeConstraint {
-        case .fit:
-            self
-        case .fill:
+        case let .fit(_, minMax):
+            self.applyHeightLimits(minMax, alignment: alignment)
+        case let .fill(minMax):
             self
                 .frame(maxHeight: .infinity, alignment: alignment)
+                .applyHeightLimits(minMax, alignment: alignment)
         case .fixed(let value):
             self
                 .frame(height: CGFloat(value), alignment: alignment)
-        case .relative:
-            // WIP: Maybe handle
+        case let .relative(_, minMax):
+            // WIP: Maybe handle % value here
+            self.applyHeightLimits(minMax, alignment: alignment)
+        }
+    }
+
+    @ViewBuilder
+    func applyWidthLimits(_ minMax: MinMax, alignment: Alignment) -> some View {
+        if minMax.hasLimit {
+            self.frame(
+                minWidth: minMax.minDimension,
+                maxWidth: minMax.effectiveMaxDimension,
+                alignment: alignment
+            )
+        } else {
             self
         }
+    }
+
+    @ViewBuilder
+    func applyHeightLimits(_ minMax: MinMax, alignment: Alignment) -> some View {
+        if minMax.hasLimit {
+            self.frame(
+                minHeight: minMax.minDimension,
+                maxHeight: minMax.effectiveMaxDimension,
+                alignment: alignment
+            )
+        } else {
+            self
+        }
+    }
+
+}
+
+extension MinMax {
+
+    fileprivate var hasLimit: Bool {
+        return self != .null
+    }
+
+    fileprivate var minDimension: CGFloat? {
+        return self.min.map { CGFloat($0) }
+    }
+
+    /// Aligned with CSS - minimum gets precedence when it is greater than the maximum.
+    fileprivate var effectiveMaxDimension: CGFloat? {
+        switch (self.min, self.max) {
+        case let (.some(minimum), .some(maximum)):
+            return CGFloat(Swift.max(minimum, maximum))
+        case let (_, .some(maximum)):
+            return CGFloat(maximum)
+        default:
+            return nil
+        }
+    }
+
+    func clamped(_ value: CGFloat) -> CGFloat {
+        if let minimum = self.minDimension, value < minimum {
+            return minimum
+        }
+
+        if let maximum = self.effectiveMaxDimension, value > maximum {
+            return maximum
+        }
+
+        return value
     }
 
 }

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
@@ -594,11 +594,11 @@ struct ViewModelFactory {
     ) -> FirstMediaType? {
         switch component {
         case .image(let image):
-            return image.size.width == .fill ? .image : nil
+            return image.size.width.isFill ? .image : nil
         case .video(let video):
-            return video.size.width == .fill ? .video : nil
+            return video.size.width.isFill ? .video : nil
         case .webView(let webView):
-            return webView.size.width == .fill ? .webView : nil
+            return webView.size.width.isFill ? .webView : nil
         case .stack(let stack):
             guard let first = stack.components.first(where: {
                 if case .fallbackHeader = $0 { return false }

--- a/RevenueCatUI/WebCheckout/WebCheckoutReturnURL.swift
+++ b/RevenueCatUI/WebCheckout/WebCheckoutReturnURL.swift
@@ -1,0 +1,89 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WebCheckoutReturnURL.swift
+//
+//  Created by Antonio Pallares on 4/9/26.
+//
+
+#if os(iOS) && canImport(WebKit)
+
+import Foundation
+
+/// How the checkout page says it ended.
+///
+/// Only a hint about which way the flow went: the backend stays the source of truth for whether a
+/// purchase actually happened.
+enum WebCheckoutReturnStatus: String {
+
+    case success
+    case cancel
+
+}
+
+/// Recognises the navigation that ends a checkout.
+///
+/// The checkout page belongs to a payment provider and exposes no JavaScript bridge, so the single
+/// signal it gives is a redirect to the return URL the backend handed it. The host watches for that
+/// navigation and cancels it, so the request never leaves the device.
+struct WebCheckoutReturnURL {
+
+    private static let statusQueryItemName = "status"
+
+    private let origin: WebViewOrigin
+    private let path: String
+
+    /// - Parameter url: The return URL configured on the checkout session.
+    ///
+    /// Fails when `url` has no resolvable origin, since no navigation could ever match it.
+    init?(url: URL) {
+        guard let origin = WebViewOrigin(url: url) else {
+            return nil
+        }
+
+        self.origin = origin
+        self.path = Self.normalizedPath(of: url)
+    }
+
+    /// Whether navigating to `url` means checkout has finished.
+    ///
+    /// Compared on origin and path alone. The query is deliberately excluded: it is where the outcome
+    /// is reported, and providers append parameters of their own next to it.
+    func matches(_ url: URL?) -> Bool {
+        guard let url, self.origin.matches(url: url) else {
+            return false
+        }
+
+        return Self.normalizedPath(of: url) == self.path
+    }
+
+    /// The outcome `url` reports, or `nil` if it carries none we recognise.
+    func status(of url: URL?) -> WebCheckoutReturnStatus? {
+        guard let url,
+              let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let value = components.queryItems?.first(where: { $0.name == Self.statusQueryItemName })?.value else {
+            return nil
+        }
+
+        return WebCheckoutReturnStatus(rawValue: value)
+    }
+
+    /// A trailing slash does not name a different endpoint, so `/a/` and `/a` compare equal.
+    private static func normalizedPath(of url: URL) -> String {
+        let path = url.path
+        guard path.count > 1, path.hasSuffix("/") else {
+            return path
+        }
+
+        return String(path.dropLast())
+    }
+
+}
+
+#endif

--- a/RevenueCatUI/WebCheckout/WebCheckoutView.swift
+++ b/RevenueCatUI/WebCheckout/WebCheckoutView.swift
@@ -1,0 +1,88 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WebCheckoutView.swift
+//
+//  Created by Antonio Pallares on 4/9/26.
+//
+
+#if os(iOS) && canImport(WebKit)
+
+import SwiftUI
+import WebKit
+
+/// Shows a checkout page, with a spinner until it first paints.
+///
+/// Deliberately has nothing to say about failure beyond hiding the page: the copy and the retry
+/// affordance belong to whatever presents this, which is also where the surrounding network failures
+/// surface. ``WebCheckoutViewModel/reload()`` is what such a host calls to start over.
+@available(iOS 15.0, *)
+struct WebCheckoutView: View {
+
+    @ObservedObject
+    var viewModel: WebCheckoutViewModel
+
+    @Environment(\.openURL)
+    private var openURL
+
+    var body: some View {
+        ZStack {
+            if self.viewModel.loadState != .failed {
+                WebCheckoutWebView(webView: self.viewModel.webView)
+            }
+
+            if self.viewModel.loadState == .loading {
+                ProgressView()
+            }
+        }
+        .onAppear {
+            self.viewModel.onOpenExternalURL = { self.openURL($0) }
+            self.viewModel.loadIfNeeded()
+        }
+    }
+
+}
+
+@available(iOS 15.0, *)
+private struct WebCheckoutWebView: UIViewRepresentable {
+
+    let webView: WKWebView
+
+    func makeUIView(context: Context) -> UIView {
+        let container = UIView()
+        self.attach(to: container)
+        return container
+    }
+
+    func updateUIView(_ container: UIView, context: Context) {
+        self.attach(to: container)
+    }
+
+    /// The web view outlives any one container, since it is owned by the view model so that loading can
+    /// start before presentation. Re-parenting on every update covers SwiftUI re-making the
+    /// representable, which would otherwise leave a container empty and the checkout blank.
+    private func attach(to container: UIView) {
+        guard self.webView.superview !== container else {
+            return
+        }
+
+        self.webView.removeFromSuperview()
+        self.webView.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(self.webView)
+        NSLayoutConstraint.activate([
+            self.webView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            self.webView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            self.webView.topAnchor.constraint(equalTo: container.topAnchor),
+            self.webView.bottomAnchor.constraint(equalTo: container.bottomAnchor)
+        ])
+    }
+
+}
+
+#endif

--- a/RevenueCatUI/WebCheckout/WebCheckoutViewModel.swift
+++ b/RevenueCatUI/WebCheckout/WebCheckoutViewModel.swift
@@ -1,0 +1,248 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WebCheckoutViewModel.swift
+//
+//  Created by Antonio Pallares on 4/9/26.
+//
+
+#if os(iOS) && canImport(WebKit)
+
+@_spi(Internal) import RevenueCat
+import SwiftUI
+import WebKit
+
+/// Owns the web view that presents a checkout page.
+///
+/// Kept separate from the view so a caller can build it, start loading, and only then present the
+/// result: the page is a payment provider's and takes a while to paint, and re-creating the web view
+/// when SwiftUI re-makes the view would restart that load.
+@available(iOS 15.0, *)
+@MainActor
+final class WebCheckoutViewModel: NSObject, ObservableObject {
+
+    enum LoadState {
+
+        case loading
+        case loaded
+        /// The page could not be shown. The presenting host decides what the customer sees; ``reload()``
+        /// starts over from the checkout URL.
+        case failed
+
+    }
+
+    @Published private(set) var loadState: LoadState = .loading
+
+    /// Called once, when the page navigates to the return URL.
+    var onFinished: ((WebCheckoutReturnStatus) -> Void)?
+
+    /// Called for links the page opens outside the checkout, for the host to hand to the browser.
+    var onOpenExternalURL: ((URL) -> Void)?
+
+    let webView: WKWebView
+
+    private let checkoutURL: URL
+    private let returnURL: WebCheckoutReturnURL?
+
+    private var hasStartedLoading = false
+    private var hasLoadedOnce = false
+    private var hasFinished = false
+
+    /// - Parameter checkoutURL: The provider-hosted page to present.
+    /// - Parameter returnURL: Where the provider sends the customer once checkout ends.
+    /// - Parameter dataStoreIdentifierStore: Supplies the website data store shared with RevenueCat's
+    /// other web views.
+    init(
+        checkoutURL: URL,
+        returnURL: URL,
+        dataStoreIdentifierStore: WebViewDataStoreIdentifierStore
+    ) {
+        self.checkoutURL = checkoutURL
+        self.returnURL = WebCheckoutReturnURL(url: returnURL)
+        self.webView = Self.makeWebView(dataStoreID: dataStoreIdentifierStore.identifier())
+
+        super.init()
+
+        self.webView.navigationDelegate = self
+        self.webView.uiDelegate = self
+
+        if self.returnURL == nil {
+            Logger.error(Strings.web_checkout_unusable_return_url(returnURL))
+        }
+    }
+
+    /// Begins the first load. Later calls do nothing, so a host can call it on every appearance.
+    func loadIfNeeded() {
+        guard !self.hasStartedLoading else {
+            return
+        }
+
+        self.hasStartedLoading = true
+        self.webView.load(URLRequest(url: self.checkoutURL))
+    }
+
+    /// Starts the checkout over from the beginning, after a failure.
+    func reload() {
+        self.hasLoadedOnce = false
+        self.loadState = .loading
+        self.webView.load(URLRequest(url: self.checkoutURL))
+    }
+
+    /// Installs no `WKUserScript`: on iOS 15 that disables Apple Pay for every document the web view
+    /// loads. https://webkit.org/blog/9674/new-webkit-features-in-safari-13/
+    private static func makeWebView(dataStoreID: UUID) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.setPersistentStoreIfAble(withID: dataStoreID)
+
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        // A swipe back through a payment flow lands on a stale step the provider has moved past.
+        webView.allowsBackForwardNavigationGestures = false
+
+        return webView
+    }
+
+    private func handleFailure(_ error: Error) {
+        // We cancel the return-URL navigation ourselves, and it arrives here looking like an error.
+        guard !WebViewNavigationFailure.isCancellation(error) else {
+            return
+        }
+
+        Logger.error(Strings.web_checkout_load_failed((error as NSError).localizedDescription))
+        self.loadState = .failed
+    }
+
+    private func finish(returnedFrom url: URL?) {
+        guard !self.hasFinished else {
+            return
+        }
+
+        self.hasFinished = true
+
+        guard let status = self.returnURL?.status(of: url) else {
+            Logger.warning(Strings.web_checkout_return_status_missing)
+            // Reported as a cancel rather than guessed optimistically: the caller confirms the outcome
+            // against the backend either way, and a wrong `success` would show the customer a purchase
+            // that never happened.
+            self.onFinished?(.cancel)
+            return
+        }
+
+        self.onFinished?(status)
+    }
+
+}
+
+@available(iOS 15.0, *)
+extension WebCheckoutViewModel: WKNavigationDelegate {
+
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+        let url = navigationAction.request.url
+        let isMainFrame = navigationAction.targetFrame?.isMainFrame ?? true
+
+        if isMainFrame, self.returnURL?.matches(url) == true {
+            decisionHandler(.cancel)
+            self.finish(returnedFrom: url)
+            return
+        }
+
+        // Everything else is allowed. The checkout URL comes from RevenueCat's backend, and the page it
+        // opens is free to send the customer through the payment provider's own domains and any bank's
+        // 3DS challenge, none of which we can enumerate ahead of time.
+        decisionHandler(.allow)
+    }
+
+    // WebKit reports an HTTP 4xx/5xx as a *successful* navigation, rendering the error body and never
+    // calling `didFail*`, so the status code has to be caught here instead.
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationResponse: WKNavigationResponse,
+        decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void
+    ) {
+        if let response = navigationResponse.response as? HTTPURLResponse,
+           WebViewHTTPStatus.isTerminalError(
+            statusCode: response.statusCode,
+            isMainFrame: navigationResponse.isForMainFrame
+           ) {
+            Logger.error(Strings.web_checkout_http_error(statusCode: response.statusCode))
+            self.loadState = .failed
+            decisionHandler(.cancel)
+            return
+        }
+
+        decisionHandler(.allow)
+    }
+
+    func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+        // Only the first load is worth a spinner. Once the page has painted, the provider's own steps
+        // keep their context on screen, and covering them would read as the checkout restarting.
+        guard !self.hasLoadedOnce else {
+            return
+        }
+
+        self.loadState = .loading
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        self.hasLoadedOnce = true
+        self.loadState = .loaded
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        self.handleFailure(error)
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        didFailProvisionalNavigation navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        self.handleFailure(error)
+    }
+
+    func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        Logger.error(Strings.web_checkout_content_process_terminated)
+        self.loadState = .failed
+    }
+
+}
+
+@available(iOS 15.0, *)
+extension WebCheckoutViewModel: WKUIDelegate {
+
+    /// Handles what the page opens in a new window, which WebKit routes here and never through the
+    /// navigation delegate. Without this, a `target="_blank"` link — the provider's terms and privacy
+    /// notices, typically — does nothing at all when tapped.
+    ///
+    /// These go to the browser rather than loading in place. The customer keeps a way back there, where
+    /// this sheet has no navigation of its own, and the checkout they were part-way through stays on
+    /// screen underneath.
+    func webView(
+        _ webView: WKWebView,
+        createWebViewWith configuration: WKWebViewConfiguration,
+        for navigationAction: WKNavigationAction,
+        windowFeatures: WKWindowFeatures
+    ) -> WKWebView? {
+        guard let url = navigationAction.request.url,
+              WebViewOrigin(url: url)?.isHTTPS == true else {
+            return nil
+        }
+
+        self.onOpenExternalURL?(url)
+
+        // Never a second web view: the checkout owns the one frame we control.
+        return nil
+    }
+
+}
+
+#endif

--- a/RevenueCatUI/WebView/WebViewNavigationFailure.swift
+++ b/RevenueCatUI/WebView/WebViewNavigationFailure.swift
@@ -1,0 +1,26 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  WebViewNavigationFailure.swift
+//
+
+import Foundation
+
+enum WebViewNavigationFailure {
+
+    // A navigation we cancelled on purpose comes back through the same `didFail` callbacks as a real
+    // failure, so every web view that returns `.cancel` from a navigation policy has to filter these
+    // out before treating an error as a broken page.
+    static func isCancellation(_ error: Error) -> Bool {
+        let nsError = error as NSError
+
+        if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorCancelled {
+            return true
+        }
+
+        // Cancelling from `decidePolicyFor` also surfaces as WebKitErrorDomain 102, "frame load
+        // interrupted by a policy change".
+        return nsError.domain == "WebKitErrorDomain" && nsError.code == 102
+    }
+
+}

--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -387,6 +387,12 @@ extension CustomerInfo {
         CustomerInfo.currentSchemaVersion
     ]
 
+    var allIdentitiesAreAnonymous: Bool {
+        guard let user = self.data.response.user else { return false }
+        if user.amr.isEmpty { return false }
+        // comparing the string directly allows for unknown-but-not-anonymous identity sources
+        return user.amr.allSatisfy { $0 == IdentitySource.anonymous.rawValue }
+    }
 }
 
 extension CustomerInfo {

--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -84,11 +84,24 @@ class IdentityManager: CurrentUserProvider {
     var currentUserIsAnonymous: Bool {
         let userID = self.currentAppUserID
 
-        lazy var currentAppUserIDLooksAnonymous = Self.userIsAnonymous(userID)
-        lazy var isLegacyAnonymousAppUserID = userID == self.deviceCache.cachedLegacyAppUserID
-        lazy var isAnonymousIdentity = tokenManager.isCurrentIdentityAnonymous
+        if Self.userIsAnonymous(userID) {
+            return true
+        }
 
-        return currentAppUserIDLooksAnonymous || isLegacyAnonymousAppUserID || isAnonymousIdentity
+        if self.deviceCache.cachedLegacyAppUserID == userID {
+            return true
+        }
+
+        if let info = try? self.customerInfoManager.cachedCustomerInfo(appUserID: userID),
+           info.allIdentitiesAreAnonymous {
+            return true
+        }
+
+        if tokenManager.isCurrentIdentityAnonymous {
+            return true
+        }
+
+        return false
     }
 
     var needsIAMLogin: Bool {

--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -135,19 +135,6 @@ class IdentityManager: CurrentUserProvider {
         }
     }
 
-    func revokeCurrentAccessToken(completion: @escaping (PurchasesError?) -> Void) {
-        guard self.currentAppUserID != Self.uiPreviewModeAppUserID else {
-            completion(ErrorUtils.unsupportedInUIPreviewModeError())
-            return
-        }
-
-        if self.tokenManager.enabled {
-            self.performAccessTokenRevocation(for: self.currentAppUserID, completion: completion)
-        } else {
-            completion(nil)
-        }
-    }
-
     func switchUser(to newAppUserID: String) {
         guard self.currentAppUserID != Self.uiPreviewModeAppUserID &&
               newAppUserID != Self.uiPreviewModeAppUserID else {
@@ -231,12 +218,6 @@ private extension IdentityManager {
             case .failure(let error):
                 completion(.failure(error))
             }
-        }
-    }
-
-    func performAccessTokenRevocation(for appUserID: String, completion: @escaping (PurchasesError?) -> Void) {
-        self.backend.token.revokeAccessTokens(for: appUserID) { error in
-            completion(error?.asPurchasesError)
         }
     }
 

--- a/Sources/Misc/Codable/RawDataContainer.swift
+++ b/Sources/Misc/Codable/RawDataContainer.swift
@@ -46,3 +46,16 @@ extension Decoder {
     }
 
 }
+
+extension Encoder {
+
+    func encodeRawData(_ rawData: [String: Any]) {
+        do {
+            var container = self.singleValueContainer()
+            try container.encode(AnyEncodable(rawData))
+        } catch {
+            Logger.warn(Strings.codable.encoding_error(error))
+        }
+    }
+
+}

--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -60,6 +60,7 @@ import Foundation
         let autoSyncPurchases: Bool
         let uiPreviewMode: Bool
         let customEntitlementComputation: Bool
+        let forceAllowTestStoreInReleaseBuilds: Bool
     }
 
     internal let storage: Storage
@@ -95,6 +96,16 @@ import Foundation
      */
     @objc public var customEntitlementComputation: Bool { self.storage.customEntitlementComputation }
 
+    /**
+     * Forces the SDK to allow using a Test Store API key in Release builds.
+     * By default, configuring the SDK with a Test Store API key in a Release build crashes the app to prevent
+     * uploading it to the App Store.
+     *
+     * - Important: Avoid enabling this except when necessary (e.g. internal builds compiled in Release that are
+     * never uploaded to the App Store), to make sure no builds using the Test Store reach the stores.
+     */
+    @objc public var forceAllowTestStoreInReleaseBuilds: Bool { self.storage.forceAllowTestStoreInReleaseBuilds }
+
     @objc public override convenience init() {
         self.init(autoSyncPurchases: true)
     }
@@ -110,6 +121,24 @@ import Foundation
         self.init(autoSyncPurchases: autoSyncPurchases,
                   customEntitlementComputation: false)
 
+    }
+
+    /**
+     * Only use a Dangerous Setting if suggested by RevenueCat support team.
+     *
+     * - Parameter autoSyncPurchases: Disable or enable subscribing to the StoreKit queue.
+     * If this is disabled, RevenueCat won't observe the StoreKit queue, and it will not sync any purchase
+     * automatically.
+     * - Parameter forceAllowTestStoreInReleaseBuilds: Forces the SDK to allow using a Test Store API key in
+     * Release builds. Avoid enabling this except when necessary, to make sure no builds using the Test Store
+     * reach the stores.
+     */
+    @objc public convenience init(autoSyncPurchases: Bool,
+                                  forceAllowTestStoreInReleaseBuilds: Bool) {
+        self.init(autoSyncPurchases: autoSyncPurchases,
+                  customEntitlementComputation: false,
+                  internalSettings: Internal.default,
+                  forceAllowTestStoreInReleaseBuilds: forceAllowTestStoreInReleaseBuilds)
     }
 
     /// - Note: this is `internal` only so the only `public` way to enable `customEntitlementComputation`
@@ -136,11 +165,13 @@ import Foundation
     internal init(autoSyncPurchases: Bool,
                   customEntitlementComputation: Bool = false,
                   internalSettings: InternalDangerousSettingsType,
-                  uiPreviewMode: Bool = false) {
+                  uiPreviewMode: Bool = false,
+                  forceAllowTestStoreInReleaseBuilds: Bool = false) {
         self.storage = Storage(
             autoSyncPurchases: autoSyncPurchases,
             uiPreviewMode: uiPreviewMode,
-            customEntitlementComputation: customEntitlementComputation
+            customEntitlementComputation: customEntitlementComputation,
+            forceAllowTestStoreInReleaseBuilds: forceAllowTestStoreInReleaseBuilds
         )
         self.internalSettings = internalSettings
     }

--- a/Sources/Networking/Operations/TokenOperations.swift
+++ b/Sources/Networking/Operations/TokenOperations.swift
@@ -170,24 +170,6 @@ final class TokenRevocationOperation: CacheableNetworkOperation, @unchecked Send
                      individualizedCacheKeyPart: appUserID)
     }
 
-    static func createFactory(
-        configuration: UserSpecificConfiguration,
-        accessToken: String,
-        appUserID: String,
-        callbackCache: CallbackCache<TokenRevokeCallback>
-    ) -> CacheableNetworkOperationFactory<TokenRevocationOperation> {
-        return .init({
-            .init(
-                configuration: configuration,
-                token: accessToken,
-                tokenTypeHint: "access_token",
-                appUserID: appUserID,
-                callbackCache: callbackCache,
-                cacheKey: $0
-            ) },
-                     individualizedCacheKeyPart: appUserID)
-    }
-
     private init(
         configuration: UserSpecificConfiguration,
         token: String,

--- a/Sources/Networking/Responses/CustomerInfoResponse.swift
+++ b/Sources/Networking/Responses/CustomerInfoResponse.swift
@@ -18,6 +18,7 @@ import Foundation
 struct CustomerInfoResponse {
 
     var subscriber: Subscriber
+    var user: User?
 
     @IgnoreHashable
     var requestDate: Date
@@ -111,6 +112,21 @@ extension CustomerInfoResponse {
         var attributes: [SubscriberAttribute]
     }
 
+    struct User {
+
+        // swiftlint:disable:next nesting
+        struct Identity {
+            var id: String?
+            var method: String
+            @IgnoreEncodable @IgnoreHashable
+            var rawData: [String: Any]
+        }
+
+        var amr: [String]
+        var id: String
+        var identities: [Identity]
+    }
+
 }
 
 // MARK: - Codable
@@ -197,6 +213,33 @@ extension CustomerInfoResponse.Transaction: Codable, Hashable {
 
 }
 
+extension CustomerInfoResponse.User: Codable, Hashable { }
+
+extension CustomerInfoResponse.User.Identity: Codable, Hashable {
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case method
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        // the "?? .none" is needed because using "decodeIfPresent" with String? type
+        // means you get back a "String??". These combined mean we support:
+        // - having a "nil" id if the field is entirely missing
+        // - having a "nil" id if the field is present with with a null value
+        // - having a non-nil id if the field is present with a string value
+        self.id = try container.decodeIfPresent(String?.self, forKey: .id) ?? .none
+        self.method = try container.decode(String.self, forKey: .method)
+        self.rawData = decoder.decodeRawData()
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        encoder.encodeRawData(rawData)
+    }
+
+}
+
 extension CustomerInfoResponse: Codable {
 
     // Note: this must be manually implemented because of the custom call to `decodeRawData`
@@ -206,6 +249,7 @@ extension CustomerInfoResponse: Codable {
 
         self.requestDate = try container.decode(Date.self, forKey: .requestDate)
         self.subscriber = try container.decode(Subscriber.self, forKey: .subscriber)
+        self.user = try container.decodeIfPresent(User.self, forKey: .user)
 
         self.rawData = decoder.decodeRawData()
     }

--- a/Sources/Networking/TokenAPI.swift
+++ b/Sources/Networking/TokenAPI.swift
@@ -76,30 +76,6 @@ class TokenAPI {
         }
     }
 
-    func revokeAccessTokens(for appUserID: String, completion: @escaping (BackendError?) -> Void) {
-        if let accessToken = tokenManager.currentAccessToken {
-            let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
-                                                                    appUserID: appUserID)
-
-            let factory = TokenRevocationOperation.createFactory(configuration: config,
-                                                                 accessToken: accessToken,
-                                                                 appUserID: appUserID,
-                                                                 callbackCache: self.revokeCallbacksCache)
-
-            let revokeCallback = TokenRevokeCallback(cacheKey: factory.cacheKey) { error in
-                if error == nil {
-                    self.tokenManager.deleteAccessToken(for: appUserID)
-                }
-                completion(error)
-            }
-            let cacheStatus = self.revokeCallbacksCache.add(revokeCallback)
-
-            self.backendConfig.operationQueue.addCacheableOperation(with: factory, cacheStatus: cacheStatus)
-        } else {
-            completion(nil)
-        }
-    }
-
 }
 
 // @unchecked because:

--- a/Sources/Networking/WebBillingHTTPRequestPath.swift
+++ b/Sources/Networking/WebBillingHTTPRequestPath.swift
@@ -67,6 +67,18 @@ extension HTTPRequest.WebBillingPath: HTTPRequestPath {
         }
     }
 
+    var relativeIAMPath: String {
+        switch self {
+        case .getWebOfferingProducts:
+            return "/rcbilling/v1/customer/offering_products"
+        case let .getWebBillingProducts(userId: _, productIds: productIds):
+            let encodedProductIds = productIds.map { productId in
+                "id=\(productId.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? productId)"
+            }.joined(separator: "&")
+            return "/rcbilling/v1/customer/products?\(encodedProductIds)"
+        }
+    }
+
     var name: String {
         switch self {
         case .getWebOfferingProducts:

--- a/Sources/Paywalls/Components/Common/PaywallComponentPropertyTypes.swift
+++ b/Sources/Paywalls/Components/Common/PaywallComponentPropertyTypes.swift
@@ -411,28 +411,46 @@ import Foundation
 
     enum SizeConstraint: Codable, Sendable, Hashable {
 
-        case fit(UInt?) // optional default size to show during loading and initial content size calculations
-        case fill
+        // optional default size to show during loading and initial content size calculations
+        case fit(UInt?, MinMax = .null)
+        case fill(MinMax)
         case fixed(UInt)
 
         // Only used for button sheet for now
-        case relative(Double)
+        case relative(Double, MinMax = .null)
+
+        /// Preserves the existing `.fill` syntax while allowing constrained fill values.
+        public static var fill: Self { .fill(.null) }
+
+        public var isFill: Bool {
+            if case .fill = self {
+                return true
+            }
+
+            return false
+        }
 
         public func encode(to encoder: any Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
 
             switch self {
-            case .fit(let value):
+            case let .fit(value, minMax):
                 try container.encode(SizeConstraintType.fit.rawValue, forKey: .type)
                 if let value {
                     try container.encode(value, forKey: .default)
                 }
-            case .fill:
+                try container.encodeIfPresent(minMax.min, forKey: .min)
+                try container.encodeIfPresent(minMax.max, forKey: .max)
+            case let .fill(minMax):
                 try container.encode(SizeConstraintType.fill.rawValue, forKey: .type)
-            case .fixed(let value):
+                try container.encodeIfPresent(minMax.min, forKey: .min)
+                try container.encodeIfPresent(minMax.max, forKey: .max)
+            case let .fixed(value):
                 try container.encode(SizeConstraintType.fixed.rawValue, forKey: .type)
                 try container.encode(value, forKey: .value)
-            case .relative(let value):
+            case let .relative(value, minMax):
+                try container.encodeIfPresent(minMax.min, forKey: .min)
+                try container.encodeIfPresent(minMax.max, forKey: .max)
                 try container.encode(SizeConstraintType.relative.rawValue, forKey: .type)
                 try container.encode(value, forKey: .value)
             }
@@ -441,23 +459,24 @@ import Foundation
         public init(from decoder: Decoder) throws {
             do {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
+                let minMax = (try? MinMax(from: decoder)) ?? .null
                 let type = try container.decode(SizeConstraintType.self, forKey: .type)
 
                 switch type {
                 case .fit:
                     let value = try container.decodeIfPresent(UInt.self, forKey: .default)
-                    self = .fit(value)
+                    self = .fit(value, minMax)
                 case .fill:
-                    self = .fill
+                    self = .fill(minMax)
                 case .fixed:
                     let value = try container.decode(UInt.self, forKey: .value)
                     self = .fixed(value)
                 case .relative:
                     let value = try container.decode(Double.self, forKey: .value)
-                    self = .relative(value)
+                    self = .relative(value, minMax)
                 }
             } catch {
-                self = .fit(nil)
+                self = .fit(nil, .null)
             }
         }
 
@@ -467,7 +486,8 @@ import Foundation
             case type
             case value
             case `default`
-
+            case min
+            case max
         }
 
         // swiftlint:disable:next nesting
@@ -482,14 +502,14 @@ import Foundation
 
         public static func == (lhs: SizeConstraint, rhs: SizeConstraint) -> Bool {
             switch (lhs, rhs) {
-            case let (.fit(left), .fit(right)):
+            case let (.fit(leftDefault, leftMinMax), .fit(rightDefault, rightMinMax)):
+                return leftDefault == rightDefault && leftMinMax == rightMinMax
+            case let (.fill(left), .fill(right)):
                 return left == right
-            case (.fill, .fill):
-                return true
             case let (.fixed(left), .fixed(right)):
                 return left == right
-            case let (.relative(left), .relative(right)):
-                return left == right
+            case let (.relative(leftValue, leftMinMax), .relative(rightValue, rightMinMax)):
+                return leftValue == rightValue && leftMinMax == rightMinMax
             default:
                 return false
             }
@@ -675,4 +695,16 @@ import Foundation
 
     }
 
+}
+
+@_spi(Internal) public struct MinMax: Codable, Hashable, Sendable {
+    public let min: UInt?
+    public let max: UInt?
+
+    public init(min: UInt?, max: UInt?) {
+        self.min = min
+        self.max = max
+    }
+
+    public static let null = MinMax(min: nil, max: nil)
 }

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -535,6 +535,15 @@ extension Configuration {
 
 extension Configuration.APIKeyValidationResult {
 
+    /// Whether configuring the SDK with this API key must be blocked in Release builds.
+    /// `uiPreviewMode` and `forceAllowTestStoreInReleaseBuilds` are opt-ins that intentionally bypass the guard.
+    // Visible for testing
+    func shouldBlockSimulatedStoreAPIKeyInRelease(dangerousSettings: DangerousSettings) -> Bool {
+        return self == .simulatedStore
+            && !dangerousSettings.uiPreviewMode
+            && !dangerousSettings.forceAllowTestStoreInReleaseBuilds
+    }
+
     func checkForSimulatedStoreAPIKeyInRelease(systemInfo: SystemInfo, apiKey: String) {
         // The `BYPASS_SIMULATED_STORE_RELEASE_CHECK` compilation flag opts out of the Release-build
         // safeguard. It exists for SDK consumers (e.g. purchases-kmp) that ship the SDK as a
@@ -542,7 +551,7 @@ extension Configuration.APIKeyValidationResult {
         // otherwise crash apps that use a Test Store API key during development. Setting this flag
         // means apps shipped to production with a Test Store API key won't be caught at runtime.
         #if !DEBUG && !BYPASS_SIMULATED_STORE_RELEASE_CHECK
-        guard self == .simulatedStore, !systemInfo.dangerousSettings.uiPreviewMode else {
+        guard self.shouldBlockSimulatedStoreAPIKeyInRelease(dangerousSettings: systemInfo.dangerousSettings) else {
             return
         }
 

--- a/Sources/RulesEngine/Evaluator.swift
+++ b/Sources/RulesEngine/Evaluator.swift
@@ -24,11 +24,12 @@ extension RulesEngine {
         ///   - variables: The resolved variable map — typically a nested object
         ///     mirroring the namespace hierarchy (`subscriber.*`, `session.*`,
         ///     etc.).
-        /// - Returns: The value the predicate evaluates to. Callers that need a
-        ///   boolean apply JSON Logic truthiness via `Value.isTruthy`.
-        static func evaluate(predicate: Value, variables: [String: Value]) throws -> Value {
+        /// - Returns: `true` when the predicate evaluates to a truthy value per
+        ///   JSON Logic rules.
+        static func evaluate(predicate: Value, variables: [String: Value]) throws -> Bool {
             let scope = Scope(root: .object(variables))
-            return try evaluateValue(predicate, vars: scope)
+            let result = try evaluateValue(predicate, vars: scope)
+            return result.isTruthy
         }
 
         /// Recursive evaluator. Module-internal so operator implementations can

--- a/Sources/RulesEngine/RulesEngineEvaluate.swift
+++ b/Sources/RulesEngine/RulesEngineEvaluate.swift
@@ -8,36 +8,11 @@ import Foundation
 
 extension RulesEngine {
 
-    /// Applies a JSON Logic transformation predicate to a variable scope.
-    ///
-    /// The predicate is evaluated against `variables` and must produce an
-    /// object, which becomes the new scope.
-    ///
-    /// - Parameters:
-    ///   - predicate: The transformation predicate as a JSON string.
-    ///   - variables: The raw variable scope.
-    /// - Returns: `.success` with the transformed scope, or `.failure` carrying
-    ///   an `EvaluationError` when parsing or evaluation fails, or when the
-    ///   predicate evaluates to anything other than an object.
-    static func transform(
-        predicate: String,
-        variables: [String: Value]
-    ) -> Result<[String: Value], EvaluationError> {
-        evaluated(predicate: predicate, variables: variables).flatMap { result in
-            guard case .object(let transformed) = result else {
-                return .failure(.typeMismatch(
-                    message: "transformation predicate expected to produce an object, got \(result)"
-                ))
-            }
-            return .success(transformed)
-        }
-    }
-
     /// Evaluates a JSON Logic predicate against a native variable scope.
     ///
     /// - Parameters:
-    ///   - predicate: The evaluation predicate as a JSON string.
-    ///   - variables: The variable scope.
+    ///   - predicate: The rule predicate as a JSON string.
+    ///   - variables: The resolved variable scope.
     /// - Returns: `.success(true)` when the predicate evaluates to a truthy
     ///   value, `.success(false)` otherwise, or `.failure` carrying
     ///   an `EvaluationError` when parsing or evaluation fails.
@@ -45,18 +20,10 @@ extension RulesEngine {
         predicate: String,
         variables: [String: Value]
     ) -> Result<Bool, EvaluationError> {
-        evaluated(predicate: predicate, variables: variables).map(\.isTruthy)
-    }
-
-    /// Parses `predicate` and evaluates it against `variables`, mapping any
-    /// thrown error into a `.failure`.
-    private static func evaluated(
-        predicate: String,
-        variables: [String: Value]
-    ) -> Result<Value, EvaluationError> {
         do {
             let predicateValue = try Value.fromJSONString(predicate)
-            return .success(try Evaluator.evaluate(predicate: predicateValue, variables: variables))
+            let result = try Evaluator.evaluate(predicate: predicateValue, variables: variables)
+            return .success(result)
         } catch let error as EvaluationError {
             return .failure(error)
         } catch {

--- a/Tests/APITesters/AllAPITests/ObjcAPITester/RCDangerousSettingsAPI.m
+++ b/Tests/APITesters/AllAPITests/ObjcAPITester/RCDangerousSettingsAPI.m
@@ -22,9 +22,12 @@
 + (void)checkAPI {
     RCDangerousSettings *defaultSettings __unused = [[RCDangerousSettings alloc] init];
     RCDangerousSettings *settings = [[RCDangerousSettings alloc] initWithAutoSyncPurchases:true];
+    RCDangerousSettings *forceAllowSettings __unused = [[RCDangerousSettings alloc] initWithAutoSyncPurchases:true
+                                                                        forceAllowTestStoreInReleaseBuilds:true];
 
     BOOL autoSyncPurchases __unused = settings.autoSyncPurchases;
     BOOL customEntitlementComputation __unused = settings.customEntitlementComputation;
+    BOOL forceAllowTestStoreInReleaseBuilds __unused = settings.forceAllowTestStoreInReleaseBuilds;
 }
 
 @end

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/DangerousSettingsAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/DangerousSettingsAPI.swift
@@ -16,9 +16,11 @@
 func checkDangerousSettingsAPI() {
     let _: DangerousSettings = DangerousSettings()
     let _: DangerousSettings = DangerousSettings(autoSyncPurchases: true)
+    let _: DangerousSettings = DangerousSettings(autoSyncPurchases: true, forceAllowTestStoreInReleaseBuilds: true)
     let settings: DangerousSettings = DangerousSettings(uiPreviewMode: true)
 
     let _: Bool = settings.autoSyncPurchases
     let _: Bool = settings.customEntitlementComputation
     let _: Bool = settings.uiPreviewMode
+    let _: Bool = settings.forceAllowTestStoreInReleaseBuilds
 }

--- a/Tests/RevenueCatUITests/PaywallsV2/SizeModifierTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/SizeModifierTests.swift
@@ -1,0 +1,86 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SizeModifierTests.swift
+
+@_spi(Internal) import RevenueCat
+@testable import RevenueCatUI
+import SwiftUI
+import XCTest
+
+#if os(iOS)
+
+@available(iOS 15.0, *)
+@MainActor
+final class SizeModifierTests: TestCase {
+
+    func testConstrainedFillIsStillClassifiedAsFill() {
+        XCTAssertTrue(PaywallComponent.SizeConstraint.fill(.init(min: 20, max: 30)).isFill)
+        XCTAssertFalse(PaywallComponent.SizeConstraint.fit(nil, .init(min: 20, max: 30)).isFill)
+    }
+
+    func testFitContentRespectsMinimumWidthAndHeight() {
+        let view = Color.clear
+            .frame(width: 10, height: 10)
+            .size(
+                .init(
+                    width: .fit(nil, .init(min: 20, max: nil)),
+                    height: .fit(nil, .init(min: 30, max: nil))
+                )
+            )
+
+        XCTAssertEqual(
+            Self.fittingSize(of: view, in: .init(width: 100, height: 100)),
+            .init(width: 20, height: 30)
+        )
+    }
+
+    func testFillRespectsMaximumWidth() {
+        let view = Color.clear
+            .size(
+                .init(
+                    width: .fill(.init(min: nil, max: 20)),
+                    height: .fixed(10)
+                )
+            )
+
+        XCTAssertEqual(Self.fittingSize(of: view, in: .init(width: 100, height: 100)).width, 20)
+    }
+
+    func testFillMinimumCanExceedParentWidth() {
+        let view = Color.clear
+            .size(
+                .init(
+                    width: .fill(.init(min: 120, max: nil)),
+                    height: .fixed(10)
+                )
+            )
+
+        XCTAssertEqual(Self.fittingSize(of: view, in: .init(width: 100, height: 100)).width, 120)
+    }
+
+    func testMinimumTakesPrecedenceOverMaximum() {
+        let view = Color.clear
+            .size(
+                .init(
+                    width: .fill(.init(min: 40, max: 20)),
+                    height: .fixed(10)
+                )
+            )
+
+        XCTAssertEqual(Self.fittingSize(of: view, in: .init(width: 100, height: 100)).width, 40)
+    }
+
+    private static func fittingSize<Content: View>(of view: Content, in proposal: CGSize) -> CGSize {
+        UIHostingController(rootView: view).sizeThatFits(in: proposal)
+    }
+
+}
+
+#endif

--- a/Tests/RevenueCatUITests/WebCheckout/WebCheckoutReturnURLTests.swift
+++ b/Tests/RevenueCatUITests/WebCheckout/WebCheckoutReturnURLTests.swift
@@ -1,0 +1,154 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WebCheckoutReturnURLTests.swift
+//
+//  Created by Antonio Pallares on 4/9/26.
+//
+
+@testable import RevenueCatUI
+import XCTest
+
+#if os(iOS) && canImport(WebKit)
+
+final class WebCheckoutReturnURLTests: TestCase {
+
+    private let returnURL = WebCheckoutReturnURL(
+        url: URL(string: "https://api.example.com/rcbilling/v1/hosted-checkout-return")!
+    )!
+
+    // MARK: - Construction
+
+    func testCannotBeBuiltFromAURLWithoutAnOrigin() {
+        XCTAssertNil(WebCheckoutReturnURL(url: URL(string: "/hosted-checkout-return")!))
+    }
+
+    // MARK: - Matching
+
+    func testMatchesTheExactURL() {
+        XCTAssertTrue(
+            self.returnURL.matches(URL(string: "https://api.example.com/rcbilling/v1/hosted-checkout-return")!)
+        )
+    }
+
+    /// The outcome arrives in the query, and providers append parameters of their own beside it.
+    func testMatchesRegardlessOfTheQuery() {
+        XCTAssertTrue(
+            self.returnURL.matches(
+                URL(string: "https://api.example.com/rcbilling/v1/hosted-checkout-return?status=success&x=1")!
+            )
+        )
+    }
+
+    func testMatchesRegardlessOfAFragment() {
+        XCTAssertTrue(
+            self.returnURL.matches(URL(string: "https://api.example.com/rcbilling/v1/hosted-checkout-return#done")!)
+        )
+    }
+
+    func testMatchesRegardlessOfATrailingSlash() {
+        XCTAssertTrue(
+            self.returnURL.matches(URL(string: "https://api.example.com/rcbilling/v1/hosted-checkout-return/")!)
+        )
+    }
+
+    func testATrailingSlashInTheConfiguredURLStillMatchesOneWithout() {
+        let withSlash = WebCheckoutReturnURL(
+            url: URL(string: "https://api.example.com/rcbilling/v1/hosted-checkout-return/")!
+        )!
+
+        XCTAssertTrue(
+            withSlash.matches(URL(string: "https://api.example.com/rcbilling/v1/hosted-checkout-return")!)
+        )
+    }
+
+    func testDoesNotMatchADifferentPath() {
+        XCTAssertFalse(
+            self.returnURL.matches(URL(string: "https://api.example.com/rcbilling/v1/hosted-checkout")!)
+        )
+    }
+
+    func testDoesNotMatchAPathThatMerelyContainsIt() {
+        XCTAssertFalse(
+            self.returnURL.matches(
+                URL(string: "https://api.example.com/rcbilling/v1/hosted-checkout-return/extra")!
+            )
+        )
+    }
+
+    func testDoesNotMatchADifferentHost() {
+        XCTAssertFalse(
+            self.returnURL.matches(URL(string: "https://evil.example/rcbilling/v1/hosted-checkout-return")!)
+        )
+    }
+
+    func testDoesNotMatchTheSameHostOverPlainHTTP() {
+        XCTAssertFalse(
+            self.returnURL.matches(URL(string: "http://api.example.com/rcbilling/v1/hosted-checkout-return")!)
+        )
+    }
+
+    func testDoesNotMatchADifferentPort() {
+        XCTAssertFalse(
+            self.returnURL.matches(URL(string: "https://api.example.com:8443/rcbilling/v1/hosted-checkout-return")!)
+        )
+    }
+
+    func testDoesNotMatchNil() {
+        XCTAssertFalse(self.returnURL.matches(nil))
+    }
+
+    // MARK: - Status
+
+    func testReadsASuccessStatus() {
+        XCTAssertEqual(
+            self.returnURL.status(
+                of: URL(string: "https://api.example.com/rcbilling/v1/hosted-checkout-return?status=success")!
+            ),
+            .success
+        )
+    }
+
+    func testReadsACancelStatus() {
+        XCTAssertEqual(
+            self.returnURL.status(
+                of: URL(string: "https://api.example.com/rcbilling/v1/hosted-checkout-return?status=cancel")!
+            ),
+            .cancel
+        )
+    }
+
+    func testReadsTheStatusAlongsideOtherParameters() {
+        XCTAssertEqual(
+            self.returnURL.status(
+                of: URL(string: "https://api.example.com/x?session=abc&status=success&locale=en")!
+            ),
+            .success
+        )
+    }
+
+    func testHasNoStatusWhenTheParameterIsAbsent() {
+        XCTAssertNil(self.returnURL.status(of: URL(string: "https://api.example.com/x?session=abc")!))
+    }
+
+    func testHasNoStatusWhenTheValueIsNotRecognized() {
+        XCTAssertNil(self.returnURL.status(of: URL(string: "https://api.example.com/x?status=maybe")!))
+    }
+
+    func testHasNoStatusWhenTheValueIsEmpty() {
+        XCTAssertNil(self.returnURL.status(of: URL(string: "https://api.example.com/x?status=")!))
+    }
+
+    func testHasNoStatusForNil() {
+        XCTAssertNil(self.returnURL.status(of: nil))
+    }
+
+}
+
+#endif

--- a/Tests/RevenueCatUITests/WebView/WebViewNavigationFailureTests.swift
+++ b/Tests/RevenueCatUITests/WebView/WebViewNavigationFailureTests.swift
@@ -1,0 +1,55 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  WebViewNavigationFailureTests.swift
+//
+//  Created by Antonio Pallares on 4/9/26.
+//
+
+@testable import RevenueCatUI
+import XCTest
+
+final class WebViewNavigationFailureTests: TestCase {
+
+    func testURLCancellationIsACancellation() {
+        XCTAssertTrue(
+            WebViewNavigationFailure.isCancellation(
+                NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled)
+            )
+        )
+    }
+
+    func testPolicyChangeIsACancellation() {
+        XCTAssertTrue(
+            WebViewNavigationFailure.isCancellation(NSError(domain: "WebKitErrorDomain", code: 102))
+        )
+    }
+
+    func testARealNetworkFailureIsNotACancellation() {
+        XCTAssertFalse(
+            WebViewNavigationFailure.isCancellation(
+                NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut)
+            )
+        )
+    }
+
+    func testAnotherWebKitErrorIsNotACancellation() {
+        XCTAssertFalse(
+            WebViewNavigationFailure.isCancellation(NSError(domain: "WebKitErrorDomain", code: 101))
+        )
+    }
+
+    /// The codes only mean cancellation within their own domain.
+    func testTheSameCodeInAnotherDomainIsNotACancellation() {
+        XCTAssertFalse(
+            WebViewNavigationFailure.isCancellation(NSError(domain: "com.example.other", code: 102))
+        )
+    }
+
+}

--- a/Tests/UnitTests/Identity/IdentityManagerTests.swift
+++ b/Tests/UnitTests/Identity/IdentityManagerTests.swift
@@ -527,64 +527,6 @@ class IdentityManagerTests: TestCase {
         expect(self.mockDeviceCache.invokedCopySubscriberAttributesParameters?.newAppUserID) == "new_user_id"
     }
 
-    // MARK: - RevokeCurrentAccessToken
-
-    func testRevokeCurrentAccessTokenFailsInUIPreviewMode() {
-        let dangerousSettings = DangerousSettings(uiPreviewMode: true)
-        self.mockSystemInfo = MockSystemInfo(
-            platformInfo: nil,
-            finishTransactions: false,
-            dangerousSettings: dangerousSettings
-        )
-        let manager = create(appUserID: "my_user_id")
-
-        let receivedError = waitUntilValue { completed in
-            manager.revokeCurrentAccessToken { error in completed(error as NSError?) }
-        }
-
-        expect(receivedError?.code) == ErrorCode.unsupportedError.rawValue
-        expect(self.mockTokenAPI.invokedRevokeAccessTokens) == false
-    }
-
-    func testRevokeCurrentAccessTokenDoesNothingWhenTokenManagerIsDisabled() {
-        let manager = self.create(appUserID: nil)
-        self.mockDeviceCache.stubbedAppUserID = "myUser"
-
-        let receivedError = waitUntilValue { completed in
-            manager.revokeCurrentAccessToken(completion: completed)
-        }
-
-        expect(receivedError).to(beNil())
-        expect(self.mockTokenAPI.invokedRevokeAccessTokens) == false
-    }
-
-    func testRevokeCurrentAccessTokenCallsTokenAPIWhenTokenManagerIsEnabled() {
-        self.mockTokenManager = MockTokenManager(enabled: true)
-        let manager = self.create(appUserID: nil)
-        self.mockDeviceCache.stubbedAppUserID = "myUser"
-
-        let receivedError = waitUntilValue { completed in
-            manager.revokeCurrentAccessToken(completion: completed)
-        }
-
-        expect(receivedError).to(beNil())
-        expect(self.mockTokenAPI.invokedRevokeAccessTokensCount) == 1
-        expect(self.mockTokenAPI.invokedRevokeAccessTokensParametersList) == ["myUser"]
-    }
-
-    func testRevokeCurrentAccessTokenPassesThroughTokenAPIErrors() {
-        self.mockTokenManager = MockTokenManager(enabled: true)
-        let manager = self.create(appUserID: nil)
-        self.mockDeviceCache.stubbedAppUserID = "myUser"
-        self.mockTokenAPI.stubbedRevokeAccessTokensResult = .missingAppUserID()
-
-        let receivedError = waitUntilValue { completed in
-            manager.revokeCurrentAccessToken { error in completed(error as NSError?) }
-        }
-
-        expect(receivedError?.code) == ErrorCode.invalidAppUserIdError.rawValue
-    }
-
     // MARK: - LogOut with IAM enabled
 
     func testLogOutDoesNotRevokeTokensWhenTokenManagerIsDisabled() {

--- a/Tests/UnitTests/Misc/DangerousSettingsTests.swift
+++ b/Tests/UnitTests/Misc/DangerousSettingsTests.swift
@@ -50,6 +50,11 @@ final class DangerousSettingsTests: TestCase {
             != DangerousSettings(uiPreviewMode: false)
     }
 
+    func testDifferentForceAllowTestStoreInReleaseBuildsIsNotEqual() {
+        expect(DangerousSettings(autoSyncPurchases: true, forceAllowTestStoreInReleaseBuilds: true))
+            != DangerousSettings(autoSyncPurchases: true, forceAllowTestStoreInReleaseBuilds: false)
+    }
+
     func testInternalSettingsAreExcludedFromEquality() {
         let defaultInternal: InternalDangerousSettingsType = DangerousSettings.Internal.default
         let customInternal: InternalDangerousSettingsType = DangerousSettings.Internal(enableReceiptFetchRetry: true)
@@ -59,6 +64,23 @@ final class DangerousSettingsTests: TestCase {
 
         expect(lhs) == rhs
         expect(lhs.hashValue) == rhs.hashValue
+    }
+
+    // MARK: - forceAllowTestStoreInReleaseBuilds
+
+    func testForceAllowTestStoreInReleaseBuildsIsDisabledByDefault() {
+        expect(DangerousSettings().forceAllowTestStoreInReleaseBuilds) == false
+        expect(DangerousSettings(autoSyncPurchases: false).forceAllowTestStoreInReleaseBuilds) == false
+        expect(DangerousSettings(uiPreviewMode: true).forceAllowTestStoreInReleaseBuilds) == false
+    }
+
+    func testForceAllowTestStoreInReleaseBuildsCanBeEnabled() {
+        let settings = DangerousSettings(autoSyncPurchases: false, forceAllowTestStoreInReleaseBuilds: true)
+
+        expect(settings.forceAllowTestStoreInReleaseBuilds) == true
+        expect(settings.autoSyncPurchases) == false
+        expect(settings.uiPreviewMode) == false
+        expect(settings.customEntitlementComputation) == false
     }
 
     // MARK: - Internal settings

--- a/Tests/UnitTests/Mocks/MockTokenAPI.swift
+++ b/Tests/UnitTests/Mocks/MockTokenAPI.swift
@@ -52,20 +52,6 @@ class MockTokenAPI: TokenAPI {
         completion(stubbedRevokeTokensResult)
     }
 
-    // MARK: - revokeAccessTokens(for:completion:)
-
-    var invokedRevokeAccessTokens = false
-    var invokedRevokeAccessTokensCount = 0
-    var invokedRevokeAccessTokensParametersList: [String] = []
-    var stubbedRevokeAccessTokensResult: BackendError?
-
-    override func revokeAccessTokens(for appUserID: String, completion: @escaping (BackendError?) -> Void) {
-        invokedRevokeAccessTokens = true
-        invokedRevokeAccessTokensCount += 1
-        invokedRevokeAccessTokensParametersList.append(appUserID)
-        completion(stubbedRevokeAccessTokensResult)
-    }
-
 }
 
 extension MockTokenAPI: @unchecked Sendable {}

--- a/Tests/UnitTests/Networking/Backend/BackendTokenRevocationTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendTokenRevocationTests.swift
@@ -84,47 +84,4 @@ class BackendTokenRevocationTests: BaseBackendTokenRevocationTests {
         expect(self.tokenManager.invokedDeleteTokens) == false
     }
 
-    // MARK: - revokeAccessTokens(for:completion:)
-
-    func testRevokeAccessTokensDoesNothingWithoutANetworkCallWhenThereIsNoAccessToken() {
-        self.tokenManager.stubbedCurrentAccessToken = nil
-
-        let receivedError = waitUntilValue { completed in
-            self.token.revokeAccessTokens(for: "user-id", completion: completed)
-        }
-
-        expect(receivedError).to(beNil())
-        expect(self.httpClient.calls).to(beEmpty())
-        expect(self.tokenManager.invokedDeleteAccessToken) == false
-    }
-
-    func testRevokeAccessTokensSendsTheAccessTokenAndDeletesItLocallyOnSuccess() throws {
-        self.tokenManager.stubbedCurrentAccessToken = "access-token-value"
-        self.httpClient.mock(requestPath: .tokenLogOut, response: .init(statusCode: .success))
-
-        let receivedError = waitUntilValue { completed in
-            self.token.revokeAccessTokens(for: "user-id", completion: completed)
-        }
-
-        expect(receivedError).to(beNil())
-        expect(self.tokenManager.invokedDeleteAccessTokenParametersList) == ["user-id"]
-
-        let body = try XCTUnwrap(self.httpClient.calls.first?.request.requestBody as? TokenRevocationOperation.Body)
-        expect(body.token) == "access-token-value"
-        expect(body.tokenTypeHint) == "access_token"
-    }
-
-    func testRevokeAccessTokensPassesNetworkErrorsAndDoesNotDeleteItLocally() {
-        self.tokenManager.stubbedCurrentAccessToken = "access-token-value"
-        let stubbedError: NetworkError = .unexpectedResponse(nil)
-        self.httpClient.mock(requestPath: .tokenLogOut, response: .init(error: stubbedError))
-
-        let receivedError = waitUntilValue { completed in
-            self.token.revokeAccessTokens(for: "user-id", completion: completed)
-        }
-
-        expect(receivedError) == .networkError(stubbedError)
-        expect(self.tokenManager.invokedDeleteAccessToken) == false
-    }
-
 }

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -300,6 +300,87 @@ class HTTPRequestTests: TestCase {
         }
     }
 
+    func testWebBillingOfferingProductsRelativePathIncludesAppUserID() {
+        let path = HTTPRequest.WebBillingPath.getWebOfferingProducts(appUserID: Self.userID)
+
+        expect(path.relativePath) == "/rcbilling/v1/subscribers/\(Self.userID)/offering_products"
+    }
+
+    func testWebBillingOfferingProductsRelativeIAMPathOmitsAppUserID() {
+        let path = HTTPRequest.WebBillingPath.getWebOfferingProducts(appUserID: Self.userID)
+
+        expect(path.relativeIAMPath) == "/rcbilling/v1/customer/offering_products"
+        expect(path.relativeIAMPath).toNot(contain(Self.userID))
+        expect(path.relativeIAMPath) != path.relativePath
+    }
+
+    func testWebBillingProductsRelativePathIncludesUserIDAndProductIDs() {
+        let path = HTTPRequest.WebBillingPath.getWebBillingProducts(userId: Self.userID, productIds: ["product_1"])
+
+        expect(path.relativePath) == "/rcbilling/v1/subscribers/\(Self.userID)/products?id=product_1"
+    }
+
+    func testWebBillingProductsRelativeIAMPathOmitsUserID() {
+        let path = HTTPRequest.WebBillingPath.getWebBillingProducts(userId: Self.userID, productIds: ["product_1"])
+
+        expect(path.relativeIAMPath) == "/rcbilling/v1/customer/products?id=product_1"
+        expect(path.relativeIAMPath).toNot(contain(Self.userID))
+        expect(path.relativeIAMPath) != path.relativePath
+    }
+
+    func testWebBillingProductsRelativeIAMPathJoinsMultipleProductIDs() {
+        // `productIds` is a `Set`, so its iteration order isn't guaranteed: compare the
+        // resulting query items as an unordered set of `id=` tokens instead of an exact string.
+        let productIds: Set<String> = ["product_1", "product_2", "product_3"]
+        let path = HTTPRequest.WebBillingPath.getWebBillingProducts(userId: Self.userID, productIds: productIds)
+
+        expect(path.relativeIAMPath).to(beginWith("/rcbilling/v1/customer/products?"))
+
+        let query = path.relativeIAMPath.replacingOccurrences(
+            of: "/rcbilling/v1/customer/products?",
+            with: ""
+        )
+        let actualTokens = Set(query.components(separatedBy: "&"))
+        let expectedTokens = Set(productIds.map { "id=\($0)" })
+
+        expect(actualTokens) == expectedTokens
+    }
+
+    func testWebBillingProductsRelativeIAMPathPercentEncodesProductIDs() {
+        let productIdWithSpace = "product with space"
+        let path = HTTPRequest.WebBillingPath.getWebBillingProducts(
+            userId: Self.userID,
+            productIds: [productIdWithSpace]
+        )
+
+        expect(path.relativeIAMPath) == "/rcbilling/v1/customer/products?id=product%20with%20space"
+        expect(path.relativeIAMPath).toNot(contain(" "))
+    }
+
+    func testWebBillingProductsRelativeIAMPathWithNoProductIDsHasEmptyQuery() {
+        let path = HTTPRequest.WebBillingPath.getWebBillingProducts(userId: Self.userID, productIds: [])
+
+        expect(path.relativeIAMPath) == "/rcbilling/v1/customer/products?"
+    }
+
+    func testWebBillingPathsURLPreferringIAMPathUsesIAMRelativePath() {
+        let offeringProductsPath = HTTPRequest.WebBillingPath.getWebOfferingProducts(appUserID: Self.userID)
+        let productsPath = HTTPRequest.WebBillingPath.getWebBillingProducts(
+            userId: Self.userID,
+            productIds: ["product_1"]
+        )
+
+        expect(offeringProductsPath.url(preferIAMPath: true)?.absoluteString)
+            == "https://api.revenuecat.com/rcbilling/v1/customer/offering_products"
+        expect(offeringProductsPath.url(preferIAMPath: false)?.absoluteString)
+            == "https://api.revenuecat.com/rcbilling/v1/subscribers/\(Self.userID)/offering_products"
+
+        expect(productsPath.url(preferIAMPath: true)?.absoluteString)
+            == "https://api.revenuecat.com/rcbilling/v1/customer/products?id=product_1"
+        expect(productsPath.url(preferIAMPath: false)?.absoluteString)
+            == "https://api.revenuecat.com/rcbilling/v1/subscribers/\(Self.userID)/products?id=product_1"
+    }
+
     func testNonMainPathsDoNotUseAPISources() {
         let paths: [any HTTPRequestPath] = [
             HTTPRequest.DiagnosticsPath.postDiagnostics

--- a/Tests/UnitTests/Networking/Responses/CustomerInfoDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/CustomerInfoDecodingTests.swift
@@ -139,6 +139,13 @@ class CustomerInfoDecodingTests: BaseHTTPResponseTest {
         expect(try CustomerInfo.decode("[]")).to(throwError(ErrorCode.customerInfoError))
     }
 
+    func testUserIsNilWhenNotPresentInResponse() throws {
+        // The base `CustomerInfo` fixture predates the `user` field and never transmits it.
+        let response: CustomerInfoResponse = try Self.decodeFixture("CustomerInfo")
+
+        expect(response.user).to(beNil())
+    }
+
 }
 
 class CustomerInfoNoOriginalSourceDecodeTests: CustomerInfoDecodingTests {
@@ -303,6 +310,50 @@ class CustomerInfoEncodingTests: BaseHTTPResponseTest {
         assertSnapshot(of: self.customerInfo.copy(with: .failed,
                                                   httpResponseOriginalSource: .loadShedder),
                        as: .backwardsCompatibleFormattedJson)
+    }
+
+}
+
+class CustomerInfoResponseUserDecodingTests: BaseHTTPResponseTest {
+
+    fileprivate var response: CustomerInfoResponse!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        self.response = try Self.decodeFixture("CustomerInfoWithUser")
+    }
+
+    func testUserIsDecoded() throws {
+        let user = try XCTUnwrap(self.response.user)
+
+        expect(user.id) == "user-123"
+        expect(user.amr) == ["pwd"]
+    }
+
+    func testUserIdentitiesAreDecoded() throws {
+        let user = try XCTUnwrap(self.response.user)
+
+        expect(user.identities).to(haveCount(2))
+
+        let first = user.identities[0]
+        expect(first.id) == "user-123"
+        expect(first.method) == "email"
+
+        let second = user.identities[1]
+        expect(second.id).to(beNil())
+        expect(second.method) == "anonymous"
+    }
+
+    func testUserIdentityRawDataIsPreserved() throws {
+        let user = try XCTUnwrap(self.response.user)
+        let first = try XCTUnwrap(user.identities.first)
+
+        expect(first.rawData["provider_id"] as? String) == "email-provider-1"
+    }
+
+    func testUserReencoding() throws {
+        expect(try self.response.encodeAndDecode()) == self.response
     }
 
 }

--- a/Tests/UnitTests/Networking/Responses/CustomerInfoResponseIdentityTests.swift
+++ b/Tests/UnitTests/Networking/Responses/CustomerInfoResponseIdentityTests.swift
@@ -1,0 +1,246 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CustomerInfoResponseIdentityTests.swift
+//
+//  Created by RevenueCat on 9/2/26.
+
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+class CustomerInfoResponseIdentityTests: TestCase {
+
+    private typealias Identity = CustomerInfoResponse.User.Identity
+
+    // MARK: - Decoding known fields
+
+    func testDecodeParsesIdAndMethod() throws {
+        let data = try XCTUnwrap("""
+        {"id": "user-123", "method": "email"}
+        """.data(using: .utf8))
+
+        let identity = try JSONDecoder().decode(Identity.self, from: data)
+
+        expect(identity.id) == "user-123"
+        expect(identity.method) == "email"
+    }
+
+    func testDecodeAllowsNilId() throws {
+        let data = try XCTUnwrap("""
+        {"id": null, "method": "anonymous"}
+        """.data(using: .utf8))
+
+        let identity = try JSONDecoder().decode(Identity.self, from: data)
+
+        expect(identity.id).to(beNil())
+        expect(identity.method) == "anonymous"
+    }
+
+    func testDecodeThrowsWhenMethodIsMissing() throws {
+        let data = try XCTUnwrap("""
+        {"id": "user-123"}
+        """.data(using: .utf8))
+
+        expect {
+            try JSONDecoder().decode(Identity.self, from: data)
+        }.to(throwError(errorType: DecodingError.self))
+    }
+
+    // MARK: - `rawData` preserves everything transmitted
+
+    func testDecodeRawDataMatchesTransmittedKnownKeys() throws {
+        let data = try XCTUnwrap("""
+        {"id": "user-123", "method": "email"}
+        """.data(using: .utf8))
+
+        let identity = try JSONDecoder().decode(Identity.self, from: data)
+
+        expect(Data.encodeJSON(identity.rawData)).to(matchJSONData(data))
+    }
+
+    func testDecodeRawDataIncludesUnknownFutureKeys() throws {
+        let data = try XCTUnwrap("""
+        {
+          "id": "user-123",
+          "method": "email",
+          "provider_id": "abc-999",
+          "verified": true,
+          "metadata": {"source": "sso"}
+        }
+        """.data(using: .utf8))
+
+        let identity = try JSONDecoder().decode(Identity.self, from: data)
+
+        // Known fields still decode correctly...
+        expect(identity.id) == "user-123"
+        expect(identity.method) == "email"
+
+        // ...and every transmitted key/value (known or not) is preserved in `rawData`,
+        // matching the wire representation exactly.
+        expect(Data.encodeJSON(identity.rawData)).to(matchJSONData(data))
+    }
+
+    func testDecodeRawDataContainsExactlyTheTransmittedKeySet() throws {
+        let data = try XCTUnwrap("""
+        {"id": "user-123", "method": "email", "created_at": 1700000000, "extra_flag": false}
+        """.data(using: .utf8))
+
+        let identity = try JSONDecoder().decode(Identity.self, from: data)
+
+        expect(Set(identity.rawData.keys)) == ["id", "method", "created_at", "extra_flag"]
+    }
+
+    func testDecodeRawDataIsUnaffectedByKeyOrder() throws {
+        let data1 = try XCTUnwrap("""
+        {"id": "user-123", "method": "email", "provider_id": "abc-999", "verified": true}
+        """.data(using: .utf8))
+        let data2 = try XCTUnwrap("""
+        {"verified": true, "method": "email", "id": "user-123", "provider_id": "abc-999"}
+        """.data(using: .utf8))
+
+        let identity1 = try JSONDecoder().decode(Identity.self, from: data1)
+        let identity2 = try JSONDecoder().decode(Identity.self, from: data2)
+
+        expect(identity1.id) == identity2.id
+        expect(identity1.method) == identity2.method
+
+        // Dictionaries are inherently unordered, so re-serializing both should
+        // produce identical JSON regardless of the order keys were transmitted in.
+        let encoded1 = try XCTUnwrap(Data.encodeJSON(identity1.rawData))
+        let encoded2 = try XCTUnwrap(Data.encodeJSON(identity2.rawData))
+        expect(encoded1) == encoded2
+    }
+
+    // MARK: - Production decoder (snake_case <-> camelCase conversion)
+    //
+    // `JSONDecoder.default` (used in production to decode `CustomerInfoResponse`) configures
+    // `.convertFromSnakeCase`. That conversion is only applied to schema-defined `CodingKey`s
+    // (like `Identity`'s `id`/`method`), not to the dynamic keys captured by `decodeRawData()`
+    // into a plain `[String: Any]` -- see the similar note on `SubscriberAttributes` decoding.
+    // These tests exist to catch a regression where `rawData` keys get silently mangled
+    // (e.g. "provider_user_id" -> "providerUserId").
+
+    func testDecodeThroughProductionDecoderPreservesSnakeCaseKeysInRawData() throws {
+        let data = try XCTUnwrap("""
+        {"id": "user-123", "method": "email", "provider_user_id": "sso-42", "linked_at_ms": 1700000000000}
+        """.data(using: .utf8))
+
+        let identity = try JSONDecoder.default.decode(Identity.self, from: data)
+
+        expect(identity.id) == "user-123"
+        expect(identity.method) == "email"
+        expect(identity.rawData["provider_user_id"] as? String) == "sso-42"
+        expect(identity.rawData["linked_at_ms"] as? Int) == 1_700_000_000_000
+        expect(identity.rawData["providerUserId"]).to(beNil())
+        expect(Data.encodeJSON(identity.rawData)).to(matchJSONData(data))
+    }
+
+    // MARK: - Encoding
+
+    func testEncodeWritesRawDataVerbatim() throws {
+        let rawData: [String: Any] = [
+            "id": "user-123",
+            "method": "email",
+            "future_key": "future_value"
+        ]
+        let identity = Identity(id: "user-123", method: "email", rawData: rawData)
+
+        let data = try JSONEncoder().encode(identity)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        expect(json["id"] as? String) == "user-123"
+        expect(json["method"] as? String) == "email"
+        expect(json["future_key"] as? String) == "future_value"
+    }
+
+    func testEncodeSerializesRawDataRatherThanTheDecodedProperties() throws {
+        // `rawData` is intentionally different from `id`/`method` here to prove that
+        // `encode(to:)` serializes `rawData` -- not the individually-decoded properties.
+        let identity = Identity(
+            id: "decoded-id",
+            method: "decoded-method",
+            rawData: ["id": "raw-id", "method": "raw-method"]
+        )
+
+        let data = try JSONEncoder().encode(identity)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        expect(json["id"] as? String) == "raw-id"
+        expect(json["method"] as? String) == "raw-method"
+    }
+
+    func testEncodeThenDecodeRoundTripPreservesAllKeys() throws {
+        let data = try XCTUnwrap("""
+        {"id": "user-123", "method": "email", "provider_id": "abc-999", "verified": true}
+        """.data(using: .utf8))
+        let original = try JSONDecoder().decode(Identity.self, from: data)
+
+        let reencoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(Identity.self, from: reencoded)
+
+        expect(decoded.id) == original.id
+        expect(decoded.method) == original.method
+
+        let originalEncoded = try XCTUnwrap(Data.encodeJSON(original.rawData))
+        let decodedEncoded = try XCTUnwrap(Data.encodeJSON(decoded.rawData))
+        expect(decodedEncoded) == originalEncoded
+    }
+
+    func testProductionEncodeDecodeRoundTripPreservesSnakeCaseKeys() throws {
+        let data = try XCTUnwrap("""
+        {"id": "user-123", "method": "email", "provider_user_id": "sso-42"}
+        """.data(using: .utf8))
+        let original = try JSONDecoder.default.decode(Identity.self, from: data)
+
+        let reencoded = try JSONEncoder.default.encode(original)
+        let decoded = try JSONDecoder.default.decode(Identity.self, from: reencoded)
+
+        expect(decoded.rawData["provider_user_id"] as? String) == "sso-42"
+
+        let originalEncoded = try XCTUnwrap(Data.encodeJSON(original.rawData))
+        let decodedEncoded = try XCTUnwrap(Data.encodeJSON(decoded.rawData))
+        expect(decodedEncoded) == originalEncoded
+    }
+
+    // MARK: - Integration through `CustomerInfoResponse.User`
+
+    func testUserIdentitiesArrayPreservesEachIdentitysRawDataIndependently() throws {
+        let data = try XCTUnwrap("""
+        {
+          "amr": ["pwd"],
+          "id": "user-123",
+          "identities": [
+            {"id": "user-123", "method": "email", "provider_id": "email-1"},
+            {"id": null, "method": "anonymous", "session_id": "sess-1"}
+          ]
+        }
+        """.data(using: .utf8))
+
+        let user = try JSONDecoder().decode(CustomerInfoResponse.User.self, from: data)
+
+        expect(user.identities).to(haveCount(2))
+
+        let first = user.identities[0]
+        expect(first.id) == "user-123"
+        expect(first.method) == "email"
+        expect(first.rawData["provider_id"] as? String) == "email-1"
+
+        let second = user.identities[1]
+        expect(second.id).to(beNil())
+        expect(second.method) == "anonymous"
+        expect(second.rawData["session_id"] as? String) == "sess-1"
+
+        // Each identity's extra keys must not leak into any other identity's `rawData`.
+        expect(first.rawData["session_id"]).to(beNil())
+        expect(second.rawData["provider_id"]).to(beNil())
+    }
+
+}

--- a/Tests/UnitTests/Networking/Responses/Fixtures/CustomerInfoWithUser.json
+++ b/Tests/UnitTests/Networking/Responses/Fixtures/CustomerInfoWithUser.json
@@ -1,0 +1,33 @@
+{
+    "schema_version": "4",
+    "original_source": "main",
+    "request_date": "2022-03-08T17:42:58Z",
+    "request_date_ms": 1646761378845,
+    "subscriber": {
+        "first_seen": "2022-03-08T17:42:58Z",
+        "last_seen": "2022-03-08T17:42:58Z",
+        "management_url": "https://apps.apple.com/account/subscriptions",
+        "non_subscriptions": {},
+        "original_app_user_id": "$RCAnonymousID:5b6fdbac3a0c4f879e43d269ecdf9ba1",
+        "original_application_version": "1.0",
+        "original_purchase_date": "2022-04-12T00:03:24Z",
+        "other_purchases": {},
+        "subscriptions": {},
+        "entitlements": {}
+    },
+    "user": {
+        "amr": ["pwd"],
+        "id": "user-123",
+        "identities": [
+            {
+                "id": "user-123",
+                "method": "email",
+                "provider_id": "email-provider-1"
+            },
+            {
+                "id": null,
+                "method": "anonymous"
+            }
+        ]
+    }
+}

--- a/Tests/UnitTests/Paywalls/Components/JSON/SizeConstraints.json
+++ b/Tests/UnitTests/Paywalls/Components/JSON/SizeConstraints.json
@@ -14,5 +14,45 @@
     "fill_fit_withDefault": {
         "width": { "type": "fill" },
         "height": { "type": "fit", "default": 2 }
+    },
+    "fit_withMin": {
+        "width": { "type": "fit", "min": 2 },
+        "height": { "type": "fit", "min": 2 }
+    },
+    "fit_withMax": {
+        "width": { "type": "fit", "max": 2 },
+        "height": { "type": "fit", "max": 2 }
+    },
+    "fit_withMinMax": {
+        "width": { "type": "fit", "min": 2, "max": 3 },
+        "height": { "type": "fit", "min": 2, "max": 3 }
+    },
+    "fill_withMin": {
+        "width": { "type": "fill", "min": 2 },
+        "height": { "type": "fill", "min": 2 }
+    },
+    "fill_withMax": {
+        "width": { "type": "fill", "max": 2 },
+        "height": { "type": "fill", "max": 2 }
+    },
+    "fill_withMinMax": {
+        "width": { "type": "fill", "min": 2, "max": 3 },
+        "height": { "type": "fill", "min": 2, "max": 3 }
+    },
+    "relative_withMin": {
+        "width": { "type": "relative", "min": 2, "value": 0.8 },
+        "height": { "type": "relative", "min": 2, "value": 0.8 }
+    },
+    "relative_withMax": {
+        "width": { "type": "relative", "max": 3, "value": 0.8 },
+        "height": { "type": "relative", "max": 3, "value": 0.8 }
+    },
+    "relative_withMinMax": {
+        "width": { "type": "relative", "min": 2, "max": 3, "value": 0.8 },
+        "height": { "type": "relative", "min": 2, "max": 3, "value": 0.8 }
+    },
+    "fixed_fit": {
+        "width": { "type": "fixed", "value": 80 },
+        "height": { "type": "fit" }
     }
 }

--- a/Tests/UnitTests/Paywalls/Components/Properties/SizeConstraintTests.swift
+++ b/Tests/UnitTests/Paywalls/Components/Properties/SizeConstraintTests.swift
@@ -24,6 +24,36 @@ final class SizeConstraintTests: TestCase {
         XCTAssertEqual(sizes.fillFill, .init(width: .fill, height: .fill))
         XCTAssertEqual(sizes.fitFill, .init(width: .fit(2), height: .fill))
         XCTAssertEqual(sizes.fillFit, .init(width: .fill, height: .fit(2)))
+        XCTAssertEqual(
+            sizes.fitWithMin,
+            .init(
+                width: .fit(nil, .init(min: 2, max: nil)),
+                height: .fit(nil, .init(min: 2, max: nil))
+            )
+        )
+        XCTAssertEqual(
+            sizes.fitWithMax,
+            .init(
+                width: .fit(nil, .init(min: nil, max: 2)),
+                height: .fit(nil, .init(min: nil, max: 2))
+            )
+        )
+        XCTAssertEqual(
+            sizes.fillWithMinMax,
+            .init(
+                width: .fill(.init(min: 2, max: 3)),
+                height: .fill(.init(min: 2, max: 3))
+            )
+        )
+        XCTAssertEqual(
+            sizes.relativeWithMinMax,
+            .init(
+                width: .relative(0.8, .init(min: 2, max: 3)),
+                height: .relative(0.8, .init(min: 2, max: 3))
+            )
+        )
+        XCTAssertTrue(sizes.fillWithMinMax.width.isFill)
+        XCTAssertFalse(sizes.fitWithMin.width.isFill)
     }
 }
 
@@ -32,11 +62,19 @@ struct Sizes: Codable {
     let fillFill: PaywallComponent.Size
     let fitFill: PaywallComponent.Size
     let fillFit: PaywallComponent.Size
+    let fitWithMin: PaywallComponent.Size
+    let fitWithMax: PaywallComponent.Size
+    let fillWithMinMax: PaywallComponent.Size
+    let relativeWithMinMax: PaywallComponent.Size
 
     enum CodingKeys: String, CodingKey {
         case fitFit = "fit_fit"
         case fillFill = "fill_fill"
         case fitFill = "fit_withDefault_fill"
         case fillFit = "fill_fit_withDefault"
+        case fitWithMin = "fit_withMin"
+        case fitWithMax = "fit_withMax"
+        case fillWithMinMax = "fill_withMinMax"
+        case relativeWithMinMax = "relative_withMinMax"
     }
 }

--- a/Tests/UnitTests/Purchasing/ConfigurationTests.swift
+++ b/Tests/UnitTests/Purchasing/ConfigurationTests.swift
@@ -39,6 +39,33 @@ class ConfigurationTests: TestCase {
         expect(Configuration.validateAndLog(apiKey: "test_eg2t9g3098bgqqn")) == .simulatedStore
     }
 
+    func testTestStoreKeyIsBlockedInReleaseByDefault() {
+        expect(Configuration.APIKeyValidationResult.simulatedStore
+            .shouldBlockSimulatedStoreAPIKeyInRelease(dangerousSettings: DangerousSettings())) == true
+    }
+
+    func testTestStoreKeyIsNotBlockedInReleaseWhenForceAllowTestStoreInReleaseBuilds() {
+        let settings = DangerousSettings(autoSyncPurchases: true, forceAllowTestStoreInReleaseBuilds: true)
+
+        expect(Configuration.APIKeyValidationResult.simulatedStore
+            .shouldBlockSimulatedStoreAPIKeyInRelease(dangerousSettings: settings)) == false
+    }
+
+    func testTestStoreKeyIsNotBlockedInReleaseWhenUIPreviewMode() {
+        let settings = DangerousSettings(uiPreviewMode: true)
+
+        expect(Configuration.APIKeyValidationResult.simulatedStore
+            .shouldBlockSimulatedStoreAPIKeyInRelease(dangerousSettings: settings)) == false
+    }
+
+    func testNonTestStoreKeysAreNotBlockedInRelease() {
+        let results: [Configuration.APIKeyValidationResult] = [.validApplePlatform, .otherPlatforms, .legacy]
+
+        for result in results {
+            expect(result.shouldBlockSimulatedStoreAPIKeyInRelease(dangerousSettings: DangerousSettings())) == false
+        }
+    }
+
     func testNoObserverModeWithStoreKit1() {
         let configuration = Configuration.Builder(withAPIKey: "test")
             .with(storeKitVersion: .storeKit1)

--- a/Tests/UnitTests/RulesEngine/Helpers/PredicateConformanceRunner.swift
+++ b/Tests/UnitTests/RulesEngine/Helpers/PredicateConformanceRunner.swift
@@ -55,7 +55,7 @@ enum PredicateConformanceRunner {
             let result = try Evaluator.evaluate(
                 predicate: fixture.predicate,
                 variables: scope(for: fixture)
-            ).isTruthy
+            )
             #expect(result == expected, "Fixture \(fixture.id)")
 
         case .error(let expectedError):

--- a/Tests/UnitTests/RulesEngine/RulesEngineEvaluateTests.swift
+++ b/Tests/UnitTests/RulesEngine/RulesEngineEvaluateTests.swift
@@ -53,54 +53,6 @@ struct RulesEngineEvaluateTests {
             return
         }
     }
-
-    @Test
-    func transformReturnsPredicateResult() throws {
-        let result = RulesEngine.transform(
-            predicate: #"{"var":"nested"}"#,
-            variables: ["nested": .object(["x": .int(1)])]
-        )
-        #expect(try result.get() == ["x": .int(1)])
-    }
-
-    @Test
-    func transformWithIdentityPredicateReturnsVariablesUnchanged() throws {
-        let variables: [String: RulesEngine.Value] = ["x": .int(1)]
-        let result = RulesEngine.transform(predicate: #"{"var":""}"#, variables: variables)
-        #expect(try result.get() == variables)
-    }
-
-    @Test
-    func transformAndEvaluateUseIndependentPredicates() throws {
-        let raw: [String: RulesEngine.Value] = ["x": .int(1)]
-        let transformed = try RulesEngine.transform(
-            predicate: #"{"var":""}"#,
-            variables: raw
-        ).get()
-        let result = RulesEngine.evaluate(
-            predicate: #"{"==":[{"var":"x"},1]}"#,
-            variables: transformed
-        )
-        #expect(try result.get() == true)
-    }
-
-    @Test
-    func transformToNonObjectReturnsTypeMismatchFailure() {
-        let result = RulesEngine.transform(predicate: #"{"var":"x"}"#, variables: ["x": .int(1)])
-        guard case .failure(.typeMismatch) = result else {
-            Issue.record("expected .failure(.typeMismatch), got \(result)")
-            return
-        }
-    }
-
-    @Test
-    func transformMalformedJSONReturnsParseFailure() {
-        let result = RulesEngine.transform(predicate: "{not json", variables: [:])
-        guard case .failure(.parse) = result else {
-            Issue.record("expected .failure(.parse), got \(result)")
-            return
-        }
-    }
 }
 
 #endif

--- a/api/revenuecat-api-ios-simulator.swiftinterface
+++ b/api/revenuecat-api-ios-simulator.swiftinterface
@@ -451,8 +451,12 @@ extension RevenueCat.Purchases {
   @objc final public var customEntitlementComputation: Swift.Bool {
     @objc get
   }
+  @objc final public var forceAllowTestStoreInReleaseBuilds: Swift.Bool {
+    @objc get
+  }
   @objc override convenience dynamic public init()
   @objc convenience public init(autoSyncPurchases: Swift.Bool = true)
+  @objc convenience public init(autoSyncPurchases: Swift.Bool, forceAllowTestStoreInReleaseBuilds: Swift.Bool)
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   @objc override final public var hash: Swift.Int {
     @objc get

--- a/api/revenuecat-api-ios.swiftinterface
+++ b/api/revenuecat-api-ios.swiftinterface
@@ -451,8 +451,12 @@ extension RevenueCat.Purchases {
   @objc final public var customEntitlementComputation: Swift.Bool {
     @objc get
   }
+  @objc final public var forceAllowTestStoreInReleaseBuilds: Swift.Bool {
+    @objc get
+  }
   @objc override convenience dynamic public init()
   @objc convenience public init(autoSyncPurchases: Swift.Bool = true)
+  @objc convenience public init(autoSyncPurchases: Swift.Bool, forceAllowTestStoreInReleaseBuilds: Swift.Bool)
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   @objc override final public var hash: Swift.Int {
     @objc get

--- a/api/revenuecat-api-macos.swiftinterface
+++ b/api/revenuecat-api-macos.swiftinterface
@@ -420,8 +420,12 @@ public protocol RawDataContainer {
   @objc final public var customEntitlementComputation: Swift.Bool {
     @objc get
   }
+  @objc final public var forceAllowTestStoreInReleaseBuilds: Swift.Bool {
+    @objc get
+  }
   @objc override convenience dynamic public init()
   @objc convenience public init(autoSyncPurchases: Swift.Bool = true)
+  @objc convenience public init(autoSyncPurchases: Swift.Bool, forceAllowTestStoreInReleaseBuilds: Swift.Bool)
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   @objc override final public var hash: Swift.Int {
     @objc get

--- a/api/revenuecat-api-tvos-simulator.swiftinterface
+++ b/api/revenuecat-api-tvos-simulator.swiftinterface
@@ -418,8 +418,12 @@ public protocol RawDataContainer {
   @objc final public var customEntitlementComputation: Swift.Bool {
     @objc get
   }
+  @objc final public var forceAllowTestStoreInReleaseBuilds: Swift.Bool {
+    @objc get
+  }
   @objc override convenience dynamic public init()
   @objc convenience public init(autoSyncPurchases: Swift.Bool = true)
+  @objc convenience public init(autoSyncPurchases: Swift.Bool, forceAllowTestStoreInReleaseBuilds: Swift.Bool)
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   @objc override final public var hash: Swift.Int {
     @objc get

--- a/api/revenuecat-api-tvos.swiftinterface
+++ b/api/revenuecat-api-tvos.swiftinterface
@@ -418,8 +418,12 @@ public protocol RawDataContainer {
   @objc final public var customEntitlementComputation: Swift.Bool {
     @objc get
   }
+  @objc final public var forceAllowTestStoreInReleaseBuilds: Swift.Bool {
+    @objc get
+  }
   @objc override convenience dynamic public init()
   @objc convenience public init(autoSyncPurchases: Swift.Bool = true)
+  @objc convenience public init(autoSyncPurchases: Swift.Bool, forceAllowTestStoreInReleaseBuilds: Swift.Bool)
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   @objc override final public var hash: Swift.Int {
     @objc get

--- a/api/revenuecat-api-visionos-simulator.swiftinterface
+++ b/api/revenuecat-api-visionos-simulator.swiftinterface
@@ -451,8 +451,12 @@ extension RevenueCat.Purchases {
   @objc final public var customEntitlementComputation: Swift.Bool {
     @objc get
   }
+  @objc final public var forceAllowTestStoreInReleaseBuilds: Swift.Bool {
+    @objc get
+  }
   @objc override convenience dynamic public init()
   @objc convenience public init(autoSyncPurchases: Swift.Bool = true)
+  @objc convenience public init(autoSyncPurchases: Swift.Bool, forceAllowTestStoreInReleaseBuilds: Swift.Bool)
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   @objc override final public var hash: Swift.Int {
     @objc get

--- a/api/revenuecat-api-visionos.swiftinterface
+++ b/api/revenuecat-api-visionos.swiftinterface
@@ -451,8 +451,12 @@ extension RevenueCat.Purchases {
   @objc final public var customEntitlementComputation: Swift.Bool {
     @objc get
   }
+  @objc final public var forceAllowTestStoreInReleaseBuilds: Swift.Bool {
+    @objc get
+  }
   @objc override convenience dynamic public init()
   @objc convenience public init(autoSyncPurchases: Swift.Bool = true)
+  @objc convenience public init(autoSyncPurchases: Swift.Bool, forceAllowTestStoreInReleaseBuilds: Swift.Bool)
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   @objc override final public var hash: Swift.Int {
     @objc get

--- a/api/revenuecat-api-watchos-simulator.swiftinterface
+++ b/api/revenuecat-api-watchos-simulator.swiftinterface
@@ -419,8 +419,12 @@ public protocol RawDataContainer {
   @objc final public var customEntitlementComputation: Swift.Bool {
     @objc get
   }
+  @objc final public var forceAllowTestStoreInReleaseBuilds: Swift.Bool {
+    @objc get
+  }
   @objc override convenience dynamic public init()
   @objc convenience public init(autoSyncPurchases: Swift.Bool = true)
+  @objc convenience public init(autoSyncPurchases: Swift.Bool, forceAllowTestStoreInReleaseBuilds: Swift.Bool)
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   @objc override final public var hash: Swift.Int {
     @objc get

--- a/api/revenuecat-api-watchos.swiftinterface
+++ b/api/revenuecat-api-watchos.swiftinterface
@@ -419,8 +419,12 @@ public protocol RawDataContainer {
   @objc final public var customEntitlementComputation: Swift.Bool {
     @objc get
   }
+  @objc final public var forceAllowTestStoreInReleaseBuilds: Swift.Bool {
+    @objc get
+  }
   @objc override convenience dynamic public init()
   @objc convenience public init(autoSyncPurchases: Swift.Bool = true)
+  @objc convenience public init(autoSyncPurchases: Swift.Bool, forceAllowTestStoreInReleaseBuilds: Swift.Bool)
   @objc override final public func isEqual(_ object: Any?) -> Swift.Bool
   @objc override final public var hash: Swift.Int {
     @objc get


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
More groundwork for presenting a web checkout in-app. The provider's page offers no JavaScript bridge, so something has to host it and recognise the one signal it gives: a redirect to the return URL.

### Description
Nothing is presented yet.

- No user scripts here: on iOS 15 a `WKUserScript` [disables Apple Pay](https://webkit.org/blog/9674/new-webkit-features-in-safari-13/) for every document the web view loads. Hence the separate `WKWebViewConfiguration` from the paywall component's, which injects a viewport script.
- The return URL is matched on origin and path, and an unrecognised `status` is reported as a cancel. The caller should confirm the outcome against the backend anyway.
- `target="_blank"` reaches `WKUIDelegate`, not the navigation delegate: allowlisted destinations continue in place, anything else goes to the browser.
- Failure copy belongs to whatever presents this, so the view only exposes the state and a reload.