### PR TITLE
Add a dangerous setting for external purchase custom links

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -19,48 +19,12 @@
       }
     },
     {
-      "identity" : "flyingfox",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swhitty/FlyingFox.git",
-      "state" : {
-        "revision" : "f7829d4aca8cbfecb410a1cce872b1b045224aa1",
-        "version" : "0.16.0"
-      }
-    },
-    {
       "identity" : "nimble",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/quick/nimble",
       "state" : {
         "revision" : "7795df4fff1a9cd231fe4867ae54f4dc5f5734f9",
         "version" : "13.7.1"
-      }
-    },
-    {
-      "identity" : "ohhttpstubs",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/AliSoftware/OHHTTPStubs.git",
-      "state" : {
-        "revision" : "12f19662426d0434d6c330c6974d53e2eb10ecd9",
-        "version" : "9.1.0"
-      }
-    },
-    {
-      "identity" : "simpledebugger",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/EmergeTools/SimpleDebugger.git",
-      "state" : {
-        "revision" : "f065263eb5db95874b690408d136b573c939db9e",
-        "version" : "1.0.0"
-      }
-    },
-    {
-      "identity" : "snapshotpreviews",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/EmergeTools/SnapshotPreviews.git",
-      "state" : {
-        "revision" : "d42446f0439217941a4e3a2ca58a643c1ac328c4",
-        "version" : "0.14.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -19,12 +19,48 @@
       }
     },
     {
+      "identity" : "flyingfox",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swhitty/FlyingFox.git",
+      "state" : {
+        "revision" : "f7829d4aca8cbfecb410a1cce872b1b045224aa1",
+        "version" : "0.16.0"
+      }
+    },
+    {
       "identity" : "nimble",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/quick/nimble",
       "state" : {
         "revision" : "7795df4fff1a9cd231fe4867ae54f4dc5f5734f9",
         "version" : "13.7.1"
+      }
+    },
+    {
+      "identity" : "ohhttpstubs",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/AliSoftware/OHHTTPStubs.git",
+      "state" : {
+        "revision" : "12f19662426d0434d6c330c6974d53e2eb10ecd9",
+        "version" : "9.1.0"
+      }
+    },
+    {
+      "identity" : "simpledebugger",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/EmergeTools/SimpleDebugger.git",
+      "state" : {
+        "revision" : "f065263eb5db95874b690408d136b573c939db9e",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "snapshotpreviews",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/EmergeTools/SnapshotPreviews.git",
+      "state" : {
+        "revision" : "d42446f0439217941a4e3a2ca58a643c1ac328c4",
+        "version" : "0.14.1"
       }
     },
     {

--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -61,6 +61,7 @@ import Foundation
         let uiPreviewMode: Bool
         let customEntitlementComputation: Bool
         let forceAllowTestStoreInReleaseBuilds: Bool
+        let useExternalPurchaseCustomLinks: Bool
     }
 
     internal let storage: Storage
@@ -105,6 +106,18 @@ import Foundation
      * never uploaded to the App Store), to make sure no builds using the Test Store reach the stores.
      */
     @objc public var forceAllowTestStoreInReleaseBuilds: Bool { self.storage.forceAllowTestStoreInReleaseBuilds }
