### PR TITLE
Keep external purchase token registrations until the backend answers

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -630,6 +630,11 @@
 		AAAA44740000000000000032 /* ExternalPurchaseManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA44740000000000000031 /* ExternalPurchaseManagerTests.swift */; };
 		AAAA44760000000000000002 /* ExternalPurchaseTokenID.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA44760000000000000001 /* ExternalPurchaseTokenID.swift */; };
 		AAAA44760000000000000012 /* ExternalPurchaseTokenIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA44760000000000000011 /* ExternalPurchaseTokenIDTests.swift */; };
+		AAAA44770000000000000002 /* ExternalPurchaseTokenRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA44770000000000000001 /* ExternalPurchaseTokenRegistration.swift */; };
+		AAAA44770000000000000012 /* ExternalPurchaseTokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA44770000000000000011 /* ExternalPurchaseTokenStore.swift */; };
+		AAAA44770000000000000022 /* ExternalPurchaseTokenStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA44770000000000000021 /* ExternalPurchaseTokenStoreTests.swift */; };
+		AAAA44770000000000000032 /* MockExternalPurchaseTokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA44770000000000000031 /* MockExternalPurchaseTokenStore.swift */; };
+		AAAA44770000000000000033 /* MockExternalPurchaseTokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA44770000000000000031 /* MockExternalPurchaseTokenStore.swift */; };
 		53E33BBB2E095B8900287158 /* SDKHealthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E33BBA2E095B8900287158 /* SDKHealthManager.swift */; };
 		551800702FF46C720055FD1B /* SecureItemStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5518006F2FF46C720055FD1B /* SecureItemStorageTests.swift */; };
 		551800772FF46C8A0055FD1B /* KeychainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551800762FF46C8A0055FD1B /* KeychainTests.swift */; };
@@ -2421,6 +2426,10 @@
 		AAAA44740000000000000031 /* ExternalPurchaseManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalPurchaseManagerTests.swift; sourceTree = "<group>"; };
 		AAAA44760000000000000001 /* ExternalPurchaseTokenID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalPurchaseTokenID.swift; sourceTree = "<group>"; };
 		AAAA44760000000000000011 /* ExternalPurchaseTokenIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalPurchaseTokenIDTests.swift; sourceTree = "<group>"; };
+		AAAA44770000000000000001 /* ExternalPurchaseTokenRegistration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalPurchaseTokenRegistration.swift; sourceTree = "<group>"; };
+		AAAA44770000000000000011 /* ExternalPurchaseTokenStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalPurchaseTokenStore.swift; sourceTree = "<group>"; };
+		AAAA44770000000000000021 /* ExternalPurchaseTokenStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalPurchaseTokenStoreTests.swift; sourceTree = "<group>"; };
+		AAAA44770000000000000031 /* MockExternalPurchaseTokenStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockExternalPurchaseTokenStore.swift; sourceTree = "<group>"; };
 		53E33BBA2E095B8900287158 /* SDKHealthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKHealthManager.swift; sourceTree = "<group>"; };
 		5518006F2FF46C720055FD1B /* SecureItemStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureItemStorageTests.swift; sourceTree = "<group>"; };
 		551800762FF46C8A0055FD1B /* KeychainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainTests.swift; sourceTree = "<group>"; };
@@ -4783,6 +4792,7 @@
 				57488BFF29CB85BE0000EE7E /* MockOfflineEntitlementsAPI.swift */,
 				1EFA95112CDBA58F00CA5951 /* MockRedeemWebPurchaseAPI.swift */,
 				AAAA44730000000000000016 /* MockExternalPurchaseTokenAPI.swift */,
+				AAAA44770000000000000031 /* MockExternalPurchaseTokenStore.swift */,
 				351B515726D44B3E00BD2BD7 /* MockOfferingsFactory.swift */,
 				F575858E26C0893600C12B97 /* MockOfferingsManager.swift */,
 				57488BE929CB83540000EE7E /* MockOfflineEntitlementsManager.swift */,
