### PR TITLE
Tell payment authorization apart from external purchase eligibility

### DIFF
--- a/Sources/Logging/Strings/ExternalPurchaseStrings.swift
+++ b/Sources/Logging/Strings/ExternalPurchaseStrings.swift
@@ -17,9 +17,10 @@ import Foundation
 
 enum ExternalPurchaseStrings {
 
-    case eligibility_resolved(_ canMakeExternalPurchases: Bool)
+    case eligibility_resolved(_ availability: ExternalPurchaseAvailability)
     case unsupported_with_test_store
     case cannot_make_external_purchases
+    case payments_not_authorized
     case notice_cancelled
     case error_showing_notice(_ error: Error)
     case no_token_available
@@ -33,12 +34,14 @@ extension ExternalPurchaseStrings: LogMessage {
 
     var description: String {
         switch self {
-        case let .eligibility_resolved(canMakeExternalPurchases):
-            return "Can make external purchases: \(canMakeExternalPurchases)."
+        case let .eligibility_resolved(availability):
+            return "External purchase availability resolved to \(availability)."
         case .unsupported_with_test_store:
             return "External purchases are not supported when the SDK is configured with a Test Store API key."
         case .cannot_make_external_purchases:
             return "Not preparing an external purchase: this app cannot offer one to this customer."
+        case .payments_not_authorized:
+            return "Not preparing an external purchase: this device does not authorize payments."
         case .notice_cancelled:
             return "The customer chose not to continue to the external purchase."
         case let .error_showing_notice(error):

--- a/Sources/Purchasing/ExternalPurchase/ExternalPurchaseCustomLinkType.swift
+++ b/Sources/Purchasing/ExternalPurchase/ExternalPurchaseCustomLinkType.swift
@@ -31,8 +31,8 @@ internal enum ExternalPurchaseAvailability: Equatable {
     /// not exist on this OS version. The app's usual way to buy is still available.
     case notEligible
 
-    /// The device does not authorize payments, which parental controls, Screen Time and MDM can withhold. Apple
-    /// asks that no purchase be offered at all in that case, external or through StoreKit:
+    /// The device does not authorize payments. Apple asks that no purchase be offered at all in that case,
+    /// external or through StoreKit:
     /// https://developer.apple.com/documentation/storekit/appstore/canmakepayments
     case paymentsNotAuthorized
 

--- a/Sources/Purchasing/ExternalPurchase/ExternalPurchaseCustomLinkType.swift
+++ b/Sources/Purchasing/ExternalPurchase/ExternalPurchaseCustomLinkType.swift
@@ -52,10 +52,10 @@ internal protocol ExternalPurchaseCustomLinkType {
 
     /// Whether the app can offer an external purchase to this customer right now.
     ///
-    /// Covers both runtime checks Apple requires before requesting a token, in the order it asks for them:
-    /// whether the device authorizes payments at all, and StoreKit's own eligibility, which accounts for the
-    /// customer's storefront so the SDK does not determine the region itself. They are kept apart because what
-    /// the app should offer instead differs, see ``ExternalPurchaseAvailability``.
+    /// Covers both runtime checks Apple requires before requesting a token: whether the device authorizes
+    /// payments at all, and StoreKit's own eligibility, which accounts for the customer's storefront so the SDK
+    /// does not determine the region itself. They are kept apart because what the app should offer instead
+    /// differs, see ``ExternalPurchaseAvailability``.
     ///
     /// Also returns ``ExternalPurchaseAvailability/notEligible`` when the API is unavailable, in which case
     /// ``token(for:)`` and ``showNotice(type:)`` throw ``ExternalPurchaseError/apiUnavailable``.

--- a/Sources/Purchasing/ExternalPurchase/ExternalPurchaseCustomLinkType.swift
+++ b/Sources/Purchasing/ExternalPurchase/ExternalPurchaseCustomLinkType.swift
@@ -21,10 +21,27 @@ internal enum ExternalPurchaseError: Error, Hashable {
 
 }
 
+/// Whether the app can offer an external purchase to this customer, and what is left to offer when it cannot.
+internal enum ExternalPurchaseAvailability: Equatable {
+
+    /// The app can offer an external purchase.
+    case available
+
+    /// External purchases do not apply to this customer: StoreKit says the app is not eligible, or the API does
+    /// not exist on this OS version. The app's usual way to buy is still available.
+    case notEligible
+
+    /// The device does not authorize payments, which parental controls, Screen Time and MDM can withhold. Apple
+    /// asks that no purchase be offered at all in that case, external or through StoreKit:
+    /// https://developer.apple.com/documentation/storekit/appstore/canmakepayments
+    case paymentsNotAuthorized
+
+}
+
 /// The part of StoreKit's `ExternalPurchaseCustomLink` that the SDK uses.
 ///
-/// ``canMakeExternalPurchases()`` is a precondition for the rest, and the notice must only be shown in response to
-/// a deliberate customer interaction, such as tapping a button.
+/// ``externalPurchaseAvailability()`` is a precondition for the rest, and the notice must only be shown in
+/// response to a deliberate customer interaction, such as tapping a button.
 internal protocol ExternalPurchaseCustomLinkType {
 
     /// Whether StoreKit's external purchase custom link API exists on the current OS version.
@@ -35,13 +52,14 @@ internal protocol ExternalPurchaseCustomLinkType {
 
     /// Whether the app can offer an external purchase to this customer right now.
     ///
-    /// Covers both runtime checks Apple requires before requesting a token: StoreKit's own eligibility, which
-    /// accounts for the customer's storefront so the SDK does not determine the region itself, and whether the
-    /// device authorizes payments at all, which parental controls, Screen Time and MDM can withhold.
+    /// Covers both runtime checks Apple requires before requesting a token, in the order it asks for them:
+    /// whether the device authorizes payments at all, and StoreKit's own eligibility, which accounts for the
+    /// customer's storefront so the SDK does not determine the region itself. They are kept apart because what
+    /// the app should offer instead differs, see ``ExternalPurchaseAvailability``.
     ///
-    /// Also returns `false` when the API is unavailable, in which case ``token(for:)`` and ``showNotice(type:)``
-    /// throw ``ExternalPurchaseError/apiUnavailable``.
-    func canMakeExternalPurchases() async -> Bool
+    /// Also returns ``ExternalPurchaseAvailability/notEligible`` when the API is unavailable, in which case
+    /// ``token(for:)`` and ``showNotice(type:)`` throw ``ExternalPurchaseError/apiUnavailable``.
+    func externalPurchaseAvailability() async -> ExternalPurchaseAvailability
 
     /// Requests an external purchase token of the given type.
     ///

--- a/Sources/Purchasing/ExternalPurchase/ExternalPurchaseManager.swift
+++ b/Sources/Purchasing/ExternalPurchase/ExternalPurchaseManager.swift
@@ -36,16 +36,16 @@ final class ExternalPurchaseManager {
     ///
     /// Safe to call before the customer intends to buy: it mints nothing, so it creates no obligation to report
     /// anything to Apple.
-    func canMakeExternalPurchases() async -> Bool {
+    func externalPurchaseAvailability() async -> ExternalPurchaseAvailability {
         guard !self.systemInfo.isSimulatedStoreAPIKey else {
             Logger.debug(Strings.externalPurchase.unsupported_with_test_store)
-            return false
+            return .notEligible
         }
 
-        let canMakeExternalPurchases = await self.customLink.canMakeExternalPurchases()
-        Logger.debug(Strings.externalPurchase.eligibility_resolved(canMakeExternalPurchases))
+        let availability = await self.customLink.externalPurchaseAvailability()
+        Logger.debug(Strings.externalPurchase.eligibility_resolved(availability))
 
-        return canMakeExternalPurchases
+        return availability
     }
 
     /// Prepares an external purchase, in response to the customer deliberately asking for one.
@@ -53,9 +53,15 @@ final class ExternalPurchaseManager {
     /// Must not be called before then: the notice may only be shown in response to a customer interaction, and
     /// every token minted here is one Apple expects a report for, whether or not a transaction follows.
     func prepareExternalPurchase(flow: ExternalPurchaseFlow) async -> ExternalPurchasePreparationResult {
-        guard await self.canMakeExternalPurchases() else {
+        switch await self.externalPurchaseAvailability() {
+        case .available:
+            break
+        case .notEligible:
             Logger.warn(Strings.externalPurchase.cannot_make_external_purchases)
-            return .stopped(.cannotMakeExternalPurchases)
+            return .stopped(.notEligible)
+        case .paymentsNotAuthorized:
+            Logger.warn(Strings.externalPurchase.payments_not_authorized)
+            return .stopped(.paymentsNotAuthorized)
         }
 
         switch await self.showNotice(type: flow.noticeType) {
@@ -90,13 +96,18 @@ internal enum ExternalPurchasePreparationResult: Equatable {
 
     enum StopReason: Equatable {
 
-        /// The storefront is not eligible, or the device does not authorize payments. The two are not
-        /// distinguishable, see ``ExternalPurchaseCustomLinkType/canMakeExternalPurchases()``.
+        /// External purchases do not apply to this customer, see ``ExternalPurchaseAvailability/notEligible``.
         ///
         /// The customer saw nothing of the external purchase, so the caller is expected to buy through StoreKit
         /// instead rather than leave them without a way to buy. Unlike the other reasons, this one does not change
         /// while the customer stays where they are.
-        case cannotMakeExternalPurchases
+        case notEligible
+
+        /// The device does not authorize payments, see ``ExternalPurchaseAvailability/paymentsNotAuthorized``.
+        ///
+        /// Unlike ``notEligible``, there is nothing to offer instead: the caller is expected to route the customer
+        /// nowhere at all.
+        case paymentsNotAuthorized
 
         /// The customer declined at the disclosure notice.
         case customerCancelledNotice

--- a/Sources/Purchasing/ExternalPurchase/StoreKitExternalPurchaseCustomLink.swift
+++ b/Sources/Purchasing/ExternalPurchase/StoreKitExternalPurchaseCustomLink.swift
@@ -39,19 +39,19 @@ internal struct StoreKitExternalPurchaseCustomLink: ExternalPurchaseCustomLinkTy
         #endif
     }
 
-    func canMakeExternalPurchases() async -> Bool {
+    func externalPurchaseAvailability() async -> ExternalPurchaseAvailability {
         #if compiler(>=6.0.2)
         guard #available(iOS 18.1, macOS 15.1, tvOS 18.1, watchOS 11.1, visionOS 2.1, *) else {
-            return false
+            return .notEligible
         }
 
         guard self.paymentAuthorizationProvider.isAuthorized() else {
-            return false
+            return .paymentsNotAuthorized
         }
 
-        return await ExternalPurchaseCustomLink.isEligible
+        return await ExternalPurchaseCustomLink.isEligible ? .available : .notEligible
         #else
-        return false
+        return .notEligible
         #endif
     }
 

--- a/Tests/UnitTests/Mocks/MockExternalPurchaseCustomLink.swift
+++ b/Tests/UnitTests/Mocks/MockExternalPurchaseCustomLink.swift
@@ -17,11 +17,11 @@ import Foundation
 final class MockExternalPurchaseCustomLink: ExternalPurchaseCustomLinkType {
 
     var stubbedIsAPIAvailable: Bool = true
-    var stubbedCanMakeExternalPurchases: Bool = true
+    var stubbedAvailability: ExternalPurchaseAvailability = .available
     var stubbedTokenResult: Result<String?, Error> = .success("test-external-purchase-token")
     var stubbedNoticeResult: Result<ExternalPurchaseNoticeResult, Error> = .success(.continued)
 
-    private(set) var invokedCanMakeExternalPurchasesCount: Int = 0
+    private(set) var invokedAvailabilityCount: Int = 0
     private(set) var invokedTokenTypes: [ExternalPurchaseTokenType] = []
     private(set) var invokedNoticeTypes: [ExternalPurchaseNoticeType] = []
 
@@ -29,9 +29,9 @@ final class MockExternalPurchaseCustomLink: ExternalPurchaseCustomLinkType {
         return self.stubbedIsAPIAvailable
     }
 
-    func canMakeExternalPurchases() async -> Bool {
-        self.invokedCanMakeExternalPurchasesCount += 1
-        return self.stubbedCanMakeExternalPurchases
+    func externalPurchaseAvailability() async -> ExternalPurchaseAvailability {
+        self.invokedAvailabilityCount += 1
+        return self.stubbedAvailability
     }
 
     func token(for tokenType: ExternalPurchaseTokenType) async throws -> String? {

--- a/Tests/UnitTests/Purchasing/ExternalPurchase/ExternalPurchaseCustomLinkTests.swift
+++ b/Tests/UnitTests/Purchasing/ExternalPurchase/ExternalPurchaseCustomLinkTests.swift
@@ -86,17 +86,22 @@ class ExternalPurchaseCustomLinkTests: TestCase {
             expect(error).to(matchError(ExternalPurchaseError.apiUnavailable))
         }
 
-        let canMakeExternalPurchases = await customLink.canMakeExternalPurchases()
-        expect(canMakeExternalPurchases) == false
+        let availability = await customLink.externalPurchaseAvailability()
+        expect(availability) == .notEligible
     }
 
-    func testCannotMakeExternalPurchasesWhenTheDeviceDoesNotAuthorizePayments() async {
+    /// Told apart from being ineligible: the caller has nothing to offer instead when the device cannot pay.
+    func testPaymentsNotAuthorizedWhenTheDeviceDoesNotAuthorizePayments() async throws {
         let customLink = StoreKitExternalPurchaseCustomLink(
             paymentAuthorizationProvider: .init(isAuthorized: { false })
         )
 
-        let canMakeExternalPurchases = await customLink.canMakeExternalPurchases()
-        expect(canMakeExternalPurchases) == false
+        guard customLink.isAPIAvailable else {
+            throw XCTSkip("Requires StoreKit's external purchase custom link API")
+        }
+
+        let availability = await customLink.externalPurchaseAvailability()
+        expect(availability) == .paymentsNotAuthorized
     }
 
 }

--- a/Tests/UnitTests/Purchasing/ExternalPurchase/ExternalPurchaseManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/ExternalPurchase/ExternalPurchaseManagerTests.swift
@@ -75,12 +75,26 @@ class ExternalPurchaseManagerTests: TestCase {
 
     // MARK: - Stopping
 
-    func testMintsNothingWhenTheCustomerCannotMakeExternalPurchases() async {
-        self.customLink.stubbedCanMakeExternalPurchases = false
+    func testMintsNothingWhenTheAppIsNotEligible() async {
+        self.customLink.stubbedAvailability = .notEligible
 
         let result = await self.manager.prepareExternalPurchase(flow: .inApp)
 
-        expect(result) == .stopped(.cannotMakeExternalPurchases)
+        expect(result) == .stopped(.notEligible)
+        expect(result.shouldProceed) == false
+        expect(self.customLink.invokedNoticeTypes).to(beEmpty())
+        expect(self.customLink.invokedTokenTypes).to(beEmpty())
+        expect(self.externalPurchaseTokenAPI.invokedPostExternalPurchaseToken) == false
+    }
+
+    /// Kept apart from being ineligible: the caller has nothing to offer instead, so it must not fall back to a
+    /// purchase of any kind.
+    func testMintsNothingWhenTheDeviceDoesNotAuthorizePayments() async {
+        self.customLink.stubbedAvailability = .paymentsNotAuthorized
+
+        let result = await self.manager.prepareExternalPurchase(flow: .inApp)
+
+        expect(result) == .stopped(.paymentsNotAuthorized)
         expect(result.shouldProceed) == false
         expect(self.customLink.invokedNoticeTypes).to(beEmpty())
         expect(self.customLink.invokedTokenTypes).to(beEmpty())
@@ -157,14 +171,15 @@ class ExternalPurchaseManagerTests: TestCase {
 
     // MARK: - Test Store
 
-    /// A Test Store key has no App Store behind it, so none of the StoreKit steps apply.
-    func testTheTestStoreCannotMakeExternalPurchases() async {
+    /// A Test Store key has no App Store behind it, so none of the StoreKit steps apply. It reads as ineligible
+    /// rather than as a device that cannot pay, so the caller keeps offering its usual way to buy.
+    func testTheTestStoreIsNotEligible() async {
         self.systemInfo.stubbedApiKeyValidationResult = .simulatedStore
 
-        let canMakeExternalPurchases = await self.manager.canMakeExternalPurchases()
+        let availability = await self.manager.externalPurchaseAvailability()
 
-        expect(canMakeExternalPurchases) == false
-        expect(self.customLink.invokedCanMakeExternalPurchasesCount) == 0
+        expect(availability) == .notEligible
+        expect(self.customLink.invokedAvailabilityCount) == 0
     }
 
     func testTheTestStoreSkipsTheWholeSequence() async {
@@ -172,7 +187,7 @@ class ExternalPurchaseManagerTests: TestCase {
 
         let result = await self.manager.prepareExternalPurchase(flow: .inApp)
 
-        expect(result) == .stopped(.cannotMakeExternalPurchases)
+        expect(result) == .stopped(.notEligible)
         expect(self.customLink.invokedNoticeTypes).to(beEmpty())
         expect(self.customLink.invokedTokenTypes).to(beEmpty())
         expect(self.externalPurchaseTokenAPI.invokedPostExternalPurchaseToken) == false
@@ -182,17 +197,17 @@ class ExternalPurchaseManagerTests: TestCase {
 
     /// Eligibility can change while the app is running, so every purchase asks for it again.
     func testResolvesEligibilityOnEveryPurchase() async {
-        self.customLink.stubbedCanMakeExternalPurchases = false
+        self.customLink.stubbedAvailability = .notEligible
 
         let whileIneligible = await self.manager.prepareExternalPurchase(flow: .inApp)
-        expect(whileIneligible) == .stopped(.cannotMakeExternalPurchases)
+        expect(whileIneligible) == .stopped(.notEligible)
 
-        self.customLink.stubbedCanMakeExternalPurchases = true
+        self.customLink.stubbedAvailability = .available
 
         let onceEligible = await self.manager.prepareExternalPurchase(flow: .inApp)
         expect(onceEligible) == .registered(tokenID: Self.tokenID)
 
-        expect(self.customLink.invokedCanMakeExternalPurchasesCount) == 2
+        expect(self.customLink.invokedAvailabilityCount) == 2
     }
 
 }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Resolves [SDK-4492](https://linear.app/revenuecat/issue/SDK-4492/ios-tell-payment-authorization-apart-from-external-purchase).

Apple asks for two runtime checks before an external purchase, and what the app should offer when each fails is not the same. Per [`canMakePayments`](https://developer.apple.com/documentation/storekit/appstore/canmakepayments), an app that is merely ineligible keeps offering its usual way to buy, while a device that does not authorize payments must not be offered a purchase at all, external or through StoreKit. The wrapper collapsed both into one `Bool`, so callers could not make that distinction.

### Description

Replaces `func canMakeExternalPurchases() async -> Bool` with `func externalPurchaseAvailability() async -> ExternalPurchaseAvailability`, where `ExternalPurchaseAvailability` is an enum
```swift
enum ExternalPurchaseAvailability {
    case available
    case notEligible
    case paymentsNotAuthorized
}
```
So callers can distinguish between `notEligible` and `paymentsNotAuthorized`, which a mere `Bool` didn't allow. 

No behavior change: nothing consumes the new stop reason yet. The link-out flow in #7663 is the first caller, where being ineligible keeps opening the link as it does today and unauthorized payments open nothing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes external-purchase gating and stop reasons in purchase-adjacent code, but behavior for existing callers is unchanged until downstream flows consume the new stop reason.
> 
> **Overview**
> Replaces the single **boolean** external-purchase eligibility check with **`ExternalPurchaseAvailability`** (`available`, `notEligible`, `paymentsNotAuthorized`) on `ExternalPurchaseCustomLinkType`, `ExternalPurchaseManager`, and the StoreKit wrapper.
> 
> **`StoreKitExternalPurchaseCustomLink`** now returns **`paymentsNotAuthorized`** when `canMakePayments()` is false instead of lumping that case with storefront/API ineligibility. **`prepareExternalPurchase`** stops with **`.notEligible`** vs **`.paymentsNotAuthorized`** (renamed from **`.cannotMakeExternalPurchases`**), with docs stating ineligible customers can still use the usual StoreKit path while unauthorized devices should not be offered any purchase.
> 
> Logging adds **`payments_not_authorized`** and eligibility logs the full availability value. Mocks and unit tests follow the new API; Test Store still surfaces as **`.notEligible`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dd01b8e735d874a8889c4885aaaaf53989a9d41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->