### PR TITLE
Apply the PaywallsTester entitlements file in the Tuist target

### DIFF
--- a/Projects/PaywallsTester/Project.swift
+++ b/Projects/PaywallsTester/Project.swift
@@ -164,6 +164,9 @@ let project = Project(
             resources: [
                 "../../Tests/TestingApps/PaywallsTester/PaywallsTester/**/*.xcassets"
             ],
+            entitlements: .file(
+                path: "../../Tests/TestingApps/PaywallsTester/PaywallsTester/PaywallsTester.entitlements"
+            ),
             dependencies: [
                 .revenueCat,
                 .revenueCatUI,


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

`PaywallsTester.entitlements` is tracked in the repo, but the Tuist target never referenced it. Tuist-generated builds therefore ran without the entitlements the file declares, with nothing in the build output pointing at it.

### Description

- Tuist-generated projects now set `CODE_SIGN_ENTITLEMENTS` for PaywallsTester, so its associated domains, app group and sandbox entitlements take effect.
- Simulator builds are unaffected. Device builds now need a provisioning profile that covers those capabilities.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-app build configuration only; aligns Tuist with existing entitlements and may require matching provisioning profiles on device builds.
> 
> **Overview**
> Tuist-generated **PaywallsTester** builds now point at `PaywallsTester.entitlements`, matching the checked-in Xcode project so **associated domains**, **app group**, and **macOS sandbox** capabilities actually apply when you generate with Tuist.
> 
> Previously the entitlements file lived in the repo but the Tuist target did not set `CODE_SIGN_ENTITLEMENTS`, so those capabilities were silently missing from Tuist builds. **Simulator** behavior is unchanged; **device** Tuist builds may need a provisioning profile that includes the same capabilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 072c7f5a1b0ae9ae4ae9e7e7e205d4b8c1652660. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->