### PR TITLE
feat(checkpoints): log checkpoint rule evaluation

### DIFF
--- a/Sources/Checkpoints/CheckpointWorkflowResolver.swift
+++ b/Sources/Checkpoints/CheckpointWorkflowResolver.swift
@@ -180,6 +180,7 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
         }
 
         let ruleEvaluation = try await self.evaluateRules(
+            for: identifier,
             in: rulesSnapshot.ruleSet.rules,
             params: params,
             audienceConfiguration: audienceConfiguration
@@ -224,12 +225,14 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
     }
 
     private func evaluateRules(
+        for identifier: String,
         in rules: [CheckpointRule],
         params: CheckpointParams,
         audienceConfiguration: AudienceConfigurationSnapshot
     ) async throws -> AudienceRuleEvaluation {
         do {
             return .completed(try await self.matchingRule(
+                for: identifier,
                 in: rules,
                 params: params,
                 audienceConfiguration: audienceConfiguration
@@ -243,6 +246,7 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
 
     /// Walks the served rules in priority order and returns the first one whose audience matches.
     private func matchingRule(
+        for identifier: String,
         in rules: [CheckpointRule],
         params: CheckpointParams,
         audienceConfiguration: AudienceConfigurationSnapshot
@@ -250,7 +254,8 @@ final class DefaultCheckpointWorkflowResolver: CheckpointWorkflowResolver {
         return try await self.localRulesEvaluator.match(
             in: rules,
             // Already filtered to valid keys by `DimensionResolver`, which exposes them under `custom.*`.
-            customVariables: params.customVariables.mapValues(\.dimensionValue)
+            customVariables: params.customVariables.mapValues(\.dimensionValue),
+            logPrefix: "[Checkpoint '\(identifier)'] "
         ) { rule in
             guard let audience = audienceConfiguration.audiences[rule.audienceId] else {
                 throw AudienceUnavailableError(audienceID: rule.audienceId)

--- a/Sources/LocalRules/LocalRulesEvaluator.swift
+++ b/Sources/LocalRules/LocalRulesEvaluator.swift
@@ -47,13 +47,16 @@ final class LocalRulesEvaluator: Sendable {
     ///
     /// For example, rules `[("a", false), ("b", true)]` return the second rule.
     /// Developer-supplied values are available to predicates under `custom.*`.
+    /// `logPrefix` is prepended to diagnostic messages without logging predicate or dimension values.
     func match<Rule: LocalRule>(
         in rules: [Rule],
-        customVariables: [String: DimensionValue] = [:]
+        customVariables: [String: DimensionValue] = [:],
+        logPrefix: String = ""
     ) async throws -> Rule? {
         return try await self.match(
             in: rules,
-            customVariables: customVariables
+            customVariables: customVariables,
+            logPrefix: logPrefix
         ) { $0.predicate }
     }
 
@@ -66,15 +69,20 @@ final class LocalRulesEvaluator: Sendable {
     func match<Rule: Sendable>(
         in rules: [Rule],
         customVariables: [String: DimensionValue] = [:],
+        logPrefix: String = "",
         predicate resolvePredicate: (Rule) async throws -> String
     ) async throws -> Rule? {
-        guard !rules.isEmpty else {
-            return nil
-        }
+        guard !rules.isEmpty else { return nil }
 
         let snapshot = try await self.dimensionResolver.snapshot(
             customVariables: customVariables
         )
+
+        Logger.verbose(Strings.localRules.evaluatingRules(
+            logPrefix: logPrefix,
+            ruleCount: rules.count,
+            dimensions: snapshot.values.keys.sorted()
+        ))
 
         var firstEvaluationError: LocalRulesEvaluationError?
 
@@ -82,24 +90,20 @@ final class LocalRulesEvaluator: Sendable {
             let predicate = try await resolvePredicate(rule)
             try Task.checkCancellation()
 
-            switch RulesEngine.evaluate(
+            let result = RulesEngine.evaluate(
                 predicate: predicate,
                 variables: snapshot.values
-            ) {
-            case .success(true):
+            )
+            let outcome = self.logEvaluationResult(
+                result,
+                logPrefix: logPrefix,
+                ruleIndex: index + 1
+            )
+            if outcome.matched {
                 return rule
-            case .success(false):
-                continue
-            case .failure(let error):
-                switch error {
-                case .unresolvedVariable(let path):
-                    Logger.debug(Strings.localRules.ruleUnresolvedVariable(ruleIndex: index, path: path))
-                    continue
-                default:
-                    if firstEvaluationError == nil {
-                        firstEvaluationError = .predicateEvaluation(ruleIndex: index, error: error)
-                    }
-                }
+            }
+            if let error = outcome.error, firstEvaluationError == nil {
+                firstEvaluationError = .predicateEvaluation(ruleIndex: index, error: error)
             }
         }
 
@@ -109,4 +113,50 @@ final class LocalRulesEvaluator: Sendable {
 
         return nil
     }
+
+    private func logEvaluationResult(
+        _ result: Result<Bool, RulesEngine.EvaluationError>,
+        logPrefix: String,
+        ruleIndex: Int
+    ) -> (matched: Bool, error: RulesEngine.EvaluationError?) {
+        switch result {
+        case .success(true):
+            Logger.verbose(Strings.localRules.ruleMatched(logPrefix: logPrefix, ruleIndex: ruleIndex))
+            return (true, nil)
+        case .success(false):
+            Logger.verbose(Strings.localRules.ruleDidNotMatch(logPrefix: logPrefix, ruleIndex: ruleIndex))
+            return (false, nil)
+        case .failure(let error):
+            switch error {
+            case .unresolvedVariable(let path):
+                Logger.verbose(Strings.localRules.ruleUnresolvedVariable(
+                    logPrefix: logPrefix,
+                    ruleIndex: ruleIndex,
+                    path: path
+                ))
+                return (false, nil)
+            default:
+                Logger.debug(Strings.localRules.ruleEvaluationFailed(
+                    logPrefix: logPrefix,
+                    ruleIndex: ruleIndex,
+                    errorKind: error.logName
+                ))
+                return (false, error)
+            }
+        }
+    }
+}
+
+private extension RulesEngine.EvaluationError {
+
+    var logName: String {
+        switch self {
+        case .parse: return "Parse"
+        case .unresolvedVariable: return "UnresolvedVariable"
+        case .typeMismatch: return "TypeMismatch"
+        case .unsupportedOperator: return "UnsupportedOperator"
+        case .unknown: return "Unknown"
+        }
+    }
+
 }

--- a/Sources/Logging/Strings/LocalRulesStrings.swift
+++ b/Sources/Logging/Strings/LocalRulesStrings.swift
@@ -11,7 +11,11 @@ enum LocalRulesStrings {
 
     case customerInfoUnavailable(Error)
     case invalidDimensionName(String, parentPath: String)
-    case ruleUnresolvedVariable(ruleIndex: Int, path: String)
+    case evaluatingRules(logPrefix: String, ruleCount: Int, dimensions: [String])
+    case ruleMatched(logPrefix: String, ruleIndex: Int)
+    case ruleDidNotMatch(logPrefix: String, ruleIndex: Int)
+    case ruleUnresolvedVariable(logPrefix: String, ruleIndex: Int, path: String)
+    case ruleEvaluationFailed(logPrefix: String, ruleIndex: Int, errorKind: String)
     case subscriberAttributesUnavailable(Error)
     case subscriberDimensionsUnavailable(Error)
 
@@ -26,8 +30,17 @@ extension LocalRulesStrings: LogMessage {
         case let .invalidDimensionName(name, parentPath):
             return "Ignoring dimension name '\(name)' under '\(parentPath)': " +
                 "a dimension name cannot be empty, whitespace-only, or contain '.'."
-        case let .ruleUnresolvedVariable(ruleIndex, path):
-            return "Rule at index \(ruleIndex) did not match because variable '\(path)' could not be resolved."
+        case let .evaluatingRules(logPrefix, ruleCount, dimensions):
+            return "\(logPrefix)Evaluating \(ruleCount) rules against dimensions \(dimensions)."
+        case let .ruleMatched(logPrefix, ruleIndex):
+            return "\(logPrefix)Rule \(ruleIndex) matched."
+        case let .ruleDidNotMatch(logPrefix, ruleIndex):
+            return "\(logPrefix)Rule \(ruleIndex) did not match."
+        case let .ruleUnresolvedVariable(logPrefix, ruleIndex, path):
+            return "\(logPrefix)Rule \(ruleIndex) did not match: it reads '\(path)', " +
+                "which this SDK does not supply."
+        case let .ruleEvaluationFailed(logPrefix, ruleIndex, errorKind):
+            return "\(logPrefix)Rule \(ruleIndex) could not be evaluated (\(errorKind))."
         case let .subscriberAttributesUnavailable(error):
             return "The subscriber attributes are unavailable, so they cannot be evaluated: \(error)."
         case let .subscriberDimensionsUnavailable(error):

--- a/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
+++ b/Tests/UnitTests/Checkpoints/CheckpointWorkflowResolverTests.swift
@@ -140,6 +140,45 @@ final class DefaultCheckpointWorkflowResolverTests: TestCase {
         XCTAssertEqual(Self.noActionReason(resolution), .noMatch)
     }
 
+    func testLogsRuleEvaluationWithCheckpointPrefix() async throws {
+        let previousLogLevel = Purchases.logLevel
+        Purchases.logLevel = .verbose
+        defer { Purchases.logLevel = previousLogLevel }
+
+        let firstWorkflowID = "wf_first"
+        let secondWorkflowID = "wf_second"
+        self.checkpointsProvider.result = .success(CheckpointRuleSet(rules: [
+            Self.rule(workflowID: firstWorkflowID, audienceID: "audience_false"),
+            Self.rule(workflowID: secondWorkflowID, audienceID: "audience_true")
+        ]))
+        self.audiencesProvider.rulesByAudienceID = [
+            "audience_false": "false",
+            "audience_true": "true"
+        ]
+        self.workflowsProvider.stubbedOfferingIdByWorkflowId = [
+            firstWorkflowID: self.offeringID,
+            secondWorkflowID: self.offeringID
+        ]
+        self.workflowsProvider.stubbedGetWorkflowResult = [
+            firstWorkflowID: Self.workflowDataResult(id: firstWorkflowID),
+            secondWorkflowID: Self.workflowDataResult(id: secondWorkflowID)
+        ]
+
+        _ = try await self.resolve()
+
+        self.logger.verifyMessageWasLogged(
+            "[Checkpoint '\(self.checkpointIdentifier)'] Rule 1 did not match.",
+            level: .verbose
+        )
+        self.logger.verifyMessageWasLogged(
+            "[Checkpoint '\(self.checkpointIdentifier)'] Rule 2 matched.",
+            level: .verbose
+        )
+        XCTAssertTrue(self.logger.messages.allSatisfy {
+            !$0.message.contains("false") && !$0.message.contains("true")
+        })
+    }
+
     func testCheckpointWithNoWorkflowsResolvesConfigurationUnavailable() async throws {
         self.workflowsProvider.stubbedOfferingIdByWorkflowId = [:]
 

--- a/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
+++ b/Tests/UnitTests/LocalRules/LocalRulesEvaluatorTests.swift
@@ -17,6 +17,7 @@
 #if canImport(Testing)
 
 import Foundation
+import Nimble
 import Testing
 
 @testable import RevenueCat
@@ -413,6 +414,10 @@ struct LocalRulesEvaluatorTests {
         // A missing local value means this audience does not match. It should
         // not make the complete rules configuration unavailable.
         let logger = TestLogHandler(testIdentifier: #function)
+        let previousLogLevel = Purchases.logLevel
+        Purchases.logLevel = .verbose
+        defer { Purchases.logLevel = previousLogLevel }
+
         let evaluator = Self.evaluator(dimensionProviders: [
             TestDimensionProvider(
                 name: "device",
@@ -428,9 +433,13 @@ struct LocalRulesEvaluatorTests {
         ])
 
         #expect(rule == nil)
-        let expectedMessage = Strings.localRules.ruleUnresolvedVariable(ruleIndex: 0, path: "unknown")
+        let expectedMessage = Strings.localRules.ruleUnresolvedVariable(
+            logPrefix: "",
+            ruleIndex: 1,
+            path: "unknown"
+        )
         #expect(logger.messages.contains {
-            $0.level == .debug && $0.message.contains(expectedMessage.description)
+            $0.level == .verbose && $0.message.contains(expectedMessage.description)
         })
     }
 
@@ -481,6 +490,70 @@ struct LocalRulesEvaluatorTests {
         ])
 
         #expect(rule?.id == nil)
+    }
+
+    @Test
+    func logsEveryRuleOutcomeWithoutPredicatesOrValues() async throws {
+        let logger = TestLogHandler(testIdentifier: #function)
+        let previousLogLevel = Purchases.logLevel
+        Purchases.logLevel = .verbose
+        defer { Purchases.logLevel = previousLogLevel }
+
+        let evaluator = Self.evaluator(dimensionProviders: [
+            TestDimensionProvider(name: "device", snapshots: [["platform": .string("iOS")]])
+        ])
+
+        _ = try? await evaluator.match(in: [
+            TestLocalRule(id: "first", predicate: "false"),
+            TestLocalRule(id: "second", predicate: "true")
+        ])
+
+        logger.verifyMessageWasLogged(
+            "Evaluating 2 rules against dimensions [\"evaluated_at\", \"platform\"].",
+            level: .verbose
+        )
+        logger.verifyMessageWasLogged("Rule 1 did not match.", level: .verbose)
+        logger.verifyMessageWasLogged("Rule 2 matched.", level: .verbose)
+        #expect(logger.messages.allSatisfy {
+            !$0.message.contains("false") && !$0.message.contains("true") && !$0.message.contains("iOS")
+        })
+    }
+
+    @Test
+    func logsUnresolvedDimensionsByName() async throws {
+        let logger = TestLogHandler(testIdentifier: #function)
+        let previousLogLevel = Purchases.logLevel
+        Purchases.logLevel = .verbose
+        defer { Purchases.logLevel = previousLogLevel }
+
+        let evaluator = Self.evaluator(dimensionProviders: [])
+
+        _ = try? await evaluator.match(in: [
+            TestLocalRule(id: "missing", predicate: #"{"var":"unknown_dimension"}"#)
+        ])
+
+        logger.verifyMessageWasLogged(
+            "Rule 1 did not match: it reads 'unknown_dimension', which this SDK does not supply.",
+            level: .verbose
+        )
+        #expect(logger.messages.allSatisfy { !$0.message.contains(#"{"var":"unknown_dimension"}"#) })
+    }
+
+    @Test
+    func logsUnevaluablePredicatesByFailureKind() async throws {
+        let logger = TestLogHandler(testIdentifier: #function)
+        let previousLogLevel = Purchases.logLevel
+        Purchases.logLevel = .verbose
+        defer { Purchases.logLevel = previousLogLevel }
+
+        let evaluator = Self.evaluator(dimensionProviders: [])
+
+        _ = try? await evaluator.match(in: [
+            TestLocalRule(id: "malformed", predicate: "{not-json")
+        ])
+
+        logger.verifyMessageWasLogged("Rule 1 could not be evaluated (Parse).", level: .debug)
+        #expect(logger.messages.allSatisfy { !$0.message.contains("{not-json") })
     }
 
     @Test


### PR DESCRIPTION
## Description
Adds logging to the Checkpoint local rule evaluation, aligned with [Android](https://github.com/RevenueCat/purchases-android/pull/4187)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes with default-empty log prefix; rule matching semantics are unchanged aside from log levels for unresolved variables.
> 
> **Overview**
> Adds **verbose diagnostic logging** for local rule evaluation during checkpoint resolution, aligned with Android. Checkpoint resolution now passes a **`[Checkpoint '<id>'] ` log prefix** into `LocalRulesEvaluator` so rule walk messages are attributable to a specific checkpoint.
> 
> **`LocalRulesEvaluator`** logs at **verbose**: how many rules run, which **dimension names** (sorted keys only) are in the snapshot, and per-rule outcomes (matched / did not match / reads an SDK-unsupplied variable). **Malformed or otherwise unevaluable predicates** still surface as **debug** logs with an error kind (e.g. Parse), without printing predicate JSON or dimension values. Rule indices in logs are **1-based**.
> 
> New and updated unit tests assert log content, levels, checkpoint prefixing, and that logs never contain predicate literals or dimension values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dbd1a9f6799a485fc65449ca19d2ea5d0d2a8a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->