### PR TITLE
Register the external purchase tokens kept from earlier attempts

### DIFF
--- a/Sources/Logging/Strings/ExternalPurchaseStrings.swift
+++ b/Sources/Logging/Strings/ExternalPurchaseStrings.swift
@@ -30,6 +30,9 @@ enum ExternalPurchaseStrings {
     case error_registering_token(_ error: BackendError)
     case registration_pending_retry(_ tokenID: String)
     case registration_discarded(_ tokenID: String)
+    case error_loading_registration(_ error: Error)
+    case registering_pending_tokens(_ count: Int)
+    case already_registering_pending_tokens
 
 }
 
@@ -63,6 +66,12 @@ extension ExternalPurchaseStrings: LogMessage {
             return "External purchase token \(tokenID) is kept to be registered again later."
         case let .registration_discarded(tokenID):
             return "External purchase token \(tokenID) will not be registered again: it was rejected."
+        case let .error_loading_registration(error):
+            return "Error loading an external purchase token registration: \(error.localizedDescription)"
+        case let .registering_pending_tokens(count):
+            return "Registering \(count) external purchase token(s) kept from an earlier attempt."
+        case .already_registering_pending_tokens:
+            return "The external purchase tokens kept from earlier attempts are already being registered."
         }
     }
 

--- a/Sources/Purchasing/ExternalPurchase/ExternalPurchaseManager.swift
+++ b/Sources/Purchasing/ExternalPurchase/ExternalPurchaseManager.swift
@@ -21,19 +21,23 @@ final class ExternalPurchaseManager {
     private let externalPurchaseTokenAPI: ExternalPurchaseTokenAPI
     private let tokenStore: ExternalPurchaseTokenStoreType
     private let currentUserProvider: CurrentUserProvider
+    private let operationDispatcher: OperationDispatcher
     private let systemInfo: SystemInfo
 
     private let isPreparing: Atomic<Bool> = false
+    private let isRegisteringPendingTokens: Atomic<Bool> = false
 
     init(customLink: ExternalPurchaseCustomLinkType,
          externalPurchaseTokenAPI: ExternalPurchaseTokenAPI,
          tokenStore: ExternalPurchaseTokenStoreType,
          currentUserProvider: CurrentUserProvider,
+         operationDispatcher: OperationDispatcher,
          systemInfo: SystemInfo) {
         self.customLink = customLink
         self.externalPurchaseTokenAPI = externalPurchaseTokenAPI
         self.tokenStore = tokenStore
         self.currentUserProvider = currentUserProvider
+        self.operationDispatcher = operationDispatcher
         self.systemInfo = systemInfo
     }
 
@@ -98,6 +102,43 @@ final class ExternalPurchaseManager {
         }
 
         return await self.registerToken(of: flow.tokenType)
+    }
+
+    /// Registers the tokens kept from earlier attempts, one at a time, so that a token minted in a session that
+    /// never reached the backend is still reported.
+    ///
+    /// Safe to call before the customer intends to buy: it mints nothing, so it creates no obligation to report
+    /// anything to Apple.
+    func registerPendingTokensIfNeeded() {
+        guard self.takesPartInTheProgramme, !self.systemInfo.isSimulatedStoreAPIKey else { return }
+
+        #if DEBUG
+        let delay: JitterableDelay = ProcessInfo.isRunningRevenueCatTests ? .none : .default
+        #else
+        let delay: JitterableDelay = .default
+        #endif
+
+        self.operationDispatcher.dispatchOnWorkerThread(jitterableDelay: delay) {
+            await self.registerPendingTokens()
+        }
+    }
+
+    func registerPendingTokens() async {
+        guard !self.isRegisteringPendingTokens.getAndSet(true) else {
+            Logger.debug(Strings.externalPurchase.already_registering_pending_tokens)
+            return
+        }
+
+        defer { self.isRegisteringPendingTokens.value = false }
+
+        let pending = self.tokenStore.allRegistrations()
+        guard !pending.isEmpty else { return }
+
+        Logger.debug(Strings.externalPurchase.registering_pending_tokens(pending.count))
+
+        for registration in pending {
+            await self.post(registration)
+        }
     }
 
 }
