### PR TITLE
Fix Paywall V2 rendering when components are provided by an offering

### DIFF
--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -368,6 +368,11 @@ extension PurchaseHandler {
             return .init(offering: offering, workflowContext: nil)
         }
 
+        if case let .offering(offering) = content,
+           offering.internalPaywallComponents != nil {
+            return .init(offering: offering, workflowContext: nil)
+        }
+
         guard let cachedOfferings = self.purchases.cachedOfferings,
               let offering = self.initialOffering(
                 content: content,
@@ -544,17 +549,17 @@ extension PurchaseHandler {
         return try await self.purchases.offerings()
     }
 
-    /// Routes a resolved offering to its own (legacy) paywall or the workflows endpoint.
-    /// `offering.paywall == nil` is the durable marker of a non-legacy paywall: a v1 paywall always
-    /// carries `paywall`, so a legacy offering renders directly without a workflow fetch. When the
-    /// offering simply has no workflow attached, it falls back to the default paywall (matching the
-    /// legacy path). Other failures (e.g. network, malformed workflow) propagate.
+    /// Routes a resolved offering to its attached paywall or the workflows endpoint. Offerings
+    /// decoded from the backend retain only `hasPaywallComponents`, so an actual components payload
+    /// identifies a render-ready offering supplied by a preview client.
     private func resolvePaywallViewData(
         for offering: Offering,
         offerings: Offerings?,
         remoteConfigEnabled: Bool
     ) async throws -> ResolvedPaywallViewData {
-        guard remoteConfigEnabled, offering.paywall == nil else {
+        guard remoteConfigEnabled,
+              offering.paywall == nil,
+              offering.internalPaywallComponents == nil else {
             return .init(offering: offering, workflowContext: nil)
         }
 

--- a/Tests/RevenueCatUITests/Data/PaywallViewConfigurationTests.swift
+++ b/Tests/RevenueCatUITests/Data/PaywallViewConfigurationTests.swift
@@ -127,6 +127,35 @@ final class PaywallViewConfigurationTests: TestCase {
         expect(result?.workflowContext?.workflow.id) == workflowContext.workflow.id
     }
 
+    func testCachedInitialPaywallViewDataUsesProvidedOfferingWithPaywallComponents() throws {
+        let (offering, _, handler) = try Self.createOfferingWithPaywallComponentsFixture()
+
+        let result = handler.cachedInitialPaywallViewData(
+            for: .offering(offering),
+            remoteConfigEnabled: true
+        )
+
+        expect(result?.offering) === offering
+        expect(result?.workflowContext).to(beNil())
+    }
+
+    func testCachedInitialPaywallViewDataDoesNotTreatComponentsMarkerAsProvidedPayload() {
+        let offering = Self.createOfferingWithPaywallComponentsMarker(identifier: "offering_a")
+        let purchases = Self.createMockPurchases()
+        let handler = Self.createPurchaseHandler(purchases: purchases)
+        purchases.cachedOfferings = Self.createOfferings(
+            [offering],
+            currentOfferingID: offering.identifier
+        )
+
+        let result = handler.cachedInitialPaywallViewData(
+            for: .offering(offering),
+            remoteConfigEnabled: true
+        )
+
+        expect(result).to(beNil())
+    }
+
     func testResolvePaywallViewDataReturnsNilWorkflowContextWhenRemoteConfigDisabled() async throws {
         let initialOffering = Self.createOffering(identifier: "offering_a")
             .withPresentedOfferingContext(Self.createPresentedOfferingContext(offeringIdentifier: "offering_a"))
@@ -292,22 +321,43 @@ final class PaywallViewConfigurationTests: TestCase {
         expect(packageContext.offeringIdentifier) == initialOffering.identifier
     }
 
-    func testResolvePaywallViewDataThrowsWhenWorkflowFetchFailsEvenWithPaywallComponents() async throws {
+    func testResolvePaywallViewDataUsesProvidedOfferingWithPaywallComponents() async throws {
         let (offering, purchases, handler) = try Self.createOfferingWithPaywallComponentsFixture()
         expect(offering.internalPaywallComponents).toNot(beNil())
         purchases.workflowBlock = { _ in
-            throw ErrorCode.networkError
+            XCTFail("Workflow endpoint should not be fetched for a provided render-ready offering")
+            throw ErrorCode.configurationError
         }
 
-        do {
-            _ = try await handler.resolvePaywallViewData(
-                for: .offering(offering),
-                remoteConfigEnabled: true
-            )
-            XCTFail("Expected resolvePaywallViewData to throw")
-        } catch {
-            expect((error as? ErrorCode)) == ErrorCode.networkError
+        let result = try await handler.resolvePaywallViewData(
+            for: .offering(offering),
+            remoteConfigEnabled: true
+        )
+
+        expect(result.offering) === offering
+        expect(result.workflowContext).to(beNil())
+    }
+
+    func testResolvePaywallViewDataFetchesWorkflowForComponentsMarkerWithoutPayload() async throws {
+        let initialOffering = Self.createOfferingWithPaywallComponentsMarker(identifier: "offering_a")
+        let workflowOffering = Self.createOffering(identifier: "offering_b")
+        let purchases = Self.createMockPurchases()
+        let handler = Self.createPurchaseHandler(purchases: purchases)
+        purchases.offeringsBlock = {
+            Self.createOfferings([initialOffering, workflowOffering])
         }
+        purchases.workflowBlock = { offeringIdentifier in
+            expect(offeringIdentifier) == initialOffering.identifier
+            return try Self.createWorkflowDataResult(offeringIdentifier: workflowOffering.identifier)
+        }
+
+        let result = try await handler.resolvePaywallViewData(
+            for: .offering(initialOffering),
+            remoteConfigEnabled: true
+        )
+
+        expect(result.offering.identifier) == workflowOffering.identifier
+        expect(result.workflowContext?.workflow.id) == "wf_test"
     }
 
     func testResolvePaywallViewDataThrowsWhenWorkflowUiConfigUnavailable() async throws {
@@ -619,6 +669,19 @@ private extension PaywallViewConfigurationTests {
             serverDescription: "Offering \(identifier)",
             metadata: [:],
             paywall: paywall,
+            availablePackages: TestData.packages,
+            webCheckoutUrl: nil
+        )
+    }
+
+    static func createOfferingWithPaywallComponentsMarker(identifier: String) -> Offering {
+        return Offering(
+            identifier: identifier,
+            serverDescription: "Offering \(identifier)",
+            metadata: [:],
+            paywall: nil,
+            paywallComponents: nil,
+            hasPaywallComponents: true,
             availablePackages: TestData.packages,
             webCheckoutUrl: nil
         )


### PR DESCRIPTION
## Description
Follow up fix after merging https://github.com/RevenueCat/purchases-ios/pull/7524, only after which I noticed one [job failed](https://app.circleci.com/pipelines/gh/RevenueCat/purchases-ios/43561/workflows/bd3264ca-240c-4e11-a5eb-ba01de46d3e7/jobs/770110) (`run-paywall-accessibility-ui-tests`) 🤦‍♂️

That PR broke a very specific path for resolving `ResolvedPaywallViewData`, where an `Offering` is passed, containing `paywallComponents`. These are no longer decoded or set by the production regular code paths, but still in two specific cases.
- The mobile app, which may use this codepath in case a V2 paywall does not have a (valid) corresponding workflow
- Previews / tests, which caused failures in `run-paywall-accessibility-ui-tests`, where as a fallback the workflow was attempted to be fetched from the server. Which does not exist, since it is using local fixtures.

## Changes
The fix was to internally just return the `.offering(offering)` directly when an offering is passed with valid paywallComponents. Bypassing cache lookup and network calls.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall routing when remote config is enabled—a core presentation path—but scope is narrow (explicit components payload vs workflow) with targeted tests.
> 
> **Overview**
> Fixes Paywall V2 resolution when callers pass an `Offering` that already carries **render-ready** paywall components (previews, accessibility UI tests, and mobile paths without a workflow). Previously, with remote config on, those offerings were treated like backend offerings that only expose `hasPaywallComponents`, so the SDK still tried to load a workflow and failed on local fixtures.
> 
> **`PurchaseHandler`** now short-circuits when `internalPaywallComponents` is set: both the cached initial path and `resolvePaywallViewData` return the supplied offering with no workflow fetch. Offerings that only have the **`hasPaywallComponents` marker** (no payload) still go through the workflow endpoint as before.
> 
> Tests were updated to cover the provided-components path, assert the marker alone is not treated as a full payload, and confirm workflow resolution still runs when only the marker is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab872c17eedabdf9276b8c64e991c19c302a80be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->