+
+    /**
+     * Whether a web purchase button that opens its link in the external browser takes part in Apple's
+     * external purchase custom link programme: the customer is shown Apple's disclosure notice, and the
+     * purchase is reported to Apple.
+     *
+     * Disabled by default. Enabling it requires the app to be enrolled in the programme and to carry the
+     * corresponding entitlement, so only enable it if RevenueCat has asked you to.
+     */
+    @_spi(Experimental) public var useExternalPurchaseCustomLinks: Bool {
+        self.storage.useExternalPurchaseCustomLinks
+    }
 
     @objc public override convenience init() {
         self.init(autoSyncPurchases: true)
@@ -152,6 +165,23 @@ import Foundation
     }
 
     /**
+     * Only use a Dangerous Setting if suggested by RevenueCat support team.
+     *
+     * - Parameter autoSyncPurchases: Disable or enable subscribing to the StoreKit queue.
+     * If this is disabled, RevenueCat won't observe the StoreKit queue, and it will not sync any purchase
+     * automatically.
+     * - Parameter useExternalPurchaseCustomLinks: Whether a web purchase button that opens its link in the
+     * external browser takes part in Apple's external purchase custom link programme.
+     */
+    @_spi(Experimental) public convenience init(autoSyncPurchases: Bool,
+                                                useExternalPurchaseCustomLinks: Bool) {
+        self.init(autoSyncPurchases: autoSyncPurchases,
+                  customEntitlementComputation: false,
+                  internalSettings: Internal.default,
+                  useExternalPurchaseCustomLinks: useExternalPurchaseCustomLinks)
+    }
+
+    /**
      * Used to initialize the SDK in UI preview mode.
      *
      * - Parameter uiPreviewMode: if `true`, the SDK will return a set of mock products instead
@@ -166,12 +196,14 @@ import Foundation
                   customEntitlementComputation: Bool = false,
                   internalSettings: InternalDangerousSettingsType,
                   uiPreviewMode: Bool = false,
-                  forceAllowTestStoreInReleaseBuilds: Bool = false) {
+                  forceAllowTestStoreInReleaseBuilds: Bool = false,
+                  useExternalPurchaseCustomLinks: Bool = false) {
         self.storage = Storage(
             autoSyncPurchases: autoSyncPurchases,
             uiPreviewMode: uiPreviewMode,
             customEntitlementComputation: customEntitlementComputation,
-            forceAllowTestStoreInReleaseBuilds: forceAllowTestStoreInReleaseBuilds
+            forceAllowTestStoreInReleaseBuilds: forceAllowTestStoreInReleaseBuilds,
+            useExternalPurchaseCustomLinks: useExternalPurchaseCustomLinks
         )
         self.internalSettings = internalSettings
     }

--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -113,7 +113,7 @@ import Foundation
      * purchase is reported to Apple.
      *
      * Disabled by default. Enabling it requires the app to be enrolled in the programme and to carry the
-     * corresponding entitlement, so only enable it if RevenueCat has asked you to.
+     * corresponding entitlement.
      */
     @_spi(Experimental) public var useExternalPurchaseCustomLinks: Bool {
         self.storage.useExternalPurchaseCustomLinks
@@ -165,8 +165,6 @@ import Foundation
     }
 
     /**
-     * Only use a Dangerous Setting if suggested by RevenueCat support team.
-     *
      * - Parameter autoSyncPurchases: Disable or enable subscribing to the StoreKit queue.
      * If this is disabled, RevenueCat won't observe the StoreKit queue, and it will not sync any purchase
      * automatically.

--- a/Tests/APITesters/AllAPITests/SwiftAPITester/DangerousSettingsAPI.swift
+++ b/Tests/APITesters/AllAPITests/SwiftAPITester/DangerousSettingsAPI.swift
@@ -11,16 +11,18 @@
 //
 //  Created by Antonio Pallares on 28/1/25.
 
-@_spi(Internal) import RevenueCat
+@_spi(Experimental) @_spi(Internal) import RevenueCat
 
 func checkDangerousSettingsAPI() {
     let _: DangerousSettings = DangerousSettings()
     let _: DangerousSettings = DangerousSettings(autoSyncPurchases: true)
     let _: DangerousSettings = DangerousSettings(autoSyncPurchases: true, forceAllowTestStoreInReleaseBuilds: true)
+    let _: DangerousSettings = DangerousSettings(autoSyncPurchases: true, useExternalPurchaseCustomLinks: true)
     let settings: DangerousSettings = DangerousSettings(uiPreviewMode: true)
 
     let _: Bool = settings.autoSyncPurchases
     let _: Bool = settings.customEntitlementComputation
     let _: Bool = settings.uiPreviewMode
     let _: Bool = settings.forceAllowTestStoreInReleaseBuilds
+    let _: Bool = settings.useExternalPurchaseCustomLinks
 }

--- a/Tests/UnitTests/Misc/DangerousSettingsTests.swift
+++ b/Tests/UnitTests/Misc/DangerousSettingsTests.swift
@@ -15,7 +15,7 @@ import Foundation
 import Nimble
 import XCTest
 
-@_spi(Internal) @testable import RevenueCat
+@_spi(Experimental) @_spi(Internal) @testable import RevenueCat
 
 final class DangerousSettingsTests: TestCase {
 
@@ -55,6 +55,11 @@ final class DangerousSettingsTests: TestCase {
             != DangerousSettings(autoSyncPurchases: true, forceAllowTestStoreInReleaseBuilds: false)
     }
 
+    func testDifferentUseExternalPurchaseCustomLinksIsNotEqual() {
+        expect(DangerousSettings(autoSyncPurchases: true, useExternalPurchaseCustomLinks: true))
+            != DangerousSettings(autoSyncPurchases: true, useExternalPurchaseCustomLinks: false)
+    }
+
     func testInternalSettingsAreExcludedFromEquality() {
         let defaultInternal: InternalDangerousSettingsType = DangerousSettings.Internal.default
         let customInternal: InternalDangerousSettingsType = DangerousSettings.Internal(enableReceiptFetchRetry: true)
@@ -81,6 +86,24 @@ final class DangerousSettingsTests: TestCase {
         expect(settings.autoSyncPurchases) == false
         expect(settings.uiPreviewMode) == false
         expect(settings.customEntitlementComputation) == false
+    }
+
+    // MARK: - useExternalPurchaseCustomLinks
+
+    func testUseExternalPurchaseCustomLinksIsDisabledByDefault() {
+        expect(DangerousSettings().useExternalPurchaseCustomLinks) == false
+        expect(DangerousSettings(autoSyncPurchases: false).useExternalPurchaseCustomLinks) == false
+        expect(DangerousSettings(uiPreviewMode: true).useExternalPurchaseCustomLinks) == false
+    }
+
+    func testUseExternalPurchaseCustomLinksCanBeEnabled() {
+        let settings = DangerousSettings(autoSyncPurchases: false, useExternalPurchaseCustomLinks: true)
+
+        expect(settings.useExternalPurchaseCustomLinks) == true
+        expect(settings.autoSyncPurchases) == false
+        expect(settings.uiPreviewMode) == false
+        expect(settings.customEntitlementComputation) == false
+        expect(settings.forceAllowTestStoreInReleaseBuilds) == false
     }
 
     // MARK: - Internal settings


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

The external purchase custom link flow needs a switch so it can be enabled per app.

### Description

Adds `useExternalPurchaseCustomLinks` dangerous setting.
- Changes no behaviour: nothing reads `useExternalPurchaseCustomLinks` yet. Read in #7663 
- `@_spi(Experimental)` and not `@objc`, so it stays out of the consumer-facing surface while the flow is in early access.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a defaulted-off experimental setting with no runtime consumers in this PR; surface is SPI-only and excluded from Obj-C API.
> 
> **Overview**
> Adds an experimental **`DangerousSettings.useExternalPurchaseCustomLinks`** flag (default **off**) so apps can opt into Apple’s external purchase custom link programme for web purchase buttons that open in the external browser (disclosure + reporting to Apple).
> 
> The value is stored in **`Storage`** for **`Hashable`/equality**, exposed via **`@_spi(Experimental)`** (not **`@objc`**), with a new convenience initializer **`DangerousSettings(autoSyncPurchases:useExternalPurchaseCustomLinks:)`**. **No SDK behaviour reads this setting yet**—it’s configuration-only until a follow-up wires it up. API tester and unit tests cover defaults, enabling, and equality.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fa5202473a1f47c904808627fd6010803d5931a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->