@@ -232,6 +273,17 @@ private extension ExternalPurchaseManager {
 
         self.tokenStore.store(registration)
 
+        guard await self.post(registration) else {
+            return .unregistered(.registrationFailed)
+        }
+
+        return .registered(tokenID: registration.tokenID)
+    }
+
+    /// Posts a kept registration, and drops it unless the backend may still accept it. Returns whether it was
+    /// accepted.
+    @discardableResult
+    func post(_ registration: ExternalPurchaseTokenRegistration) async -> Bool {
         let error: BackendError? = await Async.call { completion in
             self.externalPurchaseTokenAPI.postExternalPurchaseToken(
                 appUserID: registration.appUserID,
@@ -244,18 +296,18 @@ private extension ExternalPurchaseManager {
 
         if let error = error {
             self.handleFailedRegistration(registration, error: error)
-            return .unregistered(.registrationFailed)
+            return false
         }
 
         self.tokenStore.remove(registration)
         Logger.debug(Strings.externalPurchase.token_registered(registration.tokenID))
-        return .registered(tokenID: registration.tokenID)
+        return true
     }
 
     /// A registration the backend rejected would only be rejected again, so only one it may still accept is
     /// kept.
-    private func handleFailedRegistration(_ registration: ExternalPurchaseTokenRegistration,
-                                          error: BackendError) {
+    func handleFailedRegistration(_ registration: ExternalPurchaseTokenRegistration,
+                                  error: BackendError) {
         Logger.error(Strings.externalPurchase.error_registering_token(error))
 
         if error.isTransient {

--- a/Sources/Purchasing/ExternalPurchase/ExternalPurchaseTokenStore.swift
+++ b/Sources/Purchasing/ExternalPurchase/ExternalPurchaseTokenStore.swift
@@ -22,6 +22,9 @@ protocol ExternalPurchaseTokenStoreType: Sendable {
     /// Drop a registration the backend has answered for, whether it accepted or rejected it.
     func remove(_ registration: ExternalPurchaseTokenRegistration)
 
+    /// Every registration kept, in no particular order.
+    func allRegistrations() -> [ExternalPurchaseTokenRegistration]
+
 }
 
 /// Stores external purchase token registrations persistently on disk, so that one minted in a session that
@@ -53,6 +56,18 @@ final class ExternalPurchaseTokenStore: ExternalPurchaseTokenStoreType {
 
     func remove(_ registration: ExternalPurchaseTokenRegistration) {
         self.cache.removeObject(forKey: Self.key(for: registration))
+    }
+
+    func allRegistrations() -> [ExternalPurchaseTokenRegistration] {
+        return self.cache.allKeys().compactMap { key in
+            do {
+                return try self.cache.value(forKey: key, decoder: .default)
+            } catch {
+                Logger.error(Strings.externalPurchase.error_loading_registration(error))
+                self.cache.removeObject(forKey: key)
+                return nil
+            }
+        }
     }
 
     /// Keys become file names, so they may not contain path separators. ``ExternalPurchaseTokenID`` only

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -967,6 +967,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             externalPurchaseTokenAPI: backend.externalPurchaseTokenAPI,
             tokenStore: ExternalPurchaseTokenStore(apiKey: systemInfo.apiKey),
             currentUserProvider: identityManager,
+            operationDispatcher: operationDispatcher,
             systemInfo: systemInfo
         )
 
@@ -1024,6 +1025,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.transactionMetadataSyncHelper.syncIfNeeded(
             allowSharingAppStoreAccount: purchasesOrchestrator.allowSharingAppStoreAccount
         )
+
+        self.externalPurchaseManager.registerPendingTokensIfNeeded()
     }
 
     deinit {
@@ -3029,6 +3032,7 @@ private extension Purchases {
         self.transactionMetadataSyncHelper.syncIfNeeded(
             allowSharingAppStoreAccount: self.purchasesOrchestrator.allowSharingAppStoreAccount
         )
+        self.externalPurchaseManager.registerPendingTokensIfNeeded()
 
         #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 

--- a/Tests/UnitTests/Mocks/MockExternalPurchaseTokenAPI.swift
+++ b/Tests/UnitTests/Mocks/MockExternalPurchaseTokenAPI.swift
@@ -29,6 +29,9 @@ class MockExternalPurchaseTokenAPI: ExternalPurchaseTokenAPI {
         token: String?
     )?
 
+    /// Every identifier posted, in the order it was posted.
+    var postedTokenIDs: [String] = []
+
     var stubbedPostExternalPurchaseTokenError: BackendError?
     var postExternalPurchaseTokenCallback: (() -> Void)?
 
@@ -42,6 +45,7 @@ class MockExternalPurchaseTokenAPI: ExternalPurchaseTokenAPI {
         self.invokedPostExternalPurchaseToken = true
         self.invokedPostExternalPurchaseTokenCount += 1
         self.invokedPostExternalPurchaseTokenParameters = (appUserID, purchaseType, tokenID, token)
+        self.postedTokenIDs.append(tokenID)
 
         self.postExternalPurchaseTokenCallback?()
         completion(self.stubbedPostExternalPurchaseTokenError)

--- a/Tests/UnitTests/Mocks/MockExternalPurchaseTokenStore.swift
+++ b/Tests/UnitTests/Mocks/MockExternalPurchaseTokenStore.swift
@@ -28,4 +28,8 @@ final class MockExternalPurchaseTokenStore: ExternalPurchaseTokenStoreType {
         self.storage.modify { $0.removeAll { $0 == registration } }
     }
 
+    func allRegistrations() -> [ExternalPurchaseTokenRegistration] {
+        return self.storage.value
+    }
+
 }

--- a/Tests/UnitTests/Purchasing/ExternalPurchase/ExternalPurchaseManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/ExternalPurchase/ExternalPurchaseManagerTests.swift
@@ -25,6 +25,7 @@ class ExternalPurchaseManagerTests: TestCase {
     private var customLink: MockExternalPurchaseCustomLink!
     private var externalPurchaseTokenAPI: MockExternalPurchaseTokenAPI!
     private var tokenStore: MockExternalPurchaseTokenStore!
+    private var operationDispatcher: MockOperationDispatcher!
     private var systemInfo: MockSystemInfo!
     private var manager: ExternalPurchaseManager!
 
@@ -36,6 +37,7 @@ class ExternalPurchaseManagerTests: TestCase {
 
         self.externalPurchaseTokenAPI = MockExternalPurchaseTokenAPI()
         self.tokenStore = MockExternalPurchaseTokenStore()
+        self.operationDispatcher = MockOperationDispatcher()
 
         self.systemInfo = Self.makeSystemInfo(useExternalPurchaseCustomLinks: true)
         self.manager = self.makeManager()
@@ -321,6 +323,101 @@ class ExternalPurchaseManagerTests: TestCase {
         expect(self.customLink.invokedNoticeTypes) == [.browser, .browser]
     }
 
+    // MARK: - Registering the tokens kept from earlier attempts
+
+    /// A token minted in a session that never reached the backend is still one Apple expects a report for.
+    func testRegistersTheTokensKeptFromEarlierAttempts() async {
+        self.tokenStore.store(Self.makeRegistration(tokenID: "ept00000000000000000000000000000001"))
+        self.tokenStore.store(Self.makeRegistration(tokenID: "ept00000000000000000000000000000002"))
+
+        await self.manager.registerPendingTokens()
+
+        expect(self.externalPurchaseTokenAPI.postedTokenIDs) == [
+            "ept00000000000000000000000000000001",
+            "ept00000000000000000000000000000002"
+        ]
+        expect(self.tokenStore.storedRegistrations).to(beEmpty())
+    }
+
+    /// The registration carries the customer the token was minted for, who may no longer be the current one.
+    func testRegistersAKeptTokenAgainstTheCustomerItWasMintedFor() async throws {
+        self.tokenStore.store(ExternalPurchaseTokenRegistration(
+            tokenID: "ept00000000000000000000000000000001",
+            appUserID: "another-app-user-id",
+            purchaseType: .inApp,
+            token: nil
+        ))
+
+        await self.manager.registerPendingTokens()
+
+        let parameters = try XCTUnwrap(self.externalPurchaseTokenAPI.invokedPostExternalPurchaseTokenParameters)
+        expect(parameters.appUserID) == "another-app-user-id"
+        expect(parameters.purchaseType) == .inApp
+        expect(parameters.token).to(beNil())
+    }
+
+    func testKeepsATokenWhoseRegistrationFailsTransientlyAgain() async {
+        self.externalPurchaseTokenAPI.stubbedPostExternalPurchaseTokenError = .networkError(.offlineConnection())
+
+        let registration = Self.makeRegistration(tokenID: "ept00000000000000000000000000000001")
+        self.tokenStore.store(registration)
+
+        await self.manager.registerPendingTokens()
+
+        expect(self.tokenStore.storedRegistrations) == [registration]
+    }
+
+    func testDropsAKeptTokenTheBackendRejects() async {
+        self.externalPurchaseTokenAPI.stubbedPostExternalPurchaseTokenError = .networkError(
+            .errorResponse(.defaultResponse, .invalidRequest)
+        )
+
+        self.tokenStore.store(Self.makeRegistration(tokenID: "ept00000000000000000000000000000001"))
+
+        await self.manager.registerPendingTokens()
+
+        expect(self.tokenStore.storedRegistrations).to(beEmpty())
+    }
+
+    func testPostsNothingWhenNoTokenIsKept() async {
+        await self.manager.registerPendingTokens()
+
+        expect(self.externalPurchaseTokenAPI.invokedPostExternalPurchaseToken) == false
+    }
+
+    /// Registering happens on a foreground pass, which must not be held up by it.
+    func testRegistersTheKeptTokensOffTheCallersThread() {
+        self.tokenStore.store(Self.makeRegistration(tokenID: "ept00000000000000000000000000000001"))
+
+        self.manager.registerPendingTokensIfNeeded()
+
+        expect(self.operationDispatcher.invokedDispatchAsyncOnWorkerThread) == true
+        expect(self.externalPurchaseTokenAPI.postedTokenIDs) == ["ept00000000000000000000000000000001"]
+    }
+
+    func testRegistersNoKeptTokenWhileTheSettingIsDisabled() {
+        self.systemInfo = Self.makeSystemInfo(useExternalPurchaseCustomLinks: false)
+        self.manager = self.makeManager()
+
+        self.tokenStore.store(Self.makeRegistration(tokenID: "ept00000000000000000000000000000001"))
+
+        self.manager.registerPendingTokensIfNeeded()
+
+        expect(self.operationDispatcher.invokedDispatchAsyncOnWorkerThread) == false
+        expect(self.externalPurchaseTokenAPI.invokedPostExternalPurchaseToken) == false
+    }
+
+    func testRegistersNoKeptTokenWithATestStoreKey() {
+        self.systemInfo.stubbedApiKeyValidationResult = .simulatedStore
+
+        self.tokenStore.store(Self.makeRegistration(tokenID: "ept00000000000000000000000000000001"))
+
+        self.manager.registerPendingTokensIfNeeded()
+
+        expect(self.operationDispatcher.invokedDispatchAsyncOnWorkerThread) == false
+        expect(self.externalPurchaseTokenAPI.invokedPostExternalPurchaseToken) == false
+    }
+
     // MARK: - Helpers
 
     /// The identifier the manager generated for the registration it last posted, which is what it is expected
@@ -345,7 +442,17 @@ class ExternalPurchaseManagerTests: TestCase {
             externalPurchaseTokenAPI: self.externalPurchaseTokenAPI,
             tokenStore: self.tokenStore,
             currentUserProvider: MockCurrentUserProvider(mockAppUserID: Self.appUserID),
+            operationDispatcher: self.operationDispatcher,
             systemInfo: self.systemInfo
+        )
+    }
+
+    private static func makeRegistration(tokenID: String) -> ExternalPurchaseTokenRegistration {
+        return ExternalPurchaseTokenRegistration(
+            tokenID: tokenID,
+            appUserID: Self.appUserID,
+            purchaseType: .linkOut,
+            token: Self.token
         )
     }
 

--- a/Tests/UnitTests/Purchasing/ExternalPurchase/ExternalPurchaseTokenStoreTests.swift
+++ b/Tests/UnitTests/Purchasing/ExternalPurchase/ExternalPurchaseTokenStoreTests.swift
@@ -26,6 +26,13 @@ class ExternalPurchaseTokenStoreTests: TestCase {
         token: "test-external-purchase-token"
     )
 
+    private static let otherRegistration = ExternalPurchaseTokenRegistration(
+        tokenID: "epta51d06bc57f344ffb386dff7e2353bea",
+        appUserID: "test-app-user-id",
+        purchaseType: .linkOut,
+        token: "another-external-purchase-token"
+    )
+
     private var cache: MockLargeItemCache!
     private var store: ExternalPurchaseTokenStore!
 
@@ -101,21 +108,48 @@ class ExternalPurchaseTokenStoreTests: TestCase {
     }
 
     func testKeepsTheOtherRegistrationsWhenOneIsRemoved() throws {
-        let other = ExternalPurchaseTokenRegistration(
-            tokenID: "epta51d06bc57f344ffb386dff7e2353bea",
-            appUserID: Self.registration.appUserID,
-            purchaseType: .linkOut,
-            token: "another-external-purchase-token"
-        )
-
         self.store.store(Self.registration)
-        self.store.store(other)
+        self.store.store(Self.otherRegistration)
         self.store.remove(Self.registration)
 
         let removed = try XCTUnwrap(self.cache.removeInvocations.onlyElement)
 
         expect(removed.lastPathComponent).to(contain(Self.registration.tokenID))
-        expect(removed.lastPathComponent).toNot(contain(other.tokenID))
+        expect(removed.lastPathComponent).toNot(contain(Self.otherRegistration.tokenID))
+    }
+
+    func testReadsBackEveryRegistrationItKept() {
+        self.store.store(Self.registration)
+        self.store.store(Self.otherRegistration)
+
+        let registrations = self.store.allRegistrations()
+
+        expect(registrations).to(haveCount(2))
+        expect(registrations).to(contain(Self.registration))
+        expect(registrations).to(contain(Self.otherRegistration))
+    }
+
+    func testReadsBackNothingWhenNothingWasKept() {
+        expect(self.store.allRegistrations()).to(beEmpty())
+    }
+
+    func testDoesNotReadBackARegistrationItRemoved() {
+        self.store.store(Self.registration)
+        self.store.store(Self.otherRegistration)
+        self.store.remove(Self.registration)
+
+        expect(self.store.allRegistrations()) == [Self.otherRegistration]
+    }
+
+    /// A registration that cannot be read can never be posted, so it is dropped rather than kept forever.
+    func testDropsARegistrationItCannotRead() throws {
+        self.store.store(Self.registration)
+
+        let saved = try XCTUnwrap(self.cache.saveDataInvocations.onlyElement)
+        try self.cache.saveData(Data("not a registration".utf8), to: saved.url)
+
+        expect(self.store.allRegistrations()).to(beEmpty())
+        expect(self.cache.removeInvocations) == [saved.url]
     }
 
 }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Builds on #7681, which only keeps the failed token registrations stored on disk.

### Description
Register the external purchase tokens stored from earlier, failed attempts.
- The kept registrations are posted again at configure and on foreground, one at a time and off the caller's thread, against the customer each was minted for. Upon response, it uses the same accept, keep and drop rules as the first attempt.
- No expiry: a registration the backend may still accept is retried for as long as the app lives.