@@ -5026,6 +5036,8 @@
 				AAAA44740000000000000011 /* ExternalPurchaseManager.swift */,
 				EF0100000000000000000011 /* ExternalPurchaseNotice.swift */,
 				AAAA44760000000000000001 /* ExternalPurchaseTokenID.swift */,
+				AAAA44770000000000000001 /* ExternalPurchaseTokenRegistration.swift */,
+				AAAA44770000000000000011 /* ExternalPurchaseTokenStore.swift */,
 				EF0100000000000000000001 /* ExternalPurchaseTokenType.swift */,
 				EF0100000000000000000031 /* StoreKitExternalPurchaseCustomLink.swift */,
 			);
@@ -5039,6 +5051,7 @@
 				AAAA44740000000000000031 /* ExternalPurchaseManagerTests.swift */,
 				AAAA44750000000000000011 /* ExternalPurchaseLinkResultTests.swift */,
 				AAAA44760000000000000011 /* ExternalPurchaseTokenIDTests.swift */,
+				AAAA44770000000000000021 /* ExternalPurchaseTokenStoreTests.swift */,
 			);
 			path = ExternalPurchase;
 			sourceTree = "<group>";
@@ -7691,6 +7704,7 @@
 				3543913626F90D6A00E669DF /* TrialOrIntroPriceEligibilityCheckerSK1Tests.swift in Sources */,
 				1EFA95132CDBA58F00CA5951 /* MockRedeemWebPurchaseAPI.swift in Sources */,
 				AAAA44730000000000000017 /* MockExternalPurchaseTokenAPI.swift in Sources */,
+				AAAA44770000000000000033 /* MockExternalPurchaseTokenStore.swift in Sources */,
 				4F6E81982A81BC30006EF181 /* TestClock.swift in Sources */,
 				FD6D87592FAE4CF700CAF0F2 /* MockProductsRequest.swift in Sources */,
 				1DB9B2A72E57373900252D58 /* OfferingTests.swift in Sources */,
@@ -8298,6 +8312,8 @@
 				AAAA44750000000000000002 /* ExternalPurchaseLinkResult.swift in Sources */,
 				AAAA44740000000000000012 /* ExternalPurchaseManager.swift in Sources */,
 				AAAA44760000000000000002 /* ExternalPurchaseTokenID.swift in Sources */,
+				AAAA44770000000000000002 /* ExternalPurchaseTokenRegistration.swift in Sources */,
+				AAAA44770000000000000012 /* ExternalPurchaseTokenStore.swift in Sources */,
 				AAAA44740000000000000022 /* ExternalPurchaseStrings.swift in Sources */,
 				EF0100000000000000000012 /* ExternalPurchaseNotice.swift in Sources */,
 				EF0100000000000000000002 /* ExternalPurchaseTokenType.swift in Sources */,
@@ -8378,6 +8394,7 @@
 				EF0100000000000000000062 /* ExternalPurchaseCustomLinkTests.swift in Sources */,
 				AAAA44740000000000000032 /* ExternalPurchaseManagerTests.swift in Sources */,
 				AAAA44760000000000000012 /* ExternalPurchaseTokenIDTests.swift in Sources */,
+				AAAA44770000000000000022 /* ExternalPurchaseTokenStoreTests.swift in Sources */,
 				AAAA44750000000000000012 /* ExternalPurchaseLinkResultTests.swift in Sources */,
 				C05A00000000000000000003 /* CustomVariableKeyValidatorTests.swift in Sources */,
 				73A620000000000000000001 /* CheckpointValueTests.swift in Sources */,
@@ -8765,6 +8782,7 @@
 				5733B1A427FF9F8300EC2045 /* NetworkErrorTests.swift in Sources */,
 				1EFA95122CDBA58F00CA5951 /* MockRedeemWebPurchaseAPI.swift in Sources */,
 				AAAA44730000000000000015 /* MockExternalPurchaseTokenAPI.swift in Sources */,
