### PR TITLE
[EXTERNAL] Add the decorative media paywall fixture and accessibility control view (#7545) via @t9mike

### DIFF
--- a/Tests/TestingApps/PaywallFixtures/FixtureRootView.swift
+++ b/Tests/TestingApps/PaywallFixtures/FixtureRootView.swift
@@ -43,10 +43,7 @@ struct FixtureRootView: View {
 
 }
 
-/// Plain SwiftUI images with no RevenueCat code involved, so a test can establish what
-/// `accessibilityHidden` is expected to do in this harness before asserting the same thing
-/// about paywall media. Without this control, a paywall image showing up in the tree cannot be
-/// told apart from the test runner simply not honoring the modifier.
+/// Plain SwiftUI control, so a test can tell our bug from XCUITest ignoring the modifier.
 struct AccessibilityControlView: View {
 
     static let fixtureName = "a11y_control"

--- a/Tests/TestingApps/PaywallFixtures/FixtureRootView.swift
+++ b/Tests/TestingApps/PaywallFixtures/FixtureRootView.swift
@@ -21,8 +21,8 @@ struct FixtureRootView: View {
 
     var body: some View {
         if let requestedFixture {
-            if requestedFixture == AccessibilityControlView.fixtureName {
-                AccessibilityControlView()
+            if requestedFixture == AccessibilityHiddenControlView.fixtureName {
+                AccessibilityHiddenControlView()
             } else if let fixture = PaywallFixture(rawValue: requestedFixture) {
                 FixturePaywallView(fixture: fixture)
             } else {
@@ -43,8 +43,7 @@ struct FixtureRootView: View {
 
 }
 
-/// Plain SwiftUI control, so a test can tell our bug from XCUITest ignoring the modifier.
-struct AccessibilityControlView: View {
+struct AccessibilityHiddenControlView: View {
 
     static let fixtureName = "a11y_control"
 
@@ -61,7 +60,6 @@ struct AccessibilityControlView: View {
                 .frame(width: 41, height: 41)
                 .accessibilityHidden(true)
 
-            // The paywall's own pattern: hidden after being collapsed into one element.
             Image(systemName: "bolt.fill")
                 .resizable()
                 .frame(width: 42, height: 42)

--- a/Tests/TestingApps/PaywallFixtures/FixtureRootView.swift
+++ b/Tests/TestingApps/PaywallFixtures/FixtureRootView.swift
@@ -21,7 +21,9 @@ struct FixtureRootView: View {
 
     var body: some View {
         if let requestedFixture {
-            if let fixture = PaywallFixture(rawValue: requestedFixture) {
+            if requestedFixture == AccessibilityControlView.fixtureName {
+                AccessibilityControlView()
+            } else if let fixture = PaywallFixture(rawValue: requestedFixture) {
                 FixturePaywallView(fixture: fixture)
             } else {
                 // Named as text so a failing test reports the bad name instead of timing out.
@@ -36,6 +38,38 @@ struct FixtureRootView: View {
                 }
                 .navigationTitle("Fixtures")
             }
+        }
+    }
+
+}
+
+/// Plain SwiftUI images with no RevenueCat code involved, so a test can establish what
+/// `accessibilityHidden` is expected to do in this harness before asserting the same thing
+/// about paywall media. Without this control, a paywall image showing up in the tree cannot be
+/// told apart from the test runner simply not honoring the modifier.
+struct AccessibilityControlView: View {
+
+    static let fixtureName = "a11y_control"
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Control")
+
+            Image(systemName: "star.fill")
+                .resizable()
+                .frame(width: 40, height: 40)
+
+            Image(systemName: "heart.fill")
+                .resizable()
+                .frame(width: 41, height: 41)
+                .accessibilityHidden(true)
+
+            // The paywall's own pattern: hidden after being collapsed into one element.
+            Image(systemName: "bolt.fill")
+                .resizable()
+                .frame(width: 42, height: 42)
+                .accessibilityElement(children: .ignore)
+                .accessibilityHidden(true)
         }
     }
 

--- a/Tests/TestingApps/PaywallFixtures/PaywallFixture.swift
+++ b/Tests/TestingApps/PaywallFixtures/PaywallFixture.swift
@@ -30,9 +30,8 @@ enum PaywallFixture: String, CaseIterable {
 
     /// One badge rule per offer type, each with its own rule for its copy.
     case badgeRulesPerOffer = "badge_rules_per_offer"
-    /// Decorative media in every place a real paywall puts it: a logo image component, feature
-    /// rows with checkmark icons, package cards with a checkmark icon inside the selector
-    /// button, and a background image. Tests assert which of them reach the accessibility tree.
+    /// Media in every place a real paywall puts it, so a test can assert which of it reaches
+    /// the accessibility tree.
     case decorativeMedia = "decorative_media"
 
     var title: String {
@@ -488,8 +487,6 @@ private extension PaywallFixture {
         )
     }
 
-    /// A checkmark icon like the ones real paywalls put next to feature copy and inside
-    /// package cards. Purely decorative: the adjacent text carries the meaning.
     static func checkIcon(sizePoints: CGFloat = 20) -> PaywallComponent {
         return .icon(.init(
             baseUrl: "https://icons.pawwalls.com/icons",
@@ -508,8 +505,7 @@ private extension PaywallFixture {
         ))
     }
 
-    /// A remotely hosted photo standing in for a logo or background. The dimensions describe
-    /// the asset so aspect math is stable before the download finishes.
+    /// The dimensions describe the asset so aspect math is stable before the download finishes.
     static let sampleImageUrls = PaywallComponent.ThemeImageUrls(
         light: .init(
             width: 1024,
@@ -520,9 +516,6 @@ private extension PaywallFixture {
         )
     )
 
-    /// A package card shaped like a real offer button: name, price (via variables), and a
-    /// decorative checkmark icon inside the selector.
-    ///
     /// `hiddenLeadingText` puts an invisible text ahead of the name, standing in for a badge or
     /// promo line that resolved hidden. It renders nothing, so it must not be the one asked to
     /// speak the selection state.
@@ -562,7 +555,6 @@ private extension PaywallFixture {
         ))
     }
 
-    /// A feature row: checkmark icon plus the copy it decorates.
     static func featureRow(textLid: String) -> PaywallComponent {
         return .stack(.init(
             components: [
@@ -585,7 +577,6 @@ private extension PaywallFixture {
             componentsConfig: .init(base: .init(
                 stack: .init(
                     components: [
-                        // Header: logo image next to the title, like a real paywall's brand mark.
                         .stack(.init(
                             components: [
                                 .image(.init(

--- a/Tests/TestingApps/PaywallFixtures/PaywallFixture.swift
+++ b/Tests/TestingApps/PaywallFixtures/PaywallFixture.swift
@@ -30,6 +30,10 @@ enum PaywallFixture: String, CaseIterable {
 
     /// One badge rule per offer type, each with its own rule for its copy.
     case badgeRulesPerOffer = "badge_rules_per_offer"
+    /// Decorative media in every place a real paywall puts it: a logo image component, feature
+    /// rows with checkmark icons, package cards with a checkmark icon inside the selector
+    /// button, and a background image. Tests assert which of them reach the accessibility tree.
+    case decorativeMedia = "decorative_media"
 
     var title: String {
         switch self {
@@ -39,6 +43,8 @@ enum PaywallFixture: String, CaseIterable {
             return "Mixed page and tab packages"
         case .badgeRulesPerOffer:
             return "Badge rules per offer type"
+        case .decorativeMedia:
+            return "Decorative media"
         }
     }
 
@@ -50,6 +56,8 @@ enum PaywallFixture: String, CaseIterable {
             return Self.mixedTabsPageDefaultComponentsData()
         case .badgeRulesPerOffer:
             return Self.badgeRulesPerOfferComponentsData()
+        case .decorativeMedia:
+            return Self.decorativeMediaComponentsData()
         }
     }
 
@@ -66,6 +74,12 @@ enum PaywallFixture: String, CaseIterable {
                 Self.monthlyPackage(offeringIdentifier: self.rawValue),
                 Self.weeklyPackage(offeringIdentifier: self.rawValue),
                 Self.lifetimePackage(offeringIdentifier: self.rawValue)
+            ]
+        case .decorativeMedia:
+            return [
+                Self.annualPackage(offeringIdentifier: self.rawValue),
+                Self.monthlyPackage(offeringIdentifier: self.rawValue),
+                Self.weeklyPackage(offeringIdentifier: self.rawValue)
             ]
         }
     }
@@ -467,6 +481,169 @@ private extension PaywallFixture {
             componentsLocalizations: [
                 "en_US": [
                     "body_lid": .string("Everything you need, in one place.")
+                ]
+            ],
+            revision: 1,
+            defaultLocaleIdentifier: "en_US"
+        )
+    }
+
+    /// A checkmark icon like the ones real paywalls put next to feature copy and inside
+    /// package cards. Purely decorative: the adjacent text carries the meaning.
+    static func checkIcon(sizePoints: CGFloat = 20) -> PaywallComponent {
+        return .icon(.init(
+            baseUrl: "https://icons.pawwalls.com/icons",
+            iconName: "check",
+            formats: .init(
+                svg: "check.svg",
+                png: "check.png",
+                heic: "check.heic",
+                webp: "check.webp"
+            ),
+            size: .init(width: .fixed(UInt(sizePoints)), height: .fixed(UInt(sizePoints))),
+            padding: .zero,
+            margin: .zero,
+            color: .init(light: .hex("#000000")),
+            iconBackground: nil
+        ))
+    }
+
+    /// A remotely hosted photo standing in for a logo or background. The dimensions describe
+    /// the asset so aspect math is stable before the download finishes.
+    static let sampleImageUrls = PaywallComponent.ThemeImageUrls(
+        light: .init(
+            width: 1024,
+            height: 1024,
+            original: URL(string: "https://assets.pawwalls.com/1172568_1741034533.heic")!,
+            heic: URL(string: "https://assets.pawwalls.com/1172568_1741034533.heic")!,
+            heicLowRes: URL(string: "https://assets.pawwalls.com/1172568_1741034533.heic")!
+        )
+    )
+
+    /// A package card shaped like a real offer button: name, price (via variables), and a
+    /// decorative checkmark icon inside the selector.
+    ///
+    /// `hiddenLeadingText` puts an invisible text ahead of the name, standing in for a badge or
+    /// promo line that resolved hidden. It renders nothing, so it must not be the one asked to
+    /// speak the selection state.
+    static func decoratedPackageCard(
+        packageID: String,
+        label: String,
+        isSelectedByDefault: Bool,
+        hiddenLeadingText: Bool = false
+    ) -> PaywallComponent {
+        return .package(.init(
+            packageID: packageID,
+            isSelectedByDefault: isSelectedByDefault,
+            applePromoOfferProductCode: nil,
+            stack: .init(
+                components: [
+                    .text(.init(
+                        visible: !hiddenLeadingText,
+                        text: hiddenLeadingText ? "hidden_badge_lid" : label,
+                        color: .init(light: .hex("#000000"))
+                    )),
+                    .text(.init(
+                        visible: hiddenLeadingText ? true : nil,
+                        text: hiddenLeadingText ? label : "price_lid",
+                        color: .init(light: .hex("#000000"))
+                    )),
+                    .text(.init(
+                        text: "price_lid",
+                        color: .init(light: .hex("#000000"))
+                    )),
+                    Self.checkIcon()
+                ],
+                dimension: .horizontal(.center, .start),
+                size: .init(width: .fill, height: .fit(nil)),
+                spacing: 8,
+                padding: .init(top: 12, bottom: 12, leading: 12, trailing: 12)
+            )
+        ))
+    }
+
+    /// A feature row: checkmark icon plus the copy it decorates.
+    static func featureRow(textLid: String) -> PaywallComponent {
+        return .stack(.init(
+            components: [
+                Self.checkIcon(),
+                .text(.init(
+                    text: textLid,
+                    color: .init(light: .hex("#000000"))
+                ))
+            ],
+            dimension: .horizontal(.center, .start),
+            size: .init(width: .fill, height: .fit(nil)),
+            spacing: 8
+        ))
+    }
+
+    static func decorativeMediaComponentsData() -> PaywallComponentsData {
+        return .init(
+            templateName: "fixture-decorative-media",
+            assetBaseURL: URL(string: "https://assets.pawwalls.com")!,
+            componentsConfig: .init(base: .init(
+                stack: .init(
+                    components: [
+                        // Header: logo image next to the title, like a real paywall's brand mark.
+                        .stack(.init(
+                            components: [
+                                .image(.init(
+                                    source: Self.sampleImageUrls,
+                                    size: .init(width: .fixed(60), height: .fixed(60))
+                                )),
+                                .text(.init(
+                                    text: "heading_lid",
+                                    color: .init(light: .hex("#000000"))
+                                ))
+                            ],
+                            dimension: .horizontal(.center, .start),
+                            size: .init(width: .fill, height: .fit(nil)),
+                            spacing: 12
+                        )),
+                        .text(.init(
+                            text: "body_lid",
+                            color: .init(light: .hex("#000000"))
+                        )),
+                        Self.featureRow(textLid: "feature1_lid"),
+                        Self.featureRow(textLid: "feature2_lid"),
+                        Self.decoratedPackageCard(
+                            packageID: "$rc_annual",
+                            label: "annual",
+                            isSelectedByDefault: true
+                        ),
+                        Self.decoratedPackageCard(
+                            packageID: "$rc_monthly",
+                            label: "monthly",
+                            isSelectedByDefault: false
+                        ),
+                        Self.decoratedPackageCard(
+                            packageID: "$rc_weekly",
+                            label: "weekly",
+                            isSelectedByDefault: false,
+                            hiddenLeadingText: true
+                        )
+                    ],
+                    dimension: .vertical(.center, .start),
+                    size: .init(width: .fill, height: .fill),
+                    spacing: 16,
+                    backgroundColor: nil,
+                    padding: .init(top: 60, bottom: 24, leading: 16, trailing: 16)
+                ),
+                stickyFooter: nil,
+                background: .image(Self.sampleImageUrls, .fill, nil)
+            )),
+            componentsLocalizations: [
+                "en_US": [
+                    "heading_lid": .string("Unlock all Sundial Features"),
+                    "body_lid": .string("Every feature, one subscription."),
+                    "feature1_lid": .string("Create alerts for 34 solar events"),
+                    "feature2_lid": .string("Full featured watch app"),
+                    "annual": .string("Yearly"),
+                    "monthly": .string("Monthly"),
+                    "price_lid": .string("{{ product.price_per_period_abbreviated }}"),
+                    "weekly": .string("Weekly"),
+                    "hidden_badge_lid": .string("Hidden badge")
                 ]
             ],
             revision: 1,

--- a/Tests/TestingApps/PaywallFixturesUITests/PaywallAccessibilityUITests.swift
+++ b/Tests/TestingApps/PaywallFixturesUITests/PaywallAccessibilityUITests.swift
@@ -43,12 +43,8 @@ final class PaywallAccessibilityUITests: XCTestCase {
         try app.performAccessibilityAudit(for: [.sufficientElementDescription])
     }
 
-    /// Element queries cannot answer "is this hidden from VoiceOver": XCUITest lists elements
-    /// that carry `accessibilityHidden(true)`. This pins that down with plain SwiftUI images so
-    /// the next person does not write an assertion that silently cannot fail.
-    ///
-    /// If this starts failing, XCUITest began honoring the modifier and element queries became
-    /// usable for these assertions.
+    /// XCUITest lists elements that carry `accessibilityHidden(true)`, so element queries cannot
+    /// answer "is this hidden from VoiceOver". Fails once XCUITest starts honoring the modifier.
     func testElementQueriesListEvenHiddenImages() throws {
         let app = XCUIApplication()
         // Matches AccessibilityControlView.fixtureName in the app target, which the UI test

--- a/Tests/TestingApps/PaywallFixturesUITests/PaywallAccessibilityUITests.swift
+++ b/Tests/TestingApps/PaywallFixturesUITests/PaywallAccessibilityUITests.swift
@@ -47,8 +47,7 @@ final class PaywallAccessibilityUITests: XCTestCase {
     /// answer "is this hidden from VoiceOver". Fails once XCUITest starts honoring the modifier.
     func testElementQueriesListEvenHiddenImages() throws {
         let app = XCUIApplication()
-        // Matches AccessibilityControlView.fixtureName in the app target, which the UI test
-        // bundle does not link against.
+        // Matches AccessibilityHiddenControlView.fixtureName; the test bundle can't link it.
         app.launchEnvironment["PAYWALL_FIXTURE"] = "a11y_control"
         app.launch()
 

--- a/Tests/TestingApps/PaywallFixturesUITests/PaywallAccessibilityUITests.swift
+++ b/Tests/TestingApps/PaywallFixturesUITests/PaywallAccessibilityUITests.swift
@@ -43,6 +43,33 @@ final class PaywallAccessibilityUITests: XCTestCase {
         try app.performAccessibilityAudit(for: [.sufficientElementDescription])
     }
 
+    /// Element queries cannot answer "is this hidden from VoiceOver": XCUITest lists elements
+    /// that carry `accessibilityHidden(true)`. This pins that down with plain SwiftUI images so
+    /// the next person does not write an assertion that silently cannot fail.
+    ///
+    /// If this starts failing, XCUITest began honoring the modifier and element queries became
+    /// usable for these assertions.
+    func testElementQueriesListEvenHiddenImages() throws {
+        let app = XCUIApplication()
+        // Matches AccessibilityControlView.fixtureName in the app target, which the UI test
+        // bundle does not link against.
+        app.launchEnvironment["PAYWALL_FIXTURE"] = "a11y_control"
+        app.launch()
+
+        XCTAssertTrue(app.staticTexts["Control"].waitForExistence(timeout: 30))
+
+        let identifiers = app.images.allElementsBoundByIndex.map { $0.identifier }
+        XCTAssertTrue(identifiers.contains("star.fill"), "Visible control image missing.")
+        XCTAssertTrue(
+            identifiers.contains("heart.fill"),
+            "XCUITest now hides accessibilityHidden elements; element queries can be trusted again."
+        )
+        XCTAssertTrue(
+            identifiers.contains("bolt.fill"),
+            "XCUITest now hides collapsed-and-hidden elements; element queries can be trusted again."
+        )
+    }
+
     private func launch(fixture: String) -> XCUIApplication {
         let app = XCUIApplication()
         app.launchEnvironment["PAYWALL_FIXTURE"] = fixture


### PR DESCRIPTION
### Motivation

First of five PRs splitting up #7545 by @t9mike, which improves VoiceOver support on Paywalls V2. Landing his work as separate PRs so each behavior change gets weighed on its own instead of in one 63-file diff.

This one is only the test scaffolding the later ones measure against, no SDK change. It goes first because the selection-state PR and the decorative-media PR both need the fixture.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: this one (first of five splitting #7545)
- Branch: `external/7545-fixtures`
- Author / human owner: @facumenzella
- Agent(s): Claude Opus 5 (1M context), Claude Code
- Session source: current conversation
- Generated: 2026-09-09
- Context document version: 1

## Goal

Split external contribution #7545 (@t9mike, +1142/-45 across 63 files, four unrelated VoiceOver fixes) into smaller PRs against `main`, following the SDK Guild "Merging external contributions" process, preserving his implementation rather than rewriting it.

## Initial Prompt

"How can we split this into smaller PRs?" pointed at #7545 (the literal opener referred to uncommitted work in the current worktree; it was corrected to #7545 in the next message).

## Important Follow-up Prompts

- "5 independent? only stack when its absolutely necessary" — settled the shape.
- "all of them following what he did" — his code goes across verbatim; no reimplementation.
- "everything must be draft".
- "Each PR should mention the original PR in the PR description."

## Agent Contribution

- Analyzed #7545 and identified four independent features plus shared test scaffolding.
- Created staging branch `external/7545-voiceover` off `main`, merged his branch into it, resolved the one conflict (`PaywallFixture` enum: `main`'s `badge_rules_per_offer` vs his `decorative_media`, kept both).
- Partitioned the resolved tree into five branches, each commit authored to `t9mike <mike@muegel.org>`.
- Verified the changelog credit mechanism by reading `versioning_helper.rb:84-90` and `CHANGELOG.md`.

## Human Decisions

- Decision: five independent PRs off `main`, stacking only where unavoidable.
- Decision: this scaffolding PR lands first, then the two dependent PRs retarget from it to `main`.
- Decision: keep `via @t9mike` in every PR title.

## Key Implementation Decisions

- Decision: split his `FixtureRootView` changes across two PRs.
  - Rationale: his env-var toggles call `paywallImagesAccessibilityHidden()`, which lands with the media PR, while that PR's tests need this harness. Circular otherwise.
  - Rejected: splitting the `decorative_media` fixture in two, which would mean rewriting his fixture.
- Decision: `launchDecorativeMedia` helper goes to the two PRs that use it rather than sitting unused here.
  - Rationale: avoids dead code in this PR; costs a small conflict between those two, whichever lands second.

## Files / Symbols Touched

- `Tests/TestingApps/PaywallFixtures/PaywallFixture.swift`
  - Why: the fixture the later accessibility tests measure against
  - Symbols: `PaywallFixture.decorativeMedia`, `decorativeMediaComponentsData()`
  - Review relevance: the merge kept both this case and `main`'s `badge_rules_per_offer`; check the three switches are complete
- `Tests/TestingApps/PaywallFixtures/FixtureRootView.swift`
  - Why: routes the control fixture
  - Symbols: `AccessibilityControlView`, `FixtureRootView.body`
  - Review relevance: `FixturePaywallView.body` is deliberately unchanged here; the toggles arrive with the media PR
- `Tests/TestingApps/PaywallFixturesUITests/PaywallAccessibilityUITests.swift`
  - Why: the control test
  - Symbols: `testElementQueriesListEvenHiddenImages`
  - Review relevance: it asserts the *current* XCUITest limitation, so it starts failing if XCUITest is ever fixed, which is intended

## Dependencies / Config / Migrations

- None. Test-target only; no SDK source, no public API, no `api/*.swiftinterface` change.

## Validation

- Commands run:
  - `swift build --target RevenueCatUI`: passed (exit 0) on this branch and the other four
  - `swiftlint` (pre-commit): no violations
- Manual verification: `Not run`
- CI: `Not captured` — first push. `run-paywall-accessibility-ui-tests` exists and is wired into `run-all-tests`, but requires the `approve-full-tests` hold.

## Validation Gaps

- `testElementQueriesListEvenHiddenImages` has not been executed; `swift build` does not cover the fixtures app or UI test targets.
- The fixture renders a background image over the network, unverified here.
- @t9mike reported verifying the original PR with VoiceOver on device; not re-verified.

## Review Focus

- Is the fixture worth carrying on its own, ahead of the PRs that consume it?
- Does `AccessibilityControlView` belong in `FixtureRootView.swift` or its own file?
- The control test asserts a bug in XCUITest rather than in our code. Is that the right place for that assertion?

## Risks / Reviewer Notes

- Risk: unused fixture if the later PRs stall.
  - Evidence: the selection and media PRs are already built locally and depend on it.
  - Mitigation: none needed if they land in sequence.

## Non-goals / Out of Scope

- Any SDK behavior change; those are the other four PRs.
- Changing how CI gates the accessibility UI test job.

## Omitted Context

- Raw transcript, unrelated exploration, and repetitive attempts were omitted.

</details>




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to PaywallFixtures app and UI test targets; no SDK, API, or runtime paywall logic is modified.
> 
> **Overview**
> Adds **test-only scaffolding** for upcoming Paywalls V2 VoiceOver work—no SDK or production behavior changes.
> 
> Introduces a **`decorative_media`** paywall fixture with images/icons in header, feature rows, package cards (including a card with hidden leading text), and a fill background, plus shared builders (`checkIcon`, `decoratedPackageCard`, `featureRow`, etc.) so later UI tests can assert what reaches the accessibility tree.
> 
> Adds an **`a11y_control`** route in `FixtureRootView` via `AccessibilityHiddenControlView` (visible image vs `accessibilityHidden` vs hidden + `accessibilityElement(children: .ignore)`), and **`testElementQueriesListEvenHiddenImages`**, which documents that XCUITest still lists hidden images in element queries—intended to fail if Apple fixes that behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e90f1d741a077bbb7f12dd268d8a22d57713340. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->