### PR TITLE
fix: send X-Is-Sandbox header when using a Test Store API key

### DIFF
--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -129,7 +129,7 @@ class HTTPClient {
             "X-StoreKit-Version": "\(self.systemInfo.storeKitVersion.effectiveVersion)",
             "X-Observer-Mode-Enabled": "\(self.systemInfo.observerMode)",
             RequestHeader.retryCount.rawValue: "0",
-            RequestHeader.sandbox.rawValue: "\(self.systemInfo.isSandbox)",
+            RequestHeader.sandbox.rawValue: "\(self.systemInfo.isSandbox || self.systemInfo.isSimulatedStoreAPIKey)",
             "X-Is-Backgrounded": "\(self.systemInfo.isAppBackgroundedState)",
             "X-Is-Debug-Build": "\(self.systemInfo.isDebugBuild)",
             "X-Installation-Method": SystemInfo.installationMethod

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -797,6 +797,27 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager, HTTPRequestTim
         expect(header.value) == "false"
     }
 
+    func testPassesIsSandboxTrueForSimulatedStoreAPIKeyEvenIfNotSandbox() {
+        let headerName = "X-Is-Sandbox"
+        self.systemInfo.stubbedIsSandbox = false
+        self.systemInfo.stubbedApiKeyValidationResult = .simulatedStore
+
+        let header: Atomic<String?> = nil
+
+        stub(condition: hasHeaderNamed(headerName)) { request in
+            header.value = request.value(forHTTPHeaderField: headerName)
+            return .emptySuccessResponse()
+        }
+
+        let request = HTTPRequest(method: .post([:]), path: .mockPath)
+
+        waitUntil { completion in
+            self.client.perform(request) { (_: EmptyResponse) in completion() }
+        }
+
+        expect(header.value) == "true"
+    }
+
     func testAlwaysPassesIsDebugBuildHeaderInReleaseMode() {
         let headerName = "X-Is-Debug-Build"
         self.systemInfo.stubbedIsDebugBuild = false // "release" mode


### PR DESCRIPTION
Sends `X-Is-Sandbox: true` on every request when the SDK is configured with a Test Store API key, so backend integrations route those events to the sandbox project.

Part of SDK-4449

- [x] If applicable, unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to a request metadata header for Test Store keys, with unit test coverage and no auth or payment logic changes.
> 
> **Overview**
> Outgoing API requests now set **`X-Is-Sandbox: true`** when the SDK is configured with a **Test Store (simulated store) API key**, even if the app is not otherwise in a sandbox environment.
> 
> The sandbox header in `HTTPClient` default headers is derived from `isSandbox || isSimulatedStoreAPIKey` instead of `isSandbox` alone, so backend routing can treat Test Store traffic like sandbox events.
> 
> A unit test covers the case where `isSandbox` is false but API key validation is `.simulatedStore`, expecting the header value `"true"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dca8866c944e71899853cf5870933c3b9e4999d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->