### PR TITLE
Answer canMakePayments through AppStore rather than SKPaymentQueue

### DIFF
--- a/Sources/Purchasing/ExternalPurchase/StoreKitExternalPurchaseCustomLink.swift
+++ b/Sources/Purchasing/ExternalPurchase/StoreKitExternalPurchaseCustomLink.swift
@@ -45,7 +45,7 @@ internal struct StoreKitExternalPurchaseCustomLink: ExternalPurchaseCustomLinkTy
             return false
         }
 
-        guard self.paymentAuthorizationProvider.isAuthorized() else {
+        guard self.paymentAuthorizationProvider.canMakePayments() else {
             return false
         }
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -181,7 +181,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
      * Indicates whether the user is allowed to make payments.
      * [More information on when this might be `false` here](https://rev.cat/can-make-payments-apple)
      */
-    @objc public static func canMakePayments() -> Bool { PaymentAuthorizationProvider.storeKit.isAuthorized() }
+    @objc public static func canMakePayments() -> Bool { PaymentAuthorizationProvider.storeKit.canMakePayments() }
 
     /**
      * Set a custom log handler for redirecting logs to your own logging system.

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -181,7 +181,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
      * Indicates whether the user is allowed to make payments.
      * [More information on when this might be `false` here](https://rev.cat/can-make-payments-apple)
      */
-    @objc public static func canMakePayments() -> Bool { StoreKit1Wrapper.canMakePayments() }
+    @objc public static func canMakePayments() -> Bool { PaymentAuthorizationProvider.storeKit.isAuthorized() }
 
     /**
      * Set a custom log handler for redirecting logs to your own logging system.

--- a/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
@@ -96,10 +96,6 @@ class StoreKit1Wrapper: NSObject {
         self.paymentQueue.add(payment)
     }
 
-    static func canMakePayments() -> Bool {
-        return SKPaymentQueue.canMakePayments()
-    }
-
     func payment(with product: SK1Product) -> SKMutablePayment {
         let payment = SKMutablePayment(product: product)
         payment.simulatesAskToBuyInSandbox = Self.simulatesAskToBuyInSandbox

--- a/Sources/Support/PaymentAuthorizationProvider.swift
+++ b/Sources/Support/PaymentAuthorizationProvider.swift
@@ -15,12 +15,12 @@ import Foundation
 import StoreKit
 
 struct PaymentAuthorizationProvider {
-    var isAuthorized: () -> Bool
+    var canMakePayments: () -> Bool
 }
 
 extension PaymentAuthorizationProvider {
     static let storeKit = PaymentAuthorizationProvider(
-        isAuthorized: {
+        canMakePayments: {
             if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *) {
                 return AppStore.canMakePayments
             } else {

--- a/Sources/Support/SDKHealthManager.swift
+++ b/Sources/Support/SDKHealthManager.swift
@@ -18,7 +18,7 @@ final class SDKHealthManager: Sendable {
     #if DEBUG
     func healthReport() async -> PurchasesDiagnostics.SDKHealthReport {
         do {
-            if !paymentAuthorizationProvider.isAuthorized() {
+            if !paymentAuthorizationProvider.canMakePayments() {
                 return .init(status: .unhealthy(.notAuthorizedToMakePayments))
             }
             let appUserID = self.identityManager.currentAppUserID

--- a/Tests/UnitTests/Misc/SDKHealthManagerTests.swift
+++ b/Tests/UnitTests/Misc/SDKHealthManagerTests.swift
@@ -969,7 +969,7 @@ fileprivate extension SDKHealthManagerTests {
 fileprivate extension PaymentAuthorizationProvider {
     static func mock(canMakePayments: Bool = true) -> PaymentAuthorizationProvider {
         return PaymentAuthorizationProvider(
-            isAuthorized: { canMakePayments }
+            canMakePayments: { canMakePayments }
         )
     }
 }

--- a/Tests/UnitTests/Purchasing/ExternalPurchase/ExternalPurchaseCustomLinkTests.swift
+++ b/Tests/UnitTests/Purchasing/ExternalPurchase/ExternalPurchaseCustomLinkTests.swift
@@ -92,7 +92,7 @@ class ExternalPurchaseCustomLinkTests: TestCase {
 
     func testCannotMakeExternalPurchasesWhenTheDeviceDoesNotAuthorizePayments() async {
         let customLink = StoreKitExternalPurchaseCustomLink(
-            paymentAuthorizationProvider: .init(isAuthorized: { false })
+            paymentAuthorizationProvider: .init(canMakePayments: { false })
         )
 
         let canMakeExternalPurchases = await customLink.canMakeExternalPurchases()


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
`Purchases.canMakePayments()` answers through [`SKPaymentQueue.canMakePayments()`](https://developer.apple.com/documentation/storekit/skpaymentqueue/canmakepayments()), which Apple deprecated.

### Description
Change the implementation of `Purchases.canMakePayments()` to use the existing `PaymentAuthorizationProvider`, which prefers `AppStore.canMakePayments` and keeps the StoreKit 1 call only as the fallback below iOS 15. Callers get the same answer, only the API consulted changes. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Payment eligibility is consulted before purchases, health diagnostics, and external purchase flows; behavior should match but now depends on AppStore vs SKPaymentQueue branching by OS version.
> 
> **Overview**
> **`Purchases.canMakePayments()`** now delegates to **`PaymentAuthorizationProvider.storeKit`** instead of calling deprecated **`SKPaymentQueue.canMakePayments()`** via **`StoreKit1Wrapper`**. On supported OS versions that path uses **`AppStore.canMakePayments`**, with StoreKit 1 only as a pre–iOS 15 fallback.
> 
> The shared **`PaymentAuthorizationProvider`** closure is renamed from **`isAuthorized`** to **`canMakePayments`**, and callers (**SDK health checks**, **external purchase custom link** eligibility, tests/mocks) are updated to match. **`StoreKit1Wrapper.canMakePayments()`** is removed as redundant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 181509b9e2e0f4253afda0fb692d6beabda96380. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->