### PR TITLE
Prepare one external purchase at a time

### DIFF
--- a/RevenueCatUI/Purchasing/ExternalPurchaseLink.swift
+++ b/RevenueCatUI/Purchasing/ExternalPurchaseLink.swift
@@ -22,12 +22,32 @@ enum ExternalPurchaseLink {
     /// The link to open for a web purchase, once whatever Apple requires before the customer leaves the app
     /// has been done. `nil` when nothing should open, because the customer declined Apple's notice.
     ///
-    /// Only external browser links take part: leaving the app is what Apple's programme covers.
-    static func urlToOpen(_ url: URL, method: PaywallComponent.ButtonComponent.URLMethod) async -> URL? {
-        guard method == .externalBrowser, Purchases.isConfigured else {
+    /// The paywall is marked as busy while Apple's flow runs, so the button the customer tapped cannot start a
+    /// second one. Links that open straight away are not marked, to save a blink of a disabled button.
+    static func urlToOpen(_ url: URL,
+                          method: PaywallComponent.ButtonComponent.URLMethod,
+                          purchaseHandler: PurchaseHandler) async -> URL? {
+        guard self.applies(to: method) else {
             return url
         }
 
+        return await purchaseHandler.withExternalPurchasePreparation {
+            await self.urlToOpen(url)
+        }
+    }
+
+    /// Whether opening a link with this method goes through Apple's external purchase flow.
+    ///
+    /// Only external browser links take part: leaving the app is what Apple's programme covers.
+    private static func applies(to method: PaywallComponent.ButtonComponent.URLMethod) -> Bool {
+        guard method == .externalBrowser, Purchases.isConfigured else {
+            return false
+        }
+
+        return Purchases.shared.preparesExternalPurchaseLinks
+    }
+
+    private static func urlToOpen(_ url: URL) async -> URL? {
         switch await Purchases.shared.prepareExternalPurchaseLink() {
         case let .proceed(externalPurchaseTokenID):
             guard let externalPurchaseTokenID else {

--- a/RevenueCatUI/Purchasing/ExternalPurchaseLink.swift
+++ b/RevenueCatUI/Purchasing/ExternalPurchaseLink.swift
@@ -44,7 +44,7 @@ enum ExternalPurchaseLink {
             return false
         }
 
-        return Purchases.shared.preparesExternalPurchaseLinks
+        return Purchases.shared.useExternalPurchaseCustomLinks
     }
 
     private static func urlToOpen(_ url: URL) async -> URL? {

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -305,16 +305,29 @@ extension PurchaseHandler {
 
     /// Runs `preparation` with the paywall marked as busy, so the button the customer tapped cannot start a
     /// second trip out of the app while Apple's flow is under way.
+    ///
+    /// A call that finds the paywall already busy leaves the mark alone, so it cannot free the paywall while
+    /// the flow that set it is still running.
     func withExternalPurchasePreparation<T>(_ preparation: () async throws -> T) async rethrows -> T {
-        await MainActor.run {
+        let marked = await MainActor.run { () -> Bool in
+            guard actionTypeInProgress == nil else {
+                return false
+            }
+
             startAction(.externalPurchasePreparation)
+            return true
         }
+
         let result = try await preparation()
-        await MainActor.run {
-            if actionTypeInProgress == .externalPurchasePreparation {
-                self.actionTypeInProgress = nil
+
+        if marked {
+            await MainActor.run {
+                if actionTypeInProgress == .externalPurchasePreparation {
+                    self.actionTypeInProgress = nil
+                }
             }
         }
+
         return result
     }
 

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -29,6 +29,9 @@ final class PurchaseHandler: ObservableObject {
         case purchase
         case restore
 
+        /// What Apple requires before the customer leaves the app to pay on the web.
+        case externalPurchasePreparation
+
     }
 
     private var cancellables: Set<AnyCancellable> = Set()
@@ -294,6 +297,21 @@ extension PurchaseHandler {
         let result = try await continuation()
         await MainActor.run {
             if actionTypeInProgress == .pendingPurchaseContinuation {
+                self.actionTypeInProgress = nil
+            }
+        }
+        return result
+    }
+
+    /// Runs `preparation` with the paywall marked as busy, so the button the customer tapped cannot start a
+    /// second trip out of the app while Apple's flow is under way.
+    func withExternalPurchasePreparation<T>(_ preparation: () async throws -> T) async rethrows -> T {
+        await MainActor.run {
+            startAction(.externalPurchasePreparation)
+        }
+        let result = try await preparation()
+        await MainActor.run {
+            if actionTypeInProgress == .externalPurchasePreparation {
                 self.actionTypeInProgress = nil
             }
         }

--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
@@ -80,7 +80,7 @@ struct ButtonComponentView: View {
         }
 
         switch actionType {
-        case .purchase:
+        case .purchase, .externalPurchasePreparation:
             return false
         case .restore, .pendingPurchaseContinuation:
             return true
@@ -301,7 +301,13 @@ struct ButtonComponentView: View {
     }
 
     private func openWebPaywallLink(url: URL, method: PaywallComponent.ButtonComponent.URLMethod) async {
-        guard let url = await ExternalPurchaseLink.urlToOpen(url, method: method) else {
+        guard !self.purchaseHandler.actionInProgress else {
+            return
+        }
+
+        guard let url = await ExternalPurchaseLink.urlToOpen(url,
+                                                             method: method,
+                                                             purchaseHandler: self.purchaseHandler) else {
             return
         }
 

--- a/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/PurchaseButton/PurchaseButtonComponentView.swift
@@ -55,7 +55,7 @@ struct PurchaseButtonComponentView: View {
         }
 
         switch actionType {
-        case .purchase, .pendingPurchaseContinuation:
+        case .purchase, .pendingPurchaseContinuation, .externalPurchasePreparation:
             return true
         case .restore:
             return false
@@ -135,6 +135,10 @@ struct PurchaseButtonComponentView: View {
     private func purchaseInWeb() async throws {
         self.logIfInPreview(package: self.packageContext.package)
 
+        guard !self.purchaseHandler.actionInProgress else {
+            return
+        }
+
         guard let launchWebCheckout = self.viewModel.urlForWebCheckout(
             packageContext: self.packageContext,
             appUserID: Purchases.isConfigured ? Purchases.shared.appUserID : "",
@@ -154,7 +158,8 @@ struct PurchaseButtonComponentView: View {
 
         guard let url = await ExternalPurchaseLink.urlToOpen(
             launchWebCheckout.url,
-            method: launchWebCheckout.method
+            method: launchWebCheckout.method,
+            purchaseHandler: self.purchaseHandler
         ) else {
             return
         }

--- a/Sources/Logging/Strings/ExternalPurchaseStrings.swift
+++ b/Sources/Logging/Strings/ExternalPurchaseStrings.swift
@@ -21,6 +21,7 @@ enum ExternalPurchaseStrings {
     case unsupported_with_test_store
     case cannot_make_external_purchases
     case payments_not_authorized
+    case already_preparing
     case notice_cancelled
     case error_showing_notice(_ error: Error)
     case no_token_available
@@ -42,6 +43,8 @@ extension ExternalPurchaseStrings: LogMessage {
             return "Not preparing an external purchase: this app cannot offer one to this customer."
         case .payments_not_authorized:
             return "Not preparing an external purchase: this device does not authorize payments."
+        case .already_preparing:
+            return "Not preparing an external purchase: another one is already being prepared."
         case .notice_cancelled:
             return "The customer chose not to continue to the external purchase."
         case let .error_showing_notice(error):

--- a/Sources/Purchasing/ExternalPurchase/ExternalPurchaseLinkResult.swift
+++ b/Sources/Purchasing/ExternalPurchase/ExternalPurchaseLinkResult.swift
@@ -20,8 +20,8 @@ import Foundation
     /// Open the link, handing `externalPurchaseTokenID` to the checkout page when there is one.
     case proceed(externalPurchaseTokenID: String?)
 
-    /// Open nothing: the customer declined Apple's disclosure notice, it could not be shown, or the device does
-    /// not authorize payments.
+    /// Open nothing: the customer declined Apple's disclosure notice, it could not be shown, the device does
+    /// not authorize payments, or another link is already being prepared.
     case stopped
 
 }
@@ -44,6 +44,9 @@ extension ExternalPurchaseLinkResult {
         case .stopped(.paymentsNotAuthorized):
             // Apple asks that a device which cannot authorize payments be offered no purchase at all, so the
             // link is not opened either.
+            self = .stopped
+        case .stopped(.alreadyPreparing):
+            // The preparation already under way is the one that opens the link.
             self = .stopped
         case .stopped(.customerCancelledNotice), .stopped(.noticeFailed):
             self = .stopped

--- a/Sources/Purchasing/ExternalPurchase/ExternalPurchaseManager.swift
+++ b/Sources/Purchasing/ExternalPurchase/ExternalPurchaseManager.swift
@@ -22,6 +22,8 @@ final class ExternalPurchaseManager {
     private let currentUserProvider: CurrentUserProvider
     private let systemInfo: SystemInfo
 
+    private let isPreparing: Atomic<Bool> = false
+
     init(customLink: ExternalPurchaseCustomLinkType,
          externalPurchaseTokenAPI: ExternalPurchaseTokenAPI,
          currentUserProvider: CurrentUserProvider,
@@ -56,10 +58,20 @@ final class ExternalPurchaseManager {
     ///
     /// Must not be called before then: the notice may only be shown in response to a customer interaction, and
     /// every token minted here is one Apple expects a report for, whether or not a transaction follows.
+    ///
+    /// Only one preparation runs at a time. Asking for another while one is under way stops the new one, so a
+    /// customer tapping twice sees a single notice and mints a single token.
     func prepareExternalPurchase(flow: ExternalPurchaseFlow) async -> ExternalPurchasePreparationResult {
         guard self.takesPartInTheProgramme else {
             return .stopped(.notEligible)
         }
+
+        guard !self.isPreparing.getAndSet(true) else {
+            Logger.warn(Strings.externalPurchase.already_preparing)
+            return .stopped(.alreadyPreparing)
+        }
+
+        defer { self.isPreparing.value = false }
 
         switch await self.externalPurchaseAvailability() {
         case .available:
@@ -123,6 +135,10 @@ internal enum ExternalPurchasePreparationResult: Equatable {
         /// The notice could not be shown. Continuing without it would breach what StoreKit asks for, so this
         /// stops the purchase even though the customer did not decline.
         case noticeFailed
+
+        /// Another preparation was already under way, and that one carries the purchase. The caller is expected
+        /// to route the customer nowhere, so a second tap does not open a second checkout.
+        case alreadyPreparing
 
     }
 

--- a/Sources/Purchasing/ExternalPurchase/ExternalPurchaseManager.swift
+++ b/Sources/Purchasing/ExternalPurchase/ExternalPurchaseManager.swift
@@ -136,8 +136,7 @@ internal enum ExternalPurchasePreparationResult: Equatable {
         /// stops the purchase even though the customer did not decline.
         case noticeFailed
 
-        /// Another preparation was already under way, and that one carries the purchase. The caller is expected
-        /// to route the customer nowhere, so a second tap does not open a second checkout.
+        /// Another preparation was already under way, and that one carries the purchase.
         case alreadyPreparing
 
     }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1926,6 +1926,12 @@ public extension Purchases {
         return .init(preparationResult: await self.externalPurchaseManager.prepareExternalPurchase(flow: .linkOut))
     }
 
+    /// Whether ``prepareExternalPurchaseLink()`` has any work to do, so that `RevenueCatUI` only tells the
+    /// customer something is under way when it really is.
+    @_spi(Internal) var preparesExternalPurchaseLinks: Bool {
+        return self.systemInfo.dangerousSettings.useExternalPurchaseCustomLinks
+    }
+
     /// Used by `RevenueCatUI` to download and cache paywall images.
     @available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *)
     static let paywallImageDownloadSession: URLSession = PaywallCacheWarming.downloadSession

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1926,9 +1926,9 @@ public extension Purchases {
         return .init(preparationResult: await self.externalPurchaseManager.prepareExternalPurchase(flow: .linkOut))
     }
 
-    /// Whether ``prepareExternalPurchaseLink()`` has any work to do, so that `RevenueCatUI` only tells the
-    /// customer something is under way when it really is.
-    @_spi(Internal) var preparesExternalPurchaseLinks: Bool {
+    /// ``DangerousSettings/useExternalPurchaseCustomLinks``, so that `RevenueCatUI` only tells the customer
+    /// something is under way when ``prepareExternalPurchaseLink()`` has work to do.
+    @_spi(Internal) var useExternalPurchaseCustomLinks: Bool {
         return self.systemInfo.dangerousSettings.useExternalPurchaseCustomLinks
     }
 

--- a/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
@@ -483,6 +483,30 @@ class PurchaseHandlerTests: TestCase {
         expect(handler.actionInProgress) == false
     }
 
+    func testExternalPurchasePreparationMarksThePaywallForAsLongAsItRuns() async throws {
+        let handler: PurchaseHandler = .mock()
+
+        await handler.withExternalPurchasePreparation {
+            expect(handler.actionTypeInProgress) == .externalPurchasePreparation
+        }
+
+        expect(handler.actionInProgress) == false
+    }
+
+    /// A second tap can reach the wrapper before the first one has marked the paywall, and must not free it
+    /// while Apple's notice from the first tap is still up.
+    func testAnExternalPurchasePreparationDoesNotFreeThePaywallItDidNotMark() async throws {
+        let handler: PurchaseHandler = .mock()
+
+        await handler.withExternalPurchasePreparation {
+            await handler.withExternalPurchasePreparation {}
+
+            expect(handler.actionTypeInProgress) == .externalPurchasePreparation
+        }
+
+        expect(handler.actionInProgress) == false
+    }
+
     func testRestorePurchases() async throws {
         let handler: PurchaseHandler = .mock()
         let result = try await handler.restorePurchases()

--- a/Tests/UnitTests/Mocks/MockExternalPurchaseCustomLink.swift
+++ b/Tests/UnitTests/Mocks/MockExternalPurchaseCustomLink.swift
@@ -21,6 +21,9 @@ final class MockExternalPurchaseCustomLink: ExternalPurchaseCustomLinkType {
     var stubbedTokenResult: Result<String?, Error> = .success("test-external-purchase-token")
     var stubbedNoticeResult: Result<ExternalPurchaseNoticeResult, Error> = .success(.continued)
 
+    /// Runs while the notice is on screen, so tests can act with a preparation half way through.
+    var whileShowingNotice: (@Sendable () async -> Void)?
+
     private(set) var invokedAvailabilityCount: Int = 0
     private(set) var invokedTokenTypes: [ExternalPurchaseTokenType] = []
     private(set) var invokedNoticeTypes: [ExternalPurchaseNoticeType] = []
@@ -41,6 +44,7 @@ final class MockExternalPurchaseCustomLink: ExternalPurchaseCustomLinkType {
 
     func showNotice(type: ExternalPurchaseNoticeType) async throws -> ExternalPurchaseNoticeResult {
         self.invokedNoticeTypes.append(type)
+        await self.whileShowingNotice?()
         return try self.stubbedNoticeResult.get()
     }
 

--- a/Tests/UnitTests/Purchasing/ExternalPurchase/ExternalPurchaseLinkResultTests.swift
+++ b/Tests/UnitTests/Purchasing/ExternalPurchase/ExternalPurchaseLinkResultTests.swift
@@ -56,4 +56,11 @@ final class ExternalPurchaseLinkResultTests: TestCase {
         expect(result) == .stopped
     }
 
+    /// The link the customer is waiting for is the one the first preparation opens.
+    func testNothingOpensWhenAnotherLinkIsAlreadyBeingPrepared() {
+        let result = ExternalPurchaseLinkResult(preparationResult: .stopped(.alreadyPreparing))
+
+        expect(result) == .stopped
+    }
+
 }

--- a/Tests/UnitTests/Purchasing/ExternalPurchase/ExternalPurchaseManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/ExternalPurchase/ExternalPurchaseManagerTests.swift
@@ -236,6 +236,36 @@ class ExternalPurchaseManagerTests: TestCase {
         expect(self.customLink.invokedAvailabilityCount) == 2
     }
 
+    // MARK: - One preparation at a time
+
+    /// Every token minted is one Apple expects a report for, and a customer who taps twice while the notice is
+    /// coming up asked to buy once.
+    func testStopsAPreparationAskedForWhileAnotherIsUnderWay() async {
+        let manager = self.manager!
+        let secondResult: Atomic<ExternalPurchasePreparationResult?> = nil
+
+        self.customLink.whileShowingNotice = {
+            secondResult.value = await manager.prepareExternalPurchase(flow: .linkOut)
+        }
+
+        let firstResult = await manager.prepareExternalPurchase(flow: .linkOut)
+
+        expect(secondResult.value) == .stopped(.alreadyPreparing)
+        expect(firstResult) == .registered(tokenID: Self.tokenID)
+        expect(self.customLink.invokedNoticeTypes) == [.browser]
+        expect(self.customLink.invokedTokenTypes) == [.linkOut]
+        expect(self.externalPurchaseTokenAPI.invokedPostExternalPurchaseTokenCount) == 1
+    }
+
+    func testPreparesAgainOnceTheFirstOneIsDone() async {
+        let first = await self.manager.prepareExternalPurchase(flow: .linkOut)
+        let second = await self.manager.prepareExternalPurchase(flow: .linkOut)
+
+        expect(first) == .registered(tokenID: Self.tokenID)
+        expect(second) == .registered(tokenID: Self.tokenID)
+        expect(self.customLink.invokedNoticeTypes) == [.browser, .browser]
+    }
+
     // MARK: - Helpers
 
     private static func makeSystemInfo(useExternalPurchaseCustomLinks: Bool) -> MockSystemInfo {


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests

### Motivation

`AsyncButton` starts a task per tap and the web purchase paths never mark the paywall as busy, so tapping twice while Apple's notice is coming up mints two tokens and opens two checkouts. Each token is one Apple expects a report for.

### Description
This PR makes sure that only one external purchase preparation can happen simultaneously.
- The manager discards a preparation asked for while another is under way, so all callers get this behavior without repeating it.
- The paywall is marked while the preparation flow runs, which disables the purchase button and spins it. Links that open straight away are not affected by this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Apple external-purchase token minting and paywall purchase/web-checkout UX; incorrect locking could block checkout or still allow duplicate tokens.
> 
> **Overview**
> Prevents **double-tap web checkout** from minting multiple Apple external-purchase tokens by serializing preparation in the SDK and marking the paywall busy only when Apple's flow actually runs.
> 
> **SDK:** `ExternalPurchaseManager` now allows **one** `prepareExternalPurchase` at a time; overlapping calls return `.stopped(.alreadyPreparing)` (logged) and map to **no second link** in `ExternalPurchaseLinkResult`.
> 
> **RevenueCatUI:** Adds `PurchaseHandler.ActionType.externalPurchasePreparation` and `withExternalPurchasePreparation`, used by `ExternalPurchaseLink.urlToOpen` only for **external-browser** links when `useExternalPurchaseCustomLinks` is on—immediate links skip the busy state. Web purchase buttons guard on `actionInProgress`, show a spinner during preparation, and pass the handler into link resolution.
> 
> **Tests** cover manager concurrency, link-result mapping, and nested preparation not clearing the busy flag early.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7804c81bc360b6f7ae8725687dc8f496a5299029. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->