### PR TITLE
Fix(Paywalls) Support Web Views in looping carousels

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Carousel/CarouselComponentView.swift
@@ -162,6 +162,9 @@ private struct CarouselItem<Content: View>: Identifiable {
 private struct CarouselView<Content: View>: View {
     // MARK: - Configuration
 
+    @Environment(\.carouselState)
+    private var ancestorCarouselState
+
     private let pageAlignment: VerticalAlignment
     private let width: CGFloat
     private let initialIndex: Int
@@ -278,7 +281,8 @@ private struct CarouselView<Content: View>: View {
                         .environment(\.carouselState, CarouselState(
                             activeIndex: index,
                             pageIndex: pageIndex,
-                            originalCount: originalCount
+                            originalCount: originalCount,
+                            ancestorDistanceFromActive: self.ancestorCarouselState?.distanceFromActive ?? 0
                         ))
                         // ensure rendering doesn't need to wait on size calculations as the item
                         // attempts to enter the view

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
@@ -53,6 +53,9 @@ struct WebViewComponentView: View {
     @Environment(\.paywallStateDefaults)
     private var paywallStateDefaults
 
+    @Environment(\.carouselState)
+    private var carouselState
+
     let viewModel: WebViewComponentViewModel
 
     private var style: WebViewComponentStyle {
@@ -94,7 +97,8 @@ struct WebViewComponentView: View {
             HostedWebViewComponentView(
                 size: style.size,
                 url: url,
-                instance: instance
+                instance: instance,
+                carouselDistance: self.carouselState?.distanceFromActive ?? 0
             )
         } else if style.visible {
             // Meant to be shown but not renderable (bad URL / no resolvable origin / missing id):
@@ -146,12 +150,15 @@ private struct HostedWebViewComponentView: View {
     @ObservedObject
     var instance: WebViewInstance
 
+    let carouselDistance: Int
+
     var body: some View {
         if !self.instance.processTerminated, !self.instance.loadFailed {
             WebViewRepresentable(
                 url: self.url,
                 instance: self.instance,
-                idStore: .shared
+                idStore: .shared,
+                carouselDistance: self.carouselDistance
             )
             .webViewSize(
                 self.size,
@@ -179,14 +186,16 @@ struct WebViewRepresentable: PlatformViewRepresentable {
     let url: URL
     let instance: WebViewInstance
     let idStore: WebViewDataStoreIdentifierStore
+    /// See ``WebViewHostView/carouselDistance``.
+    var carouselDistance: Int = 0
 
     var expectedOrigin: WebViewOrigin {
         self.instance.session.expectedOrigin
     }
 
     /// One coordinator per instance, retained by the instance: `navigationDelegate` is weak, so a
-    /// coordinator owned by a `ViewThatFits` candidate would stop delivering callbacks the moment
-    /// that candidate is discarded.
+    /// coordinator owned by the representable would stop delivering callbacks the moment a parent
+    /// redraw discards that representable.
     func makeCoordinator() -> Coordinator {
         self.instance.navigationDelegate {
             let coordinator = Coordinator(expectedOrigin: self.expectedOrigin)
@@ -197,9 +206,9 @@ struct WebViewRepresentable: PlatformViewRepresentable {
         }
     }
 
-    // Deliberately no `dismantleNSView/dismantleUIView` implementation: a discarded subtree is usually just a
-    // `ViewThatFits` candidate losing the layout, and tearing the web view down there is what caused
-    // the component to blank out and reload. The component view model owns the web view instead.
+    // Deliberately no `dismantleNSView/dismantleUIView` implementation: a discarded subtree is usually just
+    // a parent redraw, and tearing the web view down there is what caused the component to blank out and
+    // reload. The component view model owns the web view instead.
     #if os(macOS)
     func makeNSView(context: Context) -> WebViewHostView {
         self.makeHost(context: context)
@@ -221,6 +230,7 @@ struct WebViewRepresentable: PlatformViewRepresentable {
     @MainActor
     private func makeHost(context: Context) -> WebViewHostView {
         let host = WebViewHostView()
+        host.carouselDistance = self.carouselDistance
 
         _ = self.instance.webView {
             self.makeWebView(context: context)
@@ -240,6 +250,8 @@ struct WebViewRepresentable: PlatformViewRepresentable {
 
     @MainActor
     private func update(_ host: WebViewHostView) {
+        // A carousel page change re-updates every copy; the instance needs the new distance before it re-evaluates.
+        host.carouselDistance = self.carouselDistance
         if host.window != nil {
             self.instance.updateHost(host)
         }

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
@@ -187,7 +187,7 @@ struct WebViewRepresentable: PlatformViewRepresentable {
     let instance: WebViewInstance
     let idStore: WebViewDataStoreIdentifierStore
     /// See ``WebViewHostView/carouselDistance``.
-    var carouselDistance: Int = 0
+    let carouselDistance: Int
 
     var expectedOrigin: WebViewOrigin {
         self.instance.session.expectedOrigin

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewComponentView.swift
@@ -253,7 +253,7 @@ struct WebViewRepresentable: PlatformViewRepresentable {
         // A carousel page change re-updates every copy; the instance needs the new distance before it re-evaluates.
         host.carouselDistance = self.carouselDistance
         if host.window != nil {
-            self.instance.updateHost(host)
+            self.instance.hostDidEnterWindow(host)
         }
     }
 

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewInstance.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewInstance.swift
@@ -35,9 +35,9 @@ final class WebViewInstance: ObservableObject {
 
     private weak var attachedHost: WebViewHostView?
 
-    /// A host that entered a window while the current host was still mounted. Remembering it lets the
-    /// current host complete the handoff when it leaves instead of stranding the web view off-screen.
-    private weak var pendingHost: WebViewHostView?
+    /// Hosts currently in a window, in entry order. Several is normal: a parent redraw can mount the new
+    /// host before unmounting the old one, and a looping carousel mounts copies of each page.
+    private var candidateHosts: [WeakHost] = []
 
     /// `true` while playback is suspended because no host is showing the web view. Tracked so suspend
     /// and resume stay paired, as WebKit requires.
@@ -115,53 +115,66 @@ final class WebViewInstance: ObservableObject {
     }
 
     func hostDidEnterWindow(_ host: WebViewHostView) {
-        guard let webView = self.webView else {
-            return
-        }
-
-        if let attachedHost = self.attachedHost,
-           attachedHost !== host,
-           attachedHost.window != nil,
-           webView.superview === attachedHost {
-            self.pendingHost = host
-            return
-        }
-
-        self.pendingHost = nil
-        self.attachWebView(to: host)
+        self.registerCandidate(host)
+        self.reconcileAttachment()
     }
 
     func hostDidLeaveWindow(_ host: WebViewHostView) {
-        if self.pendingHost === host {
-            self.pendingHost = nil
-        }
-
-        guard self.attachedHost === host else {
-            return
-        }
-
-        self.attachedHost = nil
-
-        if let pendingHost = self.pendingHost, pendingHost.window != nil {
-            self.pendingHost = nil
-            self.attachWebView(to: pendingHost)
-            return
-        }
-
-        // Nothing is showing the web view any more — the component was hidden, or the paywall went
-        // away. The web view survives on the view model, so without this an `autoplay` video would
-        // keep playing audio from a component that is no longer on screen.
-        self.setMediaPlaybackSuspended(true)
+        self.candidateHosts.removeAll { $0.host === host }
+        self.reconcileAttachment()
     }
 
-    /// Reasserts attachment for a host SwiftUI updated after it was already in a window. Unlike
-    /// ``hostDidEnterWindow(_:)``, updates from another mounted candidate do not compete for ownership.
+    /// Re-evaluates ownership for a host SwiftUI updated while it was already in a window, e.g. because
+    /// its ``WebViewHostView/carouselDistance`` changed when the carousel moved to another page.
     func updateHost(_ host: WebViewHostView) {
-        guard self.attachedHost == nil || self.attachedHost === host else {
+        self.registerCandidate(host)
+        self.reconcileAttachment()
+    }
+
+    private func registerCandidate(_ host: WebViewHostView) {
+        guard !self.candidateHosts.contains(where: { $0.host === host }) else {
             return
         }
 
-        self.attachWebView(to: host)
+        self.candidateHosts.append(WeakHost(host))
+    }
+
+    /// Moves the web view to the host that should be showing it, or suspends playback when none is.
+    private func reconcileAttachment() {
+        guard self.webView != nil else {
+            return
+        }
+
+        self.candidateHosts.removeAll { $0.host?.window == nil }
+
+        guard let preferredHost = self.preferredHost() else {
+            // Nothing is showing the web view any more — the component was hidden, or the paywall went
+            // away. The web view survives on the view model, so without this an `autoplay` video would
+            // keep playing audio from a component that is no longer on screen.
+            self.attachedHost = nil
+            self.setMediaPlaybackSuspended(true)
+            return
+        }
+
+        self.attachWebView(to: preferredHost)
+    }
+
+    /// The candidate closest to its carousel's active page. Ties go to the host already showing the web
+    /// view, then to the host that entered the window first, so a replacement host mounted during a
+    /// redraw only takes over once the current host leaves.
+    private func preferredHost() -> WebViewHostView? {
+        let candidates = self.candidateHosts.compactMap(\.host)
+        guard let closestDistance = candidates.map(\.carouselDistance).min() else {
+            return nil
+        }
+
+        if let attachedHost = self.attachedHost,
+           attachedHost.carouselDistance == closestDistance,
+           candidates.contains(where: { $0 === attachedHost }) {
+            return attachedHost
+        }
+
+        return candidates.first { $0.carouselDistance == closestDistance }
     }
 
     private func attachWebView(to host: WebViewHostView) {
@@ -201,7 +214,7 @@ final class WebViewInstance: ObservableObject {
     func tearDown() {
         self.navigationDelegateObject = nil
         self.attachedHost = nil
-        self.pendingHost = nil
+        self.candidateHosts.removeAll()
 
         guard let webView = self.webView else {
             return
@@ -221,6 +234,16 @@ final class WebViewInstance: ObservableObject {
         self.webView = nil
     }
 
+    private struct WeakHost {
+
+        weak var host: WebViewHostView?
+
+        init(_ host: WebViewHostView) {
+            self.host = host
+        }
+
+    }
+
 }
 
 /// SwiftUI-owned container that the shared `WKWebView` is re-parented into.
@@ -229,6 +252,9 @@ final class WebViewInstance: ObservableObject {
 final class WebViewHostView: NSView {
 
     var onMoveToWindow: ((WebViewHostView) -> Void)?
+
+    /// Distance from the active carousel page; `0` when active or not in a carousel. Closest host wins.
+    var carouselDistance: Int = 0
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
@@ -241,6 +267,9 @@ final class WebViewHostView: NSView {
 final class WebViewHostView: UIView {
 
     var onMoveToWindow: ((WebViewHostView) -> Void)?
+
+    /// Distance from the active carousel page; `0` when active or not in a carousel. Closest host wins.
+    var carouselDistance: Int = 0
 
     override func didMoveToWindow() {
         super.didMoveToWindow()

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewInstance.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewInstance.swift
@@ -124,13 +124,6 @@ final class WebViewInstance: ObservableObject {
         self.reconcileAttachment()
     }
 
-    /// Re-evaluates ownership for a host SwiftUI updated while it was already in a window, e.g. because
-    /// its ``WebViewHostView/carouselDistance`` changed when the carousel moved to another page.
-    func updateHost(_ host: WebViewHostView) {
-        self.registerCandidate(host)
-        self.reconcileAttachment()
-    }
-
     private func registerCandidate(_ host: WebViewHostView) {
         guard !self.candidateHosts.contains(where: { $0.host === host }) else {
             return

--- a/RevenueCatUI/Templates/V2/Components/WebView/WebViewInstance.swift
+++ b/RevenueCatUI/Templates/V2/Components/WebView/WebViewInstance.swift
@@ -139,7 +139,7 @@ final class WebViewInstance: ObservableObject {
         self.candidateHosts.append(WeakHost(host))
     }
 
-    /// Moves the web view to the host that should be showing it, or suspends playback when none is.
+    /// Moves the web view to the host that should be showing it, and suspends playback while it is off-screen.
     private func reconcileAttachment() {
         guard self.webView != nil else {
             return
@@ -156,6 +156,7 @@ final class WebViewInstance: ObservableObject {
             return
         }
 
+        self.setMediaPlaybackSuspended(preferredHost.carouselDistance > 1)
         self.attachWebView(to: preferredHost)
     }
 
@@ -183,7 +184,6 @@ final class WebViewInstance: ObservableObject {
         }
 
         self.attachedHost = host
-        self.setMediaPlaybackSuspended(false)
 
         guard webView.superview !== host else {
             return

--- a/RevenueCatUI/Templates/V2/EnvironmentObjects/CarouselState.swift
+++ b/RevenueCatUI/Templates/V2/EnvironmentObjects/CarouselState.swift
@@ -28,9 +28,24 @@ struct CarouselState: Equatable {
     /// The number of original pages (before copies for looping).
     let originalCount: Int
 
-    /// How many pages this page sits from the active one in the data array. `0` for the active page.
+    /// The effective distance inherited from all enclosing carousels.
+    private let ancestorDistanceFromActive: Int
+
+    init(
+        activeIndex: Int,
+        pageIndex: Int,
+        originalCount: Int,
+        ancestorDistanceFromActive: Int = 0
+    ) {
+        self.activeIndex = activeIndex
+        self.pageIndex = pageIndex
+        self.originalCount = originalCount
+        self.ancestorDistanceFromActive = ancestorDistanceFromActive
+    }
+
+    /// The greatest distance from the active page across this carousel and its ancestors.
     var distanceFromActive: Int {
-        return abs(activeIndex - pageIndex)
+        return max(abs(activeIndex - pageIndex), self.ancestorDistanceFromActive)
     }
 
     /// Whether this page is the currently visible page in the data array.
@@ -38,8 +53,7 @@ struct CarouselState: Equatable {
         return activeIndex == pageIndex
     }
 
-    /// Whether this page is active or adjacent to the active page in the data array.
-    /// This matches the visible "side" pages in the carousel strip.
+    /// Whether this page is active or adjacent in this carousel and every enclosing carousel.
     var isActiveOrNeighbor: Bool {
         return self.distanceFromActive <= 1
     }

--- a/RevenueCatUI/Templates/V2/EnvironmentObjects/CarouselState.swift
+++ b/RevenueCatUI/Templates/V2/EnvironmentObjects/CarouselState.swift
@@ -28,6 +28,11 @@ struct CarouselState: Equatable {
     /// The number of original pages (before copies for looping).
     let originalCount: Int
 
+    /// How many pages this page sits from the active one in the data array. `0` for the active page.
+    var distanceFromActive: Int {
+        return abs(activeIndex - pageIndex)
+    }
+
     /// Whether this page is the currently visible page in the data array.
     var isActive: Bool {
         return activeIndex == pageIndex
@@ -36,7 +41,7 @@ struct CarouselState: Equatable {
     /// Whether this page is active or adjacent to the active page in the data array.
     /// This matches the visible "side" pages in the carousel strip.
     var isActiveOrNeighbor: Bool {
-        return abs(activeIndex - pageIndex) <= 1
+        return self.distanceFromActive <= 1
     }
 
 }

--- a/Tests/RevenueCatUITests/PaywallsV2/CarouselStateTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/CarouselStateTests.swift
@@ -19,7 +19,13 @@ import XCTest
 @available(iOS 15.0, macOS 12.0, watchOS 8.0, *)
 class CarouselStateTests: TestCase {
 
-    // MARK: - Nested Carousels
+    // MARK: - Distance From Active
+
+    func testDistanceFromActiveUsesAbsoluteDataIndexDifference() {
+        XCTAssertEqual(CarouselState(activeIndex: 2, pageIndex: 2, originalCount: 5).distanceFromActive, 0)
+        XCTAssertEqual(CarouselState(activeIndex: 2, pageIndex: 0, originalCount: 5).distanceFromActive, 2)
+        XCTAssertEqual(CarouselState(activeIndex: 2, pageIndex: 4, originalCount: 5).distanceFromActive, 2)
+    }
 
     func testDistanceFromActiveIncludesEnclosingCarouselDistance() {
         let state = CarouselState(

--- a/Tests/RevenueCatUITests/PaywallsV2/CarouselStateTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/CarouselStateTests.swift
@@ -19,6 +19,20 @@ import XCTest
 @available(iOS 15.0, macOS 12.0, watchOS 8.0, *)
 class CarouselStateTests: TestCase {
 
+    // MARK: - Nested Carousels
+
+    func testDistanceFromActiveIncludesEnclosingCarouselDistance() {
+        let state = CarouselState(
+            activeIndex: 0,
+            pageIndex: 0,
+            originalCount: 3,
+            ancestorDistanceFromActive: 3
+        )
+
+        XCTAssertEqual(state.distanceFromActive, 3)
+        XCTAssertFalse(state.isActiveOrNeighbor)
+    }
+
     // MARK: - isActive Tests
 
     func testIsActiveReturnsTrueWhenIndicesMatch() {

--- a/Tests/RevenueCatUITests/PaywallsV2/WebViewInstanceTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WebViewInstanceTests.swift
@@ -372,6 +372,20 @@ final class WebViewInstanceHostAttachmentTests: TestCase {
         XCTAssertTrue(instance.isMediaPlaybackSuspended)
     }
 
+    func testMediaIsSuspendedUntilCarouselPageIsActiveOrNeighboring() {
+        let instance = Self.makeInstance()
+        _ = instance.webView { WKWebView(frame: .zero) }
+        let host = self.makeWindowedHost(carouselDistance: 2)
+
+        instance.hostDidEnterWindow(host)
+        XCTAssertTrue(instance.isMediaPlaybackSuspended)
+
+        host.carouselDistance = 1
+        instance.updateHost(host)
+
+        XCTAssertFalse(instance.isMediaPlaybackSuspended)
+    }
+
     func testMediaResumesWhenTheComponentIsShownAgain() {
         let instance = Self.makeInstance()
         _ = instance.webView { WKWebView(frame: .zero) }

--- a/Tests/RevenueCatUITests/PaywallsV2/WebViewInstanceTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WebViewInstanceTests.swift
@@ -225,7 +225,7 @@ final class WebViewInstanceHostAttachmentTests: TestCase {
         let host = self.makeWindowedHost()
 
         instance.hostDidEnterWindow(host)
-        instance.updateHost(host)
+        instance.hostDidEnterWindow(host)
 
         XCTAssertTrue(webView.superview === host)
         XCTAssertEqual(host.subviews.count, 1)
@@ -303,7 +303,7 @@ final class WebViewInstanceHostAttachmentTests: TestCase {
 
         instance.hostDidEnterWindow(activeCopy)
         instance.hostDidEnterWindow(neighborCopy)
-        instance.updateHost(neighborCopy)
+        instance.hostDidEnterWindow(neighborCopy)
 
         XCTAssertTrue(webView.superview === activeCopy)
     }
@@ -320,10 +320,10 @@ final class WebViewInstanceHostAttachmentTests: TestCase {
         XCTAssertTrue(webView.superview === firstCopy)
 
         firstCopy.carouselDistance = 2
-        instance.updateHost(firstCopy)
+        instance.hostDidEnterWindow(firstCopy)
 
         secondCopy.carouselDistance = 0
-        instance.updateHost(secondCopy)
+        instance.hostDidEnterWindow(secondCopy)
 
         XCTAssertTrue(webView.superview === secondCopy)
         XCTAssertFalse(instance.isMediaPlaybackSuspended)
@@ -338,8 +338,8 @@ final class WebViewInstanceHostAttachmentTests: TestCase {
 
         instance.hostDidEnterWindow(leftNeighbor)
         instance.hostDidEnterWindow(rightNeighbor)
-        instance.updateHost(rightNeighbor)
-        instance.updateHost(leftNeighbor)
+        instance.hostDidEnterWindow(rightNeighbor)
+        instance.hostDidEnterWindow(leftNeighbor)
 
         XCTAssertTrue(webView.superview === leftNeighbor)
     }
@@ -387,7 +387,7 @@ final class WebViewInstanceHostAttachmentTests: TestCase {
         XCTAssertTrue(instance.isMediaPlaybackSuspended)
 
         host.carouselDistance = 1
-        instance.updateHost(host)
+        instance.hostDidEnterWindow(host)
 
         XCTAssertFalse(instance.isMediaPlaybackSuspended)
     }

--- a/Tests/RevenueCatUITests/PaywallsV2/WebViewInstanceTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WebViewInstanceTests.swift
@@ -129,7 +129,12 @@ final class WebViewInstanceTests: TestCase {
             let owned = try XCTUnwrap(viewModel.webViewInstance())
             let ownedWebView = owned.webView { WKWebView(frame: .zero) }
             // Built through the real representable so the coordinator's captures are the shipping ones.
-            _ = WebViewRepresentable(url: Self.url, instance: owned, idStore: store).makeCoordinator()
+            _ = WebViewRepresentable(
+                url: Self.url,
+                instance: owned,
+                idStore: store,
+                carouselDistance: 0
+            ).makeCoordinator()
 
             instance = owned
             webView = ownedWebView

--- a/Tests/RevenueCatUITests/PaywallsV2/WebViewInstanceTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WebViewInstanceTests.swift
@@ -272,6 +272,89 @@ final class WebViewInstanceHostAttachmentTests: TestCase {
         XCTAssertTrue(webView.superview === displayed)
     }
 
+    // MARK: - Carousel copies
+
+    /// In a looping carousel the off-screen copy at the start of the strip enters the window first; the
+    /// copy the user is looking at must win regardless.
+    func testActiveCarouselPageTakesTheWebViewFromAnEarlierOffscreenCopy() {
+        let instance = Self.makeInstance()
+        let webView = instance.webView { WKWebView(frame: .zero) }
+        let offscreenCopy = self.makeWindowedHost(carouselDistance: 3)
+        let activeCopy = self.makeWindowedHost(carouselDistance: 0)
+
+        instance.hostDidEnterWindow(offscreenCopy)
+        XCTAssertTrue(webView.superview === offscreenCopy)
+
+        instance.hostDidEnterWindow(activeCopy)
+
+        XCTAssertTrue(webView.superview === activeCopy)
+    }
+
+    func testFartherCarouselCopyCannotTakeTheWebViewFromTheActivePage() {
+        let instance = Self.makeInstance()
+        let webView = instance.webView { WKWebView(frame: .zero) }
+        let activeCopy = self.makeWindowedHost(carouselDistance: 0)
+        let neighborCopy = self.makeWindowedHost(carouselDistance: 1)
+
+        instance.hostDidEnterWindow(activeCopy)
+        instance.hostDidEnterWindow(neighborCopy)
+        instance.updateHost(neighborCopy)
+
+        XCTAssertTrue(webView.superview === activeCopy)
+    }
+
+    /// Swiping changes every copy's distance without any host leaving the window.
+    func testWebViewFollowsTheActivePageWhenTheCarouselMoves() {
+        let instance = Self.makeInstance()
+        let webView = instance.webView { WKWebView(frame: .zero) }
+        let firstCopy = self.makeWindowedHost(carouselDistance: 0)
+        let secondCopy = self.makeWindowedHost(carouselDistance: 2)
+
+        instance.hostDidEnterWindow(firstCopy)
+        instance.hostDidEnterWindow(secondCopy)
+        XCTAssertTrue(webView.superview === firstCopy)
+
+        firstCopy.carouselDistance = 2
+        secondCopy.carouselDistance = 0
+        instance.updateHost(firstCopy)
+        instance.updateHost(secondCopy)
+
+        XCTAssertTrue(webView.superview === secondCopy)
+        XCTAssertFalse(instance.isMediaPlaybackSuspended)
+    }
+
+    /// A 2-page loop peeks both neighbours at equal distance; the holder must not bounce between them.
+    func testEquallyDistantCopiesDoNotStealTheWebViewFromEachOther() {
+        let instance = Self.makeInstance()
+        let webView = instance.webView { WKWebView(frame: .zero) }
+        let leftNeighbor = self.makeWindowedHost(carouselDistance: 1)
+        let rightNeighbor = self.makeWindowedHost(carouselDistance: 1)
+
+        instance.hostDidEnterWindow(leftNeighbor)
+        instance.hostDidEnterWindow(rightNeighbor)
+        instance.updateHost(rightNeighbor)
+        instance.updateHost(leftNeighbor)
+
+        XCTAssertTrue(webView.superview === leftNeighbor)
+    }
+
+    func testWebViewFallsBackToTheClosestRemainingCopyWhenTheActiveOneLeaves() {
+        let instance = Self.makeInstance()
+        let webView = instance.webView { WKWebView(frame: .zero) }
+        let farCopy = self.makeWindowedHost(carouselDistance: 3)
+        let activeCopy = self.makeWindowedHost(carouselDistance: 0)
+        let nearCopy = self.makeWindowedHost(carouselDistance: 1)
+
+        instance.hostDidEnterWindow(farCopy)
+        instance.hostDidEnterWindow(activeCopy)
+        instance.hostDidEnterWindow(nearCopy)
+
+        activeCopy.removeFromSuperview()
+        instance.hostDidLeaveWindow(activeCopy)
+
+        XCTAssertTrue(webView.superview === nearCopy)
+    }
+
     // MARK: - Media playback
 
     /// The web view outlives the subtree now, so a hidden component would otherwise keep playing.
@@ -303,7 +386,7 @@ final class WebViewInstanceHostAttachmentTests: TestCase {
         XCTAssertFalse(instance.isMediaPlaybackSuspended)
     }
 
-    /// A `ViewThatFits` swap hands the web view straight over, so playback must not be interrupted.
+    /// A redraw hands the web view straight over to the new host, so playback must not be interrupted.
     func testHandoffBetweenCandidatesDoesNotSuspendMedia() {
         let instance = Self.makeInstance()
         _ = instance.webView { WKWebView(frame: .zero) }
@@ -340,8 +423,9 @@ final class WebViewInstanceHostAttachmentTests: TestCase {
         )
     }
 
-    private func makeWindowedHost() -> WebViewHostView {
+    private func makeWindowedHost(carouselDistance: Int = 0) -> WebViewHostView {
         let host = WebViewHostView()
+        host.carouselDistance = carouselDistance
 
         #if os(macOS)
         let window = NSWindow(

--- a/Tests/RevenueCatUITests/PaywallsV2/WebViewInstanceTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WebViewInstanceTests.swift
@@ -315,8 +315,9 @@ final class WebViewInstanceHostAttachmentTests: TestCase {
         XCTAssertTrue(webView.superview === firstCopy)
 
         firstCopy.carouselDistance = 2
-        secondCopy.carouselDistance = 0
         instance.updateHost(firstCopy)
+
+        secondCopy.carouselDistance = 0
         instance.updateHost(secondCopy)
 
         XCTAssertTrue(webView.superview === secondCopy)

--- a/Tests/RevenueCatUITests/PaywallsV2/WebViewInstanceTests.swift
+++ b/Tests/RevenueCatUITests/PaywallsV2/WebViewInstanceTests.swift
@@ -245,7 +245,7 @@ final class WebViewInstanceHostAttachmentTests: TestCase {
 
     /// SwiftUI may mount the incoming representable before unmounting the outgoing one. The incoming
     /// request must complete when the outgoing host leaves without requiring another update callback.
-    func testPendingHostTakesTheWebViewWhenTheCurrentHostLeavesItsWindow() {
+    func testIncomingCandidateTakesTheWebViewWhenTheAttachedHostLeavesItsWindow() {
         let instance = Self.makeInstance()
         let webView = instance.webView { WKWebView(frame: .zero) }
         let outgoing = self.makeWindowedHost()
@@ -261,16 +261,16 @@ final class WebViewInstanceHostAttachmentTests: TestCase {
         XCTAssertTrue(webView.superview === incoming)
     }
 
-    func testPendingHostIsForgottenIfItLeavesBeforeTheCurrentHost() {
+    func testCandidateIsRemovedIfItLeavesBeforeTheAttachedHost() {
         let instance = Self.makeInstance()
         let webView = instance.webView { WKWebView(frame: .zero) }
         let displayed = self.makeWindowedHost()
-        let pending = self.makeWindowedHost()
+        let candidate = self.makeWindowedHost()
 
         instance.hostDidEnterWindow(displayed)
-        instance.hostDidEnterWindow(pending)
-        pending.removeFromSuperview()
-        instance.hostDidLeaveWindow(pending)
+        instance.hostDidEnterWindow(candidate)
+        candidate.removeFromSuperview()
+        instance.hostDidLeaveWindow(candidate)
         displayed.removeFromSuperview()
         instance.hostDidLeaveWindow(displayed)
 


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->
<!-- AI agents: fill in this template, and also follow the "Pull Requests" section in AGENTS.md. -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

If a carousel contained a webview and the carousel was set to loop, it would look like the webview didn't load for a very long time.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->
We actually introduced a bug to fix a different bug… And it caused us to only allow one host to own a webview. When we loop carousels, we duplicate the pages. Those pages using the web view all point to the same web view and only one of them can display it. Unfortunately, this meant that the off-screen pages were attempting to render the web view so it wasn't until the loop completed that the web view would be visible at all.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared WKWebView attachment and WebKit media suspension across multiple SwiftUI hosts; behavior is well-tested but touches carousel + web view lifecycle edge cases.
> 
> **Overview**
> Fixes **looping carousels** where a shared paywall `WKWebView` could stay attached to an off-screen duplicate page, so the web view looked blank until the carousel finished a full loop.
> 
> **Carousel state** now propagates **`distanceFromActive`** (including nested carousels via `ancestorDistanceFromActive`) instead of `originalCount` / `isActive`, and each carousel page passes that distance into its subtree.
> 
> **Web view hosting** replaces single-host / pending-host logic with **`reconcile`**: track multiple windowed **candidate hosts**, attach the shared web view to the host with the **smallest `carouselDistance`**, and **suspend media** when distance is greater than 1. Media suspend/resume is **deferred to the next main-actor turn** so per-copy SwiftUI updates during a swipe do not flicker playback.
> 
> Tests cover carousel distance behavior, host selection on swipe, tie-breaking, and media suspension.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24c1a7c9573b0c10be8b163d0077799e247026f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->