+				AAAA44770000000000000032 /* MockExternalPurchaseTokenStore.swift in Sources */,
 				351B517026D44E8D00BD2BD7 /* MockDateProvider.swift in Sources */,
 				4F2F2F142A3CEAB500652B24 /* FileHandlerTests.swift in Sources */,
 				4F1E84012A6062C1000AF177 /* ImageSnapshot.swift in Sources */,

--- a/Sources/Logging/Strings/ExternalPurchaseStrings.swift
+++ b/Sources/Logging/Strings/ExternalPurchaseStrings.swift
@@ -28,6 +28,8 @@ enum ExternalPurchaseStrings {
     case error_requesting_token(_ error: Error)
     case token_registered(_ tokenID: String)
     case error_registering_token(_ error: BackendError)
+    case registration_pending_retry(_ tokenID: String)
+    case registration_discarded(_ tokenID: String)
 
 }
 
@@ -57,6 +59,10 @@ extension ExternalPurchaseStrings: LogMessage {
             return "Registered external purchase token \(tokenID)."
         case let .error_registering_token(error):
             return "Error registering the external purchase token: \(error.localizedDescription)"
+        case let .registration_pending_retry(tokenID):
+            return "External purchase token \(tokenID) is kept to be registered again later."
+        case let .registration_discarded(tokenID):
+            return "External purchase token \(tokenID) will not be registered again: it was rejected."
         }
     }
 

--- a/Sources/Purchasing/ExternalPurchase/ExternalPurchaseManager.swift
+++ b/Sources/Purchasing/ExternalPurchase/ExternalPurchaseManager.swift
@@ -19,6 +19,7 @@ final class ExternalPurchaseManager {
 
     private let customLink: ExternalPurchaseCustomLinkType
     private let externalPurchaseTokenAPI: ExternalPurchaseTokenAPI
+    private let tokenStore: ExternalPurchaseTokenStoreType
     private let currentUserProvider: CurrentUserProvider
     private let systemInfo: SystemInfo
 
@@ -26,10 +27,12 @@ final class ExternalPurchaseManager {
 
     init(customLink: ExternalPurchaseCustomLinkType,
          externalPurchaseTokenAPI: ExternalPurchaseTokenAPI,
+         tokenStore: ExternalPurchaseTokenStoreType,
          currentUserProvider: CurrentUserProvider,
          systemInfo: SystemInfo) {
         self.customLink = customLink
         self.externalPurchaseTokenAPI = externalPurchaseTokenAPI
+        self.tokenStore = tokenStore
         self.currentUserProvider = currentUserProvider
         self.systemInfo = systemInfo
     }
@@ -220,25 +223,47 @@ private extension ExternalPurchaseManager {
             Logger.debug(Strings.externalPurchase.no_token_available)
         }
 
-        let tokenID = ExternalPurchaseTokenID.generate()
+        let registration = ExternalPurchaseTokenRegistration(
+            tokenID: ExternalPurchaseTokenID.generate(),
+            appUserID: self.currentUserProvider.currentAppUserID,
+            purchaseType: tokenType,
+            token: token
+        )
+
+        self.tokenStore.store(registration)
 
         let error: BackendError? = await Async.call { completion in
             self.externalPurchaseTokenAPI.postExternalPurchaseToken(
-                appUserID: self.currentUserProvider.currentAppUserID,
-                purchaseType: tokenType,
-                tokenID: tokenID,
-                token: token,
+                appUserID: registration.appUserID,
+                purchaseType: registration.purchaseType,
+                tokenID: registration.tokenID,
+                token: registration.token,
                 completion: completion
             )
         }
 
         if let error = error {
-            Logger.error(Strings.externalPurchase.error_registering_token(error))
+            self.handleFailedRegistration(registration, error: error)
             return .unregistered(.registrationFailed)
         }
 
-        Logger.debug(Strings.externalPurchase.token_registered(tokenID))
-        return .registered(tokenID: tokenID)
+        self.tokenStore.remove(registration)
+        Logger.debug(Strings.externalPurchase.token_registered(registration.tokenID))
+        return .registered(tokenID: registration.tokenID)
+    }
+
+    /// A registration the backend rejected would only be rejected again, so only one it may still accept is
+    /// kept.
+    private func handleFailedRegistration(_ registration: ExternalPurchaseTokenRegistration,
+                                          error: BackendError) {
+        Logger.error(Strings.externalPurchase.error_registering_token(error))
+
+        if error.isTransient {
+            Logger.debug(Strings.externalPurchase.registration_pending_retry(registration.tokenID))
+        } else {
+            self.tokenStore.remove(registration)
+            Logger.debug(Strings.externalPurchase.registration_discarded(registration.tokenID))
+        }
     }
 
 }

