### PR TITLE
Refresh after returning from the management URL browser

### DIFF
--- a/RevenueCatUI/CustomerCenter/Mocks/MockCustomerCenterPurchases.swift
+++ b/RevenueCatUI/CustomerCenter/Mocks/MockCustomerCenterPurchases.swift
@@ -65,8 +65,10 @@ final class MockCustomerCenterPurchases: @unchecked Sendable, CustomerCenterPurc
     }
 
     var customerInfoFetchPolicy: CacheFetchPolicy?
+    var customerInfoFetchCount = 0
     func customerInfo(fetchPolicy: CacheFetchPolicy) async throws -> RevenueCat.CustomerInfo {
         customerInfoFetchPolicy = fetchPolicy
+        customerInfoFetchCount += 1
 
         if let customerInfoError {
             throw customerInfoError

--- a/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
@@ -157,8 +157,13 @@ class BaseManageSubscriptionViewModel: ObservableObject {
         }
     }
 
+    /// Whether the browser we just closed could have changed the subscription.
+    /// A custom URL can't, so we don't pay for a sync on every one of those.
+    private(set) var browserMayHaveChangedSubscription = false
+
     func onDismissInAppBrowser() {
         self.inAppBrowserURL = nil
+        self.browserMayHaveChangedSubscription = false
     }
 
     func displayAllInAppCurrenciesScreen() {
@@ -231,6 +236,7 @@ private extension BaseManageSubscriptionViewModel {
 
     private func handleNonAppStoreCancel() {
         if let url = purchaseInformation?.managementURL {
+            self.browserMayHaveChangedSubscription = true
             self.inAppBrowserURL = IdentifiableURL(url: url)
         }
     }

--- a/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/BaseManageSubscriptionViewModel.swift
@@ -157,8 +157,8 @@ class BaseManageSubscriptionViewModel: ObservableObject {
         }
     }
 
-    /// Whether the browser we just closed could have changed the subscription.
-    /// A custom URL can't, so we don't pay for a sync on every one of those.
+    /// Whether the browser we just closed was the store's management URL, where the customer
+    /// can cancel or resubscribe. Custom URLs are left out, we can't know what they point at.
     private(set) var browserMayHaveChangedSubscription = false
 
     func onDismissInAppBrowser() {
@@ -182,6 +182,9 @@ private extension BaseManageSubscriptionViewModel {
 
 #if os(iOS) || targetEnvironment(macCatalyst)
     private func onPathSelected(path: CustomerCenterConfigData.HelpPath, withActiveProductId: String?) async {
+        // stale from a browser whose onDismiss never fired, don't let it refresh the next one
+        self.browserMayHaveChangedSubscription = false
+
         switch path.type {
         case .missingPurchase:
             self.showRestoreAlert = true

--- a/RevenueCatUI/CustomerCenter/ViewModels/SubscriptionDetailViewModel.swift
+++ b/RevenueCatUI/CustomerCenter/ViewModels/SubscriptionDetailViewModel.swift
@@ -115,7 +115,18 @@ final class SubscriptionDetailViewModel: BaseManageSubscriptionViewModel {
             .store(in: &cancellables)
     }
 
-    func refreshPurchase() {
+    override func onDismissInAppBrowser() {
+        let subscriptionMayHaveChanged = browserMayHaveChangedSubscription
+        super.onDismissInAppBrowser()
+
+        if subscriptionMayHaveChanged {
+            // syncPurchases posts the local App Store receipt and hands back cached CustomerInfo
+            // when there are no Apple transactions, which is exactly the case here, so fetch instead.
+            refreshPurchase(shouldSync: false)
+        }
+    }
+
+    func refreshPurchase(shouldSync: Bool = true) {
         refreshingCancellable = customerInfoViewModel.publisher(for: purchaseInformation)?
             .dropFirst() // skip current value
             .sink(receiveValue: { @MainActor [weak self] in
@@ -126,7 +137,7 @@ final class SubscriptionDetailViewModel: BaseManageSubscriptionViewModel {
         isRefreshing = true
 
         Task {
-            await customerInfoViewModel.loadScreen(shouldSync: true)
+            await customerInfoViewModel.loadScreen(shouldSync: shouldSync)
             // In case loadScreen does not trigger a new update (error)
             isRefreshing = false
         }

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
@@ -160,7 +160,11 @@ struct SubscriptionDetailView: View {
             }
             .sheet(item: self.$viewModel.inAppBrowserURL,
                    onDismiss: {
+                let shouldRefresh = self.viewModel.browserMayHaveChangedSubscription
                 self.viewModel.onDismissInAppBrowser()
+                if shouldRefresh {
+                    self.viewModel.refreshPurchase()
+                }
             }, content: { inAppBrowserURL in
                 SafariView(url: inAppBrowserURL.url)
             })

--- a/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
+++ b/RevenueCatUI/CustomerCenter/Views/SubscriptionDetailView.swift
@@ -160,11 +160,7 @@ struct SubscriptionDetailView: View {
             }
             .sheet(item: self.$viewModel.inAppBrowserURL,
                    onDismiss: {
-                let shouldRefresh = self.viewModel.browserMayHaveChangedSubscription
                 self.viewModel.onDismissInAppBrowser()
-                if shouldRefresh {
-                    self.viewModel.refreshPurchase()
-                }
             }, content: { inAppBrowserURL in
                 SafariView(url: inAppBrowserURL.url)
             })

--- a/Tests/RevenueCatUITests/CustomerCenter/BaseManageSubscriptionViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/BaseManageSubscriptionViewModelTests.swift
@@ -130,6 +130,64 @@ final class BaseManageSubscriptionViewModelTests: TestCase {
         expect(viewModel.relevantPathsForPurchase.contains(where: { $0.type == .refundRequest })).toNot(beNil())
     }
 
+    // MARK: - In-app browser refresh
+
+    func testManagementURLBrowserFlagsSubscriptionMayHaveChanged() async {
+        let purchase = PurchaseInformation.mock(
+            store: .playStore,
+            isSubscription: true,
+            managementURL: URL(string: "https://play.google.com/store/account/subscriptions")!
+        )
+
+        let viewModel = BaseManageSubscriptionViewModel(
+            screen: BaseManageSubscriptionViewModelTests.default,
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchaseInformation: purchase,
+            purchasesProvider: MockCustomerCenterPurchases())
+
+        let cancelPath = CustomerCenterConfigData.HelpPath(
+            id: "cancel",
+            title: "Cancel subscription",
+            type: .cancel,
+            detail: nil
+        )
+        await viewModel.handleHelpPath(cancelPath)
+
+        expect(viewModel.inAppBrowserURL).toNot(beNil())
+        expect(viewModel.browserMayHaveChangedSubscription) == true
+
+        viewModel.onDismissInAppBrowser()
+        expect(viewModel.browserMayHaveChangedSubscription) == false
+    }
+
+    func testCustomURLBrowserDoesNotFlagSubscriptionMayHaveChanged() async {
+        let purchase = PurchaseInformation.mock(
+            store: .playStore,
+            isSubscription: true,
+            managementURL: URL(string: "https://play.google.com/store/account/subscriptions")!
+        )
+
+        let viewModel = BaseManageSubscriptionViewModel(
+            screen: BaseManageSubscriptionViewModelTests.default,
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchaseInformation: purchase,
+            purchasesProvider: MockCustomerCenterPurchases())
+
+        let customURLPath = CustomerCenterConfigData.HelpPath(
+            id: "custom",
+            title: "Help center",
+            url: URL(string: "https://revenuecat.com/help")!,
+            openMethod: .inApp,
+            type: .customUrl,
+            detail: nil
+        )
+        await viewModel.handleHelpPath(customURLPath)
+
+        expect(viewModel.inAppBrowserURL).toNot(beNil())
+        // a custom link can't change the subscription, so no sync on dismiss
+        expect(viewModel.browserMayHaveChangedSubscription) == false
+    }
+
     func testShowsRefundIfRefundWindowIsForever() {
         let purchase = PurchaseInformation.mock(
             isSubscription: true,

--- a/Tests/RevenueCatUITests/CustomerCenter/SubscriptionDetailViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/SubscriptionDetailViewModelTests.swift
@@ -56,12 +56,92 @@ final class SubscriptionDetailViewModelTests: TestCase {
         expect(viewModel.browserMayHaveChangedSubscription) == true
 
         viewModel.onDismissInAppBrowser()
-        try await Task.sleep(nanoseconds: 200_000_000)
 
         // syncPurchases posts the Apple receipt and returns cached info when there are
         // no Apple transactions, which is this exact case
-        expect(purchases.syncPurchasesCount) == 0
+        await expect(purchases.customerInfoFetchCount).toEventually(equal(1))
         expect(purchases.customerInfoFetchPolicy) == .fetchCurrent
+        expect(purchases.syncPurchasesCount) == 0
+    }
+
+    func testCustomURLBrowserDismissDoesNotRefresh() async throws {
+        let purchases = MockCustomerCenterPurchases()
+        let viewModel = SubscriptionDetailViewModel(
+            customerInfoViewModel: CustomerCenterViewModel(
+                actionWrapper: CustomerCenterActionWrapper(),
+                purchasesProvider: purchases
+            ),
+            screen: CustomerCenterConfigData.default.screens[.management]!,
+            showPurchaseHistory: false,
+            showVirtualCurrencies: false,
+            allowsMissingPurchaseAction: false,
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchaseInformation: .mock(
+                store: .playStore,
+                isSubscription: true,
+                managementURL: URL(string: "https://play.google.com/store/account/subscriptions")!
+            ),
+            purchasesProvider: purchases
+        )
+
+        let customURLPath = CustomerCenterConfigData.HelpPath(
+            id: "custom",
+            title: "Help center",
+            url: URL(string: "https://revenuecat.com/help")!,
+            openMethod: .inApp,
+            type: .customUrl,
+            detail: nil
+        )
+        await viewModel.handleHelpPath(customURLPath)
+        viewModel.onDismissInAppBrowser()
+
+        try await Task.sleep(nanoseconds: 200_000_000)
+        expect(purchases.customerInfoFetchCount) == 0
+    }
+
+    func testManagementURLFlagDoesNotLeakIntoALaterCustomURL() async throws {
+        let purchases = MockCustomerCenterPurchases()
+        let viewModel = SubscriptionDetailViewModel(
+            customerInfoViewModel: CustomerCenterViewModel(
+                actionWrapper: CustomerCenterActionWrapper(),
+                purchasesProvider: purchases
+            ),
+            screen: CustomerCenterConfigData.default.screens[.management]!,
+            showPurchaseHistory: false,
+            showVirtualCurrencies: false,
+            allowsMissingPurchaseAction: false,
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchaseInformation: .mock(
+                store: .playStore,
+                isSubscription: true,
+                managementURL: URL(string: "https://play.google.com/store/account/subscriptions")!
+            ),
+            purchasesProvider: purchases
+        )
+
+        // management URL opens, but its onDismiss never fires
+        await viewModel.handleHelpPath(CustomerCenterConfigData.HelpPath(
+            id: "cancel",
+            title: "Cancel subscription",
+            type: .cancel,
+            detail: nil
+        ))
+        expect(viewModel.browserMayHaveChangedSubscription) == true
+
+        // a custom URL opens next, dismissing it shouldn't refresh
+        await viewModel.handleHelpPath(CustomerCenterConfigData.HelpPath(
+            id: "custom",
+            title: "Help center",
+            url: URL(string: "https://revenuecat.com/help")!,
+            openMethod: .inApp,
+            type: .customUrl,
+            detail: nil
+        ))
+        expect(viewModel.browserMayHaveChangedSubscription) == false
+
+        viewModel.onDismissInAppBrowser()
+        try await Task.sleep(nanoseconds: 200_000_000)
+        expect(purchases.customerInfoFetchCount) == 0
     }
 
     func testShouldShowContactSupport() {

--- a/Tests/RevenueCatUITests/CustomerCenter/SubscriptionDetailViewModelTests.swift
+++ b/Tests/RevenueCatUITests/CustomerCenter/SubscriptionDetailViewModelTests.swift
@@ -26,6 +26,44 @@ import XCTest
 @MainActor
 final class SubscriptionDetailViewModelTests: TestCase {
 
+    func testBrowserDismissRefreshesWithoutSyncingPurchases() async throws {
+        let purchases = MockCustomerCenterPurchases()
+        let viewModel = SubscriptionDetailViewModel(
+            customerInfoViewModel: CustomerCenterViewModel(
+                actionWrapper: CustomerCenterActionWrapper(),
+                purchasesProvider: purchases
+            ),
+            screen: CustomerCenterConfigData.default.screens[.management]!,
+            showPurchaseHistory: false,
+            showVirtualCurrencies: false,
+            allowsMissingPurchaseAction: false,
+            actionWrapper: CustomerCenterActionWrapper(),
+            purchaseInformation: .mock(
+                store: .playStore,
+                isSubscription: true,
+                managementURL: URL(string: "https://play.google.com/store/account/subscriptions")!
+            ),
+            purchasesProvider: purchases
+        )
+
+        let cancelPath = CustomerCenterConfigData.HelpPath(
+            id: "cancel",
+            title: "Cancel subscription",
+            type: .cancel,
+            detail: nil
+        )
+        await viewModel.handleHelpPath(cancelPath)
+        expect(viewModel.browserMayHaveChangedSubscription) == true
+
+        viewModel.onDismissInAppBrowser()
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        // syncPurchases posts the Apple receipt and returns cached info when there are
+        // no Apple transactions, which is this exact case
+        expect(purchases.syncPurchasesCount) == 0
+        expect(purchases.customerInfoFetchPolicy) == .fetchCurrent
+    }
+
     func testShouldShowContactSupport() {
         let viewModelAppStore = SubscriptionDetailViewModel(
             customerInfoViewModel: CustomerCenterViewModel(


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

Non App Store subscriptions send the customer to a browser to manage the subscription. On dismiss we only cleared the URL, so they could cancel (or resubscribe) there, come back, and still see the old state until something else forced a sync.

The App Store path already handles this: `.showingManageSubscriptions` opens the StoreKit sheet and `SubscriptionDetailView` refreshes on dismiss with `loadScreen(shouldSync: true)`. The browser path just never got the same treatment.

Came up in review on #7617, splitting it out since it's pre-existing and unrelated to that change.

### Description

Refreshes when the browser closes, but only for the management URL flow. The same sheet also serves custom URL paths, and those can't change the subscription, so they don't pay for a `syncPurchases`.
