### PR TITLE
Remove assertion

### DIFF
--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -467,8 +467,6 @@ extension HTTPRequest.Path: HTTPRequestPath {
             return "subscribers/\(Self.escape(appUserID))/virtual_currencies"
 
         case .spendVirtualCurrencies:
-            assertionFailure("The .spendVirtualCurrencies endpoint is only allowed when IAM is enabled")
-            Logger.error("The .spendVirtualCurrencies endpoint is only allowed when IAM is enabled")
             return "customer/virtual_currencies/spend"
 
         case .postCreateTicket:


### PR DESCRIPTION
The non-IAM path is used when logging (it's part of the `.description`), so even when IAM is enabled, this can still cause issues. Attempting to spend without enabling IAM will still fail.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only behavior change; no change to which URL is used for authenticated IAM requests or server-side enforcement.
> 
> **Overview**
> Removes **`assertionFailure`** and **`Logger.error`** from the `.spendVirtualCurrencies` branch in `HTTPRequest.Path.pathComponent`, so resolving the non-IAM relative path no longer crashes or logs an error when that case is evaluated.
> 
> That path is still returned for descriptions and logging (e.g. `NetworkStrings` uses `path.relativePath`) even when IAM is enabled and real traffic uses `relativeIAMPath`. Actual spend calls without IAM remain blocked elsewhere; this only fixes incorrect guards on path string construction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e0b0580c1bcc3c5a6937a3836d79d5d4ed7aa98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->