--- a/Sources/Purchasing/ExternalPurchase/ExternalPurchaseTokenRegistration.swift
+++ b/Sources/Purchasing/ExternalPurchase/ExternalPurchaseTokenRegistration.swift
@@ -1,0 +1,42 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ExternalPurchaseTokenRegistration.swift
+//
+//  Created by Antonio Pallares on 10/9/26.
+
+import Foundation
+
+/// Everything the backend needs to register an external purchase token.
+///
+/// Kept because Apple expects a report for every token minted, including the ones whose registration did not
+/// reach RevenueCat, so a registration has to survive the session it was minted in.
+internal struct ExternalPurchaseTokenRegistration: Codable, Equatable, Sendable {
+
+    /// The identifier generated for this registration, which the checkout is handed.
+    let tokenID: String
+
+    /// The customer the token was minted for.
+    let appUserID: String
+
+    let purchaseType: ExternalPurchaseTokenType
+
+    /// The StoreKit token, absent where StoreKit had none to give.
+    let token: String?
+
+    /// The SDK encodes keys into snake case and decodes them back into camel case, and that round trip does
+    /// not return an `ID` suffix, so the keys are spelled out.
+    private enum CodingKeys: String, CodingKey {
+        case tokenID = "tokenId"
+        case appUserID = "appUserId"
+        case purchaseType
+        case token
+    }
+
+}

--- a/Sources/Purchasing/ExternalPurchase/ExternalPurchaseTokenStore.swift
+++ b/Sources/Purchasing/ExternalPurchase/ExternalPurchaseTokenStore.swift
@@ -1,0 +1,64 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ExternalPurchaseTokenStore.swift
+//
+//  Created by Antonio Pallares on 10/9/26.
+
+import Foundation
+
+/// Keeps the external purchase token registrations the backend has yet to answer for.
+protocol ExternalPurchaseTokenStoreType: Sendable {
+
+    /// Keep a registration, before it is posted.
+    func store(_ registration: ExternalPurchaseTokenRegistration)
+
+    /// Drop a registration the backend has answered for, whether it accepted or rejected it.
+    func remove(_ registration: ExternalPurchaseTokenRegistration)
+
+}
+
+/// Stores external purchase token registrations persistently on disk, so that one minted in a session that
+/// never reached the backend can still be posted in a later one.
+final class ExternalPurchaseTokenStore: ExternalPurchaseTokenStoreType {
+
+    private static let storeKeyPrefix = "external_purchase_token_registration_"
+
+    private let cache: SynchronizedLargeItemCache
+
+    init(apiKey: String, fileManager: LargeItemCacheType = FileManager.default) {
+        let directoryType: DirectoryHelper.DirectoryType
+        #if os(tvOS)
+        directoryType = .cache
+        #else
+        directoryType = .applicationSupport(overrideURL: nil)
+        #endif
+
+        self.cache = SynchronizedLargeItemCache(
+            cache: fileManager,
+            basePath: "external-purchase-tokens-\(apiKey)",
+            directoryType: directoryType
+        )
+    }
+
+    func store(_ registration: ExternalPurchaseTokenRegistration) {
+        self.cache.set(codable: registration, forKey: Self.key(for: registration))
+    }
+
+    func remove(_ registration: ExternalPurchaseTokenRegistration) {
+        self.cache.removeObject(forKey: Self.key(for: registration))
+    }
+
+    /// Keys become file names, so they may not contain path separators. ``ExternalPurchaseTokenID`` only
+    /// generates identifiers that are safe to use as they are.
+    private static func key(for registration: ExternalPurchaseTokenRegistration) -> String {
+        return Self.storeKeyPrefix + registration.tokenID
+    }
+
+}

