### PR TITLE
Fix URL-open publishing on a background thread

### DIFF
--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -1417,16 +1417,19 @@ extension EnvironmentValues {
 }
 
 /// Lightweight wrapper so views can report opened URLs without depending on the full `PurchaseHandler`.
-struct URLOpenedNotifier {
+struct URLOpenedNotifier: Sendable {
 
-    private let action: (URL) -> Void
+    private let action: @MainActor @Sendable (URL) -> Void
 
-    init(action: @escaping (URL) -> Void = { _ in }) {
+    init(action: @escaping @MainActor @Sendable (URL) -> Void = { _ in }) {
         self.action = action
     }
 
     func callAsFunction(_ url: URL) {
-        self.action(url)
+        let action = self.action
+        Task { @MainActor in
+            action(url)
+        }
     }
 
 }

--- a/RevenueCatUI/View+PurchaseRestoreCompleted.swift
+++ b/RevenueCatUI/View+PurchaseRestoreCompleted.swift
@@ -573,6 +573,7 @@ private struct OnWebCheckoutOpenedModifier: ViewModifier {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@MainActor
 private struct OnURLOpenedModifier: ViewModifier {
 
     let handler: URLOpenedHandler

--- a/Tests/RevenueCatUITests/PaywallsV2/BrowserNavigateToTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/BrowserNavigateToTests.swift
@@ -97,6 +97,21 @@ final class BrowserNavigateToTests: TestCase {
         expect(result.inAppBrowserURL).to(beNil())
     }
 
+    func testURLOpenedNotifierDispatchesToTheMainActorWhenCalledFromBackground() async {
+        let actionExpectation = expectation(description: "URL opened action")
+        let url = Self.url
+        let notifier = URLOpenedNotifier { _ in
+            XCTAssertTrue(Thread.isMainThread)
+            actionExpectation.fulfill()
+        }
+
+        await Task.detached {
+            notifier(url)
+        }.value
+
+        await fulfillment(of: [actionExpectation], timeout: 1)
+    }
+
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)


### PR DESCRIPTION
## Description
Fixes an issue reported in https://github.com/RevenueCat/purchases-ios/issues/7629. When tapping a link or button we handle this through SwiftUI's `OpenURLAction`, but (at least) on macOS this is not guaranteed to be called on the main thread.

## Changes
Solves the issue centrally in the `URLOpenedNotifier` by calling the passed `action` on the `@MainActor` + added a test ensuring it is only called on the main thread.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Threading fix localized to URL-open notification with a regression test; no auth, purchase, or data-path changes.
> 
> **Overview**
> Fixes paywall **URL-open** callbacks firing off the main thread (e.g. macOS `OpenURLAction`), which could break UI work in `onURLOpened` handlers.
> 
> **`URLOpenedNotifier`** now conforms to **`Sendable`**, types its closure as **`@MainActor @Sendable`**, and **`callAsFunction`** always runs that closure inside **`Task { @MainActor in ... }`** so invocations from a background thread still land on the main actor. **`OnURLOpenedModifier`** is marked **`@MainActor`** to align with **`URLOpenedHandler`**.
> 
> Adds an async test that invokes the notifier from **`Task.detached`** and asserts the action runs on the main thread.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d15212eef1a364530ce44174dc535c1241ce6471. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->