### PR TITLE
Wire countdown component overrides for visibility gating

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -3307,6 +3307,7 @@
 		E78770053AB84EF380CC0C1D /* TextComponentViewLoadingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextComponentViewLoadingTests.swift; sourceTree = "<group>"; };
 		E7D46162A95A4706925EC868 /* TabControlHapticFeedbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabControlHapticFeedbackTests.swift; sourceTree = "<group>"; };
 		E7EAAD1DC166ABD68E484EAA /* RootViewSheetDismissalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewSheetDismissalTests.swift; sourceTree = "<group>"; };
+		C0D47E51A9B3F2C4D8E60A17 /* CountdownComponentViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountdownComponentViewTests.swift; sourceTree = "<group>"; };
 		E7EB64E9D44783DD16A28B05 /* WebViewComponentViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewComponentViewTests.swift; sourceTree = "<group>"; };
 		ECCBB32E1734BAD9232A3001 /* CapturingLogger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CapturingLogger.swift; sourceTree = "<group>"; };
 		ECEA10EF63BC10F9BE6DB9F5 /* WorkflowPreviewTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowPreviewTests.swift; sourceTree = "<group>"; };
@@ -3583,6 +3584,7 @@
 		030890822D2B77DD0069677B /* PaywallsV2 */ = {
 			isa = PBXGroup;
 			children = (
+				C0D47E51A9B3F2C4D8E60A17 /* CountdownComponentViewTests.swift */,
 				E7EB64E9D44783DD16A28B05 /* WebViewComponentViewTests.swift */,
 				C3E609D42BFA15783D609EB2 /* WebViewInstanceTests.swift */,
 				9E7AD021B4580265DFDF6A02 /* WebViewComponentNavigationPolicyTests.swift */,

--- a/RevenueCatUI/Templates/V2/Components/Countdown/CountdownComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Countdown/CountdownComponentView.swift
@@ -39,6 +39,9 @@ struct CountdownComponentView: View {
     @Environment(\.paywallStateDefaults)
     private var paywallStateDefaults
 
+    @Environment(\.paywallWindowSize)
+    private var paywallWindowSize
+
     private let viewModel: CountdownComponentViewModel
     private let onDismiss: () -> Void
 
@@ -66,7 +69,8 @@ struct CountdownComponentView: View {
             selectedPackageId: self.selectedPackageId,
             customVariables: self.customVariables,
             stateValues: self.paywallStateValues,
-            stateDefaults: self.paywallStateDefaults
+            stateDefaults: self.paywallStateDefaults,
+            windowSize: self.paywallWindowSize
         )
     }
 

--- a/RevenueCatUI/Templates/V2/Components/Countdown/CountdownComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Countdown/CountdownComponentView.swift
@@ -14,6 +14,31 @@ import SwiftUI
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct CountdownComponentView: View {
 
+    @EnvironmentObject
+    private var packageContext: PackageContext
+
+    @EnvironmentObject
+    private var introOfferEligibilityContext: IntroOfferEligibilityContext
+
+    @EnvironmentObject
+    private var paywallPromoOfferCache: PaywallPromoOfferCache
+
+    @Environment(\.componentViewState)
+    private var componentViewState
+
+    @Environment(\.screenCondition)
+    private var screenCondition
+
+    @Environment(\.customPaywallVariables)
+    private var customVariables
+    @Environment(\.selectedPackageId)
+    private var selectedPackageId
+
+    @Environment(\.paywallStateValues)
+    private var paywallStateValues
+    @Environment(\.paywallStateDefaults)
+    private var paywallStateDefaults
+
     private let viewModel: CountdownComponentViewModel
     private let onDismiss: () -> Void
 
@@ -31,7 +56,27 @@ struct CountdownComponentView: View {
         ))
     }
 
+    private var visible: Bool {
+        let currentPackage = self.packageContext.package
+        return self.viewModel.visible(
+            state: self.componentViewState,
+            condition: self.screenCondition,
+            isEligibleForIntroOffer: self.introOfferEligibilityContext.isEligible(package: currentPackage),
+            isEligibleForPromoOffer: self.paywallPromoOfferCache.isMostLikelyEligible(for: currentPackage),
+            selectedPackageId: self.selectedPackageId,
+            customVariables: self.customVariables,
+            stateValues: self.paywallStateValues,
+            stateDefaults: self.paywallStateDefaults
+        )
+    }
+
     var body: some View {
+        if self.visible {
+            self.countdownContent
+        }
+    }
+
+    private var countdownContent: some View {
         Group {
             if let endStackViewModel = viewModel.endStackViewModel, countdownState.hasEnded {
                 StackComponentView(
@@ -99,6 +144,7 @@ struct CountdownComponentView_Previews: PreviewProvider {
                         padding: .init(top: 20, bottom: 20, leading: 20, trailing: 20)
                     )
                 ),
+                uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
                 // swiftlint:disable:next force_try
                 countdownStackViewModel: try! .init(
                     component: .init(

--- a/RevenueCatUI/Templates/V2/Components/Countdown/CountdownComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Countdown/CountdownComponentViewModel.swift
@@ -124,6 +124,8 @@ final class CountdownState: ObservableObject {
     // MARK: - Public API
 
     func start() {
+        updateCountdown()
+
         guard self.timer == nil, self.targetDate != nil, !self.hasEnded else { return }
 
         let timer = Timer.publish(every: 1.0, on: RunLoop.main, in: .default)

--- a/RevenueCatUI/Templates/V2/Components/Countdown/CountdownComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Countdown/CountdownComponentViewModel.swift
@@ -54,13 +54,15 @@ class CountdownComponentViewModel {
         selectedPackageId: String?,
         customVariables: [String: CustomVariableValue],
         stateValues: [String: PaywallComponent.ConditionValue] = [:],
-        stateDefaults: [String: PaywallComponent.ConditionValue] = [:]
+        stateDefaults: [String: PaywallComponent.ConditionValue] = [:],
+        windowSize: CGSize? = nil
     ) -> Bool {
         let conditionContext = self.uiConfigProvider.conditionContext(
             selectedPackageId: selectedPackageId,
             customVariables: customVariables,
             stateValues: stateValues,
-            stateDefaults: stateDefaults
+            stateDefaults: stateDefaults,
+            windowSize: windowSize
         )
 
         let partial = PresentedCountdownPartial.buildPartial(

--- a/RevenueCatUI/Templates/V2/Components/Countdown/CountdownComponentViewModel.swift
+++ b/RevenueCatUI/Templates/V2/Components/Countdown/CountdownComponentViewModel.swift
@@ -11,11 +11,12 @@ import Foundation
 
 #if !os(tvOS) // For Paywalls V2
 
+typealias PresentedCountdownPartial = PaywallComponent.PartialCountdownComponent
+
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-// Note: CountdownComponent has an `overrides` property in its data model, but condition evaluation
-// is not wired here. Overrides are handled by the child stack view models (countdownStack, endStack,
+// Note: The component-level `overrides` are evaluated here only to gate the visibility of the whole
+// countdown. Styling overrides are handled by the child stack view models (countdownStack, endStack,
 // fallbackStack), which each support conditional configurability independently.
-// This is consistent with the Android SDK.
 class CountdownComponentViewModel {
 
     let component: PaywallComponent.CountdownComponent
@@ -23,16 +24,69 @@ class CountdownComponentViewModel {
     let endStackViewModel: StackComponentViewModel?
     let fallbackStackViewModel: StackComponentViewModel?
 
+    private let uiConfigProvider: UIConfigProvider
+    private let presentedOverrides: PresentedOverrides<PresentedCountdownPartial>?
+
     init(
         component: PaywallComponent.CountdownComponent,
+        uiConfigProvider: UIConfigProvider,
         countdownStackViewModel: StackComponentViewModel,
         endStackViewModel: StackComponentViewModel?,
-        fallbackStackViewModel: StackComponentViewModel?
+        fallbackStackViewModel: StackComponentViewModel?,
+        discardRules: Bool = false
     ) {
         self.component = component
+        self.uiConfigProvider = uiConfigProvider
         self.countdownStackViewModel = countdownStackViewModel
         self.endStackViewModel = endStackViewModel
         self.fallbackStackViewModel = fallbackStackViewModel
+        self.presentedOverrides = component.overrides?.toPresentedOverrides(discardRules: discardRules)
+    }
+
+    /// Resolves whether the countdown should be rendered for the current presentation context,
+    /// applying any matching overrides on top of the base component value.
+    // swiftlint:disable:next function_parameter_count
+    func visible(
+        state: ComponentViewState,
+        condition: ScreenCondition,
+        isEligibleForIntroOffer: Bool,
+        isEligibleForPromoOffer: Bool,
+        selectedPackageId: String?,
+        customVariables: [String: CustomVariableValue],
+        stateValues: [String: PaywallComponent.ConditionValue] = [:],
+        stateDefaults: [String: PaywallComponent.ConditionValue] = [:]
+    ) -> Bool {
+        let conditionContext = self.uiConfigProvider.conditionContext(
+            selectedPackageId: selectedPackageId,
+            customVariables: customVariables,
+            stateValues: stateValues,
+            stateDefaults: stateDefaults
+        )
+
+        let partial = PresentedCountdownPartial.buildPartial(
+            state: state,
+            condition: condition,
+            isEligibleForIntroOffer: isEligibleForIntroOffer,
+            isEligibleForPromoOffer: isEligibleForPromoOffer,
+            conditionContext: conditionContext,
+            with: self.presentedOverrides
+        )
+
+        return partial?.visible ?? self.component.visible ?? true
+    }
+
+}
+
+extension PresentedCountdownPartial: PresentedPartial {
+
+    static func combine(
+        _ base: PaywallComponent.PartialCountdownComponent?,
+        with other: PaywallComponent.PartialCountdownComponent?
+    ) -> Self {
+        return .init(
+            visible: other?.visible ?? base?.visible,
+            style: other?.style ?? base?.style
+        )
     }
 
 }

--- a/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
+++ b/RevenueCatUI/Templates/V2/ViewModelHelpers/ViewModelFactory.swift
@@ -510,9 +510,11 @@ struct ViewModelFactory {
             return .countdown(
                 CountdownComponentViewModel(
                     component: component,
+                    uiConfigProvider: uiConfigProvider,
                     countdownStackViewModel: countdownStackViewModel,
                     endStackViewModel: endStackViewModel,
-                    fallbackStackViewModel: fallbackStackViewModel
+                    fallbackStackViewModel: fallbackStackViewModel,
+                    discardRules: discardRules
                 )
             )
         case .webView(let component):

--- a/Sources/Paywalls/Components/PaywallCountdownComponent.swift
+++ b/Sources/Paywalls/Components/PaywallCountdownComponent.swift
@@ -21,6 +21,7 @@ import Foundation
 
         let type: ComponentType
         public let name: String?
+        public let visible: Bool?
         public let style: CountdownStyle
         public let countFrom: CountFrom
         public let countdownStack: PaywallComponent.StackComponent
@@ -31,6 +32,7 @@ import Foundation
         public init(
             id: String? = nil,
             name: String? = nil,
+            visible: Bool? = nil,
             style: CountdownStyle,
             countFrom: CountFrom,
             countdownStack: PaywallComponent.StackComponent,
@@ -40,6 +42,7 @@ import Foundation
         ) {
             self.type = .countdown
             self.name = name
+            self.visible = visible
             self.style = style
             self.countFrom = countFrom
             self.countdownStack = countdownStack
@@ -51,6 +54,7 @@ import Foundation
         private enum CodingKeys: String, CodingKey {
             case type
             case name
+            case visible
             case style
             case countFrom
             case countdownStack
@@ -63,6 +67,7 @@ import Foundation
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.type = try container.decode(ComponentType.self, forKey: .type)
             self.name = try container.decodeIfPresent(String.self, forKey: .name)
+            self.visible = try container.decodeIfPresent(Bool.self, forKey: .visible)
             self.style = try container.decode(CountdownStyle.self, forKey: .style)
             self.countFrom = try container.decode(CountFrom.self, forKey: .countFrom)
             self.countdownStack = try container.decode(PaywallComponent.StackComponent.self, forKey: .countdownStack)
@@ -78,6 +83,7 @@ import Foundation
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(type, forKey: .type)
             try container.encodeIfPresent(name, forKey: .name)
+            try container.encodeIfPresent(visible, forKey: .visible)
             try container.encode(style, forKey: .style)
             try container.encode(countFrom, forKey: .countFrom)
             try container.encode(countdownStack, forKey: .countdownStack)
@@ -89,6 +95,7 @@ import Foundation
         public func hash(into hasher: inout Hasher) {
             hasher.combine(type)
             hasher.combine(name)
+            hasher.combine(visible)
             hasher.combine(style)
             hasher.combine(countFrom)
             hasher.combine(countdownStack)
@@ -100,6 +107,7 @@ import Foundation
         public static func == (lhs: CountdownComponent, rhs: CountdownComponent) -> Bool {
             return lhs.type == rhs.type &&
                    lhs.name == rhs.name &&
+                   lhs.visible == rhs.visible &&
                    lhs.style == rhs.style &&
                    lhs.countFrom == rhs.countFrom &&
                    lhs.countdownStack == rhs.countdownStack &&
@@ -167,18 +175,25 @@ import Foundation
     }
 
     final class PartialCountdownComponent: PaywallPartialComponent {
+        public let visible: Bool?
         public let style: CountdownComponent.CountdownStyle?
 
-        public init(style: CountdownComponent.CountdownStyle? = nil) {
+        public init(
+            visible: Bool? = nil,
+            style: CountdownComponent.CountdownStyle? = nil
+        ) {
+            self.visible = visible
             self.style = style
         }
 
         public func hash(into hasher: inout Hasher) {
+            hasher.combine(visible)
             hasher.combine(style)
         }
 
         public static func == (lhs: PartialCountdownComponent, rhs: PartialCountdownComponent) -> Bool {
-            return lhs.style == rhs.style
+            return lhs.visible == rhs.visible &&
+                   lhs.style == rhs.style
         }
     }
 

--- a/Tests/RevenueCatUITests/PaywallsV2/CountdownComponentViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/CountdownComponentViewTests.swift
@@ -127,6 +127,23 @@ final class CountdownComponentViewTests: TestCase {
         XCTAssertFalse(Self.resolvedVisible(viewModel, state: .selected))
     }
 
+    func testVisibleAppliesWindowWidthVisibilityOverride() {
+        let viewModel = Self.makeViewModel(
+            visible: true,
+            overrides: [
+                .init(
+                    extendedConditions: [.windowWidth(operator: .greaterThanOrEqual, value: 700)],
+                    properties: .init(visible: false)
+                )
+            ]
+        )
+
+        // Unknown window size never matches; narrow doesn't match; wide hides the countdown.
+        XCTAssertTrue(Self.resolvedVisible(viewModel, windowSize: nil))
+        XCTAssertTrue(Self.resolvedVisible(viewModel, windowSize: CGSize(width: 390, height: 844)))
+        XCTAssertFalse(Self.resolvedVisible(viewModel, windowSize: CGSize(width: 904, height: 640)))
+    }
+
     // MARK: - Rule discarding
 
     func testDiscardRulesStripsRuleBasedCountdownOverrides() {
@@ -243,7 +260,8 @@ final class CountdownComponentViewTests: TestCase {
     private static func resolvedVisible(
         _ viewModel: CountdownComponentViewModel,
         state: ComponentViewState = .default,
-        condition: ScreenCondition = .compact
+        condition: ScreenCondition = .compact,
+        windowSize: CGSize? = nil
     ) -> Bool {
         viewModel.visible(
             state: state,
@@ -251,7 +269,8 @@ final class CountdownComponentViewTests: TestCase {
             isEligibleForIntroOffer: false,
             isEligibleForPromoOffer: false,
             selectedPackageId: nil,
-            customVariables: [:]
+            customVariables: [:],
+            windowSize: windowSize
         )
     }
 

--- a/Tests/RevenueCatUITests/PaywallsV2/CountdownComponentViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/CountdownComponentViewTests.swift
@@ -114,6 +114,72 @@ final class CountdownComponentViewTests: TestCase {
         XCTAssertFalse(Self.resolvedVisible(viewModel, condition: .expanded))
     }
 
+    func testVisibleLaterMatchingOverrideWins() {
+        let viewModel = Self.makeViewModel(
+            visible: true,
+            overrides: [
+                .init(conditions: [.selected], properties: .init(visible: true)),
+                .init(conditions: [.selected], properties: .init(visible: false))
+            ]
+        )
+
+        // Both overrides match the selected state; combine ordering means the later one wins.
+        XCTAssertFalse(Self.resolvedVisible(viewModel, state: .selected))
+    }
+
+    // MARK: - Rule discarding
+
+    func testDiscardRulesStripsRuleBasedCountdownOverrides() {
+        let overrides: PaywallComponent.ComponentOverrides<PaywallComponent.PartialCountdownComponent> = [
+            .init(
+                extendedConditions: [.selectedPackage(operator: .in, packages: ["monthly"])],
+                properties: .init(visible: false)
+            )
+        ]
+
+        func visibleWhenMonthlySelected(discardRules: Bool) -> Bool {
+            Self.makeViewModel(
+                visible: true,
+                overrides: overrides,
+                discardRules: discardRules
+            ).visible(
+                state: .default,
+                condition: .compact,
+                isEligibleForIntroOffer: false,
+                isEligibleForPromoOffer: false,
+                selectedPackageId: "monthly",
+                customVariables: [:]
+            )
+        }
+
+        // Honored: selecting the package hides the countdown.
+        XCTAssertFalse(visibleWhenMonthlySelected(discardRules: false))
+        // Discarded: the rule is stripped, so the base (visible) value stands.
+        XCTAssertTrue(visibleWhenMonthlySelected(discardRules: true))
+    }
+
+    // MARK: - CountdownState
+
+    @MainActor
+    func testStartRefreshesStateAfterDeadlinePassesWhileStopped() async throws {
+        let state = CountdownState(
+            targetDate: Date().addingTimeInterval(0.1),
+            countFrom: .minutes
+        )
+        state.start()
+        XCTAssertFalse(state.hasEnded)
+        state.stop()
+
+        // Let the deadline pass while the countdown is hidden (stopped).
+        try await Task.sleep(nanoseconds: 300_000_000)
+        XCTAssertFalse(state.hasEnded)
+
+        // Re-showing must reflect the current time immediately, without waiting for a timer tick.
+        state.start()
+        XCTAssertTrue(state.hasEnded)
+        XCTAssertEqual(state.countdownTime.seconds, 0)
+    }
+
     // MARK: - Helpers
 
     private static let stackJSON = """

--- a/Tests/RevenueCatUITests/PaywallsV2/CountdownComponentViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/CountdownComponentViewTests.swift
@@ -1,0 +1,194 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CountdownComponentViewTests.swift
+//
+
+@_spi(Internal) @testable import RevenueCat
+@testable import RevenueCatUI
+import SwiftUI
+import XCTest
+// swiftlint:disable force_try
+
+#if !os(tvOS)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+final class CountdownComponentViewTests: TestCase {
+
+    // MARK: - Decoding
+
+    func testCodableRoundTripWithVisibleOverride() throws {
+        let jsonData = Data("""
+        {
+          "type": "countdown",
+          "visible": true,
+          "style": { "type": "date", "date": "2035-01-01T00:00:00Z" },
+          "count_from": "days",
+          "countdown_stack": \(Self.stackJSON),
+          "overrides": [
+            {
+              "conditions": [{ "type": "selected" }],
+              "properties": { "visible": false }
+            }
+          ]
+        }
+        """.utf8)
+
+        let countdown = try JSONDecoder.default
+            .decode(PaywallComponent.CountdownComponent.self, from: jsonData)
+
+        XCTAssertEqual(countdown.visible, true)
+        XCTAssertEqual(countdown.overrides?.count, 1)
+        XCTAssertEqual(countdown.overrides?.first?.conditions, [.selected])
+        XCTAssertEqual(countdown.overrides?.first?.properties.visible, false)
+
+        let reencoded = try JSONEncoder.default.encode(countdown)
+        let countdown2 = try JSONDecoder.default
+            .decode(PaywallComponent.CountdownComponent.self, from: reencoded)
+
+        XCTAssertEqual(countdown, countdown2)
+    }
+
+    func testViewModelFactoryPreservesOverrides() throws {
+        let result = try Self.viewModel(decodedFrom: """
+        {
+          "type": "countdown",
+          "style": { "type": "date", "date": "2035-01-01T00:00:00Z" },
+          "count_from": "days",
+          "countdown_stack": \(Self.stackJSON),
+          "overrides": [
+            {
+              "conditions": [{ "type": "selected" }],
+              "properties": { "visible": false }
+            }
+          ]
+        }
+        """)
+
+        guard case .countdown(let built) = result else {
+            return XCTFail("Expected .countdown view model")
+        }
+
+        // Default state keeps the base (visible) value; the selected override only applies when selected.
+        XCTAssertTrue(Self.resolvedVisible(built))
+        XCTAssertFalse(Self.resolvedVisible(built, state: .selected))
+    }
+
+    // MARK: - Visibility resolution
+
+    func testVisibleDefaultsToTrue() {
+        XCTAssertTrue(Self.resolvedVisible(Self.makeViewModel()))
+        XCTAssertFalse(Self.resolvedVisible(Self.makeViewModel(visible: false)))
+    }
+
+    func testVisibleAppliesSelectedVisibilityOverride() {
+        let viewModel = Self.makeViewModel(
+            visible: false,
+            overrides: [
+                .init(conditions: [.selected], properties: .init(visible: true))
+            ]
+        )
+
+        // Default state keeps the base (hidden) value.
+        XCTAssertFalse(Self.resolvedVisible(viewModel))
+        // Selected state applies the override and shows the countdown.
+        XCTAssertTrue(Self.resolvedVisible(viewModel, state: .selected))
+    }
+
+    func testVisibleAppliesSizeClassVisibilityOverride() {
+        let viewModel = Self.makeViewModel(
+            visible: true,
+            overrides: [
+                .init(conditions: [.expanded], properties: .init(visible: false))
+            ]
+        )
+
+        // Compact keeps the base (visible) value; expanded hides it.
+        XCTAssertTrue(Self.resolvedVisible(viewModel, condition: .compact))
+        XCTAssertFalse(Self.resolvedVisible(viewModel, condition: .expanded))
+    }
+
+    // MARK: - Helpers
+
+    private static let stackJSON = """
+    {
+        "type": "stack",
+        "dimension": { "type": "vertical", "alignment": "center", "distribution": "start" },
+        "size": { "width": { "type": "fill" }, "height": { "type": "fit" } },
+        "padding": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 },
+        "margin": { "top": 0, "bottom": 0, "leading": 0, "trailing": 0 },
+        "components": []
+    }
+    """
+
+    /// Decodes a component from `json` and runs it through the real `ViewModelFactory`, exercising the
+    /// full decode-to-view-model seam.
+    private static func viewModel(decodedFrom json: String) throws -> PaywallComponentViewModel {
+        let component = try JSONDecoder.default.decode(PaywallComponent.self, from: Data(json.utf8))
+
+        return try ViewModelFactory().toViewModel(
+            component: component,
+            packageValidator: PackageValidator(),
+            offering: .init(
+                identifier: "test_offering",
+                serverDescription: "Test Offering",
+                metadata: [:],
+                availablePackages: [],
+                webCheckoutUrl: nil
+            ),
+            localizationProvider: .init(locale: Locale(identifier: "en_US"), localizedStrings: [:]),
+            uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+            colorScheme: .light
+        )
+    }
+
+    private static func makeViewModel(
+        visible: Bool? = nil,
+        overrides: PaywallComponent.ComponentOverrides<PaywallComponent.PartialCountdownComponent>? = nil,
+        discardRules: Bool = false
+    ) -> CountdownComponentViewModel {
+        let stack = PaywallComponent.StackComponent(components: [])
+        return CountdownComponentViewModel(
+            component: .init(
+                visible: visible,
+                style: .date(Date(timeIntervalSince1970: 0)),
+                countFrom: .days,
+                countdownStack: stack,
+                overrides: overrides
+            ),
+            uiConfigProvider: .init(uiConfig: PreviewUIConfig.make()),
+            countdownStackViewModel: try! .init(
+                component: stack,
+                localizationProvider: .init(locale: Locale(identifier: "en_US"), localizedStrings: [:]),
+                colorScheme: .light
+            ),
+            endStackViewModel: nil,
+            fallbackStackViewModel: nil,
+            discardRules: discardRules
+        )
+    }
+
+    private static func resolvedVisible(
+        _ viewModel: CountdownComponentViewModel,
+        state: ComponentViewState = .default,
+        condition: ScreenCondition = .compact
+    ) -> Bool {
+        viewModel.visible(
+            state: state,
+            condition: condition,
+            isEligibleForIntroOffer: false,
+            isEligibleForPromoOffer: false,
+            selectedPackageId: nil,
+            customVariables: [:]
+        )
+    }
+
+}
+
+#endif


### PR DESCRIPTION
### Motivation
`CountdownComponent` has an `overrides` field in the schema, but nothing evaluated it — a silent no-op for paywall authors (flagged in review of #7645). Follow-up agreed there: component-level overrides gate the whole countdown; child stacks keep handling styling.

### Description
- `visible` added to `CountdownComponent` and `PartialCountdownComponent` (the partial's only property — countdown-level overrides are gating-only)
- `CountdownComponentViewModel` resolves overrides like siblings (`PresentedPartial` + condition context); the view renders nothing when resolved `visible` is false
- Base `visible: false` + override `visible: true` supports show-only-when-X rules
- 5 tests: Codable round-trip, factory preservation, selected-state override, size-class override, default-true

### Notes
- Backend counterpart: RevenueCat/khepri#24984 (schema previously rejected countdown overrides entirely)
- Android counterpart: RevenueCat/purchases-android#4199
- Whichever lands after #7645: one-line follow-up to pass `windowSize` into the countdown's resolver so window size rules apply here too (until then they safely never match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