--- a/Sources/Purchasing/ExternalPurchase/ExternalPurchaseTokenType.swift
+++ b/Sources/Purchasing/ExternalPurchase/ExternalPurchaseTokenType.swift
@@ -18,7 +18,7 @@ import Foundation
 /// StoreKit takes this as a plain `String`, and which values apply depends on the storefront and on the flow the
 /// customer is about to enter. Modelled as a `RawRepresentable` struct rather than an enum so that a value the SDK
 /// does not know about can still be forwarded to StoreKit.
-internal struct ExternalPurchaseTokenType: RawRepresentable, Hashable, Sendable, Encodable {
+internal struct ExternalPurchaseTokenType: RawRepresentable, Hashable, Sendable, Codable {
 
     let rawValue: String
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -965,6 +965,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.externalPurchaseManager = ExternalPurchaseManager(
             customLink: StoreKitExternalPurchaseCustomLink(),
             externalPurchaseTokenAPI: backend.externalPurchaseTokenAPI,
+            tokenStore: ExternalPurchaseTokenStore(apiKey: systemInfo.apiKey),
             currentUserProvider: identityManager,
             systemInfo: systemInfo
         )

--- a/Tests/UnitTests/Mocks/MockExternalPurchaseTokenStore.swift
+++ b/Tests/UnitTests/Mocks/MockExternalPurchaseTokenStore.swift
@@ -1,0 +1,31 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MockExternalPurchaseTokenStore.swift
+//
+//  Created by Antonio Pallares on 10/9/26.
+
+import Foundation
+@testable import RevenueCat
+
+final class MockExternalPurchaseTokenStore: ExternalPurchaseTokenStoreType {
+
+    private let storage: Atomic<[ExternalPurchaseTokenRegistration]> = .init([])
+
+    var storedRegistrations: [ExternalPurchaseTokenRegistration] { return self.storage.value }
+
+    func store(_ registration: ExternalPurchaseTokenRegistration) {
+        self.storage.modify { $0.append(registration) }
+    }
+
+    func remove(_ registration: ExternalPurchaseTokenRegistration) {
+        self.storage.modify { $0.removeAll { $0 == registration } }
+    }
+
+}

--- a/Tests/UnitTests/Purchasing/ExternalPurchase/ExternalPurchaseManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/ExternalPurchase/ExternalPurchaseManagerTests.swift
@@ -24,6 +24,7 @@ class ExternalPurchaseManagerTests: TestCase {
 
     private var customLink: MockExternalPurchaseCustomLink!
     private var externalPurchaseTokenAPI: MockExternalPurchaseTokenAPI!
+    private var tokenStore: MockExternalPurchaseTokenStore!
     private var systemInfo: MockSystemInfo!
     private var manager: ExternalPurchaseManager!
 
@@ -34,6 +35,7 @@ class ExternalPurchaseManagerTests: TestCase {
         self.customLink.stubbedTokenResult = .success(Self.token)
 
         self.externalPurchaseTokenAPI = MockExternalPurchaseTokenAPI()
+        self.tokenStore = MockExternalPurchaseTokenStore()
 
         self.systemInfo = Self.makeSystemInfo(useExternalPurchaseCustomLinks: true)
         self.manager = self.makeManager()
@@ -157,6 +159,62 @@ class ExternalPurchaseManagerTests: TestCase {
         expect(result.shouldProceed) == true
         expect(result.tokenID).to(beNil())
         expect(self.externalPurchaseTokenAPI.invokedPostExternalPurchaseTokenCount) == 1
+    }
+
+    // MARK: - Keeping the registration
+
+    /// Apple expects a report for every token minted, so the registration is kept before the post that may
+    /// never land.
+    func testKeepsTheRegistrationBeforePostingIt() async throws {
+        let store = try XCTUnwrap(self.tokenStore)
+        let keptWhilePosting: Atomic<[ExternalPurchaseTokenRegistration]> = .init([])
+
+        self.externalPurchaseTokenAPI.postExternalPurchaseTokenCallback = {
+            keptWhilePosting.value = store.storedRegistrations
+        }
+
+        _ = await self.manager.prepareExternalPurchase(flow: .linkOut)
+
+        let kept = try XCTUnwrap(keptWhilePosting.value.onlyElement)
+        expect(kept.tokenID) == self.postedTokenID
+        expect(kept.appUserID) == Self.appUserID
+        expect(kept.purchaseType) == .linkOut
+        expect(kept.token) == Self.token
+    }
+
+    func testDropsTheRegistrationOnceTheBackendAcceptsIt() async {
+        _ = await self.manager.prepareExternalPurchase(flow: .linkOut)
+
+        expect(self.tokenStore.storedRegistrations).to(beEmpty())
+    }
+
+    /// A registration lost to a connection failure can still land later, which is what keeping it is for.
+    func testKeepsTheRegistrationWhenThePostFailsTransiently() async throws {
+        self.externalPurchaseTokenAPI.stubbedPostExternalPurchaseTokenError = .networkError(.offlineConnection())
+
+        _ = await self.manager.prepareExternalPurchase(flow: .linkOut)
+
+        let kept = try XCTUnwrap(self.tokenStore.storedRegistrations.onlyElement)
+        expect(kept.tokenID) == self.postedTokenID
+
+        self.logger.verifyMessageWasLogged(Strings.externalPurchase.registration_pending_retry(kept.tokenID),
+                                           level: .debug)
+    }
+
+    /// A rejection is the backend's answer, so posting the same registration again would only be rejected
+    /// again.
+    func testDropsTheRegistrationWhenTheBackendRejectsIt() async throws {
+        self.externalPurchaseTokenAPI.stubbedPostExternalPurchaseTokenError = .networkError(
+            .errorResponse(.defaultResponse, .invalidRequest)
+        )
+
+        _ = await self.manager.prepareExternalPurchase(flow: .linkOut)
+
+        let tokenID = try XCTUnwrap(self.postedTokenID)
+        expect(self.tokenStore.storedRegistrations).to(beEmpty())
+
+        self.logger.verifyMessageWasLogged(Strings.externalPurchase.registration_discarded(tokenID),
+                                           level: .debug)
     }
 
     // MARK: - Dangerous setting
@@ -285,6 +343,7 @@ class ExternalPurchaseManagerTests: TestCase {
         return ExternalPurchaseManager(
             customLink: self.customLink,
             externalPurchaseTokenAPI: self.externalPurchaseTokenAPI,
+            tokenStore: self.tokenStore,
             currentUserProvider: MockCurrentUserProvider(mockAppUserID: Self.appUserID),
             systemInfo: self.systemInfo
         )

--- a/Tests/UnitTests/Purchasing/ExternalPurchase/ExternalPurchaseTokenStoreTests.swift
+++ b/Tests/UnitTests/Purchasing/ExternalPurchase/ExternalPurchaseTokenStoreTests.swift
@@ -1,0 +1,121 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ExternalPurchaseTokenStoreTests.swift
+//
+//  Created by Antonio Pallares on 10/9/26.
+
+import Foundation
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+class ExternalPurchaseTokenStoreTests: TestCase {
+
+    private static let registration = ExternalPurchaseTokenRegistration(
+        tokenID: "ept13dcbc01adaa44db9b1691a6be2f9929",
+        appUserID: "test-app-user-id",
+        purchaseType: .linkOut,
+        token: "test-external-purchase-token"
+    )
+
+    private var cache: MockLargeItemCache!
+    private var store: ExternalPurchaseTokenStore!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        self.cache = MockLargeItemCache()
+        self.store = ExternalPurchaseTokenStore(apiKey: "test_api_key", fileManager: self.cache)
+    }
+
+    /// A registration has to outlive the app being killed, so it goes to a directory the system does not
+    /// reclaim, other than on tvOS where there is none.
+    func testKeepsRegistrationsOutsideTheCacheDirectory() throws {
+        let invocation = try XCTUnwrap(self.cache.createDirectoryInvocations.first)
+
+        switch invocation.directoryType {
+        #if os(tvOS)
+        case .cache:
+            break
+        #else
+        case .applicationSupport:
+            break
+        #endif
+        default:
+            fail("Unexpected directory type: \(invocation.directoryType)")
+        }
+    }
+
+    func testStoresEveryFieldTheRegistrationNeeds() throws {
+        self.store.store(Self.registration)
+
+        let saved = try XCTUnwrap(self.cache.saveDataInvocations.onlyElement)
+        let decoded = try JSONDecoder.default.decode(ExternalPurchaseTokenRegistration.self, from: saved.data)
+
+        expect(decoded) == Self.registration
+    }
+
+    /// Where StoreKit had no token to give, the registration still has to be kept: the backend generates a
+    /// token for it.
+    func testStoresARegistrationThatCarriesNoToken() throws {
+        let registration = ExternalPurchaseTokenRegistration(
+            tokenID: "ept13dcbc01adaa44db9b1691a6be2f9929",
+            appUserID: "test-app-user-id",
+            purchaseType: .inApp,
+            token: nil
+        )
+
+        self.store.store(registration)
+
+        let saved = try XCTUnwrap(self.cache.saveDataInvocations.onlyElement)
+        let decoded = try JSONDecoder.default.decode(ExternalPurchaseTokenRegistration.self, from: saved.data)
+
+        expect(decoded) == registration
+    }
+
+    func testFilesARegistrationUnderItsOwnIdentifier() throws {
+        self.store.store(Self.registration)
+
+        let saved = try XCTUnwrap(self.cache.saveDataInvocations.onlyElement)
+
+        expect(saved.url.lastPathComponent)
+            == "external_purchase_token_registration_\(Self.registration.tokenID)"
+    }
+
+    func testRemovesTheRegistrationItStored() throws {
+        self.store.store(Self.registration)
+        self.store.remove(Self.registration)
+
+        let saved = try XCTUnwrap(self.cache.saveDataInvocations.onlyElement)
+        let removed = try XCTUnwrap(self.cache.removeInvocations.onlyElement)
+
+        expect(removed) == saved.url
+    }
+
+    func testKeepsTheOtherRegistrationsWhenOneIsRemoved() throws {
+        let other = ExternalPurchaseTokenRegistration(
+            tokenID: "epta51d06bc57f344ffb386dff7e2353bea",
+            appUserID: Self.registration.appUserID,
+            purchaseType: .linkOut,
+            token: "another-external-purchase-token"
+        )
+
+        self.store.store(Self.registration)
+        self.store.store(other)
+        self.store.remove(Self.registration)
+
+        let removed = try XCTUnwrap(self.cache.removeInvocations.onlyElement)
+
+        expect(removed.lastPathComponent).to(contain(Self.registration.tokenID))
+        expect(removed.lastPathComponent).toNot(contain(other.tokenID))
+    }
+
+}


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Apple expects a report for every external purchase token minted, including the ones whose registration never reaches RevenueCat, so a registration has to outlive the session that minted it. SDK-4493.

### Description
- A registration (token id, app user id, purchase type and token) is written to disk before the post, and dropped once the backend accepts it, or rejects it with a `4xx`. A transient failure leaves it on disk.
- Nothing retries the kept registrations yet: the sweep is SDK-4494, stacked on top of this.

Draft while the backend field name for the SDK-supplied id is unconfirmed, same as its base PR.